### PR TITLE
sdk: lower compile times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,7 +3526,6 @@ dependencies = [
  "async-once-cell",
  "async-rx",
  "async-stream",
- "async-trait",
  "async_cell",
  "chrono",
  "eyeball",

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -26,7 +26,6 @@ async_cell = "0.2.2"
 async-once-cell = "0.5.2"
 async-rx = { workspace = true }
 async-stream = { workspace = true }
-async-trait = { workspace = true }
 chrono = "0.4.23"
 eyeball = { workspace = true }
 eyeball-im = { workspace = true }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -73,7 +73,6 @@ use crate::{
 };
 
 /// When adding an event, useful information related to the source of the event.
-#[derive(Clone)]
 pub(super) enum Flow {
     /// The event was locally created.
     Local {
@@ -103,7 +102,6 @@ pub(super) enum Flow {
     },
 }
 
-#[derive(Clone)]
 pub(super) struct TimelineEventContext {
     pub(super) sender: OwnedUserId,
     pub(super) sender_profile: Option<Profile>,
@@ -693,10 +691,10 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
     fn handle_poll_start(&mut self, c: NewUnstablePollStartEventContent, should_add: bool) {
         let mut poll_state = PollState::new(c);
-        if let Flow::Remote { event_id, .. } = self.ctx.flow.clone() {
+        if let Flow::Remote { event_id, .. } = &self.ctx.flow {
             // Applying the cache to remote events only because local echoes
             // don't have an event ID that could be referenced by responses yet.
-            self.meta.poll_pending_events.apply(&event_id, &mut poll_state);
+            self.meta.poll_pending_events.apply(event_id, &mut poll_state);
         }
 
         if should_add {

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -188,7 +188,7 @@ impl EventTimelineItem {
 
         let room = client.get_room(room_id);
         let sender_profile = if let Some(room) = room {
-            let mut profile = room.profile_from_latest_event(&latest_event).await;
+            let mut profile = room.profile_from_latest_event(&latest_event);
 
             // Fallback to the slow path.
             if profile.is_none() {

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -81,7 +81,7 @@ mod state;
 
 /// Data associated to the current timeline focus.
 #[derive(Debug)]
-enum TimelineFocusData {
+enum TimelineFocusData<P: RoomDataProvider> {
     /// The timeline receives live events from the sync.
     Live,
 
@@ -91,7 +91,7 @@ enum TimelineFocusData {
         /// The event id we've started to focus on.
         event_id: OwnedEventId,
         /// The paginator instance.
-        paginator: Paginator,
+        paginator: Paginator<P>,
         /// Number of context events to request for the first request.
         num_context_events: u16,
     },
@@ -107,7 +107,7 @@ pub(super) struct TimelineInner<P: RoomDataProvider = Room> {
     state: Arc<RwLock<TimelineInnerState>>,
 
     /// Inner mutable focus state.
-    focus: Arc<RwLock<TimelineFocusData>>,
+    focus: Arc<RwLock<TimelineFocusData<P>>>,
 
     /// A [`RoomDataProvider`] implementation, providing data.
     ///
@@ -239,7 +239,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         let (focus_data, is_live) = match focus {
             TimelineFocus::Live => (TimelineFocusData::Live, LiveTimelineUpdatesAllowed::All),
             TimelineFocus::Event { target, num_context_events } => {
-                let paginator = Paginator::new(Box::new(room_data_provider.clone()));
+                let paginator = Paginator::new(room_data_provider.clone());
                 (
                     TimelineFocusData::Event { paginator, event_id: target, num_context_events },
                     LiveTimelineUpdatesAllowed::None,

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -30,6 +30,7 @@ use matrix_sdk::{
     room::{EventWithContextResponse, Messages, MessagesOptions},
     send_queue::RoomSendQueueUpdate,
     test_utils::events::EventFactory,
+    BoxFuture,
 };
 use matrix_sdk_base::latest_event::LatestEvent;
 use matrix_sdk_test::{EventBuilder, ALICE, BOB};
@@ -318,14 +319,12 @@ impl PaginableRoom for TestRoomDataProvider {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl PinnedEventsRoom for TestRoomDataProvider {
-    async fn load_event(
-        &self,
-        _event_id: &EventId,
+    fn load_event<'a>(
+        &'a self,
+        _event_id: &'a EventId,
         _config: Option<RequestConfig>,
-    ) -> Result<SyncTimelineEvent, PaginatorError> {
+    ) -> BoxFuture<'a, Result<SyncTimelineEvent, PaginatorError>> {
         unimplemented!();
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -303,8 +303,6 @@ impl TestRoomDataProvider {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl PaginableRoom for TestRoomDataProvider {
     async fn event_with_context(
         &self,

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future::Future;
+
 use async_trait::async_trait;
 use indexmap::IndexMap;
 #[cfg(feature = "e2e-encryption")]
@@ -34,7 +36,6 @@ use tracing::{debug, error};
 use super::{Profile, TimelineBuilder};
 use crate::timeline::{self, pinned_events_loader::PinnedEventsRoom, Timeline};
 
-#[async_trait]
 pub trait RoomExt {
     /// Get a [`Timeline`] for this room.
     ///
@@ -43,7 +44,7 @@ pub trait RoomExt {
     /// independent events.
     ///
     /// This is the same as using `room.timeline_builder().build()`.
-    async fn timeline(&self) -> Result<Timeline, timeline::Error>;
+    fn timeline(&self) -> impl Future<Output = Result<Timeline, timeline::Error>> + Send;
 
     /// Get a [`TimelineBuilder`] for this room.
     ///
@@ -56,7 +57,6 @@ pub trait RoomExt {
     fn timeline_builder(&self) -> TimelineBuilder;
 }
 
-#[async_trait]
 impl RoomExt for Room {
     async fn timeline(&self) -> Result<Timeline, timeline::Error> {
         self.timeline_builder().build().await

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -609,7 +609,7 @@ struct RoomEventCacheInner {
     ///
     /// It's protected behind a lock to avoid multiple accesses to the paginator
     /// at the same time.
-    pagination: RoomPaginationData,
+    pagination: RoomPaginationData<WeakRoom>,
 }
 
 impl RoomEventCacheInner {
@@ -630,7 +630,7 @@ impl RoomEventCacheInner {
             all_events_cache,
             sender,
             pagination: RoomPaginationData {
-                paginator: Paginator::new(Box::new(weak_room)),
+                paginator: Paginator::new(weak_room),
                 waited_for_initial_prev_token: Mutex::new(false),
                 token_notifier: Default::default(),
             },

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -25,19 +25,19 @@ use tokio::{
 use tracing::{debug, instrument, trace};
 
 use super::{
-    paginator::{PaginationResult, Paginator, PaginatorState},
+    paginator::{PaginableRoom, PaginationResult, Paginator, PaginatorState},
     store::Gap,
     BackPaginationOutcome, Result, RoomEventCacheInner,
 };
 use crate::event_cache::{linked_chunk::ChunkContent, store::RoomEvents};
 
 #[derive(Debug)]
-pub(super) struct RoomPaginationData {
+pub(super) struct RoomPaginationData<PR: PaginableRoom> {
     /// A notifier that we received a new pagination token.
     pub token_notifier: Notify,
 
     /// The stateful paginator instance used for the integrated pagination.
-    pub paginator: Paginator,
+    pub paginator: Paginator<PR>,
 
     /// Have we ever waited for a previous-batch-token to come from sync? We do
     /// this at most once per room, the first time we try to run backward

--- a/crates/matrix-sdk/src/event_cache/paginator.rs
+++ b/crates/matrix-sdk/src/event_cache/paginator.rs
@@ -94,9 +94,9 @@ impl From<Option<String>> for PaginationToken {
 /// forward from it.
 ///
 /// See also the module-level documentation.
-pub struct Paginator {
+pub struct Paginator<PR: PaginableRoom> {
     /// The room in which we're going to run the pagination.
-    room: Box<dyn PaginableRoom>,
+    room: PR,
 
     /// Current state of the paginator.
     state: SharedObservable<PaginatorState>,
@@ -113,7 +113,7 @@ pub struct Paginator {
 }
 
 #[cfg(not(tarpaulin_include))]
-impl std::fmt::Debug for Paginator {
+impl<PR: PaginableRoom> std::fmt::Debug for Paginator<PR> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Don't include the room in the debug output.
         f.debug_struct("Paginator")
@@ -186,9 +186,9 @@ impl Drop for ResetStateGuard {
     }
 }
 
-impl Paginator {
+impl<PR: PaginableRoom> Paginator<PR> {
     /// Create a new [`Paginator`], given a room implementation.
-    pub fn new(room: Box<dyn PaginableRoom>) -> Self {
+    pub fn new(room: PR) -> Self {
         Self {
             room,
             state: SharedObservable::new(PaginatorState::Initial),
@@ -701,7 +701,7 @@ mod tests {
     #[async_test]
     async fn test_start_from() {
         // Prepare test data.
-        let room = Box::new(TestRoom::new(false, *ROOM_ID, *USER_ID));
+        let room = TestRoom::new(false, *ROOM_ID, *USER_ID);
 
         let event_id = event_id!("$yoyoyo");
         let event_factory = &room.event_factory;
@@ -749,7 +749,7 @@ mod tests {
     #[async_test]
     async fn test_start_from_with_num_events() {
         // Prepare test data.
-        let room = Box::new(TestRoom::new(false, *ROOM_ID, *USER_ID));
+        let room = TestRoom::new(false, *ROOM_ID, *USER_ID);
 
         let event_id = event_id!("$yoyoyo");
         let event_factory = &room.event_factory;
@@ -780,7 +780,7 @@ mod tests {
     #[async_test]
     async fn test_paginate_backward() {
         // Prepare test data.
-        let room = Box::new(TestRoom::new(false, *ROOM_ID, *USER_ID));
+        let room = TestRoom::new(false, *ROOM_ID, *USER_ID);
 
         let event_id = event_id!("$yoyoyo");
         let event_factory = &room.event_factory;
@@ -852,7 +852,7 @@ mod tests {
     #[async_test]
     async fn test_paginate_backward_with_limit() {
         // Prepare test data.
-        let room = Box::new(TestRoom::new(false, *ROOM_ID, *USER_ID));
+        let room = TestRoom::new(false, *ROOM_ID, *USER_ID);
 
         let event_id = event_id!("$yoyoyo");
         let event_factory = &room.event_factory;
@@ -896,7 +896,7 @@ mod tests {
     #[async_test]
     async fn test_paginate_forward() {
         // Prepare test data.
-        let room = Box::new(TestRoom::new(false, *ROOM_ID, *USER_ID));
+        let room = TestRoom::new(false, *ROOM_ID, *USER_ID);
 
         let event_id = event_id!("$yoyoyo");
         let event_factory = &room.event_factory;
@@ -967,7 +967,7 @@ mod tests {
 
     #[async_test]
     async fn test_state() {
-        let room = Box::new(TestRoom::new(true, *ROOM_ID, *USER_ID));
+        let room = TestRoom::new(true, *ROOM_ID, *USER_ID);
 
         *room.prev_batch_token.lock().await = Some("prev".to_owned());
         *room.next_batch_token.lock().await = Some("next".to_owned());
@@ -1107,7 +1107,7 @@ mod tests {
 
         #[async_test]
         async fn test_abort_while_starting_from() {
-            let room = Box::new(AbortingRoom::default());
+            let room = AbortingRoom::default();
 
             let paginator = Arc::new(Paginator::new(room.clone()));
 
@@ -1140,7 +1140,7 @@ mod tests {
 
         #[async_test]
         async fn test_abort_while_paginating() {
-            let room = Box::new(AbortingRoom::default());
+            let room = AbortingRoom::default();
 
             // Assuming a paginator ready to back- or forward- paginate,
             let paginator = Paginator::new(room.clone());


### PR DESCRIPTION
This series of patches, investigated using Fasterthanlime's [good advice](https://fasterthanli.me/articles/why-is-my-rust-build-so-slow#rustc-self-profiling), helped lowering the compiles times from 44 seconds to 4 on my machine, for the `matrix-sdk-ui` crate.

Compile times for the `matrix-sdk` crate have also been lowered from 33 to 12 seconds.

Overall, for a plain `cargo build`:

- before: 113 seconds
- after: 54 seconds

Each commit can be reviewed independently.

See also: https://github.com/rust-lang/rust/issues/87012