### PR TITLE
crypto: Error when sending keys to previously-verified users with identity-based strategy

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -2,14 +2,20 @@
 
 Breaking changes:
 
-- `EventSendState` now has four additional variants: `VerifiedUserHasUnsignedDevice`,
-  `VerifiedUserChangedIdentity`, `CrossSigningNotSetup`, and
-  `SendingFromUnverifiedDevice`. The first two reflect problems with verified users in
-  the room and as such can only be returned when the room key recipient strategy has
-  `error_on_verified_user_problem` set, or when using the identity-based strategy. The
-  last two indicate that your own device is not properly cross-signed, which is a
-  requirement when using the identity-based strategy, and can only be returned when
-  using the identity-based strategy.
+- `EventSendState` now has two additional variants: `CrossSigningNotSetup` and
+  `SendingFromUnverifiedDevice`. These indicate that your own device is not
+  properly cross-signed, which is a requirement when using the identity-based
+  strategy, and can only be returned when using the identity-based strategy.
+
+  In addition, the `VerifiedUserHasUnsignedDevice` and
+  `VerifiedUserChangedIdentity` variants can be returned when using the
+  identity-based strategy, in addition to when using the device-based strategy
+  with `error_on_verified_user_problem` is set.
+
+- `EventSendState` now has two additional variants: `VerifiedUserHasUnsignedDevice` and
+  `VerifiedUserChangedIdentity`. These reflect problems with verified users in the room
+  and as such can only be returned when the room key recipient strategy has
+  `error_on_verified_user_problem` set.
 
 - The `AuthenticationService` has been removed:
     - Instead of calling `configure_homeserver`, build your own client with the `serverNameOrHomeserverUrl` builder

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 Breaking changes:
 
-- `EventSendState` now has two additional variants: `VerifiedUserHasUnsignedDevice` and
-  `VerifiedUserChangedIdentity`. These reflect problems with verified users in the room
-  and as such can only be returned when the room key recipient strategy has
-  `error_on_verified_user_problem` set.
+- `EventSendState` now has four additional variants: `VerifiedUserHasUnsignedDevice`,
+  `VerifiedUserChangedIdentity`, `CrossSigningNotSetup`, and
+  `SendingFromUnverifiedDevice`. The first two reflect problems with verified users in
+  the room and as such can only be returned when the room key recipient strategy has
+  `error_on_verified_user_problem` set, or when using the identity-based strategy. The
+  last two indicate that your own device is not properly cross-signed, which is a
+  requirement when using the identity-based strategy, and can only be returned when
+  using the identity-based strategy.
 
 - The `AuthenticationService` has been removed:
     - Instead of calling `configure_homeserver`, build your own client with the `serverNameOrHomeserverUrl` builder

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -918,11 +918,20 @@ pub enum EventSendState {
     ///
     /// Happens only when the room key recipient strategy (as set by
     /// [`ClientBuilder::room_key_recipient_strategy`]) has
-    /// [`error_on_verified_user_problem`](CollectStrategy::DeviceBasedStrategy::error_on_verified_user_problem) set.
+    /// [`error_on_verified_user_problem`](CollectStrategy::DeviceBasedStrategy::error_on_verified_user_problem)
+    /// set, or when using [`CollectStrategy::IdentityBasedStrategy`].
     VerifiedUserChangedIdentity {
         /// The users that were previously verified, but are no longer
         users: Vec<String>,
     },
+
+    /// The user does not have cross-signing set up, but
+    /// [`CollectStrategy::IdentityBasedStrategy`] was used.
+    CrossSigningNotSetup,
+
+    /// The current device is not verified, but
+    /// [`CollectStrategy::IdentityBasedStrategy`] was used.
+    SendingFromUnverifiedDevice,
 
     /// The local event has been sent to the server, but unsuccessfully: The
     /// sending has failed.
@@ -977,6 +986,10 @@ fn event_send_state_from_sending_failed(error: &Error, is_recoverable: bool) -> 
             VerifiedUserChangedIdentity(bad_users) => EventSendState::VerifiedUserChangedIdentity {
                 users: bad_users.iter().map(|user_id| user_id.to_string()).collect(),
             },
+
+            CrossSigningNotSetup => EventSendState::CrossSigningNotSetup,
+
+            SendingFromUnverifiedDevice => EventSendState::SendingFromUnverifiedDevice,
         },
 
         _ => EventSendState::SendingFailed { error: error.to_string(), is_recoverable },

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -56,6 +56,11 @@ Breaking changes:
   `OlmMachine::share_room_key` to fail with an error if any verified users on
   the recipient list have unsigned devices, or are no lonver verified.
 
