### PR TITLE
fix(ffi): New fields formatter to remove duplicated span fields

### DIFF
--- a/bindings/matrix-sdk-ffi/src/platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform.rs
@@ -97,17 +97,19 @@ where
 
             if let Some(scope) = ctx.event_scope() {
                 writer.write_str(" | spans: ")?;
+
                 let mut first = true;
 
                 for span in scope.from_root() {
                     if !first {
                         writer.write_str(" > ")?;
                     }
-                    first = false;
-                    write!(writer, "{}", span.metadata().name())?;
 
-                    let ext = span.extensions();
-                    if let Some(fields) = &ext.get::<FormattedFields<N>>() {
+                    first = false;
+
+                    write!(writer, "{}", span.name())?;
+
+                    if let Some(fields) = &span.extensions().get::<FormattedFields<N>>() {
                         if !fields.is_empty() {
                             write!(writer, "{{{fields}}}")?;
                         }


### PR DESCRIPTION
This patch fixes a bug in the tracing system. It introduces one
fields formatter _per layer_ to force the fields to be recorded in
different span extensions, and thus to remove the duplicated fields in
`FormattedFields`.

The patch contains links to the bug report in `tokio-rs/tracing`. This
patch is a workaround.

---

* Fix #3494 