### PR TITLE
feat(sdk): Subscribe to many rooms only via Sliding Sync

### DIFF
--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -373,8 +373,8 @@ impl NotificationClient {
             .build()
             .await?;
 
-        sync.subscribe_to_room(
-            room_id.to_owned(),
+        sync.subscribe_to_rooms(
+            &[room_id],
             Some(assign!(http::request::RoomSubscription::default(), {
                 required_state,
                 timeline_limit: Some(uint!(16))

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -19,8 +19,7 @@ use std::{ops::Deref, sync::Arc};
 
 use async_once_cell::OnceCell as AsyncOnceCell;
 use matrix_sdk::SlidingSync;
-use matrix_sdk_base::sliding_sync::http;
-use ruma::{events::StateEventType, RoomId};
+use ruma::RoomId;
 
 use super::Error;
 use crate::{
@@ -86,28 +85,6 @@ impl Room {
     /// Get the underlying [`matrix_sdk::Room`].
     pub fn inner_room(&self) -> &matrix_sdk::Room {
         &self.inner.room
-    }
-
-    /// Subscribe to this room.
-    ///
-    /// It means that all events from this room will be received every time, no
-    /// matter how the `RoomList` is configured.
-    pub fn subscribe(&self, settings: Option<http::request::RoomSubscription>) {
-        let mut settings = settings.unwrap_or_default();
-
-        // Make sure to always include the room creation event in the required state
-        // events, to know what the room version is.
-        if !settings
-            .required_state
-            .iter()
-            .any(|(event_type, _state_key)| *event_type == StateEventType::RoomCreate)
-        {
-            settings.required_state.push((StateEventType::RoomCreate, "".to_owned()));
-        }
-
-        self.inner
-            .sliding_sync
-            .subscribe_to_room(self.inner.room.room_id().to_owned(), Some(settings))
     }
 
     /// Get the timeline of the room if one exists.

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2128,19 +2128,20 @@ async fn test_room_subscription() -> Result<(), Error> {
         },
     };
 
-    let room1 = room_list.room(room_id_1).unwrap();
-
     // Subscribe.
 
-    room1.subscribe(Some(assign!(RoomSubscription::default(), {
-        required_state: vec![
-            (StateEventType::RoomName, "".to_owned()),
-            (StateEventType::RoomTopic, "".to_owned()),
-            (StateEventType::RoomAvatar, "".to_owned()),
-            (StateEventType::RoomCanonicalAlias, "".to_owned()),
-        ],
-        timeline_limit: Some(uint!(30)),
-    })));
+    room_list.subscribe_to_rooms(
+        &[room_id_1],
+        Some(assign!(RoomSubscription::default(), {
+            required_state: vec![
+                (StateEventType::RoomName, "".to_owned()),
+                (StateEventType::RoomTopic, "".to_owned()),
+                (StateEventType::RoomAvatar, "".to_owned()),
+                (StateEventType::RoomCanonicalAlias, "".to_owned()),
+            ],
+            timeline_limit: Some(uint!(30)),
+        })),
+    );
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -139,7 +139,7 @@ Notably, this map only knows about the rooms that have come down [Sliding
 Sync protocol][MSC] and if the given room isn't in any active list range, it
 may be stale. Additionally to selecting the room data via the room lists,
 the [Sliding Sync protocol][MSC] allows to subscribe to specific rooms via
-the [`subscribe_to_room()`](SlidingSync::subscribe_to_room). Any room subscribed
+the [`subscribe_to_rooms()`](SlidingSync::subscribe_to_rooms). Any room subscribed
 to will receive updates (with the given settings) regardless of whether they are
 visible in any list. The most common case for using this API is when the user
 enters a room - as we want to receive the incoming new messages regardless of

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -398,7 +398,7 @@ impl App {
             .get_selected_room_id(Some(selected))
             .and_then(|room_id| self.ui_rooms.lock().unwrap().get(&room_id).cloned())
         {
-            room.subscribe(None);
+            self.sync_service.room_list_service().subscribe_to_rooms(&[room.room_id()], None);
             self.current_room_subscription = Some(room);
         }
     }


### PR DESCRIPTION
This patch changes the `SlidingSync::subscribe_to_room` method to `subscribe_to_rooms`. Note the plural form. It's now mandatory to subscribe to a set of rooms. The idea is to avoid calling this method repeatedly. Why? Because each time the method is called, it sends a `SlidingSyncInternalMessage` of kind `SyncLoopSkipOverCurrentIteration`, i.e. it cancels the in-flight sliding sync request, to start over with a new one (with the new room subscription). A problem arises when the async runtime (here, Tokio) is busy: in this case, the internal message channel can be filled pretty easily because its size is 8. Messages are not consumed as fast as they are inserted. By changing this API: subscribing to multiple rooms will result in a single internal message, instead of one per room.

Consequently, the rest of the patch moves the `subscribe` method of `room_list_service::Room` to `room_list_service::RoomListService` because it now concerns multiple rooms instead of a single one.
