### PR TITLE
feat(sdk): Live updates for pinned events timeline with replacements and redactions

### DIFF
--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -478,7 +478,7 @@ impl NotificationClient {
             return Err(Error::UnknownRoom);
         };
 
-        let response = room.event_with_context(event_id, true, uint!(0)).await?;
+        let response = room.event_with_context(event_id, true, uint!(0), None).await?;
 
         let mut timeline_event = response.event.ok_or(Error::ContextMissingEvent)?;
         let state_events = response.state;

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -261,17 +261,13 @@ impl TimelineBuilder {
                         RoomEventCacheUpdate::AddTimelineEvents { events, origin } => {
                             trace!("Received new timeline events.");
 
-                            // Note: we deliberately choose to not handle
-                            // updates/reactions/redactions for pinned events.
-                            if !is_pinned_events {
-                                inner.add_events_at(
-                                    events,
-                                    TimelineEnd::Back,
-                                    match origin {
-                                        EventsOrigin::Sync => RemoteEventOrigin::Sync,
-                                    }
-                                ).await;
-                            }
+                            inner.add_events_at(
+                                events,
+                                TimelineEnd::Back,
+                                match origin {
+                                    EventsOrigin::Sync => RemoteEventOrigin::Sync,
+                                }
+                            ).await;
                         }
 
                         RoomEventCacheUpdate::AddEphemeralEvents { events } => {

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -346,6 +346,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         let can_add_to_live = match self.live_timeline_updates_type {
                             LiveTimelineUpdatesAllowed::PinnedEvents => {
                                 room_data_provider.is_pinned_event(event_id)
+                                    || room_data_provider
+                                        .is_replacement_for_pinned_event(&event_kind)
                             }
                             LiveTimelineUpdatesAllowed::All => true,
                             LiveTimelineUpdatesAllowed::None => false,

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -17,6 +17,7 @@ use std::{fmt::Formatter, num::NonZeroUsize, sync::Arc};
 use futures_util::{future::join_all, FutureExt as _};
 use matrix_sdk::{
     config::RequestConfig, event_cache::paginator::PaginatorError, BoxFuture, Room,
+    SendOutsideWasm, SyncOutsideWasm,
 };
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedEventId};
@@ -112,10 +113,10 @@ impl PinnedEventsLoader {
     }
 }
 
-pub trait PinnedEventsRoom {
+pub trait PinnedEventsRoom: SendOutsideWasm + SyncOutsideWasm {
     /// Load a single room event using the cache or network and any events
     /// related to it, if they are cached.
-    async fn load_event_with_relations<'a>(
+    fn load_event_with_relations<'a>(
         &'a self,
         event_id: &'a EventId,
         request_config: Option<RequestConfig>,
@@ -148,7 +149,7 @@ pub trait PinnedEventsRoom {
 }
 
 impl PinnedEventsRoom for Room {
-    async fn load_event_with_relations<'a>(
+    fn load_event_with_relations<'a>(
         &'a self,
         event_id: &'a EventId,
         request_config: Option<RequestConfig>,

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -23,6 +23,7 @@ use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedEventId};
 use thiserror::Error;
 use tracing::{debug, warn};
+use crate::timeline::event_handler::TimelineEventKind;
 
 const MAX_CONCURRENT_REQUESTS: usize = 10;
 
@@ -117,6 +118,22 @@ pub trait PinnedEventsRoom: SendOutsideWasm + SyncOutsideWasm {
     /// It avoids having to clone the whole list of event ids to check a single
     /// value.
     fn is_pinned_event(&self, event_id: &EventId) -> bool;
+
+    /// Returns whether the passed `event_kind` is either an edit or a redaction
+    /// of a pinned event.
+    fn is_replacement_for_pinned_event(&self, event_kind: &TimelineEventKind) -> bool {
+        match event_kind {
+            TimelineEventKind::Message { relations, .. } => {
+                if let Some(orig_ev) = &relations.replace {
+                    self.is_pinned_event(orig_ev.event_id())
+                } else {
+                    false
+                }
+            }
+            TimelineEventKind::Redaction { redacts } => self.is_pinned_event(redacts),
+            _ => false,
+        }
+    }
 }
 
 impl PinnedEventsRoom for Room {

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -319,11 +319,11 @@ impl PaginableRoom for TestRoomDataProvider {
 }
 
 impl PinnedEventsRoom for TestRoomDataProvider {
-    fn load_event<'a>(
+    async fn load_event_with_relations<'a>(
         &'a self,
         _event_id: &'a EventId,
-        _config: Option<RequestConfig>,
-    ) -> BoxFuture<'a, Result<SyncTimelineEvent, PaginatorError>> {
+        _request_config: Option<RequestConfig>,
+    ) -> BoxFuture<'a, Result<(SyncTimelineEvent, Vec<SyncTimelineEvent>), PaginatorError>> {
         unimplemented!();
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -319,7 +319,7 @@ impl PaginableRoom for TestRoomDataProvider {
 }
 
 impl PinnedEventsRoom for TestRoomDataProvider {
-    async fn load_event_with_relations<'a>(
+    fn load_event_with_relations<'a>(
         &'a self,
         _event_id: &'a EventId,
         _request_config: Option<RequestConfig>,

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -15,7 +15,10 @@ use matrix_sdk_ui::{
     timeline::{TimelineFocus, TimelineItemContent},
     Timeline,
 };
-use ruma::{event_id, owned_room_id, MilliSecondsSinceUnixEpoch, OwnedRoomId};
+use ruma::{
+    event_id, events::room::message::RoomMessageEventContentWithoutRelation, owned_room_id,
+    MilliSecondsSinceUnixEpoch, OwnedRoomId,
+};
 use serde_json::json;
 use stream_assert::assert_pending;
 use wiremock::MockServer;
@@ -402,7 +405,11 @@ async fn test_edited_events_are_reflected_in_sync() {
     test_helper.server.reset().await;
 
     let edited_event = f
-        .replacement_msg("edited message!", event_id!("$1"))
+        .text_msg("edited message!")
+        .edit(
+            event_id!("$1"),
+            RoomMessageEventContentWithoutRelation::text_plain("* edited message!"),
+        )
         .event_id(event_id!("$2"))
         .server_ts(MilliSecondsSinceUnixEpoch::now())
         .into_timeline();
@@ -425,7 +432,7 @@ async fn test_edited_events_are_reflected_in_sync() {
         assert_eq!(index, 1);
         match value.as_event().unwrap().content() {
             TimelineItemContent::Message(m) => {
-                assert_eq!(m.body(), "edited message!")
+                assert_eq!(m.body(), "* edited message!")
             }
             _ => panic!("Should be a message event"),
         }
@@ -547,7 +554,11 @@ async fn test_edited_events_survive_pinned_event_ids_change() {
     test_helper.server.reset().await;
 
     let edited_pinned_event = f
-        .replacement_msg("edited message!", event_id!("$1"))
+        .text_msg("* edited message!")
+        .edit(
+            event_id!("$1"),
+            RoomMessageEventContentWithoutRelation::text_plain("edited message!"),
+        )
         .event_id(event_id!("$2"))
         .server_ts(MilliSecondsSinceUnixEpoch::now())
         .into_timeline();

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -570,8 +570,9 @@ impl RoomEventCache {
 
     /// Save a single event in the event cache, for further retrieval with
     /// [`Self::event`].
-    // This doesn't insert the event into the linked chunk. In the future there'll
-    // be no distinction between the linked chunk and the separate cache.
+    // TODO: This doesn't insert the event into the linked chunk. In the future
+    // there'll be no distinction between the linked chunk and the separate
+    // cache. There is a discussion in https://github.com/matrix-org/matrix-rust-sdk/issues/3886.
     pub(crate) async fn save_event(&self, event: SyncTimelineEvent) {
         if let Some(event_id) = event.event_id() {
             let mut cache = self.inner.all_events_cache.write().await;
@@ -586,8 +587,9 @@ impl RoomEventCache {
     /// Save some events in the event cache, for further retrieval with
     /// [`Self::event`]. This function will save them using a single lock,
     /// as opposed to [`Self::save_event`].
-    // This doesn't insert the event into the linked chunk. In the future there'll
-    // be no distinction between the linked chunk and the separate cache.
+    // TODO: This doesn't insert the event into the linked chunk. In the future
+    // there'll be no distinction between the linked chunk and the separate
+    // cache. There is a discussion in https://github.com/matrix-org/matrix-rust-sdk/issues/3886.
     pub(crate) async fn save_events(&self, events: impl IntoIterator<Item = SyncTimelineEvent>) {
         let mut cache = self.inner.all_events_cache.write().await;
         for event in events {

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -574,15 +574,10 @@ impl RoomEventCache {
     // be no distinction between the linked chunk and the separate cache.
     pub(crate) async fn save_event(&self, event: SyncTimelineEvent) {
         if let Some(event_id) = event.event_id() {
-            let mut cache = self.inner
-                .all_events_cache
-                .write()
-                .await;
+            let mut cache = self.inner.all_events_cache.write().await;
 
             self.inner.append_related_event(&mut cache, &event);
-            cache.events
-                .insert(event_id, (self.inner.room_id.clone(), event));
-
+            cache.events.insert(event_id, (self.inner.room_id.clone(), event));
         } else {
             warn!("couldn't save event without event id in the event cache");
         }

--- a/crates/matrix-sdk/src/event_cache/paginator.rs
+++ b/crates/matrix-sdk/src/event_cache/paginator.rs
@@ -467,9 +467,9 @@ impl PaginableRoom for Room {
         lazy_load_members: bool,
         num_events: UInt,
     ) -> Result<EventWithContextResponse, PaginatorError> {
-        let response = match self.event_with_context(event_id, lazy_load_members, num_events).await
-        {
-            Ok(result) => result,
+        let response =
+            match self.event_with_context(event_id, lazy_load_members, num_events, None).await {
+                Ok(result) => result,
 
             Err(err) => {
                 // If the error was a 404, then the event wasn't found on the server;
@@ -482,10 +482,10 @@ impl PaginableRoom for Room {
                     }
                 }
 
-                // Otherwise, just return a wrapped error.
-                return Err(PaginatorError::SdkError(Box::new(err)));
-            }
-        };
+                    // Otherwise, just return a wrapped error.
+                    return Err(PaginatorError::SdkError(Box::new(err)));
+                }
+            };
 
         Ok(response)
     }

--- a/crates/matrix-sdk/src/event_cache/paginator.rs
+++ b/crates/matrix-sdk/src/event_cache/paginator.rs
@@ -471,16 +471,16 @@ impl PaginableRoom for Room {
             match self.event_with_context(event_id, lazy_load_members, num_events, None).await {
                 Ok(result) => result,
 
-            Err(err) => {
-                // If the error was a 404, then the event wasn't found on the server;
-                // special case this to make it easy to react to
-                // such an error.
-                if let Some(error) = err.as_client_api_error() {
-                    if error.status_code == 404 {
-                        // Event not found
-                        return Err(PaginatorError::EventNotFound(event_id.to_owned()));
+                Err(err) => {
+                    // If the error was a 404, then the event wasn't found on the server;
+                    // special case this to make it easy to react to
+                    // such an error.
+                    if let Some(error) = err.as_client_api_error() {
+                        if error.status_code == 404 {
+                            // Event not found
+                            return Err(PaginatorError::EventNotFound(event_id.to_owned()));
+                        }
                     }
-                }
 
                     // Otherwise, just return a wrapped error.
                     return Err(PaginatorError::SdkError(Box::new(err)));

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -94,7 +94,7 @@ async fn test_event_with_context() -> Result<()> {
 
     {
         // First /context query: only the target event, no context around it.
-        let response = room.event_with_context(&event_id, false, uint!(0)).await?;
+        let response = room.event_with_context(&event_id, false, uint!(0), None).await?;
 
         let target = response
             .event
@@ -113,7 +113,8 @@ async fn test_event_with_context() -> Result<()> {
 
     {
         // Next query: an event that doesn't exist (hopefully!).
-        let response = room.event_with_context(event_id!("$lolololol"), false, uint!(0)).await;
+        let response =
+            room.event_with_context(event_id!("$lolololol"), false, uint!(0), None).await;
 
         // Servers answers with 404.
         assert_let!(Err(err) = response);
@@ -123,7 +124,7 @@ async fn test_event_with_context() -> Result<()> {
     {
         // Next query: target event with a context of 3 events. There
         // should be some previous and next tokens.
-        let response = room.event_with_context(&event_id, false, uint!(3)).await?;
+        let response = room.event_with_context(&event_id, false, uint!(3), None).await?;
 
         let target = response
             .event


### PR DESCRIPTION
This is a follow-up PR for https://github.com/matrix-org/matrix-rust-sdk/pull/3870.

## Changes

- Make `TimelineEventBuilder` process synced events for `TimelineFocus::PinnedEvents` too.
- Use the relationship cache added in https://github.com/matrix-org/matrix-rust-sdk/pull/3870 to load pinned events and other events related to them so their final timeline event results contain the changes those would add (edits, redactions, reactions, etc.).
- Make `Room::event_with_context` also save its results to the cache.
- Add new tests for pinned events and related events.
- Fix the pinned events benchmark in `room_bench`.

The end result of this is the pinned events timeline now reacts to edits and redactions, and those values are kept even when the event list reloads.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
