### PR TITLE
timeline: only use the send queue mechanism to send reactions

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -603,7 +603,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                             ReactionStatus::LocalToRemote(send_handle)
                         }
                         TimelineEventItemId::EventId(event_id) => {
-                            ReactionStatus::Remote(event_id.clone())
+                            ReactionStatus::RemoteToRemote(event_id.clone())
                         }
                     },
                 },
@@ -1070,7 +1070,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         reaction.sender_id,
                         ReactionInfo {
                             timestamp: reaction.timestamp,
-                            status: ReactionStatus::Remote(reaction_event_id),
+                            status: ReactionStatus::RemoteToRemote(reaction_event_id),
                         },
                     );
                 }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -620,7 +620,7 @@ pub enum ReactionStatus {
     /// The handle is missing only in testing contexts.
     LocalToRemote(Option<SendHandle>),
     /// It's a remote reaction to a remote event.
-    Remote(OwnedEventId),
+    RemoteToRemote(OwnedEventId),
 }
 
 /// Information about a single reaction stored in [`ReactionsByKeyBySender`].

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -500,7 +500,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
                 }
             }
 
-            ReactionStatus::Remote(event_id) => {
+            ReactionStatus::RemoteToRemote(event_id) => {
                 // Assume the redaction will work; we'll re-add the reaction if it didn't.
                 let mut reactions = item.reactions().clone();
                 let reaction_info = reactions.remove_reaction(user_id, &annotation.key);
@@ -730,7 +730,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
                                 .and_then(|by_user| by_user.get_mut(&reaction_key.sender))
                             {
                                 trace!("updated reaction status to sent");
-                                entry.status = ReactionStatus::Remote(event_id.to_owned());
+                                entry.status = ReactionStatus::RemoteToRemote(event_id.to_owned());
                                 txn.items.set(item_pos, event_item.with_reactions(reactions));
                                 txn.commit();
                                 return;

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -16,7 +16,7 @@ use std::{io, sync::Arc};
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
-use matrix_sdk::{test_utils::events::EventFactory, Error};
+use matrix_sdk::{send_queue::RoomSendQueueUpdate, test_utils::events::EventFactory, Error};
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE, BOB};
 use ruma::{
     event_id,
@@ -266,11 +266,9 @@ async fn test_day_divider_removed_after_local_echo_disappeared() {
 
     // Cancel the local echo.
     timeline
-        .handle_room_send_queue_update(
-            matrix_sdk::send_queue::RoomSendQueueUpdate::CancelledLocalEvent {
-                transaction_id: txn_id,
-            },
-        )
+        .handle_room_send_queue_update(RoomSendQueueUpdate::CancelledLocalEvent {
+            transaction_id: txn_id,
+        })
         .await;
 
     let items = timeline.inner.items().await;
@@ -328,11 +326,9 @@ async fn test_read_marker_removed_after_local_echo_disappeared() {
 
     // Cancel the local echo.
     timeline
-        .handle_room_send_queue_update(
-            matrix_sdk::send_queue::RoomSendQueueUpdate::CancelledLocalEvent {
-                transaction_id: txn_id,
-            },
-        )
+        .handle_room_send_queue_update(RoomSendQueueUpdate::CancelledLocalEvent {
+            transaction_id: txn_id,
+        })
         .await;
 
     let items = timeline.inner.items().await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -71,7 +71,7 @@ macro_rules! assert_reaction_is_updated {
         let reaction = reactions.get(*ALICE).unwrap();
         match reaction.status {
             ReactionStatus::LocalToRemote(_) => assert!(!$is_remote_echo),
-            ReactionStatus::Remote(_) => assert!($is_remote_echo),
+            ReactionStatus::RemoteToRemote(_) => assert!($is_remote_echo),
         };
         event
     }};

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -48,6 +48,7 @@ mod pagination;
 mod pinned_event;
 mod profiles;
 mod queue;
+mod reactions;
 mod read_receipts;
 mod replies;
 mod subscribe;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
@@ -1,0 +1,173 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use assert_matches2::{assert_let, assert_matches};
+use eyeball_im::VectorDiff;
+use futures_util::{FutureExt as _, StreamExt as _};
+use matrix_sdk::test_utils::{events::EventFactory, logged_in_client_with_server};
+use matrix_sdk_test::{
+    async_test,
+    mocks::{mock_encryption_state, mock_redaction},
+    JoinedRoomBuilder, SyncResponseBuilder, ALICE,
+};
+use matrix_sdk_ui::timeline::{ReactionStatus, RoomExt as _};
+use ruma::{event_id, events::relation::Annotation, room_id};
+use serde_json::json;
+use wiremock::{
+    matchers::{header, method, path_regex},
+    Mock, ResponseTemplate,
+};
+
+use crate::mock_sync;
+
+#[async_test]
+async fn test_abort_before_being_sent() {
+    // This test checks that a reaction could be aborted *before* or *while* it's
+    // being sent by the send queue.
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let (client, server) = logged_in_client_with_server().await;
+    let user_id = client.user_id().unwrap();
+
+    // Make the test aware of the room.
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(Default::default()).await.unwrap();
+    server.reset().await;
+
+    mock_encryption_state(&server, false).await;
+
+    let room = client.get_room(room_id).unwrap();
+    let timeline = room.timeline().await.unwrap();
+    let (initial_items, mut stream) = timeline.subscribe().await;
+
+    assert!(initial_items.is_empty());
+
+    let f = EventFactory::new();
+
+    let event_id = event_id!("$1");
+    sync_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            .add_timeline_event(f.text_msg("hello").sender(&ALICE).event_id(event_id)),
+    );
+
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(Default::default()).await.unwrap();
+    server.reset().await;
+
+    assert_let!(Some(VectorDiff::PushBack { value: first }) = stream.next().await);
+    let item = first.as_event().unwrap();
+    assert_eq!(item.content().as_message().unwrap().body(), "hello");
+
+    assert_let!(Some(VectorDiff::PushFront { value: day_divider }) = stream.next().await);
+    assert!(day_divider.is_day_divider());
+
+    // Now we try to add two reactions to this message…
+
+    // Mock the send endpoint with a delay, to give us time to abort the sending.
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!({
+                    "event_id": "$2",
+                }))
+                .set_delay(Duration::from_millis(150)),
+        )
+        .expect(1)
+        .named("send")
+        .mount(&server)
+        .await;
+
+    mock_redaction(event_id!("$3")).mount(&server).await;
+
+    // We add the reaction…
+    timeline.toggle_reaction(&Annotation::new(event_id.to_owned(), "👍".to_owned())).await.unwrap();
+
+    // First toggle (local echo).
+    {
+        assert_let!(Some(VectorDiff::Set { index: 1, value: item }) = stream.next().await);
+
+        let reactions = item.as_event().unwrap().reactions();
+        assert_eq!(reactions.len(), 1);
+        assert_matches!(
+            &reactions.get("👍").unwrap().get(user_id).unwrap().status,
+            ReactionStatus::LocalToRemote(_)
+        );
+
+        assert!(stream.next().now_or_never().is_none());
+    }
+
+    // We toggle another reaction at the same time…
+    timeline.toggle_reaction(&Annotation::new(event_id.to_owned(), "🥰".to_owned())).await.unwrap();
+
+    {
+        assert_let!(Some(VectorDiff::Set { index: 1, value: item }) = stream.next().await);
+
+        let reactions = item.as_event().unwrap().reactions();
+        assert_eq!(reactions.len(), 2);
+        assert_matches!(
+            &reactions.get("👍").unwrap().get(user_id).unwrap().status,
+            ReactionStatus::LocalToRemote(_)
+        );
+        assert_matches!(
+            &reactions.get("🥰").unwrap().get(user_id).unwrap().status,
+            ReactionStatus::LocalToRemote(_)
+        );
+
+        assert!(stream.next().now_or_never().is_none());
+    }
+
+    // Then we remove the first one; because it was being sent, it should lead to a
+    // redaction event.
+    timeline.toggle_reaction(&Annotation::new(event_id.to_owned(), "👍".to_owned())).await.unwrap();
+
+    {
+        assert_let!(Some(VectorDiff::Set { index: 1, value: item }) = stream.next().await);
+
+        let reactions = item.as_event().unwrap().reactions();
+        assert_eq!(reactions.len(), 1);
+        assert_matches!(
+            &reactions.get("🥰").unwrap().get(user_id).unwrap().status,
+            ReactionStatus::LocalToRemote(_)
+        );
+
+        assert!(stream.next().now_or_never().is_none());
+    }
+
+    // But because the first one was being sent, this one won't and the local echo
+    // could be discarded.
+    timeline.toggle_reaction(&Annotation::new(event_id.to_owned(), "🥰".to_owned())).await.unwrap();
+
+    {
+        assert_let!(Some(VectorDiff::Set { index: 1, value: item }) = stream.next().await);
+
+        let reactions = item.as_event().unwrap().reactions();
+        assert!(reactions.is_empty());
+
+        assert!(stream.next().now_or_never().is_none());
+    }
+
+    // In a real-world setup with a background sync, the reaction may flash to the
+    // user, because the sync may return the reaction event, and later the
+    // redaction of the reaction. In our case, we're done here.
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(stream.next().now_or_never().is_none());
+}

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -19,16 +19,13 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use assign::assign;
 use eyeball_im::{Vector, VectorDiff};
-use futures_core::Stream;
-use futures_util::{future::join_all, FutureExt, StreamExt};
+use futures_util::{FutureExt, StreamExt};
 use matrix_sdk::ruma::{
     api::client::room::create_room::v3::Request as CreateRoomRequest,
     events::{relation::Annotation, room::message::RoomMessageEventContent},
-    EventId, MilliSecondsSinceUnixEpoch, UserId,
+    MilliSecondsSinceUnixEpoch,
 };
-use matrix_sdk_ui::timeline::{
-    EventSendState, EventTimelineItem, RoomExt, TimelineEventItemId, TimelineItem,
-};
+use matrix_sdk_ui::timeline::{EventSendState, ReactionStatus, RoomExt, TimelineItem};
 use tokio::{
     spawn,
     task::JoinHandle,
@@ -37,6 +34,24 @@ use tokio::{
 use tracing::{debug, warn};
 
 use crate::helpers::TestClientBuilder;
+
+/// Checks that there a timeline update, and returns the EventTimelineItem.
+///
+/// A macro to help lowering compile times and getting better error locations.
+macro_rules! assert_event_is_updated {
+    ($stream:expr, $event_id:expr, $index:expr) => {{
+        assert_let!(
+            Ok(Some(VectorDiff::Set { index: i, value: event })) =
+                timeout(Duration::from_secs(1), $stream.next()).await
+        );
+        assert_eq!(i, $index, "unexpected position for event update, value = {event:?}");
+
+        let event = event.as_event().unwrap();
+        assert_eq!(event.event_id().unwrap(), $event_id);
+
+        event.to_owned()
+    }};
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_toggling_reaction() -> Result<()> {
@@ -96,7 +111,7 @@ async fn test_toggling_reaction() -> Result<()> {
 
     // Create a timeline for this room.
     debug!("Creating timeline…");
-    let timeline = room.timeline().await.unwrap();
+    let timeline = Arc::new(room.timeline().await.unwrap());
 
     // Send message.
     debug!("Sending initial message…");
@@ -131,125 +146,48 @@ async fn test_toggling_reaction() -> Result<()> {
     let reaction = Annotation::new(event_id.clone(), "👍".to_owned());
 
     // Toggle reaction multiple times.
-    let all_tests = async move {
-        for _ in 0..3 {
-            debug!("Starting the toggle reaction tests…");
+    for _ in 0..3 {
+        debug!("Starting the toggle reaction tests…");
 
-            // Add
-            timeline.toggle_reaction(&reaction).await.expect("toggling reaction");
-            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
-            assert_remote_added(&mut stream, &user_id, &event_id, &reaction, message_position)
-                .await;
+        // Add the reaction.
+        timeline.toggle_reaction(&reaction).await.expect("toggling reaction");
 
-            // Redact
-            timeline.toggle_reaction(&reaction).await.expect("toggling reaction the second time");
-            assert_redacted(&mut stream, &event_id, message_position).await;
-
-            // Add, redact, add, redact, add
-            join_all((0..5).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
-            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
-            assert_redacted(&mut stream, &event_id, message_position).await;
-            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
-            assert_redacted(&mut stream, &event_id, message_position).await;
-            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
-            assert_remote_added(&mut stream, &user_id, &event_id, &reaction, message_position)
-                .await;
-
-            // Redact, add, redact, add
-            join_all((0..4).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
-            assert_redacted(&mut stream, &event_id, message_position).await;
-            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
-            assert_redacted(&mut stream, &event_id, message_position).await;
-            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
-            assert_remote_added(&mut stream, &user_id, &event_id, &reaction, message_position)
-                .await;
-
-            // Redact, add, redact, add, redact
-            join_all((0..5).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
-            assert_redacted(&mut stream, &event_id, message_position).await;
-            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
-            assert_redacted(&mut stream, &event_id, message_position).await;
-            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
-            assert_redacted(&mut stream, &event_id, message_position).await;
-
-            // Add, redact, add, redact
-            join_all((0..4).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
-            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
-            assert_redacted(&mut stream, &event_id, message_position).await;
-            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
-            assert_redacted(&mut stream, &event_id, message_position).await;
+        // Local echo is added.
+        {
+            let event = assert_event_is_updated!(stream, event_id, message_position);
+            let reactions = event.reactions().get(&reaction.key).unwrap();
+            let reaction = reactions.get(&user_id).unwrap();
+            assert_matches!(reaction.status, ReactionStatus::LocalToRemote(..));
         }
-    };
 
-    timeout(Duration::from_secs(10), all_tests).await.expect("timed out");
+        // Remote echo is added.
+        {
+            let event = assert_event_is_updated!(stream, event_id, message_position);
+
+            let reactions = event.reactions().get(&reaction.key).unwrap();
+            assert_eq!(reactions.keys().count(), 1);
+
+            let reaction = reactions.get(&user_id).unwrap();
+            assert_matches!(reaction.status, ReactionStatus::Remote(..));
+
+            // Remote event should have a timestamp <= than now.
+            // Note: this can actually be equal because if the timestamp from
+            // server is not available, it might be created with a local call to `now()`
+            assert!(reaction.timestamp <= MilliSecondsSinceUnixEpoch::now());
+            assert!(stream.next().now_or_never().is_none());
+        }
+
+        // Redact the reaction.
+        timeline.toggle_reaction(&reaction).await.expect("toggling reaction the second time");
+
+        // The reaction is removed.
+        let event = assert_event_is_updated!(stream, event_id, message_position);
+        assert!(event.reactions().is_empty());
+
+        assert!(stream.next().now_or_never().is_none());
+    }
 
     Ok(())
-}
-
-async fn assert_local_added(
-    stream: &mut (impl Stream<Item = VectorDiff<Arc<TimelineItem>>> + Unpin),
-    user_id: &UserId,
-    event_id: &EventId,
-    reaction: &Annotation,
-    message_position: usize,
-) {
-    let event = assert_event_is_updated(stream, event_id, message_position).await;
-
-    let (reaction_tx_id, reaction_event_id) = {
-        let reactions = event.reactions().get(&reaction.key).unwrap();
-        let reaction = reactions.get(user_id).unwrap();
-        match &reaction.id {
-            TimelineEventItemId::TransactionId(txn_id) => (Some(txn_id), None),
-            TimelineEventItemId::EventId(event_id) => (None, Some(event_id)),
-        }
-    };
-    assert_matches!(reaction_tx_id, Some(_));
-    // Event ID hasn't been received from homeserver yet
-    assert_matches!(reaction_event_id, None);
-}
-
-async fn assert_redacted(
-    stream: &mut (impl Stream<Item = VectorDiff<Arc<TimelineItem>>> + Unpin),
-    event_id: &EventId,
-    message_position: usize,
-) {
-    let event = assert_event_is_updated(stream, event_id, message_position).await;
-    assert!(event.reactions().is_empty());
-}
-
-async fn assert_remote_added(
-    stream: &mut (impl Stream<Item = VectorDiff<Arc<TimelineItem>>> + Unpin),
-    user_id: &UserId,
-    event_id: &EventId,
-    reaction: &Annotation,
-    message_position: usize,
-) {
-    let event = assert_event_is_updated(stream, event_id, message_position).await;
-
-    let reactions = event.reactions().get(&reaction.key).unwrap();
-    assert_eq!(reactions.keys().count(), 1);
-
-    let reaction = reactions.get(user_id).unwrap();
-    assert_matches!(reaction.id, TimelineEventItemId::EventId(..));
-
-    // Remote event should have a timestamp <= than now.
-    // Note: this can actually be equal because if the timestamp from
-    // server is not available, it might be created with a local call to `now()`
-    assert!(reaction.timestamp <= MilliSecondsSinceUnixEpoch::now());
-}
-
-async fn assert_event_is_updated(
-    stream: &mut (impl Stream<Item = VectorDiff<Arc<TimelineItem>>> + Unpin),
-    event_id: &EventId,
-    index: usize,
-) -> EventTimelineItem {
-    assert_let!(Some(VectorDiff::Set { index: i, value: event }) = stream.next().await);
-    assert_eq!(i, index, "unexpected position for event update, value = {event:?}");
-
-    let event = event.as_event().unwrap();
-    assert_eq!(event.event_id().unwrap(), event_id);
-
-    event.to_owned()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -168,7 +168,7 @@ async fn test_toggling_reaction() -> Result<()> {
             assert_eq!(reactions.keys().count(), 1);
 
             let reaction = reactions.get(&user_id).unwrap();
-            assert_matches!(reaction.status, ReactionStatus::Remote(..));
+            assert_matches!(reaction.status, ReactionStatus::RemoteToRemote(..));
 
             // Remote event should have a timestamp <= than now.
             // Note: this can actually be equal because if the timestamp from


### PR DESCRIPTION
Independently of #3749, we can, as of today, start using the send queue only to send reactions, instead of having the logic of sending reactions in the timeline itself

There was a mechanism to queue adding/removing a reaction, with the possibility to get observable updates for each add/remove that occurred. In some contexts, if you quickly tapped a reaction button on ElementX apps, you could observe it: the reaction would be added, then removed, then added back, etc. until it stabilized.

I don't see the user value for this: if I quickly tap the reaction button, I'd expect the sending of the reaction to be aborted, if it can, instead of delayed into a redaction event that's subsequently sent. The sending queue allows doing this for free, so making use of that.

I've also removed tests which value was also unclear or suspect.