### PR TITLE
pinned events: limit the max amount of concurrent requests to load pinned events

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -198,7 +198,10 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
             client.event_cache().empty_immutable_cache().await;
 
             let timeline = Timeline::builder(&room)
-                .with_focus(TimelineFocus::PinnedEvents { max_events_to_load: 100 })
+                .with_focus(TimelineFocus::PinnedEvents {
+                    max_events_to_load: 100,
+                    max_concurrent_requests: 10,
+                })
                 .build()
                 .await
                 .expect("Could not create timeline");

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -233,6 +233,7 @@ impl Room {
         &self,
         internal_id_prefix: Option<String>,
         max_events_to_load: u16,
+        max_concurrent_requests: u16,
     ) -> Result<Arc<Timeline>, ClientError> {
         let room = &self.inner;
 
@@ -242,8 +243,10 @@ impl Room {
             builder = builder.with_internal_id_prefix(internal_id_prefix);
         }
 
-        let timeline =
-            builder.with_focus(TimelineFocus::PinnedEvents { max_events_to_load }).build().await?;
+        let timeline = builder
+            .with_focus(TimelineFocus::PinnedEvents { max_events_to_load, max_concurrent_requests })
+            .build()
+            .await?;
 
         Ok(Timeline::new(timeline))
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -253,11 +253,12 @@ impl<P: RoomDataProvider> TimelineController<P> {
                 )
             }
 
-            TimelineFocus::PinnedEvents { max_events_to_load } => (
+            TimelineFocus::PinnedEvents { max_events_to_load, max_concurrent_requests } => (
                 TimelineFocusData::PinnedEvents {
                     loader: PinnedEventsLoader::new(
                         Arc::new(room_data_provider.clone()),
                         max_events_to_load as usize,
+                        max_concurrent_requests as usize,
                     ),
                 },
                 TimelineFocusKind::PinnedEvents,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -173,7 +173,7 @@ pub enum TimelineFocus {
     Event { target: OwnedEventId, num_context_events: u16 },
 
     /// Only show pinned events.
-    PinnedEvents { max_events_to_load: u16 },
+    PinnedEvents { max_events_to_load: u16, max_concurrent_requests: u16 },
 }
 
 impl Timeline {


### PR DESCRIPTION
Depends on https://github.com/matrix-org/matrix-rust-sdk/pull/3840.

`RequestConfig::max_concurrent_requests` won't work for requests to a same endpoint, since it's a global value that can only be passed to `HttpClient` when created.

To replace it I added a buffered stream that can run at most `MAX_PINNED_EVENTS_CONCURRENT_REQUESTS` (10) requests concurrently.

There is also a test to make sure this max concurrency mechanism works.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
