### PR TITLE
Fixes for the `TimelineFocus::PinnedEvents` timeline

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -122,7 +122,8 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
     let (client, server) = runtime.block_on(logged_in_client_with_server());
 
     let mut sync_response_builder = SyncResponseBuilder::new();
-    let mut joined_room_builder = JoinedRoomBuilder::new(&room_id);
+    let mut joined_room_builder =
+        JoinedRoomBuilder::new(&room_id).add_state_event(StateTestEvent::Encryption);
 
     let pinned_event_ids: Vec<OwnedEventId> = (0..PINNED_EVENTS_COUNT)
         .map(|i| EventId::parse(format!("${i}")).expect("Invalid event id"))
@@ -185,6 +186,9 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
         b.to_async(&runtime).iter(|| async {
             assert!(!room.pinned_event_ids().is_empty());
             assert_eq!(room.pinned_event_ids().len(), PINNED_EVENTS_COUNT);
+
+            // Reset cache so it always loads the events from the mocked endpoint
+            room.clear_pinned_events().await;
 
             let timeline = Timeline::builder(&room)
                 .with_focus(TimelineFocus::PinnedEvents { max_events_to_load: 100 })

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -248,8 +248,7 @@ impl Room {
     }
 
     pub async fn clear_pinned_events_cache(&self) {
-        let pinned_event_ids = self.inner.pinned_event_ids();
-        self.inner.client().pinned_event_cache().remove_bulk(&pinned_event_ids).await;
+        self.inner.clear_pinned_events().await;
     }
 
     pub fn is_encrypted(&self) -> Result<bool, ClientError> {

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -36,8 +36,8 @@ impl PinnedEventsLoader {
     /// `max_concurrent_requests` allows, to avoid overwhelming the server.
     ///
     /// It returns a `Result` with either a
-    /// chronologically sorted list of retrieved `SyncTimelineEvent`s  or a
-    /// `PinnedEventsLoaderError`.
+    /// reversed chronologically sorted list of retrieved `SyncTimelineEvent`s
+    /// or a `PinnedEventsLoaderError`.
     pub async fn load_events(
         &self,
         cache: &PinnedEventCache,
@@ -104,9 +104,10 @@ impl PinnedEventsLoader {
                 .unwrap_or_else(|_| MilliSecondsSinceUnixEpoch::now())
         }
 
+        // Sort using reversed chronological ordering (newest -> oldest)
         let sorted_events = loaded_events
             .into_iter()
-            .sorted_by(|e1, e2| timestamp(e1).cmp(&timestamp(e2)))
+            .sorted_by(|e1, e2| timestamp(e1).cmp(&timestamp(e2)).reverse())
             .collect();
 
         Ok(sorted_events)

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -67,10 +67,10 @@ async fn test_new_pinned_events_are_added_on_sync() {
     // The list is reloaded, so it's reset
     assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::Clear);
     assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::PushBack { value } => {
-        assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$1"));
+        assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$2"));
     });
     assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::PushBack { value } => {
-        assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$2"));
+        assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$1"));
     });
     assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::PushFront { value } => {
         assert!(value.is_day_divider());

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2352,6 +2352,12 @@ impl Room {
         Ok(self.room_power_levels().await?.user_can_trigger_room_notification(user_id))
     }
 
+    /// Removes the cached pinned events associated with this room.
+    pub async fn clear_pinned_events(&self) {
+        let pinned_event_ids = self.pinned_event_ids();
+        self.client.inner.pinned_event_cache.remove_bulk(&pinned_event_ids).await;
+    }
+
     /// Get a list of servers that should know this room.
     ///
     /// Uses the synced members of the room and the suggested [routing


### PR DESCRIPTION
## Changes

- Use reversed chronological order for the events, as the rest of the timelines do.
- Add `fn sdk::Room::clear_pinned_events_cache`, previously this was only in the FFI layer.
- Fix benchmark and tests after the changes above.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
