### PR TITLE
testing: create `ruma_response_from_json`

### DIFF
--- a/benchmarks/benches/crypto_bench.rs
+++ b/benchmarks/benches/crypto_bench.rs
@@ -3,14 +3,11 @@ use std::{ops::Deref, sync::Arc};
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use matrix_sdk_crypto::{EncryptionSettings, OlmMachine};
 use matrix_sdk_sqlite::SqliteCryptoStore;
-use matrix_sdk_test::response_from_file;
+use matrix_sdk_test::ruma_response_from_json;
 use ruma::{
-    api::{
-        client::{
-            keys::{claim_keys, get_keys},
-            to_device::send_event_to_device::v3::Response as ToDeviceResponse,
-        },
-        IncomingResponse,
+    api::client::{
+        keys::{claim_keys, get_keys},
+        to_device::send_event_to_device::v3::Response as ToDeviceResponse,
     },
     device_id, room_id, user_id, DeviceId, OwnedUserId, TransactionId, UserId,
 };
@@ -28,25 +25,19 @@ fn alice_device_id() -> &'static DeviceId {
 fn keys_query_response() -> get_keys::v3::Response {
     let data = include_bytes!("crypto_bench/keys_query.json");
     let data: Value = serde_json::from_slice(data).unwrap();
-    let data = response_from_file(&data);
-    get_keys::v3::Response::try_from_http_response(data)
-        .expect("Can't parse the `/keys/upload` response")
+    ruma_response_from_json(&data)
 }
 
 fn keys_claim_response() -> claim_keys::v3::Response {
     let data = include_bytes!("crypto_bench/keys_claim.json");
     let data: Value = serde_json::from_slice(data).unwrap();
-    let data = response_from_file(&data);
-    claim_keys::v3::Response::try_from_http_response(data)
-        .expect("Can't parse the `/keys/upload` response")
+    ruma_response_from_json(&data)
 }
 
 fn huge_keys_query_response() -> get_keys::v3::Response {
     let data = include_bytes!("crypto_bench/keys_query_2000_members.json");
     let data: Value = serde_json::from_slice(data).unwrap();
-    let data = response_from_file(&data);
-    get_keys::v3::Response::try_from_http_response(data)
-        .expect("Can't parse the `/keys/query` response")
+    ruma_response_from_json(&data)
 }
 
 pub fn keys_query(c: &mut Criterion) {

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1617,15 +1617,10 @@ fn handle_room_member_event_for_profiles(
 #[cfg(test)]
 mod tests {
     use matrix_sdk_test::{
-        async_test, response_from_file, sync_timeline_event, InvitedRoomBuilder, LeftRoomBuilder,
-        StateTestEvent, StrippedStateTestEvent, SyncResponseBuilder,
+        async_test, ruma_response_from_json, sync_timeline_event, InvitedRoomBuilder,
+        LeftRoomBuilder, StateTestEvent, StrippedStateTestEvent, SyncResponseBuilder,
     };
-    use ruma::{
-        api::{client as api, IncomingResponse},
-        room_id,
-        serde::Raw,
-        user_id, UserId,
-    };
+    use ruma::{api::client as api, room_id, serde::Raw, user_id, UserId};
     use serde_json::{json, value::to_raw_value};
 
     use super::BaseClient;
@@ -1685,7 +1680,7 @@ mod tests {
 
         let client = logged_in_base_client(Some(user_id)).await;
 
-        let response = api::sync::sync_events::v3::Response::try_from_http_response(response_from_file(&json!({
+        let response = ruma_response_from_json(&json!({
             "next_batch": "asdkl;fjasdkl;fj;asdkl;f",
             "device_one_time_keys_count": {
                 "signed_curve25519": 50u64
@@ -1754,7 +1749,7 @@ mod tests {
                     }
                 }
             }
-        }))).expect("static json doesn't fail to parse");
+        }));
 
         client.receive_sync_response(response).await.unwrap();
 
@@ -1848,39 +1843,36 @@ mod tests {
             .await
             .unwrap();
 
-        let response = api::sync::sync_events::v3::Response::try_from_http_response(
-            response_from_file(&json!({
-                "next_batch": "asdkl;fjasdkl;fj;asdkl;f",
-                "rooms": {
-                    "join": {
-                        "!ithpyNKDtmhneaTQja:example.org": {
-                            "state": {
-                                "events": [
-                                    {
-                                        "invalid": "invalid",
+        let response = ruma_response_from_json(&json!({
+            "next_batch": "asdkl;fjasdkl;fj;asdkl;f",
+            "rooms": {
+                "join": {
+                    "!ithpyNKDtmhneaTQja:example.org": {
+                        "state": {
+                            "events": [
+                                {
+                                    "invalid": "invalid",
+                                },
+                                {
+                                    "content": {
+                                        "name": "The room name"
                                     },
-                                    {
-                                        "content": {
-                                            "name": "The room name"
-                                        },
-                                        "event_id": "$143273582443PhrSn:example.org",
-                                        "origin_server_ts": 1432735824653u64,
-                                        "room_id": "!jEsUZKDJdhlrceRyVU:example.org",
-                                        "sender": "@example:example.org",
-                                        "state_key": "",
-                                        "type": "m.room.name",
-                                        "unsigned": {
-                                            "age": 1234
-                                        }
-                                    },
-                                ]
-                            }
+                                    "event_id": "$143273582443PhrSn:example.org",
+                                    "origin_server_ts": 1432735824653u64,
+                                    "room_id": "!jEsUZKDJdhlrceRyVU:example.org",
+                                    "sender": "@example:example.org",
+                                    "state_key": "",
+                                    "type": "m.room.name",
+                                    "unsigned": {
+                                        "age": 1234
+                                    }
+                                },
+                            ]
                         }
                     }
                 }
-            })),
-        )
-        .expect("static json doesn't fail to parse");
+            }
+        }));
 
         client.receive_sync_response(response).await.unwrap();
         client

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -27,7 +27,7 @@ _disable-minimum-rotation-period-ms = []
 message-ids = []
 
 # Testing helpers for implementations based upon this
-testing = ["dep:http"]
+testing = ["matrix-sdk-test"]
 
 [dependencies]
 aes = "0.8.1"
@@ -43,11 +43,11 @@ futures-core = { workspace = true }
 futures-util = { workspace = true }
 hkdf = "0.12.3"
 hmac = "0.12.1"
-http = { workspace = true, optional = true } # feature = testing only
 itertools = { workspace = true }
 js_option = "0.1.1"
 matrix-sdk-qrcode = { workspace = true, optional = true }
 matrix-sdk-common = { workspace = true }
+matrix-sdk-test = { workspace = true, optional = true }  # feature = testing only
 pbkdf2 = { version = "0.12.2", default-features = false }
 rand = { workspace = true }
 rmp-serde = "1.1.1"

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1068,10 +1068,10 @@ pub(crate) mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     use assert_matches::assert_matches;
-    use matrix_sdk_test::{async_test, response_from_file, test_json};
+    use matrix_sdk_test::{async_test, ruma_response_from_json, test_json};
     use ruma::{
-        api::{client::keys::get_keys::v3::Response as KeyQueryResponse, IncomingResponse},
-        device_id, user_id, TransactionId,
+        api::client::keys::get_keys::v3::Response as KeyQueryResponse, device_id, user_id,
+        TransactionId,
     };
     use serde_json::{json, Value};
     use tokio::sync::Mutex;
@@ -1419,8 +1419,7 @@ pub(crate) mod tests {
                 "self_signing_keys": DataSet::ssk_b(),
             });
 
-        let kq_response = KeyQueryResponse::try_from_http_response(response_from_file(&data))
-            .expect("Can't parse the `/keys/upload` response");
+        let kq_response: KeyQueryResponse = ruma_response_from_json(&data);
         machine.mark_request_as_sent(&TransactionId::new(), &kq_response).await.unwrap();
 
         // The identity should not need any user approval now

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -2409,16 +2409,6 @@ pub struct EncryptionSyncChanges<'a> {
     pub next_batch_token: Option<String>,
 }
 
-#[cfg(any(feature = "testing", test))]
-#[allow(dead_code)]
-pub(crate) mod testing {
-    use http::Response;
-
-    pub fn response_from_file(json: &serde_json::Value) -> Response<Vec<u8>> {
-        Response::builder().status(200).body(json.to_string().as_bytes().to_vec()).unwrap()
-    }
-}
-
 #[cfg(test)]
 pub(crate) mod test_helpers;
 

--- a/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
+++ b/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
@@ -17,12 +17,9 @@
 
 use std::collections::BTreeMap;
 
-use matrix_sdk_test::test_json;
+use matrix_sdk_test::{ruma_response_from_json, test_json};
 use ruma::{
-    api::{
-        client::keys::{claim_keys, get_keys, upload_keys},
-        IncomingResponse,
-    },
+    api::client::keys::{claim_keys, get_keys, upload_keys},
     device_id,
     encryption::OneTimeKey,
     events::dummy::ToDeviceDummyEventContent,
@@ -30,10 +27,7 @@ use ruma::{
     user_id, DeviceId, OwnedDeviceKeyId, TransactionId, UserId,
 };
 
-use crate::{
-    machine::testing::response_from_file, store::Changes, types::events::ToDeviceEvent, DeviceData,
-    OlmMachine,
-};
+use crate::{store::Changes, types::events::ToDeviceEvent, DeviceData, OlmMachine};
 
 /// These keys need to be periodically uploaded to the server.
 type OneTimeKeys = BTreeMap<OwnedDeviceKeyId, Raw<OneTimeKey>>;
@@ -51,15 +45,13 @@ fn user_id() -> &'static UserId {
 }
 
 fn keys_upload_response() -> upload_keys::v3::Response {
-    let data = response_from_file(&test_json::KEYS_UPLOAD);
-    upload_keys::v3::Response::try_from_http_response(data)
-        .expect("Can't parse the `/keys/upload` response")
+    let json = &test_json::KEYS_UPLOAD;
+    ruma_response_from_json(json)
 }
 
-fn keys_query_response() -> get_keys::v3::Response {
-    let data = response_from_file(&test_json::KEYS_QUERY);
-    get_keys::v3::Response::try_from_http_response(data)
-        .expect("Can't parse the `/keys/upload` response")
+pub fn keys_query_response() -> get_keys::v3::Response {
+    let json = &test_json::KEYS_QUERY;
+    ruma_response_from_json(json)
 }
 
 pub async fn get_prepared_machine_test_helper(

--- a/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
@@ -18,12 +18,8 @@ use assert_matches2::{assert_let, assert_matches};
 use matrix_sdk_common::deserialized_responses::{
     DeviceLinkProblem, ShieldState, VerificationLevel, VerificationState,
 };
-use matrix_sdk_test::{async_test, test_json};
+use matrix_sdk_test::{async_test, ruma_response_from_json, test_json};
 use ruma::{
-    api::{
-        client::keys::{get_keys, get_keys::v3::Response as KeyQueryResponse},
-        IncomingResponse,
-    },
     events::{room::message::RoomMessageEventContent, AnyMessageLikeEventContent},
     room_id,
     serde::Raw,
@@ -37,7 +33,6 @@ use crate::{
         test_helpers::{
             get_machine_pair_with_setup_sessions_test_helper, get_prepared_machine_test_helper,
         },
-        testing::response_from_file,
         tests,
     },
     olm::{InboundGroupSession, OutboundGroupSession, SenderData},
@@ -293,9 +288,7 @@ pub async fn mark_alice_identity_as_verified_test_helper(alice: &OlmMachine, bob
       }
     );
 
-    let kq_response = KeyQueryResponse::try_from_http_response(response_from_file(&json))
-        .expect("Can't parse the `/keys/upload` response");
-
+    let kq_response = ruma_response_from_json(&json);
     alice.receive_keys_query_response(&TransactionId::new(), &kq_response).await.unwrap();
     bob.receive_keys_query_response(&TransactionId::new(), &kq_response).await.unwrap();
 
@@ -317,9 +310,8 @@ async fn test_verification_states_multiple_device() {
 
     let other_user_id = user_id!("@web2:localhost:8482");
 
-    let data = response_from_file(&test_json::KEYS_QUERY_TWO_DEVICES_ONE_SIGNED);
-    let response = get_keys::v3::Response::try_from_http_response(data)
-        .expect("Can't parse the `/keys/upload` response");
+    let json = &test_json::KEYS_QUERY_TWO_DEVICES_ONE_SIGNED;
+    let response = ruma_response_from_json(json);
 
     let (device_change, identity_change) =
         bob.receive_keys_query_response(&TransactionId::new(), &response).await.unwrap();

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -20,17 +20,11 @@ use itertools::Itertools;
 use matrix_sdk_common::deserialized_responses::{
     UnableToDecryptInfo, UnsignedDecryptionResult, UnsignedEventLocation,
 };
-use matrix_sdk_test::{async_test, message_like_event_content, test_json};
+use matrix_sdk_test::{async_test, message_like_event_content, ruma_response_from_json, test_json};
 use ruma::{
-    api::{
-        client::{
-            keys::{
-                get_keys::{self, v3::Response as KeyQueryResponse},
-                upload_keys,
-            },
-            sync::sync_events::DeviceLists,
-        },
-        IncomingResponse,
+    api::client::{
+        keys::{get_keys, upload_keys},
+        sync::sync_events::DeviceLists,
     },
     device_id,
     events::{
@@ -51,7 +45,7 @@ use vodozemac::{
     Ed25519PublicKey,
 };
 
-use super::{testing::response_from_file, CrossSigningBootstrapRequests};
+use super::CrossSigningBootstrapRequests;
 use crate::{
     error::EventError,
     machine::{
@@ -103,15 +97,13 @@ fn user_id() -> &'static UserId {
 }
 
 fn keys_upload_response() -> upload_keys::v3::Response {
-    let data = response_from_file(&test_json::KEYS_UPLOAD);
-    upload_keys::v3::Response::try_from_http_response(data)
-        .expect("Can't parse the `/keys/upload` response")
+    let json = &test_json::KEYS_UPLOAD;
+    ruma_response_from_json(json)
 }
 
 fn keys_query_response() -> get_keys::v3::Response {
-    let data = response_from_file(&test_json::KEYS_QUERY);
-    get_keys::v3::Response::try_from_http_response(data)
-        .expect("Can't parse the `/keys/upload` response")
+    let json = &test_json::KEYS_QUERY;
+    ruma_response_from_json(json)
 }
 
 pub fn to_device_requests_to_content(
@@ -749,9 +741,7 @@ pub async fn setup_cross_signing_for_machine_test_helper(alice: &OlmMachine, bob
       }
     );
 
-    let kq_response = KeyQueryResponse::try_from_http_response(response_from_file(&json))
-        .expect("Can't parse the `/keys/upload` response");
-
+    let kq_response = ruma_response_from_json(&json);
     alice.receive_keys_query_response(&TransactionId::new(), &kq_response).await.unwrap();
     bob.receive_keys_query_response(&TransactionId::new(), &kq_response).await.unwrap();
 }
@@ -810,9 +800,7 @@ async fn sign_alice_device_for_machine_test_helper(alice: &OlmMachine, bob: &Olm
       }
     );
 
-    let kq_response = KeyQueryResponse::try_from_http_response(response_from_file(&json))
-        .expect("Can't parse the `/keys/upload` response");
-
+    let kq_response = ruma_response_from_json(&json);
     alice.receive_keys_query_response(&TransactionId::new(), &kq_response).await.unwrap();
     bob.receive_keys_query_response(&TransactionId::new(), &kq_response).await.unwrap();
 }

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
@@ -779,14 +779,11 @@ mod tests {
     };
 
     use assert_matches2::assert_let;
-    use matrix_sdk_test::{async_test, response_from_file};
+    use matrix_sdk_test::{async_test, ruma_response_from_json};
     use ruma::{
-        api::{
-            client::{
-                keys::{claim_keys, get_keys, upload_keys},
-                to_device::send_event_to_device::v3::Response as ToDeviceResponse,
-            },
-            IncomingResponse,
+        api::client::{
+            keys::{claim_keys, get_keys, upload_keys},
+            to_device::send_event_to_device::v3::Response as ToDeviceResponse,
         },
         device_id,
         events::room::history_visibility::HistoryVisibility,
@@ -826,9 +823,7 @@ mod tests {
     fn keys_query_response() -> get_keys::v3::Response {
         let data = include_bytes!("../../../../../benchmarks/benches/crypto_bench/keys_query.json");
         let data: Value = serde_json::from_slice(data).unwrap();
-        let data = response_from_file(&data);
-        get_keys::v3::Response::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        ruma_response_from_json(&data)
     }
 
     fn bob_keys_query_response() -> get_keys::v3::Response {
@@ -856,10 +851,7 @@ mod tests {
                 }
             }
         });
-        let data = response_from_file(&data);
-
-        get_keys::v3::Response::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        ruma_response_from_json(&data)
     }
 
     /// Returns a keys claim response for device `BOBDEVICE` of user
@@ -882,10 +874,7 @@ mod tests {
                 }
             }
         });
-        let data = response_from_file(&data);
-
-        claim_keys::v3::Response::try_from_http_response(data)
-            .expect("Can't parse the keys claim response")
+        ruma_response_from_json(&data)
     }
 
     /// Returns a key claim response for device `NMMBNBUSNR` of user
@@ -893,9 +882,7 @@ mod tests {
     fn keys_claim_response() -> claim_keys::v3::Response {
         let data = include_bytes!("../../../../../benchmarks/benches/crypto_bench/keys_claim.json");
         let data: Value = serde_json::from_slice(data).unwrap();
-        let data = response_from_file(&data);
-        claim_keys::v3::Response::try_from_http_response(data)
-            .expect("Can't parse the keys claim response")
+        ruma_response_from_json(&data)
     }
 
     async fn machine_with_user_test_helper(user_id: &UserId, device_id: &DeviceId) -> OlmMachine {
@@ -1370,9 +1357,7 @@ mod tests {
                 }
             }
         });
-        let keys_query =
-            get_keys::v3::Response::try_from_http_response(response_from_file(&keys_query_data))
-                .unwrap();
+        let keys_query: get_keys::v3::Response = ruma_response_from_json(&keys_query_data);
         let txn_id = TransactionId::new();
         machine.mark_request_as_sent(&txn_id, &keys_query).await.unwrap();
 

--- a/testing/matrix-sdk-test/src/lib.rs
+++ b/testing/matrix-sdk-test/src/lib.rs
@@ -152,10 +152,15 @@ pub fn sync_response(kind: SyncResponseFile) -> SyncResponse {
         SyncResponseFile::Voip => &test_json::VOIP_SYNC,
     };
 
-    let response = Response::builder().body(data.to_string().as_bytes().to_vec()).unwrap();
-    SyncResponse::try_from_http_response(response).unwrap()
+    ruma_response_from_json(data)
 }
 
-pub fn response_from_file(json: &JsonValue) -> Response<Vec<u8>> {
-    Response::builder().status(200).body(json.to_string().as_bytes().to_vec()).unwrap()
+/// Build a typed Ruma [`IncomingResponse`] object from a json body.
+pub fn ruma_response_from_json<ResponseType: IncomingResponse>(
+    json: &serde_json::Value,
+) -> ResponseType {
+    let json_bytes = serde_json::to_vec(json).expect("JSON-serialization of response value failed");
+    let http_response =
+        Response::builder().status(200).body(json_bytes).expect("Failed to build HTTP response");
+    ResponseType::try_from_http_response(http_response).expect("Can't parse the response json")
 }

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -1,10 +1,10 @@
 use ruma::{
-    api::{client::keys::get_keys::v3::Response as KeyQueryResponse, IncomingResponse},
-    device_id, user_id, DeviceId, UserId,
+    api::client::keys::get_keys::v3::Response as KeyQueryResponse, device_id, user_id, DeviceId,
+    UserId,
 };
 use serde_json::{json, Value};
 
-use crate::response_from_file;
+use crate::ruma_response_from_json;
 
 /// This set of keys/query response was generated using a local synapse.
 /// Each users was created, device added according to needs and the payload
@@ -95,10 +95,7 @@ impl KeyDistributionTestData {
             }
         });
 
-        let data = response_from_file(&data);
-
-        KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        ruma_response_from_json(&data)
     }
 
     /// Dan has cross-signing setup, one device is cross signed `JHPUERYQUW`,
@@ -200,10 +197,7 @@ impl KeyDistributionTestData {
                 }
         });
 
-        let data = response_from_file(&data);
-
-        KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        ruma_response_from_json(&data)
     }
 
     /// Same as `dan_keys_query_response` but `FRGNMZVOKA` was removed.
