### PR TITLE
sdk-ui: add `PinnedEventsLoaderError::TimelineReloadFailed`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -51,6 +51,7 @@ impl PinnedEventsLoader {
             .rev()
             .collect();
 
+        let has_pinned_event_ids = !pinned_event_ids.is_empty();
         let mut loaded_events = Vec::new();
         let mut event_ids_to_request = Vec::new();
         for ev_id in pinned_event_ids {
@@ -89,9 +90,13 @@ impl PinnedEventsLoader {
 
             for handle in handles {
                 if let Ok(Ok(ev)) = handle.await {
-                    loaded_events.push(ev)
+                    loaded_events.push(ev);
                 }
             }
+        }
+
+        if has_pinned_event_ids && loaded_events.is_empty() {
+            return Err(PinnedEventsLoaderError::TimelineReloadFailed);
         }
 
         info!("Saving {} pinned events to the cache", loaded_events.len());
@@ -197,4 +202,7 @@ pub enum PinnedEventsLoaderError {
 
     #[error("Timeline focus is not pinned events.")]
     TimelineFocusNotPinnedEvents,
+
+    #[error("Could not load pinned events.")]
+    TimelineReloadFailed,
 }


### PR DESCRIPTION
This error will be returned when the room has pinned event ids but the timeline couldn't load any of them. 

We need to make this distinction instead of just failing as soon as the first request fails because we don't want an incorrect pinned event id to break loading any other existing events, or have a single failed request with poor connectivity to invalidate the rest of them.

Also fix and add new tests.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
