### PR TITLE
Remove the Session cache from the cryptostore implementations

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -338,10 +338,6 @@ async fn save_changes(
     processed_steps += 1;
     listener(processed_steps, total_steps);
 
-    // The Sessions were created with incorrect device keys, so clear the cache
-    // so that they'll get recreated with correct ones.
-    store.clear_caches().await;
-
     Ok(())
 }
 

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -1528,17 +1528,6 @@ impl OlmMachine {
         }
         .into()
     }
-
-    /// Clear any in-memory caches because they may be out of sync with the
-    /// underlying data store.
-    ///
-    /// The crypto store layer is caching olm sessions for a given device.
-    /// When used in a multi-process context this cache will get outdated.
-    /// If the machine is used by another process, the cache must be
-    /// invalidating when the main process is resumed.
-    pub async fn clear_crypto_cache(&self) {
-        self.inner.clear_crypto_cache().await
-    }
 }
 
 impl OlmMachine {

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -256,7 +256,6 @@ impl BaseClient {
 
         // Recreate the `OlmMachine` and wipe the in-memory cache in the store
         // because we suspect it has stale data.
-        self.crypto_store.clear_caches().await;
         let olm_machine = OlmMachine::with_store(
             &session_meta.user_id,
             &session_meta.device_id,

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -32,6 +32,9 @@ Changes:
 
 Breaking changes:
 
+- Remove the method `OlmMachine::clear_crypto_cache()`, crypto stores are not
+  supposed to have any caches anymore.
+
 - Add a `custom_account` argument to the `OlmMachine::with_store()` method, this
   allows users to learn their identity keys before they get access to the user
   and device ID.

--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -96,7 +96,8 @@ impl DehydratedDevices {
         let user_identity = self.inner.store().private_identity();
 
         let account = Account::new_dehydrated(user_id);
-        let store = Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()));
+        let store =
+            Arc::new(CryptoStoreWrapper::new(user_id, account.device_id(), MemoryStore::new()));
 
         let verification_machine = VerificationMachine::new(
             account.static_data().clone(),

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1177,7 +1177,7 @@ mod tests {
         let device_id = DeviceId::new();
 
         let account = Account::with_device_id(&user_id, &device_id);
-        let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
+        let store = Arc::new(CryptoStoreWrapper::new(&user_id, &device_id, MemoryStore::new()));
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification =
             VerificationMachine::new(account.static_data.clone(), identity.clone(), store.clone());
@@ -1197,7 +1197,8 @@ mod tests {
         let another_device =
             DeviceData::from_account(&Account::with_device_id(&user_id, alice2_device_id()));
 
-        let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
+        let store =
+            Arc::new(CryptoStoreWrapper::new(&user_id, account.device_id(), MemoryStore::new()));
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification =
             VerificationMachine::new(account.static_data.clone(), identity.clone(), store.clone());

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -686,7 +686,8 @@ impl DeviceData {
         store: &CryptoStoreWrapper,
     ) -> OlmResult<Option<Session>> {
         if let Some(sender_key) = self.curve25519_key() {
-            if let Some(mut sessions) = store.get_sessions(&sender_key.to_base64()).await? {
+            if let Some(sessions) = store.get_sessions(&sender_key.to_base64()).await? {
+                let mut sessions = sessions.lock().await;
                 sessions.sort_by_key(|s| s.creation_time);
 
                 Ok(sessions.last().cloned())

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1067,7 +1067,7 @@ pub(crate) mod testing {
         let user_id = user_id.to_owned();
         let account = Account::with_device_id(&user_id, device_id);
         let static_account = account.static_data().clone();
-        let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
+        let store = Arc::new(CryptoStoreWrapper::new(&user_id, device_id, MemoryStore::new()));
         let verification =
             VerificationMachine::new(static_account.clone(), identity.clone(), store.clone());
         let store = Store::new(static_account, identity, store, verification);

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1098,7 +1098,11 @@ pub(crate) mod tests {
         let verification_machine = VerificationMachine::new(
             Account::with_device_id(second.user_id(), second.device_id()).static_data,
             private_identity,
-            Arc::new(CryptoStoreWrapper::new(second.user_id(), MemoryStore::new())),
+            Arc::new(CryptoStoreWrapper::new(
+                second.user_id(),
+                second.device_id(),
+                MemoryStore::new(),
+            )),
         );
 
         let first = Device {
@@ -1139,7 +1143,11 @@ pub(crate) mod tests {
         let verification_machine = VerificationMachine::new(
             Account::with_device_id(device.user_id(), device.device_id()).static_data,
             id.clone(),
-            Arc::new(CryptoStoreWrapper::new(device.user_id(), MemoryStore::new())),
+            Arc::new(CryptoStoreWrapper::new(
+                device.user_id(),
+                device.device_id(),
+                MemoryStore::new(),
+            )),
         );
 
         let public_identity = identity.to_public_identity().await.unwrap();

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -1250,11 +1250,9 @@ impl Account {
                 let mut errors_by_olm_session = Vec::new();
 
                 if let Some(sessions) = existing_sessions {
-                    let sessions = &mut *sessions.lock().await;
-
                     // Try to decrypt the message using each Session we share with the
                     // given curve25519 sender key.
-                    for session in sessions.iter_mut() {
+                    for mut session in sessions {
                         match session.decrypt(message).await {
                             Ok(p) => {
                                 // success!
@@ -1282,7 +1280,7 @@ impl Account {
             OlmMessage::PreKey(prekey_message) => {
                 // First try to decrypt using an existing session.
                 if let Some(sessions) = existing_sessions {
-                    for session in sessions.lock().await.iter_mut() {
+                    for mut session in sessions {
                         if prekey_message.session_id() != session.session_id() {
                             // wrong session
                             continue;

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -1252,7 +1252,7 @@ impl Account {
                 if let Some(sessions) = existing_sessions {
                     // Try to decrypt the message using each Session we share with the
                     // given curve25519 sender key.
-                    for mut session in sessions {
+                    for session in sessions.lock().await.iter_mut() {
                         match session.decrypt(message).await {
                             Ok(p) => {
                                 // success!
@@ -1280,7 +1280,7 @@ impl Account {
             OlmMessage::PreKey(prekey_message) => {
                 // First try to decrypt using an existing session.
                 if let Some(sessions) = existing_sessions {
-                    for mut session in sessions {
+                    for session in sessions.lock().await.iter_mut() {
                         if prekey_message.session_id() != session.session_id() {
                             // wrong session
                             continue;

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
@@ -913,7 +913,11 @@ mod tests {
     }
 
     fn create_store(me: &TestUser) -> Store {
-        let store_wrapper = Arc::new(CryptoStoreWrapper::new(&me.user_id, MemoryStore::new()));
+        let store_wrapper = Arc::new(CryptoStoreWrapper::new(
+            &me.user_id,
+            me.account.device_id(),
+            MemoryStore::new(),
+        ));
 
         let verification_machine = VerificationMachine::new(
             me.account.deref().clone(),
@@ -1078,7 +1082,11 @@ mod tests {
                 Arc::new(Mutex::new(PrivateCrossSigningIdentity::new(
                     account.user_id().to_owned(),
                 ))),
-                Arc::new(CryptoStoreWrapper::new(account.user_id(), MemoryStore::new())),
+                Arc::new(CryptoStoreWrapper::new(
+                    account.user_id(),
+                    account.device_id(),
+                    MemoryStore::new(),
+                )),
             ),
             own_identity: None,
             device_owner_identity: None,

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -217,7 +217,11 @@ macro_rules! cryptostore_integration_tests {
                     .await
                     .expect("Can't save account");
 
-                let changes = Changes { sessions: vec![session.clone()], ..Default::default() };
+                let changes = Changes {
+                    sessions: vec![session.clone()],
+                    devices: DeviceChanges { new: vec![DeviceData::from_account(&account)], ..Default::default() },
+                    ..Default::default()
+                };
 
                 store.save_changes(changes).await.unwrap();
 
@@ -226,9 +230,9 @@ macro_rules! cryptostore_integration_tests {
                     .await
                     .expect("Can't load sessions")
                     .unwrap();
-                let loaded_session = sessions.lock().await.get(0).cloned().unwrap();
+                let loaded_session = sessions.get(0).cloned().expect("We should find the session in the store.");
 
-                assert_eq!(&session, &loaded_session);
+                assert_eq!(&session, &loaded_session, "The loaded session should be the same one we put into the store.");
             }
 
             #[async_test]
@@ -263,8 +267,7 @@ macro_rules! cryptostore_integration_tests {
                     store.save_changes(changes).await.unwrap();
 
                     let sessions = store.get_sessions(&sender_key).await.unwrap().unwrap();
-                    let sessions_lock = sessions.lock().await;
-                    let session = &sessions_lock[0];
+                    let session = &sessions[0];
 
                     assert_eq!(session_id, session.session_id());
 
@@ -279,8 +282,7 @@ macro_rules! cryptostore_integration_tests {
                 assert_eq!(account, loaded_account);
 
                 let sessions = store.get_sessions(&sender_key).await.unwrap().unwrap();
-                let sessions_lock = sessions.lock().await;
-                let session = &sessions_lock[0];
+                let session = &sessions[0];
 
                 assert_eq!(session_id, session.session_id());
             }

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -345,7 +345,6 @@ impl<'a> SyncedKeyQueryManager<'a> {
 #[derive(Debug)]
 pub(crate) struct StoreCache {
     store: Arc<CryptoStoreWrapper>,
-
     tracked_users: StdRwLock<BTreeSet<OwnedUserId>>,
     loaded_tracked_users: RwLock<bool>,
     account: Mutex<Option<Account>>,

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -1009,6 +1009,13 @@ impl Store {
         self.save_changes(changes).await
     }
 
+    pub(crate) async fn get_sessions(
+        &self,
+        sender_key: &str,
+    ) -> Result<Option<Arc<Mutex<Vec<Session>>>>> {
+        self.inner.store.get_sessions(sender_key).await
+    }
+
     pub(crate) async fn save_changes(&self, changes: Changes) -> Result<()> {
         self.inner.store.save_changes(changes).await
     }

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -578,7 +578,7 @@ mod tests {
         let _ = VerificationMachine::new(
             alice.static_data,
             identity,
-            Arc::new(CryptoStoreWrapper::new(alice_id(), MemoryStore::new())),
+            Arc::new(CryptoStoreWrapper::new(alice_id(), alice_device_id(), MemoryStore::new())),
         );
     }
 

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -861,14 +861,18 @@ pub(crate) mod tests {
         bob_store.save_devices(vec![alice_device]);
 
         let alice_store = VerificationStore {
-            inner: Arc::new(CryptoStoreWrapper::new(alice.user_id(), alice_store)),
+            inner: Arc::new(CryptoStoreWrapper::new(
+                alice.user_id(),
+                alice.device_id(),
+                alice_store,
+            )),
             account: alice.static_data.clone(),
             private_identity: alice_private_identity.into(),
         };
 
         let bob_store = VerificationStore {
             account: bob.static_data.clone(),
-            inner: Arc::new(CryptoStoreWrapper::new(bob.user_id(), bob_store)),
+            inner: Arc::new(CryptoStoreWrapper::new(bob.user_id(), bob.device_id(), bob_store)),
             private_identity: bob_private_identity.into(),
         };
 

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -52,7 +52,7 @@ use tracing::{error, info, trace, warn};
 use crate::{
     error::SignatureError,
     gossiping::{GossipMachine, GossipRequest},
-    olm::{PrivateCrossSigningIdentity, Session, StaticAccountData},
+    olm::{PrivateCrossSigningIdentity, StaticAccountData},
     store::{Changes, CryptoStoreWrapper},
     types::Signatures,
     CryptoStoreError, DeviceData, LocalTrust, OutgoingVerificationRequest, OwnUserIdentityData,
@@ -164,13 +164,6 @@ impl VerificationStore {
         user_id: &UserId,
     ) -> Result<HashMap<OwnedDeviceId, DeviceData>, CryptoStoreError> {
         self.inner.get_user_devices(user_id).await
-    }
-
-    pub async fn get_sessions(
-        &self,
-        sender_key: &str,
-    ) -> Result<Option<Arc<Mutex<Vec<Session>>>>, CryptoStoreError> {
-        self.inner.get_sessions(sender_key).await
     }
 
     /// Get the signatures that have signed our own device.

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -909,8 +909,8 @@ mod tests {
         user_id!("@example:localhost")
     }
 
-    fn memory_store(user_id: &UserId) -> Arc<CryptoStoreWrapper> {
-        Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()))
+    fn memory_store(user_id: &UserId, device_id: &DeviceId) -> Arc<CryptoStoreWrapper> {
+        Arc::new(CryptoStoreWrapper::new(user_id, device_id, MemoryStore::new()))
     }
 
     fn device_id() -> &'static DeviceId {
@@ -920,7 +920,7 @@ mod tests {
     #[async_test]
     async fn test_verification_creation() {
         let account = Account::with_device_id(user_id(), device_id());
-        let store = memory_store(account.user_id());
+        let store = memory_store(account.user_id(), account.device_id());
 
         let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned());
         let master_key = private_identity.master_public_key().await.unwrap();
@@ -984,7 +984,7 @@ mod tests {
     async fn test_reciprocate_receival() {
         let test = |flow_id: FlowId| async move {
             let alice_account = Account::with_device_id(user_id(), device_id());
-            let store = memory_store(alice_account.user_id());
+            let store = memory_store(alice_account.user_id(), alice_account.device_id());
 
             let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned());
 
@@ -1023,7 +1023,7 @@ mod tests {
             );
             assert_matches!(alice_verification.state(), QrVerificationState::Started);
 
-            let bob_store = memory_store(bob_account.user_id());
+            let bob_store = memory_store(bob_account.user_id(), bob_account.device_id());
 
             let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned());
             let bob_store = VerificationStore {

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -912,7 +912,11 @@ mod tests {
 
         let alice_store = VerificationStore {
             account: alice.static_data.clone(),
-            inner: Arc::new(CryptoStoreWrapper::new(alice.user_id(), MemoryStore::new())),
+            inner: Arc::new(CryptoStoreWrapper::new(
+                alice.user_id(),
+                alice_device_id(),
+                MemoryStore::new(),
+            )),
             private_identity: Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())).into(),
         };
 
@@ -921,7 +925,7 @@ mod tests {
 
         let bob_store = VerificationStore {
             account: bob.static_data.clone(),
-            inner: Arc::new(CryptoStoreWrapper::new(bob.user_id(), bob_store)),
+            inner: Arc::new(CryptoStoreWrapper::new(bob.user_id(), bob_device_id(), bob_store)),
             private_identity: Mutex::new(PrivateCrossSigningIdentity::empty(bob_id())).into(),
         };
 

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -27,10 +27,7 @@ use matrix_sdk_crypto::{
         InboundGroupSession, OutboundGroupSession, PickledInboundGroupSession,
         PrivateCrossSigningIdentity, Session, StaticAccountData,
     },
-    store::{
-        caches::SessionStore, BackupKeys, Changes, CryptoStore, PendingChanges, RoomKeyCounts,
-        RoomSettings,
-    },
+    store::{BackupKeys, Changes, CryptoStore, PendingChanges, RoomKeyCounts, RoomSettings},
     types::events::room_key_withheld::RoomKeyWithheldEvent,
     Account, DeviceData, GossipRequest, GossippedSecret, SecretInfo, TrackedUser, UserIdentityData,
 };
@@ -63,7 +60,6 @@ pub struct SqliteCryptoStore {
 
     // DB values cached in memory
     static_account: Arc<RwLock<Option<StaticAccountData>>>,
-    session_cache: SessionStore,
     save_changes_lock: Arc<Mutex<()>>,
 }
 
@@ -112,7 +108,6 @@ impl SqliteCryptoStore {
             path: None,
             pool,
             static_account: Arc::new(RwLock::new(None)),
-            session_cache: SessionStore::new(),
             save_changes_lock: Default::default(),
         })
     }
@@ -681,13 +676,6 @@ impl SqliteObjectCryptoStoreExt for deadpool_sqlite::Object {}
 impl CryptoStore for SqliteCryptoStore {
     type Error = Error;
 
-    async fn clear_caches(&self) {
-        self.session_cache.clear()
-        // We don't need to clear `static_account` as it only contains immutable
-        // data therefore cannot get out of sync with the underlying
-        // store.
-    }
-
     async fn load_account(&self) -> Result<Option<Account>> {
         let conn = self.acquire().await?;
         if let Some(pickle) = conn.get_kv("account").await? {
@@ -754,13 +742,12 @@ impl CryptoStore for SqliteCryptoStore {
             if let Some(i) = changes.private_identity { Some(i.pickle().await) } else { None };
 
         let mut session_changes = Vec::new();
+
         for session in changes.sessions {
             let session_id = self.encode_key("session", session.session_id());
             let sender_key = self.encode_key("session", session.sender_key().to_base64());
             let pickle = session.pickle().await;
             session_changes.push((session_id, sender_key, pickle));
-
-            self.session_cache.add(session).await;
         }
 
         let mut inbound_session_changes = Vec::new();
@@ -779,11 +766,9 @@ impl CryptoStore for SqliteCryptoStore {
         }
 
         let this = self.clone();
-        let clear_caches = self
-            .acquire()
+        self.acquire()
             .await?
             .with_transaction(move |txn| {
-                let mut clear_caches = false;
                 if let Some(pickled_private_identity) = &pickled_private_identity {
                     let serialized_private_identity =
                         this.serialize_value(pickled_private_identity)?;
@@ -805,16 +790,7 @@ impl CryptoStore for SqliteCryptoStore {
                     txn.set_kv("backup_version_v1", &serialized_backup_version)?;
                 }
 
-                let account_info = this.get_static_account();
                 for device in changes.devices.new.iter().chain(&changes.devices.changed) {
-                    // If our own device key changes, we need to clear the
-                    // session cache because the sessions contain a copy of our
-                    // device key.
-                    if account_info.clone().is_some_and(|info| {
-                        info.user_id == device.user_id() && info.device_id == device.device_id()
-                    }) {
-                        clear_caches = true;
-                    }
                     let user_id = this.encode_key("device", device.user_id().as_bytes());
                     let device_id = this.encode_key("device", device.device_id().as_bytes());
                     let data = this.serialize_value(&device)?;
@@ -885,13 +861,9 @@ impl CryptoStore for SqliteCryptoStore {
                     txn.set_secret(&secret_name, &value)?;
                 }
 
-                Ok::<_, Error>(clear_caches)
+                Ok::<_, Error>(())
             })
             .await?;
-
-        if clear_caches {
-            self.clear_caches().await;
-        }
 
         Ok(())
     }
@@ -918,27 +890,26 @@ impl CryptoStore for SqliteCryptoStore {
         self.save_changes(Changes { inbound_group_sessions: sessions, ..Changes::default() }).await
     }
 
-    async fn get_sessions(&self, sender_key: &str) -> Result<Option<Arc<Mutex<Vec<Session>>>>> {
-        if self.session_cache.get(sender_key).is_none() {
-            let device_keys = self.get_own_device().await?.as_device_keys().clone();
+    async fn get_sessions(&self, sender_key: &str) -> Result<Option<Vec<Session>>> {
+        let device_keys = self.get_own_device().await?.as_device_keys().clone();
 
-            let sessions = self
-                .acquire()
-                .await?
-                .get_sessions_for_sender_key(self.encode_key("session", sender_key.as_bytes()))
-                .await?
-                .into_iter()
-                .map(|bytes| {
-                    let pickle = self.deserialize_value(&bytes)?;
-                    Session::from_pickle(device_keys.clone(), pickle)
-                        .map_err(|_| Error::AccountUnset)
-                })
-                .collect::<Result<_>>()?;
+        let sessions: Vec<_> = self
+            .acquire()
+            .await?
+            .get_sessions_for_sender_key(self.encode_key("session", sender_key.as_bytes()))
+            .await?
+            .into_iter()
+            .map(|bytes| {
+                let pickle = self.deserialize_value(&bytes)?;
+                Session::from_pickle(device_keys.clone(), pickle).map_err(|_| Error::AccountUnset)
+            })
+            .collect::<Result<_>>()?;
 
-            self.session_cache.set_for_sender(sender_key, sessions);
+        if sessions.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(sessions))
         }
-
-        Ok(self.session_cache.get(sender_key))
     }
 
     #[instrument(skip(self))]
@@ -1122,7 +1093,11 @@ impl CryptoStore for SqliteCryptoStore {
 
     async fn get_own_device(&self) -> Result<DeviceData> {
         let account_info = self.get_static_account().ok_or(Error::AccountUnset)?;
-        Ok(self.get_device(&account_info.user_id, &account_info.device_id).await?.unwrap())
+
+        Ok(self
+            .get_device(&account_info.user_id, &account_info.device_id)
+            .await?
+            .expect("We should be able to find our own device."))
     }
 
     async fn get_user_identity(&self, user_id: &UserId) -> Result<Option<UserIdentityData>> {
@@ -1451,12 +1426,7 @@ mod tests {
 
 #[cfg(test)]
 mod encrypted_tests {
-    use matrix_sdk_crypto::{
-        cryptostore_integration_tests, cryptostore_integration_tests_time,
-        store::{Changes, CryptoStore as _, DeviceChanges, PendingChanges},
-        DeviceData,
-    };
-    use matrix_sdk_test::async_test;
+    use matrix_sdk_crypto::{cryptostore_integration_tests, cryptostore_integration_tests_time};
     use once_cell::sync::Lazy;
     use tempfile::{tempdir, TempDir};
     use tokio::fs;
@@ -1480,69 +1450,6 @@ mod encrypted_tests {
         SqliteCryptoStore::open(tmpdir_path.to_str().unwrap(), Some(pass))
             .await
             .expect("Can't create a passphrase protected store")
-    }
-
-    #[async_test]
-    async fn cache_cleared() {
-        let store = get_store("cache_cleared", None, true).await;
-        // Given we created a session and saved it in the store
-        let (account, session) = cryptostore_integration_tests::get_account_and_session().await;
-        let sender_key = session.sender_key.to_base64();
-
-        store
-            .save_pending_changes(PendingChanges { account: Some(account.deep_clone()) })
-            .await
-            .expect("Can't save account");
-
-        let changes = Changes { sessions: vec![session.clone()], ..Default::default() };
-        store.save_changes(changes).await.unwrap();
-
-        store.session_cache.get(&sender_key).expect("We should have a session");
-
-        // When we clear the caches
-        store.clear_caches().await;
-
-        // Then the session is no longer in the cache
-        assert!(
-            store.session_cache.get(&sender_key).is_none(),
-            "Session should not be in the cache!"
-        );
-    }
-
-    #[async_test]
-    async fn cache_cleared_after_device_update() {
-        let store = get_store("cache_cleared_after_device_update", None, true).await;
-        // Given we created a session and saved it in the store
-        let (account, session) = cryptostore_integration_tests::get_account_and_session().await;
-        let sender_key = session.sender_key.to_base64();
-
-        store
-            .save_pending_changes(PendingChanges { account: Some(account.deep_clone()) })
-            .await
-            .expect("Can't save account");
-
-        let changes = Changes { sessions: vec![session.clone()], ..Default::default() };
-        store.save_changes(changes).await.unwrap();
-
-        store.session_cache.get(&sender_key).expect("We should have a session");
-
-        // When we save a new version of our device keys
-        store
-            .save_changes(Changes {
-                devices: DeviceChanges {
-                    new: vec![DeviceData::from_account(&account)],
-                    ..Default::default()
-                },
-                ..Default::default()
-            })
-            .await
-            .unwrap();
-
-        // Then the session is no longer in the cache
-        assert!(
-            store.session_cache.get(&sender_key).is_none(),
-            "Session should not be in the cache!"
-        );
     }
 
     cryptostore_integration_tests!();


### PR DESCRIPTION
This PR is another step in the https://github.com/matrix-org/matrix-rust-sdk/issues/2624 epic. It moves the Olm `Session` cache from each individual cryptostore implementation to the `CryptoStoreWrapper`.

While the wrapper shouldn't be the final destination for this cache it does help with our current multi-process support which relied on the `CryptoStore::clear_caches()` method. This method is now gone and no further caches should be added to the store implementations.

Review commit by commit isn't advised as the API changed and changed back when the cache was removed and re-added.

- [x] Public API changes documented in changelogs (optional)