### PR TITLE
test: get rid of `TestTimeline::handle_live_message_event` in favor of `handle_live_event`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -131,6 +131,7 @@ async fn test_remote_echo_full_trip() {
 async fn test_remote_echo_new_position() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
+    let f = EventFactory::new();
 
     // Given a local event…
     let txn_id = timeline
@@ -147,7 +148,7 @@ async fn test_remote_echo_new_position() {
     assert!(day_divider.is_day_divider());
 
     // … and another event that comes back before the remote echo
-    timeline.handle_live_message_event(&BOB, RoomMessageEventContent::text_plain("test")).await;
+    timeline.handle_live_event(f.text_msg("test").sender(&BOB)).await;
 
     // … and is inserted before the local echo item
     let bob_message = assert_next_matches!(stream, VectorDiff::PushFront { value } => value);
@@ -187,8 +188,9 @@ async fn test_day_divider_duplication() {
     let timeline = TestTimeline::new();
 
     // Given two remote events from one day, and a local event from another day…
-    timeline.handle_live_message_event(&BOB, RoomMessageEventContent::text_plain("A")).await;
-    timeline.handle_live_message_event(&BOB, RoomMessageEventContent::text_plain("B")).await;
+    let f = EventFactory::new().sender(&BOB);
+    timeline.handle_live_event(f.text_msg("A")).await;
+    timeline.handle_live_event(f.text_msg("B")).await;
     timeline
         .handle_local_event(AnyMessageLikeEventContent::RoomMessage(
             RoomMessageEventContent::text_plain("C"),

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -131,7 +131,7 @@ async fn test_remote_echo_full_trip() {
 async fn test_remote_echo_new_position() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     // Given a local event…
     let txn_id = timeline
@@ -234,7 +234,7 @@ async fn test_day_divider_duplication() {
 async fn test_day_divider_removed_after_local_echo_disappeared() {
     let timeline = TestTimeline::new();
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     timeline
         .handle_live_event(
@@ -282,14 +282,14 @@ async fn test_day_divider_removed_after_local_echo_disappeared() {
 
 #[async_test]
 async fn test_read_marker_removed_after_local_echo_disappeared() {
-    let f = EventFactory::new();
-
     let event_id = event_id!("$1");
 
     let timeline = TestTimeline::with_room_data_provider(
         TestRoomDataProvider::default().with_fully_read_marker(event_id.to_owned()),
     )
     .with_settings(TimelineInnerSettings { track_read_receipts: true, ..Default::default() });
+
+    let f = &timeline.factory;
 
     // Use `replace_with_initial_remote_events` which initializes the read marker;
     // other methods don't, by default.

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -14,7 +14,6 @@
 
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
-use matrix_sdk::test_utils::events::EventFactory;
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE};
 use ruma::{
     events::room::message::{MessageType, RedactedRoomMessageEventContent},
@@ -30,7 +29,8 @@ async fn test_live_redacted() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
+
     timeline
         .handle_live_redacted_message_event(*ALICE, RedactedRoomMessageEventContent::new())
         .await;
@@ -57,7 +57,7 @@ async fn test_live_sanitized() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
     timeline
         .handle_live_event(
             f.text_html("**original** message", "<strong>original</strong> message").sender(&ALICE),

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -25,7 +25,7 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use matrix_sdk::{
     crypto::{decrypt_room_key_export, types::events::UtdCause, OlmMachine},
-    test_utils::{events::EventFactory, test_client_builder},
+    test_utils::test_client_builder,
 };
 use matrix_sdk_test::{async_test, BOB};
 use ruma::{
@@ -85,7 +85,7 @@ async fn test_retry_message_decryption() {
     let timeline = TestTimeline::with_unable_to_decrypt_hook(utd_hook.clone());
     let mut stream = timeline.subscribe().await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
     timeline
         .handle_live_event(
             f.event(RoomEncryptedEventContent::new(
@@ -200,7 +200,7 @@ async fn test_retry_edit_decryption() {
         -----END MEGOLM SESSION DATA-----";
 
     let timeline = TestTimeline::new();
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     let encrypted = EncryptedEventScheme::MegolmV1AesSha2(
         MegolmV1AesSha2ContentInit {
@@ -313,7 +313,7 @@ async fn test_retry_edit_and_more() {
     }
 
     let timeline = TestTimeline::new();
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     timeline
         .handle_live_event(
@@ -401,7 +401,7 @@ async fn test_retry_message_decryption_highlighted() {
         -----END MEGOLM SESSION DATA-----";
 
     let timeline = TestTimeline::new();
-    let f = EventFactory::new();
+    let f = &timeline.factory;
     let mut stream = timeline.subscribe().await;
 
     timeline

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -25,7 +25,7 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use matrix_sdk::{
     crypto::{decrypt_room_key_export, types::events::UtdCause, OlmMachine},
-    test_utils::test_client_builder,
+    test_utils::{events::EventFactory, test_client_builder},
 };
 use matrix_sdk_test::{async_test, BOB};
 use ruma::{
@@ -85,10 +85,10 @@ async fn test_retry_message_decryption() {
     let timeline = TestTimeline::with_unable_to_decrypt_hook(utd_hook.clone());
     let mut stream = timeline.subscribe().await;
 
+    let f = EventFactory::new();
     timeline
-        .handle_live_message_event(
-            &BOB,
-            RoomEncryptedEventContent::new(
+        .handle_live_event(
+            f.event(RoomEncryptedEventContent::new(
                 EncryptedEventScheme::MegolmV1AesSha2(
                     MegolmV1AesSha2ContentInit {
                         ciphertext: "\
@@ -106,7 +106,8 @@ async fn test_retry_message_decryption() {
                     .into(),
                 ),
                 None,
-            ),
+            ))
+            .sender(&BOB),
         )
         .await;
 
@@ -199,6 +200,7 @@ async fn test_retry_edit_decryption() {
         -----END MEGOLM SESSION DATA-----";
 
     let timeline = TestTimeline::new();
+    let f = EventFactory::new();
 
     let encrypted = EncryptedEventScheme::MegolmV1AesSha2(
         MegolmV1AesSha2ContentInit {
@@ -214,7 +216,9 @@ async fn test_retry_edit_decryption() {
         }
         .into(),
     );
-    timeline.handle_live_message_event(&BOB, RoomEncryptedEventContent::new(encrypted, None)).await;
+    timeline
+        .handle_live_event(f.event(RoomEncryptedEventContent::new(encrypted, None)).sender(&BOB))
+        .await;
 
     let event_id =
         timeline.inner.items().await[1].as_event().unwrap().event_id().unwrap().to_owned();
@@ -236,11 +240,11 @@ async fn test_retry_edit_decryption() {
         .into(),
     );
     timeline
-        .handle_live_message_event(
-            &BOB,
-            assign!(RoomEncryptedEventContent::new(encrypted, None), {
+        .handle_live_event(
+            f.event(assign!(RoomEncryptedEventContent::new(encrypted, None), {
                 relates_to: Some(Relation::Replacement(Replacement::new(event_id))),
-            }),
+            }))
+            .sender(&BOB),
         )
         .await;
 
@@ -309,16 +313,17 @@ async fn test_retry_edit_and_more() {
     }
 
     let timeline = TestTimeline::new();
+    let f = EventFactory::new();
 
     timeline
-        .handle_live_message_event(
-            &BOB,
-            encrypted_message(
+        .handle_live_event(
+            f.event(encrypted_message(
                 "AwgDEoABQsTrPTYDh22PTmfODR9EucX3qLl3buDcahHPjKJA8QIM+wW0s+e08Zi7/JbLdnZL1VL\
                  jO47HcRhxDTyHZPXPg8wd1l0Qb3irjnCnS7LFAc98+ko18CFJUGNeRZZwzGiorKK5VLMv0WQZI8\
                  mBZdKIaqDTUBFvcvbn2gQaWtUipQdJQRKyv2h0AWveVkv75lp5hRb7jolCi08oMX8cM+V3Zzyi7\
                  mlPAzZjDz0PaRbQwfbMTTHkcL7TZybBi4vLX4f5ZR2Iiysc7gw",
-            ),
+            ))
+            .sender(&BOB),
         )
         .await;
 
@@ -333,21 +338,20 @@ async fn test_retry_edit_and_more() {
          4uEzsQ0",
     );
     timeline
-        .handle_live_message_event(
-            &BOB,
-            assign!(msg2, { relates_to: Some(Relation::Replacement(Replacement::new(event_id))) }),
+        .handle_live_event(
+            f.event(assign!(msg2, { relates_to: Some(Relation::Replacement(Replacement::new(event_id))) })).sender(&BOB),
         )
         .await;
 
     timeline
-        .handle_live_message_event(
-            &BOB,
-            encrypted_message(
+        .handle_live_event(
+            f.event(encrypted_message(
                 "AwgFEoABUAwzBLYStHEa1RaZtojePQ6sue9terXNMFufeLKci/UcpOpZC9o3lDxp9rxlNjk4Ii+\
                  fkOeSClib/qxt+wLszeQZVa04bRr6byK1dOhlptvAPjUCcEsaHyMMR1AnjT2vmFlJRGviwN6cvQ\
                  2r/fEvAW/9QB+N6fX4g9729bt5ftXRqa5QI7NA351RNUveRHxVvx+2x0WJArQjYGRk7tMS2rUto\
                  IYt2ZY17nE1UJjN7M87STnCF9c9qy4aGNqIpeVIht6XbtgD7gQ",
-            ),
+            ))
+            .sender(&BOB),
         )
         .await;
 
@@ -397,12 +401,12 @@ async fn test_retry_message_decryption_highlighted() {
         -----END MEGOLM SESSION DATA-----";
 
     let timeline = TestTimeline::new();
+    let f = EventFactory::new();
     let mut stream = timeline.subscribe().await;
 
     timeline
-        .handle_live_message_event(
-            &BOB,
-            RoomEncryptedEventContent::new(
+        .handle_live_event(
+            f.event(RoomEncryptedEventContent::new(
                 EncryptedEventScheme::MegolmV1AesSha2(
                     MegolmV1AesSha2ContentInit {
                         ciphertext: "\
@@ -419,7 +423,8 @@ async fn test_retry_message_decryption_highlighted() {
                     .into(),
                 ),
                 None,
-            ),
+            ))
+            .sender(&BOB),
         )
         .await;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
-use matrix_sdk::test_utils::events::EventFactory;
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE, BOB};
 use ruma::events::{
     room::{
@@ -41,7 +40,7 @@ async fn test_default_filter() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     // Test edits work.
     timeline.handle_live_event(f.text_msg("The first message").sender(&ALICE)).await;
@@ -99,7 +98,7 @@ async fn test_filter_always_false() {
         ..Default::default()
     });
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
     timeline.handle_live_event(f.text_msg("The first message").sender(&ALICE)).await;
 
     timeline
@@ -131,7 +130,7 @@ async fn test_custom_filter() {
     });
     let mut stream = timeline.subscribe().await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
     timeline.handle_live_event(f.text_msg("The first message").sender(&ALICE)).await;
     let _item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let _day_divider = assert_next_matches!(stream, VectorDiff::PushFront { value } => value);
@@ -199,7 +198,7 @@ async fn test_event_type_filter_include_only_room_names() {
         event_filter: Arc::new(move |event, _| event_filter.filter(event)),
         ..Default::default()
     });
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     // Add a non-encrypted message event
     timeline.handle_live_event(f.text_msg("The first message").sender(&ALICE)).await;
@@ -247,7 +246,7 @@ async fn test_event_type_filter_exclude_messages() {
         event_filter: Arc::new(move |event, _| event_filter.filter(event)),
         ..Default::default()
     });
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     // Add a message event
     timeline.handle_live_event(f.text_msg("The first message").sender(&ALICE)).await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
@@ -14,7 +14,6 @@
 
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
-use matrix_sdk::test_utils::events::EventFactory;
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE, BOB};
 use ruma::{
     events::{room::message::MessageType, MessageLikeEventType, StateEventType},
@@ -30,7 +29,7 @@ async fn invalid_edit() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
     timeline.handle_live_event(f.text_msg("test").sender(&ALICE)).await;
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let msg = item.content().as_message().unwrap();

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -201,10 +201,11 @@ impl TestTimeline {
     }
 
     async fn send_poll_start(&self, sender: &UserId, content: UnstablePollStartContentBlock) {
+        // TODO: consider putting it in the `TestTimeline` itself?
         let event_content = AnyMessageLikeEventContent::UnstablePollStart(
             NewUnstablePollStartEventContent::new(content).into(),
         );
-        self.handle_live_message_event(sender, event_content).await;
+        self.handle_live_event(self.factory.event(event_content).sender(sender)).await;
     }
 
     async fn send_poll_start_with_id(
@@ -228,14 +229,14 @@ impl TestTimeline {
                 poll_id.to_owned(),
             ),
         );
-        self.handle_live_message_event(sender, event_content).await
+        self.handle_live_event(self.factory.event(event_content).sender(sender)).await
     }
 
     async fn send_poll_end(&self, sender: &UserId, text: &str, poll_id: &EventId) {
         let event_content = AnyMessageLikeEventContent::UnstablePollEnd(
             UnstablePollEndEventContent::new(text, poll_id.to_owned()),
         );
-        self.handle_live_message_event(sender, event_content).await
+        self.handle_live_event(self.factory.event(event_content).sender(sender)).await
     }
 
     async fn send_poll_edit(
@@ -247,7 +248,7 @@ impl TestTimeline {
         let content =
             ReplacementUnstablePollStartEventContent::new(content, original_id.to_owned());
         let event_content = AnyMessageLikeEventContent::UnstablePollStart(content.into());
-        self.handle_live_message_event(sender, event_content).await
+        self.handle_live_event(self.factory.event(event_content).sender(sender)).await
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -201,7 +201,6 @@ impl TestTimeline {
     }
 
     async fn send_poll_start(&self, sender: &UserId, content: UnstablePollStartContentBlock) {
-        // TODO: consider putting it in the `TestTimeline` itself?
         let event_content = AnyMessageLikeEventContent::UnstablePollStart(
             NewUnstablePollStartEventContent::new(content).into(),
         );

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -94,9 +94,9 @@ async fn test_add_reaction_success() {
 
 #[async_test]
 async fn test_redact_reaction_success() {
-    let f = EventFactory::new();
-
     let timeline = TestTimeline::new();
+    let f = &timeline.factory;
+
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
     let reaction = create_reaction(&msg_id);
@@ -127,7 +127,7 @@ async fn test_redact_reaction_failure() {
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     let event_id = event_id!("$1");
     timeline

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -21,9 +21,8 @@ use futures_core::Stream;
 use matrix_sdk::test_utils::events::EventFactory;
 use matrix_sdk_test::{async_test, ALICE, BOB};
 use ruma::{
-    event_id,
-    events::{relation::Annotation, room::message::RoomMessageEventContent},
-    server_name, uint, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, TransactionId, UserId,
+    event_id, events::relation::Annotation, server_name, uint, EventId, MilliSecondsSinceUnixEpoch,
+    OwnedEventId, TransactionId, UserId,
 };
 use stream_assert::assert_next_matches;
 
@@ -292,9 +291,7 @@ async fn send_first_message(
     timeline: &TestTimeline,
     stream: &mut (impl Stream<Item = VectorDiff<Arc<TimelineItem>>> + Unpin),
 ) -> (OwnedEventId, usize) {
-    timeline
-        .handle_live_message_event(&BOB, RoomMessageEventContent::text_plain("I want you to react"))
-        .await;
+    timeline.handle_live_event(timeline.factory.text_msg("I want you to react").sender(&BOB)).await;
 
     let item = assert_next_matches!(*stream, VectorDiff::PushBack { value } => value);
     let event_id = item.as_event().unwrap().clone().event_id().unwrap().to_owned();

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -18,19 +18,13 @@ use eyeball_im::VectorDiff;
 use matrix_sdk::test_utils::events::EventFactory;
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_test::{async_test, ALICE, BOB};
-use ruma::{
-    events::{
-        reaction::RedactedReactionEventContent,
-        room::{
-            message::{
-                AddMentions, ForwardThread, OriginalSyncRoomMessageEvent,
-                RedactedRoomMessageEventContent, RoomMessageEventContent,
-            },
-            name::RoomNameEventContent,
-        },
-        FullStateEventContent,
+use ruma::events::{
+    reaction::RedactedReactionEventContent,
+    room::{
+        message::{OriginalSyncRoomMessageEvent, RedactedRoomMessageEventContent},
+        name::RoomNameEventContent,
     },
-    owned_room_id,
+    FullStateEventContent,
 };
 use stream_assert::assert_next_matches;
 
@@ -87,14 +81,7 @@ async fn test_redact_replied_to_event() {
         first_item.original_json().unwrap().deserialize_as().unwrap();
 
     timeline
-        .handle_live_message_event(
-            &BOB,
-            RoomMessageEventContent::text_plain("Hello, alice.").make_reply_to(
-                &first_event.into_full_event(owned_room_id!("!whocares:local.host")),
-                ForwardThread::Yes,
-                AddMentions::No,
-            ),
-        )
+        .handle_live_event(f.text_msg("Hello, alice.").sender(&BOB).reply_to(&first_event.event_id))
         .await;
 
     let second_item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -15,7 +15,6 @@
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
-use matrix_sdk::test_utils::events::EventFactory;
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_test::{async_test, ALICE, BOB};
 use ruma::events::{
@@ -39,7 +38,7 @@ async fn test_redact_state_event() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     timeline
         .handle_live_state_event(
@@ -71,7 +70,7 @@ async fn test_redact_replied_to_event() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     timeline.handle_live_event(f.text_msg("Hello, world!").sender(&ALICE)).await;
 
@@ -110,7 +109,7 @@ async fn test_reaction_redaction() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     timeline.handle_live_event(f.text_msg("hi!").sender(&ALICE)).await;
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
@@ -136,7 +135,7 @@ async fn test_reaction_redaction_timeline_filter() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     // Initialise a timeline with a redacted reaction.
     timeline
@@ -183,7 +182,7 @@ async fn test_reaction_redaction_timeline_filter() {
 async fn test_receive_unredacted() {
     let timeline = TestTimeline::new();
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     // send two events, second one redacted
     timeline.handle_live_event(f.text_msg("about to be redacted").sender(&ALICE)).await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
@@ -1,6 +1,5 @@
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
-use matrix_sdk::test_utils::events::EventFactory;
 use matrix_sdk_base::deserialized_responses::{ShieldState, ShieldStateCode};
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE};
 use ruma::{
@@ -15,7 +14,7 @@ use crate::timeline::{tests::TestTimeline, EventSendState};
 async fn test_no_shield_in_unencrypted_room() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     timeline.handle_live_event(f.text_msg("Unencrypted message.").sender(&ALICE)).await;
 
@@ -29,7 +28,7 @@ async fn test_sent_in_clear_shield() {
     let timeline = TestTimeline::with_is_room_encrypted(true);
     let mut stream = timeline.subscribe().await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
     timeline.handle_live_event(f.text_msg("Unencrypted message.").sender(&ALICE)).await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);

--- a/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
@@ -1,5 +1,6 @@
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
+use matrix_sdk::test_utils::events::EventFactory;
 use matrix_sdk_base::deserialized_responses::{ShieldState, ShieldStateCode};
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE};
 use ruma::{
@@ -14,13 +15,9 @@ use crate::timeline::{tests::TestTimeline, EventSendState};
 async fn test_no_shield_in_unencrypted_room() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
+    let f = EventFactory::new();
 
-    timeline
-        .handle_live_message_event(
-            &ALICE,
-            RoomMessageEventContent::text_plain("Unencrypted message."),
-        )
-        .await;
+    timeline.handle_live_event(f.text_msg("Unencrypted message.").sender(&ALICE)).await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let shield = item.as_event().unwrap().get_shield(false);
@@ -32,12 +29,8 @@ async fn test_sent_in_clear_shield() {
     let timeline = TestTimeline::with_is_room_encrypted(true);
     let mut stream = timeline.subscribe().await;
 
-    timeline
-        .handle_live_message_event(
-            &ALICE,
-            RoomMessageEventContent::text_plain("Unencrypted message."),
-        )
-        .await;
+    let f = EventFactory::new();
+    timeline.handle_live_event(f.text_msg("Unencrypted message.").sender(&ALICE)).await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let shield = item.as_event().unwrap().get_shield(false);

--- a/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
@@ -16,7 +16,6 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use chrono::{Datelike, Local, TimeZone};
 use eyeball_im::VectorDiff;
-use matrix_sdk::test_utils::events::EventFactory;
 use matrix_sdk_test::{async_test, ALICE, BOB};
 use ruma::{
     event_id,
@@ -32,7 +31,7 @@ async fn test_day_divider() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     timeline
         .handle_live_event(f.text_msg("This is a first message on the first day").sender(*ALICE))
@@ -92,7 +91,7 @@ async fn test_update_read_marker() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 
-    let f = EventFactory::new();
+    let f = &timeline.factory;
 
     timeline.handle_live_event(f.text_msg("A").sender(&ALICE)).await;
 


### PR DESCRIPTION
By using the `EventFactory` a bit more.

Part of #3716.