### PR TITLE
crypto: Make the return type of is_owner_of_session more specific

### DIFF
--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -135,6 +135,12 @@ impl std::fmt::Display for MismatchedIdentityKeysError {
     }
 }
 
+impl From<MismatchedIdentityKeysError> for MegolmError {
+    fn from(value: MismatchedIdentityKeysError) -> Self {
+        MegolmError::MismatchedIdentityKeys(value)
+    }
+}
+
 /// Error that occurs when decrypting an event that is malformed.
 #[derive(Error, Debug)]
 pub enum EventError {

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use ruma::{CanonicalJsonError, IdParseError, OwnedDeviceId, OwnedRoomId, OwnedUserId};
+use serde::{ser::SerializeMap, Serializer};
 use serde_json::Error as SerdeError;
 use thiserror::Error;
 use vodozemac::{Curve25519PublicKey, Ed25519PublicKey};
@@ -93,16 +94,7 @@ pub enum MegolmError {
     #[error(
         "decryption failed because of mismatched identity keys of the sending device and those recorded in the to-device message"
     )]
-    MismatchedIdentityKeys {
-        /// The Ed25519 key recorded in the room key's to-device message.
-        key_ed25519: Box<Ed25519PublicKey>,
-        /// The Ed25519 identity key of the device sending the room key.
-        device_ed25519: Option<Box<Ed25519PublicKey>>,
-        /// The Curve25519 key recorded in the room key's to-device message.
-        key_curve25519: Box<Curve25519PublicKey>,
-        /// The Curve25519 identity key of the device sending the room key.
-        device_curve25519: Option<Box<Curve25519PublicKey>>,
-    },
+    MismatchedIdentityKeys(MismatchedIdentityKeysError),
 
     /// The encrypted megolm message couldn't be decoded.
     #[error(transparent)]
@@ -115,6 +107,32 @@ pub enum MegolmError {
     /// The storage layer returned an error.
     #[error(transparent)]
     Store(#[from] CryptoStoreError),
+}
+
+/// Decryption failed because of a mismatch between the identity keys of the
+/// device we received the room key from and the identity keys recorded in
+/// the plaintext of the room key to-device message.
+#[derive(Error, Debug)]
+pub struct MismatchedIdentityKeysError {
+    /// The Ed25519 key recorded in the room key's to-device message.
+    pub key_ed25519: Box<Ed25519PublicKey>,
+    /// The Ed25519 identity key of the device sending the room key.
+    pub device_ed25519: Option<Box<Ed25519PublicKey>>,
+    /// The Curve25519 key recorded in the room key's to-device message.
+    pub key_curve25519: Box<Curve25519PublicKey>,
+    /// The Curve25519 identity key of the device sending the room key.
+    pub device_curve25519: Option<Box<Curve25519PublicKey>>,
+}
+
+impl std::fmt::Display for MismatchedIdentityKeysError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut ser = f.serialize_struct("MismatchedIdentityKeysError", 4)?;
+        ser.serialize_entry("key_ed25519", &self.key_ed25519)?;
+        ser.serialize_entry("device_ed25519", &self.device_ed25519)?;
+        ser.serialize_entry("key_curve25519", &self.key_curve25519)?;
+        ser.serialize_entry("device_curve25519", &self.device_curve25519)?;
+        ser.end()
+    }
 }
 
 /// Error that occurs when decrypting an event that is malformed.


### PR DESCRIPTION
Make the return type of is_owner_of_session more specific, so we can use it in contexts that expect e.g. an `OlmError` instead of `MegolmError`.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/3751