### PR TITLE
crypto: crypto store wrapper migration framework

### DIFF
--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -96,7 +96,7 @@ impl DehydratedDevices {
         let user_identity = self.inner.store().private_identity();
 
         let account = Account::new_dehydrated(user_id);
-        let store = Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()));
+        let store = Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()).await.unwrap());
 
         let verification_machine = VerificationMachine::new(
             account.static_data().clone(),

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1177,7 +1177,7 @@ mod tests {
         let device_id = DeviceId::new();
 
         let account = Account::with_device_id(&user_id, &device_id);
-        let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
+        let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()).await.unwrap());
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification =
             VerificationMachine::new(account.static_data.clone(), identity.clone(), store.clone());
@@ -1197,7 +1197,7 @@ mod tests {
         let another_device =
             DeviceData::from_account(&Account::with_device_id(&user_id, alice2_device_id()));
 
-        let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
+        let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()).await.unwrap());
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification =
             VerificationMachine::new(account.static_data.clone(), identity.clone(), store.clone());

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1067,7 +1067,7 @@ pub(crate) mod testing {
         let user_id = user_id.to_owned();
         let account = Account::with_device_id(&user_id, device_id);
         let static_account = account.static_data().clone();
-        let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
+        let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()).await.unwrap());
         let verification =
             VerificationMachine::new(static_account.clone(), identity.clone(), store.clone());
         let store = Store::new(static_account, identity, store, verification);

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1084,8 +1084,8 @@ pub(crate) mod tests {
         assert_eq!("1", with_serializer.version.unwrap());
     }
 
