### PR TITLE
crypto: Replace the implementation of get_verification_state with SenderDataFinder

### DIFF
--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -112,7 +112,7 @@ pub enum MegolmError {
 /// Decryption failed because of a mismatch between the identity keys of the
 /// device we received the room key from and the identity keys recorded in
 /// the plaintext of the room key to-device message.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub struct MismatchedIdentityKeysError {
     /// The Ed25519 key recorded in the room key's to-device message.
     pub key_ed25519: Box<Ed25519PublicKey>,
@@ -138,6 +138,12 @@ impl std::fmt::Display for MismatchedIdentityKeysError {
 impl From<MismatchedIdentityKeysError> for MegolmError {
     fn from(value: MismatchedIdentityKeysError) -> Self {
         MegolmError::MismatchedIdentityKeys(value)
+    }
+}
+
+impl From<MismatchedIdentityKeysError> for SessionCreationError {
+    fn from(value: MismatchedIdentityKeysError) -> Self {
+        SessionCreationError::MismatchedIdentityKeys(value)
     }
 }
 
@@ -325,6 +331,15 @@ pub enum SessionCreationError {
     /// The given device keys are invalid.
     #[error("The given device keys are invalid")]
     InvalidDeviceKeys(#[from] SignatureError),
+
+    /// There was a mismatch between the identity keys of the device we received
+    /// the room key from and the identity keys recorded in the plaintext of the
+    /// room key to-device message.
+    #[error(
+        "There was a mismatch between the identity keys of the sending device \
+        and those recorded in the to-device message"
+    )]
+    MismatchedIdentityKeys(MismatchedIdentityKeysError),
 }
 
 /// Errors that can be returned by

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1419,11 +1419,13 @@ impl OlmMachine {
                 // We found a matching device, let's check if it owns the session.
                 if !(device.is_owner_of_session(session)?) {
                     // The key cannot be linked to an owning device.
+                    // Refuse to provide the device_id since this device is not the owner of this
+                    // session.
                     (
                         VerificationState::Unverified(VerificationLevel::None(
                             DeviceLinkProblem::InsecureSource,
                         )),
-                        Some(device_id),
+                        None,
                     )
                 } else {
                     // We only consider cross trust and not local trust. If your own device is not

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -471,6 +471,12 @@ impl InboundGroupSession {
 
         Ok((decrypted_object, decrypted.message_index))
     }
+
+    /// For test only, mark this session as imported.
+    #[cfg(test)]
+    pub(crate) fn mark_as_imported(&mut self) {
+        self.imported = true;
+    }
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
@@ -154,6 +154,18 @@ impl<'a> SenderDataFinder<'a> {
         finder.have_device_keys(&device_keys).await
     }
 
+    /// Find the device using the curve key provided, and decide whether we
+    /// trust the sender.
+    pub(crate) async fn find_using_curve_key(
+        store: &'a Store,
+        sender_curve_key: Curve25519PublicKey,
+        sender_user_id: &'a UserId,
+        session: &'a InboundGroupSession,
+    ) -> Result<SenderData, SessionDeviceCheckError> {
+        let finder = Self { store, session };
+        finder.search_for_device(sender_curve_key, sender_user_id).await
+    }
+
     /// Step A (start - we have a to-device message containing a room key)
     async fn have_event(
         &self,

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
@@ -674,6 +674,7 @@ mod tests {
         sender_is_ourself: bool,
         sender_is_verified: bool,
         session_signing_key_differs_from_device: bool,
+        session_is_imported: bool,
     }
 
     impl TestOptions {
@@ -686,6 +687,7 @@ mod tests {
                 sender_is_ourself: false,
                 sender_is_verified: false,
                 session_signing_key_differs_from_device: false,
+                session_is_imported: false,
             }
         }
 
@@ -721,6 +723,11 @@ mod tests {
 
         fn session_signing_key_differs_from_device(mut self) -> Self {
             self.session_signing_key_differs_from_device = true;
+            self
+        }
+
+        fn session_is_imported(mut self) -> Self {
+            self.session_is_imported = true;
             self
         }
     }
@@ -767,7 +774,7 @@ mod tests {
                 sender_device.inner.ed25519_key().unwrap()
             };
 
-            let session = InboundGroupSession::new(
+            let mut session = InboundGroupSession::new(
                 sender_device.inner.curve25519_key().unwrap(),
                 signing_key,
                 room_id,
@@ -777,6 +784,9 @@ mod tests {
                 None,
             )
             .unwrap();
+            if options.session_is_imported {
+                session.mark_as_imported();
+            }
 
             Self { sender, sender_device, store, room_key_event, session }
         }


### PR DESCRIPTION
Replace the implementation of `get_verification_state` with `SenderDataFinder`, since they are now equivalent.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/3751

As part of developing this PR, I created (and then removed) this commit: 282320f79ed2447d2d39f4ca7f60df02dbfb5a2f which proves that for every case, converting from `SenderDataFinder`'s result into a `VerificationState` and an `Option<DeviceId>` produces the same result as the old `get_verification_state` code, so we can safely replace it.