### PR TITLE
sdk: basic support for sending location beacons

### DIFF
--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -521,8 +521,13 @@ pub enum BeaconError {
     #[error("Must join the room to access beacon information.")]
     Stripped,
 
+    // The beacon event could not be deserialized.
     #[error("Deserialization error: {0}")]
     Deserialization(#[from] serde_json::Error),
+
+    // The beacon event is expired.
+    #[error("The beacon event has expired.")]
+    NotLive,
 
     // Allow for other errors to be wrapped.
     #[error("Other error: {0}")]

--- a/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
@@ -1,0 +1,155 @@
+use std::time::{Duration, UNIX_EPOCH};
+
+use matrix_sdk::{config::SyncSettings, instant::SystemTime};
+use matrix_sdk_test::{async_test, test_json, DEFAULT_TEST_ROOM_ID};
+use ruma::event_id;
+use serde_json::json;
+use wiremock::{
+    matchers::{body_partial_json, header, method, path_regex},
+    Mock, ResponseTemplate,
+};
+
+use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync};
+#[async_test]
+async fn test_send_location_beacon() {
+    let (client, server) = logged_in_client_with_server().await;
+
+    // Validate request body and response, partial body matching due to
+    // auto-generated `org.matrix.msc3488.ts`.
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/org.matrix.msc3672.beacon/.*"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(body_partial_json(json!({
+            "m.relates_to": {
+                "event_id": "$15139375514XsgmR:localhost",
+                "rel_type": "m.reference"
+            },
+             "org.matrix.msc3488.location": {
+                "uri": "geo:48.8588448,2.2943506"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EVENT_ID))
+        .mount(&server)
+        .await;
+
+    let current_timestamp =
+        SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_millis()
+            as u64;
+
+    mock_sync(
+        &server,
+        json!({
+            "next_batch": "s526_47314_0_7_1_1_1_1_1",
+            "rooms": {
+                "join": {
+                    *DEFAULT_TEST_ROOM_ID: {
+                        "state": {
+                            "events": [
+                                {
+                                    "content": {
+                                        "description": "Live Share",
+                                        "live": true,
+                                        "org.matrix.msc3488.ts": current_timestamp,
+                                        "timeout": 600_000,
+                                        "org.matrix.msc3488.asset": { "type": "m.self" }
+                                    },
+                                    "event_id": "$15139375514XsgmR:localhost",
+                                    "origin_server_ts": 1_636_829_458,
+                                    "sender": "@example:localhost",
+                                    "state_key": "@example:localhost",
+                                    "type": "org.matrix.msc3672.beacon_info",
+                                    "unsigned": {
+                                        "age": 7034220
+                                    }
+                                },
+                            ]
+                        }
+                    }
+                }
+            }
+
+        }),
+        None,
+    )
+    .await;
+
+    mock_encryption_state(&server, false).await;
+
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    client.sync_once(sync_settings).await.unwrap();
+
+    let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
+
+    let response = room.send_location_beacon("geo:48.8588448,2.2943506".to_owned()).await.unwrap();
+
+    assert_eq!(event_id!("$h29iv0s8:example.com"), response.event_id)
+}
+
+#[async_test]
+async fn test_send_location_beacon_fails_without_starting_live_share() {
+    let (client, server) = logged_in_client_with_server().await;
+
+    mock_sync(&server, &*test_json::SYNC, None).await;
+
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    client.sync_once(sync_settings).await.unwrap();
+
+    let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
+
+    let response = room.send_location_beacon("geo:48.8588448,2.2943506".to_owned()).await;
+
+    assert!(response.is_err());
+}
+
+#[async_test]
+async fn test_send_location_beacon_with_expired_live_share() {
+    let (client, server) = logged_in_client_with_server().await;
+
+    mock_sync(
+        &server,
+        json!({
+            "next_batch": "s526_47314_0_7_1_1_1_1_1",
+            "rooms": {
+                "join": {
+                    *DEFAULT_TEST_ROOM_ID: {
+                        "state": {
+                            "events": [
+                                {
+                                    "content": {
+                                        "description": "Live Share",
+                                        "live": false,
+                                        "org.matrix.msc3488.ts": 1_636_829_458,
+                                        "timeout": 3000,
+                                        "org.matrix.msc3488.asset": { "type": "m.self" }
+                                    },
+                                    "event_id": "$15139375514XsgmR:localhost",
+                                    "origin_server_ts": 1_636_829_458,
+                                    "sender": "@example:localhost",
+                                    "state_key": "@example:localhost",
+                                    "type": "org.matrix.msc3672.beacon_info",
+                                    "unsigned": {
+                                        "age": 7034220
+                                    }
+                                },
+                            ]
+                        }
+                    }
+                }
+            }
+
+        }),
+        None,
+    )
+    .await;
+
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    client.sync_once(sync_settings).await.unwrap();
+
+    let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
+
+    let response = room.send_location_beacon("geo:48.8588448,2.2943506".to_owned()).await;
+
+    assert!(response.is_err());
+}

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -1,12 +1,13 @@
 use std::{
     sync::{Arc, Mutex},
-    time::Duration,
+    time::{Duration, UNIX_EPOCH},
 };
 
 use futures_util::future::join_all;
 use js_int::uint;
 use matrix_sdk::{
     config::SyncSettings,
+    instant::SystemTime,
     room::{edit::EditedContent, Receipts, ReportedContentScore, RoomMemberRole},
     test_utils::events::EventFactory,
 };