@@ -286,10 +280,7 @@ impl KeyDistributionTestData {
                 }
         });
 
-        let data = response_from_file(&data);
-
-        KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        ruma_response_from_json(&data)
     }
 
     /// Dave is a user that has not enabled cross-signing
@@ -318,10 +309,7 @@ impl KeyDistributionTestData {
             }
         });
 
-        let data = response_from_file(&data);
-
-        KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        ruma_response_from_json(&data)
     }
 
     /// Good is a user that has all his devices correctly cross-signed
@@ -419,10 +407,7 @@ impl KeyDistributionTestData {
             }
         });
 
-        let data = response_from_file(&data);
-
-        KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        ruma_response_from_json(&data)
     }
 
     pub fn me_id() -> &'static UserId {
@@ -541,7 +526,7 @@ impl IdentityChangeDataSet {
     /// A key query with an identity (Ia), and a first device `GYKSNAWLVK`
     /// signed by Ia.
     pub fn key_query_with_identity_a() -> KeyQueryResponse {
-        let data = response_from_file(&json!({
+        let data = json!({
             "device_keys": {
                 "@bob:localhost": {
                     "GYKSNAWLVK": Self::device_keys_payload_1_signed_by_a()
@@ -551,9 +536,8 @@ impl IdentityChangeDataSet {
             "master_keys": Self::msk_a(),
             "self_signing_keys": Self::ssk_a(),
             "user_signing_keys": {}
-        }));
-        KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        });
+        ruma_response_from_json(&data)
     }
 
     pub fn msk_b() -> Value {
@@ -619,7 +603,7 @@ impl IdentityChangeDataSet {
     /// `ATWKQFSFRN` is signed with the new identity but `GYKSNAWLVK` is still
     /// signed by the old identity (Ia).
     pub fn key_query_with_identity_b() -> KeyQueryResponse {
-        let data = response_from_file(&json!({
+        let data = json!({
             "device_keys": {
                 "@bob:localhost": {
                     "ATWKQFSFRN": Self::device_keys_payload_2_signed_by_b(),
@@ -629,15 +613,14 @@ impl IdentityChangeDataSet {
             "failures": {},
             "master_keys": Self::msk_b(),
             "self_signing_keys": Self::ssk_b(),
-        }));
-        KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        });
+        ruma_response_from_json(&data)
     }
 
     /// A key query with no identity and a new device `OPABMDDXGX` (not
     /// cross-signed).
     pub fn key_query_with_identity_no_identity() -> KeyQueryResponse {
-        let data = response_from_file(&json!({
+        let data = json!({
             "device_keys": {
                 "@bob:localhost": {
                     "ATWKQFSFRN": Self::device_keys_payload_2_signed_by_b(),
@@ -662,9 +645,8 @@ impl IdentityChangeDataSet {
                 }
             },
             "failures": {},
-        }));
-        KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        });
+        ruma_response_from_json(&data)
     }
 }
 
@@ -744,10 +726,7 @@ impl PreviouslyVerifiedTestData {
             }
         });
 
-        let data = response_from_file(&data);
-
-        KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        ruma_response_from_json(&data)
     }
 
     pub fn device_keys_payload_bob_unsigned_device() -> Value {
@@ -839,10 +818,7 @@ impl PreviouslyVerifiedTestData {
             "user_signing_keys": {}
         });
 
-        let data = response_from_file(&data);
-
-        KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        ruma_response_from_json(&data)
     }
 
     pub fn bob_device_1_id() -> &'static DeviceId {
@@ -940,10 +916,7 @@ impl PreviouslyVerifiedTestData {
             "user_signing_keys": {}
         });
 
-        let data = response_from_file(&data);
-
-        KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        ruma_response_from_json(&data)
     }
 
     pub fn device_1_keys_payload_carol() -> Value {
@@ -1043,10 +1016,7 @@ impl PreviouslyVerifiedTestData {
             "user_signing_keys": {}
         });
 
-        let data = response_from_file(&data);
-
-        KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        ruma_response_from_json(&data)
     }
 
     pub fn carol_keys_query_response_signed() -> KeyQueryResponse {
@@ -1082,9 +1052,6 @@ impl PreviouslyVerifiedTestData {
             "user_signing_keys": {}
         });
 
-        let data = response_from_file(&data);
-
-        KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
+        ruma_response_from_json(&data)
     }
 }


### PR DESCRIPTION
We had *two* copies of `response_from_file`, and all calls to them were always immediately followed by an operation to parse the response as a Ruma response object.

We can save a whole lot of boilerplate with a generic function that wraps the json into an HTTP response *and* parses it into a Ruma object.