### PR TITLE
UI Timeline: Build a ShieldState for an unencrypted event in an encrypted room.

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -29,6 +29,7 @@ const AUTHENTICITY_NOT_GUARANTEED: &str =
 const UNVERIFIED_IDENTITY: &str = "Encrypted by an unverified user.";
 const UNSIGNED_DEVICE: &str = "Encrypted by a device not verified by its owner.";
 const UNKNOWN_DEVICE: &str = "Encrypted by an unknown or deleted device.";
+pub const SENT_IN_CLEAR: &str = "Sent in clear.";
 
 /// Represents the state of verification for a decrypted message sent by a
 /// device.

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -158,9 +158,17 @@ impl TimelineBuilder {
         let (_, mut event_subscriber) = room_event_cache.subscribe().await?;
 
         let is_live = matches!(focus, TimelineFocus::Live);
+        let is_room_encrypted =
+            room.is_encrypted().await.map_err(|_| Error::UnknownEncryptionState)?;
 
-        let inner = TimelineInner::new(room, focus, internal_id_prefix, unable_to_decrypt_hook)
-            .with_settings(settings);
+        let inner = TimelineInner::new(
+            room,
+            focus,
+            internal_id_prefix,
+            unable_to_decrypt_hook,
+            is_room_encrypted,
+        )
+        .with_settings(settings);
 
         let has_events = inner.init_focus(&room_event_cache).await?;
 

--- a/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
@@ -638,6 +638,7 @@ mod tests {
             timestamp,
             TimelineItemContent::RedactedMessage,
             event_kind,
+            false,
         )
     }
 
@@ -646,7 +647,7 @@ mod tests {
         let mut items = ObservableVector::new();
         let mut txn = items.transaction();
 
-        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None);
+        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None, false);
 
         let timestamp = MilliSecondsSinceUnixEpoch(uint!(42));
         let timestamp_next_day =
@@ -680,7 +681,7 @@ mod tests {
         let mut items = ObservableVector::new();
         let mut txn = items.transaction();
 
-        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None);
+        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None, false);
 
         let timestamp = MilliSecondsSinceUnixEpoch(uint!(42));
         let timestamp_next_day =
@@ -712,7 +713,7 @@ mod tests {
         let mut items = ObservableVector::new();
         let mut txn = items.transaction();
 
-        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None);
+        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None, false);
 
         let timestamp = MilliSecondsSinceUnixEpoch(uint!(42));
         let timestamp_next_day =
@@ -746,7 +747,7 @@ mod tests {
         let mut items = ObservableVector::new();
         let mut txn = items.transaction();
 
-        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None);
+        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None, false);
 
         let timestamp = MilliSecondsSinceUnixEpoch(uint!(42));
         let timestamp_next_day =
@@ -776,7 +777,7 @@ mod tests {
         let mut items = ObservableVector::new();
         let mut txn = items.transaction();
 
-        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None);
+        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None, false);
 
         let timestamp = MilliSecondsSinceUnixEpoch(uint!(42));
 
@@ -802,7 +803,7 @@ mod tests {
         let mut items = ObservableVector::new();
         let mut txn = items.transaction();
 
-        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None);
+        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None, false);
 
         let timestamp = MilliSecondsSinceUnixEpoch(uint!(42));
 
@@ -826,7 +827,7 @@ mod tests {
         let mut items = ObservableVector::new();
         let mut txn = items.transaction();
 
-        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None);
+        let mut meta = TimelineInnerMetadata::new(ruma::RoomVersionId::V11, None, None, false);
 
         let timestamp = MilliSecondsSinceUnixEpoch(uint!(42));
 

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -48,6 +48,10 @@ pub enum Error {
     #[error("Failed toggling reaction")]
     FailedToToggleReaction,
 
+    /// Couldn't read the encryption state of the room.
+    #[error("The room's encryption state is unknown.")]
+    UnknownEncryptionState,
+
     /// Something went wrong with the room event cache.
     #[error("Something went wrong with the room event cache.")]
     EventCacheError(#[from] EventCacheError),

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -884,7 +884,16 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             }
         };
 
