### PR TITLE
Shields: Add a code field for easier mapping of the state.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,6 +3299,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uniffi",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = { workspace = true }
 futures-util = { workspace = true }
 hmac = "0.12.1"
 http = { workspace = true }
-matrix-sdk-common = { workspace = true }
+matrix-sdk-common = { workspace = true, features = ["uniffi"] }
 pbkdf2 = "0.12.2"
 rand = { workspace = true }
 ruma = { workspace = true }
@@ -35,7 +35,7 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # keep in sync with uniffi dependency in matrix-sdk-ffi, and uniffi_bindgen in ffi CI job
-uniffi = { workspace = true , features = ["cli"]}
+uniffi = { workspace = true, features = ["cli"] }
 vodozemac = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -33,7 +33,9 @@ pub use error::{
 use js_int::UInt;
 pub use logger::{set_logger, Logger};
 pub use machine::{KeyRequestPair, OlmMachine, SignatureVerification};
-use matrix_sdk_common::deserialized_responses::ShieldState as RustShieldState;
+use matrix_sdk_common::deserialized_responses::{
+    ShieldState as RustShieldState, ShieldStateColor as RustShieldStateColor,
+};
 use matrix_sdk_crypto::{
     olm::{IdentityKeys, InboundGroupSession, SenderData, Session},
     store::{Changes, CryptoStore, PendingChanges, RoomSettings as RustRoomSettings},
@@ -731,14 +733,32 @@ pub struct ShieldState {
 
 impl From<RustShieldState> for ShieldState {
     fn from(value: RustShieldState) -> Self {
-        match value {
-            RustShieldState::Red { message } => {
-                Self { color: ShieldColor::Red, message: Some(message.to_owned()) }
+        match &value {
+            RustShieldState::AuthenticityNotGuaranteed { color } => {
+                Self { color: color.into(), message: value.message().map(ToOwned::to_owned) }
             }
-            RustShieldState::Grey { message } => {
-                Self { color: ShieldColor::Grey, message: Some(message.to_owned()) }
+            RustShieldState::UnknownDevice { color } => {
+                Self { color: color.into(), message: value.message().map(ToOwned::to_owned) }
+            }
+            RustShieldState::UnsignedDevice { color } => {
+                Self { color: color.into(), message: value.message().map(ToOwned::to_owned) }
+            }
+            RustShieldState::UnverifiedIdentity { color } => {
+                Self { color: color.into(), message: value.message().map(ToOwned::to_owned) }
+            }
+            RustShieldState::SentInClear { color } => {
+                Self { color: color.into(), message: value.message().map(ToOwned::to_owned) }
             }
             RustShieldState::None => Self { color: ShieldColor::None, message: None },
+        }
+    }
+}
+
+impl From<&RustShieldStateColor> for ShieldColor {
+    fn from(value: &RustShieldStateColor) -> Self {
+        match value {
+            RustShieldStateColor::Red => ShieldColor::Red,
+            RustShieldStateColor::Grey => ShieldColor::Grey,
         }
     }
 }

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -33,9 +33,7 @@ pub use error::{
 use js_int::UInt;
 pub use logger::{set_logger, Logger};
 pub use machine::{KeyRequestPair, OlmMachine, SignatureVerification};
-use matrix_sdk_common::deserialized_responses::{
-    ShieldState as RustShieldState, ShieldStateColor as RustShieldStateColor,
-};
+use matrix_sdk_common::deserialized_responses::{ShieldState as RustShieldState, ShieldStateCode};
 use matrix_sdk_crypto::{
     olm::{IdentityKeys, InboundGroupSession, SenderData, Session},
     store::{Changes, CryptoStore, PendingChanges, RoomSettings as RustRoomSettings},
@@ -728,37 +726,24 @@ pub enum ShieldColor {
 #[allow(missing_docs)]
 pub struct ShieldState {
     color: ShieldColor,
+    code: Option<ShieldStateCode>,
     message: Option<String>,
 }
 
 impl From<RustShieldState> for ShieldState {
     fn from(value: RustShieldState) -> Self {
-        match &value {
-            RustShieldState::AuthenticityNotGuaranteed { color } => {
-                Self { color: color.into(), message: value.message().map(ToOwned::to_owned) }
-            }
-            RustShieldState::UnknownDevice { color } => {
-                Self { color: color.into(), message: value.message().map(ToOwned::to_owned) }
-            }
-            RustShieldState::UnsignedDevice { color } => {
-                Self { color: color.into(), message: value.message().map(ToOwned::to_owned) }
-            }
-            RustShieldState::UnverifiedIdentity { color } => {
-                Self { color: color.into(), message: value.message().map(ToOwned::to_owned) }
-            }
-            RustShieldState::SentInClear { color } => {
-                Self { color: color.into(), message: value.message().map(ToOwned::to_owned) }
-            }
-            RustShieldState::None => Self { color: ShieldColor::None, message: None },
-        }
-    }
-}
-
-impl From<&RustShieldStateColor> for ShieldColor {
-    fn from(value: &RustShieldStateColor) -> Self {
         match value {
-            RustShieldStateColor::Red => ShieldColor::Red,
-            RustShieldStateColor::Grey => ShieldColor::Grey,
+            RustShieldState::Red { code, message } => Self {
+                color: ShieldColor::Red,
+                code: Some(code),
+                message: Some(message.to_owned()),
+            },
+            RustShieldState::Grey { code, message } => Self {
+                color: ShieldColor::Grey,
+                code: Some(code),
+                message: Some(message.to_owned()),
+            },
+            RustShieldState::None => Self { color: ShieldColor::None, code: None, message: None },
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -24,7 +24,7 @@ use matrix_sdk::{
         AttachmentConfig, AttachmentInfo, BaseAudioInfo, BaseFileInfo, BaseImageInfo,
         BaseThumbnailInfo, BaseVideoInfo, Thumbnail,
     },
-    deserialized_responses::ShieldState as RustShieldState,
+    deserialized_responses::ShieldState,
     Error,
 };
 use matrix_sdk_ui::timeline::{
@@ -923,28 +923,9 @@ impl From<&matrix_sdk_ui::timeline::EventSendState> for EventSendState {
     }
 }
 
-/// Recommended decorations for decrypted messages, representing the message's
-/// authenticity properties.
-#[derive(uniffi::Enum)]
-pub enum ShieldState {
-    /// A red shield with a tooltip containing the associated message should be
-    /// presented.
-    Red { message: String },
-    /// A grey shield with a tooltip containing the associated message should be
-    /// presented.
-    Grey { message: String },
-    /// No shield should be presented.
-    None,
-}
-
-impl From<RustShieldState> for ShieldState {
-    fn from(value: RustShieldState) -> Self {
-        match value {
-            RustShieldState::Red { message } => Self::Red { message: message.to_owned() },
-            RustShieldState::Grey { message } => Self::Grey { message: message.to_owned() },
-            RustShieldState::None => Self::None,
-        }
-    }
+#[uniffi::export]
+pub fn message_for_shield_state(shield_state: ShieldState) -> Option<String> {
+    shield_state.message().map(ToOwned::to_owned)
 }
 
 #[derive(uniffi::Object)]

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -24,7 +24,7 @@ use matrix_sdk::{
         AttachmentConfig, AttachmentInfo, BaseAudioInfo, BaseFileInfo, BaseImageInfo,
         BaseThumbnailInfo, BaseVideoInfo, Thumbnail,
     },
-    deserialized_responses::ShieldState,
+    deserialized_responses::{ShieldState as RustShieldState, ShieldStateCode},
     Error,
 };
 use matrix_sdk_ui::timeline::{
@@ -923,9 +923,32 @@ impl From<&matrix_sdk_ui::timeline::EventSendState> for EventSendState {
     }
 }
 
-#[uniffi::export]
-pub fn message_for_shield_state(shield_state: ShieldState) -> Option<String> {
-    shield_state.message().map(ToOwned::to_owned)
+/// Recommended decorations for decrypted messages, representing the message's
+/// authenticity properties.
+#[derive(uniffi::Enum)]
+pub enum ShieldState {
+    /// A red shield with a tooltip containing the associated message should be
+    /// presented.
+    Red { code: ShieldStateCode, message: String },
+    /// A grey shield with a tooltip containing the associated message should be
+    /// presented.
+    Grey { code: ShieldStateCode, message: String },
+    /// No shield should be presented.
+    None,
+}
+
+impl From<RustShieldState> for ShieldState {
+    fn from(value: RustShieldState) -> Self {
+        match value {
+            RustShieldState::Red { code, message } => {
+                Self::Red { code, message: message.to_owned() }
+            }
+            RustShieldState::Grey { code, message } => {
+                Self::Grey { code, message: message.to_owned() }
+            }
+            RustShieldState::None => Self::None,
+        }
+    }
 }
 
 #[derive(uniffi::Object)]

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -25,7 +25,7 @@ experimental-sliding-sync = [
     "ruma/unstable-msc3575",
     "ruma/unstable-simplified-msc3575",
 ]
-uniffi = ["dep:uniffi", "matrix-sdk-crypto?/uniffi"]
+uniffi = ["dep:uniffi", "matrix-sdk-crypto?/uniffi", "matrix-sdk-common/uniffi"]
 
 # "message-ids" feature doesn't do anything and is deprecated.
 message-ids = []

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -17,6 +17,7 @@ targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [features]
 js = ["instant/wasm-bindgen", "wasm-bindgen-futures"]
+uniffi = ["dep:uniffi"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -28,6 +29,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true, features = ["rt", "time"] }
+uniffi = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 futures-util = { workspace = true, features = ["channel"] }

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -97,3 +97,6 @@ macro_rules! boxed_into_future {
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 #[cfg(not(target_arch = "wasm32"))]
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!();

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -2388,8 +2388,8 @@ pub(crate) mod tests {
     use futures_util::{pin_mut, FutureExt, StreamExt};
     use itertools::Itertools;
     use matrix_sdk_common::deserialized_responses::{
-        DeviceLinkProblem, ShieldState, UnableToDecryptInfo, UnsignedDecryptionResult,
-        UnsignedEventLocation, VerificationLevel, VerificationState,
+        DeviceLinkProblem, EncryptionInfo, ShieldState, ShieldStateColor, UnableToDecryptInfo,
+        UnsignedDecryptionResult, UnsignedEventLocation, VerificationLevel, VerificationState,
     };
     use matrix_sdk_test::{async_test, message_like_event_content, test_json};
     use ruma::{
@@ -3346,15 +3346,13 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_decryption_verification_state() {
-        macro_rules! assert_shield {
-            ($foo: ident, $strict: ident, $lax: ident) => {
-                let lax = $foo.verification_state.to_shield_state_lax();
-                let strict = $foo.verification_state.to_shield_state_strict();
+        let assert_shield = |info: EncryptionInfo, strict: ShieldState, lax: ShieldState| {
+            let info_lax = info.verification_state.to_shield_state_lax();
+            let info_strict = info.verification_state.to_shield_state_strict();
 
-                assert_matches!(lax, ShieldState::$lax { .. });
-                assert_matches!(strict, ShieldState::$strict { .. });
-            };
-        }
+            assert_eq!(info_lax, lax);
+            assert_eq!(info_strict, strict);
+        };
         let (alice, bob) =
             get_machine_pair_with_setup_sessions_test_helper(alice_id(), user_id(), false).await;
         let room_id = room_id!("!test:example.org");
@@ -3411,7 +3409,11 @@ pub(crate) mod tests {
             encryption_info.verification_state
         );
 
-        assert_shield!(encryption_info, Red, Red);
+        assert_shield(
+            encryption_info,
+            ShieldState::UnverifiedIdentity { color: ShieldStateColor::Red },
+            ShieldState::UnsignedDevice { color: ShieldStateColor::Red },
+        );
 
         // get_room_event_encryption_info should return the same information
         let encryption_info = bob.get_room_event_encryption_info(&event, room_id).await.unwrap();
@@ -3419,7 +3421,11 @@ pub(crate) mod tests {
             VerificationState::Unverified(VerificationLevel::UnsignedDevice),
             encryption_info.verification_state
         );
-        assert_shield!(encryption_info, Red, Red);
+        assert_shield(
+            encryption_info,
+            ShieldState::UnverifiedIdentity { color: ShieldStateColor::Red },
+            ShieldState::UnsignedDevice { color: ShieldStateColor::Red },
+        );
 
         // Local trust state has no effect
         bob.get_device(alice.user_id(), alice_device_id(), None)
@@ -3434,7 +3440,11 @@ pub(crate) mod tests {
             VerificationState::Unverified(VerificationLevel::UnsignedDevice),
             encryption_info.verification_state
         );
-        assert_shield!(encryption_info, Red, Red);
+        assert_shield(
+            encryption_info,
+            ShieldState::UnverifiedIdentity { color: ShieldStateColor::Red },
+            ShieldState::UnsignedDevice { color: ShieldStateColor::Red },
+        );
 
         setup_cross_signing_for_machine_test_helper(&alice, &bob).await;
         let bob_id_from_alice = alice.get_identity(bob.user_id(), None).await.unwrap();
@@ -3449,7 +3459,11 @@ pub(crate) mod tests {
             VerificationState::Unverified(VerificationLevel::UnsignedDevice),
             encryption_info.verification_state
         );
-        assert_shield!(encryption_info, Red, Red);
+        assert_shield(
+            encryption_info,
+            ShieldState::UnverifiedIdentity { color: ShieldStateColor::Red },
+            ShieldState::UnsignedDevice { color: ShieldStateColor::Red },
+        );
 
         // Let alice sign her device
         sign_alice_device_for_machine_test_helper(&alice, &bob).await;
@@ -3461,7 +3475,11 @@ pub(crate) mod tests {
             encryption_info.verification_state
         );
 
-        assert_shield!(encryption_info, Red, None);
+        assert_shield(
+            encryption_info,
+            ShieldState::UnverifiedIdentity { color: ShieldStateColor::Red },
+            ShieldState::None,
+        );
 
         // Given alice is verified
         mark_alice_identity_as_verified_test_helper(&alice, &bob).await;
@@ -3476,7 +3494,7 @@ pub(crate) mod tests {
         let encryption_info = bob.get_room_event_encryption_info(&event, room_id).await.unwrap();
         // Then it should say Verified
         assert_eq!(VerificationState::Verified, encryption_info.verification_state);
-        assert_shield!(encryption_info, None, None);
+        assert_shield(encryption_info, ShieldState::None, ShieldState::None);
 
         // And the updated SenderData should have been saved into the store.
         let session = load_session(&bob, room_id, &event).await.unwrap().unwrap();
@@ -3497,7 +3515,11 @@ pub(crate) mod tests {
             encryption_info.verification_state
         );
 
-        assert_shield!(encryption_info, Red, Grey);
+        assert_shield(
+            encryption_info,
+            ShieldState::AuthenticityNotGuaranteed { color: ShieldStateColor::Red },
+            ShieldState::AuthenticityNotGuaranteed { color: ShieldStateColor::Grey },
+        );
     }
 
     async fn load_session(

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -22,7 +22,7 @@ use matrix_sdk::{
     Client, Error,
 };
 use matrix_sdk_base::{
-    deserialized_responses::{SyncTimelineEvent, SENT_IN_CLEAR},
+    deserialized_responses::{ShieldStateColor, SyncTimelineEvent},
     latest_event::LatestEvent,
 };
 use once_cell::sync::Lazy;
@@ -382,7 +382,7 @@ impl EventTimelineItem {
                     Some(info.verification_state.to_shield_state_lax())
                 }
             }
-            None => Some(ShieldState::Grey { message: SENT_IN_CLEAR }),
+            None => Some(ShieldState::SentInClear { color: ShieldStateColor::Grey }),
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -382,7 +382,7 @@ impl EventTimelineItem {
                     Some(info.verification_state.to_shield_state_lax())
                 }
             }
-            None => Some(ShieldState::Grey {
+            None => Some(ShieldState::Red {
                 code: ShieldStateCode::SentInClear,
                 message: SENT_IN_CLEAR,
             }),

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -22,7 +22,7 @@ use matrix_sdk::{
     Client, Error,
 };
 use matrix_sdk_base::{
-    deserialized_responses::{ShieldStateColor, SyncTimelineEvent},
+    deserialized_responses::{ShieldStateCode, SyncTimelineEvent, SENT_IN_CLEAR},
     latest_event::LatestEvent,
 };
 use once_cell::sync::Lazy;
@@ -382,7 +382,10 @@ impl EventTimelineItem {
                     Some(info.verification_state.to_shield_state_lax())
                 }
             }
-            None => Some(ShieldState::SentInClear { color: ShieldStateColor::Grey }),
+            None => Some(ShieldState::Grey {
+                code: ShieldStateCode::SentInClear,
+                message: SENT_IN_CLEAR,
+            }),
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
-use matrix_sdk_base::deserialized_responses::ShieldState;
+use matrix_sdk_base::deserialized_responses::{ShieldState, ShieldStateColor};
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE};
 use ruma::{
     event_id,
@@ -41,7 +41,7 @@ async fn test_sent_in_clear_shield() {
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let shield = item.as_event().unwrap().get_shield(false);
-    assert_eq!(shield, Some(ShieldState::Grey { message: "Sent in clear." }));
+    assert_eq!(shield, Some(ShieldState::SentInClear { color: ShieldStateColor::Grey }));
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
-use matrix_sdk_base::deserialized_responses::{ShieldState, ShieldStateColor};
+use matrix_sdk_base::deserialized_responses::{ShieldState, ShieldStateCode};
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE};
 use ruma::{
     event_id,
@@ -41,7 +41,10 @@ async fn test_sent_in_clear_shield() {
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let shield = item.as_event().unwrap().get_shield(false);
-    assert_eq!(shield, Some(ShieldState::SentInClear { color: ShieldStateColor::Grey }));
+    assert_eq!(
+        shield,
+        Some(ShieldState::Grey { code: ShieldStateCode::SentInClear, message: "Sent in clear." })
+    );
 }
 
 #[async_test]
@@ -111,5 +114,8 @@ async fn test_local_sent_in_clear_shield() {
     // Then the remote echo should now be showing the shield.
     assert!(!event_item.is_local_echo());
     let shield = event_item.get_shield(false);
-    assert_eq!(shield, Some(ShieldState::Grey { message: "Sent in clear." }));
+    assert_eq!(
+        shield,
+        Some(ShieldState::Grey { code: ShieldStateCode::SentInClear, message: "Sent in clear." })
+    );
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
@@ -43,7 +43,7 @@ async fn test_sent_in_clear_shield() {
     let shield = item.as_event().unwrap().get_shield(false);
     assert_eq!(
         shield,
-        Some(ShieldState::Grey { code: ShieldStateCode::SentInClear, message: "Sent in clear." })
+        Some(ShieldState::Red { code: ShieldStateCode::SentInClear, message: "Sent in clear." })
     );
 }
 
@@ -116,6 +116,6 @@ async fn test_local_sent_in_clear_shield() {
     let shield = event_item.get_shield(false);
     assert_eq!(
         shield,
-        Some(ShieldState::Grey { code: ShieldStateCode::SentInClear, message: "Sent in clear." })
+        Some(ShieldState::Red { code: ShieldStateCode::SentInClear, message: "Sent in clear." })
     );
 }


### PR DESCRIPTION
Following on from the conversation over on https://github.com/element-hq/element-x-ios/pull/3051#discussion_r1680872736 this PR adds a `code` field to the `ShieldState` so that it can be easily mapped by apps that need to provide a translated description to the user.

Note: This PR also adds uniffi to the matrix_sdk_common crate to avoid a duplicate type in the FFI for the code.