### PR TITLE
Timeline: Update the human readable description for the SentInClear shield.

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -29,7 +29,7 @@ const AUTHENTICITY_NOT_GUARANTEED: &str =
 const UNVERIFIED_IDENTITY: &str = "Encrypted by an unverified user.";
 const UNSIGNED_DEVICE: &str = "Encrypted by a device not verified by its owner.";
 const UNKNOWN_DEVICE: &str = "Encrypted by an unknown or deleted device.";
-pub const SENT_IN_CLEAR: &str = "Sent in clear.";
+pub const SENT_IN_CLEAR: &str = "Not encrypted.";
 
 /// Represents the state of verification for a decrypted message sent by a
 /// device.

--- a/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
@@ -43,7 +43,7 @@ async fn test_sent_in_clear_shield() {
     let shield = item.as_event().unwrap().get_shield(false);
     assert_eq!(
         shield,
-        Some(ShieldState::Red { code: ShieldStateCode::SentInClear, message: "Sent in clear." })
+        Some(ShieldState::Red { code: ShieldStateCode::SentInClear, message: "Not encrypted." })
     );
 }
 
@@ -116,6 +116,6 @@ async fn test_local_sent_in_clear_shield() {
     let shield = event_item.get_shield(false);
     assert_eq!(
         shield,
-        Some(ShieldState::Red { code: ShieldStateCode::SentInClear, message: "Sent in clear." })
+        Some(ShieldState::Red { code: ShieldStateCode::SentInClear, message: "Not encrypted." })
     );
 }


### PR DESCRIPTION
The new message is more understandable in the timeline context and is consistent with current implementations (Element Web)