### PR TITLE
crypto: Allow querying InboundGroupSessions using curve key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2542,9 +2542,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexed_db_futures"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc2083760572ee02385ab8b7c02c20925d2dd1f97a1a25a8737a238608f1152"
+checksum = "43315957678a70eb21fb0d2384fe86dde0d6c859a01e24ce127eb65a0143d28c"
 dependencies = [
  "accessory",
  "cfg-if",
@@ -6592,9 +6592,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "serde",

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -36,8 +36,8 @@ use vodozemac::{
 };
 
 use super::{
-    BackedUpRoomKey, ExportedRoomKey, OutboundGroupSession, SenderData, SessionCreationError,
-    SessionKey,
+    BackedUpRoomKey, ExportedRoomKey, OutboundGroupSession, SenderData, SenderDataType,
+    SessionCreationError, SessionKey,
 };
 use crate::{
     error::{EventError, MegolmResult},
@@ -476,6 +476,13 @@ impl InboundGroupSession {
     #[cfg(test)]
     pub(crate) fn mark_as_imported(&mut self) {
         self.imported = true;
+    }
+
+    /// Return the [`SenderDataType`] of our [`SenderData`]. This is used during
+    /// serialization, to allow us to store the type in a separate queryable
+    /// column/property.
+    pub fn sender_data_type(&self) -> SenderDataType {
+        self.sender_data.to_type()
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use outbound::ShareState;
 pub use outbound::{
     EncryptionSettings, OutboundGroupSession, PickledOutboundGroupSession, ShareInfo,
 };
-pub use sender_data::{KnownSenderData, SenderData};
+pub use sender_data::{KnownSenderData, SenderData, SenderDataType};
 pub(crate) use sender_data_finder::SenderDataFinder;
 use thiserror::Error;
 pub use vodozemac::megolm::{ExportedSessionKey, SessionKey};

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -191,6 +191,19 @@ impl SenderData {
             SenderData::SenderVerified(..) => 4,
         }
     }
+
+    /// Return our type as a [`SenderDataType`].
+    pub fn to_type(&self) -> SenderDataType {
+        match self {
+            Self::UnknownDevice { .. } => SenderDataType::UnknownDevice,
+            Self::DeviceInfo { .. } => SenderDataType::DeviceInfo,
+            Self::SenderUnverifiedButPreviouslyVerified { .. } => {
+                SenderDataType::SenderUnverifiedButPreviouslyVerified
+            }
+            Self::SenderUnverified { .. } => SenderDataType::SenderUnverified,
+            Self::SenderVerified { .. } => SenderDataType::SenderVerified,
+        }
+    }
 }
 
 /// Used when deserialising and the sender_data property is missing.
@@ -264,6 +277,23 @@ impl From<SenderDataReader> for SenderData {
             }
         }
     }
