### PR TITLE
crypto: Mark all new SenderData info as non-legacy

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine/tests/megolm_sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/megolm_sender_data.rs
@@ -66,7 +66,7 @@ async fn test_receive_megolm_session_from_unknown_device() {
     assert_matches!(
         session.sender_data,
         SenderData::UnknownDevice {legacy_session, owner_check_failed} => {
-            assert!(legacy_session); // TODO: change when https://github.com/matrix-org/matrix-rust-sdk/pull/3785 lands
+            assert!(!legacy_session);
             assert!(!owner_check_failed);
         }
     );
@@ -102,8 +102,8 @@ async fn test_receive_megolm_session_from_known_device() {
 
     assert_matches!(
         session.sender_data,
-        SenderData::DeviceInfo {legacy_session, ..} => {
-            assert!(legacy_session); // TODO: change when https://github.com/matrix-org/matrix-rust-sdk/pull/3785 lands
+        SenderData::DeviceInfo { legacy_session, .. } => {
+            assert!(!legacy_session);
         }
     );
 }
@@ -158,7 +158,7 @@ async fn test_update_unknown_device_senderdata_on_keys_query() {
     assert_matches!(
         session.sender_data,
         SenderData::DeviceInfo {legacy_session, ..} => {
-            assert!(legacy_session); // TODO: change when https://github.com/matrix-org/matrix-rust-sdk/pull/3785 lands
+            assert!(!legacy_session);
         }
     );
 }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -771,7 +771,7 @@ mod tests {
                 "signing_key":{"ed25519":"wTRTdz4rn4EY+68cKPzpMdQ6RAlg7T8cbTmEjaXuUww"},
                 "sender_data":{
                     "UnknownDevice":{
-                        "legacy_session":true
+                        "legacy_session":false
                     }
                 },
                 "room_id":"!test:localhost",

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -95,26 +95,12 @@ pub enum SenderData {
 impl SenderData {
     /// Create a [`SenderData`] which contains no device info.
     pub fn unknown() -> Self {
-        Self::UnknownDevice {
-            // TODO: when we have implemented all of SenderDataFinder,
-            // legacy_session should be set to false, but for now we leave
-            // it as true because we might lose device info while
-            // this code is still in transition.
-            legacy_session: true,
-            owner_check_failed: false,
-        }
+        Self::UnknownDevice { legacy_session: false, owner_check_failed: false }
     }
 
     /// Create a [`SenderData`] which contains device info.
     pub fn device_info(device_keys: DeviceKeys) -> Self {
-        Self::DeviceInfo {
-            device_keys,
-            // TODO: when we have implemented all of SenderDataFinder,
-            // legacy_session should be set to false, but for now we leave
-            // it as true because we might lose device info while
-            // this code is still in transition.
-            legacy_session: true,
-        }
+        Self::DeviceInfo { device_keys, legacy_session: false }
     }
 
     /// Create a [`SenderData`] with a known but unverified sender, where the
@@ -209,9 +195,8 @@ impl SenderData {
 /// Used when deserialising and the sender_data property is missing.
 /// If we are deserialising an InboundGroupSession session with missing
 /// sender_data, this must be a legacy session (i.e. it was created before we
-/// started tracking sender data). We set its legacy flag to true, and set it up
-/// to be retried soon, so we can populate it with trust information if it is
-/// available.
+/// started tracking sender data). We set its legacy flag to true, so we can
+/// populate it with trust information if it is available later.
 impl Default for SenderData {
     fn default() -> Self {
         Self::legacy()


### PR DESCRIPTION
Since we now have a clear idea of the structure, and anything we create now should be usable in future.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3544

Explanation:

This whole feature (SenderData) is about allowing us to know whether a session was created by a trusted person.

Sessions that we created in the past before this feature existed need to be treated differently: we can't just consider them all untrusted.

The `legacy_session` flag is our way of knowing that this session was created before we introduced the feature, or that we have imported the session from somewhere that does not support storing this information (at time of writing, neither key storage nor import/export persist the SenderData info).

This means that we can choose to hide messages that we don't trust, but still display messages from legacy sessions (if we want to).

Up until now, we have been marking all sessions as legacy, but since the feature is now complete, we can start saying new sessions are not legacy.