### PR TITLE
rtc: Handle non-MXID call member event state keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5065,7 +5065,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.10.1"
-source = "git+https://github.com/matrix-org/ruma?rev=79289381444e886c454302e1e8f5b5f62f249a57#79289381444e886c454302e1e8f5b5f62f249a57"
+source = "git+https://github.com/matrix-org/ruma?rev=e87f1d839e3821f0fb0ba20fb3164fedbc90a25c#e87f1d839e3821f0fb0ba20fb3164fedbc90a25c"
 dependencies = [
  "assign",
  "js_int",
@@ -5082,7 +5082,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.18.0"
-source = "git+https://github.com/matrix-org/ruma?rev=79289381444e886c454302e1e8f5b5f62f249a57#79289381444e886c454302e1e8f5b5f62f249a57"
+source = "git+https://github.com/matrix-org/ruma?rev=e87f1d839e3821f0fb0ba20fb3164fedbc90a25c#e87f1d839e3821f0fb0ba20fb3164fedbc90a25c"
 dependencies = [
  "as_variant",
  "assign",
@@ -5105,7 +5105,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.13.0"
-source = "git+https://github.com/matrix-org/ruma?rev=79289381444e886c454302e1e8f5b5f62f249a57#79289381444e886c454302e1e8f5b5f62f249a57"
+source = "git+https://github.com/matrix-org/ruma?rev=e87f1d839e3821f0fb0ba20fb3164fedbc90a25c#e87f1d839e3821f0fb0ba20fb3164fedbc90a25c"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -5137,7 +5137,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.28.1"
-source = "git+https://github.com/matrix-org/ruma?rev=79289381444e886c454302e1e8f5b5f62f249a57#79289381444e886c454302e1e8f5b5f62f249a57"
+source = "git+https://github.com/matrix-org/ruma?rev=e87f1d839e3821f0fb0ba20fb3164fedbc90a25c#e87f1d839e3821f0fb0ba20fb3164fedbc90a25c"
 dependencies = [
  "as_variant",
  "indexmap 2.2.6",
@@ -5162,7 +5162,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.9.0"
-source = "git+https://github.com/matrix-org/ruma?rev=79289381444e886c454302e1e8f5b5f62f249a57#79289381444e886c454302e1e8f5b5f62f249a57"
+source = "git+https://github.com/matrix-org/ruma?rev=e87f1d839e3821f0fb0ba20fb3164fedbc90a25c#e87f1d839e3821f0fb0ba20fb3164fedbc90a25c"
 dependencies = [
  "http 1.1.0",
  "js_int",
@@ -5176,7 +5176,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.2.0"
-source = "git+https://github.com/matrix-org/ruma?rev=79289381444e886c454302e1e8f5b5f62f249a57#79289381444e886c454302e1e8f5b5f62f249a57"
+source = "git+https://github.com/matrix-org/ruma?rev=e87f1d839e3821f0fb0ba20fb3164fedbc90a25c#e87f1d839e3821f0fb0ba20fb3164fedbc90a25c"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5188,7 +5188,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.5"
-source = "git+https://github.com/matrix-org/ruma?rev=79289381444e886c454302e1e8f5b5f62f249a57#79289381444e886c454302e1e8f5b5f62f249a57"
+source = "git+https://github.com/matrix-org/ruma?rev=e87f1d839e3821f0fb0ba20fb3164fedbc90a25c#e87f1d839e3821f0fb0ba20fb3164fedbc90a25c"
 dependencies = [
  "js_int",
  "thiserror",
@@ -5197,7 +5197,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.13.0"
-source = "git+https://github.com/matrix-org/ruma?rev=79289381444e886c454302e1e8f5b5f62f249a57#79289381444e886c454302e1e8f5b5f62f249a57"
+source = "git+https://github.com/matrix-org/ruma?rev=e87f1d839e3821f0fb0ba20fb3164fedbc90a25c#e87f1d839e3821f0fb0ba20fb3164fedbc90a25c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -5212,7 +5212,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.9.0"
-source = "git+https://github.com/matrix-org/ruma?rev=79289381444e886c454302e1e8f5b5f62f249a57#79289381444e886c454302e1e8f5b5f62f249a57"
+source = "git+https://github.com/matrix-org/ruma?rev=e87f1d839e3821f0fb0ba20fb3164fedbc90a25c#e87f1d839e3821f0fb0ba20fb3164fedbc90a25c"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ once_cell = "1.16.0"
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { git = "https://github.com/matrix-org/ruma", rev = "79289381444e886c454302e1e8f5b5f62f249a57", features = [
+ruma = { git = "https://github.com/matrix-org/ruma", rev = "e87f1d839e3821f0fb0ba20fb3164fedbc90a25c", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -61,7 +61,7 @@ ruma = { git = "https://github.com/matrix-org/ruma", rev = "79289381444e886c4543
     "unstable-msc4075",
     "unstable-msc4140",
 ] }
-ruma-common = { git = "https://github.com/matrix-org/ruma", rev = "79289381444e886c454302e1e8f5b5f62f249a57" }
+ruma-common = { git = "https://github.com/matrix-org/ruma", rev = "e87f1d839e3821f0fb0ba20fb3164fedbc90a25c" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -327,30 +327,26 @@ impl BaseRoomInfo {
 /// - `<user ID>_<string>`
 /// - `_<user ID>_<string>`
 fn get_user_id_for_state_key(state_key: &str) -> Option<OwnedUserId> {
-    match UserId::parse(state_key) {
-        Ok(user_id) => Some(user_id),
-        Err(_) => {
-            // Ignore leading underscore if present
-            // (used for avoiding auth rules on @-prefixed state keys)
-            let state_key = state_key.strip_prefix('_').unwrap_or(state_key);
-            if state_key.starts_with('@') {
-                if let Some(colon_idx) = state_key.find(':') {
-                    let state_key_user_id = match state_key[colon_idx + 1..].find('_') {
-                        None => state_key,
-                        Some(suffix_idx) => &state_key[..colon_idx + 1 + suffix_idx],
-                    };
-                    match UserId::parse(state_key_user_id) {
-                        Ok(user_id) => Some(user_id),
-                        Err(_) => None,
-                    }
-                } else {
-                    None
-                }
-            } else {
-                None
+    if let Ok(user_id) = UserId::parse(state_key) {
+        return Some(user_id);
+    }
+
+    // Ignore leading underscore if present
+    // (used for avoiding auth rules on @-prefixed state keys)
+    let state_key = state_key.strip_prefix('_').unwrap_or(state_key);
+    if state_key.starts_with('@') {
+        if let Some(colon_idx) = state_key.find(':') {
+            let state_key_user_id = match state_key[colon_idx + 1..].find('_') {
+                None => state_key,
+                Some(suffix_idx) => &state_key[..colon_idx + 1 + suffix_idx],
+            };
+            if let Ok(user_id) = UserId::parse(state_key_user_id) {
+                return Some(user_id);
             }
         }
     }
+
+    None
 }
 
 bitflags! {

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -197,7 +197,7 @@ impl BaseRoomInfo {
 
                 let state_key = m.state_key();
                 let owned_user_id = match UserId::parse(state_key) {
-                    Ok(u) => u,
+                    Ok(user_id) => user_id,
                     Err(_) => {
                         // Ignore leading underscore if present
                         // (used for avoiding auth rules on @-prefixed state keys)
@@ -209,7 +209,7 @@ impl BaseRoomInfo {
                                     Some(suffix_idx) => &state_key[..colon_idx + 1 + suffix_idx],
                                 };
                                 match UserId::parse(state_key_user_id) {
-                                    Ok(u) => u,
+                                    Ok(user_id) => user_id,
                                     Err(_) => return false,
                                 }
                             } else {

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -570,9 +570,10 @@ impl RoomMemberships {
 mod tests {
     use std::ops::Not;
 
+    use assert_matches::assert_matches;
     use ruma::events::tag::{TagInfo, TagName, Tags};
 
-    use super::{BaseRoomInfo, RoomNotableTags};
+    use super::{get_user_id_for_state_key, BaseRoomInfo, RoomNotableTags};
 
     #[test]
     fn test_handle_notable_tags_favourite() {
@@ -602,5 +603,20 @@ mod tests {
         tags.clear();
         base_room_info.handle_notable_tags(&tags);
         assert!(base_room_info.notable_tags.contains(RoomNotableTags::LOW_PRIORITY).not());
+    }
+
+    #[test]
+    fn test_get_user_id_from_state_key() {
+        assert_matches!(get_user_id_for_state_key(""), None);
+        assert_matches!(get_user_id_for_state_key("abc"), None);
+        assert_matches!(get_user_id_for_state_key("username:example.org"), None);
+
+        assert_matches!(get_user_id_for_state_key("@username:example.org"), Some(_));
+        assert_matches!(get_user_id_for_state_key("@username:example.org_valid_suffix"), Some(_));
+        assert_matches!(get_user_id_for_state_key("@username:example.org:invalid_suffix"), None);
+
+        assert_matches!(get_user_id_for_state_key("_@username:example.org"), Some(_));
+        assert_matches!(get_user_id_for_state_key("_@username:example.org_valid_suffix"), Some(_));
+        assert_matches!(get_user_id_for_state_key("_@username:example.org:invalid_suffix"), None);
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -322,7 +322,7 @@ impl BaseRoomInfo {
     }
 }
 
-/// Extact a user ID from a state key that matches one of the following formats:
+/// Extract a user ID from a state key that matches one of the following formats:
 /// - `<user ID>`
 /// - `<user ID>_<string>`
 /// - `_<user ID>_<string>`

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -567,7 +567,10 @@ mod tests {
     use std::ops::Not;
 
     use assert_matches::assert_matches;
-    use ruma::events::tag::{TagInfo, TagName, Tags};
+    use ruma::{
+        events::tag::{TagInfo, TagName, Tags},
+        user_id,
+    };
 
     use super::{get_user_id_for_state_key, BaseRoomInfo, RoomNotableTags};
 
@@ -605,14 +608,32 @@ mod tests {
     fn test_get_user_id_for_state_key() {
         assert_matches!(get_user_id_for_state_key(""), None);
         assert_matches!(get_user_id_for_state_key("abc"), None);
-        assert_matches!(get_user_id_for_state_key("username:example.org"), None);
+        assert_matches!(get_user_id_for_state_key("@nocolon"), None);
+        assert_matches!(get_user_id_for_state_key("@noserverpart:"), None);
+        assert_matches!(get_user_id_for_state_key("@noserverpart:_suffix"), None);
 
-        assert_matches!(get_user_id_for_state_key("@username:example.org"), Some(_));
-        assert_matches!(get_user_id_for_state_key("@username:example.org_valid_suffix"), Some(_));
-        assert_matches!(get_user_id_for_state_key("@username:example.org:invalid_suffix"), None);
+        let user_id = user_id!("@username:example.org");
 
-        assert_matches!(get_user_id_for_state_key("_@username:example.org"), Some(_));
-        assert_matches!(get_user_id_for_state_key("_@username:example.org_valid_suffix"), Some(_));
-        assert_matches!(get_user_id_for_state_key("_@username:example.org:invalid_suffix"), None);
+        assert_matches!(
+            get_user_id_for_state_key(user_id.as_str()),
+            Some(captured_user_id) => assert_eq!(captured_user_id, user_id));
+        assert_matches!(
+            get_user_id_for_state_key(format!("{user_id}_valid_suffix").as_str()),
+            Some(captured_user_id) => assert_eq!(captured_user_id, user_id));
+        assert_matches!(
+            get_user_id_for_state_key(format!("{user_id}:invalid_suffix").as_str()),
+            None
+        );
+
+        assert_matches!(
+            get_user_id_for_state_key(format!("_{user_id}").as_str()),
+            Some(captured_user_id) => assert_eq!(captured_user_id, user_id));
+        assert_matches!(
+            get_user_id_for_state_key(format!("_{user_id}_valid_suffix").as_str()),
+            Some(captured_user_id) => assert_eq!(captured_user_id, user_id));
+        assert_matches!(
+            get_user_id_for_state_key(format!("_{user_id}:invalid_suffix").as_str()),
+            None
+        );
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -566,7 +566,6 @@ impl RoomMemberships {
 mod tests {
     use std::ops::Not;
 
-    use assert_matches::assert_matches;
     use ruma::{
         events::tag::{TagInfo, TagName, Tags},
         user_id,
@@ -606,34 +605,29 @@ mod tests {
 
     #[test]
     fn test_get_user_id_for_state_key() {
-        assert_matches!(get_user_id_for_state_key(""), None);
-        assert_matches!(get_user_id_for_state_key("abc"), None);
-        assert_matches!(get_user_id_for_state_key("@nocolon"), None);
-        assert_matches!(get_user_id_for_state_key("@noserverpart:"), None);
-        assert_matches!(get_user_id_for_state_key("@noserverpart:_suffix"), None);
+        assert!(get_user_id_for_state_key("").is_none());
+        assert!(get_user_id_for_state_key("abc").is_none());
+        assert!(get_user_id_for_state_key("@nocolon").is_none());
+        assert!(get_user_id_for_state_key("@noserverpart:").is_none());
+        assert!(get_user_id_for_state_key("@noserverpart:_suffix").is_none());
 
         let user_id = user_id!("@username:example.org");
 
-        assert_matches!(
-            get_user_id_for_state_key(user_id.as_str()),
-            Some(captured_user_id) => assert_eq!(captured_user_id, user_id));
-        assert_matches!(
-            get_user_id_for_state_key(format!("{user_id}_valid_suffix").as_str()),
-            Some(captured_user_id) => assert_eq!(captured_user_id, user_id));
-        assert_matches!(
-            get_user_id_for_state_key(format!("{user_id}:invalid_suffix").as_str()),
-            None
+        assert_eq!(get_user_id_for_state_key(user_id.as_str()).as_deref(), Some(user_id));
+        assert_eq!(
+            get_user_id_for_state_key(format!("{user_id}_valid_suffix").as_str()).as_deref(),
+            Some(user_id)
         );
+        assert!(get_user_id_for_state_key(format!("{user_id}:invalid_suffix").as_str()).is_none());
 
-        assert_matches!(
-            get_user_id_for_state_key(format!("_{user_id}").as_str()),
-            Some(captured_user_id) => assert_eq!(captured_user_id, user_id));
-        assert_matches!(
-            get_user_id_for_state_key(format!("_{user_id}_valid_suffix").as_str()),
-            Some(captured_user_id) => assert_eq!(captured_user_id, user_id));
-        assert_matches!(
-            get_user_id_for_state_key(format!("_{user_id}:invalid_suffix").as_str()),
-            None
+        assert_eq!(
+            get_user_id_for_state_key(format!("_{user_id}").as_str()).as_deref(),
+            Some(user_id)
         );
+        assert_eq!(
+            get_user_id_for_state_key(format!("_{user_id}_valid_suffix").as_str()).as_deref(),
+            Some(user_id)
+        );
+        assert!(get_user_id_for_state_key(format!("_{user_id}:invalid_suffix").as_str()).is_none());
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -322,7 +322,7 @@ impl BaseRoomInfo {
     }
 }
 
-/// Extract a user ID from a state key that matches one of the following formats:
+/// Extract a user ID from a state key that matches one of these formats:
 /// - `<user ID>`
 /// - `<user ID>_<string>`
 /// - `_<user ID>_<string>`

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -602,7 +602,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_user_id_from_state_key() {
+    fn test_get_user_id_for_state_key() {
         assert_matches!(get_user_id_for_state_key(""), None);
         assert_matches!(get_user_id_for_state_key("abc"), None);
         assert_matches!(get_user_id_for_state_key("username:example.org"), None);

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -201,10 +201,7 @@ impl BaseRoomInfo {
                     Err(_) => {
                         // Ignore leading underscore if present
                         // (used for avoiding auth rules on @-prefixed state keys)
-                        let state_key = match state_key.strip_prefix('_') {
-                            None => state_key,
-                            Some(stripped_state_key) => stripped_state_key,
-                        };
+                        let state_key = state_key.strip_prefix('_').unwrap_or(state_key);
                         if state_key.starts_with('@') {
                             if let Some(colon_idx) = state_key.find(':') {
                                 let state_key_user_id = match state_key[colon_idx + 1..].find('_') {

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -2624,7 +2624,7 @@ mod tests {
             // we can simply use now here since this will be dropped when using a MinimalStateEvent
             // in the roomInfo
             origin_server_ts: timestamp(0),
-            state_key: user_id.to_owned(),
+            state_key: user_id.to_string(),
             unsigned: StateUnsigned::new(),
         }))
     }


### PR DESCRIPTION
Update Ruma dependency to expect call membership state events with state keys that are arbitrary strings, not just pure MXIDs.

When a call membership state key does not exactly match the format of an MXID, treat it as a valid state key if it starts with an MXID followed by an underscore, with that MXID designating the owner of the event.

(The state key may also be optionally prefixed with an underscore, which is permitted as a way to bypass pre-MSC3757 authorization rules against sending state events with state keys that do not exactly match the sender's MXID.)

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>
