### PR TITLE
sdk: Handle a clippy nightly warning

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -956,10 +956,8 @@ impl StickyData for SlidingSyncStickyParameters {
         request.room_subscriptions = self
             .room_subscriptions
             .iter()
-            .filter_map(|(room_id, (state, room_subscription))| {
-                matches!(state, RoomSubscriptionState::Pending)
-                    .then(|| (room_id.clone(), room_subscription.clone()))
-            })
+            .filter(|(_, (state, _))| matches!(state, RoomSubscriptionState::Pending))
+            .map(|(room_id, (_, room_subscription))| (room_id.clone(), room_subscription.clone()))
             .collect();
         request.extensions = self.extensions.clone();
     }


### PR DESCRIPTION
On my version of clippy nightly, these lines triggered the [`filter_map_bool_then`](https://rust-lang.github.io/rust-clippy/master/index.html#/filter_map_bool_then) lint.
