### PR TITLE
MatrixRTC: fix different devices from the same user overwriting the room info state event.

### DIFF
--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -212,7 +212,7 @@ impl BaseRoomInfoV1 {
             name,
             tombstone,
             topic,
-            rtc_member: BTreeMap::new(),
+            rtc_member_events: BTreeMap::new(),
             is_marked_unread: false,
             notable_tags: RoomNotableTags::empty(),
             pinned_events: None,


### PR DESCRIPTION
With the new event format we have one event per device (not one event per user). Consequently it does not make a lot of sense to store the state events in the room info using the user id as the keys for the Map of state events.

Instead a tuple of userId and deviceId is used.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
