### PR TITLE
Sync: Don't spuriously show spinner

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -301,11 +301,11 @@ impl RoomListService {
 
             loop {
                 let (sync_indicator, yield_delay) = match current_state {
-                    State::Init | State::Recovering | State::Error { .. } => {
+                    State::Init | State::Error { .. } => {
                         (SyncIndicator::Show, delay_before_showing)
                     }
 
-                    State::SettingUp | State::Running | State::Terminated { .. } => {
+                    State::SettingUp | State::Recovering | State::Running | State::Terminated { .. } => {
                         (SyncIndicator::Hide, delay_before_hiding)
                     }
                 };

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2525,30 +2525,26 @@ async fn test_sync_indicator() -> Result<(), Error> {
                 SyncIndicator::Show,
                 under DELAY_BEFORE_SHOWING + request_margin,
             );
+
+            // Then, once the sync is done, the `SyncIndicator` must be hidden.
+            assert_next_sync_indicator!(
+                sync_indicator,
+                SyncIndicator::Hide,
+                under request_4_delay - DELAY_BEFORE_SHOWING
+                    + DELAY_BEFORE_HIDING
+                    + request_margin,
+            );
         }
 
         in_between_requests_synchronizer.recv().await.unwrap();
         assert_pending!(sync_indicator);
 
         // Request 5.
-        {
-            // It takes time for the system to recover…
-            assert_next_sync_indicator!(
-                sync_indicator,
-                SyncIndicator::Show,
-                under DELAY_BEFORE_SHOWING + request_margin,
-            );
 
-            // But finally, the system has recovered and is running. Time to hide the
-            // `SyncIndicator`.
-            assert_next_sync_indicator!(
-                sync_indicator,
-                SyncIndicator::Hide,
-                under request_5_delay - DELAY_BEFORE_SHOWING
-                    + DELAY_BEFORE_HIDING
-                    + request_margin,
-            );
-        }
+        in_between_requests_synchronizer.recv().await.unwrap();
+
+        // Even though request 5 took a while, the `SyncIndicator` shouldn't show.
+        assert_pending!(sync_indicator);
     });
 
     // Request 1.
@@ -2617,6 +2613,8 @@ async fn test_sync_indicator() -> Result<(), Error> {
         },
         after delay = request_5_delay, // Slow request!
     };
+
+    in_between_requests_synchronizer_sender.send(()).await.unwrap();
 
     sync_indicator_task.await.unwrap();
 


### PR DESCRIPTION
We should only show the spinner if the *first* sliding sync request is taking a while. If we have received some data and the second request takes a while, that is OK.

For the state transition of `Init -> SettingUp` this is handled correctly, however for `Terminated -> Recovering -> Running` we waited until the second request returned before hiding the sync spinner. This meant that if the first request returned quickly the app would show new data and *then* the sync spinner would show (if the second request took time).

This situation occurs frequently with the new SSS API, where if all the new data was returned in the first sync then the second sync would block waiting for new data, triggering the sync spinner.

--- 

Not sure if this needs a changelog entry, as it really only is noticeable with SSS.