### PR TITLE
sdk-ui: Add `TimelineFocus::PinnedEvents`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,12 +541,14 @@ dependencies = [
  "matrix-sdk-crypto",
  "matrix-sdk-sqlite",
  "matrix-sdk-test",
+ "matrix-sdk-ui",
  "pprof",
  "ruma",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "wiremock",
 ]
 
 [[package]]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -13,12 +13,14 @@ matrix-sdk-base = { workspace = true }
 matrix-sdk-crypto = { workspace = true }
 matrix-sdk-sqlite = { workspace = true, features = ["crypto-store"] }
 matrix-sdk-test = { workspace = true }
+matrix-sdk-ui = { workspace = true }
 matrix-sdk = { workspace = true, features = ["native-tls", "e2e-encryption", "sqlite"] }
 ruma = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3.3.0"
 tokio = { workspace = true, default-features = false, features = ["rt-multi-thread"] }
+wiremock = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }

--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -1,20 +1,32 @@
+use std::time::Duration;
+
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use matrix_sdk::utils::IntoRawStateEventContent;
+use matrix_sdk::{
+    config::SyncSettings,
+    test_utils::{events::EventFactory, logged_in_client_with_server},
+    utils::IntoRawStateEventContent,
+};
 use matrix_sdk_base::{
     store::StoreConfig, BaseClient, RoomInfo, RoomState, SessionMeta, StateChanges, StateStore,
 };
 use matrix_sdk_sqlite::SqliteStateStore;
-use matrix_sdk_test::EventBuilder;
+use matrix_sdk_test::{EventBuilder, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder};
+use matrix_sdk_ui::{timeline::TimelineFocus, Timeline};
 use ruma::{
     api::client::membership::get_member_events,
     device_id,
     events::room::member::{RoomMemberEvent, RoomMemberEventContent},
-    owned_room_id,
+    owned_room_id, owned_user_id,
     serde::Raw,
-    user_id, OwnedUserId,
+    user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId,
 };
+use serde::Serialize;
 use serde_json::json;
 use tokio::runtime::Builder;
