### PR TITLE
crypto: Add variants to SenderData to represent different verification states

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -32,15 +32,24 @@ Changes:
 
 Breaking changes:
 
+  **NOTE**: this version causes changes to the format of the serialised data in
+  the CryptoStore, meaning that, once upgraded, it will not be possible to roll
+  back applications to earlier versions without breaking user sessions.
+
+- Change the structure of the `SenderData` enum to separate variants for
+  previously-verified, unverified and verified.
+  ([#3877](https://github.com/matrix-org/matrix-rust-sdk/pull/3877))
+
+- Where `EncryptionInfo` is returned it may include the new `PreviouslyVerified`
+  variant of `VerificationLevel` to indicate that the user was previously
+  verified and is no longer verified.
+  ([#3877](https://github.com/matrix-org/matrix-rust-sdk/pull/3877))
+
 - Expose new methods `OwnUserIdentity::was_previously_verified`,
   `OwnUserIdentity::withdraw_verification`, and
   `OwnUserIdentity::has_verification_violation`, which track whether our own
   identity was previously verified.
   ([#3846](https://github.com/matrix-org/matrix-rust-sdk/pull/3846))
-
-  **NOTE**: this causes changes to the format of the serialised data in the
-  CryptoStore, meaning that, once upgraded, it will not be possible to roll
-  back applications to earlier versions without breaking user sessions.
 
 - Add a new `error_on_verified_user_problem` property to
   `CollectStrategy::DeviceBasedStrategy`, which, when set, causes

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -66,8 +66,8 @@ use crate::{
     identities::{user::UserIdentities, Device, IdentityManager, UserDevices},
     olm::{
         Account, CrossSigningStatus, EncryptionSettings, IdentityKeys, InboundGroupSession,
-        OlmDecryptionInfo, PrivateCrossSigningIdentity, SenderData, SenderDataFinder, SessionType,
-        StaticAccountData,
+        KnownSenderData, OlmDecryptionInfo, PrivateCrossSigningIdentity, SenderData,
+        SenderDataFinder, SessionType, StaticAccountData,
     },
     requests::{IncomingResponse, OutgoingRequest, UploadSigningKeysRequest},
     session_manager::{GroupSessionManager, SessionManager},
@@ -2359,10 +2359,13 @@ fn sender_data_to_verification_state(
             VerificationState::Unverified(VerificationLevel::UnsignedDevice),
             Some(device_keys.device_id),
         ),
-        SenderData::SenderKnown { master_key_verified: false, device_id, .. } => {
+        SenderData::SenderUnverifiedButPreviouslyVerified(KnownSenderData {
+            device_id, ..
+        }) => (VerificationState::Unverified(VerificationLevel::PreviouslyVerified), device_id),
+        SenderData::SenderUnverified(KnownSenderData { device_id, .. }) => {
             (VerificationState::Unverified(VerificationLevel::UnverifiedIdentity), device_id)
         }
-        SenderData::SenderKnown { master_key_verified: true, device_id, .. } => {
+        SenderData::SenderVerified(KnownSenderData { device_id, .. }) => {
             (VerificationState::Verified, device_id)
         }
     }

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -1439,10 +1439,26 @@ impl OlmMachine {
         session: &InboundGroupSession,
         sender: &UserId,
     ) -> MegolmResult<(VerificationState, Option<OwnedDeviceId>)> {
-        let sender_data = if session.sender_data.is_known() {
-            // The existing sender_data is known, so there is no need to recalculate it.
-            session.sender_data.clone()
-        } else {
+        /// Whether we should recalculate the Megolm sender's data, given the
+        /// current sender data. We only want to recalculate if it might
+        /// increase trust and allow us to decrypt messages that we
+        /// otherwise might refuse to decrypt.
+        ///
+        /// We recalculate for all states except:
+        ///
+        /// - SenderUnverified: the sender is trusted enough that we will
+        ///   decrypt their messages in all cases, or
+        /// - SenderVerified: the sender is the most trusted they can be.
+        fn should_recalculate_sender_data(sender_data: &SenderData) -> bool {
+            matches!(
+                sender_data,
+                SenderData::UnknownDevice { .. }
+                    | SenderData::DeviceInfo { .. }
+                    | SenderData::SenderUnverifiedButPreviouslyVerified { .. }
+            )
+        }
+
+        let sender_data = if should_recalculate_sender_data(&session.sender_data) {
             // The session is not sure of the sender yet. Calculate it.
             let calculated_sender_data = SenderDataFinder::find_using_curve_key(
                 self.store(),
@@ -1465,6 +1481,8 @@ impl OlmMachine {
                 // No - use the existing data.
                 session.sender_data.clone()
             }
+        } else {
+            session.sender_data.clone()
         };
 
         Ok(sender_data_to_verification_state(sender_data, session.has_been_imported()))

--- a/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
@@ -187,7 +187,7 @@ async fn test_decryption_verification_state() {
 
     // And the updated SenderData should have been saved into the store.
     let session = load_session(&bob, room_id, &event).await.unwrap().unwrap();
-    assert_let!(SenderData::SenderKnown { .. } = session.sender_data);
+    assert_let!(SenderData::SenderVerified { .. } = session.sender_data);
 
     // Simulate an imported session, to change verification state
     let imported = InboundGroupSession::from_export(&export).unwrap();

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use outbound::ShareState;
 pub use outbound::{
     EncryptionSettings, OutboundGroupSession, PickledOutboundGroupSession, ShareInfo,
 };
-pub use sender_data::SenderData;
+pub use sender_data::{KnownSenderData, SenderData};
 pub(crate) use sender_data_finder::SenderDataFinder;
 use thiserror::Error;
 pub use vodozemac::megolm::{ExportedSessionKey, SessionKey};

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -166,13 +166,6 @@ impl SenderData {
         Self::UnknownDevice { legacy_session: true, owner_check_failed: false }
     }
 
-    /// Returns true if this is SenderKnown and `master_key_verified` is true.
-    pub(crate) fn is_known(&self) -> bool {
-        matches!(self, SenderData::SenderUnverifiedButPreviouslyVerified { .. })
-            || matches!(self, SenderData::SenderUnverified { .. })
-            || matches!(self, SenderData::SenderVerified { .. })
-    }
-
     /// Returns `Greater` if this `SenderData` represents a greater level of
     /// trust than the supplied one, `Equal` if they have the same level, and
     /// `Less` if the supplied one has a greater level of trust.
@@ -354,34 +347,6 @@ mod tests {
 
         let end: SenderData = serde_json::from_str(json).expect("Failed to parse!");
         assert_let!(SenderData::SenderVerified { .. } = end);
-    }
-
-    #[test]
-    fn known_session_is_known() {
-        let user_id = user_id!("@u:s.co");
-        let device_id = device_id!("DEV");
-        let master_key =
-            Ed25519PublicKey::from_base64("2/5LWJMow5zhJqakV88SIc7q/1pa8fmkfgAzx72w9G4").unwrap();
-
-        assert!(!SenderData::unknown().is_known());
-        assert!(SenderData::sender_previously_verified(user_id, device_id, master_key).is_known());
-        assert!(SenderData::sender_unverified(user_id, device_id, master_key).is_known());
-        assert!(SenderData::sender_verified(user_id, device_id, master_key).is_known());
-    }
-
-    #[test]
-    fn unknown_and_device_sessions_are_not_known() {
-        // Anything that is not SenderKnown is not know and verified.
-        assert!(!SenderData::unknown().is_known());
-
-        let device_keys = DeviceKeys::new(
-            owned_user_id!("@u:s.co"),
-            owned_device_id!("DEV"),
-            Vec::new(),
-            BTreeMap::new(),
-            Signatures::new(),
-        );
-        assert!(!SenderData::device_info(device_keys).is_known());
     }
 
     #[test]

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -26,7 +26,7 @@ mod utility;
 pub use account::{Account, OlmMessageHash, PickledAccount, StaticAccountData};
 pub(crate) use account::{OlmDecryptionInfo, SessionType};
 pub use group_sessions::{
-    BackedUpRoomKey, EncryptionSettings, ExportedRoomKey, InboundGroupSession,
+    BackedUpRoomKey, EncryptionSettings, ExportedRoomKey, InboundGroupSession, KnownSenderData,
     OutboundGroupSession, PickledInboundGroupSession, PickledOutboundGroupSession, SenderData,
     SessionCreationError, SessionExportError, SessionKey, ShareInfo,
 };

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Breaking changes:
 
+- Add a `PreviouslyVerified` variant to `VerificationLevel` indicating that the identity is unverified and previously it was verified.
 - Replace the `Notification` type from Ruma in `SyncResponse` and `Client::register_notification_handler`
   by a custom one
 - `Room::can_user_redact` and `Member::can_redact` are split between `*_redact_own` and `*_redact_other`


### PR DESCRIPTION
(Slightly-modified version of https://github.com/matrix-org/matrix-rust-sdk/pull/3856/)

As [previously discussed](https://github.com/matrix-org/matrix-rust-sdk/pull/3701/files#r1721932382)