-        let mut item = EventTimelineItem::new(sender, sender_profile, timestamp, content, kind);
+        let is_room_encrypted = self.meta.is_room_encrypted;
+
+        let mut item = EventTimelineItem::new(
+            sender,
+            sender_profile,
+            timestamp,
+            content,
+            kind,
+            is_room_encrypted,
+        );
 
         match &self.ctx.flow {
             Flow::Local { .. } => {

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -119,11 +119,20 @@ impl EventTimelineItem {
 
     /// If the supplied low-level `SyncTimelineEvent` is suitable for use as the
     /// `latest_event` in a message preview, wrap it as an `EventTimelineItem`.
+    ///
+    /// **Note:** Timeline items created via this constructor do **not** produce
+    /// the correct ShieldState when calling
+    /// [`get_shield`][EventTimelineItem::get_shield]. This is because they are
+    /// intended for display in the room list which a) is unlikely to show
+    /// shields and b) would incur a significant performance overhead.
     pub async fn from_latest_event(
         client: Client,
         room_id: &RoomId,
         latest_event: LatestEvent,
     ) -> Option<EventTimelineItem> {
+        // TODO: We shouldn't be returning an EventTimelineItem here because we're
+        // starting to diverge on what kind of data we need. The note above is a
+        // potential footgun which could one day turn into a security issue.
         use super::traits::RoomDataProvider;
 
         let SyncTimelineEvent { event: raw_sync_event, encryption_info, .. } =

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -227,6 +227,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         focus: TimelineFocus,
         internal_id_prefix: Option<String>,
         unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
+        is_room_encrypted: bool,
     ) -> Self {
         let (focus_data, is_live) = match focus {
             TimelineFocus::Live => (TimelineFocusData::Live, true),
@@ -244,6 +245,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
             is_live,
             internal_id_prefix,
             unable_to_decrypt_hook,
+            is_room_encrypted,
         );
 
         Self {

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -75,6 +75,7 @@ impl TimelineInnerState {
         is_live_timeline: bool,
         internal_id_prefix: Option<String>,
         unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
+        is_room_encrypted: bool,
     ) -> Self {
         Self {
             // Upstream default capacity is currently 16, which is making
@@ -85,6 +86,7 @@ impl TimelineInnerState {
                 room_version,
                 internal_id_prefix,
                 unable_to_decrypt_hook,
+                is_room_encrypted,
             ),
             is_live_timeline,
         }
@@ -723,6 +725,8 @@ pub(in crate::timeline) struct TimelineInnerMetadata {
     /// This value is constant over the lifetime of the metadata.
     pub(crate) unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
 
+    pub(crate) is_room_encrypted: bool,
+
     /// Matrix room version of the timeline's room, or a sensible default.
     ///
     /// This value is constant over the lifetime of the metadata.
@@ -757,6 +761,7 @@ impl TimelineInnerMetadata {
         room_version: RoomVersionId,
         internal_id_prefix: Option<String>,
         unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
+        is_room_encrypted: bool,
     ) -> Self {
         Self {
             all_events: Default::default(),
@@ -771,6 +776,7 @@ impl TimelineInnerMetadata {
             room_version,
             unable_to_decrypt_hook,
             internal_id_prefix,
+            is_room_encrypted,
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -90,6 +90,7 @@ impl TestTimeline {
                 TimelineFocus::Live,
                 Some(prefix),
                 None,
+                false,
             ),
             event_builder: EventBuilder::new(),
         }
@@ -97,7 +98,7 @@ impl TestTimeline {
 
     fn with_room_data_provider(room_data_provider: TestRoomDataProvider) -> Self {
         Self {
-            inner: TimelineInner::new(room_data_provider, TimelineFocus::Live, None, None),
+            inner: TimelineInner::new(room_data_provider, TimelineFocus::Live, None, None, false),
             event_builder: EventBuilder::new(),
         }
     }
@@ -109,6 +110,7 @@ impl TestTimeline {
                 TimelineFocus::Live,
                 None,
                 Some(hook),
+                true,
             ),
             event_builder: EventBuilder::new(),
         }

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -71,6 +71,7 @@ mod polls;
 mod reactions;
 mod read_receipts;
 mod redaction;
+mod shields;
 mod virt;
 
 struct TestTimeline {
@@ -111,6 +112,19 @@ impl TestTimeline {
                 None,
                 Some(hook),
                 true,
+            ),
+            event_builder: EventBuilder::new(),
+        }
+    }
+
+    fn with_is_room_encrypted(encrypted: bool) -> Self {
+        Self {
+            inner: TimelineInner::new(
+                TestRoomDataProvider::default(),
+                TimelineFocus::Live,
+                None,
+                None,
+                encrypted,
             ),
             event_builder: EventBuilder::new(),
         }

--- a/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
@@ -1,0 +1,41 @@
+use eyeball_im::VectorDiff;
+use matrix_sdk_base::deserialized_responses::ShieldState;
+use matrix_sdk_test::{async_test, ALICE};
+use ruma::events::room::message::RoomMessageEventContent;
+use stream_assert::assert_next_matches;
+
+use crate::timeline::tests::TestTimeline;
+
+#[async_test]
+async fn test_no_shield_in_unencrypted_room() {
+    let timeline = TestTimeline::new();
+    let mut stream = timeline.subscribe().await;
+
+    timeline
+        .handle_live_message_event(
+            &ALICE,
+            RoomMessageEventContent::text_plain("Unencrypted message."),
+        )
+        .await;
+
+    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let shield = item.as_event().unwrap().get_shield(false);
+    assert!(shield.is_none());
+}
+
+#[async_test]
+async fn test_sent_in_clear_shield() {
+    let timeline = TestTimeline::with_is_room_encrypted(true);
+    let mut stream = timeline.subscribe().await;
+
+    timeline
+        .handle_live_message_event(
+            &ALICE,
+            RoomMessageEventContent::text_plain("Unencrypted message."),
+        )
+        .await;
+
+    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let shield = item.as_event().unwrap().get_shield(false);
+    assert_eq!(shield, Some(ShieldState::Grey { message: "Sent in clear." }));
+}

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -29,7 +29,10 @@ use stream_assert::{assert_next_matches, assert_pending};
 use tokio::{spawn, sync::mpsc::channel, task::yield_now};
 use wiremock::MockServer;
 
-use crate::timeline::sliding_sync::{assert_timeline_stream, timeline_event};
+use crate::{
+    mock_encryption_state,
+    timeline::sliding_sync::{assert_timeline_stream, timeline_event},
+};
 
 async fn new_room_list_service() -> Result<(Client, MockServer, RoomListService), Error> {
     let (client, server) = logged_in_client_with_server().await;
@@ -2270,6 +2273,8 @@ async fn test_room_timeline() -> Result<(), Error> {
         },
     };
 
+    mock_encryption_state(&server, false).await;
+
     let room = room_list.room(room_id)?;
     room.init_timeline_with_builder(room.default_room_timeline_builder().await.unwrap()).await?;
     let timeline = room.timeline().unwrap();
@@ -2320,6 +2325,7 @@ async fn test_room_timeline() -> Result<(), Error> {
 #[async_test]
 async fn test_room_latest_event() -> Result<(), Error> {
     let (_, server, room_list) = new_room_list_service().await?;
+    mock_encryption_state(&server, false).await;
 
     let sync = room_list.sync();
     pin_mut!(sync);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -52,11 +52,11 @@ async fn test_echo() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
-
-    mock_encryption_state(&server, false).await;
 
     Mock::given(method("PUT"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
@@ -140,6 +140,7 @@ async fn test_retry_failed() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
 
     client.send_queue().set_enabled(true).await;
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
@@ -216,6 +217,8 @@ async fn test_dedup_by_event_id_late() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
@@ -290,6 +293,8 @@ async fn test_cancel_failed() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -62,6 +62,8 @@ async fn test_edit() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
@@ -165,6 +167,8 @@ async fn test_edit_local_echo() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
@@ -276,6 +280,8 @@ async fn test_send_edit() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) =
@@ -349,6 +355,8 @@ async fn test_send_reply_edit() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
@@ -443,6 +451,8 @@ async fn test_send_edit_poll() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) =
@@ -533,6 +543,8 @@ async fn test_send_edit_when_timeline_is_clear() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -30,7 +30,7 @@ use matrix_sdk_ui::{timeline::TimelineFocus, Timeline};
 use ruma::{event_id, events::room::message::RoomMessageEventContent, room_id};
 use stream_assert::assert_pending;
 
-use crate::{mock_context, mock_messages, mock_sync};
+use crate::{mock_context, mock_encryption_state, mock_messages, mock_sync};
 
 #[async_test]
 async fn test_new_focused() {
@@ -67,6 +67,8 @@ async fn test_new_focused() {
         vec![],
     )
     .await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Timeline::builder(&room)
@@ -207,6 +209,8 @@ async fn test_focused_timeline_reacts() {
     )
     .await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = Timeline::builder(&room)
         .with_focus(TimelineFocus::Event {
@@ -301,6 +305,8 @@ async fn test_focused_timeline_doesnt_show_local_echoes() {
         vec![],
     )
     .await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Timeline::builder(&room)

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -37,7 +37,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::mock_sync;
+use crate::{mock_encryption_state, mock_sync};
 
 mod echo;
 mod edit;
@@ -63,6 +63,8 @@ async fn test_reaction() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
@@ -171,6 +173,8 @@ async fn test_redacted_message() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
@@ -227,6 +231,8 @@ async fn test_redact_message() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
@@ -308,6 +314,8 @@ async fn test_read_marker() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
@@ -391,6 +399,8 @@ async fn test_sync_highlighted() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
@@ -456,6 +466,8 @@ async fn test_duplicate_maintains_correct_order() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
@@ -639,6 +651,7 @@ impl PinningTestSetup<'_> {
     }
 
     async fn timeline(&self) -> matrix_sdk_ui::Timeline {
+        mock_encryption_state(&self.server, false).await;
         let room = self.client.get_room(self.room_id).unwrap();
         room.timeline().await.unwrap()
     }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -46,7 +46,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::mock_sync;
+use crate::{mock_encryption_state, mock_sync};
 
 #[async_test]
 async fn test_back_pagination() {
@@ -60,6 +60,8 @@ async fn test_back_pagination() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
@@ -162,6 +164,8 @@ async fn test_back_pagination_highlighted() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
@@ -244,6 +248,8 @@ async fn test_wait_for_token() {
     client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
 
@@ -305,6 +311,8 @@ async fn test_dedup_pagination() {
     client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
 
@@ -364,6 +372,8 @@ async fn test_timeline_reset_while_paginating() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
@@ -561,6 +571,8 @@ async fn test_empty_chunk() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
@@ -650,6 +662,8 @@ async fn test_until_num_items_with_empty_chunk() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
@@ -765,6 +779,8 @@ async fn test_back_pagination_aborted() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());

--- a/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
@@ -31,7 +31,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::mock_sync;
+use crate::{mock_encryption_state, mock_sync};
 
 #[async_test]
 async fn test_update_sender_profiles() {
@@ -45,6 +45,8 @@ async fn test_update_sender_profiles() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -127,6 +127,8 @@ async fn test_retry_order() {
     mock_sync(&server, sync_response_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) =
@@ -228,6 +230,8 @@ async fn test_reloaded_failed_local_echoes_are_marked_as_failed() {
 
     mock_sync(&server, sync_response_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -40,7 +40,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::mock_sync;
+use crate::{mock_encryption_state, mock_sync};
 
 fn filter_notice(ev: &AnySyncTimelineEvent, _room_version: &RoomVersionId) -> bool {
     match ev {
@@ -70,6 +70,8 @@ async fn test_read_receipts_updates() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
@@ -299,6 +301,8 @@ async fn test_read_receipts_updates_on_filtered_events() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline_builder().event_filter(filter_notice).build().await.unwrap();
     let (items, mut timeline_stream) = timeline.subscribe().await;
@@ -506,6 +510,8 @@ async fn test_send_single_receipt() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
@@ -854,6 +860,8 @@ async fn test_mark_as_read() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
 
@@ -956,6 +964,8 @@ async fn test_send_multiple_receipts() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
@@ -1170,6 +1180,8 @@ async fn test_latest_user_read_receipt() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -51,6 +51,8 @@ async fn test_in_reply_to_details() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
@@ -182,6 +184,8 @@ async fn test_transfer_in_reply_to_details_to_re_received_item() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
 
@@ -258,6 +262,8 @@ async fn test_send_reply() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
@@ -370,6 +376,8 @@ async fn test_send_reply_to_self() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) =
@@ -465,6 +473,8 @@ async fn test_send_reply_to_threaded() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
@@ -571,6 +581,8 @@ async fn test_send_reply_with_event_id() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
@@ -688,6 +700,8 @@ async fn test_send_reply_with_event_id_that_is_redacted() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -223,6 +223,8 @@ macro_rules! assert_timeline_stream {
 
 pub(crate) use assert_timeline_stream;
 
+use crate::mock_encryption_state;
+
 async fn new_sliding_sync(lists: Vec<SlidingSyncListBuilder>) -> Result<(MockServer, SlidingSync)> {
     let (client, server) = logged_in_client_with_server().await;
 
@@ -316,6 +318,8 @@ async fn test_timeline_basic() -> Result<()> {
 
     create_one_room(&server, &sliding_sync, &mut stream, room_id, "Room Name".to_owned()).await?;
 
+    mock_encryption_state(&server, false).await;
+
     let (timeline_items, mut timeline_stream) =
         timeline_test_helper(&sliding_sync, room_id).await?;
     assert!(timeline_items.is_empty());
@@ -362,6 +366,8 @@ async fn test_timeline_duplicated_events() -> Result<()> {
     let room_id = room_id!("!foo:bar.org");
 
     create_one_room(&server, &sliding_sync, &mut stream, room_id, "Room Name".to_owned()).await?;
+
+    mock_encryption_state(&server, false).await;
 
     let (_, mut timeline_stream) = timeline_test_helper(&sliding_sync, room_id).await?;
 
@@ -439,6 +445,8 @@ async fn test_timeline_read_receipts_are_updated_live() -> Result<()> {
     let room_id = room_id!("!foo:bar.org");
 
     create_one_room(&server, &sliding_sync, &mut stream, room_id, "Room Name".to_owned()).await?;
+
+    mock_encryption_state(&server, false).await;
 
     let (timeline_items, mut timeline_stream) =
         timeline_test_helper(&sliding_sync, room_id).await?;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -38,7 +38,7 @@ use ruma::{
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
 
-use crate::mock_sync;
+use crate::{mock_encryption_state, mock_sync};
 
 #[async_test]
 async fn test_batched() {
@@ -53,6 +53,8 @@ async fn test_batched() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline_builder().event_filter(|_, _| true).build().await.unwrap();
@@ -101,6 +103,8 @@ async fn test_event_filter() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline_builder().event_filter(|_, _| true).build().await.unwrap();
@@ -208,6 +212,8 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline_builder().build().await.unwrap();
     let (_, timeline_stream) = timeline.subscribe().await;
@@ -313,6 +319,8 @@ async fn test_profile_updates() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
+
+    mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline_builder().build().await.unwrap();


### PR DESCRIPTION
This PR makes the following changes:
- Add a property to the timeline so that it knows whether the room is encrypted or not.
- Pass this value when building timeline items and use it inside `get_shield` to add a new ShieldState.
- Add tests for the ShieldState of an unencrypted item in both and encrypted and unencrypted timeline.