### PR TITLE
Make `message-ids` feature the default

### DIFF
--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -21,12 +21,14 @@ e2e-encryption = ["dep:matrix-sdk-crypto"]
 js = ["matrix-sdk-common/js", "matrix-sdk-crypto?/js", "ruma/js", "matrix-sdk-store-encryption/js"]
 qrcode = ["matrix-sdk-crypto?/qrcode"]
 automatic-room-key-forwarding = ["matrix-sdk-crypto?/automatic-room-key-forwarding"]
-message-ids = ["matrix-sdk-crypto?/message-ids"]
 experimental-sliding-sync = [
     "ruma/unstable-msc3575",
     "ruma/unstable-simplified-msc3575",
 ]
 uniffi = ["dep:uniffi", "matrix-sdk-crypto?/uniffi"]
+
+# "message-ids" feature doesn't do anything and is deprecated.
+message-ids = []
 
 # helpers for testing features build upon this
 testing = [

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Changes:
 
+- Add message IDs to all outgoing to-device messages encrypted by
+  `matrix-sdk-crypto`. The `message-ids` feature of `matrix-sdk-crypto` and
+  `matrix-sdk-base` is now a no-op.
+  ([#3776](https://github.com/matrix-org/matrix-rust-sdk/pull/3776))
+
 - Log the content of received `m.room_key.withheld` to-device events.
   ([#3591](https://github.com/matrix-org/matrix-rust-sdk/pull/3591))
 

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -19,10 +19,12 @@ default = []
 automatic-room-key-forwarding = []
 js = ["ruma/js", "vodozemac/js", "matrix-sdk-common/js"]
 qrcode = ["dep:matrix-sdk-qrcode"]
-message-ids = ["dep:ulid"]
 experimental-algorithms = []
 uniffi = ["dep:uniffi"]
 _disable-minimum-rotation-period-ms = []
+
+# "message-ids" feature doesn't do anything and is deprecated.
+message-ids = []
 
 # Testing helpers for implementations based upon this
 testing = ["dep:http"]
@@ -60,7 +62,7 @@ tokio = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 url = { workspace = true }
-ulid = { version = "1.0.0", optional = true }
+ulid = { version = "1.0.0" }
 uniffi = { workspace = true, optional = true }
 vodozemac = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
@@ -598,7 +598,6 @@ impl GroupSessionManager {
     /// Given a to-device request, build a recipient map suitable for logging.
     ///
     /// Returns a list of triples of (message_id, user id, device_id).
-    #[cfg(feature = "message-ids")]
     fn to_device_request_to_log_list(
         request: &Arc<ToDeviceRequest>,
     ) -> Vec<(String, String, String)> {
@@ -622,21 +621,6 @@ impl GroupSessionManager {
                     user_id.to_string(),
                     device.to_string(),
                 ));
-            }
-        }
-        result
-    }
-
-    /// Given a to-device request, build a recipient map suitable for logging.
-    ///
-    /// Returns a list of pairs of (user id, device_id).
-    #[cfg(not(feature = "message-ids"))]
-    fn to_device_request_to_log_list(request: &Arc<ToDeviceRequest>) -> Vec<(String, String)> {
-        let mut result: Vec<(String, String)> = Vec::new();
-
-        for (user_id, device_map) in &request.messages {
-            for device in device_map.keys() {
-                result.push((user_id.to_string(), device.to_string()));
             }
         }
         result

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -21,7 +21,6 @@ testing = ["matrix-sdk-sqlite?/testing", "matrix-sdk-indexeddb?/testing", "matri
 
 e2e-encryption = [
     "matrix-sdk-base/e2e-encryption",
-    "matrix-sdk-base/message-ids",
     "matrix-sdk-sqlite?/crypto-store",        # activate crypto-store on sqlite if given
     "matrix-sdk-indexeddb?/e2e-encryption",   # activate on indexeddb if given
 ]


### PR DESCRIPTION
The feature is now a no-op.

Will fix (I hope) https://github.com/element-hq/element-android/issues/8872