@@ -37,7 +38,6 @@ use crate::{
     logged_in_client_with_server, mock_encryption_state, mock_sync, mock_sync_with_new_room,
     synced_client,
 };
-
 #[async_test]
 async fn test_invite_user_by_id() {
     let (client, server) = logged_in_client_with_server().await;
@@ -1002,4 +1002,96 @@ async fn test_stop_sharing_live_location() {
     assert_eq!(content.asset.type_, AssetType::Self_);
 
     assert!(!content.live);
+}
+
+#[async_test]
+async fn test_send_location_beacon() {
+    let (client, server) = logged_in_client_with_server().await;
+
+    // Validate request body and response, partial body matching due to
+    // auto-generated `org.matrix.msc3488.ts`.
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/org.matrix.msc3672.beacon/.*"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(body_partial_json(json!({
+            "m.relates_to": {
+                "event_id": "$15139375514XsgmR:localhost",
+                "rel_type": "m.reference"
+            },
+             "org.matrix.msc3488.location": {
+                "uri": "geo:48.8588448,2.2943506"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EVENT_ID))
+        .mount(&server)
+        .await;
+
+    let current_timestamp =
+        SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_millis()
+            as u64;
+
+    mock_sync(
+        &server,
+        json!({
+            "next_batch": "s526_47314_0_7_1_1_1_1_1",
+            "rooms": {
+                "join": {
+                    *DEFAULT_TEST_ROOM_ID: {
+                        "state": {
+                            "events": [
+                                {
+                                    "content": {
+                                        "description": "Live Share",
+                                        "live": true,
+                                        "org.matrix.msc3488.ts": current_timestamp,
+                                        "timeout": 600_000,
+                                        "org.matrix.msc3488.asset": { "type": "m.self" }
+                                    },
+                                    "event_id": "$15139375514XsgmR:localhost",
+                                    "origin_server_ts": 1_636_829_458,
+                                    "sender": "@example:localhost",
+                                    "state_key": "@example:localhost",
+                                    "type": "org.matrix.msc3672.beacon_info",
+                                    "unsigned": {
+                                        "age": 7034220
+                                    }
+                                },
+                            ]
+                        }
+                    }
+                }
+            }
+
+        }),
+        None,
+    )
+    .await;
+
+    mock_encryption_state(&server, false).await;
+
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    client.sync_once(sync_settings).await.unwrap();
+
+    let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
+
+    let response = room.send_location_beacon("geo:48.8588448,2.2943506".to_owned()).await.unwrap();
+
+    assert_eq!(event_id!("$h29iv0s8:example.com"), response.event_id)
+}
+
+#[async_test]
+async fn test_send_location_beacon_fails_without_starting_live_share() {
+    let (client, server) = logged_in_client_with_server().await;
+
+    mock_sync(&server, &*test_json::SYNC, None).await;
+
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    client.sync_once(sync_settings).await.unwrap();
+
+    let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
+
+    let result = room.send_location_beacon("geo:48.8588448,2.2943506".to_owned()).await;
+
+    assert!(result.is_err());
 }

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -1,13 +1,12 @@
 use std::{
     sync::{Arc, Mutex},
-    time::{Duration, UNIX_EPOCH},
+    time::Duration,
 };
 
 use futures_util::future::join_all;
 use js_int::uint;
 use matrix_sdk::{
     config::SyncSettings,
-    instant::SystemTime,
     room::{edit::EditedContent, Receipts, ReportedContentScore, RoomMemberRole},
     test_utils::events::EventFactory,
 };
