### PR TITLE
ffi: expose room membership through the RoomListItem and allow invited rooms to be build differently than "full" ones

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -41,7 +41,7 @@ use crate::{
     TaskHandle,
 };
 
-#[derive(uniffi::Enum)]
+#[derive(Debug, uniffi::Enum)]
 pub enum Membership {
     Invited,
     Joined,

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -23,7 +23,7 @@ use tokio::sync::RwLock;
 
 use crate::{
     error::ClientError,
-    room::Room,
+    room::{Membership, Room},
     room_info::RoomInfo,
     timeline::{EventTimelineItem, Timeline},
     timeline_event_filter::TimelineEventTypeFilter,
@@ -50,6 +50,8 @@ pub enum RoomListError {
     InitializingTimeline { error: String },
     #[error("Event cache ran into an error: {error}")]
     EventCache { error: String },
+    #[error("The requested room doesn't match the membership requirements")]
+    IncorrectRoomMembership,
 }
 
 impl From<matrix_sdk_ui::room_list_service::Error> for RoomListError {
@@ -603,10 +605,35 @@ impl RoomListItem {
         Ok(RoomInfo::new(self.inner.inner_room()).await?)
     }
 
+    /// The room's current membership state
+    fn membership(&self) -> Membership {
+        self.inner.inner_room().state().into()
+    }
+
+    /// Builds a `Room` FFI from an invited room without initializing its
+    /// internal timeline
+    ///
+    /// An error will be returned if the room is a state different than invited
+    ///
+    /// ⚠️ Holding on to this room instance after it has been joined is not
+    /// safe. Use `full_room` instead
+    fn invited_room(&self) -> Result<Arc<Room>, RoomListError> {
+        if !matches!(self.membership(), Membership::Invited) {
+            return Err(RoomListError::IncorrectRoomMembership);
+        }
+
+        Ok(Arc::new(Room::new(self.inner.inner_room().clone())))
+    }
+
     /// Build a full `Room` FFI object, filling its associated timeline.
     ///
-    /// If its internal timeline hasn't been initialized, it'll fail.
+    /// An error will be returned if the room is a state different than joined
+    /// or if its internal timeline hasn't been initialized.
     fn full_room(&self) -> Result<Arc<Room>, RoomListError> {
+        if !matches!(self.membership(), Membership::Joined) {
+            return Err(RoomListError::IncorrectRoomMembership);
+        }
+
         if let Some(timeline) = self.inner.timeline() {
             Ok(Arc::new(Room::with_timeline(
                 self.inner.inner_room().clone(),


### PR DESCRIPTION
We're finding ourselves in the situation in which we can't interact with invites through normal Room APIs as `full_room`s can't be build from the RoomListItem. Full rooms require the timeline to be configured before use and the timeline can't be configured because encryption cannot be fetched for invited rooms on homeservers that have previews disabled (see #3848 and #3850)

In response we now expose the room's membership directly from the `RoomListItem` so that the final client can chose which of the 2 rooms types (invited or full) to ask for before using aforementioned APIs.

Powers https://github.com/element-hq/element-x-ios/pull/3189