### PR TITLE
ffi: provide manual cancellation mechanism for identity/cross-signing reset handles

### DIFF
--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -434,6 +434,10 @@ impl IdentityResetHandle {
             self.inner.reset(None).await.map_err(|e| ClientError::Generic { msg: e.to_string() })
         }
     }
+
+    pub async fn cancel(&self) {
+        self.inner.cancel().await;
+    }
 }
 
 #[derive(uniffi::Enum)]

--- a/crates/matrix-sdk/src/encryption/recovery/mod.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/mod.rs
@@ -669,4 +669,9 @@ impl IdentityResetHandle {
 
         Ok(())
     }
+
+    /// Cancel the ongoing identity reset process
+    pub async fn cancel(&self) {
+        self.cross_signing_reset_handle.cancel().await;
+    }
 }


### PR DESCRIPTION
Works around swift issue where nil-ing the handle is not enough for it to get cancelled.