### PR TITLE
Add variants to SenderData to represent different verification states

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -27,6 +27,7 @@ use crate::debug::{DebugRawEvent, DebugStructExt};
 const AUTHENTICITY_NOT_GUARANTEED: &str =
     "The authenticity of this encrypted message can't be guaranteed on this device.";
 const UNVERIFIED_IDENTITY: &str = "Encrypted by an unverified user.";
+const PREVIOUSLY_VERIFIED: &str = "Encrypted by a previously-verified user.";
 const UNSIGNED_DEVICE: &str = "Encrypted by a device not verified by its owner.";
 const UNKNOWN_DEVICE: &str = "Encrypted by an unknown or deleted device.";
 pub const SENT_IN_CLEAR: &str = "Not encrypted.";
@@ -88,7 +89,9 @@ impl VerificationState {
         match self {
             VerificationState::Verified => ShieldState::None,
             VerificationState::Unverified(level) => match level {
-                VerificationLevel::UnverifiedIdentity | VerificationLevel::UnsignedDevice => {
+                VerificationLevel::UnverifiedIdentity
+                | VerificationLevel::PreviouslyVerified
+                | VerificationLevel::UnsignedDevice => {
                     ShieldState::Red {
                         code: ShieldStateCode::UnverifiedIdentity,
                         message: UNVERIFIED_IDENTITY,
@@ -122,9 +125,15 @@ impl VerificationState {
                 VerificationLevel::UnverifiedIdentity => {
                     // If you didn't show interest in verifying that user we don't
                     // nag you with an error message.
-                    // TODO: We should detect identity rotation of a previously trusted identity and
-                    // then warn see https://github.com/matrix-org/matrix-rust-sdk/issues/1129
                     ShieldState::None
+                }
+                VerificationLevel::PreviouslyVerified => {
+                    // This is a high warning. The sender was previously
+                    // verified, but changed their identity.
+                    ShieldState::Red {
+                        code: ShieldStateCode::PreviouslyVerified,
+                        message: PREVIOUSLY_VERIFIED,
+                    }
                 }
                 VerificationLevel::UnsignedDevice => {
                     // This is a high warning. The sender hasn't verified his own device.
@@ -163,6 +172,10 @@ impl VerificationState {
 pub enum VerificationLevel {
     /// The message was sent by a user identity we have not verified.
     UnverifiedIdentity,
+
+    /// The message was sent by a user identity we have not verified, but the
+    /// user was previously verified.
+    PreviouslyVerified,
 
     /// The message was sent by a device not linked to (signed by) any user
     /// identity.
@@ -227,6 +240,8 @@ pub enum ShieldStateCode {
     UnverifiedIdentity,
     /// An unencrypted event in an encrypted room.
     SentInClear,
+    /// The sender was previously verified but changed their identity.
+    PreviouslyVerified,
 }
 
 /// The algorithm specific information of a decrypted event.

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -91,12 +91,10 @@ impl VerificationState {
             VerificationState::Unverified(level) => match level {
                 VerificationLevel::UnverifiedIdentity
                 | VerificationLevel::PreviouslyVerified
-                | VerificationLevel::UnsignedDevice => {
-                    ShieldState::Red {
-                        code: ShieldStateCode::UnverifiedIdentity,
-                        message: UNVERIFIED_IDENTITY,
-                    }
-                }
+                | VerificationLevel::UnsignedDevice => ShieldState::Red {
+                    code: ShieldStateCode::UnverifiedIdentity,
+                    message: UNVERIFIED_IDENTITY,
+                },
                 VerificationLevel::None(link) => match link {
                     DeviceLinkProblem::MissingDevice => ShieldState::Red {
                         code: ShieldStateCode::UnknownDevice,

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -66,8 +66,8 @@ use crate::{
     identities::{user::UserIdentities, Device, IdentityManager, UserDevices},
     olm::{
         Account, CrossSigningStatus, EncryptionSettings, IdentityKeys, InboundGroupSession,
-        OlmDecryptionInfo, PrivateCrossSigningIdentity, SenderData, SenderDataFinder, SessionType,
-        StaticAccountData,
+        KnownSenderData, OlmDecryptionInfo, PrivateCrossSigningIdentity, SenderData,
+        SenderDataFinder, SessionType, StaticAccountData,
     },
     requests::{IncomingResponse, OutgoingRequest, UploadSigningKeysRequest},
     session_manager::{GroupSessionManager, SessionManager},
@@ -2359,10 +2359,13 @@ fn sender_data_to_verification_state(
             VerificationState::Unverified(VerificationLevel::UnsignedDevice),
             Some(device_keys.device_id),
         ),
-        SenderData::SenderKnown { master_key_verified: false, device_id, .. } => {
+        SenderData::SenderUnverifiedButPreviouslyVerified(KnownSenderData {
+            device_id, ..
+        }) => (VerificationState::Unverified(VerificationLevel::PreviouslyVerified), device_id),
+        SenderData::SenderUnverified(KnownSenderData { device_id, .. }) => {
             (VerificationState::Unverified(VerificationLevel::UnverifiedIdentity), device_id)
         }
-        SenderData::SenderKnown { master_key_verified: true, device_id, .. } => {
+        SenderData::SenderVerified(KnownSenderData { device_id, .. }) => {
             (VerificationState::Verified, device_id)
         }
     }

--- a/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
@@ -187,7 +187,7 @@ async fn test_decryption_verification_state() {
 
     // And the updated SenderData should have been saved into the store.
     let session = load_session(&bob, room_id, &event).await.unwrap().unwrap();
-    assert_let!(SenderData::SenderKnown { .. } = session.sender_data);
+    assert_let!(SenderData::SenderVerified { .. } = session.sender_data);
 
     // Simulate an imported session, to change verification state
     let imported = InboundGroupSession::from_export(&export).unwrap();

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use outbound::ShareState;
 pub use outbound::{
     EncryptionSettings, OutboundGroupSession, PickledOutboundGroupSession, ShareInfo,
 };
-pub use sender_data::SenderData;
+pub use sender_data::{KnownSenderData, SenderData};
 pub(crate) use sender_data_finder::SenderDataFinder;
 use thiserror::Error;
 pub use vodozemac::megolm::{ExportedSessionKey, SessionKey};

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -166,13 +166,6 @@ impl SenderData {
         Self::UnknownDevice { legacy_session: true, owner_check_failed: false }
     }
 
-    /// Returns true if this is SenderKnown and `master_key_verified` is true.
-    pub(crate) fn is_known(&self) -> bool {
-        matches!(self, SenderData::SenderUnverifiedButPreviouslyVerified { .. })
-            || matches!(self, SenderData::SenderUnverified { .. })
-            || matches!(self, SenderData::SenderVerified { .. })
-    }
-
     /// Returns `Greater` if this `SenderData` represents a greater level of
     /// trust than the supplied one, `Equal` if they have the same level, and
     /// `Less` if the supplied one has a greater level of trust.
@@ -354,34 +347,6 @@ mod tests {
 
         let end: SenderData = serde_json::from_str(json).expect("Failed to parse!");
         assert_let!(SenderData::SenderVerified { .. } = end);
-    }
-
-    #[test]
-    fn known_session_is_known() {
-        let user_id = user_id!("@u:s.co");
-        let device_id = device_id!("DEV");
-        let master_key =
-            Ed25519PublicKey::from_base64("2/5LWJMow5zhJqakV88SIc7q/1pa8fmkfgAzx72w9G4").unwrap();
-
-        assert!(!SenderData::unknown().is_known());
-        assert!(SenderData::sender_previously_verified(user_id, device_id, master_key).is_known());
-        assert!(SenderData::sender_unverified(user_id, device_id, master_key).is_known());
-        assert!(SenderData::sender_verified(user_id, device_id, master_key).is_known());
-    }
-
-    #[test]
-    fn unknown_and_device_sessions_are_not_known() {
-        // Anything that is not SenderKnown is not know and verified.
-        assert!(!SenderData::unknown().is_known());
-
-        let device_keys = DeviceKeys::new(
-            owned_user_id!("@u:s.co"),
-            owned_device_id!("DEV"),
-            Vec::new(),
-            BTreeMap::new(),
-            Signatures::new(),
-        );
-        assert!(!SenderData::device_info(device_keys).is_known());
     }
 
     #[test]

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -20,7 +20,7 @@ use vodozemac::Ed25519PublicKey;
 
 use crate::types::DeviceKeys;
 
-/// Information about the sender of a megolm session where we know their
+/// Information about the sender of a megolm session where we know the
 /// cross-signing identity of the sender.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct KnownSenderData {
@@ -75,7 +75,7 @@ pub enum SenderData {
         legacy_session: bool,
     },
 
-    /// We have found proof that this user, with this cross-signing key, send
+    /// We have found proof that this user, with this cross-signing key, sent
     /// the to-device message that established this session, but we have not yet
     /// verified the cross-signing key, and we had verified a previous
     /// cross-signing key for this user.

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -20,11 +20,30 @@ use vodozemac::Ed25519PublicKey;
 
 use crate::types::DeviceKeys;
 
+/// Information about the sender of a megolm session where we know their
+/// cross-signing identity of the sender.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct KnownSenderData {
+    /// The user ID of the user who established this session.
+    pub user_id: OwnedUserId,
+
+    /// The device ID of the device that send the session.
+    /// This is an `Option` for backwards compatibility, but we should always
+    /// populate it on creation.
+    pub device_id: Option<OwnedDeviceId>,
+
+    /// The cross-signing key of the user who established this session.
+    pub master_key: Box<Ed25519PublicKey>,
+}
+
 /// Information on the device and user that sent the megolm session data to us
 ///
 /// Sessions start off in `UnknownDevice` state, and progress into `DeviceInfo`
 /// state when we get the device info. Finally, if we can look up the sender
-/// using the device info, the session can be moved into `SenderKnown` state.
+/// using the device info, the session can be moved into
+/// `SenderUnverifiedButPreviouslyVerified`, `SenderUnverified`, or
+/// `SenderVerified` state, depending on the verification status of the user.
+/// If the user's verification state changes, the state may change accordingly.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum SenderData {
     /// We have not yet found the (signed) device info for the sending device,
@@ -55,26 +74,21 @@ pub enum SenderData {
         legacy_session: bool,
     },
 
+    /// We have found proof that this user, with this cross-signing key, send
+    /// the to-device message that established this session, but we have not yet
+    /// verified the cross-signing key, and we had verified a previous
+    /// cross-signing key for this user.
+    SenderUnverifiedButPreviouslyVerified(KnownSenderData),
+
     /// We have found proof that this user, with this cross-signing key, sent
-    /// the to-device message that established this session.
-    SenderKnown {
-        /// The user ID of the user who established this session.
-        user_id: OwnedUserId,
+    /// the to-device message that established this session, but we have not yet
+    /// verified the cross-signing key.
+    SenderUnverified(KnownSenderData),
 
-        /// The device ID of the device that send the session.
-        /// This is an `Option` for backwards compatibility, but we should
-        /// always populate it on creation.
-        device_id: Option<OwnedDeviceId>,
-
-        /// The cross-signing key of the user who established this session.
-        master_key: Box<Ed25519PublicKey>,
-
-        /// Whether, at the time we checked the signature on the device,
-        /// we had actively verified that `master_key` belongs to the user.
-        /// If false, we had simply accepted the key as this user's latest
-        /// key.
-        master_key_verified: bool,
-    },
+    /// We have found proof that this user, with this cross-signing key, sent
+    /// the to-device message that established this session, and we have
+    /// verified the cross-signing key.
+    SenderVerified(KnownSenderData),
 }
 
 impl SenderData {
@@ -102,19 +116,43 @@ impl SenderData {
         }
     }
 
-    /// Create a [`SenderData`] with a known sender.
-    pub fn sender_known(
+    /// Create a [`SenderData`] with a known but unverified sender, where the sender was previously verified.
+    pub fn sender_previously_verified(
         user_id: &UserId,
         device_id: &DeviceId,
         master_key: Ed25519PublicKey,
-        master_key_verified: bool,
     ) -> Self {
-        Self::SenderKnown {
+        Self::SenderUnverifiedButPreviouslyVerified(KnownSenderData {
             user_id: user_id.to_owned(),
             device_id: Some(device_id.to_owned()),
             master_key: Box::new(master_key),
-            master_key_verified,
-        }
+        })
+    }
+
+    /// Create a [`SenderData`] with a known but unverified sender.
+    pub fn sender_unverified(
+        user_id: &UserId,
+        device_id: &DeviceId,
+        master_key: Ed25519PublicKey,
+    ) -> Self {
+        Self::SenderUnverified(KnownSenderData {
+            user_id: user_id.to_owned(),
+            device_id: Some(device_id.to_owned()),
+            master_key: Box::new(master_key),
+        })
+    }
+
+    /// Create a [`SenderData`] with a verified sender.
+    pub fn sender_verified(
+        user_id: &UserId,
+        device_id: &DeviceId,
+        master_key: Ed25519PublicKey,
+    ) -> Self {
+        Self::SenderVerified(KnownSenderData {
+            user_id: user_id.to_owned(),
+            device_id: Some(device_id.to_owned()),
+            master_key: Box::new(master_key),
+        })
     }
 
     /// Create a [`SenderData`] which has the legacy flag set. Caution: messages
@@ -128,7 +166,9 @@ impl SenderData {
 
     /// Returns true if this is SenderKnown and `master_key_verified` is true.
     pub(crate) fn is_known(&self) -> bool {
-        matches!(self, SenderData::SenderKnown { .. })
+        matches!(self, SenderData::SenderUnverifiedButPreviouslyVerified { .. })
+            || matches!(self, SenderData::SenderUnverified { .. })
+            || matches!(self, SenderData::SenderVerified { .. })
     }
 
     /// Returns `Greater` if this `SenderData` represents a greater level of
@@ -151,8 +191,9 @@ impl SenderData {
         match self {
             SenderData::UnknownDevice { .. } => 0,
             SenderData::DeviceInfo { .. } => 1,
-            SenderData::SenderKnown { master_key_verified: false, .. } => 2,
-            SenderData::SenderKnown { master_key_verified: true, .. } => 3,
+            SenderData::SenderUnverifiedButPreviouslyVerified(..) => 2,
+            SenderData::SenderUnverified(..) => 3,
+            SenderData::SenderVerified(..) => 4,
         }
     }
 }
@@ -249,7 +290,7 @@ mod tests {
             "#;
 
         let end: SenderData = serde_json::from_str(json).expect("Failed to parse!");
-        assert_let!(SenderData::SenderKnown { .. } = end);
+        assert_let!(SenderData::SenderVerified { .. } = end);
     }
 
     #[test]
@@ -259,8 +300,10 @@ mod tests {
         let master_key =
             Ed25519PublicKey::from_base64("2/5LWJMow5zhJqakV88SIc7q/1pa8fmkfgAzx72w9G4").unwrap();
 
-        assert!(SenderData::sender_known(user_id, device_id, master_key, true).is_known());
-        assert!(SenderData::sender_known(user_id, device_id, master_key, false).is_known());
+        assert!(!SenderData::unknown().is_known());
+        assert!(SenderData::sender_previously_verified(user_id, device_id, master_key).is_known());
+        assert!(SenderData::sender_unverified(user_id, device_id, master_key).is_known());
+        assert!(SenderData::sender_verified(user_id, device_id, master_key).is_known());
     }
 
     #[test]
@@ -291,9 +334,9 @@ mod tests {
         let master_key =
             Ed25519PublicKey::from_base64("2/5LWJMow5zhJqakV88SIc7q/1pa8fmkfgAzx72w9G4").unwrap();
         let sender_unverified =
-            SenderData::sender_known(user_id!("@u:s.co"), device_id!("DEV"), master_key, false);
+            SenderData::sender_unverified(user_id!("@u:s.co"), device_id!("DEV"), master_key);
         let sender_verified =
-            SenderData::sender_known(user_id!("@u:s.co"), device_id!("DEV"), master_key, true);
+            SenderData::sender_verified(user_id!("@u:s.co"), device_id!("DEV"), master_key);
 
         assert_eq!(unknown.compare_trust_level(&unknown), Ordering::Equal);
         assert_eq!(device_keys.compare_trust_level(&device_keys), Ordering::Equal);
@@ -313,23 +356,39 @@ mod tests {
         ));
         let master_key =
             Ed25519PublicKey::from_base64("2/5LWJMow5zhJqakV88SIc7q/1pa8fmkfgAzx72w9G4").unwrap();
+        let sender_previously_verified = SenderData::sender_previously_verified(
+            user_id!("@u:s.co"),
+            device_id!("DEV"),
+            master_key,
+        );
         let sender_unverified =
-            SenderData::sender_known(user_id!("@u:s.co"), device_id!("DEV"), master_key, false);
+            SenderData::sender_unverified(user_id!("@u:s.co"), device_id!("DEV"), master_key);
         let sender_verified =
-            SenderData::sender_known(user_id!("@u:s.co"), device_id!("DEV"), master_key, true);
+            SenderData::sender_verified(user_id!("@u:s.co"), device_id!("DEV"), master_key);
 
         assert_eq!(unknown.compare_trust_level(&device_keys), Ordering::Less);
+        assert_eq!(unknown.compare_trust_level(&sender_previously_verified), Ordering::Less);
         assert_eq!(unknown.compare_trust_level(&sender_unverified), Ordering::Less);
         assert_eq!(unknown.compare_trust_level(&sender_verified), Ordering::Less);
         assert_eq!(device_keys.compare_trust_level(&unknown), Ordering::Greater);
+        assert_eq!(sender_previously_verified.compare_trust_level(&unknown), Ordering::Greater);
         assert_eq!(sender_unverified.compare_trust_level(&unknown), Ordering::Greater);
         assert_eq!(sender_verified.compare_trust_level(&unknown), Ordering::Greater);
 
         assert_eq!(device_keys.compare_trust_level(&sender_unverified), Ordering::Less);
         assert_eq!(device_keys.compare_trust_level(&sender_verified), Ordering::Less);
+        assert_eq!(sender_previously_verified.compare_trust_level(&device_keys), Ordering::Greater);
         assert_eq!(sender_unverified.compare_trust_level(&device_keys), Ordering::Greater);
         assert_eq!(sender_verified.compare_trust_level(&device_keys), Ordering::Greater);
 
+        assert_eq!(
+            sender_previously_verified.compare_trust_level(&sender_verified),
+            Ordering::Less
+        );
+        assert_eq!(
+            sender_previously_verified.compare_trust_level(&sender_unverified),
+            Ordering::Less
+        );
         assert_eq!(sender_unverified.compare_trust_level(&sender_verified), Ordering::Less);
         assert_eq!(sender_verified.compare_trust_level(&sender_unverified), Ordering::Greater);
     }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -116,7 +116,8 @@ impl SenderData {
         }
     }
 
-    /// Create a [`SenderData`] with a known but unverified sender, where the sender was previously verified.
+    /// Create a [`SenderData`] with a known but unverified sender, where the
+    /// sender was previously verified.
     pub fn sender_previously_verified(
         user_id: &UserId,
         device_id: &DeviceId,

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -26,7 +26,7 @@ mod utility;
 pub use account::{Account, OlmMessageHash, PickledAccount, StaticAccountData};
 pub(crate) use account::{OlmDecryptionInfo, SessionType};
 pub use group_sessions::{
-    BackedUpRoomKey, EncryptionSettings, ExportedRoomKey, InboundGroupSession,
+    BackedUpRoomKey, EncryptionSettings, ExportedRoomKey, InboundGroupSession, KnownSenderData,
     OutboundGroupSession, PickledInboundGroupSession, PickledOutboundGroupSession, SenderData,
     SessionCreationError, SessionExportError, SessionKey, ShareInfo,
 };


### PR DESCRIPTION
<!-- description of the changes in this PR -->
as [previously discussed](https://github.com/matrix-org/matrix-rust-sdk/pull/3701/files#r1721932382)

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
