### PR TITLE
Use NDK 27 for the Kotlin bindings

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -91,7 +91,7 @@ jobs:
         uses: nttld/setup-ndk@v1
         id: install-ndk
         with:
-          ndk-version: r25c
+          ndk-version: r27
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/bindings/matrix-sdk-ffi/build.rs
+++ b/bindings/matrix-sdk-ffi/build.rs
@@ -18,11 +18,11 @@ fn setup_x86_64_android_workaround() {
                 "Unsupported OS. You must use either Linux, MacOS or Windows to build the crate."
             ),
         };
-        const DEFAULT_CLANG_VERSION: &str = "14.0.7";
+        const DEFAULT_CLANG_VERSION: &str = "18";
         let clang_version =
             env::var("NDK_CLANG_VERSION").unwrap_or_else(|_| DEFAULT_CLANG_VERSION.to_owned());
         let linux_x86_64_lib_dir = format!(
-            "toolchains/llvm/prebuilt/{build_os}-x86_64/lib64/clang/{clang_version}/lib/linux/"
+            "toolchains/llvm/prebuilt/{build_os}-x86_64/lib/clang/{clang_version}/lib/linux/"
         );
         println!("cargo:rustc-link-search={android_ndk_home}/{linux_x86_64_lib_dir}");
         println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");


### PR DESCRIPTION
This seems to fix the Kotlin bindings issues we were seeing until now. And no more workaround needed it seems!

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
