### PR TITLE
crypto: change `Identity::is_x_signed` methods to return bool

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -744,7 +744,7 @@ impl DeviceData {
             |(own_identity, device_identity)| {
                 match device_identity {
                     UserIdentityData::Own(_) => {
-                        own_identity.is_verified() && own_identity.is_device_signed(self).is_ok()
+                        own_identity.is_verified() && own_identity.is_device_signed(self)
                     }
 
                     // If it's a device from someone else, first check
@@ -766,7 +766,7 @@ impl DeviceData {
         match device_owner_identity {
             // If it's one of our own devices, just check that
             // we signed the device.
-            UserIdentityData::Own(identity) => identity.is_device_signed(self).is_ok(),
+            UserIdentityData::Own(identity) => identity.is_device_signed(self),
             // If it's a device from someone else, check
             // if the other user has signed this device.
             UserIdentityData::Other(device_identity) => {

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -752,7 +752,7 @@ impl DeviceData {
                     // check if the other user has signed this device.
                     UserIdentityData::Other(device_identity) => {
                         own_identity.is_identity_verified(device_identity)
-                            && device_identity.is_device_signed(self).is_ok()
+                            && device_identity.is_device_signed(self)
                     }
                 }
             },
@@ -769,9 +769,7 @@ impl DeviceData {
             UserIdentityData::Own(identity) => identity.is_device_signed(self),
             // If it's a device from someone else, check
             // if the other user has signed this device.
-            UserIdentityData::Other(device_identity) => {
-                device_identity.is_device_signed(self).is_ok()
-            }
+            UserIdentityData::Other(device_identity) => device_identity.is_device_signed(self),
         }
     }
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1458,7 +1458,7 @@ pub(crate) mod tests {
         let identity = manager.store.get_user_identity(other_user).await.unwrap().unwrap();
         let identity = identity.other().unwrap();
 
-        identity.is_device_signed(&device).unwrap();
+        assert!(identity.is_device_signed(&device));
     }
 
     #[async_test]
@@ -2113,7 +2113,7 @@ pub(crate) mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert!(bob_identity.is_device_signed(&bob_device).is_ok());
+        assert!(bob_identity.is_device_signed(&bob_device));
         // there is also a pin violation
         assert!(bob_identity.has_pin_violation());
         // Fixing the pin violation won't fix the verification latch violation

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -529,9 +529,8 @@ impl IdentityManager {
         } else {
             // First time seen, create the identity. The current MSK will be pinned.
             let identity = OtherUserIdentityData::new(master_key, self_signing)?;
-            let is_verified = maybe_verified_own_identity.map_or(false, |own_user_identity| {
-                own_user_identity.is_identity_signed(&identity).is_ok()
-            });
+            let is_verified = maybe_verified_own_identity
+                .map_or(false, |own_user_identity| own_user_identity.is_identity_signed(&identity));
             if is_verified {
                 identity.mark_as_previously_verified();
             }
@@ -2217,7 +2216,7 @@ pub(crate) mod tests {
         let bob_identity =
             machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap().other().unwrap();
         // Carol is verified by our identity but our own identity is not yet trusted
-        assert!(own_identity.is_identity_signed(&bob_identity).is_ok());
+        assert!(own_identity.is_identity_signed(&bob_identity));
         assert!(!bob_identity.was_previously_verified());
 
         let carol_identity = machine
@@ -2228,7 +2227,7 @@ pub(crate) mod tests {
             .other()
             .unwrap();
         // Carol is verified by our identity but our own identity is not yet trusted
-        assert!(own_identity.is_identity_signed(&carol_identity).is_ok());
+        assert!(own_identity.is_identity_signed(&carol_identity));
         assert!(!carol_identity.was_previously_verified());
 
         // Marking our own identity as trusted should update the existing identities
@@ -2267,7 +2266,7 @@ pub(crate) mod tests {
         let bob_identity =
             machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap().other().unwrap();
         // Carol is verified by our identity but our own identity is not yet trusted
-        assert!(own_identity.is_identity_signed(&bob_identity).is_ok());
+        assert!(own_identity.is_identity_signed(&bob_identity));
         assert!(!bob_identity.was_previously_verified());
 
         let carol_identity = machine
@@ -2278,7 +2277,7 @@ pub(crate) mod tests {
             .other()
             .unwrap();
         // Carol is verified by our identity but our own identity is not yet trusted
-        assert!(own_identity.is_identity_signed(&carol_identity).is_ok());
+        assert!(own_identity.is_identity_signed(&carol_identity));
         assert!(!carol_identity.was_previously_verified());
 
         // Marking our own identity as trusted should update the existing identities

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -762,14 +762,9 @@ impl OtherUserIdentityData {
     ///
     /// * `device` - The device that should be checked for a valid signature.
     ///
-    /// Returns an empty result if the signature check succeeded, otherwise a
-    /// SignatureError indicating why the check failed.
-    pub(crate) fn is_device_signed(&self, device: &DeviceData) -> Result<(), SignatureError> {
-        if self.user_id() != device.user_id() {
-            return Err(SignatureError::UserIdMismatch);
-        }
-
-        self.self_signing_key.verify_device(device)
+    /// Returns `true` if the signature check succeeded, otherwise `false`.
+    pub(crate) fn is_device_signed(&self, device: &DeviceData) -> bool {
+        self.user_id() == device.user_id() && self.self_signing_key.verify_device(device).is_ok()
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -895,7 +895,7 @@ impl OwnUserIdentityData {
     /// * `identity` - The identity of another user which we want to check has
     ///   been verified.
     pub fn is_identity_verified(&self, identity: &OtherUserIdentityData) -> bool {
-        self.is_verified() && self.is_identity_signed(identity).is_ok()
+        self.is_verified() && self.is_identity_signed(identity)
     }
 
     /// Check if the given identity has been signed by this identity.
@@ -909,13 +909,9 @@ impl OwnUserIdentityData {
     /// * `identity` - The identity of another user that we want to check if it
     ///   has been signed.
     ///
-    /// Returns an empty result if the signature check succeeded, otherwise a
-    /// SignatureError indicating why the check failed.
-    pub(crate) fn is_identity_signed(
-        &self,
-        identity: &OtherUserIdentityData,
-    ) -> Result<(), SignatureError> {
-        self.user_signing_key.verify_master_key(&identity.master_key)
+    /// Returns `true` if the signature check succeeded, otherwise `false`.
+    pub(crate) fn is_identity_signed(&self, identity: &OtherUserIdentityData) -> bool {
+        self.user_signing_key.verify_master_key(&identity.master_key).is_ok()
     }
 
     /// Check if the given device has been signed by this identity.

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -942,8 +942,7 @@ mod tests {
             .own_identity
             .as_ref()
             .unwrap()
-            .is_identity_signed(&bob_identity.inner)
-            .is_ok());
+            .is_identity_signed(&bob_identity.inner));
         assert!(!bob_identity.is_verified());
 
         let bob_unsigned_device = machine

--- a/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
+++ b/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
@@ -184,7 +184,7 @@ impl CryptoStoreWrapper {
                 .and_then(|i| i.other())
             {
                 if !other_identity.was_previously_verified()
-                    && own_identity_after.is_identity_signed(other_identity).is_ok()
+                    && own_identity_after.is_identity_signed(other_identity)
                 {
                     trace!(?tracked_user.user_id, "Marking set verified_latch to true.");
                     other_identity.mark_as_previously_verified();


### PR DESCRIPTION
There are a set of methods in `OwnUserIdentityData` and `OtherUserIdentityData` which return an error if a device or identity is unverified. All the callers end up calling `is_ok()` on the result, so we may as well just return a bool.