### PR TITLE
common: generate wasm bindings for ShieldStateCode on wasm architectures

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -24,6 +24,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::debug::{DebugRawEvent, DebugStructExt};
 
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
 const AUTHENTICITY_NOT_GUARANTEED: &str =
     "The authenticity of this encrypted message can't be guaranteed on this device.";
 const UNVERIFIED_IDENTITY: &str = "Encrypted by an unverified user.";
@@ -225,8 +228,9 @@ pub enum ShieldState {
 }
 
 /// A machine-readable representation of the authenticity for a `ShieldState`.
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub enum ShieldStateCode {
     /// Not enough information available to check the authenticity.
     AuthenticityNotGuaranteed,

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -21,11 +21,10 @@ use ruma::{
     DeviceKeyAlgorithm, OwnedDeviceId, OwnedEventId, OwnedUserId,
 };
 use serde::{Deserialize, Serialize};
-
-use crate::debug::{DebugRawEvent, DebugStructExt};
-
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
+
+use crate::debug::{DebugRawEvent, DebugStructExt};
 
 const AUTHENTICITY_NOT_GUARANTEED: &str =
     "The authenticity of this encrypted message can't be guaranteed on this device.";


### PR DESCRIPTION
If we're building for the wasm architecture, jump through the hoops to tell
wasm_bindgen about `ShieldStateCode`. This solves the need to declare an
identical copy of `ShieldStateCode` in the wasm bindings.