+}
+
+/// Used when serializing [`crate::olm::group_sessions::InboundGroupSession`]s.
+/// We want just the type of the session's [`SenderData`] to be queryable, so we
+/// store the type as a separate column/property in the database.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
+pub enum SenderDataType {
+    /// The [`SenderData`] is of type `UnknownDevice`.
+    UnknownDevice = 1,
+    /// The [`SenderData`] is of type `DeviceInfo`.
+    DeviceInfo = 2,
+    /// The [`SenderData`] is of type `SenderUnverifiedButPreviouslyVerified`.
+    SenderUnverifiedButPreviouslyVerified = 3,
+    /// The [`SenderData`] is of type `SenderUnverified`.
+    SenderUnverified = 4,
+    /// The [`SenderData`] is of type `SenderVerified`.
+    SenderVerified = 5,
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -28,7 +28,7 @@ pub(crate) use account::{OlmDecryptionInfo, SessionType};
 pub use group_sessions::{
     BackedUpRoomKey, EncryptionSettings, ExportedRoomKey, InboundGroupSession, KnownSenderData,
     OutboundGroupSession, PickledInboundGroupSession, PickledOutboundGroupSession, SenderData,
-    SessionCreationError, SessionExportError, SessionKey, ShareInfo,
+    SenderDataType, SessionCreationError, SessionExportError, SessionKey, ShareInfo,
 };
 pub(crate) use group_sessions::{SenderDataFinder, ShareState};
 pub use session::{PickledSession, Session};

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -48,7 +48,7 @@ macro_rules! cryptostore_integration_tests {
             use $crate::{
                 olm::{
                     Account, Curve25519PublicKey, InboundGroupSession, OlmMessageHash,
-                    PrivateCrossSigningIdentity, Session,
+                    PrivateCrossSigningIdentity, SenderData, SenderDataType, Session
                 },
                 store::{
                     BackupDecryptionKey, Changes, CryptoStore, DeviceChanges, GossipRequest,
@@ -71,6 +71,9 @@ macro_rules! cryptostore_integration_tests {
                     EventEncryptionAlgorithm,
                 },
                 GossippedSecret, LocalTrust, DeviceData, SecretInfo, ToDeviceRequest, TrackedUser,
+                vodozemac::{
+                    megolm::{GroupSession, SessionConfig},
+                },
             };
 
             use super::get_store;
@@ -559,6 +562,118 @@ macro_rules! cryptostore_integration_tests {
 
                 assert_eq!(store.get_inbound_group_sessions().await.unwrap().len(), 1);
                 assert_eq!(store.inbound_group_session_counts(None).await.unwrap().total, 1);
+            }
+
+            #[async_test]
+            async fn test_fetch_inbound_group_sessions_for_device() {
+                // Given a store exists, containing inbound group sessions from different devices
+                let (account, store) =
+                    get_loaded_store("fetch_inbound_group_sessions_for_device").await;
+
+                let dev1 = Curve25519PublicKey::from_base64(
+                    "wjLpTLRqbqBzLs63aYaEv2Boi6cFEbbM/sSRQ2oAKk4"
+                ).unwrap();
+                let dev2 = Curve25519PublicKey::from_base64(
+                    "LTpv2DGMhggPAXO02+7f68CNEp6A40F0Yl8B094Y8gc"
+                ).unwrap();
+
+                let dev_1_unknown_a = create_session(&account, &dev1, SenderDataType::UnknownDevice).await;
+                let dev_1_unknown_b = create_session(&account, &dev1, SenderDataType::UnknownDevice).await;
+
+                let dev_1_keys_a = create_session(&account, &dev1, SenderDataType::DeviceInfo).await;
+                let dev_1_keys_b = create_session(&account, &dev1, SenderDataType::DeviceInfo).await;
+                let dev_1_keys_c = create_session(&account, &dev1, SenderDataType::DeviceInfo).await;
+                let dev_1_keys_d = create_session(&account, &dev1, SenderDataType::DeviceInfo).await;
+
+                let dev_2_unknown = create_session(
+                    &account, &dev2, SenderDataType::UnknownDevice).await;
+
+                let dev_2_keys = create_session(
+                    &account, &dev2, SenderDataType::DeviceInfo).await;
+
+                let sessions = vec![
+                    dev_1_unknown_a.clone(),
+                    dev_1_unknown_b.clone(),
+                    dev_1_keys_a.clone(),
+                    dev_1_keys_b.clone(),
+                    dev_1_keys_c.clone(),
+                    dev_1_keys_d.clone(),
+                    dev_2_unknown.clone(),
+                    dev_2_keys.clone(),
+                ];
+
+                let changes = Changes {
+                    inbound_group_sessions: sessions,
+                    ..Default::default()
+                };
+                store.save_changes(changes).await.expect("Can't save group session");
+
+                // When we fetch the list of sessions for device 1, unknown
+                let sessions_1_u = store.get_inbound_group_sessions_for_device_batch(
+                    dev1,
+                    SenderDataType::UnknownDevice,
+                    None,
+                    10
+                ).await.expect("Failed to get sessions for dev1");
+
+                // Then the expected sessions are returned
+                assert_session_lists_eq(sessions_1_u, [dev_1_unknown_a, dev_1_unknown_b], "device 1 sessions");
+
+                // And when we ask for the list of sessions for device 2, with device keys
+                let sessions_2_d = store
+                    .get_inbound_group_sessions_for_device_batch(dev2, SenderDataType::DeviceInfo, None, 10)
+                    .await
+                    .expect("Failed to get sessions for dev2");
+
+                // Then the matching session is returned
+                assert_eq!(sessions_2_d, vec![dev_2_keys], "device 2 sessions");
+
+                // And we can fetch device 1, keys in batches.
+                // We call the batch function repeatedly, to ensure it terminates correctly.
+                let mut sessions_1_k = Vec::new();
+                let mut previous_last_session_id: Option<String> = None;
+                loop {
+                    let mut sessions_1_k_batch = store.get_inbound_group_sessions_for_device_batch(
+                        dev1,
+                        SenderDataType::DeviceInfo,
+                        previous_last_session_id,
+                        2
+                    ).await.expect("Failed to get batch 1");
+
+                    // If there are no results in the batch, we have reached the end of the results.
+                    let Some(last_session) = sessions_1_k_batch.last() else {
+                        break;
+                    };
+
+                    // Check that there are exactly two results in the batch
+                    assert_eq!(sessions_1_k_batch.len(), 2);
+
+                    previous_last_session_id = Some(last_session.session_id().to_owned());
+                    sessions_1_k.append(&mut sessions_1_k_batch);
+                }
+
+                assert_session_lists_eq(
+                    sessions_1_k,
+                    [dev_1_keys_a, dev_1_keys_b, dev_1_keys_c, dev_1_keys_d],
+                    "device 1 batched results"
+                );
+            }
+
+            /// Assert that two lists of sessions are the same, modulo ordering.
+            ///
+            /// There is no requirement for `get_inbound_group_sessions_for_device_batch` to
+            /// return the results in a specific order. This helper ensures that the two lists
+            /// of inbound group sessions are equivalent, without worrying about the ordering.
+            fn assert_session_lists_eq<I, J>(actual: I, expected: J, message: &str)
+                where I: IntoIterator<Item = InboundGroupSession>, J: IntoIterator<Item = InboundGroupSession>
+            {
+                let sorter = |a: &InboundGroupSession, b: &InboundGroupSession| Ord::cmp(a.session_id(), b.session_id());
+
+                let mut actual = Vec::from_iter(actual);
+                actual.sort_unstable_by(sorter);
+                let mut expected = Vec::from_iter(expected);
+                expected.sort_unstable_by(sorter);
+                assert_eq!(actual, expected, "{}", message);
             }
 
             #[async_test]
@@ -1111,6 +1226,39 @@ macro_rules! cryptostore_integration_tests {
 
             fn session_info(session: &InboundGroupSession) -> (&RoomId, &str) {
                 (&session.room_id(), &session.session_id())
+            }
+
+            async fn create_session(
+                account: &Account,
+                device_curve_key: &Curve25519PublicKey,
+                sender_data_type: SenderDataType,
+            ) -> InboundGroupSession {
+                let sender_data = match sender_data_type {
+                    SenderDataType::UnknownDevice => {
+                        SenderData::UnknownDevice { legacy_session: false, owner_check_failed: false }
+                    }
+                    SenderDataType::DeviceInfo => SenderData::DeviceInfo {
+                        device_keys: account.device_keys().clone(),
+                        legacy_session: false,
+                    },
+                    SenderDataType::SenderUnverifiedButPreviouslyVerified =>
+                        panic!("SenderUnverifiedButPreviouslyVerified not supported"),
+                    SenderDataType::SenderUnverified=> panic!("SenderUnverified not supported"),
+                    SenderDataType::SenderVerified => panic!("SenderVerified not supported"),
+                };
+
+                let session_key = GroupSession::new(SessionConfig::default()).session_key();
+
+                InboundGroupSession::new(
+                    device_curve_key.clone(),
+                    account.device_keys().ed25519_key().unwrap(),
+                    room_id!("!r:s.co"),
+                    &session_key,
+                    sender_data,
+                    EventEncryptionAlgorithm::MegolmV1AesSha2,
+                    None,
+                )
+                .unwrap()
             }
         }
     };

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -25,7 +25,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 gloo-utils = { version = "0.2.0", features = ["serde"] }
 growable-bloom-filter = { workspace = true, optional = true }
-indexed_db_futures = "0.4.1"
+indexed_db_futures = "0.5.0"
 js-sys = { version = "0.3.58" }
 matrix-sdk-base = { workspace = true, features = ["js"], optional = true }
 matrix-sdk-crypto = { workspace = true, features = ["js"], optional = true }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
@@ -410,8 +410,11 @@ mod tests {
 
         let session_dbo = InboundGroupSessionIndexedDbObject {
             pickled_session: serializer.maybe_encrypt_value(pickled_session).unwrap(),
+            session_id: None,
             needs_backup: false,
             backed_up_to: -1,
+            sender_key: None,
+            sender_data_type: None,
         };
         let session_js: JsValue = serde_wasm_bindgen::to_value(&session_dbo).unwrap();
 
@@ -477,22 +480,25 @@ mod tests {
     /// Test migrating `inbound_group_sessions` data from store v5 to latest,
     /// on a store with encryption disabled.
     #[async_test]
-    async fn test_v8_v10_migration_unencrypted() {
-        test_v8_v10_migration_with_cipher("test_v8_migration_unencrypted", None).await
+    async fn test_v8_v10_v12_migration_unencrypted() {
+        test_v8_v10_v12_migration_with_cipher("test_v8_migration_unencrypted", None).await
     }
 
     /// Test migrating `inbound_group_sessions` data from store v5 to store v8,
     /// on a store with encryption enabled.
     #[async_test]
-    async fn test_v8_v10_migration_encrypted() {
+    async fn test_v8_v10_v12_migration_encrypted() {
         let cipher = StoreCipher::new().unwrap();
-        test_v8_v10_migration_with_cipher("test_v8_migration_encrypted", Some(Arc::new(cipher)))
-            .await;
+        test_v8_v10_v12_migration_with_cipher(
+            "test_v8_migration_encrypted",
+            Some(Arc::new(cipher)),
+        )
+        .await;
     }
 
-    /// Helper function for `test_v8_v10_migration_{un,}encrypted`: test
-    /// migrating `inbound_group_sessions` data from store v5 to store v10.
-    async fn test_v8_v10_migration_with_cipher(
+    /// Helper function for `test_v8_v10_v12_migration_{un,}encrypted`: test
+    /// migrating `inbound_group_sessions` data from store v5 to store v12.
+    async fn test_v8_v10_v12_migration_with_cipher(
         db_prefix: &str,
         store_cipher: Option<Arc<StoreCipher>>,
     ) {
@@ -536,13 +542,16 @@ mod tests {
         assert!(!fetched_not_backed_up_session.backed_up());
 
         // For v10: they have the backed_up_to property and it is indexed
-        assert_matches_v10_schema(db_name, store, fetched_backed_up_session).await;
+        assert_matches_v10_schema(&db_name, &store, &fetched_backed_up_session).await;
+
+        // For v12: they have the session_id, sender_key and sender_data_type properties
+        assert_matches_v12_schema(&db_name, &store, &fetched_backed_up_session).await;
     }
 
     async fn assert_matches_v10_schema(
-        db_name: String,
-        store: IndexeddbCryptoStore,
-        fetched_backed_up_session: InboundGroupSession,
+        db_name: &str,
+        store: &IndexeddbCryptoStore,
+        fetched_backed_up_session: &InboundGroupSession,
     ) {
         let db = IdbDatabase::open(&db_name).unwrap().await.unwrap();
         assert!(db.version() >= 10.0);
@@ -559,6 +568,41 @@ mod tests {
         assert_eq!(idb_object.backed_up_to, -1);
         assert!(raw_store.index_names().find(|idx| idx == "backed_up_to").is_some());
 
+        db.close();
+    }
+
+    async fn assert_matches_v12_schema(
+        db_name: &str,
+        store: &IndexeddbCryptoStore,
+        session: &InboundGroupSession,
+    ) {
+        let db = IdbDatabase::open(&db_name).unwrap().await.unwrap();
+        assert!(db.version() >= 10.0);
+        let transaction = db.transaction_on_one("inbound_group_sessions3").unwrap();
+        let raw_store = transaction.object_store("inbound_group_sessions3").unwrap();
+        let key = store
+            .serializer
+            .encode_key(keys::INBOUND_GROUP_SESSIONS_V3, (session.room_id(), session.session_id()));
+        let idb_object: InboundGroupSessionIndexedDbObject =
+            serde_wasm_bindgen::from_value(raw_store.get(&key).unwrap().await.unwrap().unwrap())
+                .unwrap();
+
+        assert_eq!(
+            idb_object.session_id,
+            Some(
+                store
+                    .serializer
+                    .encode_key_as_string(keys::INBOUND_GROUP_SESSIONS_V3, session.session_id())
+            )
+        );
+        assert_eq!(
+            idb_object.sender_key,
+            Some(store.serializer.encode_key_as_string(
+                keys::INBOUND_GROUP_SESSIONS_V3,
+                session.sender_key().to_base64()
+            ))
+        );
+        assert_eq!(idb_object.sender_data_type, Some(session.sender_data_type() as u8));
         db.close();
     }
 

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs
@@ -1,0 +1,37 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Migration code that moves from inbound_group_sessions2 to
+//! inbound_group_sessions3, shrinking the values stored in each record.
+
+use indexed_db_futures::IdbKeyPath;
+use web_sys::DomException;
+
+use crate::crypto_store::{keys, migrations::do_schema_upgrade, Result};
+
+/// Perform the schema upgrade v11 to v12, adding an index on
+/// `(curve_key, sender_data_type, session_id)` to `inbound_group_sessions3`.
+pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
+    do_schema_upgrade(name, 12, |_, transaction, _| {
+        let object_store = transaction.object_store(keys::INBOUND_GROUP_SESSIONS_V3)?;
+
+        object_store.create_index(
+            keys::INBOUND_GROUP_SESSIONS_SENDER_KEY_INDEX,
+            &IdbKeyPath::str_sequence(&["sender_key", "sender_data_type", "session_id"]),
+        )?;
+
+        Ok(())
+    })
+    .await
+}

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -64,6 +64,8 @@ mod keys {
     pub const INBOUND_GROUP_SESSIONS_V3: &str = "inbound_group_sessions3";
     pub const INBOUND_GROUP_SESSIONS_BACKUP_INDEX: &str = "backup";
     pub const INBOUND_GROUP_SESSIONS_BACKED_UP_TO_INDEX: &str = "backed_up_to";
+    pub const INBOUND_GROUP_SESSIONS_SENDER_KEY_INDEX: &str =
+        "inbound_group_session_sender_key_sender_data_type_idx";
 
     pub const OUTBOUND_GROUP_SESSIONS: &str = "outbound_group_sessions";
 

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -21,10 +21,12 @@ use async_trait::async_trait;
 use gloo_utils::format::JsValueSerdeExt;
 use hkdf::Hkdf;
 use indexed_db_futures::prelude::*;
+use js_sys::Array;
 use matrix_sdk_crypto::{
     olm::{
-        InboundGroupSession, OlmMessageHash, OutboundGroupSession, PickledInboundGroupSession,
-        PrivateCrossSigningIdentity, Session, StaticAccountData,
+        Curve25519PublicKey, InboundGroupSession, OlmMessageHash, OutboundGroupSession,
+        PickledInboundGroupSession, PrivateCrossSigningIdentity, SenderDataType, Session,
+        StaticAccountData,
     },
     store::{
         BackupKeys, Changes, CryptoStore, CryptoStoreError, PendingChanges, RoomKeyCounts,
@@ -936,6 +938,16 @@ impl_crypto_store! {
             |value| self.deserialize_inbound_group_session(value),
             INBOUND_GROUP_SESSIONS_BATCH_SIZE
         ).await
+    }
+
+    async fn get_inbound_group_sessions_for_device_batch(
+        &self,
+        sender_key: Curve25519PublicKey,
+        sender_data_type: SenderDataType,
+        after_session_id: Option<String>,
+        limit: usize,
+    ) -> Result<Vec<InboundGroupSession>> {
+        todo!();
     }
 
     async fn inbound_group_session_counts(&self, _backup_version: Option<&str>) -> Result<RoomKeyCounts> {

--- a/crates/matrix-sdk-sqlite/migrations/crypto_store/009_inbound_group_session_sender_key_sender_data_type.sql
+++ b/crates/matrix-sdk-sqlite/migrations/crypto_store/009_inbound_group_session_sender_key_sender_data_type.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "inbound_group_session"
+    ADD COLUMN "sender_key" BLOB;
+
+ALTER TABLE "inbound_group_session"
+    ADD COLUMN "sender_data_type" INTEGER;
+
+-- Create an index on sender curve25519 key and sender_data type, to help with
+-- `get_inbound_group_sessions_for_device_batch`.
+--
+-- `session_id` is included so that the results are sorted by (hashed) session id.
+CREATE INDEX "inbound_group_session_sender_key_sender_data_type_idx"
+    ON "inbound_group_session" ("sender_key", "sender_data_type", "session_id");

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -25,7 +25,7 @@ use deadpool_sqlite::{Object as SqliteAsyncConn, Pool as SqlitePool, Runtime};
 use matrix_sdk_crypto::{
     olm::{
         InboundGroupSession, OutboundGroupSession, PickledInboundGroupSession,
-        PrivateCrossSigningIdentity, Session, StaticAccountData,
+        PrivateCrossSigningIdentity, SenderDataType, Session, StaticAccountData,
     },
     store::{BackupKeys, Changes, CryptoStore, PendingChanges, RoomKeyCounts, RoomSettings},
     types::events::room_key_withheld::RoomKeyWithheldEvent,
@@ -40,6 +40,7 @@ use rusqlite::{params_from_iter, OptionalExtension};
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::{fs, sync::Mutex};
 use tracing::{debug, instrument, warn};
+use vodozemac::Curve25519PublicKey;
 
 use crate::{
     error::{Error, Result},
@@ -945,6 +946,16 @@ impl CryptoStore for SqliteCryptoStore {
                 self.deserialize_and_unpickle_inbound_group_session(value, backed_up)
             })
             .collect()
+    }
+
+    async fn get_inbound_group_sessions_for_device_batch(
+        &self,
+        sender_key: Curve25519PublicKey,
+        sender_data_type: SenderDataType,
+        after_session_id: Option<String>,
+        limit: usize,
+    ) -> Result<Vec<InboundGroupSession>, Self::Error> {
+        todo!()
     }
 
     async fn inbound_group_session_counts(


### PR DESCRIPTION
This PR adds a new method `CryptoStore::get_inbound_group_sessions_for_device_batch`, which is required for us to be able to update the information we hold about inbound group sessions when we get a `/keys/query` response (https://github.com/matrix-org/matrix-rust-sdk/issues/3753).

Strongly suggest reviewing commit-by-commit!

Fixes #3752