### PR TITLE
sdk-ui: add `fn Room::event_with_config`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -26,6 +26,7 @@ use futures_core::Stream;
 use futures_util::{FutureExt, StreamExt};
 use indexmap::IndexMap;
 use matrix_sdk::{
+    config::RequestConfig,
     deserialized_responses::{SyncTimelineEvent, TimelineEvent},
     event_cache::paginator::{PaginableRoom, PaginatorError},
     room::{EventWithContextResponse, Messages, MessagesOptions},
@@ -321,7 +322,11 @@ impl PaginableRoom for TestRoomDataProvider {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl PinnedEventsRoom for TestRoomDataProvider {
-    async fn event(&self, _event_id: &EventId) -> Result<SyncTimelineEvent, PaginatorError> {
+    async fn event_with_config(
+        &self,
+        _event_id: &EventId,
+        _config: Option<RequestConfig>,
+    ) -> Result<SyncTimelineEvent, PaginatorError> {
         unimplemented!();
     }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -389,9 +389,19 @@ impl Room {
 
     /// Fetch the event with the given `EventId` in this room.
     pub async fn event(&self, event_id: &EventId) -> Result<TimelineEvent> {
+        self.event_with_config(event_id, None).await
+    }
+
+    /// Fetch the event with the given `EventId` in this room, using the
+    /// provided  `RequestConfig`.
+    pub async fn event_with_config(
+        &self,
+        event_id: &EventId,
+        request_config: Option<RequestConfig>,
+    ) -> Result<TimelineEvent> {
         let request =
             get_room_event::v3::Request::new(self.room_id().to_owned(), event_id.to_owned());
-        let event = self.client.send(request, None).await?.event;
+        let event = self.client.send(request, request_config).await?.event;
         self.try_decrypt_event(event).await
     }
 


### PR DESCRIPTION
This method works the same as `Room::event` but you can provide a custom `RequestConfig` to it.

It's especially useful for the pinned events timeline, since we need a max number of retries and a max number of concurrent requests. With this we can remove some unnecessary complexity.

Related but not depending on https://github.com/matrix-org/matrix-rust-sdk/pull/3807.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