+use wiremock::{
+    matchers::{header, method, path, path_regex, query_param, query_param_is_missing},
+    Mock, MockServer, Request, ResponseTemplate,
+};
 
 pub fn receive_all_members_benchmark(c: &mut Criterion) {
     const MEMBERS_IN_ROOM: usize = 100000;
@@ -99,6 +111,120 @@ pub fn receive_all_members_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
+pub fn load_pinned_events_benchmark(c: &mut Criterion) {
+    const PINNED_EVENTS_COUNT: usize = 100;
+
+    let runtime = Builder::new_multi_thread().enable_all().build().expect("Can't create runtime");
+    let room_id = owned_room_id!("!room:example.com");
+    let sender_id = owned_user_id!("@sender:example.com");
+
+    let f = EventFactory::new().room(&room_id).sender(&sender_id);
+    let (client, server) = runtime.block_on(logged_in_client_with_server());
+
+    let mut sync_response_builder = SyncResponseBuilder::new();
+    let mut joined_room_builder = JoinedRoomBuilder::new(&room_id);
+
+    let pinned_event_ids: Vec<OwnedEventId> = (0..PINNED_EVENTS_COUNT)
+        .map(|i| EventId::parse(format!("${i}")).expect("Invalid event id"))
+        .collect();
+    joined_room_builder = joined_room_builder.add_state_event(StateTestEvent::Custom(json!(
+        {
+            "content": {
+                "pinned": pinned_event_ids
+            },
+            "event_id": "$15139375513VdeRF:localhost",
+            "origin_server_ts": 151393755,
+            "sender": "@example:localhost",
+            "state_key": "",
+            "type": "m.room.pinned_events",
+            "unsigned": {
+                "age": 703422
+            }
+        }
+    )));
+    let response_json =
+        sync_response_builder.add_joined_room(joined_room_builder).build_json_sync_response();
+    runtime.block_on(mock_sync(&server, response_json, None));
+
+    let sync_settings = SyncSettings::default();
+    runtime.block_on(client.sync_once(sync_settings)).expect("Could not sync");
+    runtime.block_on(server.reset());
+
+    runtime.block_on(
+        Mock::given(method("GET"))
+            .and(path_regex(r"/_matrix/client/r0/rooms/.*/event/.*"))
+            .respond_with(move |r: &Request| {
+                let segments: Vec<&str> = r.url.path_segments().expect("Invalid path").collect();
+                let event_id_str = segments[6];
+                // let f = EventFactory::new().room(&room_id)
+                let event_id = EventId::parse(event_id_str).expect("Invalid event id in response");
+                let event = f
+                    .text_msg(format!("Message {event_id_str}"))
+                    .event_id(&event_id)
+                    .server_ts(MilliSecondsSinceUnixEpoch::now())
+                    .into_raw_sync();
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_millis(50))
+                    .set_body_json(event.json())
+            })
+            .mount(&server),
+    );
+    // runtime.block_on(server.reset());
+
+    let room = client.get_room(&room_id).expect("Room not found");
+    assert!(!room.pinned_event_ids().is_empty());
+    assert_eq!(room.pinned_event_ids().len(), PINNED_EVENTS_COUNT);
+
+    let count = PINNED_EVENTS_COUNT;
+    let name = format!("{count} pinned events");
+    let mut group = c.benchmark_group("Test");
+    group.throughput(Throughput::Elements(count as u64));
+    group.sample_size(10);
+
+    group.bench_function(BenchmarkId::new("load_pinned_events", name), |b| {
+        b.to_async(&runtime).iter(|| async {
+            assert!(!room.pinned_event_ids().is_empty());
+            assert_eq!(room.pinned_event_ids().len(), PINNED_EVENTS_COUNT);
+
+            let timeline = Timeline::builder(&room)
+                .with_focus(TimelineFocus::PinnedEvents { max_events_to_load: 100 })
+                .build()
+                .await
+                .expect("Could not create timeline");
+
+            let (items, _) = timeline.subscribe().await;
+            assert_eq!(items.len(), PINNED_EVENTS_COUNT + 1);
+            timeline.clear().await;
+        });
+    });
+
+    {
+        let _guard = runtime.enter();
+        runtime.block_on(server.reset());
+        drop(client);
+        drop(server);
+    }
+
+    group.finish();
+}
+
+async fn mock_sync(server: &MockServer, response_body: impl Serialize, since: Option<String>) {
+    let mut mock_builder = Mock::given(method("GET"))
+        .and(path("/_matrix/client/r0/sync"))
+        .and(header("authorization", "Bearer 1234"));
+
+    if let Some(since) = since {
+        mock_builder = mock_builder.and(query_param("since", since));
+    } else {
+        mock_builder = mock_builder.and(query_param_is_missing("since"));
+    }
+
+    mock_builder
+        .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+        .mount(server)
+        .await;
+}
+
 fn criterion() -> Criterion {
     #[cfg(target_os = "linux")]
     let criterion = Criterion::default().with_profiler(pprof::criterion::PProfProfiler::new(
@@ -114,6 +240,6 @@ fn criterion() -> Criterion {
 criterion_group! {
     name = room;
     config = criterion();
-    targets = receive_all_members_benchmark,
+    targets = receive_all_members_benchmark, load_pinned_events_benchmark,
 }
 criterion_main!(room);

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -228,6 +228,25 @@ impl Room {
         Ok(Timeline::new(timeline))
     }
 
+    pub async fn pinned_events_timeline(
+        &self,
+        internal_id_prefix: Option<String>,
+        max_events_to_load: u16,
+    ) -> Result<Arc<Timeline>, ClientError> {
+        let room = &self.inner;
+
+        let mut builder = matrix_sdk_ui::timeline::Timeline::builder(room);
+
+        if let Some(internal_id_prefix) = internal_id_prefix {
+            builder = builder.with_internal_id_prefix(internal_id_prefix);
+        }
+
+        let timeline =
+            builder.with_focus(TimelineFocus::PinnedEvents { max_events_to_load }).build().await?;
+
+        Ok(Timeline::new(timeline))
+    }
+
     pub fn is_encrypted(&self) -> Result<bool, ClientError> {
         Ok(RUNTIME.block_on(self.inner.is_encrypted())?)
     }

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -66,7 +66,7 @@ impl RoomInfo {
         for (id, level) in power_levels_map.iter() {
             user_power_levels.insert(id.to_string(), *level);
         }
-        let pinned_event_ids = room.pinned_events().iter().map(|id| id.to_string()).collect();
+        let pinned_event_ids = room.pinned_event_ids().iter().map(|id| id.to_string()).collect();
 
         Ok(Self {
             id: room.room_id().to_string(),

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -949,11 +949,6 @@ impl Room {
         self.inner.read().recency_stamp
     }
 
-    /// Get the list of event ids for pinned events in this room.
-    pub fn pinned_event_ids(&self) -> Vec<OwnedEventId> {
-        self.inner.get().base_info.pinned_events.map(|content| content.pinned).unwrap_or_default()
-    }
-
     /// Get a `Stream` of loaded pinned events for this room.
     /// If no pinned events are found a single empty `Vec` will be returned.
     pub fn pinned_event_ids_stream(&self) -> impl Stream<Item = Vec<OwnedEventId>> {
@@ -962,19 +957,9 @@ impl Room {
             .map(|i| i.base_info.pinned_events.map(|c| c.pinned).unwrap_or_default())
     }
 
-    /// Checks if an `EventId` is currently pinned.
-    /// It avoids having to clone the whole list of event ids to check a single
-    /// value.
-    ///
-    /// Returns `true` if the provided `event_id` is pinned, `false` otherwise.
-    pub fn is_pinned_event(&self, event_id: &EventId) -> bool {
-        self.inner
-            .read()
-            .base_info
-            .pinned_events
-            .as_ref()
-            .map(|p| p.pinned.contains(&event_id.to_owned()))
-            .unwrap_or_default()
+    /// Returns the current pinned event ids for this room.
+    pub fn pinned_event_ids(&self) -> Vec<OwnedEventId> {
+        self.inner.read().pinned_event_ids()
     }
 }
 
@@ -1494,6 +1479,24 @@ impl RoomInfo {
     #[cfg(feature = "experimental-sliding-sync")]
     pub(crate) fn update_recency_stamp(&mut self, stamp: u64) {
         self.recency_stamp = Some(stamp);
+    }
+
+    /// Returns the current pinned event ids for this room.
+    pub fn pinned_event_ids(&self) -> Vec<OwnedEventId> {
+        self.base_info.pinned_events.clone().map(|c| c.pinned).unwrap_or_default()
+    }
+
+    /// Checks if an `EventId` is currently pinned.
+    /// It avoids having to clone the whole list of event ids to check a single
+    /// value.
+    ///
+    /// Returns `true` if the provided `event_id` is pinned, `false` otherwise.
+    pub fn is_pinned_event(&self, event_id: &EventId) -> bool {
+        self.base_info
+            .pinned_events
+            .as_ref()
+            .map(|p| p.pinned.contains(&event_id.to_owned()))
+            .unwrap_or_default()
     }
 }
 

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -2194,7 +2194,7 @@ mod tests {
 
         // The newly created room has no pinned event ids
         let room = client.get_room(room_id).unwrap();
-        let pinned_event_ids = room.pinned_events();
+        let pinned_event_ids = room.pinned_event_ids();
         assert!(pinned_event_ids.is_empty());
 
         // Load new pinned event id
@@ -2208,7 +2208,7 @@ mod tests {
         let response = response_with_room(room_id, room_response);
         client.process_sliding_sync(&response, &(), true).await.expect("Failed to process sync");
 
-        let pinned_event_ids = room.pinned_events();
+        let pinned_event_ids = room.pinned_event_ids();
         assert_eq!(pinned_event_ids.len(), 1);
         assert_eq!(pinned_event_ids[0], pinned_event_id);
 
@@ -2222,7 +2222,7 @@ mod tests {
         ));
         let response = response_with_room(room_id, room_response);
         client.process_sliding_sync(&response, &(), true).await.expect("Failed to process sync");
-        let pinned_event_ids = room.pinned_events();
+        let pinned_event_ids = room.pinned_event_ids();
         assert!(pinned_event_ids.is_empty());
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -158,12 +158,13 @@ impl TimelineBuilder {
         let (_, mut event_subscriber) = room_event_cache.subscribe().await?;
 
         let is_live = matches!(focus, TimelineFocus::Live);
+        let is_pinned_events = matches!(focus, TimelineFocus::PinnedEvents { .. });
         let is_room_encrypted =
             room.is_encrypted().await.map_err(|_| Error::UnknownEncryptionState)?;
 
         let inner = TimelineInner::new(
             room,
-            focus,
+            focus.clone(),
             internal_id_prefix,
             unable_to_decrypt_hook,
             is_room_encrypted,
@@ -175,6 +176,27 @@ impl TimelineBuilder {
         let room = inner.room();
         let client = room.client();
 
+        let mut pinned_event_ids_stream = room.pinned_event_ids_stream();
+        let pinned_events_join_handle = if is_pinned_events {
+            Some(spawn({
+                let inner = inner.clone();
+                async move {
+                    while let Some(_) = pinned_event_ids_stream.next().await {
+                        if let Ok(events) = inner.pinned_events_load_events().await {
+                            inner
+                                .replace_with_initial_remote_events(
+                                    events,
+                                    RemoteEventOrigin::Pagination,
+                                )
+                                .await;
+                        }
+                    }
+                }
+            }))
+        } else {
+            None
+        };
+
         let room_update_join_handle = spawn({
             let room_event_cache = room_event_cache.clone();
             let inner = inner.clone();
@@ -182,6 +204,8 @@ impl TimelineBuilder {
             let span =
                 info_span!(parent: Span::none(), "room_update_handler", room_id = ?room.room_id());
             span.follows_from(Span::current());
+
+            let focus = Arc::new(focus);
 
             async move {
                 trace!("Spawned the event subscriber task.");
@@ -239,13 +263,25 @@ impl TimelineBuilder {
                         RoomEventCacheUpdate::AddTimelineEvents { events, origin } => {
                             trace!("Received new timeline events.");
 
-                            inner.add_events_at(
-                                events,
-                                TimelineEnd::Back,
-                                match origin {
-                                    EventsOrigin::Sync => RemoteEventOrigin::Sync,
+                            // Special case for pinned events: when we receive new events what we'll do is
+                            // updated the cache for those events that are pinned and reload the
+                            // list.
+                            match &*focus.clone() {
+                                TimelineFocus::PinnedEvents { .. } => {
+                                    if let Ok(events) = inner.pinned_events_load_events().await {
+                                        inner.replace_with_initial_remote_events(events, RemoteEventOrigin::Sync).await;
+                                    }
                                 }
-                            ).await;
+                                _ => {
+                                    inner.add_events_at(
+                                        events,
+                                        TimelineEnd::Back,
+                                        match origin {
+                                            EventsOrigin::Sync => RemoteEventOrigin::Sync,
+                                        }
+                                    ).await;
+                                }
+                            }
                         }
 
                         RoomEventCacheUpdate::AddEphemeralEvents { events } => {
@@ -363,6 +399,7 @@ impl TimelineBuilder {
                 client,
                 event_handler_handles: handles,
                 room_update_join_handle,
+                pinned_events_join_handle,
                 room_key_from_backups_join_handle,
                 local_echo_listener_handle,
                 _event_cache_drop_handle: event_cache_drop,

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -20,6 +20,8 @@ use matrix_sdk::{
 };
 use thiserror::Error;
 
+use crate::timeline::pinned_events_loader::PinnedEventsLoaderError;
+
 /// Errors specific to the timeline.
 #[derive(Error, Debug)]
 #[non_exhaustive]
@@ -59,6 +61,10 @@ pub enum Error {
     /// An error happened during pagination.
     #[error("An error happened during pagination.")]
     PaginationError(#[from] PaginationError),
+
+    /// An error happened during pagination.
+    #[error("An error happened when loading pinned events.")]
+    PinnedEventsError(#[from] PinnedEventsLoaderError),
 
     /// An error happened while operating the room's send queue.
     #[error(transparent)]

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -64,7 +64,7 @@ use super::{
 };
 use crate::{
     events::SyncTimelineEventWithoutContent,
-    timeline::{event_item::ReactionInfo, reactions::PendingReaction},
+    timeline::{event_item::ReactionInfo, reactions::PendingReaction, traits::RoomDataProvider},
     DEFAULT_SANITIZER_MODE,
 };
 
@@ -266,7 +266,15 @@ pub(super) struct TimelineEventHandler<'a, 'o> {
     meta: &'a mut TimelineInnerMetadata,
     ctx: TimelineEventContext,
     result: HandleEventResult,
-    is_live_timeline: bool,
+    live_timeline_updates_type: LiveTimelineUpdatesAllowed,
+}
+
+/// Types of live updates expected in this timeline.
+#[derive(Debug, Clone)]
+pub enum LiveTimelineUpdatesAllowed {
+    All,
+    PinnedEvents,
+    None,
 }
 
 impl<'a, 'o> TimelineEventHandler<'a, 'o> {
@@ -274,12 +282,12 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         state: &'a mut TimelineInnerStateTransaction<'o>,
         ctx: TimelineEventContext,
     ) -> Self {
-        let TimelineInnerStateTransaction { items, meta, is_live_timeline, .. } = state;
+        let TimelineInnerStateTransaction { items, meta, live_timeline_updates_type, .. } = state;
         Self {
             items,
             meta,
             ctx,
-            is_live_timeline: *is_live_timeline,
+            live_timeline_updates_type: live_timeline_updates_type.clone(),
             result: HandleEventResult::default(),
         }
     }
@@ -291,11 +299,12 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
     /// `raw_event` is only needed to determine the cause of any UTDs,
     /// so if we know this is not a UTD it can be None.
     #[instrument(skip_all, fields(txn_id, event_id, position))]
-    pub(super) async fn handle_event(
+    pub(super) async fn handle_event<P: RoomDataProvider>(
         mut self,
         day_divider_adjuster: &mut DayDividerAdjuster,
         event_kind: TimelineEventKind,
         raw_event: Option<&Raw<AnySyncTimelineEvent>>,
+        room_data_provider: &P,
     ) -> HandleEventResult {
         let span = tracing::Span::current();
 
@@ -308,7 +317,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
                 // Only add new timeline items if we're in the live mode, i.e. not in the
                 // event-focused mode.
-                self.is_live_timeline
+                matches!(self.live_timeline_updates_type, LiveTimelineUpdatesAllowed::All)
             }
 
             Flow::Remote { event_id, txn_id, position, should_add, .. } => {
@@ -337,7 +346,14 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         // If the event comes the sync (or is unknown), consider adding it only if
                         // the timeline is in live mode; we don't want to display arbitrary sync
                         // events in an event-focused timeline.
-                        self.is_live_timeline && *should_add
+                        let can_add_to_live = match self.live_timeline_updates_type {
+                            LiveTimelineUpdatesAllowed::PinnedEvents => {
+                                room_data_provider.room_is_pinned_event_id(event_id)
+                            }
+                            LiveTimelineUpdatesAllowed::All => true,
+                            LiveTimelineUpdatesAllowed::None => false,
+                        };
+                        can_add_to_live && *should_add
                     }
                     RemoteEventOrigin::Pagination | RemoteEventOrigin::Cache => {
                         // Otherwise, forward the previous decision to add it.

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -348,7 +348,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         // events in an event-focused timeline.
                         let can_add_to_live = match self.live_timeline_updates_type {
                             LiveTimelineUpdatesAllowed::PinnedEvents => {
-                                room_data_provider.room_is_pinned_event_id(event_id)
+                                room_data_provider.is_pinned_event(event_id)
                             }
                             LiveTimelineUpdatesAllowed::All => true,
                             LiveTimelineUpdatesAllowed::None => false,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -63,6 +63,8 @@ use ruma::{
 use thiserror::Error;
 use tracing::{error, instrument, trace, warn};
 
+use crate::timeline::pinned_events_loader::PinnedEventsRoom;
+
 mod builder;
 mod day_dividers;
 mod error;

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -1,0 +1,221 @@
+use std::{collections::BTreeMap, fmt::Formatter, sync::Arc};
+
+use itertools::Itertools;
+use matrix_sdk::{event_cache::paginator::PaginatorError, Room, SendOutsideWasm, SyncOutsideWasm};
+use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
+use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedEventId};
+use thiserror::Error;
+use tokio::sync::{RwLock, Semaphore};
+
+/// Utility to load the pinned events in a room.
+pub struct PinnedEventsLoader {
+    room: Arc<Box<dyn PinnedEventsRoom>>,
+    max_events_to_load: usize,
+    max_concurrent_requests: usize,
+    cache: PinnedEventCache,
+}
+
+impl PinnedEventsLoader {
+    /// Creates a new `PinnedEventsLoader` instance.
+    pub fn new(room: Box<dyn PinnedEventsRoom>, max_events_to_load: usize) -> Self {
+        Self {
+            room: Arc::new(room),
+            max_events_to_load,
+            max_concurrent_requests: 10,
+            cache: PinnedEventCache {
+                inner: Arc::new(InnerPinnedEventCache { events: Default::default() }),
+            },
+        }
+    }
+
+    /// Loads the pinned events in this room, using the cache first and then
+    /// requesting the event from the homeserver if it couldn't be found.
+    /// This method will perform as many concurrent requests for events as
+    /// `max_concurrent_requests` allows, to avoid overwhelming the server.
+    ///
+    /// It returns a `Result` with either a
+    /// chronologically sorted list of retrieved `SyncTimelineEvent`s  or a
+    /// `PinnedEventsLoaderError`.
+    pub async fn load_events(&self) -> Result<Vec<SyncTimelineEvent>, PinnedEventsLoaderError> {
+        let pinned_event_ids: Vec<OwnedEventId> = self
+            .room
+            .room_pinned_event_ids()
+            .into_iter()
+            .rev()
+            .take(self.max_events_to_load)
+            .rev()
+            .collect();
+
+        let mut loaded_events = Vec::new();
+        let mut event_ids_to_request = Vec::new();
+        for ev_id in pinned_event_ids {
+            if let Some(ev) = self.cache.get(&ev_id).await {
+                loaded_events.push(ev.clone());
+            } else {
+                event_ids_to_request.push(ev_id);
+            }
+        }
+
+        if !event_ids_to_request.is_empty() {
+            let semaphore = Arc::new(Semaphore::new(self.max_concurrent_requests));
+            let provider = Arc::new(self.room.clone());
+            let mut handles = Vec::new();
+
+            for id in event_ids_to_request {
+                handles.push(tokio::spawn({
+                    let semaphore = Arc::clone(&semaphore);
+                    let provider = Arc::clone(&provider);
+                    async move {
+                        let permit = semaphore
+                            .acquire()
+                            .await
+                            .map_err(|_| PinnedEventsLoaderError::SemaphoreNotAcquired)?;
+                        let ret = provider
+                            .room_event(&id)
+                            .await
+                            .map_err(|_| PinnedEventsLoaderError::EventNotFound(id.to_owned()));
+                        drop(permit);
+                        ret
+                    }
+                }));
+            }
+
+            for handle in handles {
+                if let Ok(Ok(ev)) = handle.await {
+                    loaded_events.push(ev)
+                }
+            }
+        }
+
+        self.cache.set_bulk(&loaded_events).await;
+
+        fn timestamp(item: &SyncTimelineEvent) -> MilliSecondsSinceUnixEpoch {
+            item.event
+                .deserialize()
+                .map(|e| e.origin_server_ts())
+                .unwrap_or_else(|_| MilliSecondsSinceUnixEpoch::now())
+        }
+
+        let sorted_events = loaded_events
+            .into_iter()
+            .sorted_by(|e1, e2| timestamp(e1).cmp(&timestamp(e2)))
+            .collect();
+
+        Ok(sorted_events)
+    }
+
+    /// Updates the cache with the provided events if they're associated with a
+    /// pinned event id, then reloads the list of pinned events if there
+    /// were any changes.
+    ///
+    /// Returns an `Option` with either a new list of events if any of them
+    /// changed in this update or `None` if they didn't.
+    pub async fn update_if_needed(
+        &self,
+        events: Vec<impl Into<SyncTimelineEvent>>,
+    ) -> Option<Vec<SyncTimelineEvent>> {
+        let mut to_update = Vec::new();
+        for ev in events {
+            let ev = ev.into();
+            if let Some(ev_id) = ev.event_id() {
+                if self.room.room_is_pinned_event_id(&ev_id) {
+                    to_update.push(ev);
+                }
+            }
+        }
+
+        if !to_update.is_empty() {
+            self.cache.set_bulk(&to_update).await;
+            self.load_events().await.ok()
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait PinnedEventsRoom: SendOutsideWasm + SyncOutsideWasm {
+    /// Load a single room event.
+    async fn room_event(&self, event_id: &EventId) -> Result<SyncTimelineEvent, PaginatorError>;
+
+    /// Get the pinned event ids for a room.
+    fn room_pinned_event_ids(&self) -> Vec<OwnedEventId>;
+
+    /// Checks whether an event id is pinned in this room.
+    fn room_is_pinned_event_id(&self, event_id: &EventId) -> bool;
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl PinnedEventsRoom for Room {
+    async fn room_event(&self, event_id: &EventId) -> Result<SyncTimelineEvent, PaginatorError> {
+        self.event(event_id)
+            .await
+            .map(|e| e.into())
+            .map_err(|err| PaginatorError::SdkError(Box::new(err)))
+    }
+
+    fn room_pinned_event_ids(&self) -> Vec<OwnedEventId> {
+        self.pinned_event_ids()
+    }
+
+    fn room_is_pinned_event_id(&self, event_id: &EventId) -> bool {
+        self.is_pinned_event(event_id)
+    }
+}
+
+#[cfg(not(tarpaulin_include))]
+impl std::fmt::Debug for PinnedEventsLoader {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PinnedEventsLoader")
+            .field("max_concurrent_requests", &self.max_concurrent_requests)
+            .finish()
+    }
+}
+
+/// Errors related to `PinnedEventsLoader` usage.
+#[derive(Error, Debug)]
+pub enum PinnedEventsLoaderError {
+    #[error("Semaphore for requests couldn't be acquired. It was probably aborted.")]
+    SemaphoreNotAcquired,
+
+    #[error("No event found for the given event id.")]
+    EventNotFound(OwnedEventId),
+
+    #[error("Timeline focus is not pinned events.")]
+    TimelineFocusNotPinnedEvents,
+}
+
+/// Cache used to store the events associated with pinned event ids.
+///
+/// Cloning is shallow, and thus is cheap to do.
+#[derive(Clone)]
+pub(crate) struct PinnedEventCache {
+    inner: Arc<InnerPinnedEventCache>,
+}
+
+impl PinnedEventCache {
+    /// Gets the event associated with the provided event id, if it exists in
+    /// the cache.
+    pub(crate) async fn get(&self, event_id: &EventId) -> Option<SyncTimelineEvent> {
+        let cache = self.inner.events.read().await;
+        cache.get(event_id).cloned()
+    }
+
+    /// Adds a list of pinned events to the cache in a performant way.
+    pub(crate) async fn set_bulk(&self, events: &Vec<SyncTimelineEvent>) {
+        let mut cache = self.inner.events.write().await;
+        for ev in events {
+            if let Some(ev_id) = ev.event_id() {
+                cache.insert(ev_id.to_owned(), ev.clone());
+            }
+        }
+    }
+}
+
+/// The non-cloneable implementation of the cache.
+struct InnerPinnedEventCache {
+    /// The pinned events of the room.
+    events: RwLock<BTreeMap<OwnedEventId, SyncTimelineEvent>>,
+}

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -321,15 +321,15 @@ impl PaginableRoom for TestRoomDataProvider {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl PinnedEventsRoom for TestRoomDataProvider {
-    async fn room_event(&self, _event_id: &EventId) -> Result<SyncTimelineEvent, PaginatorError> {
+    async fn event(&self, _event_id: &EventId) -> Result<SyncTimelineEvent, PaginatorError> {
         unimplemented!();
     }
 
-    fn room_pinned_event_ids(&self) -> Vec<OwnedEventId> {
+    fn pinned_event_ids(&self) -> Vec<OwnedEventId> {
         unimplemented!();
     }
 
-    fn room_is_pinned_event_id(&self, _event_id: &EventId) -> bool {
+    fn is_pinned_event(&self, _event_id: &EventId) -> bool {
         unimplemented!();
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -58,7 +58,9 @@ use super::{
     traits::RoomDataProvider,
     EventTimelineItem, Profile, TimelineFocus, TimelineInner, TimelineItem,
 };
-use crate::unable_to_decrypt_hook::UtdHookManager;
+use crate::{
+    timeline::pinned_events_loader::PinnedEventsRoom, unable_to_decrypt_hook::UtdHookManager,
+};
 
 mod basic;
 mod echo;
@@ -312,6 +314,22 @@ impl PaginableRoom for TestRoomDataProvider {
     }
 
     async fn messages(&self, _opts: MessagesOptions) -> Result<Messages, PaginatorError> {
+        unimplemented!();
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl PinnedEventsRoom for TestRoomDataProvider {
+    async fn room_event(&self, _event_id: &EventId) -> Result<SyncTimelineEvent, PaginatorError> {
+        unimplemented!();
+    }
+
+    fn room_pinned_event_ids(&self) -> Vec<OwnedEventId> {
+        unimplemented!();
+    }
+
+    fn room_is_pinned_event_id(&self, _event_id: &EventId) -> bool {
         unimplemented!();
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -31,7 +31,7 @@ use ruma::{
 use tracing::{debug, error};
 
 use super::{Profile, TimelineBuilder};
-use crate::timeline::{self, Timeline};
+use crate::timeline::{self, pinned_events_loader::PinnedEventsRoom, Timeline};
 
 #[async_trait]
 pub trait RoomExt {
@@ -67,7 +67,9 @@ impl RoomExt for Room {
 }
 
 #[async_trait]
-pub(super) trait RoomDataProvider: Clone + Send + Sync + 'static + PaginableRoom {
+pub(super) trait RoomDataProvider:
+    Clone + Send + Sync + 'static + PaginableRoom + PinnedEventsRoom
+{
     fn own_user_id(&self) -> &UserId;
     fn room_version(&self) -> RoomVersionId;
     async fn profile_from_user_id(&self, user_id: &UserId) -> Option<Profile>;

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -83,6 +83,22 @@ async fn mock_context(
         .await;
 }
 
+/// Mocks the /event endpoint
+#[allow(clippy::too_many_arguments)] // clippy you've got such a fixed mindset
+async fn mock_event(
+    server: &MockServer,
+    room_id: &RoomId,
+    event_id: &EventId,
+    event: TimelineEvent,
+) {
+    Mock::given(method("GET"))
+        .and(path(format!("/_matrix/client/r0/rooms/{room_id}/event/{event_id}")))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(event.event.json()))
+        .mount(server)
+        .await;
+}
+
 /// Mocks the /messages endpoint.
 ///
 /// Note: pass `chunk` in the correct order: topological for forward pagination,

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -43,6 +43,7 @@ mod echo;
 mod edit;
 mod focus_event;
 mod pagination;
+mod pinned_event;
 mod profiles;
 mod queue;
 mod read_receipts;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -75,7 +75,6 @@ async fn test_new_pinned_events_are_added_on_sync() {
     assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::PushFront { value } => {
         assert!(value.is_day_divider());
     });
-    assert_pending!(timeline_stream);
     test_helper.server.reset().await;
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -1,0 +1,270 @@
+use std::time::Duration;
+
+use assert_matches::assert_matches;
+use eyeball_im::VectorDiff;
+use futures_util::StreamExt;
+use matrix_sdk::{
+    config::SyncSettings,
+    sync::SyncResponse,
+    test_utils::{events::EventFactory, logged_in_client_with_server},
+    Client,
+};
+use matrix_sdk_test::{async_test, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder, BOB};
+use matrix_sdk_ui::{timeline::TimelineFocus, Timeline};
+use ruma::{event_id, owned_room_id, OwnedEventId, OwnedRoomId};
+use serde_json::json;
+use stream_assert::assert_pending;
+use wiremock::MockServer;
+
+use crate::{mock_event, mock_sync};
+
+#[async_test]
+async fn test_new_pinned_events_are_added_on_sync() {
+    let mut test_helper = TestHelper::new().await;
+    let room_id = test_helper.room_id.clone();
+
+    // Join the room
+    let _ = test_helper.setup_initial_sync_response().await;
+    test_helper.server.reset().await;
+
+    // Load initial timeline items: a text message and a `m.room.pinned_events` with
+    // events $1 and $2 pinned
+    let _ = test_helper
+        .setup_sync_response(vec![("$1", "in the end", false)], Some(vec!["$1", "$2"]))
+        .await;
+
+    let room = test_helper.client.get_room(&room_id).unwrap();
+    let timeline = Timeline::builder(&room)
+        .with_focus(TimelineFocus::PinnedEvents { max_events_to_load: 100 })
+        .build()
+        .await
+        .unwrap();
+    test_helper.server.reset().await;
+
+    assert!(
+        timeline.live_back_pagination_status().await.is_none(),
+        "there should be no live back-pagination status for a focused timeline"
+    );
+
+    // Load timeline items
+    let (items, mut timeline_stream) = timeline.subscribe().await;
+
+    assert_eq!(items.len(), 1 + 1); // event item + a day divider
+    assert!(items[0].is_day_divider());
+    assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "in the end");
+    assert_pending!(timeline_stream);
+    test_helper.server.reset().await;
+
+    // Load new pinned event contents from sync, $2 was pinned but wasn't available
+    // before
+    let _ = test_helper
+        .setup_sync_response(
+            vec![("$2", "pinned message!", true), ("$3", "normal message", true)],
+            None,
+        )
+        .await;
+
+    // The list is reloaded, so it's reset
+    assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::Clear);
+    assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::PushBack { value } => {
+        assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$1"));
+    });
+    assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::PushBack { value } => {
+        assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$2"));
+    });
+    assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::PushFront { value } => {
+        assert!(value.is_day_divider());
+    });
+    assert_pending!(timeline_stream);
+    test_helper.server.reset().await;
+}
+
+#[async_test]
+async fn test_new_pinned_event_ids_reload_the_timeline() {
+    let mut test_helper = TestHelper::new().await;
+    let room_id = test_helper.room_id.clone();
+
+    // Join the room
+    let _ = test_helper.setup_initial_sync_response().await;
+    test_helper.server.reset().await;
+
+    // Load initial timeline items: 2 text messages and a `m.room.pinned_events`
+    // with event $1 and $2 pinned
+    let _ = test_helper
+        .setup_sync_response(
+            vec![("$1", "in the end", false), ("$2", "it doesn't even matter", true)],
+            Some(vec!["$1"]),
+        )
+        .await;
+
+    let room = test_helper.client.get_room(&room_id).unwrap();
+    let timeline = Timeline::builder(&room)
+        .with_focus(TimelineFocus::PinnedEvents { max_events_to_load: 100 })
+        .build()
+        .await
+        .unwrap();
+
+    assert!(
+        timeline.live_back_pagination_status().await.is_none(),
+        "there should be no live back-pagination status for a focused timeline"
+    );
+
+    let (items, mut timeline_stream) = timeline.subscribe().await;
+
+    assert_eq!(items.len(), 1 + 1); // event item + a day divider
+    assert!(items[0].is_day_divider());
+    assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "in the end");
+    assert_pending!(timeline_stream);
+    test_helper.server.reset().await;
+
+    // Reload timeline with new pinned event ids
+    let _ = test_helper
+        .setup_sync_response(
+            vec![("$1", "in the end", false), ("$2", "it doesn't even matter", false)],
+            Some(vec!["$1", "$2"]),
+        )
+        .await;
+
+    assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::Clear);
+    assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::PushBack { value } => {
+        assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$1"));
+    });
+    assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::PushBack { value } => {
+        assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$2"));
+    });
+    assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::PushFront { value } => {
+        assert!(value.is_day_divider());
+    });
+    assert_pending!(timeline_stream);
+    test_helper.server.reset().await;
+
+    // Reload timeline with no pinned event ids
+    let _ = test_helper
+        .setup_sync_response(
+            vec![("$1", "in the end", false), ("$2", "it doesn't even matter", false)],
+            Some(Vec::new()),
+        )
+        .await;
+
+    assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::Clear);
+    assert_pending!(timeline_stream);
+    test_helper.server.reset().await;
+}
+
+#[async_test]
+async fn test_max_events_to_load_is_honored() {
+    let mut test_helper = TestHelper::new().await;
+    let room_id = test_helper.room_id.clone();
+
+    // Join the room
+    let _ = test_helper.setup_initial_sync_response().await;
+    test_helper.server.reset().await;
+
+    // Load initial timeline items: a text message and a `m.room.pinned_events`
+    // with event $1 and $2 pinned
+    let _ = test_helper
+        .setup_sync_response(vec![("$1", "in the end", false)], Some(vec!["$1", "$2"]))
+        .await;
+
+    let room = test_helper.client.get_room(&room_id).unwrap();
+    let timeline = Timeline::builder(&room)
+        .with_focus(TimelineFocus::PinnedEvents { max_events_to_load: 1 })
+        .build()
+        .await
+        .unwrap();
+
+    assert!(
+        timeline.live_back_pagination_status().await.is_none(),
+        "there should be no live back-pagination status for a focused timeline"
+    );
+
+    let (items, mut timeline_stream) = timeline.subscribe().await;
+
+    assert!(items.is_empty()); // We're only taking the last event id, `$2`, and it's not available
+    assert_pending!(timeline_stream);
+    test_helper.server.reset().await;
+}
+
+struct TestHelper {
+    pub client: Client,
+    pub server: MockServer,
+    pub room_id: OwnedRoomId,
+    pub sync_settings: SyncSettings,
+    pub sync_response_builder: SyncResponseBuilder,
+}
+
+impl TestHelper {
+    async fn new() -> Self {
+        let (client, server) = logged_in_client_with_server().await;
+        Self {
+            client,
+            server,
+            room_id: owned_room_id!("!a98sd12bjh:example.org"),
+            sync_settings: SyncSettings::new().timeout(Duration::from_millis(3000)),
+            sync_response_builder: SyncResponseBuilder::new(),
+        }
+    }
+
+    async fn setup_initial_sync_response(&mut self) -> Result<SyncResponse, matrix_sdk::Error> {
+        let joined_room_builder = JoinedRoomBuilder::new(&self.room_id)
+            // Set up encryption
+            .add_state_event(StateTestEvent::Encryption);
+
+        // Mark the room as joined.
+        let json_response = self
+            .sync_response_builder
+            .add_joined_room(joined_room_builder)
+            .build_json_sync_response();
+        mock_sync(&self.server, json_response, None).await;
+        self.client.sync_once(self.sync_settings.clone()).await
+    }
+
+    async fn setup_sync_response(
+        &mut self,
+        text_messages: Vec<(&str, &str, bool)>,
+        pinned_event_ids: Option<Vec<&str>>,
+    ) -> Result<SyncResponse, matrix_sdk::Error> {
+        let mut joined_room_builder = JoinedRoomBuilder::new(&self.room_id);
+        for (id, txt, add_to_timeline) in text_messages {
+            let event_id: OwnedEventId = id.try_into().unwrap();
+            let f = EventFactory::new().room(&self.room_id);
+            let event_builder = f.text_msg(txt).event_id(&event_id).sender(*BOB);
+            mock_event(&self.server, &self.room_id, &event_id, event_builder.into_timeline()).await;
+
+            if add_to_timeline {
+                let event_builder = f.text_msg(txt).event_id(&event_id).sender(*BOB);
+                joined_room_builder = joined_room_builder
+                    .add_timeline_event(event_builder.into_raw_timeline().cast());
+            }
+        }
+
+        if let Some(pinned_event_ids) = pinned_event_ids {
+            let pinned_event_ids: Vec<String> =
+                pinned_event_ids.into_iter().map(|id| id.to_owned()).collect();
+            joined_room_builder =
+                joined_room_builder.add_state_event(StateTestEvent::Custom(json!(
+                    {
+                        "content": {
+                            "pinned": pinned_event_ids
+                        },
+                        "event_id": "$15139375513VdeRF:localhost",
+                        "origin_server_ts": 151393755,
+                        "sender": "@example:localhost",
+                        "state_key": "",
+                        "type": "m.room.pinned_events",
+                        "unsigned": {
+                            "age": 703422
+                        }
+                    }
+                )))
+        }
+
+        // Mark the room as joined.
+        let json_response = self
+            .sync_response_builder
+            .add_joined_room(joined_room_builder)
+            .build_json_sync_response();
+        mock_sync(&self.server, json_response, None).await;
+        self.client.sync_once(self.sync_settings.clone()).await
+    }
+}

--- a/testing/matrix-sdk-test/src/test_json/sync_events.rs
+++ b/testing/matrix-sdk-test/src/test_json/sync_events.rs
@@ -320,7 +320,7 @@ pub static NAME_STRIPPED: Lazy<JsonValue> = Lazy::new(|| {
 pub static PINNED_EVENTS: Lazy<JsonValue> = Lazy::new(|| {
     json!({
         "content": {
-            "pinned": [ "$a" ]
+            "pinned": [ "$a", "$b" ]
         },
         "event_id": "$15139375513VdeRF:localhost",
         "origin_server_ts": 151393755,


### PR DESCRIPTION
## Changes

- Create a new type of `TimelineFocus`, `TimelineFocus::PinnedEvents` that will use the pinned event ids in `RoomInfo` to load the associated events, cache them and sort them chronologically.
- Create `PinnedEventsRoom` trait to be able to provide the necessary data to the new timeline type.
- Change the `is_live` parameter used in the `Timeline` code for a `LiveTimelineUpdatesAllowed` enum to distinguish between timelines that need to process every update (live timeline), those who don't need to process any (the focused one) and those which may need to process *some* items (pinned events one).
- Add tests and a benchmark for the concurrent pinned event loading.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
