### PR TITLE
feat(sdk): `compute_limited` is only useful for the SS proxy

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -259,8 +259,9 @@ impl SlidingSync {
 
         trace!(yes = must_process_rooms_response, "Must process rooms response?");
 
-        // Compute `limited`, if we're interested in a room list query.
-        if must_process_rooms_response {
+        // Compute `limited` for the SS proxy only, if we're interested in a room list
+        // query.
+        if !self.inner.client.is_simplified_sliding_sync_enabled() && must_process_rooms_response {
             let known_rooms = self.inner.rooms.read().await;
             compute_limited(&known_rooms, &mut sliding_sync_response.rooms);
         }


### PR DESCRIPTION
This patch restricts the call to `compute_limited` to the sliding sync proxy implementation (aka MCS3575). It is not necessary for the sliding sync native implementation (aka Simplified MSC3575). The proxy doesn't implement the `limited` flag, contrary to Synapse. Let's not run workarounds when we don't need them.