### PR TITLE
Remove redundant `testing` feature from matrix-sdk-crypto

### DIFF
--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -36,7 +36,6 @@ testing = [
     "dep:assert_matches2",
     "dep:http",
     "dep:matrix-sdk-test",
-    "matrix-sdk-crypto?/testing",
 ]
 
 [dependencies]

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -26,9 +26,6 @@ _disable-minimum-rotation-period-ms = []
 # "message-ids" feature doesn't do anything and is deprecated.
 message-ids = []
 
-# Testing helpers for implementations based upon this
-testing = ["dep:http"]
-
 [dependencies]
 aes = "0.8.1"
 as_variant = { workspace = true }

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -34,7 +34,7 @@ use tracing::{instrument, trace, warn};
 use vodozemac::{olm::SessionConfig, Curve25519PublicKey, Ed25519PublicKey};
 
 use super::{atomic_bool_deserializer, atomic_bool_serializer};
-#[cfg(any(test, feature = "testing", doc))]
+#[cfg(any(test, doc))]
 use crate::OlmMachine;
 use crate::{
     error::{EventError, MismatchedIdentityKeysError, OlmError, OlmResult, SignatureError},
@@ -936,7 +936,7 @@ impl DeviceData {
         self.deleted.store(true, Ordering::Relaxed);
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(test)]
     #[allow(dead_code)]
     /// Generate the Device from a reference of an OlmMachine.
     pub async fn from_machine_test_helper(
@@ -998,7 +998,7 @@ impl PartialEq for DeviceData {
 }
 
 /// Testing Facilities for Device Management
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 #[allow(dead_code)]
 pub(crate) mod testing {
     use serde_json::json;

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1062,7 +1062,7 @@ fn debug_log_keys_query_response(
     );
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 #[allow(dead_code)]
 pub(crate) mod testing {
     use std::sync::Arc;

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -991,7 +991,7 @@ impl OwnUserIdentityData {
 }
 
 /// Testing Facilities
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 #[allow(dead_code)]
 pub(crate) mod testing {
     use ruma::{api::client::keys::get_keys::v3::Response as KeyQueryResponse, user_id};

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -33,7 +33,7 @@ pub mod types;
 mod utilities;
 mod verification;
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 /// Testing facilities and helpers for crypto tests
 pub mod testing {
     pub use crate::identities::{

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -2318,7 +2318,7 @@ impl OlmMachine {
         Ok(())
     }
 
-    #[cfg(any(feature = "testing", test))]
+    #[cfg(test)]
     /// Returns whether this `OlmMachine` is the same another one.
     ///
     /// Useful for testing purposes only.
@@ -2327,7 +2327,7 @@ impl OlmMachine {
     }
 
     /// Testing purposes only.
-    #[cfg(any(feature = "testing", test))]
+    #[cfg(test)]
     pub async fn uploaded_key_count(&self) -> Result<u64, CryptoStoreError> {
         let cache = self.inner.store.cache().await?;
         let account = cache.account().await?;
@@ -2409,7 +2409,7 @@ pub struct EncryptionSyncChanges<'a> {
     pub next_batch_token: Option<String>,
 }
 
-#[cfg(any(feature = "testing", test))]
+#[cfg(test)]
 #[allow(dead_code)]
 pub(crate) mod testing {
     use http::Response;

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -230,7 +230,7 @@ impl StaticAccountData {
         Ok((outbound, inbound))
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(test)]
     #[allow(dead_code)]
     /// Testing only facility to create a group session pair with default
     /// settings.
@@ -1075,7 +1075,7 @@ impl Account {
         Ok(InboundCreationResult { session, plaintext })
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(test)]
     #[allow(dead_code)]
     /// Testing only helper to create a session for the given Account
     pub async fn create_session_for_test_helper(

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -542,14 +542,14 @@ impl PrivateCrossSigningIdentity {
 
     /// Create a new cross signing identity without signing the device that
     /// created it.
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(test)]
     #[allow(dead_code)]
     pub fn new(user_id: OwnedUserId) -> Self {
         let master = MasterSigning::new(user_id.to_owned());
         Self::new_helper(&user_id, master)
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(test)]
     #[allow(dead_code)]
     /// Testing helper to reset this CrossSigning with a fresh one using the
     /// local identity

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -84,7 +84,7 @@ mod error;
 mod memorystore;
 mod traits;
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 #[macro_use]
 #[allow(missing_docs)]
 pub mod integration_tests;

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["e2e-encryption", "state-store"]
 state-store = ["dep:matrix-sdk-base", "growable-bloom-filter"]
 e2e-encryption = ["dep:matrix-sdk-crypto"]
-testing = ["matrix-sdk-crypto?/testing"]
+testing = []
 
 [dependencies]
 anyhow = { workspace = true }
@@ -52,7 +52,7 @@ assert_matches = { workspace = true }
 assert_matches2 = { workspace = true }
 matrix-sdk-base = { workspace = true, features = ["testing"] }
 matrix-sdk-common = { workspace = true, features = ["js"] }
-matrix-sdk-crypto = { workspace = true, features = ["js", "testing"] }
+matrix-sdk-crypto = { workspace = true, features = ["js"] }
 matrix-sdk-test = { workspace = true }
 rand = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["registry", "tracing-log"] }

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = { workspace = true }
 
 [features]
 default = ["state-store"]
-testing = ["matrix-sdk-crypto?/testing"]
+testing = []
 
 bundled = ["rusqlite/bundled"]
 crypto-store = ["dep:matrix-sdk-crypto"]
@@ -36,7 +36,7 @@ vodozemac = { workspace = true }
 assert_matches = { workspace = true }
 glob = "0.3.0"
 matrix-sdk-base = { workspace = true, features = ["testing"] }
-matrix-sdk-crypto = { workspace = true, features = ["testing"] }
+matrix-sdk-crypto = { workspace = true }
 matrix-sdk-test = { workspace = true }
 once_cell = { workspace = true }
 similar-asserts = { workspace = true }


### PR DESCRIPTION
Nobody actually needs any of this, so we may as well kill it off.