### PR TITLE
Test: improve documentation of `PreviouslyVerifiedTestData`

### DIFF
--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -729,29 +729,6 @@ impl PreviouslyVerifiedTestData {
         ruma_response_from_json(&data)
     }
 
-    pub fn device_keys_payload_bob_unsigned_device() -> Value {
-        json!({
-            "algorithms": [
-                "m.olm.v1.curve25519-aes-sha2",
-                "m.megolm.v1.aes-sha2"
-            ],
-            "device_id": "XCYNVRMTER",
-            "keys": {
-                "curve25519:XCYNVRMTER": "xGKYkFcHGlJ+I1yiefPyZu1EY8i2h1eed5uk3PAW6GA",
-                "ed25519:XCYNVRMTER": "EsU8MJzTYE+/VJs1K9HkGqb8UXCByPioynGrV28WocU"
-            },
-            "signatures": {
-                "@bob:localhost": {
-                    "ed25519:XCYNVRMTER": "yZ7cpaoA+0rRx+bmklsP1iAd0eGPH6gsdywC11VE98/mrcbeFuxjQVn39Ds7h+vmciu5GRzwWgDgv+6go6FHAQ",
-                    // Remove the cross-signature
-                    // "ed25519:e8JFSrW8LW3UK6SSXh2ZESUzptFbapr28/+WqndD+Xk": "xYnGmU9FEdoavB5P743gx3xbEy29tlfRX5lT3JO0dWhHdsP+muqBXUYMBl1RRFeZtIE0GYc9ORb6Yf88EdeoCw"
-                }
-            },
-            "user_id": "@bob:localhost",
-            "unsigned": {}
-        })
-    }
-
     pub fn bob_keys_query_response_signed() -> KeyQueryResponse {
         let data = json!({
             "device_keys": {
@@ -775,7 +752,26 @@ impl PreviouslyVerifiedTestData {
                         "user_id": "@bob:localhost",
                         "unsigned": {}
                     },
-                    "XCYNVRMTER": Self::device_keys_payload_bob_unsigned_device(),
+                    "XCYNVRMTER": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "XCYNVRMTER",
+                        "keys": {
+                            "curve25519:XCYNVRMTER": "xGKYkFcHGlJ+I1yiefPyZu1EY8i2h1eed5uk3PAW6GA",
+                            "ed25519:XCYNVRMTER": "EsU8MJzTYE+/VJs1K9HkGqb8UXCByPioynGrV28WocU"
+                        },
+                        "signatures": {
+                            "@bob:localhost": {
+                                "ed25519:XCYNVRMTER": "yZ7cpaoA+0rRx+bmklsP1iAd0eGPH6gsdywC11VE98/mrcbeFuxjQVn39Ds7h+vmciu5GRzwWgDgv+6go6FHAQ",
+                                // Remove the cross-signature
+                                // "ed25519:e8JFSrW8LW3UK6SSXh2ZESUzptFbapr28/+WqndD+Xk": "xYnGmU9FEdoavB5P743gx3xbEy29tlfRX5lT3JO0dWhHdsP+muqBXUYMBl1RRFeZtIE0GYc9ORb6Yf88EdeoCw"
+                            }
+                        },
+                        "user_id": "@bob:localhost",
+                        "unsigned": {},
+                    },
                 }
             },
             "failures": {},

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -915,7 +915,7 @@ impl PreviouslyVerifiedTestData {
         ruma_response_from_json(&data)
     }
 
-    pub fn device_1_keys_payload_carol() -> Value {
+    fn device_1_keys_payload_carol() -> Value {
         json!({
             // Not self signed
             "algorithms": [
@@ -936,7 +936,7 @@ impl PreviouslyVerifiedTestData {
         })
     }
 
-    pub fn device_2_keys_payload_carol() -> Value {
+    fn device_2_keys_payload_carol() -> Value {
         // Self-signed device
         json!({
             "algorithms": [
@@ -958,7 +958,7 @@ impl PreviouslyVerifiedTestData {
         })
     }
 
-    pub fn ssk_payload_carol() -> Value {
+    fn ssk_payload_carol() -> Value {
         json!({
             "@carol:localhost": {
                 "keys": {

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -915,6 +915,24 @@ impl PreviouslyVerifiedTestData {
         ruma_response_from_json(&data)
     }
 
+    /// Device ID of Carol's signed device.
+    ///
+    /// The device is returned as part of
+    /// [`Self::carol_keys_query_response_signed`] and
+    /// [`Self::carol_keys_query_response_unsigned`].
+    pub fn carol_signed_device_id() -> &'static DeviceId {
+        device_id!("JBRBCHOFDZ")
+    }
+
+    /// Device ID of Carol's unsigned device.
+    ///
+    /// The device is returned as part of
+    /// [`Self::carol_keys_query_response_signed`] and
+    /// [`Self::carol_keys_query_response_unsigned`].
+    pub fn carol_unsigned_device_id() -> &'static DeviceId {
+        device_id!("BAZAPVEHGA")
+    }
+
     fn device_1_keys_payload_carol() -> Value {
         json!({
             // Not self signed


### PR DESCRIPTION
`PreviouslyVerifiedTestData` is currently an unfortunate code dump. Attempt to make it a bit less write-only with some explanation of wtf the methods do.