### PR TITLE
testing: add a mocks module in matrix-sdk-test to reuse mock endpoints across test suites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3503,6 +3503,7 @@ dependencies = [
  "tokio",
  "tracing-subscriber",
  "wasm-bindgen-test",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -14,7 +14,6 @@
 
 use itertools::Itertools as _;
 use matrix_sdk::deserialized_responses::TimelineEvent;
-use matrix_sdk_test::test_json;
 use ruma::{events::AnyStateEvent, serde::Raw, EventId, RoomId};
 use serde::Serialize;
 use serde_json::json;
@@ -123,28 +122,4 @@ async fn mock_messages(
         .expect(1)
         .mount(server)
         .await;
-}
-
-/// Mount a Mock on the given server to handle the `GET
-/// /rooms/.../state/m.room.encryption` endpoint with an option whether it
-/// should return an encryption event or not.
-async fn mock_encryption_state(server: &MockServer, is_encrypted: bool) {
-    let builder = Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/m.*room.*encryption.?"))
-        .and(header("authorization", "Bearer 1234"));
-
-    if is_encrypted {
-        builder
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(&*test_json::sync_events::ENCRYPTION_CONTENT),
-            )
-            .mount(server)
-            .await;
-    } else {
-        builder
-            .respond_with(ResponseTemplate::new(404).set_body_json(&*test_json::NOT_FOUND))
-            .mount(server)
-            .await;
-    }
 }

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -5,7 +5,10 @@ use std::{
 
 use assert_matches::assert_matches;
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
-use matrix_sdk_test::{async_test, sync_timeline_event, JoinedRoomBuilder, SyncResponseBuilder};
+use matrix_sdk_test::{
+    async_test, mocks::mock_encryption_state, sync_timeline_event, JoinedRoomBuilder,
+    SyncResponseBuilder,
+};
 use matrix_sdk_ui::{
     notification_client::{
         NotificationClient, NotificationEvent, NotificationProcessSetup, NotificationStatus,
@@ -20,7 +23,7 @@ use wiremock::{
 };
 
 use crate::{
-    mock_encryption_state, mock_sync,
+    mock_sync,
     sliding_sync::{check_requests, PartialSlidingSyncRequest, SlidingSyncMatcher},
 };
 

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -10,7 +10,7 @@ use matrix_sdk::{test_utils::logged_in_client_with_server, Client};
 use matrix_sdk_base::{
     sliding_sync::http::request::RoomSubscription, sync::UnreadNotificationsCount,
 };
-use matrix_sdk_test::async_test;
+use matrix_sdk_test::{async_test, mocks::mock_encryption_state};
 use matrix_sdk_ui::{
     room_list_service::{
         filters::{new_filter_fuzzy_match_room_name, new_filter_non_left, new_filter_none},
@@ -29,10 +29,7 @@ use stream_assert::{assert_next_matches, assert_pending};
 use tokio::{spawn, sync::mpsc::channel, task::yield_now};
 use wiremock::MockServer;
 
-use crate::{
-    mock_encryption_state,
-    timeline::sliding_sync::{assert_timeline_stream, timeline_event},
-};
+use crate::timeline::sliding_sync::{assert_timeline_stream, timeline_event};
 
 async fn new_room_list_service() -> Result<(Client, MockServer, RoomListService), Error> {
     let (client, server) = logged_in_client_with_server().await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -22,7 +22,10 @@ use matrix_sdk::{
     config::SyncSettings, executor::spawn, ruma::MilliSecondsSinceUnixEpoch,
     test_utils::logged_in_client_with_server,
 };
-use matrix_sdk_test::{async_test, sync_timeline_event, JoinedRoomBuilder, SyncResponseBuilder};
+use matrix_sdk_test::{
+    async_test, mocks::mock_encryption_state, sync_timeline_event, JoinedRoomBuilder,
+    SyncResponseBuilder,
+};
 use matrix_sdk_ui::timeline::{EventSendState, RoomExt, TimelineItemContent};
 use ruma::{
     event_id,
@@ -37,7 +40,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{mock_encryption_state, mock_sync};
+use crate::mock_sync;
 
 #[async_test]
 async fn test_echo() {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -20,7 +20,8 @@ use eyeball_im::VectorDiff;
 use futures_util::{FutureExt, StreamExt};
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
-    async_test, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB,
+    async_test, mocks::mock_encryption_state, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder,
+    ALICE, BOB,
 };
 use matrix_sdk_ui::timeline::{EventSendState, RoomExt, TimelineDetails, TimelineItemContent};
 use ruma::{
@@ -46,7 +47,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{mock_encryption_state, mock_sync};
+use crate::mock_sync;
 
 #[async_test]
 async fn test_edit() {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -24,13 +24,14 @@ use matrix_sdk::{
     test_utils::{events::EventFactory, logged_in_client_with_server},
 };
 use matrix_sdk_test::{
-    async_test, sync_timeline_event, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB,
+    async_test, mocks::mock_encryption_state, sync_timeline_event, JoinedRoomBuilder,
+    SyncResponseBuilder, ALICE, BOB,
 };
 use matrix_sdk_ui::{timeline::TimelineFocus, Timeline};
 use ruma::{event_id, events::room::message::RoomMessageEventContent, room_id};
 use stream_assert::assert_pending;
 
-use crate::{mock_context, mock_encryption_state, mock_messages, mock_sync};
+use crate::{mock_context, mock_messages, mock_sync};
 
 #[async_test]
 async fn test_new_focused() {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -23,8 +23,8 @@ use matrix_sdk::{
     test_utils::{events::EventFactory, logged_in_client_with_server},
 };
 use matrix_sdk_test::{
-    async_test, sync_timeline_event, JoinedRoomBuilder, RoomAccountDataTestEvent, StateTestEvent,
-    SyncResponseBuilder,
+    async_test, mocks::mock_redaction, sync_timeline_event, JoinedRoomBuilder,
+    RoomAccountDataTestEvent, StateTestEvent, SyncResponseBuilder,
 };
 use matrix_sdk_ui::timeline::{EventSendState, RoomExt, TimelineItemContent, VirtualTimelineItem};
 use ruma::{
@@ -262,14 +262,7 @@ async fn test_redact_message() {
     assert!(day_divider.is_day_divider());
 
     // Redacting a remote event works.
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/redact/.*?/.*?"))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "event_id": "$42"
-        })))
-        .mount(&server)
-        .await;
+    mock_redaction(event_id!("$42")).mount(&server).await;
 
     let event_id = first.as_event().unwrap();
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -23,8 +23,10 @@ use matrix_sdk::{
     test_utils::{events::EventFactory, logged_in_client_with_server},
 };
 use matrix_sdk_test::{
-    async_test, mocks::mock_redaction, sync_timeline_event, JoinedRoomBuilder,
-    RoomAccountDataTestEvent, StateTestEvent, SyncResponseBuilder,
+    async_test,
+    mocks::{mock_encryption_state, mock_redaction},
+    sync_timeline_event, JoinedRoomBuilder, RoomAccountDataTestEvent, StateTestEvent,
+    SyncResponseBuilder,
 };
 use matrix_sdk_ui::timeline::{EventSendState, RoomExt, TimelineItemContent, VirtualTimelineItem};
 use ruma::{
@@ -37,7 +39,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{mock_encryption_state, mock_sync};
+use crate::mock_sync;
 
 mod echo;
 mod edit;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -22,7 +22,8 @@ use futures_util::{
 };
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
-    async_test, EventBuilder, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder, ALICE, BOB,
+    async_test, mocks::mock_encryption_state, EventBuilder, JoinedRoomBuilder, StateTestEvent,
+    SyncResponseBuilder, ALICE, BOB,
 };
 use matrix_sdk_ui::timeline::{
     AnyOtherFullStateEventContent, LiveBackPaginationStatus, RoomExt, TimelineItemContent,
@@ -46,7 +47,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{mock_encryption_state, mock_sync};
+use crate::mock_sync;
 
 #[async_test]
 async fn test_back_pagination() {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
@@ -17,8 +17,8 @@ use std::{sync::Arc, time::Duration};
 use assert_matches::assert_matches;
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
-    async_test, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB, CAROL,
-    DEFAULT_TEST_ROOM_ID,
+    async_test, mocks::mock_encryption_state, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder,
+    ALICE, BOB, CAROL, DEFAULT_TEST_ROOM_ID,
 };
 use matrix_sdk_ui::timeline::{RoomExt, TimelineDetails};
 use ruma::events::room::{
@@ -31,7 +31,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{mock_encryption_state, mock_sync};
+use crate::mock_sync;
 
 #[async_test]
 async fn test_update_sender_profiles() {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -19,7 +19,10 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
-use matrix_sdk_test::{async_test, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder, ALICE};
+use matrix_sdk_test::{
+    async_test, mocks::mock_encryption_state, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder,
+    ALICE,
+};
 use matrix_sdk_ui::timeline::{EventItemOrigin, EventSendState, RoomExt};
 use ruma::{
     event_id, events::room::message::RoomMessageEventContent, room_id, MilliSecondsSinceUnixEpoch,
@@ -32,7 +35,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{mock_encryption_state, mock_sync};
+use crate::mock_sync;
 
 #[async_test]
 async fn test_message_order() {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -20,8 +20,8 @@ use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{config::SyncSettings, room::Receipts, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
-    async_test, sync_timeline_event, EphemeralTestEvent, JoinedRoomBuilder,
-    RoomAccountDataTestEvent, SyncResponseBuilder, ALICE, BOB,
+    async_test, mocks::mock_encryption_state, sync_timeline_event, EphemeralTestEvent,
+    JoinedRoomBuilder, RoomAccountDataTestEvent, SyncResponseBuilder, ALICE, BOB,
 };
 use matrix_sdk_ui::timeline::RoomExt;
 use ruma::{
@@ -40,7 +40,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{mock_encryption_state, mock_sync};
+use crate::mock_sync;
 
 fn filter_notice(ev: &AnySyncTimelineEvent, _room_version: &RoomVersionId) -> bool {
     match ev {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -10,7 +10,8 @@ use matrix_sdk::{
 };
 use matrix_sdk_base::timeout::timeout;
 use matrix_sdk_test::{
-    async_test, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB, CAROL,
+    async_test, mocks::mock_encryption_state, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder,
+    ALICE, BOB, CAROL,
 };
 use matrix_sdk_ui::timeline::{
     Error as TimelineError, EventSendState, RoomExt, TimelineDetails, TimelineItemContent,
@@ -36,7 +37,7 @@ use wiremock::{
     Mock, Request, ResponseTemplate,
 };
 
-use crate::{mock_encryption_state, mock_sync};
+use crate::mock_sync;
 
 #[async_test]
 async fn test_in_reply_to_details() {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -23,7 +23,7 @@ use matrix_sdk::{
     test_utils::logged_in_client_with_server, SlidingSync, SlidingSyncList, SlidingSyncListBuilder,
     SlidingSyncMode, UpdateSummary,
 };
-use matrix_sdk_test::async_test;
+use matrix_sdk_test::{async_test, mocks::mock_encryption_state};
 use matrix_sdk_ui::{
     timeline::{TimelineItem, TimelineItemKind, VirtualTimelineItem},
     Timeline,
@@ -222,8 +222,6 @@ macro_rules! assert_timeline_stream {
 }
 
 pub(crate) use assert_timeline_stream;
-
-use crate::mock_encryption_state;
 
 async fn new_sliding_sync(lists: Vec<SlidingSyncListBuilder>) -> Result<(MockServer, SlidingSync)> {
     let (client, server) = logged_in_client_with_server().await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -23,8 +23,8 @@ use matrix_sdk::{
     test_utils::{events::EventFactory, logged_in_client_with_server},
 };
 use matrix_sdk_test::{
-    async_test, sync_timeline_event, EventBuilder, GlobalAccountDataTestEvent, JoinedRoomBuilder,
-    SyncResponseBuilder, ALICE, BOB,
+    async_test, mocks::mock_encryption_state, sync_timeline_event, EventBuilder,
+    GlobalAccountDataTestEvent, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB,
 };
 use matrix_sdk_ui::timeline::{RoomExt, TimelineDetails, TimelineItemContent};
 use ruma::{
@@ -38,7 +38,7 @@ use ruma::{
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
 
-use crate::{mock_encryption_state, mock_sync};
+use crate::mock_sync;
 
 #[async_test]
 async fn test_batched() {

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -6,7 +6,7 @@ use matrix_sdk_test::{test_json, SyncResponseBuilder};
 use ruma::RoomId;
 use serde::Serialize;
 use wiremock::{
-    matchers::{header, method, path, path_regex, query_param, query_param_is_missing},
+    matchers::{header, method, path, query_param, query_param_is_missing},
     Mock, MockGuard, MockServer, ResponseTemplate,
 };
 
@@ -76,30 +76,6 @@ async fn mock_sync_scoped(
         .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
         .mount_as_scoped(server)
         .await
-}
-
-/// Mount a Mock on the given server to handle the `GET
-/// /rooms/.../state/m.room.encryption` endpoint with an option whether it
-/// should return an encryption event or not.
-async fn mock_encryption_state(server: &MockServer, is_encrypted: bool) {
-    let builder = Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/m.*room.*encryption.?"))
-        .and(header("authorization", "Bearer 1234"));
-
-    if is_encrypted {
-        builder
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(&*test_json::sync_events::ENCRYPTION_CONTENT),
-            )
-            .mount(server)
-            .await;
-    } else {
-        builder
-            .respond_with(ResponseTemplate::new(404).set_body_json(&*test_json::NOT_FOUND))
-            .mount(server)
-            .await;
-    }
 }
 
 /// Does a sync for a given room, and returns its `Room` object.

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -10,7 +10,7 @@ use matrix_sdk::{
     config::SyncSettings,
     test_utils::logged_in_client_with_server,
 };
-use matrix_sdk_test::{async_test, test_json, DEFAULT_TEST_ROOM_ID};
+use matrix_sdk_test::{async_test, mocks::mock_encryption_state, test_json, DEFAULT_TEST_ROOM_ID};
 use ruma::{event_id, events::Mentions, owned_user_id, uint};
 use serde_json::json;
 use wiremock::{
@@ -18,7 +18,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{mock_encryption_state, mock_sync};
+use crate::mock_sync;
 
 #[async_test]
 async fn test_room_attachment_send() {
@@ -474,6 +474,8 @@ async fn test_room_attachment_generate_thumbnail_not_fallback_format() {
 #[cfg(feature = "image-proc")]
 #[async_test]
 async fn test_room_attachment_generate_thumbnail_bigger_than_image() {
+    use matrix_sdk_test::mocks::mock_encryption_state;
+
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))

--- a/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, UNIX_EPOCH};
 
 use matrix_sdk::{config::SyncSettings, instant::SystemTime};
-use matrix_sdk_test::{async_test, test_json, DEFAULT_TEST_ROOM_ID};
+use matrix_sdk_test::{async_test, mocks::mock_encryption_state, test_json, DEFAULT_TEST_ROOM_ID};
 use ruma::event_id;
 use serde_json::json;
 use wiremock::{
@@ -9,7 +9,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync};
+use crate::{logged_in_client_with_server, mock_sync};
 #[async_test]
 async fn test_send_location_beacon() {
     let (client, server) = logged_in_client_with_server().await;

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -12,7 +12,7 @@ use matrix_sdk::{
 use matrix_sdk_base::RoomState;
 use matrix_sdk_test::{
     async_test,
-    mocks::mock_redaction,
+    mocks::{mock_encryption_state, mock_redaction},
     test_json::{self, sync::CUSTOM_ROOM_POWER_LEVELS},
     EphemeralTestEvent, GlobalAccountDataTestEvent, JoinedRoomBuilder, SyncResponseBuilder,
     DEFAULT_TEST_ROOM_ID,
@@ -33,10 +33,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{
-    logged_in_client_with_server, mock_encryption_state, mock_sync, mock_sync_with_new_room,
-    synced_client,
-};
+use crate::{logged_in_client_with_server, mock_sync, mock_sync_with_new_room, synced_client};
 #[async_test]
 async fn test_invite_user_by_id() {
     let (client, server) = logged_in_client_with_server().await;

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -16,7 +16,9 @@ use matrix_sdk::{
     },
     Client, MemoryStore,
 };
-use matrix_sdk_test::{async_test, InvitedRoomBuilder, JoinedRoomBuilder, LeftRoomBuilder};
+use matrix_sdk_test::{
+    async_test, mocks::mock_redaction, InvitedRoomBuilder, JoinedRoomBuilder, LeftRoomBuilder,
+};
 use ruma::{
     api::MatrixVersion,
     event_id,
@@ -735,13 +737,7 @@ async fn test_cancellation() {
         .await;
 
     // The redact of txn1 will happen because we asked for it previously.
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/redact/.*?/.*?"))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"event_id": "$1"})))
-        .expect(1)
-        .mount(&server)
-        .await;
+    mock_redaction(event_id!("$1")).expect(1).mount(&server).await;
 
     let handle1 = q.send(RoomMessageEventContent::text_plain("msg1").into()).await.unwrap();
     let handle2 = q.send(RoomMessageEventContent::text_plain("msg2").into()).await.unwrap();

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -17,7 +17,9 @@ use matrix_sdk::{
     Client, MemoryStore,
 };
 use matrix_sdk_test::{
-    async_test, mocks::mock_redaction, InvitedRoomBuilder, JoinedRoomBuilder, LeftRoomBuilder,
+    async_test,
+    mocks::{mock_encryption_state, mock_redaction},
+    InvitedRoomBuilder, JoinedRoomBuilder, LeftRoomBuilder,
 };
 use ruma::{
     api::MatrixVersion,
@@ -39,7 +41,7 @@ use wiremock::{
     Mock, Request, ResponseTemplate,
 };
 
-use crate::{mock_encryption_state, mock_sync_with_new_room};
+use crate::mock_sync_with_new_room;
 
 fn mock_send_event(returned_event_id: &EventId) -> Mock {
     Mock::given(method("PUT"))

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -26,7 +26,8 @@ use matrix_sdk::{
 };
 use matrix_sdk_common::{executor::spawn, timeout::timeout};
 use matrix_sdk_test::{
-    async_test, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB,
+    async_test, mocks::mock_encryption_state, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder,
+    ALICE, BOB,
 };
 use once_cell::sync::Lazy;
 use ruma::{
@@ -48,7 +49,7 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync};
+use crate::{logged_in_client_with_server, mock_sync};
 
 /// Create a JSON string from a [`json!`][serde_json::json] "literal".
 #[macro_export]

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = { workspace = true }
 ctor = "0.2.0"
 tokio = { workspace = true, features = ["rt", "macros"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+wiremock = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.6", default-features = false, features = ["js"] }

--- a/testing/matrix-sdk-test/src/lib.rs
+++ b/testing/matrix-sdk-test/src/lib.rs
@@ -110,6 +110,10 @@ pub mod __macro_support {
 }
 
 mod event_builder;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod mocks;
+
 pub mod notification_settings;
 mod sync_builder;
 pub mod test_json;

--- a/testing/matrix-sdk-test/src/mocks.rs
+++ b/testing/matrix-sdk-test/src/mocks.rs
@@ -1,0 +1,32 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Mocks useful to reuse across different testing contexts.
+
+use ruma::EventId;
+use serde_json::json;
+use wiremock::{
+    matchers::{header, method, path_regex},
+    Mock, ResponseTemplate,
+};
+
+/// Mount a mock for a redaction endpoint, that will always work and return a
+/// 200 response.
+pub fn mock_redaction(event_id: &EventId) -> Mock {
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/redact/.*?/.*?"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "event_id": event_id })))
+        .named("redact")
+}


### PR DESCRIPTION
What it says on the tin.