@@ -1002,150 +1001,4 @@ async fn test_stop_sharing_live_location() {
     assert_eq!(content.asset.type_, AssetType::Self_);
 
     assert!(!content.live);
-}
-
-#[async_test]
-async fn test_send_location_beacon() {
-    let (client, server) = logged_in_client_with_server().await;
-
-    // Validate request body and response, partial body matching due to
-    // auto-generated `org.matrix.msc3488.ts`.
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/org.matrix.msc3672.beacon/.*"))
-        .and(header("authorization", "Bearer 1234"))
-        .and(body_partial_json(json!({
-            "m.relates_to": {
-                "event_id": "$15139375514XsgmR:localhost",
-                "rel_type": "m.reference"
-            },
-             "org.matrix.msc3488.location": {
-                "uri": "geo:48.8588448,2.2943506"
-            }
-        })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EVENT_ID))
-        .mount(&server)
-        .await;
-
-    let current_timestamp =
-        SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_millis()
-            as u64;
-
-    mock_sync(
-        &server,
-        json!({
-            "next_batch": "s526_47314_0_7_1_1_1_1_1",
-            "rooms": {
-                "join": {
-                    *DEFAULT_TEST_ROOM_ID: {
-                        "state": {
-                            "events": [
-                                {
-                                    "content": {
-                                        "description": "Live Share",
-                                        "live": true,
-                                        "org.matrix.msc3488.ts": current_timestamp,
-                                        "timeout": 600_000,
-                                        "org.matrix.msc3488.asset": { "type": "m.self" }
-                                    },
-                                    "event_id": "$15139375514XsgmR:localhost",
-                                    "origin_server_ts": 1_636_829_458,
-                                    "sender": "@example:localhost",
-                                    "state_key": "@example:localhost",
-                                    "type": "org.matrix.msc3672.beacon_info",
-                                    "unsigned": {
-                                        "age": 7034220
-                                    }
-                                },
-                            ]
-                        }
-                    }
-                }
-            }
-
-        }),
-        None,
-    )
-    .await;
-
-    mock_encryption_state(&server, false).await;
-
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
-
-    client.sync_once(sync_settings).await.unwrap();
-
-    let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
-
-    let response = room.send_location_beacon("geo:48.8588448,2.2943506".to_owned()).await.unwrap();
-
-    assert_eq!(event_id!("$h29iv0s8:example.com"), response.event_id)
-}
-
-#[async_test]
-async fn test_send_location_beacon_fails_without_starting_live_share() {
-    let (client, server) = logged_in_client_with_server().await;
-
-    mock_sync(&server, &*test_json::SYNC, None).await;
-
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
-    client.sync_once(sync_settings).await.unwrap();
-
-    let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
-
-    let response = room.send_location_beacon("geo:48.8588448,2.2943506".to_owned()).await;
-
-    assert!(response.is_err());
-}
-
-#[async_test]
-async fn test_send_location_beacon_with_expired_live_share() {
-    let (client, server) = logged_in_client_with_server().await;
-
-    mock_sync(
-        &server,
-        json!({
-            "next_batch": "s526_47314_0_7_1_1_1_1_1",
-            "rooms": {
-                "join": {
-                    *DEFAULT_TEST_ROOM_ID: {
-                        "state": {
-                            "events": [
-                                {
-                                    "content": {
-                                        "description": "Live Share",
-                                        "live": false,
-                                        "org.matrix.msc3488.ts": 1_636_829_458,
-                                        "timeout": 3000,
-                                        "org.matrix.msc3488.asset": { "type": "m.self" }
-                                    },
-                                    "event_id": "$15139375514XsgmR:localhost",
-                                    "origin_server_ts": 1_636_829_458,
-                                    "sender": "@example:localhost",
-                                    "state_key": "@example:localhost",
-                                    "type": "org.matrix.msc3672.beacon_info",
-                                    "unsigned": {
-                                        "age": 7034220
-                                    }
-                                },
-                            ]
-                        }
-                    }
-                }
-            }
-
-        }),
-        None,
-    )
-    .await;
-
-    mock_encryption_state(&server, false).await;
-
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
-
-    client.sync_once(sync_settings).await.unwrap();
-
-    let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
-
-    let response = room.send_location_beacon("geo:48.8588448,2.2943506".to_owned()).await;
-
-    assert!(response.is_err());
 }

--- a/crates/matrix-sdk/tests/integration/room/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/mod.rs
@@ -1,4 +1,5 @@
 mod attachment;
+mod beacon;
 mod common;
 mod joined;
 mod left;


### PR DESCRIPTION
This MR introduces basic functionality for sending beacons associated with a live location share, as outlined in the https://github.com/matrix-org/matrix-spec-proposals/pull/3489. This foundational support allows users to send their live location beacon.

**Key Changes**
- `send_location_beacon`: simple support for sending a `beacon` message event with related `beacon_info` event id.


These changes were adapted from a previous MR discussion, available for reference [here](https://github.com/matrix-org/matrix-rust-sdk/pull/3621).

**Follow-up**

This does not save any `beacon` message events with its associated `beacon_info`. This MR simply introduces `beacon` sending support with the intention of follow on MRs to build on this basic functionality.

Signed-off-by: 
