### PR TITLE
sqlite: Use a transaction for chunked queries

### DIFF
--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -510,15 +510,13 @@ trait SqliteObjectCryptoStoreExt: SqliteObjectExt {
 
         let session_ids_len = session_ids.len();
 
-        self.chunk_large_query_over(session_ids, None, move |session_ids| {
-            async move {
-                // Safety: placeholders is not generated using any user input except the number
-                // of session IDs, so it is safe from injection.
-                let sql_params = repeat_vars(session_ids_len);
-                let query = format!("UPDATE inbound_group_session SET backed_up = TRUE where session_id IN ({sql_params})");
-                self.prepare(query, move |mut stmt| stmt.execute(params_from_iter(session_ids.iter()))).await?;
-                Ok(Vec::<&str>::new())
-            }
+        self.chunk_large_query_over(session_ids, None, move |txn, session_ids| {
+            // Safety: placeholders is not generated using any user input except the number
+            // of session IDs, so it is safe from injection.
+            let sql_params = repeat_vars(session_ids_len);
+            let query = format!("UPDATE inbound_group_session SET backed_up = TRUE where session_id IN ({sql_params})");
+            txn.prepare(&query)?.execute(params_from_iter(session_ids.iter()))?;
+            Ok(Vec::<()>::new())
         }).await?;
 
         Ok(())

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -681,15 +681,17 @@ trait SqliteObjectStateStoreExt: SqliteObjectExt {
     async fn get_kv_blobs(&self, keys: Vec<Key>) -> Result<Vec<Vec<u8>>> {
         let keys_length = keys.len();
 
-        self.chunk_large_query_over(keys, Some(keys_length), |keys| {
+        self.chunk_large_query_over(keys, Some(keys_length), |txn, keys| {
             let sql_params = repeat_vars(keys.len());
             let sql = format!("SELECT value FROM kv_blob WHERE key IN ({sql_params})");
 
             let params = rusqlite::params_from_iter(keys);
 
-            self.prepare(sql, move |mut stmt| {
-                stmt.query(params)?.mapped(|row| row.get(0)).collect()
-            })
+            Ok(txn
+                .prepare(&sql)?
+                .query(params)?
+                .mapped(|row| row.get(0))
+                .collect::<Result<_, _>>()?)
         })
         .await
     }
@@ -709,15 +711,15 @@ trait SqliteObjectStateStoreExt: SqliteObjectExt {
                 })
                 .await?)
         } else {
-            self.chunk_large_query_over(states, None, |states| {
+            self.chunk_large_query_over(states, None, |txn, states| {
                 let sql_params = repeat_vars(states.len());
                 let sql = format!("SELECT data FROM room_info WHERE state IN ({sql_params})");
 
-                self.prepare(sql, move |mut stmt| {
-                    stmt.query(rusqlite::params_from_iter(states))?
-                        .mapped(|row| row.get(0))
-                        .collect()
-                })
+                Ok(txn
+                    .prepare(&sql)?
+                    .query(rusqlite::params_from_iter(states))?
+                    .mapped(|row| row.get(0))
+                    .collect::<Result<_, _>>()?)
             })
             .await
         }
@@ -729,7 +731,7 @@ trait SqliteObjectStateStoreExt: SqliteObjectExt {
         event_type: Key,
         state_keys: Vec<Key>,
     ) -> Result<Vec<(bool, Vec<u8>)>> {
-        self.chunk_large_query_over(state_keys, None, move |state_keys: Vec<Key>| {
+        self.chunk_large_query_over(state_keys, None, move |txn, state_keys: Vec<Key>| {
             let sql_params = repeat_vars(state_keys.len());
             let sql = format!(
                 "SELECT stripped, data FROM state_event
@@ -740,9 +742,11 @@ trait SqliteObjectStateStoreExt: SqliteObjectExt {
                 [room_id.clone(), event_type.clone()].into_iter().chain(state_keys),
             );
 
-            self.prepare(sql, |mut stmt| {
-                stmt.query(params)?.mapped(|row| Ok((row.get(0)?, row.get(1)?))).collect()
-            })
+            Ok(txn
+                .prepare(&sql)?
+                .query(params)?
+                .mapped(|row| Ok((row.get(0)?, row.get(1)?)))
+                .collect::<Result<_, _>>()?)
         })
         .await
     }
@@ -772,7 +776,7 @@ trait SqliteObjectStateStoreExt: SqliteObjectExt {
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
         let user_ids_length = user_ids.len();
 
-        self.chunk_large_query_over(user_ids, Some(user_ids_length), move |user_ids| {
+        self.chunk_large_query_over(user_ids, Some(user_ids_length), move |txn, user_ids| {
             let sql_params = repeat_vars(user_ids.len());
             let sql = format!(
                 "SELECT user_id, data FROM profile WHERE room_id = ? AND user_id IN ({sql_params})"
@@ -780,9 +784,11 @@ trait SqliteObjectStateStoreExt: SqliteObjectExt {
 
             let params = rusqlite::params_from_iter(iter::once(room_id.clone()).chain(user_ids));
 
-            self.prepare(sql, move |mut stmt| {
-                stmt.query(params)?.mapped(|row| Ok((row.get(0)?, row.get(1)?))).collect()
-            })
+            Ok(txn
+                .prepare(&sql)?
+                .query(params)?
+                .mapped(|row| Ok((row.get(0)?, row.get(1)?)))
+                .collect::<Result<_, _>>()?)
         })
         .await
     }
@@ -794,7 +800,7 @@ trait SqliteObjectStateStoreExt: SqliteObjectExt {
             })
             .await?
         } else {
-            self.chunk_large_query_over(memberships, None, move |memberships| {
+            self.chunk_large_query_over(memberships, None, move |txn, memberships| {
                 let sql_params = repeat_vars(memberships.len());
                 let sql = format!(
                     "SELECT data FROM member WHERE room_id = ? AND membership IN ({sql_params})"
@@ -803,9 +809,11 @@ trait SqliteObjectStateStoreExt: SqliteObjectExt {
                 let params =
                     rusqlite::params_from_iter(iter::once(room_id.clone()).chain(memberships));
 
-                self.prepare(sql, move |mut stmt| {
-                    stmt.query(params)?.mapped(|row| row.get(0)).collect()
-                })
+                Ok(txn
+                    .prepare(&sql)?
+                    .query(params)?
+                    .mapped(|row| row.get(0))
+                    .collect::<Result<_, _>>()?)
             })
             .await?
         };
@@ -846,7 +854,7 @@ trait SqliteObjectStateStoreExt: SqliteObjectExt {
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
         let names_length = names.len();
 
-        self.chunk_large_query_over(names, Some(names_length), move |names| {
+        self.chunk_large_query_over(names, Some(names_length), move |txn, names| {
             let sql_params = repeat_vars(names.len());
             let sql = format!(
                 "SELECT name, data FROM display_name WHERE room_id = ? AND name IN ({sql_params})"
@@ -854,9 +862,11 @@ trait SqliteObjectStateStoreExt: SqliteObjectExt {
 
             let params = rusqlite::params_from_iter(iter::once(room_id.clone()).chain(names));
 
-            self.prepare(sql, move |mut stmt| {
-                stmt.query(params)?.mapped(|row| Ok((row.get(0)?, row.get(1)?))).collect()
-            })
+            Ok(txn
+                .prepare(&sql)?
+                .query(params)?
+                .mapped(|row| Ok((row.get(0)?, row.get(1)?)))
+                .collect::<Result<_, _>>()?)
         })
         .await
     }

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use core::fmt;
-use std::{borrow::Borrow, cmp::min, future::Future, iter, ops::Deref};
+use std::{borrow::Borrow, cmp::min, iter, ops::Deref};
 
 use async_trait::async_trait;
 use itertools::Itertools;
@@ -91,18 +91,15 @@ pub(crate) trait SqliteObjectExt {
         E: From<rusqlite::Error> + Send + 'static,
         F: FnOnce(&Transaction<'_>) -> Result<T, E> + Send + 'static;
 
-    async fn limit(&self, limit: Limit) -> i32;
-
-    async fn chunk_large_query_over<Query, Fut, Res>(
+    async fn chunk_large_query_over<Query, Res>(
         &self,
         mut keys_to_chunk: Vec<Key>,
         result_capacity: Option<usize>,
         do_query: Query,
     ) -> Result<Vec<Res>>
     where
-        Query: Fn(Vec<Key>) -> Fut + Send + Sync,
-        Fut: Future<Output = Result<Vec<Res>, rusqlite::Error>> + Send,
-        Res: Send;
+        Res: Send + 'static,
+        Query: Fn(&Transaction<'_>, Vec<Key>) -> Result<Vec<Res>> + Send + 'static;
 }
 
 #[async_trait]
@@ -164,57 +161,26 @@ impl SqliteObjectExt for deadpool_sqlite::Object {
         .unwrap()
     }
 
-    async fn limit(&self, limit: Limit) -> i32 {
-        self.interact(move |conn| conn.limit(limit)).await.expect("Failed to fetch limit")
-    }
-
     /// Chunk a large query over some keys.
     ///
     /// Imagine there is a _dynamic_ query that runs potentially large number of
     /// parameters, so much that the maximum number of parameters can be hit.
     /// Then, this helper is for you. It will execute the query on chunks of
     /// parameters.
-    async fn chunk_large_query_over<Query, Fut, Res>(
+    async fn chunk_large_query_over<Query, Res>(
         &self,
-        mut keys_to_chunk: Vec<Key>,
+        keys_to_chunk: Vec<Key>,
         result_capacity: Option<usize>,
         do_query: Query,
     ) -> Result<Vec<Res>>
     where
-        Query: Fn(Vec<Key>) -> Fut + Send + Sync,
-        Fut: Future<Output = Result<Vec<Res>, rusqlite::Error>> + Send,
-        Res: Send,
+        Res: Send + 'static,
+        Query: Fn(&Transaction<'_>, Vec<Key>) -> Result<Vec<Res>> + Send + 'static,
     {
-        // Divide by 2 to allow space for more static parameters (not part of
-        // `keys_to_chunk`).
-        let maximum_chunk_size = self.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER).await / 2;
-        let maximum_chunk_size: usize = maximum_chunk_size
-            .try_into()
-            .map_err(|_| Error::SqliteMaximumVariableNumber(maximum_chunk_size))?;
-
-        if keys_to_chunk.len() < maximum_chunk_size {
-            // Chunking isn't necessary.
-            let chunk = keys_to_chunk;
-
-            Ok(do_query(chunk).await?)
-        } else {
-            // Chunking _is_ necessary.
-
-            // Define the accumulator.
-            let capacity = result_capacity.unwrap_or_default();
-            let mut all_results = Vec::with_capacity(capacity);
-
-            while !keys_to_chunk.is_empty() {
-                // Chunk and run the query.
-                let tail = keys_to_chunk.split_off(min(keys_to_chunk.len(), maximum_chunk_size));
-                let chunk = keys_to_chunk;
-                keys_to_chunk = tail;
-
-                all_results.extend(do_query(chunk).await?);
-            }
-
-            Ok(all_results)
-        }
+        self.with_transaction(move |txn| {
+            txn.chunk_large_query_over(keys_to_chunk, result_capacity, do_query)
+        })
+        .await
     }
 }
 
@@ -229,6 +195,62 @@ impl SqliteConnectionExt for rusqlite::Connection {
             (key, value),
         )?;
         Ok(())
+    }
+}
+
+pub(crate) trait SqliteTransactionExt {
+    fn chunk_large_query_over<Query, Res>(
+        &self,
+        keys_to_chunk: Vec<Key>,
+        result_capacity: Option<usize>,
+        do_query: Query,
+    ) -> Result<Vec<Res>>
+    where
+        Res: Send + 'static,
+        Query: Fn(&Transaction<'_>, Vec<Key>) -> Result<Vec<Res>> + Send + 'static;
+}
+
+impl<'a> SqliteTransactionExt for Transaction<'a> {
+    fn chunk_large_query_over<Query, Res>(
+        &self,
+        mut keys_to_chunk: Vec<Key>,
+        result_capacity: Option<usize>,
+        do_query: Query,
+    ) -> Result<Vec<Res>>
+    where
+        Res: Send + 'static,
+        Query: Fn(&Transaction<'_>, Vec<Key>) -> Result<Vec<Res>> + Send + 'static,
+    {
+        // Divide by 2 to allow space for more static parameters (not part of
+        // `keys_to_chunk`).
+        let maximum_chunk_size = self.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER) / 2;
+        let maximum_chunk_size: usize = maximum_chunk_size
+            .try_into()
+            .map_err(|_| Error::SqliteMaximumVariableNumber(maximum_chunk_size))?;
+
+        if keys_to_chunk.len() < maximum_chunk_size {
+            // Chunking isn't necessary.
+            let chunk = keys_to_chunk;
+
+            Ok(do_query(self, chunk)?)
+        } else {
+            // Chunking _is_ necessary.
+
+            // Define the accumulator.
+            let capacity = result_capacity.unwrap_or_default();
+            let mut all_results = Vec::with_capacity(capacity);
+
+            while !keys_to_chunk.is_empty() {
+                // Chunk and run the query.
+                let tail = keys_to_chunk.split_off(min(keys_to_chunk.len(), maximum_chunk_size));
+                let chunk = keys_to_chunk;
+                keys_to_chunk = tail;
+
+                all_results.extend(do_query(self, chunk)?);
+            }
+
+            Ok(all_results)
+        }
     }
 }
 


### PR DESCRIPTION
Allows the operation to be atomic, and to chunk part of a transaction.

I believe that this change makes sense on its own, but for context I will need to be able to chunk part of a transaction in an upcoming PR.