### PR TITLE
sdk: add global `PinnedEventCache` instead of having a single instance per timeline

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -247,6 +247,11 @@ impl Room {
         Ok(Timeline::new(timeline))
     }
 
+    pub async fn clear_pinned_events_cache(&self) {
+        let pinned_event_ids = self.inner.pinned_event_ids();
+        self.inner.client().pinned_event_cache().remove_bulk(&pinned_event_ids).await;
+    }
+
     pub fn is_encrypted(&self) -> Result<bool, ClientError> {
         Ok(RUNTIME.block_on(self.inner.is_encrypted())?)
     }

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -150,6 +150,7 @@ impl TimelineBuilder {
 
         let client = room.client();
         let event_cache = client.event_cache();
+        let pinned_event_cache = Arc::new(client.pinned_event_cache().clone());
 
         // Subscribe the event cache to sync responses, in case we hadn't done it yet.
         event_cache.subscribe()?;
@@ -171,7 +172,7 @@ impl TimelineBuilder {
         )
         .with_settings(settings);
 
-        let has_events = inner.init_focus(&room_event_cache).await?;
+        let has_events = inner.init_focus(&room_event_cache, &pinned_event_cache).await?;
 
         let room = inner.room();
         let client = room.client();
@@ -180,9 +181,10 @@ impl TimelineBuilder {
             let mut pinned_event_ids_stream = room.pinned_event_ids_stream();
             Some(spawn({
                 let inner = inner.clone();
+                let cache = pinned_event_cache.clone();
                 async move {
                     while pinned_event_ids_stream.next().await.is_some() {
-                        if let Ok(events) = inner.pinned_events_load_events().await {
+                        if let Ok(events) = inner.pinned_events_load_events(&cache).await {
                             inner
                                 .replace_with_initial_remote_events(
                                     events,
@@ -267,7 +269,7 @@ impl TimelineBuilder {
                             // events, update the pinned events cache with them, reload the list of pinned event ids and reload
                             // the list of pinned events with this info.
                             if let TimelineFocus::PinnedEvents { .. } = &*focus.clone() {
-                                if let Ok(events) = inner.pinned_events_load_events().await {
+                                if let Ok(events) = inner.pinned_events_load_events(&pinned_event_cache).await {
                                     inner.replace_with_initial_remote_events(events, RemoteEventOrigin::Sync).await;
                                 }
                             } else {

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -354,6 +354,20 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         }
     }
 
+    pub(crate) async fn pinned_events_update(
+        &self,
+        events: Vec<SyncTimelineEvent>,
+        pinned_event_cache: &PinnedEventCache,
+    ) -> Option<Result<Vec<SyncTimelineEvent>, PinnedEventsLoaderError>> {
+        let focus_guard = self.focus.read().await;
+
+        if let TimelineFocusData::PinnedEvents { loader } = &*focus_guard {
+            loader.update_if_needed(events, pinned_event_cache).await
+        } else {
+            Some(Err(PinnedEventsLoaderError::TimelineFocusNotPinnedEvents))
+        }
+    }
+
     /// Run a backward pagination (in focused mode) and append the results to
     /// the timeline.
     ///

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -26,6 +26,7 @@ use matrix_sdk::crypto::OlmMachine;
 use matrix_sdk::{
     deserialized_responses::SyncTimelineEvent,
     event_cache::{paginator::Paginator, RoomEventCache},
+    pinned_events_cache::PinnedEventCache,
     send_queue::{LocalEcho, RoomSendQueueUpdate, SendHandle},
     Result, Room,
 };
@@ -282,6 +283,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
     pub(super) async fn init_focus(
         &self,
         room_event_cache: &RoomEventCache,
+        pinned_event_cache: &PinnedEventCache,
     ) -> Result<bool, Error> {
         let focus_guard = self.focus.read().await;
 
@@ -319,7 +321,10 @@ impl<P: RoomDataProvider> TimelineInner<P> {
             }
 
             TimelineFocusData::PinnedEvents { loader } => {
-                let loaded_events = loader.load_events().await.map_err(Error::PinnedEventsError)?;
+                let loaded_events = loader
+                    .load_events(pinned_event_cache)
+                    .await
+                    .map_err(Error::PinnedEventsError)?;
 
                 drop(focus_guard);
 
@@ -338,11 +343,12 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 
     pub(crate) async fn pinned_events_load_events(
         &self,
+        pinned_event_cache: &PinnedEventCache,
     ) -> Result<Vec<SyncTimelineEvent>, PinnedEventsLoaderError> {
         let focus_guard = self.focus.read().await;
 
         if let TimelineFocusData::PinnedEvents { loader } = &*focus_guard {
-            loader.load_events().await
+            loader.load_events(pinned_event_cache).await
         } else {
             Err(PinnedEventsLoaderError::TimelineFocusNotPinnedEvents)
         }

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -11,6 +11,8 @@ use thiserror::Error;
 use tokio::sync::Semaphore;
 use tracing::info;
 
+const MAX_CONCURRENT_REQUESTS: usize = 10;
+
 /// Utility to load the pinned events in a room.
 pub struct PinnedEventsLoader {
     room: Arc<Box<dyn PinnedEventsRoom>>,
@@ -21,7 +23,11 @@ pub struct PinnedEventsLoader {
 impl PinnedEventsLoader {
     /// Creates a new `PinnedEventsLoader` instance.
     pub fn new(room: Box<dyn PinnedEventsRoom>, max_events_to_load: usize) -> Self {
-        Self { room: Arc::new(room), max_events_to_load, max_concurrent_requests: 10 }
+        Self {
+            room: Arc::new(room),
+            max_events_to_load,
+            max_concurrent_requests: MAX_CONCURRENT_REQUESTS,
+        }
     }
 
     /// Loads the pinned events in this room, using the cache first and then

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -116,7 +116,7 @@ impl PinnedEventsLoader {
         &self,
         events: Vec<impl Into<SyncTimelineEvent>>,
         cache: &PinnedEventCache,
-    ) -> Option<Vec<SyncTimelineEvent>> {
+    ) -> Option<Result<Vec<SyncTimelineEvent>, PinnedEventsLoaderError>> {
         let mut to_update = Vec::new();
         for ev in events {
             let ev = ev.into();
@@ -129,7 +129,7 @@ impl PinnedEventsLoader {
 
         if !to_update.is_empty() {
             cache.set_bulk(&to_update).await;
-            self.load_events(cache).await.ok()
+            Some(self.load_events(cache).await)
         } else {
             None
         }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -88,6 +88,7 @@ use crate::{
     http_client::HttpClient,
     matrix_auth::MatrixAuth,
     notification_settings::NotificationSettings,
+    pinned_events_cache::PinnedEventCache,
     room_preview::RoomPreview,
     send_queue::SendQueueData,
     sync::{RoomUpdate, SyncResponse},
@@ -286,6 +287,9 @@ pub(crate) struct ClientInner {
     /// It becomes active when [`EventCache::subscribe`] is called.
     pub(crate) event_cache: OnceCell<EventCache>,
 
+    /// A central cache for pinned events.
+    pub(crate) pinned_event_cache: PinnedEventCache,
+
     /// End-to-end encryption related state.
     #[cfg(feature = "e2e-encryption")]
     pub(crate) e2ee: EncryptionData,
@@ -341,6 +345,7 @@ impl ClientInner {
             respect_login_well_known,
             sync_beat: event_listener::Event::new(),
             event_cache,
+            pinned_event_cache: PinnedEventCache::new(),
             send_queue_data: send_queue,
             #[cfg(feature = "e2e-encryption")]
             e2ee: EncryptionData::new(encryption_settings),
@@ -2228,6 +2233,11 @@ impl Client {
     pub fn event_cache(&self) -> &EventCache {
         // SAFETY: always initialized in the `Client` ctor.
         self.inner.event_cache.get().unwrap()
+    }
+
+    /// The [`PinnedEventCache`] instance for this [`Client`].
+    pub fn pinned_event_cache(&self) -> &PinnedEventCache {
+        &self.inner.pinned_event_cache
     }
 }
 

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -96,5 +96,8 @@ uniffi::setup_scaffolding!();
 #[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
 
+/// Contains the pinned events cache implementation.
+pub mod pinned_events_cache;
+
 #[cfg(test)]
 matrix_sdk_test::init_tracing_for_tests!();

--- a/crates/matrix-sdk/src/pinned_events_cache.rs
+++ b/crates/matrix-sdk/src/pinned_events_cache.rs
@@ -1,0 +1,50 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
+use ruma::{EventId, OwnedEventId};
+use tokio::sync::RwLock;
+
+/// Cache used to store the events associated with pinned event ids.
+///
+/// Cloning is shallow, and thus is cheap to do.
+#[derive(Clone, Debug)]
+pub struct PinnedEventCache {
+    inner: Arc<InnerPinnedEventCache>,
+}
+
+impl PinnedEventCache {
+    /// Creates a new empty pinned events cache.
+    pub fn new() -> Self {
+        Self { inner: Arc::new(InnerPinnedEventCache { events: Default::default() }) }
+    }
+
+    /// Gets the event associated with the provided event id, if it exists in
+    /// the cache.
+    pub async fn get(&self, event_id: &EventId) -> Option<SyncTimelineEvent> {
+        let cache = self.inner.events.read().await;
+        cache.get(event_id).cloned()
+    }
+
+    /// Adds a list of pinned events to the cache in a performant way.
+    pub async fn set_bulk(&self, events: &Vec<SyncTimelineEvent>) {
+        let mut cache = self.inner.events.write().await;
+        for ev in events {
+            if let Some(ev_id) = ev.event_id() {
+                cache.insert(ev_id.to_owned(), ev.clone());
+            }
+        }
+    }
+}
+
+impl Default for PinnedEventCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The non-cloneable implementation of the cache.
+#[derive(Debug)]
+struct InnerPinnedEventCache {
+    /// The pinned events.
+    events: RwLock<BTreeMap<OwnedEventId, SyncTimelineEvent>>,
+}

--- a/crates/matrix-sdk/src/pinned_events_cache.rs
+++ b/crates/matrix-sdk/src/pinned_events_cache.rs
@@ -34,6 +34,15 @@ impl PinnedEventCache {
             }
         }
     }
+
+    /// Removes the pinned events associated to the provided event ids from the
+    /// cache.
+    pub async fn remove_bulk(&self, event_ids: &Vec<OwnedEventId>) {
+        let mut cache = self.inner.events.write().await;
+        for ev_id in event_ids {
+            cache.remove(ev_id);
+        }
+    }
 }
 
 impl Default for PinnedEventCache {


### PR DESCRIPTION
## Changes

- Moves the `PinnedEventCache` from `sdk-ui` to `sdk` so it can work in the same way as `EventCache`, attached to a `Client`.
- Remove the `PinnedEventCache` included inside `PinnedEventsLoader`, now you need to provide a cache for the loading event methods.
- Add a way to clear the cached pinned events for a room.
- Add a test to verify this change works as expected.

## Why

Loading pinned events is expensive and slow-ish for rooms with lots of them since we have no bulk `/event` or `/context` endpoint to load a set of events given their event ids, and we need to perform those requests concurrently. To avoid this, a cache was added, but it only worked for events you had already loaded in the same `Timeline` instance so if you exited the room and entered it again you'd still have to reload every single pinned event again.

With the new cache implementation pinned events are kept in memory so reloading them when returning to an already visited room is almost instant. However, this means the events are kept in memory indefinitely so we may want to either:

- Move this cache to a disk-based one. Which will probably be quite complex although probably the most correct way to do this. I have no idea how to do this at the moment, and I'd rather wait until someone with more knowledge about the SDK can tell me if the idea makes any sense.
- Add a way to clear the cache for a room at will: for this PR I've implemented it in `ffi::Room::clear_pinned_events_cache`.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