-    #[test]
-    fn own_identity_check_signatures() {
+    #[async_test]
+    async fn own_identity_check_signatures() {
         let response = own_key_query();
         let identity = get_own_identity();
         let (first, second) = device(&response);
@@ -1098,7 +1098,7 @@ pub(crate) mod tests {
         let verification_machine = VerificationMachine::new(
             Account::with_device_id(second.user_id(), second.device_id()).static_data,
             private_identity,
-            Arc::new(CryptoStoreWrapper::new(second.user_id(), MemoryStore::new())),
+            Arc::new(CryptoStoreWrapper::new(second.user_id(), MemoryStore::new()).await.unwrap()),
         );
 
         let first = Device {
@@ -1139,7 +1139,7 @@ pub(crate) mod tests {
         let verification_machine = VerificationMachine::new(
             Account::with_device_id(device.user_id(), device.device_id()).static_data,
             id.clone(),
-            Arc::new(CryptoStoreWrapper::new(device.user_id(), MemoryStore::new())),
+            Arc::new(CryptoStoreWrapper::new(device.user_id(), MemoryStore::new()).await.unwrap()),
         );
 
         let public_identity = identity.to_public_identity().await.unwrap();

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -173,7 +173,8 @@ impl OlmMachine {
         let account = Account::rehydrate(pickle_key, self.user_id(), device_id, device_data)?;
         let static_account = account.static_data().clone();
 
-        let store = Arc::new(CryptoStoreWrapper::new(self.user_id(), MemoryStore::new()));
+        let store =
+            Arc::new(CryptoStoreWrapper::new(self.user_id(), MemoryStore::new()).await.unwrap());
         let device = DeviceData::from_account(&account);
         store.save_pending_changes(PendingChanges { account: Some(account) }).await?;
         store
@@ -356,7 +357,7 @@ impl OlmMachine {
         });
 
         let identity = Arc::new(Mutex::new(identity));
-        let store = Arc::new(CryptoStoreWrapper::new(user_id, store));
+        let store = Arc::new(CryptoStoreWrapper::new(user_id, store).await?);
         Ok(OlmMachine::new_helper(device_id, store, static_account, identity, maybe_backup_key))
     }
 

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -680,7 +680,7 @@ mod tests {
         let device_id = device_id();
 
         let account = Account::with_device_id(user_id, device_id);
-        let store = Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()));
+        let store = Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()).await.unwrap());
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(user_id)));
         let verification = VerificationMachine::new(
             account.static_data().clone(),

--- a/crates/matrix-sdk-crypto/src/store/error.rs
+++ b/crates/matrix-sdk-crypto/src/store/error.rs
@@ -82,6 +82,10 @@ pub enum CryptoStoreError {
     /// An error due to an invalid generation in a cross-process locking scheme.
     #[error("invalid lock generation: {0}")]
     InvalidLockGeneration(String),
+
+    /// A problem when migrating the crypto store wrapper
+    #[error("Crypto store wrapper error: {0}")]
+    CryptoStoreWrapperMigrationError(String),
 }
 
 impl CryptoStoreError {

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -578,7 +578,7 @@ mod tests {
         let _ = VerificationMachine::new(
             alice.static_data,
             identity,
-            Arc::new(CryptoStoreWrapper::new(alice_id(), MemoryStore::new())),
+            Arc::new(CryptoStoreWrapper::new(alice_id(), MemoryStore::new()).await.unwrap()),
         );
     }
 

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -868,14 +868,14 @@ pub(crate) mod tests {
         bob_store.save_devices(vec![alice_device]);
 
         let alice_store = VerificationStore {
-            inner: Arc::new(CryptoStoreWrapper::new(alice.user_id(), alice_store)),
+            inner: Arc::new(CryptoStoreWrapper::new(alice.user_id(), alice_store).await.unwrap()),
             account: alice.static_data.clone(),
             private_identity: alice_private_identity.into(),
         };
 
         let bob_store = VerificationStore {
             account: bob.static_data.clone(),
-            inner: Arc::new(CryptoStoreWrapper::new(bob.user_id(), bob_store)),
+            inner: Arc::new(CryptoStoreWrapper::new(bob.user_id(), bob_store).await.unwrap()),
             private_identity: bob_private_identity.into(),
         };
 

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -902,8 +902,8 @@ mod tests {
         device_id!("BOBDEVCIE")
     }
 
-    fn machine_pair_test_helper() -> (VerificationStore, DeviceData, VerificationStore, DeviceData)
-    {
+    async fn machine_pair_test_helper(
+    ) -> (VerificationStore, DeviceData, VerificationStore, DeviceData) {
         let alice = Account::with_device_id(alice_id(), alice_device_id());
         let alice_device = DeviceData::from_account(&alice);
 
@@ -912,7 +912,9 @@ mod tests {
 
         let alice_store = VerificationStore {
             account: alice.static_data.clone(),
-            inner: Arc::new(CryptoStoreWrapper::new(alice.user_id(), MemoryStore::new())),
+            inner: Arc::new(
+                CryptoStoreWrapper::new(alice.user_id(), MemoryStore::new()).await.unwrap(),
+            ),
             private_identity: Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())).into(),
         };
 
@@ -921,7 +923,7 @@ mod tests {
 
         let bob_store = VerificationStore {
             account: bob.static_data.clone(),
-            inner: Arc::new(CryptoStoreWrapper::new(bob.user_id(), bob_store)),
+            inner: Arc::new(CryptoStoreWrapper::new(bob.user_id(), bob_store).await.unwrap()),
             private_identity: Mutex::new(PrivateCrossSigningIdentity::empty(bob_id())).into(),
         };
 
@@ -930,7 +932,7 @@ mod tests {
 
     #[async_test]
     async fn sas_wrapper_full() {
-        let (alice_store, alice_device, bob_store, bob_device) = machine_pair_test_helper();
+        let (alice_store, alice_device, bob_store, bob_device) = machine_pair_test_helper().await;
 
         let identities = alice_store.get_identities(bob_device).await.unwrap();
 
@@ -1004,7 +1006,7 @@ mod tests {
 
     #[async_test]
     async fn sas_with_restricted_methods() {
-        let (alice_store, alice_device, bob_store, bob_device) = machine_pair_test_helper();
+        let (alice_store, alice_device, bob_store, bob_device) = machine_pair_test_helper().await;
         let identities = alice_store.get_identities(bob_device).await.unwrap();
 
         let short_auth_strings = vec![ShortAuthenticationString::Decimal];


### PR DESCRIPTION
<!-- description of the changes in this PR -->

The rust-sdk offers an abstraction of the persistence layer via the `CryptoStore`.
There are several implementation, with each of them having their own migration framework to manage their internal data format.
There is some basic migration support at the OlmMachine layer via serde serialization/deserialization. Like for example the use of `#[serde(default)]` that allows to add a default static value for a field added in a json model, or [Serialization helpers](https://github.com/matrix-org/matrix-rust-sdk/blob/fba61751d57f0161b9f2f8f7dec025945edf886f/crates/matrix-sdk-crypto/src/identities/user.rs#L442) like for identity migration.

But this only allows static/basic migration with no access to other existing data.
There is a need to be able to do more in a migration, like seen in [this PR](https://github.com/matrix-org/matrix-rust-sdk/pull/3795), were we are adding a new flag on identities that needs to access the current identity as well as the identity currently migrated. This can be solved by marking all users as dirty, and we have no way to do that currently (appart from doing it in each store implementation?)


This PR adds basic support for such migration.
It impacts a lots of files because the `CryptoStoreWrapper::new` function needs now to be async


- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
