### PR TITLE
Crypto: add helper methods to `UserIdentities`

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -285,10 +285,7 @@ impl OlmMachine {
             if let Some(identity) =
                 self.runtime.block_on(self.inner.get_identity(&user_id, None))?
             {
-                match identity {
-                    UserIdentities::Own(i) => i.is_verified(),
-                    UserIdentities::Other(i) => i.is_verified(),
-                }
+                identity.is_verified()
             } else {
                 false
             },

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -2137,13 +2137,8 @@ pub(crate) mod tests {
         let txn_id = TransactionId::new();
         machine.mark_request_as_sent(&txn_id, &keys_query).await.unwrap();
 
-        let carol_identity = machine
-            .get_identity(DataSet::carol_id(), None)
-            .await
-            .unwrap()
-            .unwrap()
-            .other()
-            .unwrap();
+        let carol_identity =
+            machine.get_identity(DataSet::carol_id(), None).await.unwrap().unwrap();
         // The identity is not verified
         assert!(!carol_identity.is_verified());
         // The verified latch is off
@@ -2213,43 +2208,30 @@ pub(crate) mod tests {
         let own_identity =
             machine.get_identity(DataSet::own_id(), None).await.unwrap().unwrap().own().unwrap();
 
-        let bob_identity =
-            machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap().other().unwrap();
-        // Carol is verified by our identity but our own identity is not yet trusted
-        assert!(own_identity.is_identity_signed(&bob_identity));
+        let bob_identity = machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap();
+        // Bob is verified by our identity but our own identity is not yet trusted
         assert!(!bob_identity.was_previously_verified());
+        assert!(own_identity.is_identity_signed(&bob_identity.other().unwrap()));
 
-        let carol_identity = machine
-            .get_identity(DataSet::carol_id(), None)
-            .await
-            .unwrap()
-            .unwrap()
-            .other()
-            .unwrap();
+        let carol_identity =
+            machine.get_identity(DataSet::carol_id(), None).await.unwrap().unwrap();
         // Carol is verified by our identity but our own identity is not yet trusted
-        assert!(own_identity.is_identity_signed(&carol_identity));
         assert!(!carol_identity.was_previously_verified());
+        assert!(own_identity.is_identity_signed(&carol_identity.other().unwrap()));
 
         // Marking our own identity as trusted should update the existing identities
         let _ = own_identity.verify().await;
 
-        let own_identity =
-            machine.get_identity(DataSet::own_id(), None).await.unwrap().unwrap().own().unwrap();
+        let own_identity = machine.get_identity(DataSet::own_id(), None).await.unwrap().unwrap();
         assert!(own_identity.is_verified());
 
-        let carol_identity = machine
-            .get_identity(DataSet::carol_id(), None)
-            .await
-            .unwrap()
-            .unwrap()
-            .other()
-            .unwrap();
+        let carol_identity =
+            machine.get_identity(DataSet::carol_id(), None).await.unwrap().unwrap();
         assert!(carol_identity.is_verified());
         // The latch should be set now
         assert!(carol_identity.was_previously_verified());
 
-        let bob_identity =
-            machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap().other().unwrap();
+        let bob_identity = machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap();
         assert!(bob_identity.is_verified());
         // The latch should be set now
         assert!(bob_identity.was_previously_verified());
@@ -2290,23 +2272,16 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let own_identity =
-            machine.get_identity(DataSet::own_id(), None).await.unwrap().unwrap().own().unwrap();
+        let own_identity = machine.get_identity(DataSet::own_id(), None).await.unwrap().unwrap();
         assert!(own_identity.is_verified());
 
-        let carol_identity = machine
-            .get_identity(DataSet::carol_id(), None)
-            .await
-            .unwrap()
-            .unwrap()
-            .other()
-            .unwrap();
+        let carol_identity =
+            machine.get_identity(DataSet::carol_id(), None).await.unwrap().unwrap();
         assert!(carol_identity.is_verified());
         // The latch should be set now
         assert!(carol_identity.was_previously_verified());
 
-        let bob_identity =
-            machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap().other().unwrap();
+        let bob_identity = machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap();
         assert!(bob_identity.is_verified());
         // The latch should be set now
         assert!(bob_identity.was_previously_verified());

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -86,6 +86,52 @@ impl UserIdentities {
             }
         }
     }
+
+    /// Check if this user identity is verified.
+    ///
+    /// For our own identity, this means either that we have checked the public
+    /// keys in the identity against the private keys; or that the identity
+    /// has been manually marked as verified via
+    /// [`OwnUserIdentity::verify`].
+    ///
+    /// For another user's identity, it means that we have verified our own
+    /// identity as above, *and* that the other user's identity has been signed
+    /// by our own user-signing key.
+    pub fn is_verified(&self) -> bool {
+        match self {
+            UserIdentities::Own(u) => u.is_verified(),
+            UserIdentities::Other(u) => u.is_verified(),
+        }
+    }
+
+    /// True if we verified this identity at some point in the past.
+    ///
+    /// To reset this latch back to `false`, one must call
+    /// [`UserIdentities::withdraw_verification()`].
+    pub fn was_previously_verified(&self) -> bool {
+        match self {
+            UserIdentities::Own(u) => u.was_previously_verified(),
+            UserIdentities::Other(u) => u.was_previously_verified(),
+        }
+    }
+
+    /// Reset the flag that records that the identity has been verified, thus
+    /// clearing [`Self::was_previously_verified`] and
+    /// [`Self::has_verification_violation`].
+    pub async fn withdraw_verification(&self) -> Result<(), CryptoStoreError> {
+        match self {
+            UserIdentities::Own(u) => u.withdraw_verification().await,
+            UserIdentities::Other(u) => u.withdraw_verification().await,
+        }
+    }
+
+    /// Was this identity previously verified, and is no longer?
+    pub fn has_verification_violation(&self) -> bool {
+        match self {
+            UserIdentities::Own(u) => u.has_verification_violation(),
+            UserIdentities::Other(u) => u.has_verification_violation(),
+        }
+    }
 }
 
 impl From<OwnUserIdentity> for UserIdentities {

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1700,7 +1700,6 @@ pub(crate) mod tests {
 
         // Double-check that we have a verified identity
         let own_identity = machine.get_identity(DataSet::own_id(), None).await.unwrap().unwrap();
-        let own_identity = own_identity.own().unwrap();
         assert!(own_identity.is_verified());
         assert!(own_identity.was_previously_verified());
         assert!(!own_identity.has_verification_violation());
@@ -1712,7 +1711,6 @@ pub(crate) mod tests {
         // That should give an identity that is no longer verified, with a verification
         // violation.
         let own_identity = machine.get_identity(DataSet::own_id(), None).await.unwrap().unwrap();
-        let own_identity = own_identity.own().unwrap();
         assert!(!own_identity.is_verified());
         assert!(own_identity.was_previously_verified());
         assert!(own_identity.has_verification_violation());

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -350,10 +350,7 @@ impl UserIdentity {
     /// # anyhow::Ok(()) };
     /// ```
     pub fn is_verified(&self) -> bool {
-        match &self.inner.identity {
-            CryptoUserIdentities::Own(identity) => identity.is_verified(),
-            CryptoUserIdentities::Other(identity) => identity.is_verified(),
-        }
+        self.inner.identity.is_verified()
     }
 
     /// Get the public part of the Master key of this user identity.


### PR DESCRIPTION
We have a bunch of methods which are the same in both `OtherUserIdentity` and `OwnUserIdentity`, so add some convenience methods to access them.