### PR TITLE
pinned events: a collection of small refactorings

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -250,7 +250,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
             TimelineFocus::PinnedEvents { max_events_to_load } => (
                 TimelineFocusData::PinnedEvents {
                     loader: PinnedEventsLoader::new(
-                        Box::new(room_data_provider.clone()),
+                        Arc::new(room_data_provider.clone()),
                         max_events_to_load as usize,
                     ),
                 },
@@ -341,7 +341,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         }
     }
 
-    pub(crate) async fn pinned_events_load_events(
+    pub(crate) async fn reload_pinned_events(
         &self,
         pinned_event_cache: &PinnedEventCache,
     ) -> Result<Vec<SyncTimelineEvent>, PinnedEventsLoaderError> {
@@ -354,7 +354,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         }
     }
 
-    pub(crate) async fn pinned_events_update(
+    pub(crate) async fn update_pinned_events_if_needed(
         &self,
         events: Vec<SyncTimelineEvent>,
         pinned_event_cache: &PinnedEventCache,

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -354,20 +354,6 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         }
     }
 
-    pub(crate) async fn update_pinned_events_if_needed(
-        &self,
-        events: Vec<SyncTimelineEvent>,
-        pinned_event_cache: &PinnedEventCache,
-    ) -> Option<Result<Vec<SyncTimelineEvent>, PinnedEventsLoaderError>> {
-        let focus_guard = self.focus.read().await;
-
-        if let TimelineFocusData::PinnedEvents { loader } = &*focus_guard {
-            loader.update_if_needed(events, pinned_event_cache).await
-        } else {
-            Some(Err(PinnedEventsLoaderError::TimelineFocusNotPinnedEvents))
-        }
-    }
-
     /// Run a backward pagination (in focused mode) and append the results to
     /// the timeline.
     ///

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -118,35 +118,6 @@ impl PinnedEventsLoader {
 
         Ok(loaded_events)
     }
