### PR TITLE
feat(sdk): Add `Room::cached_user_defined_notification_mode`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -39,7 +39,7 @@ pub struct RoomInfo {
     user_power_levels: HashMap<String, i64>,
     highlight_count: u64,
     notification_count: u64,
-    user_defined_notification_mode: Option<RoomNotificationMode>,
+    cached_user_defined_notification_mode: Option<RoomNotificationMode>,
     has_room_call: bool,
     active_room_call_participants: Vec<String>,
     /// Whether this room has been explicitly marked as unread
@@ -98,9 +98,8 @@ impl RoomInfo {
             user_power_levels,
             highlight_count: unread_notification_counts.highlight_count,
             notification_count: unread_notification_counts.notification_count,
-            user_defined_notification_mode: room
-                .user_defined_notification_mode()
-                .await
+            cached_user_defined_notification_mode: room
+                .cached_user_defined_notification_mode()
                 .map(Into::into),
             has_room_call: room.has_active_room_call(),
             active_room_call_participants: room

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -29,6 +29,7 @@ pub mod deserialized_responses;
 mod error;
 pub mod latest_event;
 pub mod media;
+pub mod notification_settings;
 mod rooms;
 
 pub mod read_receipts;

--- a/crates/matrix-sdk-base/src/notification_settings.rs
+++ b/crates/matrix-sdk-base/src/notification_settings.rs
@@ -1,0 +1,26 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for that specific language governing permissions and
+// limitations under the License.
+
+//! Some shared types about notification settings.
+
+/// Enum representing the push notification modes for a room.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoomNotificationMode {
+    /// Receive notifications for all messages.
+    AllMessages,
+    /// Receive notifications for mentions and keywords only.
+    MentionsAndKeywordsOnly,
+    /// Do not receive any notifications.
+    Mute,
+}

--- a/crates/matrix-sdk-base/src/notification_settings.rs
+++ b/crates/matrix-sdk-base/src/notification_settings.rs
@@ -14,8 +14,10 @@
 
 //! Some shared types about notification settings.
 
+use serde::{Deserialize, Serialize};
+
 /// Enum representing the push notification modes for a room.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 pub enum RoomNotificationMode {
     /// Receive notifications for all messages.
     AllMessages,

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -64,6 +64,7 @@ use super::{
 use crate::latest_event::LatestEvent;
 use crate::{
     deserialized_responses::MemberEvent,
+    notification_settings::RoomNotificationMode,
     read_receipts::RoomReadReceipts,
     store::{DynStateStore, Result as StoreResult, StateStoreExt},
     sync::UnreadNotificationsCount,
@@ -657,6 +658,31 @@ impl Room {
         self.inner.read().cached_display_name.clone()
     }
 
+    /// Update the cached user defined notification mode.
+    ///
+    /// This is automatically recomputed on every successful sync, and the
+    /// cached result can be retrieved in
+    /// [`Self::cached_user_defined_notification_mode`].
+    pub fn update_cached_user_defined_notification_mode(&self, mode: RoomNotificationMode) {
+        self.inner.update_if(|info| {
+            if info.cached_user_defined_notification_mode.as_ref() != Some(&mode) {
+                info.cached_user_defined_notification_mode = Some(mode);
+
+                true
+            } else {
+                false
+            }
+        });
+    }
+
+    /// Returns the cached user defined notification mode, if available.
+    ///
+    /// This cache is refilled every time we call
+    /// [`Self::update_user_defined_notification_mode`].
+    pub fn cached_user_defined_notification_mode(&self) -> Option<RoomNotificationMode> {
+        self.inner.read().cached_user_defined_notification_mode
+    }
+
     /// Return the last event in this room, if one has been cached during
     /// sliding sync.
     #[cfg(feature = "experimental-sliding-sync")]
@@ -1020,6 +1046,10 @@ pub struct RoomInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) cached_display_name: Option<DisplayName>,
 
+    /// Cached user defined notification mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) cached_user_defined_notification_mode: Option<RoomNotificationMode>,
+
     /// The recency stamp of this room.
     ///
     /// It's not to be confused with `origin_server_ts` of the latest event.
@@ -1066,6 +1096,7 @@ impl RoomInfo {
             base_info: Box::new(BaseRoomInfo::new()),
             warned_about_unknown_room_version: Arc::new(false.into()),
             cached_display_name: None,
+            cached_user_defined_notification_mode: None,
             #[cfg(feature = "experimental-sliding-sync")]
             recency_stamp: None,
         }
@@ -1710,6 +1741,7 @@ mod tests {
             read_receipts: Default::default(),
             warned_about_unknown_room_version: Arc::new(false.into()),
             cached_display_name: None,
+            cached_user_defined_notification_mode: None,
             recency_stamp: Some(42),
         };
 
@@ -1856,7 +1888,8 @@ mod tests {
         assert_eq!(
             info.cached_display_name.as_ref(),
             Some(&DisplayName::Calculated("lol".to_owned()))
-        )
+        );
+        assert!(info.cached_user_defined_notification_mode.is_none());
     }
 
     #[async_test]

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1691,9 +1691,7 @@ mod tests {
     use stream_assert::{assert_pending, assert_ready};
     use web_time::{Duration, SystemTime};
 
-    #[cfg(feature = "experimental-sliding-sync")]
-    use super::SyncInfo;
-    use super::{compute_display_name_from_heroes, Room, RoomHero, RoomInfo, RoomState};
+    use super::{compute_display_name_from_heroes, Room, RoomHero, RoomInfo, RoomState, SyncInfo};
     #[cfg(any(feature = "experimental-sliding-sync", feature = "e2e-encryption"))]
     use crate::latest_event::LatestEvent;
     use crate::{
@@ -1804,16 +1802,18 @@ mod tests {
         assert_eq!(serde_json::to_value(info).unwrap(), info_json);
     }
 
+    // Ensure we can still deserialize RoomInfos before we added things to its
+    // schema
+    //
+    // In an ideal world, we must not change this test. Please see
+    // [`test_room_info_serialization`] if you want to test a “recent” `RoomInfo`
+    // deserialization.
     #[test]
-    #[cfg(feature = "experimental-sliding-sync")]
     fn test_room_info_deserialization_without_optional_items() {
-        // Ensure we can still deserialize RoomInfos before we added things to its
-        // schema
+        use ruma::{owned_mxc_uri, owned_user_id};
 
         // The following JSON should never change if we want to be able to read in old
         // cached state
-
-        use ruma::{owned_mxc_uri, owned_user_id};
         let info_json = json!({
             "room_id": "!gda78o:server.tld",
             "room_state": "Invited",
@@ -1848,7 +1848,86 @@ mod tests {
                 "tombstone": null,
                 "topic": null,
             },
-            "cached_display_name": { "Calculated": "lol" }
+        });
+
+        let info: RoomInfo = serde_json::from_value(info_json).unwrap();
+
+        assert_eq!(info.room_id, room_id!("!gda78o:server.tld"));
+        assert_eq!(info.room_state, RoomState::Invited);
+        assert_eq!(info.notification_counts.highlight_count, 1);
+        assert_eq!(info.notification_counts.notification_count, 2);
+        assert_eq!(
+            info.summary.room_heroes,
+            vec![RoomHero {
+                user_id: owned_user_id!("@somebody:example.org"),
+                display_name: Some("Somebody".to_owned()),
+                avatar_url: Some(owned_mxc_uri!("mxc://example.org/abc")),
+            }]
+        );
+        assert_eq!(info.summary.joined_member_count, 5);
+        assert_eq!(info.summary.invited_member_count, 0);
+        assert!(info.members_synced);
+        assert_eq!(info.last_prev_batch, Some("pb".to_owned()));
+        assert_eq!(info.sync_info, SyncInfo::FullySynced);
+        assert!(info.encryption_state_synced);
+        assert!(info.base_info.avatar.is_none());
+        assert!(info.base_info.canonical_alias.is_none());
+        assert!(info.base_info.create.is_none());
+        assert_eq!(info.base_info.dm_targets.len(), 0);
+        assert!(info.base_info.encryption.is_none());
+        assert!(info.base_info.guest_access.is_none());
+        assert!(info.base_info.history_visibility.is_none());
+        assert!(info.base_info.join_rules.is_none());
+        assert_eq!(info.base_info.max_power_level, 100);
+        assert!(info.base_info.name.is_none());
+        assert!(info.base_info.tombstone.is_none());
+        assert!(info.base_info.topic.is_none());
+    }
+
+    #[test]
+    #[cfg(feature = "experimental-sliding-sync")]
+    fn test_room_info_deserialization() {
+        use ruma::{owned_mxc_uri, owned_user_id};
+
+        use crate::notification_settings::RoomNotificationMode;
+
+        let info_json = json!({
+            "room_id": "!gda78o:server.tld",
+            "room_state": "Invited",
+            "notification_counts": {
+                "highlight_count": 1,
+                "notification_count": 2,
+            },
+            "summary": {
+                "room_heroes": [{
+                    "user_id": "@somebody:example.org",
+                    "display_name": "Somebody",
+                    "avatar_url": "mxc://example.org/abc"
+                }],
+                "joined_member_count": 5,
+                "invited_member_count": 0,
+            },
+            "members_synced": true,
+            "last_prev_batch": "pb",
+            "sync_info": "FullySynced",
+            "encryption_state_synced": true,
+            "base_info": {
+                "avatar": null,
+                "canonical_alias": null,
+                "create": null,
+                "dm_targets": [],
+                "encryption": null,
+                "guest_access": null,
+                "history_visibility": null,
+                "join_rules": null,
+                "max_power_level": 100,
+                "name": null,
+                "tombstone": null,
+                "topic": null,
+            },
+            "cached_display_name": { "Calculated": "lol" },
+            "cached_user_defined_notification_mode": "Mute",
+            "recency_stamp": 42,
         });
 
         let info: RoomInfo = serde_json::from_value(info_json).unwrap();
@@ -1887,9 +1966,13 @@ mod tests {
 
         assert_eq!(
             info.cached_display_name.as_ref(),
-            Some(&DisplayName::Calculated("lol".to_owned()))
+            Some(&DisplayName::Calculated("lol".to_owned())),
         );
-        assert!(info.cached_user_defined_notification_mode.is_none());
+        assert_eq!(
+            info.cached_user_defined_notification_mode.as_ref(),
+            Some(&RoomNotificationMode::Mute)
+        );
+        assert_eq!(info.recency_stamp.as_ref(), Some(&42));
     }
 
     #[async_test]

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -678,7 +678,7 @@ impl Room {
     /// Returns the cached user defined notification mode, if available.
     ///
     /// This cache is refilled every time we call
-    /// [`Self::update_user_defined_notification_mode`].
+    /// [`Self::update_cached_user_defined_notification_mode`].
     pub fn cached_user_defined_notification_mode(&self) -> Option<RoomNotificationMode> {
         self.inner.read().cached_user_defined_notification_mode
     }
@@ -1041,7 +1041,7 @@ pub struct RoomInfo {
 
     /// Cached display name, useful for sync access.
     ///
-    /// Filled by calling [`Self::compute_display_name`]. It's automatically
+    /// Filled by calling [`Room::compute_display_name`]. It's automatically
     /// filled at start when creating a room, or on every successful sync.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) cached_display_name: Option<DisplayName>,

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -125,6 +125,7 @@ impl RoomInfoV1 {
             base_info: base_info.migrate(create),
             warned_about_unknown_room_version: Arc::new(false.into()),
             cached_display_name: None,
+            cached_user_defined_notification_mode: None,
             #[cfg(feature = "experimental-sliding-sync")]
             recency_stamp: None,
         }

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -23,21 +23,12 @@ mod command;
 mod rule_commands;
 mod rules;
 
+pub use matrix_sdk_base::notification_settings::RoomNotificationMode;
+
 use crate::{
     config::RequestConfig, error::NotificationSettingsError, event_handler::EventHandlerDropGuard,
     Client, Result,
 };
-
-/// Enum representing the push notification modes for a room.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RoomNotificationMode {
-    /// Receive notifications for all messages.
-    AllMessages,
-    /// Receive notifications for mentions and keywords only.
-    MentionsAndKeywordsOnly,
-    /// Do not receive any notifications.
-    Mute,
-}
 
 /// Whether or not a room is encrypted
 #[derive(Debug, Clone, Copy)]

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for that specific language governing permissions and
+// limitations under the License.
+
 //! High-level push notification settings API
 
 use std::sync::Arc;

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2671,7 +2671,8 @@ impl Room {
     /// Get the user-defined notification mode.
     ///
     /// The result is cached for fast and non-async call. To read the cached
-    /// result, use [`Self::cached_user_defined_notification_mode`].
+    /// result, use
+    /// [`matrix_sdk_base::Room::cached_user_defined_notification_mode`].
     //
     // Note for maintainers:
     //

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -137,3 +137,130 @@ async fn update_in_memory_caches(client: &Client, response: &SyncResponse) -> Re
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use matrix_sdk_base::notification_settings::RoomNotificationMode;
+    use matrix_sdk_test::async_test;
+    use ruma::{assign, room_id, serde::Raw};
+    use serde_json::json;
+
+    use crate::{
+        error::Result, sliding_sync::http, test_utils::logged_in_client_with_server,
+        SlidingSyncList, SlidingSyncMode,
+    };
+
+    #[async_test]
+    async fn test_cache_user_defined_notification_mode() -> Result<()> {
+        let (client, _server) = logged_in_client_with_server().await;
+        let room_id = room_id!("!r0:matrix.org");
+
+        let sliding_sync = client
+            .sliding_sync("test")?
+            .with_account_data_extension(
+                assign!(http::request::AccountData::default(), { enabled: Some(true) }),
+            )
+            .add_list(
+                SlidingSyncList::builder("all")
+                    .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
+            )
+            .build()
+            .await?;
+
+        // Mock a sync response.
+        // A `m.push_rules` with `room` is cached during the sync.
+        {
+            let server_response = assign!(http::Response::new("0".to_owned()), {
+                rooms: BTreeMap::from([(
+                    room_id.to_owned(),
+                    http::response::Room::default(),
+                )]),
+                extensions: assign!(http::response::Extensions::default(), {
+                    account_data: assign!(http::response::AccountData::default(), {
+                        global: vec![
+                            Raw::from_json_string(
+                                json!({
+                                    "type": "m.push_rules",
+                                    "content": {
+                                        "global": {
+                                            "room": [
+                                                {
+                                                    "actions": ["notify"],
+                                                    "rule_id": room_id,
+                                                    "default": false,
+                                                    "enabled": true,
+                                                },
+                                            ],
+                                        },
+                                    },
+                                })
+                                .to_string(),
+                            ).unwrap()
+                        ]
+                    })
+                })
+            });
+
+            let mut pos_guard = sliding_sync.inner.position.clone().lock_owned().await;
+            sliding_sync.handle_response(server_response.clone(), &mut pos_guard).await?;
+        }
+
+        // The room must exist, since it's been synced.
+        let room = client.get_room(room_id).unwrap();
+
+        // The room has a cached user-defined notification mode.
+        assert_eq!(
+            room.cached_user_defined_notification_mode(),
+            Some(RoomNotificationMode::AllMessages),
+        );
+
+        // Mock a sync response.
+        // A `m.push_rules` with `room` is cached during the sync.
+        // It overwrites the previous cache.
+        {
+            let server_response = assign!(http::Response::new("0".to_owned()), {
+                rooms: BTreeMap::from([(
+                    room_id.to_owned(),
+                    http::response::Room::default(),
+                )]),
+                extensions: assign!(http::response::Extensions::default(), {
+                    account_data: assign!(http::response::AccountData::default(), {
+                        global: vec![
+                            Raw::from_json_string(
+                                json!({
+                                    "type": "m.push_rules",
+                                    "content": {
+                                        "global": {
+                                            "room": [
+                                                {
+                                                    "actions": [],
+                                                    "rule_id": room_id,
+                                                    "default": false,
+                                                    "enabled": true,
+                                                },
+                                            ],
+                                        },
+                                    },
+                                })
+                                .to_string(),
+                            ).unwrap()
+                        ]
+                    })
+                })
+            });
+
+            let mut pos_guard = sliding_sync.inner.position.clone().lock_owned().await;
+            sliding_sync.handle_response(server_response.clone(), &mut pos_guard).await?;
+        }
+
+        // The room has an updated cached user-defined notification mode.
+        assert_eq!(
+            room.cached_user_defined_notification_mode(),
+            Some(RoomNotificationMode::MentionsAndKeywordsOnly),
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This patch should be reviewed commit by commit.

In `matrix_sdk_ffi::RoomInfo`, there is a `user_defined_notification_mode` field. To compute a value for this field, it takes quite a non-negligeable amount of time because the store is hit (because the account data must be read to compute a `NotificationSettings` object). If a lot of `RoomInfo` are created (it happens in some apps that want to display a lot of rooms), it can quickly create a performance bottleneck.

This pull request solves the problem by caching the result of `Room::user_defined_notification_mode()` into `Room::cached_user_defined_notification_mode()`. This cache is updated for every sync, similarly to what we do for the room name for example.

This time, it's a bit different as this mechanism happens in `matrix-sdk` instead of `matrix-sdk-base`. The cache sadly lives in `matrix_sdk_base::RoomInfo`. This is going to be clean up with a bigger refactoring later.

The `matrix_sdk_ffi::RoomInfo::user_defined_notification_mode` is renamed `cached_user_defined_notification_mode`, that's the only public API change.

---

* Closes https://github.com/matrix-org/matrix-rust-sdk/issues/3827