### PR TITLE
 feat(sdk): Sliding sync has a timeout if all lists require a timeout

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -1032,7 +1032,7 @@ mod tests {
 
     #[async_test]
     #[allow(clippy::await_holding_lock)]
-    async fn test_sliding_sync_inner_update_maximum_number_of_rooms() {
+    async fn test_inner_update_maximum_number_of_rooms() {
         let (sender, _receiver) = channel(1);
 
         let mut list = SlidingSyncList::builder("foo")
@@ -1085,7 +1085,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sliding_sync_state_serialization() {
+    fn test_sliding_sync_list_loading_state_serialization() {
         assert_json_roundtrip!(from SlidingSyncListLoadingState: SlidingSyncListLoadingState::NotLoaded => json!("NotLoaded"));
         assert_json_roundtrip!(from SlidingSyncListLoadingState: SlidingSyncListLoadingState::Preloaded => json!("Preloaded"));
         assert_json_roundtrip!(from SlidingSyncListLoadingState: SlidingSyncListLoadingState::PartiallyLoaded => json!("PartiallyLoaded"));

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -385,7 +385,7 @@ pub enum SlidingSyncListLoadingState {
 
 impl SlidingSyncListLoadingState {
     /// Check whether the state is [`Self::FullyLoaded`].
-    pub fn is_fully_loaded(&self) -> bool {
+    fn is_fully_loaded(&self) -> bool {
         matches!(self, Self::FullyLoaded)
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -353,14 +353,24 @@ pub enum SlidingSyncListLoadingState {
     /// Sliding Sync has not started to load anything yet.
     #[default]
     NotLoaded,
+
     /// Sliding Sync has been preloaded, i.e. restored from a cache for example.
     Preloaded,
+
     /// Updates are received from the loaded rooms, and new rooms are being
     /// fetched in the background.
     PartiallyLoaded,
+
     /// Updates are received for all the loaded rooms, and all rooms have been
     /// loaded!
     FullyLoaded,
+}
+
+impl SlidingSyncListLoadingState {
+    /// Check whether the state is [`Self::FullyLoaded`].
+    pub fn is_fully_loaded(&self) -> bool {
+        matches!(self, Self::FullyLoaded)
+    }
 }
 
 /// Builder for a new sliding sync list in selective mode.
@@ -498,6 +508,7 @@ impl SlidingSyncMode {
 mod tests {
     use std::{
         cell::Cell,
+        ops::Not,
         sync::{Arc, Mutex},
     };
 
@@ -1090,6 +1101,14 @@ mod tests {
         assert_json_roundtrip!(from SlidingSyncListLoadingState: SlidingSyncListLoadingState::Preloaded => json!("Preloaded"));
         assert_json_roundtrip!(from SlidingSyncListLoadingState: SlidingSyncListLoadingState::PartiallyLoaded => json!("PartiallyLoaded"));
         assert_json_roundtrip!(from SlidingSyncListLoadingState: SlidingSyncListLoadingState::FullyLoaded => json!("FullyLoaded"));
+    }
+
+    #[test]
+    fn test_sliding_sync_list_loading_state_is_fully_loaded() {
+        assert!(SlidingSyncListLoadingState::NotLoaded.is_fully_loaded().not());
+        assert!(SlidingSyncListLoadingState::Preloaded.is_fully_loaded().not());
+        assert!(SlidingSyncListLoadingState::PartiallyLoaded.is_fully_loaded().not());
+        assert!(SlidingSyncListLoadingState::FullyLoaded.is_fully_loaded());
     }
 
     #[test]

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -115,6 +115,12 @@ impl SlidingSyncListRequestGenerator {
         }
     }
 
+    /// Check whether this request generator is of kind
+    /// [`SlidingSyncListRequestGeneratorKind::Selective`].
+    pub(super) fn is_selective(&self) -> bool {
+        matches!(self.kind, SlidingSyncListRequestGeneratorKind::Selective)
+    }
+
     /// Return a view on the ranges requested by this generator.
     ///
     /// For generators in the selective mode, this is the initial set of ranges.
@@ -326,7 +332,7 @@ fn create_range(
 
 #[cfg(test)]
 mod tests {
-    use std::ops::RangeInclusive;
+    use std::ops::{Not, RangeInclusive};
 
     use assert_matches::assert_matches;
 
@@ -389,6 +395,7 @@ mod tests {
 
         assert!(request_generator.ranges.is_empty());
         assert_eq!(request_generator.kind, SlidingSyncListRequestGeneratorKind::Selective);
+        assert!(request_generator.is_selective());
     }
 
     #[test]
@@ -407,6 +414,7 @@ mod tests {
                 requested_end: None,
             }
         );
+        assert!(request_generator.is_selective().not());
     }
 
     #[test]
@@ -425,5 +433,6 @@ mod tests {
                 requested_end: None,
             }
         );
+        assert!(request_generator.is_selective().not());
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -8,26 +8,25 @@
 //! * There is a set of ranges,
 //! * Each request asks to load the particular ranges.
 //!
-//! In [`SlidingSyncMode::PagingFullSync`]:
+//! In [`SlidingSyncMode::Paging`]:
 //!
 //! * There is a `batch_size`,
 //! * Each request asks to load a new successive range containing exactly
 //!   `batch_size` rooms.
 //!
-//! In [`SlidingSyncMode::GrowingFullSync]:
+//! In [`SlidingSyncMode::Growing]:
 //!
 //! * There is a `batch_size`,
 //! * Each request asks to load a new range, always starting from 0, but where
 //!   the end is incremented by `batch_size` every time.
 //!
-//! The number of rooms to load is capped by the
-//! [`SlidingSyncList::maximum_number_of_rooms`], i.e. the real number of
-//! rooms it is possible to load. This value comes from the server.
+//! The number of rooms to load is capped by a `maximum_number_of_rooms`, i.e.
+//! the real number of rooms it is possible to load. This value comes from the
+//! server.
 //!
 //! The number of rooms to load can _also_ be capped by the
-//! [`SlidingSyncList::full_sync_maximum_number_of_rooms_to_fetch`], i.e. a
-//! user-specified limit representing the maximum number of rooms the user
-//! actually wants to load.
+//! `maximum_number_of_rooms_to_fetch`, i.e. a user-specified limit representing
+//! the maximum number of rooms the user actually wants to load.
 
 use std::cmp::min;
 
@@ -80,7 +79,7 @@ pub(in super::super) struct SlidingSyncListRequestGenerator {
     ranges: Ranges,
 
     /// The kind of request generator.
-    pub(super) kind: SlidingSyncListRequestGeneratorKind,
+    kind: SlidingSyncListRequestGeneratorKind,
 }
 
 impl SlidingSyncListRequestGenerator {


### PR DESCRIPTION
This patch updates when sliding sync requests have a `timeout`.

Prior to this patch, all requests had a `timeout` query, set to the
`poll_timeout` duration value. However it means: if there is no data
to return, wait `timeout` milliseconds for new data before returning.
This definition is correct. Problem: if the current range of a list
has no data, the server will wait! It means that, in a situation where
there is no update at all, but the client is fetching all rooms batch by
batch, it will wait `poll_timeout` for each batch!

The behaviour described above is absolutely correct. Some server
implementations are less strict though, and we didn't realise our code
was doing that, because the server had some optimisations to ignore the
timeout if the range wasn't covering all the rooms. Nonetheless, a new
server implementation (namely Synapse) is strict, and it confirms we
have a bug here.

This patch then configures a `timeout` if all lists require a `timeout`,
otherwise there is no `timeout`, which is equivalent to `timeout=0`.

---

* Fixes https://github.com/element-hq/element-x-ios/issues/3165#issuecomment-2295700461