-
-    /// Updates the cache with the provided events if they're associated with a
-    /// pinned event id, then reloads the list of pinned events if there
-    /// were any changes.
-    ///
-    /// Returns an `Option` with either a new list of events if any of them
-    /// changed in this update or `None` if they didn't.
-    pub async fn update_if_needed(
-        &self,
-        events: Vec<impl Into<SyncTimelineEvent>>,
-        cache: &PinnedEventCache,
-    ) -> Option<Result<Vec<SyncTimelineEvent>, PinnedEventsLoaderError>> {
-        let mut to_update = Vec::new();
-        for ev in events {
-            let ev = ev.into();
-            if let Some(ev_id) = ev.event_id() {
-                if self.room.is_pinned_event(&ev_id) {
-                    to_update.push(ev);
-                }
-            }
-        }
-
-        if !to_update.is_empty() {
-            cache.set_bulk(to_update).await;
-            Some(self.load_events(cache).await)
-        } else {
-            None
-        }
-    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -87,7 +87,7 @@ impl PinnedEventsLoader {
             let new_events = join_all(event_ids_to_request.into_iter().map(|event_id| {
                 let provider = Arc::clone(&provider);
                 async move {
-                    match provider.event_with_config(&event_id, request_config).await {
+                    match provider.fetch_event(&event_id, request_config).await {
                         Ok(event) => Some(event),
                         Err(err) => {
                             warn!("error when loading pinned event: {err}");
@@ -124,7 +124,7 @@ impl PinnedEventsLoader {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait PinnedEventsRoom: SendOutsideWasm + SyncOutsideWasm {
     /// Load a single room event.
-    async fn event_with_config(
+    async fn fetch_event(
         &self,
         event_id: &EventId,
         request_config: Option<RequestConfig>,
@@ -143,7 +143,7 @@ pub trait PinnedEventsRoom: SendOutsideWasm + SyncOutsideWasm {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl PinnedEventsRoom for Room {
-    async fn event_with_config(
+    async fn fetch_event(
         &self,
         event_id: &EventId,
         request_config: Option<RequestConfig>,

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -28,7 +28,10 @@ const MAX_CONCURRENT_REQUESTS: usize = 10;
 
 /// Utility to load the pinned events in a room.
 pub struct PinnedEventsLoader {
+    /// Backend to load pinned events.
     room: Arc<Box<dyn PinnedEventsRoom>>,
+    /// Maximum number of pinned events to load (either from network or the
+    /// cache).
     max_events_to_load: usize,
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -8,7 +8,7 @@ use matrix_sdk::{
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedEventId};
 use thiserror::Error;
-use tracing::{info, warn};
+use tracing::{debug, warn};
 
 const MAX_CONCURRENT_REQUESTS: usize = 10;
 
@@ -55,10 +55,10 @@ impl PinnedEventsLoader {
         let mut event_ids_to_request = Vec::new();
         for ev_id in pinned_event_ids {
             if let Some(ev) = cache.get(&ev_id).await {
-                info!("Loading pinned event {ev_id} from cache");
+                debug!("Loading pinned event {ev_id} from cache");
                 loaded_events.push(ev.clone());
             } else {
-                info!("Loading pinned event {ev_id} from HS");
+                debug!("Loading pinned event {ev_id} from HS");
                 event_ids_to_request.push(ev_id);
             }
         }
@@ -93,7 +93,7 @@ impl PinnedEventsLoader {
             return Err(PinnedEventsLoaderError::TimelineReloadFailed);
         }
 
-        info!("Saving {} pinned events to the cache", loaded_events.len());
+        debug!("Saving {} pinned events to the cache", loaded_events.len());
         cache.set_bulk(&loaded_events).await;
 
         // Sort using chronological ordering (oldest -> newest)

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -16,17 +16,12 @@ const MAX_CONCURRENT_REQUESTS: usize = 10;
 pub struct PinnedEventsLoader {
     room: Arc<Box<dyn PinnedEventsRoom>>,
     max_events_to_load: usize,
-    max_concurrent_requests: usize,
 }
 
 impl PinnedEventsLoader {
     /// Creates a new `PinnedEventsLoader` instance.
     pub fn new(room: Box<dyn PinnedEventsRoom>, max_events_to_load: usize) -> Self {
-        Self {
-            room: Arc::new(room),
-            max_events_to_load,
-            max_concurrent_requests: MAX_CONCURRENT_REQUESTS,
-        }
+        Self { room: Arc::new(room), max_events_to_load }
     }
 
     /// Loads the pinned events in this room, using the cache first and then
@@ -69,7 +64,7 @@ impl PinnedEventsLoader {
             let request_config = Some(
                 RequestConfig::default()
                     .retry_limit(3)
-                    .max_concurrent_requests(NonZeroUsize::new(self.max_concurrent_requests)),
+                    .max_concurrent_requests(NonZeroUsize::new(MAX_CONCURRENT_REQUESTS)),
             );
 
             let new_events = join_all(event_ids_to_request.into_iter().map(|event_id| {
@@ -184,7 +179,7 @@ impl PinnedEventsRoom for Room {
 impl std::fmt::Debug for PinnedEventsLoader {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PinnedEventsLoader")
-            .field("max_concurrent_requests", &self.max_concurrent_requests)
+            .field("max_events_to_load", &self.max_events_to_load)
             .finish()
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::{fmt::Formatter, num::NonZeroUsize, sync::Arc};
 
 use futures_util::future::join_all;

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -322,7 +322,7 @@ impl PaginableRoom for TestRoomDataProvider {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl PinnedEventsRoom for TestRoomDataProvider {
-    async fn event_with_config(
+    async fn fetch_event(
         &self,
         _event_id: &EventId,
         _config: Option<RequestConfig>,

--- a/crates/matrix-sdk/src/pinned_events_cache.rs
+++ b/crates/matrix-sdk/src/pinned_events_cache.rs
@@ -26,11 +26,11 @@ impl PinnedEventCache {
     }
 
     /// Adds a list of pinned events to the cache in a performant way.
-    pub async fn set_bulk(&self, events: &Vec<SyncTimelineEvent>) {
+    pub async fn set_bulk(&self, events: Vec<SyncTimelineEvent>) {
         let mut cache = self.inner.events.write().await;
         for ev in events {
             if let Some(ev_id) = ev.event_id() {
-                cache.insert(ev_id.to_owned(), ev.clone());
+                cache.insert(ev_id.to_owned(), ev);
             }
         }
     }


### PR DESCRIPTION
To make the code more idiomatic, avoid having too many concepts, rename a few things, etc.

Next I'll merge the pinned event cache into the event cache, because there's no reason to have two different event caches.