### PR TITLE
Identity reset backup fixes

### DIFF
--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -203,11 +203,12 @@ impl Backups {
                 self.set_state(BackupState::Unknown);
 
                 info!("Backup successfully disabled and deleted");
+
+                Ok(())
             } else {
                 info!("Backup is not enabled, can't disable it");
+                Err(Error::BackupNotEnabled)
             }
-
-            Ok(())
         };
 
         let result = future.await;

--- a/crates/matrix-sdk/src/encryption/recovery/mod.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/mod.rs
@@ -394,7 +394,7 @@ impl Recovery {
     /// # anyhow::Ok(()) };
     /// ```
     pub async fn reset_identity(&self) -> Result<Option<IdentityResetHandle>> {
-        self.client.encryption().backups().disable().await?; // 1.
+        self.client.encryption().backups().disable_and_delete().await?; // 1.
 
         // 2. (We can't delete account data events)
         self.client.account().set_account_data(SecretStorageDisabledContent {}).await?;

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -360,6 +360,10 @@ pub enum Error {
     /// An error coming from the event cache subsystem.
     #[error(transparent)]
     EventCache(#[from] EventCacheError),
+
+    /// Backups are not enabled
+    #[error("backups are not enabled")]
+    BackupNotEnabled,
 }
 
 #[rustfmt::skip] // stop rustfmt breaking the `<code>` in docs across multiple lines


### PR DESCRIPTION
This PR handles 2 different issues:
1) The normal `backups().disable` method does not delete the remote backup if the backups haven't been setup yet locally
2) and it doesn't throw an error or reset the backup state when that happens

We've introduced a new `delete_backup` method what **will** delete remote backups and that can be used from the identity reset flows to correctly setup the fresh session.