### PR TITLE
sdk-ui: reverse (again) the order in the pinned events timeline

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -36,7 +36,7 @@ impl PinnedEventsLoader {
     /// `max_concurrent_requests` allows, to avoid overwhelming the server.
     ///
     /// It returns a `Result` with either a
-    /// reversed chronologically sorted list of retrieved `SyncTimelineEvent`s
+    /// chronologically sorted list of retrieved `SyncTimelineEvent`s
     /// or a `PinnedEventsLoaderError`.
     pub async fn load_events(
         &self,
@@ -109,10 +109,10 @@ impl PinnedEventsLoader {
                 .unwrap_or_else(|_| MilliSecondsSinceUnixEpoch::now())
         }
 
-        // Sort using reversed chronological ordering (newest -> oldest)
+        // Sort using chronological ordering (oldest -> newest)
         let sorted_events = loaded_events
             .into_iter()
-            .sorted_by(|e1, e2| timestamp(e1).cmp(&timestamp(e2)).reverse())
+            .sorted_by(|e1, e2| timestamp(e1).cmp(&timestamp(e2)))
             .collect();
 
         Ok(sorted_events)

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -67,10 +67,10 @@ async fn test_new_pinned_events_are_added_on_sync() {
     // The list is reloaded, so it's reset
     assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::Clear);
     assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::PushBack { value } => {
-        assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$2"));
+        assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$1"));
     });
     assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::PushBack { value } => {
-        assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$1"));
+        assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$2"));
     });
     assert_matches!(timeline_stream.next().await.unwrap(), VectorDiff::PushFront { value } => {
         assert!(value.is_day_divider());


### PR DESCRIPTION
This way it matches the rest of timelines in the SDK, I reversed it here because I didn't realise most clients just do this reversal of ordering themselves. As they do, they need the same order for this timeline too to be able to reuse their existing logic.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
