### PR TITLE
update DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,12 +71,11 @@ Matrix*](https://matrix.org/category/this-week-in-matrix/) updates for the SDK.
 
 In order to have a concrete record that your contribution is intentional
 and you agree to license it under the same terms as the project's license, we've
-adopted the same lightweight approach that the Linux Kernel
-(https://www.kernel.org/doc/Documentation/SubmittingPatches), Docker
-(https://github.com/docker/docker/blob/master/CONTRIBUTING.md), and many other
-projects use: the DCO (Developer Certificate of Origin:
-http://developercertificate.org/). This is a simple declaration that you wrote
-the contribution or otherwise have the right to contribute it to Matrix:
+adopted the same lightweight approach that the [Linux Kernel](https://www.kernel.org/doc/Documentation/SubmittingPatches),
+[Docker](https://github.com/docker/docker/blob/master/CONTRIBUTING.md), and many other
+projects use: the DCO ([Developer Certificate of Origin](http://developercertificate.org/)).
+This is a simple declaration that you wrote the contribution or otherwise have the right
+to contribute it to Matrix:
 
 ```
 Developer Certificate of Origin
@@ -122,11 +121,6 @@ include the line in your commit or pull request comment:
 ```
 Signed-off-by: Your Name <your@email.example.org>
 ```
-
-We accept contributions under a legally identifiable name, such as your name on
-government documentation or common-law names (names claimed by legitimate usage
-or repute). Unfortunately, we cannot accept anonymous contributions at this
-time.
 
 Git allows you to add this signoff automatically when using the `-s` flag to
 `git commit`, which uses the name and email set in your `user.name` and


### PR DESCRIPTION
Updating the DCO in line with updated Foundation policy, wherein we are not requiring "real" or "legally identifiable" names in order to contribute.

Signed-off-by: Josh Simmons <git@josh.tel>
