### PR TITLE
ffi: allow the clients to provide a custom `RequestConfig`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf, sync::Arc};
+use std::{fs, num::NonZeroUsize, path::PathBuf, sync::Arc, time::Duration};
 
 use futures_util::StreamExt;
 use matrix_sdk::{
@@ -259,6 +259,7 @@ pub struct ClientBuilder {
     additional_root_certificates: Vec<Vec<u8>>,
     disable_built_in_root_certificates: bool,
     encryption_settings: EncryptionSettings,
+    request_config: Option<RequestConfig>,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -288,6 +289,7 @@ impl ClientBuilder {
                     matrix_sdk::encryption::BackupDownloadStrategy::AfterDecryptionFailure,
                 auto_enable_backups: false,
             },
+            request_config: Default::default(),
         })
     }
 
@@ -442,6 +444,13 @@ impl ClientBuilder {
         Arc::new(builder)
     }
 
+    /// Add a default request config to this client.
+    pub fn request_config(self: Arc<Self>, config: RequestConfig) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.request_config = Some(config);
+        Arc::new(builder)
+    }
+
     pub async fn build(self: Arc<Self>) -> Result<Arc<Client>, ClientBuildError> {
         let builder = unwrap_or_clone_arc(self);
         let mut inner_builder = MatrixClient::builder();
@@ -537,6 +546,27 @@ impl ClientBuilder {
             inner_builder = inner_builder.requires_sliding_sync();
         }
 
+        if let Some(config) = builder.request_config {
+            let mut updated_config = matrix_sdk::config::RequestConfig::default();
+            if let Some(retry_limit) = config.retry_limit {
+                updated_config = updated_config.retry_limit(retry_limit);
+            }
+            if let Some(timeout) = config.timeout {
+                updated_config = updated_config.timeout(Duration::from_millis(timeout));
+            }
+            if let Some(max_concurrent_requests) = config.max_concurrent_requests {
+                if max_concurrent_requests > 0 {
+                    updated_config = updated_config.max_concurrent_requests(NonZeroUsize::new(
+                        max_concurrent_requests as usize,
+                    ));
+                }
+            }
+            if let Some(retry_timeout) = config.retry_timeout {
+                updated_config = updated_config.retry_timeout(Duration::from_millis(retry_timeout));
+            }
+            inner_builder = inner_builder.request_config(updated_config);
+        }
+
         let sdk_client = inner_builder.build().await?;
 
         Ok(Arc::new(
@@ -601,4 +631,17 @@ impl ClientBuilder {
 
         Ok(client)
     }
+}
+
+#[derive(Clone, uniffi::Record)]
+/// The config to use for HTTP requests by default in this client.
+pub struct RequestConfig {
+    /// Max number of retries.
+    retry_limit: Option<u64>,
+    /// Timeout for a request in milliseconds.
+    timeout: Option<u64>,
+    /// Max number of concurrent requests. No value means no limits.
+    max_concurrent_requests: Option<u64>,
+    /// Base delay between retries.
+    retry_timeout: Option<u64>,
 }


### PR DESCRIPTION
Without this, the default request config would always be used. This meant having unlimited retries for almost every request, even with no network connection.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
