### PR TITLE
Expose `room_key_recipient_strategy` through higher-level SDK crates

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -13,3 +13,4 @@ Breaking changes:
 
 Additions:
 
+- Add `ClientBuilder::room_key_recipient_strategy`

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -1,5 +1,6 @@
 # unreleased
 
+- Add `BaseClient::room_key_recipient_strategy` field
 - Replace the `Notification` type from Ruma in `SyncResponse` and `StateChanges` by a custom one
 - The ambiguity maps in `SyncResponse` are moved to `JoinedRoom` and `LeftRoom`
 - `AmbiguityCache` contains the room member's user ID

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -36,6 +36,7 @@ use crate::{Device, UserIdentities};
 /// Strategy to collect the devices that should receive room keys for the
 /// current discussion.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum CollectStrategy {
     /// Device based sharing strategy.
     DeviceBasedStrategy {

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -25,6 +25,7 @@ Breaking changes:
 
 Additions:
 
+- new `ClientBuilder::with_room_key_recipient_strategy` method
 - new `Room.set_account_data` and `Room.set_account_data_raw` RoomAccountData setters, analogous to the GlobalAccountData
 - new `RequestConfig.max_concurrent_requests` which allows to limit the maximum number of concurrent requests the internal HTTP client issues (all others have to wait until the number drops below that threshold again)
 - Expose new method `Client::Oidc::login_with_qr_code()`.


### PR DESCRIPTION
https://github.com/matrix-org/matrix-rust-sdk/pull/3810 added a new option to the `CollectStrategy` used when collecting recipients for encrypted room keys. We need to expose that to applications via the FFI bindings.

Part of https://github.com/element-hq/element-internal/issues/614