### PR TITLE
crypto: In sqlite, use the SQL column value for backed_up everywhere

### DIFF
--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -158,8 +158,10 @@ impl SqliteCryptoStore {
     ) -> Result<InboundGroupSession> {
         let mut pickle: PickledInboundGroupSession = self.deserialize_value(&value)?;
 
-        // backed_up SQL column is source of truth, backed_up field in pickle
-        // needed for other stores though
+        // The `backed_up` SQL column is the source of truth, because we update it
+        // inside `mark_inbound_group_sessions_as_backed_up` and don't update
+        // the pickled value inside the `data` column (until now, when we are puling it
+        // out of the DB).
         pickle.backed_up = backed_up;
 
         Ok(InboundGroupSession::from_pickle(pickle)?)


### PR DESCRIPTION
Most times we pulled an InboundGroupSession from the sqlite DB, we were overriding whatever value for `backed_up` was stored inside the pickled value, and using the value stored in the SQL column.
    
But when we pulled a single InboundGroupSession from the DB by ID, we did not override it.
    
I am fairly sure this was an accidental oversight, so this change corrects it, and unifies the code with other places we create these objects.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/3544
Applies on top of https://github.com/matrix-org/matrix-rust-sdk/pull/3862