+  When `CallectStrategy::IdentityBasedStrategy` is used,
+  `OlmMachine::share_room_key` will fail with an error if any verified users on
+  the recipient list are no longer verified, or if our own device is not
+  properly cross-signed.
+
   Also remove `CollectStrategy::new_device_based`: callers should construct a
   `CollectStrategy::DeviceBasedStrategy` directly.
 
@@ -63,6 +68,7 @@ Breaking changes:
   a list of booleans.
   ([#3810](https://github.com/matrix-org/matrix-rust-sdk/pull/3810))
   ([#3816](https://github.com/matrix-org/matrix-rust-sdk/pull/3816))
+  ([#3896](https://github.com/matrix-org/matrix-rust-sdk/pull/3896))
 
 - Remove the method `OlmMachine::clear_crypto_cache()`, crypto stores are not
   supposed to have any caches anymore.

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -409,13 +409,13 @@ pub enum SessionRecipientCollectionError {
     VerifiedUserChangedIdentity(Vec<OwnedUserId>),
 
     /// Cross-signing is required for encryption when using
-    /// [`CollectStrategy::IdentityBased`].
-    #[error("Encryption failed because cross-signing is not setup on your account")]
+    /// [`CollectStrategy::IdentityBasedStrategy`].
+    #[error("Encryption failed because cross-signing is not set up on your account")]
     CrossSigningNotSetup,
 
     /// The current device needs to be verified when encrypting using
-    /// [`CollectStrategy::IdentityBased`]. Apps should prevent sending in the
-    /// UI to avoid hitting this case.
+    /// [`CollectStrategy::IdentityBasedStrategy`]. Apps should prevent sending
+    /// in the UI to avoid hitting this case.
     #[error("Encryption failed because your device is not verified")]
     SendingFromUnverifiedDevice,
 }

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -408,14 +408,23 @@ pub enum SessionRecipientCollectionError {
     #[error("one or more users that were verified have changed their identity")]
     VerifiedUserChangedIdentity(Vec<OwnedUserId>),
 
-    /// Cross-signing is required for encryption when using
-    /// [`CollectStrategy::IdentityBasedStrategy`].
+    /// Cross-signing has not been configured on our own identity.
+    ///
+    /// Happens only with [`CollectStrategy::IdentityBasedStrategy`].
+    /// (Cross-signing is required for encryption when using
+    /// `IdentityBasedStrategy`.) Apps should detect this condition and prevent
+    /// sending in the UI rather than waiting for this error to be returned when
+    /// encrypting.
     #[error("Encryption failed because cross-signing is not set up on your account")]
     CrossSigningNotSetup,
 
-    /// The current device needs to be verified when encrypting using
-    /// [`CollectStrategy::IdentityBasedStrategy`]. Apps should prevent sending
-    /// in the UI to avoid hitting this case.
+    /// The current device has not been cross-signed by our own identity.
+    ///
+    /// Happens only with [`CollectStrategy::IdentityBasedStrategy`].
+    /// (Cross-signing is required for encryption when using
+    /// `IdentityBasedStrategy`.) Apps should detect this condition and prevent
+    /// sending in the UI rather than waiting for this error to be returned when
+    /// encrypting.
     #[error("Encryption failed because your device is not verified")]
     SendingFromUnverifiedDevice,
 }

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -391,7 +391,7 @@ pub enum SessionRecipientCollectionError {
     ///
     /// Happens only with [`CollectStrategy::DeviceBasedStrategy`] when
     /// [`error_on_verified_user_problem`](`CollectStrategy::DeviceBasedStrategy::error_on_verified_user_problem`)
-    /// is true.
+    /// is true, or with [`CollectStrategy::IdentityBasedStrategy`].
     ///
     /// In order to resolve this, the user can:
     ///
@@ -407,4 +407,15 @@ pub enum SessionRecipientCollectionError {
     /// The caller can then retry the encryption operation.
     #[error("one or more users that were verified have changed their identity")]
     VerifiedUserChangedIdentity(Vec<OwnedUserId>),
+
+    /// Cross-signing is required for encryption when using
+    /// [`CollectStrategy::IdentityBased`].
+    #[error("Encryption failed because cross-signing is not setup on your account")]
+    CrossSigningNotSetup,
+
+    /// The current device needs to be verified when encrypting using
+    /// [`CollectStrategy::IdentityBased`]. Apps should prevent sending in the
+    /// UI to avoid hitting this case.
+    #[error("Encryption failed because your device is not verified")]
+    SendingFromUnverifiedDevice,
 }

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -1322,8 +1322,6 @@ mod tests {
             .await
             .unwrap()
             .unwrap()
-            .other()
-            .unwrap()
             .withdraw_verification()
             .await
             .unwrap();
@@ -1382,14 +1380,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(machine
-            .get_identity(user2, None)
-            .await
-            .unwrap()
-            .unwrap()
-            .other()
-            .unwrap()
-            .is_verified());
+        assert!(machine.get_identity(user2, None).await.unwrap().unwrap().is_verified());
 
         // And now the key share should succeed.
         machine

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -1341,7 +1341,6 @@ mod tests {
             .unwrap();
         let raw_extracted =
             verification_request.signed_keys.get(user2).unwrap().iter().next().unwrap().1.get();
-        dbg!(raw_extracted);
         let signed_key: crate::types::CrossSigningKey =
             serde_json::from_str(raw_extracted).unwrap();
         let new_signatures = signed_key.signatures.get(KeyDistributionTestData::me_id()).unwrap();
@@ -1374,7 +1373,7 @@ mod tests {
         }
         );
 
-        let kq_response = matrix_sdk_test::ruma_response_from_json(dbg!(&json));
+        let kq_response = matrix_sdk_test::ruma_response_from_json(&json);
         machine
             .mark_request_as_sent(
                 &TransactionId::new(),

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -1263,3 +1263,151 @@ impl PreviouslyVerifiedTestData {
         ruma_response_from_json(&data)
     }
 }
+
+/// A set of keys query to test identity changes,
+/// For user @malo, that performed an identity change with the same device.
+pub struct MaloIdentityChangeDataSet {}
+
+#[allow(dead_code)]
+impl MaloIdentityChangeDataSet {
+    pub fn user_id() -> &'static UserId {
+        user_id!("@malo:localhost")
+    }
+
+    pub fn device_id() -> &'static DeviceId {
+        device_id!("NZFSPBRLDO")
+    }
+
+    /// @malo's keys before their identity change
+    pub fn initial_key_query() -> KeyQueryResponse {
+        let data = json!({
+            "device_keys": {
+                "@malo:localhost": {
+                    "NZFSPBRLDO": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "NZFSPBRLDO",
+                        "keys": {
+                            "curve25519:NZFSPBRLDO": "L3jdbw42+9i+K7LPjAY+kmqG9nr2n/U0ow8hEbLCoCs",
+                            "ed25519:NZFSPBRLDO": "VDJt3xI4SzrgQkuE3sEIauluaXawx3wWoWOynPI8Zko"
+                        },
+                        "signatures": {
+                            "@malo:localhost": {
+                                "ed25519:NZFSPBRLDO": "lmtbdrJ5xBweo677Fg2qrSHsRi4R3x2WNlvSNJY6Zbg0R5lJS9syN2HZw/irL9PA644GYm4QM/t+DX0grnn+BQ",
+                                "ed25519:+wbxNfSuDrch1jKuydQmEf4qlA4u4NgwqNXNuLVwug8": "Ql1fq+SvVDx+8mjNMzSaR0hBCEkdPirbs2+BK0gwsIH1zkuMADnBoNWP7LJiKo/EO9gnpiCzyQQgI4e9pIVPDA"
+                            }
+                        },
+                        "user_id": "@malo:localhost",
+                        "unsigned": {}
+                    }
+                }
+            },
+            "failures": {},
+            "master_keys": {
+                "@malo:localhost": {
+                    "keys": {
+                        "ed25519:WBxliSP29guYr4ux0MW6otRe3V/wOLXXElpOcOmpdlE": "WBxliSP29guYr4ux0MW6otRe3V/wOLXXElpOcOmpdlE"
+                    },
+                    "signatures": {
+                        "@malo:localhost": {
+                            "ed25519:NZFSPBRLDO": "crJcXqFpEHRM8KNUw419XrVFaHoM8/kV4ebgpuuIiD9wfX0AhHE2iGRGpKzsrVCqne9k181/uN0sgDMpK2y4Aw",
+                            "ed25519:WBxliSP29guYr4ux0MW6otRe3V/wOLXXElpOcOmpdlE": "/xwFF5AC3GhkpvJ449Srh8kNQS6CXAxQMmBpQvPEHx5BHPXJ08u2ZDd1EPYY4zk4QsePk+tEYu8gDnB0bggHCA"
+                        }
+                    },
+                    "usage": [
+                        "master"
+                    ],
+                    "user_id": "@malo:localhost"
+                }
+            },
+            "self_signing_keys": {
+                "@malo:localhost": {
+                    "keys": {
+                        "ed25519:+wbxNfSuDrch1jKuydQmEf4qlA4u4NgwqNXNuLVwug8": "+wbxNfSuDrch1jKuydQmEf4qlA4u4NgwqNXNuLVwug8"
+                    },
+                    "signatures": {
+                        "@malo:localhost": {
+                            "ed25519:WBxliSP29guYr4ux0MW6otRe3V/wOLXXElpOcOmpdlE": "sSGQ6ny6aXtIvgKPGOYJzcmnNDSkbaJFVRe9wekOry7EaiWf2l28MkGTUBt4cPoRiMkNjuRBupNEARqHF72sAQ"
+                        }
+                    },
+                    "usage": [
+                        "self_signing"
+                    ],
+                    "user_id": "@malo:localhost"
+                }
+            },
+            "user_signing_keys": {},
+        });
+
+        ruma_response_from_json(&data)
+    }
+
+    /// @malo's keys after their identity change
+    pub fn updated_key_query() -> KeyQueryResponse {
+        let data = json!({
+            "device_keys": {
+                "@malo:localhost": {
+                    "NZFSPBRLDO": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "NZFSPBRLDO",
+                        "keys": {
+                            "curve25519:NZFSPBRLDO": "L3jdbw42+9i+K7LPjAY+kmqG9nr2n/U0ow8hEbLCoCs",
+                            "ed25519:NZFSPBRLDO": "VDJt3xI4SzrgQkuE3sEIauluaXawx3wWoWOynPI8Zko"
+                        },
+                        "signatures": {
+                            "@malo:localhost": {
+                                "ed25519:NZFSPBRLDO": "lmtbdrJ5xBweo677Fg2qrSHsRi4R3x2WNlvSNJY6Zbg0R5lJS9syN2HZw/irL9PA644GYm4QM/t+DX0grnn+BQ",
+                                "ed25519:+wbxNfSuDrch1jKuydQmEf4qlA4u4NgwqNXNuLVwug8": "Ql1fq+SvVDx+8mjNMzSaR0hBCEkdPirbs2+BK0gwsIH1zkuMADnBoNWP7LJiKo/EO9gnpiCzyQQgI4e9pIVPDA",
+                                "ed25519:8my6+zgnzEP0ZqmQFyvscJh7isHlf8lxBmHg+fzdJkE": "OvqDE7C2mrHxjwNyMIEz+m/AO6I6lM5HoPYY2bvLjrJJDOF5sJOtw4JoYiCWyt90ZIWsbEqmfbazrblLD50tCg"
+                            }
+                        },
+                        "user_id": "@malo:localhost",
+                        "unsigned": {}
+                    }
+                }
+            },
+            "failures": {},
+            "master_keys": {
+                "@malo:localhost": {
+                    "keys": {
+                        "ed25519:dv2Mk7bFlRtP/0oSZpB01Ouc5frCXKfG8Bn9YrFxbxU": "dv2Mk7bFlRtP/0oSZpB01Ouc5frCXKfG8Bn9YrFxbxU"
+                    },
+                    "signatures": {
+                        "@malo:localhost": {
+                            "ed25519:NZFSPBRLDO": "2Ye96l4srBSWskNQszuMpea1r97rFoUyfNqegvu/hGeP47w0OVvqYuNtZRNwqb7TMS7aPEn6l9lhWEk7v06wCg",
+                            "ed25519:dv2Mk7bFlRtP/0oSZpB01Ouc5frCXKfG8Bn9YrFxbxU": "btkxAJpJeVtc9wgBmeHUI9QDpojd6ddLxK11E3403KoTQtP6Mnr5GsVdQr1HJToG7PG4k4eEZGWxVZr1GPndAA"
+                        }
+                    },
+                    "usage": [
+                        "master"
+                    ],
+                    "user_id": "@malo:localhost"
+                }
+            },
+            "self_signing_keys": {
+                "@malo:localhost": {
+                    "keys": {
+                        "ed25519:8my6+zgnzEP0ZqmQFyvscJh7isHlf8lxBmHg+fzdJkE": "8my6+zgnzEP0ZqmQFyvscJh7isHlf8lxBmHg+fzdJkE"
+                    },
+                    "signatures": {
+                        "@malo:localhost": {
+                            "ed25519:dv2Mk7bFlRtP/0oSZpB01Ouc5frCXKfG8Bn9YrFxbxU": "KJt0y1p8v8RGLGk2wUyCMbX1irXJqup/mdRuG/cxJxs24BZhDMyIzyGrGXnWq2gx3I4fKIMtFPi/ecxf92ePAQ"
+                        }
+                    },
+                    "usage": [
+                        "self_signing"
+                    ],
+                    "user_id": "@malo:localhost"
+                }
+            },
+            "user_signing_keys": {}
+        });
+
+        ruma_response_from_json(&data)
+    }
+}


### PR DESCRIPTION
This is the rest of https://github.com/matrix-org/matrix-rust-sdk/pull/3662, on top of https://github.com/matrix-org/matrix-rust-sdk/pull/3884.

3662 says:

> Part of invisible crypto, follow up of https://github.com/matrix-org/matrix-rust-sdk/pull/3639
>
> Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3565

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
