### PR TITLE
crypto: Check the device owns the session in SenderDataFinder

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -66,8 +66,8 @@ use crate::{
     identities::{user::UserIdentities, Device, IdentityManager, UserDevices},
     olm::{
         Account, CrossSigningStatus, EncryptionSettings, IdentityKeys, InboundGroupSession,
-        OlmDecryptionInfo, PrivateCrossSigningIdentity, SenderData, SenderDataFinder,
-        SenderDataRetryDetails, SessionType, StaticAccountData,
+        OlmDecryptionInfo, PrivateCrossSigningIdentity, SenderData, SenderDataFinder, SessionType,
+        StaticAccountData,
     },
     requests::{IncomingResponse, OutgoingRequest, UploadSigningKeysRequest},
     session_manager::{GroupSessionManager, SessionManager},
@@ -821,11 +821,7 @@ impl OlmMachine {
             event.keys.ed25519,
             &content.room_id,
             &content.session_key,
-            // TODO: set legacy_session to false when we have retry logic
-            SenderData::UnknownDevice {
-                retry_details: SenderDataRetryDetails::retry_soon(),
-                legacy_session: true,
-            },
+            SenderData::unknown(),
             event.content.algorithm(),
             None,
         );

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -699,10 +699,12 @@ mod tests {
         // And we populated the InboundGroupSession's sender_data with a default value,
         // with legacy_session set to true.
         assert_let!(
-            SenderData::UnknownDevice { retry_details, legacy_session } = unpickled.sender_data
+            SenderData::UnknownDevice { retry_details, legacy_session, owner_check_failed } =
+                unpickled.sender_data
         );
         assert_eq!(retry_details.retry_count, 0);
         assert!(legacy_session);
+        assert!(!owner_check_failed);
     }
 
     #[async_test]
@@ -832,13 +834,14 @@ mod tests {
 
         // And we populated the InboundGroupSession's sender_data with the provided
         // values
-        let SenderData::UnknownDevice { retry_details, legacy_session } = unpickled.sender_data
-        else {
-            panic!("Expected sender_data to be UnknownDevice!");
-        };
+        assert_let!(
+            SenderData::UnknownDevice { retry_details, legacy_session, owner_check_failed } =
+                unpickled.sender_data
+        );
         assert_eq!(retry_details.retry_count, 0);
         assert_eq!(retry_details.next_retry_time_ms.0, UInt::new(98765).unwrap());
         assert!(!legacy_session);
+        assert!(!owner_check_failed);
     }
 
     #[async_test]

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
@@ -317,16 +317,7 @@ mod tests {
     async fn test_providing_no_device_data_returns_sender_data_with_no_device_info() {
         // Given that the device is not in the store and the initial event has no device
         // info
-        let setup = TestSetup::new(TestOptions {
-            store_contains_device: false,
-            store_contains_sender_identity: false,
-            device_is_signed: true,
-            event_contains_device_keys: false,
-            sender_is_ourself: false,
-            sender_is_verified: false,
-            session_is_owned_by_device: true,
-        })
-        .await;
+        let setup = TestSetup::new(TestOptions::new()).await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
 
         // When we try to find sender data
@@ -352,16 +343,9 @@ mod tests {
     #[async_test]
     async fn test_if_the_todevice_event_contains_device_info_it_is_captured() {
         // Given that the signed device keys are in the event
-        let setup = TestSetup::new(TestOptions {
-            store_contains_device: false,
-            store_contains_sender_identity: false,
-            device_is_signed: true,
-            event_contains_device_keys: true,
-            sender_is_ourself: false,
-            sender_is_verified: false,
-            session_is_owned_by_device: true,
-        })
-        .await;
+        let setup =
+            TestSetup::new(TestOptions::new().device_is_signed().event_contains_device_keys())
+                .await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
 
         // When we try to find sender data
@@ -387,16 +371,8 @@ mod tests {
     async fn test_picks_up_device_info_from_the_store_if_missing_from_the_todevice_event() {
         // Given that the device keys are not in the event but the device is in the
         // store
-        let setup = TestSetup::new(TestOptions {
-            store_contains_device: true,
-            store_contains_sender_identity: false,
-            device_is_signed: true,
-            event_contains_device_keys: false,
-            sender_is_ourself: false,
-            sender_is_verified: false,
-            session_is_owned_by_device: true,
-        })
-        .await;
+        let setup =
+            TestSetup::new(TestOptions::new().store_contains_device().device_is_signed()).await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
 
         // When we try to find sender data
@@ -422,16 +398,7 @@ mod tests {
     async fn test_adds_device_info_even_if_it_is_not_signed() {
         // Given that the the device is in the store
         // But it is not signed
-        let setup = TestSetup::new(TestOptions {
-            store_contains_device: true,
-            store_contains_sender_identity: false,
-            device_is_signed: false,
-            event_contains_device_keys: false,
-            sender_is_ourself: false,
-            sender_is_verified: false,
-            session_is_owned_by_device: true,
-        })
-        .await;
+        let setup = TestSetup::new(TestOptions::new().store_contains_device()).await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
 
         // When we try to find sender data
@@ -457,15 +424,13 @@ mod tests {
     #[async_test]
     async fn test_adds_sender_data_for_own_verified_device_and_user_using_device_from_store() {
         // Given the device is in the store, and we sent the event
-        let setup = TestSetup::new(TestOptions {
-            store_contains_device: true,
-            store_contains_sender_identity: true,
-            device_is_signed: true,
-            event_contains_device_keys: false,
-            sender_is_ourself: true,
-            sender_is_verified: false,
-            session_is_owned_by_device: true,
-        })
+        let setup = TestSetup::new(
+            TestOptions::new()
+                .store_contains_device()
+                .store_contains_sender_identity()
+                .device_is_signed()
+                .sender_is_ourself(),
+        )
         .await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
 
@@ -487,15 +452,12 @@ mod tests {
     #[async_test]
     async fn test_adds_sender_data_for_other_verified_device_and_user_using_device_from_store() {
         // Given the device is in the store, and someone else sent the event
-        let setup = TestSetup::new(TestOptions {
-            store_contains_device: true,
-            store_contains_sender_identity: true,
-            device_is_signed: true,
-            event_contains_device_keys: false,
-            sender_is_ourself: false,
-            sender_is_verified: false,
-            session_is_owned_by_device: true,
-        })
+        let setup = TestSetup::new(
+            TestOptions::new()
+                .store_contains_device()
+                .store_contains_sender_identity()
+                .device_is_signed(),
+        )
         .await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
 
@@ -517,15 +479,13 @@ mod tests {
     #[async_test]
     async fn test_adds_sender_data_for_own_device_and_user_using_device_from_event() {
         // Given the device keys are in the event, and we sent the event
-        let setup = TestSetup::new(TestOptions {
-            store_contains_device: false,
-            store_contains_sender_identity: true,
-            device_is_signed: true,
-            event_contains_device_keys: true,
-            sender_is_ourself: true,
-            sender_is_verified: false,
-            session_is_owned_by_device: true,
-        })
+        let setup = TestSetup::new(
+            TestOptions::new()
+                .store_contains_sender_identity()
+                .device_is_signed()
+                .event_contains_device_keys()
+                .sender_is_ourself(),
+        )
         .await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
 
@@ -547,15 +507,12 @@ mod tests {
     #[async_test]
     async fn test_adds_sender_data_for_other_verified_device_and_user_using_device_from_event() {
         // Given the device keys are in the event, and someone else sent the event
-        let setup = TestSetup::new(TestOptions {
-            store_contains_device: false,
-            store_contains_sender_identity: true,
-            device_is_signed: true,
-            event_contains_device_keys: true,
-            sender_is_ourself: false,
-            sender_is_verified: false,
-            session_is_owned_by_device: true,
-        })
+        let setup = TestSetup::new(
+            TestOptions::new()
+                .store_contains_sender_identity()
+                .device_is_signed()
+                .event_contains_device_keys(),
+        )
         .await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
 
@@ -577,18 +534,16 @@ mod tests {
     #[async_test]
     async fn test_does_not_add_sender_data_for_a_session_not_owned_by_the_device() {
         // Given everything is the same as the above test
-        let setup = TestSetup::new(TestOptions {
-            store_contains_device: false,
-            store_contains_sender_identity: true,
-            device_is_signed: true,
-            event_contains_device_keys: true,
-            sender_is_ourself: false,
-            sender_is_verified: false,
-            session_is_owned_by_device: false,
-        })
+        // except the session is not owned by the device
+        let setup = TestSetup::new(
+            TestOptions::new()
+                .store_contains_sender_identity()
+                .device_is_signed()
+                .event_contains_device_keys()
+                .session_signing_key_differs_from_device(),
+        )
         .await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
-        // Except the session is not owned by the device
 
         // When we try to find sender data
         let sender_data = finder
@@ -615,15 +570,15 @@ mod tests {
     #[async_test]
     async fn test_notes_master_key_is_verified_for_own_identity() {
         // Given we can find the device, and we sent the event, and we are verified
-        let setup = TestSetup::new(TestOptions {
-            store_contains_device: true,
-            store_contains_sender_identity: true,
-            device_is_signed: true,
-            event_contains_device_keys: true,
-            sender_is_ourself: true,
-            sender_is_verified: true,
-            session_is_owned_by_device: true,
-        })
+        let setup = TestSetup::new(
+            TestOptions::new()
+                .store_contains_device()
+                .store_contains_sender_identity()
+                .device_is_signed()
+                .event_contains_device_keys()
+                .sender_is_ourself()
+                .sender_is_verified(),
+        )
         .await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
 
@@ -647,15 +602,14 @@ mod tests {
     async fn test_notes_master_key_is_verified_for_other_identity() {
         // Given we can find the device, and someone else sent the event
         // And the sender is verified
-        let setup = TestSetup::new(TestOptions {
-            store_contains_device: true,
-            store_contains_sender_identity: true,
-            device_is_signed: true,
-            event_contains_device_keys: true,
-            sender_is_ourself: false,
-            sender_is_verified: true,
-            session_is_owned_by_device: true,
-        })
+        let setup = TestSetup::new(
+            TestOptions::new()
+                .store_contains_device()
+                .store_contains_sender_identity()
+                .device_is_signed()
+                .event_contains_device_keys()
+                .sender_is_verified(),
+        )
         .await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
 
@@ -678,16 +632,9 @@ mod tests {
     #[async_test]
     async fn test_can_add_user_sender_data_based_on_a_provided_device() {
         // Given the device is not in the store or the event
-        let setup = TestSetup::new(TestOptions {
-            store_contains_device: false,
-            store_contains_sender_identity: true,
-            device_is_signed: true,
-            event_contains_device_keys: false,
-            sender_is_ourself: false,
-            sender_is_verified: false,
-            session_is_owned_by_device: true,
-        })
-        .await;
+        let setup =
+            TestSetup::new(TestOptions::new().store_contains_sender_identity().device_is_signed())
+                .await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
 
         // When we supply the device keys directly while asking for the sender data
@@ -710,7 +657,56 @@ mod tests {
         event_contains_device_keys: bool,
         sender_is_ourself: bool,
         sender_is_verified: bool,
-        session_is_owned_by_device: bool,
+        session_signing_key_differs_from_device: bool,
+    }
+
+    impl TestOptions {
+        fn new() -> Self {
+            Self {
+                store_contains_device: false,
+                store_contains_sender_identity: false,
+                device_is_signed: false,
+                event_contains_device_keys: false,
+                sender_is_ourself: false,
+                sender_is_verified: false,
+                session_signing_key_differs_from_device: false,
+            }
+        }
+
+        fn store_contains_device(mut self) -> Self {
+            self.store_contains_device = true;
+            self
+        }
+
+        fn store_contains_sender_identity(mut self) -> Self {
+            self.store_contains_sender_identity = true;
+            self
+        }
+
+        fn device_is_signed(mut self) -> Self {
+            self.device_is_signed = true;
+            self
+        }
+
+        fn event_contains_device_keys(mut self) -> Self {
+            self.event_contains_device_keys = true;
+            self
+        }
+
+        fn sender_is_ourself(mut self) -> Self {
+            self.sender_is_ourself = true;
+            self
+        }
+
+        fn sender_is_verified(mut self) -> Self {
+            self.sender_is_verified = true;
+            self
+        }
+
+        fn session_signing_key_differs_from_device(mut self) -> Self {
+            self.session_signing_key_differs_from_device = true;
+            self
+        }
     }
 
     struct TestSetup {
@@ -748,11 +744,11 @@ mod tests {
                 &options,
             );
 
-            let signing_key = if options.session_is_owned_by_device {
-                sender_device.inner.ed25519_key().unwrap()
-            } else {
+            let signing_key = if options.session_signing_key_differs_from_device {
                 Ed25519PublicKey::from_base64("2/5LWJMow5zhJqakV88SIc7q/1pa8fmkfgAzx72w9G4")
                     .unwrap()
+            } else {
+                sender_device.inner.ed25519_key().unwrap()
             };
 
             let session = InboundGroupSession::new(

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
@@ -42,7 +42,7 @@ use crate::{
     },
     store::{Changes, CryptoStoreWrapper, Result as StoreResult, Store},
     types::events::{room::encrypted::RoomEncryptedEventContent, room_key_withheld::WithheldCode},
-    DeviceData, EncryptionSettings, OlmError, ToDeviceRequest,
+    Device, DeviceData, EncryptionSettings, OlmError, ToDeviceRequest,
 };
 
 #[derive(Clone, Debug)]
@@ -379,14 +379,31 @@ impl GroupSessionManager {
         outbound: OutboundGroupSession,
         encryption_settings: EncryptionSettings,
         changes: &mut Changes,
-        sender_data: SenderData,
+        own_device: Option<Device>,
     ) -> OlmResult<OutboundGroupSession> {
         Ok(if should_rotate {
             let old_session_id = outbound.session_id();
 
-            let (outbound, inbound) = self
-                .create_outbound_group_session(room_id, encryption_settings, sender_data)
+            let (outbound, mut inbound) = self
+                .create_outbound_group_session(room_id, encryption_settings, SenderData::unknown())
                 .await?;
+
+            // Use our own device info to populate the SenderData that validates the
+            // InboundGroupSession that we create as a pair to the OutboundGroupSession we
+            // are sending out.
+            let own_sender_data = if let Some(device) = own_device {
+                SenderDataFinder::find_using_device_keys(
+                    &self.store,
+                    device.as_device_keys().clone(),
+                    &inbound,
+                )
+                .await?
+            } else {
+                error!("Unable to find our own device!");
+                SenderData::unknown()
+            };
+            inbound.sender_data = own_sender_data;
+
             changes.outbound_group_sessions.push(outbound.clone());
             changes.inbound_group_sessions.push(inbound);
 
@@ -644,41 +661,41 @@ impl GroupSessionManager {
     ) -> OlmResult<Vec<Arc<ToDeviceRequest>>> {
         trace!("Checking if a room key needs to be shared");
 
+        let account = self.store.static_account();
+        let device = self.store.get_device(account.user_id(), account.device_id()).await?;
+
         let encryption_settings = encryption_settings.into();
         let mut changes = Changes::default();
-
-        // Use our own device info to populate the SenderData that validates the
-        // InboundGroupSession that we create as a pair to the OutboundGroupSession we
-        // are sending out.
-        let account = self.store.static_account();
-        let device = self.store.get_device(account.user_id(), account.device_id()).await;
-        let own_sender_data = match device {
-            Ok(Some(device)) => {
-                SenderDataFinder::find_using_device_keys(
-                    &self.store,
-                    device.as_device_keys().clone(),
-                )
-                .await?
-            }
-            _ => {
-                error!("Unable to find our own device!");
-                SenderData::unknown()
-            }
-        };
 
         // Try to get an existing session or create a new one.
         let (outbound, inbound) = self
             .get_or_create_outbound_session(
                 room_id,
                 encryption_settings.clone(),
-                own_sender_data.clone(),
+                SenderData::unknown(),
             )
             .await?;
         tracing::Span::current().record("session_id", outbound.session_id());
 
         // Having an inbound group session here means that we created a new
         // group session pair, which we then need to store.
-        if let Some(inbound) = inbound {
+        if let Some(mut inbound) = inbound {
+            // Use our own device info to populate the SenderData that validates the
+            // InboundGroupSession that we create as a pair to the OutboundGroupSession we
+            // are sending out.
+            let own_sender_data = if let Some(device) = &device {
+                SenderDataFinder::find_using_device_keys(
+                    &self.store,
+                    device.as_device_keys().clone(),
+                    &inbound,
+                )
+                .await?
+            } else {
+                error!("Unable to find our own device!");
+                SenderData::unknown()
+            };
+            inbound.sender_data = own_sender_data;
+
             changes.outbound_group_sessions.push(outbound.clone());
             changes.inbound_group_sessions.push(inbound);
         }
@@ -696,7 +713,7 @@ impl GroupSessionManager {
                 outbound,
                 encryption_settings,
                 &mut changes,
-                own_sender_data,
+                device,
             )
             .await?;
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3754

When we are verifying who sent a session, make sure we do the "backwards" check that the device we have found is actual the owner of the session.

Review commit by commit