### PR TITLE
sqlite: Rename types and traits and refactoring

### DIFF
--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -45,7 +45,7 @@ use crate::{
     error::{Error, Result},
     get_or_create_store_cipher,
     utils::{
-        load_db_version, repeat_vars, Key, SqliteAsyncConnExt, SqliteConnectionExt as _,
+        load_db_version, repeat_vars, Key, SqliteAsyncConnExt, SqliteKeyValueStoreConnExt,
         SqliteObjectStoreExt as _,
     },
     OpenStoreError,

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -45,8 +45,8 @@ use crate::{
     error::{Error, Result},
     get_or_create_store_cipher,
     utils::{
-        load_db_version, repeat_vars, Key, SqliteAsyncConnExt, SqliteKeyValueStoreConnExt,
-        SqliteObjectStoreExt as _,
+        load_db_version, repeat_vars, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
+        SqliteKeyValueStoreConnExt,
     },
     OpenStoreError,
 };

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -14,8 +14,8 @@ use tracing::debug;
 use crate::{
     error::{Error, Result},
     get_or_create_store_cipher,
-    utils::{load_db_version, Key, SqliteAsyncConnExt},
-    OpenStoreError, SqliteObjectStoreExt,
+    utils::{load_db_version, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt},
+    OpenStoreError,
 };
 
 mod keys {

--- a/crates/matrix-sdk-sqlite/src/lib.rs
+++ b/crates/matrix-sdk-sqlite/src/lib.rs
@@ -35,7 +35,7 @@ pub use self::error::OpenStoreError;
 pub use self::event_cache_store::SqliteEventCacheStore;
 #[cfg(feature = "state-store")]
 pub use self::state_store::SqliteStateStore;
-use self::utils::SqliteObjectStoreExt;
+use self::utils::SqliteKeyValueStoreAsyncConnExt;
 
 async fn get_or_create_store_cipher(
     passphrase: &str,

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -42,8 +42,10 @@ use tracing::{debug, warn};
 use crate::{
     error::{Error, Result},
     get_or_create_store_cipher,
-    utils::{load_db_version, repeat_vars, Key, SqliteAsyncConnExt},
-    OpenStoreError, SqliteObjectStoreExt,
+    utils::{
+        load_db_version, repeat_vars, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
+    },
+    OpenStoreError,
 };
 
 mod keys {


### PR DESCRIPTION
 To make it easier to understand what the types and traits do, rename:
 - `SqliteConn` to `SqliteAsyncConn`,
 - `SqliteObjectExt` to `SqliteAsyncConnExt`
 - `SqliteConnectionExt` to `SqliteKeyValueStoreConnectionExt`
 - `SqliteObjectStoreExt` to `SqliteKeyValueStoreAsyncConnExt`.

And refactor the code to put more methods in `SqliteKeyValueStoreAsyncConnExt`, to avoid free functions that take an `&SqliteAsyncConn` and reduce code duplication.

