### PR TITLE
timeline: re-export `ReactionsByKeyBySender` and `ReactionInfo` types

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -90,7 +90,7 @@ pub use self::{
     event_item::{
         AnyOtherFullStateEventContent, EncryptedMessage, EventItemOrigin, EventSendState,
         EventTimelineItem, InReplyToDetails, MemberProfileChange, MembershipChange, Message,
-        OtherState, Profile, ReactionsByKeyBySender, ReactionInfo, RepliedToEvent,
+        OtherState, Profile, ReactionInfo, ReactionsByKeyBySender, RepliedToEvent,
         RoomMembershipChange, Sticker, TimelineDetails, TimelineEventItemId, TimelineItemContent,
     },
     event_type_filter::TimelineEventTypeFilter,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -90,8 +90,8 @@ pub use self::{
     event_item::{
         AnyOtherFullStateEventContent, EncryptedMessage, EventItemOrigin, EventSendState,
         EventTimelineItem, InReplyToDetails, MemberProfileChange, MembershipChange, Message,
-        OtherState, Profile, RepliedToEvent, RoomMembershipChange, Sticker, TimelineDetails,
-        TimelineEventItemId, TimelineItemContent,
+        OtherState, Profile, ReactionsByKeyBySender, ReactionInfo, RepliedToEvent,
+        RoomMembershipChange, Sticker, TimelineDetails, TimelineEventItemId, TimelineItemContent,
     },
     event_type_filter::TimelineEventTypeFilter,
     inner::default_event_filter,


### PR DESCRIPTION
This tiny change allows one to easily name the return type of `EventTimelineItem::reactions()` such that you can use it in a function signature. Same goes for the `ReactionInfo` type.

I think this was likely just a small oversight in recent changes to the reactions API, so hopefully it's not controversial.

Without this, it's impossible to write a function that uses `ReactionsByKeyBySender` or `ReactionInfo` in the signature.

Signed-off-by: Kevin Boos <kevinaboos@gmail.com>
