### PR TITLE
sdk: lower compile times too by using `async_trait` less

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -82,7 +82,7 @@ mod state;
 
 /// Data associated to the current timeline focus.
 #[derive(Debug)]
-enum TimelineFocusData {
+enum TimelineFocusData<P: RoomDataProvider> {
     /// The timeline receives live events from the sync.
     Live,
 
@@ -92,7 +92,7 @@ enum TimelineFocusData {
         /// The event id we've started to focus on.
         event_id: OwnedEventId,
         /// The paginator instance.
-        paginator: Paginator,
+        paginator: Paginator<P>,
         /// Number of context events to request for the first request.
         num_context_events: u16,
     },
@@ -108,7 +108,7 @@ pub(super) struct TimelineInner<P: RoomDataProvider = Room> {
     state: Arc<RwLock<TimelineInnerState>>,
 
     /// Inner mutable focus state.
-    focus: Arc<RwLock<TimelineFocusData>>,
+    focus: Arc<RwLock<TimelineFocusData<P>>>,
 
     /// A [`RoomDataProvider`] implementation, providing data.
     ///
@@ -240,7 +240,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         let (focus_data, is_live) = match focus {
             TimelineFocus::Live => (TimelineFocusData::Live, LiveTimelineUpdatesAllowed::All),
             TimelineFocus::Event { target, num_context_events } => {
-                let paginator = Paginator::new(Box::new(room_data_provider.clone()));
+                let paginator = Paginator::new(room_data_provider.clone());
                 (
                     TimelineFocusData::Event { paginator, event_id: target, num_context_events },
                     LiveTimelineUpdatesAllowed::None,

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -16,6 +16,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
+    future::Future,
     sync::Arc,
 };
 
@@ -303,20 +304,21 @@ impl TestRoomDataProvider {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl PaginableRoom for TestRoomDataProvider {
-    async fn event_with_context(
+    fn event_with_context(
         &self,
         _event_id: &EventId,
         _lazy_load_members: bool,
         _num_events: UInt,
-    ) -> Result<EventWithContextResponse, PaginatorError> {
-        unimplemented!();
+    ) -> impl Future<Output = Result<EventWithContextResponse, PaginatorError>> {
+        async { unimplemented!() }
     }
 
-    async fn messages(&self, _opts: MessagesOptions) -> Result<Messages, PaginatorError> {
-        unimplemented!();
+    fn messages(
+        &self,
+        _opts: MessagesOptions,
+    ) -> impl Future<Output = Result<Messages, PaginatorError>> {
+        async { unimplemented!() }
     }
 }
 

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -543,7 +543,7 @@ struct RoomEventCacheInner {
     ///
     /// It's protected behind a lock to avoid multiple accesses to the paginator
     /// at the same time.
-    pagination: RoomPaginationData,
+    pagination: RoomPaginationData<WeakRoom>,
 }
 
 impl RoomEventCacheInner {
@@ -560,7 +560,7 @@ impl RoomEventCacheInner {
             all_events,
             sender,
             pagination: RoomPaginationData {
-                paginator: Paginator::new(Box::new(weak_room)),
+                paginator: Paginator::new(weak_room),
                 waited_for_initial_prev_token: Mutex::new(false),
                 token_notifier: Default::default(),
             },

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -25,19 +25,19 @@ use tokio::{
 use tracing::{debug, instrument, trace};
 
 use super::{
-    paginator::{PaginationResult, Paginator, PaginatorState},
+    paginator::{PaginableRoom, PaginationResult, Paginator, PaginatorState},
     store::Gap,
     BackPaginationOutcome, Result, RoomEventCacheInner,
 };
 use crate::event_cache::{linked_chunk::ChunkContent, store::RoomEvents};
 
 #[derive(Debug)]
-pub(super) struct RoomPaginationData {
+pub(super) struct RoomPaginationData<PR: PaginableRoom> {
     /// A notifier that we received a new pagination token.
     pub token_notifier: Notify,
 
     /// The stateful paginator instance used for the integrated pagination.
-    pub paginator: Paginator,
+    pub paginator: Paginator<PR>,
 
     /// Have we ever waited for a previous-batch-token to come from sync? We do
     /// this at most once per room, the first time we try to run backward

--- a/crates/matrix-sdk/src/event_cache/paginator.rs
+++ b/crates/matrix-sdk/src/event_cache/paginator.rs
@@ -94,9 +94,9 @@ impl From<Option<String>> for PaginationToken {
 /// forward from it.
 ///
 /// See also the module-level documentation.
-pub struct Paginator {
+pub struct Paginator<PR: PaginableRoom> {
     /// The room in which we're going to run the pagination.
-    room: Box<dyn PaginableRoom>,
+    room: PR,
 
     /// Current state of the paginator.
     state: SharedObservable<PaginatorState>,
@@ -113,7 +113,7 @@ pub struct Paginator {
 }
 
 #[cfg(not(tarpaulin_include))]
-impl std::fmt::Debug for Paginator {
+impl<PR: PaginableRoom> std::fmt::Debug for Paginator<PR> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Don't include the room in the debug output.
         f.debug_struct("Paginator")
@@ -186,9 +186,9 @@ impl Drop for ResetStateGuard {
     }
 }
 
-impl Paginator {
+impl<PR: PaginableRoom> Paginator<PR> {
     /// Create a new [`Paginator`], given a room implementation.
-    pub fn new(room: Box<dyn PaginableRoom>) -> Self {
+    pub fn new(room: PR) -> Self {
         Self {
             room,
             state: SharedObservable::new(PaginatorState::Initial),
@@ -701,7 +701,7 @@ mod tests {
     #[async_test]
     async fn test_start_from() {
         // Prepare test data.
-        let room = Box::new(TestRoom::new(false, *ROOM_ID, *USER_ID));
+        let room = TestRoom::new(false, *ROOM_ID, *USER_ID);
 
         let event_id = event_id!("$yoyoyo");
         let event_factory = &room.event_factory;
@@ -749,7 +749,7 @@ mod tests {
     #[async_test]
     async fn test_start_from_with_num_events() {
         // Prepare test data.
-        let room = Box::new(TestRoom::new(false, *ROOM_ID, *USER_ID));
+        let room = TestRoom::new(false, *ROOM_ID, *USER_ID);
 
         let event_id = event_id!("$yoyoyo");
         let event_factory = &room.event_factory;
@@ -780,7 +780,7 @@ mod tests {
     #[async_test]
     async fn test_paginate_backward() {
         // Prepare test data.
-        let room = Box::new(TestRoom::new(false, *ROOM_ID, *USER_ID));
+        let room = TestRoom::new(false, *ROOM_ID, *USER_ID);
 
         let event_id = event_id!("$yoyoyo");
         let event_factory = &room.event_factory;
@@ -852,7 +852,7 @@ mod tests {
     #[async_test]
     async fn test_paginate_backward_with_limit() {
         // Prepare test data.
-        let room = Box::new(TestRoom::new(false, *ROOM_ID, *USER_ID));
+        let room = TestRoom::new(false, *ROOM_ID, *USER_ID);
 
         let event_id = event_id!("$yoyoyo");
         let event_factory = &room.event_factory;
@@ -896,7 +896,7 @@ mod tests {
     #[async_test]
     async fn test_paginate_forward() {
         // Prepare test data.
-        let room = Box::new(TestRoom::new(false, *ROOM_ID, *USER_ID));
+        let room = TestRoom::new(false, *ROOM_ID, *USER_ID);
 
         let event_id = event_id!("$yoyoyo");
         let event_factory = &room.event_factory;
@@ -967,7 +967,7 @@ mod tests {
 
     #[async_test]
     async fn test_state() {
-        let room = Box::new(TestRoom::new(true, *ROOM_ID, *USER_ID));
+        let room = TestRoom::new(true, *ROOM_ID, *USER_ID);
 
         *room.prev_batch_token.lock().await = Some("prev".to_owned());
         *room.next_batch_token.lock().await = Some("next".to_owned());
@@ -1107,7 +1107,7 @@ mod tests {
 
         #[async_test]
         async fn test_abort_while_starting_from() {
-            let room = Box::new(AbortingRoom::default());
+            let room = AbortingRoom::default();
 
             let paginator = Arc::new(Paginator::new(room.clone()));
 
@@ -1140,7 +1140,7 @@ mod tests {
 
         #[async_test]
         async fn test_abort_while_paginating() {
-            let room = Box::new(AbortingRoom::default());
+            let room = AbortingRoom::default();
 
             // Assuming a paginator ready to back- or forward- paginate,
             let paginator = Paginator::new(room.clone());


### PR DESCRIPTION
This one is slightly more controversial than #3879, since it makes the code slightly less legible. But it's pretty sweet in that it also divides the compiles times of matrix-sdk by more than two on my machine, from 33 seconds to 12 seconds.

With this PR and #3879, the overall build time for multiverse goes from 113 seconds (cold build cache) down to 65 seconds (cold build cache too).

See also: https://github.com/rust-lang/rust/issues/87012