### PR TITLE
crypto: Configurable sender trust checking on decrypting

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -17,7 +17,8 @@ use matrix_sdk_crypto::{
     decrypt_room_key_export, encrypt_room_key_export,
     olm::ExportedRoomKey,
     store::{BackupDecryptionKey, Changes},
-    LocalTrust, OlmMachine as InnerMachine, ToDeviceRequest, UserIdentities,
+    DecryptionSettings, LocalTrust, OlmMachine as InnerMachine, ToDeviceRequest, TrustRequirement,
+    UserIdentities,
 };
 use ruma::{
     api::{
@@ -881,7 +882,13 @@ impl OlmMachine {
         let event: Raw<_> = serde_json::from_str(&event)?;
         let room_id = RoomId::parse(room_id)?;
 
-        let decrypted = self.runtime.block_on(self.inner.decrypt_room_event(&event, &room_id))?;
+        let decryption_settings =
+            DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
+        let decrypted = self.runtime.block_on(self.inner.decrypt_room_event(
+            &event,
+            &room_id,
+            &decryption_settings,
+        ))?;
 
         if handle_verification_events {
             if let Ok(AnyTimelineEvent::MessageLike(e)) = decrypted.event.deserialize() {

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -189,6 +189,22 @@ pub enum VerificationLevel {
     None(DeviceLinkProblem),
 }
 
+impl fmt::Display for VerificationLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        let display = match self {
+            VerificationLevel::UnverifiedIdentity => "The sender's identity was not verified",
+            VerificationLevel::PreviouslyVerified => {
+                "The sender's identity was previously verified but has changed"
+            }
+            VerificationLevel::UnsignedDevice => {
+                "The sending device was not signed by the user's identity"
+            }
+            VerificationLevel::None(..) => "The sending device is not known",
+        };
+        write!(f, "{}", display)
+    }
+}
+
 /// The sub-enum containing detailed information on why we were not able to link
 /// a message back to a device.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -36,6 +36,14 @@ Breaking changes:
   the CryptoStore, meaning that, once upgraded, it will not be possible to roll
   back applications to earlier versions without breaking user sessions.
 
+- `OlmMachine::decrypt_room_event` now takes a `DecryptionSettings` argument,
+  which includes a `TrustRequirement` indicating the required trust level for
+  the sending device.  When it is called with `TrustRequirement` other than
+  `TrustRequirement::Unverified`, it may return the new
+  `MegolmError::SenderIdentityNotTrusted` variant if the sending device does not
+  satisfy the required trust level.
+  ([#3899](https://github.com/matrix-org/matrix-rust-sdk/pull/3899))
+
 - Change the structure of the `SenderData` enum to separate variants for
   previously-verified, unverified and verified.
   ([#3877](https://github.com/matrix-org/matrix-rust-sdk/pull/3877))

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -14,6 +14,7 @@
 
 use std::collections::BTreeMap;
 
+use matrix_sdk_common::deserialized_responses::VerificationLevel;
 use ruma::{CanonicalJsonError, IdParseError, OwnedDeviceId, OwnedRoomId, OwnedUserId};
 use serde::{ser::SerializeMap, Serializer};
 use serde_json::Error as SerdeError;
@@ -115,6 +116,12 @@ pub enum MegolmError {
     /// The storage layer returned an error.
     #[error(transparent)]
     Store(#[from] CryptoStoreError),
+
+    /// An encrypted message wasn't decrypted, because the sender's
+    /// cross-signing identity did not satisfy the requested
+    /// [`crate::TrustRequirement`].
+    #[error("decryption failed because trust requirement not satisfied: {0}")]
+    SenderIdentityNotTrusted(VerificationLevel),
 }
 
 /// Decryption failed because of a mismatch between the identity keys of the

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -91,6 +91,7 @@ pub use requests::{
     IncomingResponse, KeysBackupRequest, KeysQueryRequest, OutgoingRequest, OutgoingRequests,
     OutgoingVerificationRequest, RoomMessageRequest, ToDeviceRequest, UploadSigningKeysRequest,
 };
+use serde::{Deserialize, Serialize};
 pub use session_manager::CollectStrategy;
 pub use store::{
     CrossSigningKeyExport, CryptoStoreError, SecretImportError, SecretInfo, TrackedUser,
@@ -112,3 +113,25 @@ matrix_sdk_test::init_tracing_for_tests!();
 
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
+
+/// The trust level in the sender's device that is required to decrypt an
+/// event.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum TrustRequirement {
+    /// Decrypt events from everyone regardless of trust.
+    Untrusted,
+    /// Only decrypt events from cross-signed devices or legacy sessions (Megolm
+    /// sessions created before we started collecting trust information).
+    CrossSignedOrLegacy,
+    /// Only decrypt events from cross-signed devices.
+    CrossSigned,
+}
+
+/// Settings for decrypting messages
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DecryptionSettings {
+    /// The trust level in the sender's device that is required to decrypt the
+    /// event. If the sender's device is not sufficiently trusted,
+    /// [`MegolmError::SenderIdentityNotTrusted`] will be returned.
+    pub sender_device_trust_requirement: TrustRequirement,
+}

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -934,8 +934,6 @@ impl OlmMachine {
         &self,
         room_id: &RoomId,
     ) -> OlmResult<()> {
-        use crate::olm::SenderData;
-
         let (_, session) = self
             .inner
             .group_session_manager
@@ -957,8 +955,6 @@ impl OlmMachine {
         &self,
         room_id: &RoomId,
     ) -> OlmResult<InboundGroupSession> {
-        use crate::olm::SenderData;
-
         let (_, session) = self
             .inner
             .group_session_manager
@@ -1609,6 +1605,13 @@ impl OlmMachine {
         match result {
             Ok((decrypted_event, _)) => {
                 let encryption_info = self.get_encryption_info(&session, &event.sender).await?;
+
+                self.check_sender_trust_requirement(
+                    &session,
+                    &encryption_info,
+                    &decryption_settings.sender_device_trust_requirement,
+                )?;
+
                 Ok((decrypted_event, encryption_info))
             }
             Err(error) => Err(
@@ -1630,6 +1633,55 @@ impl OlmMachine {
                     error
                 },
             ),
+        }
+    }
+
+    /// Check that the sender of a Megolm session satisfies the trust
+    /// requirement from the decryption settings.
+    fn check_sender_trust_requirement(
+        &self,
+        session: &InboundGroupSession,
+        encryption_info: &EncryptionInfo,
+        trust_requirement: &TrustRequirement,
+    ) -> MegolmResult<()> {
+        /// Get the error from the encryption information.
+        fn encryption_info_to_error(encryption_info: &EncryptionInfo) -> MegolmResult<()> {
+            // When this is called, the verification state *must* be unverified,
+            // otherwise the sender_data would have been SenderVerified
+            let VerificationState::Unverified(verification_level) =
+                &encryption_info.verification_state
+            else {
+                unreachable!("inconsistent verification state");
+            };
+            Err(MegolmError::SenderIdentityNotTrusted(verification_level.clone()))
+        }
+
+        match trust_requirement {
+            TrustRequirement::Untrusted => Ok(()),
+
+            TrustRequirement::CrossSignedOrLegacy => match &session.sender_data {
+                // Reject if the sender was previously verified, but changed
+                // their identity and is not verified any more.
+                SenderData::SenderUnverifiedButPreviouslyVerified(..) => Err(
+                    MegolmError::SenderIdentityNotTrusted(VerificationLevel::PreviouslyVerified),
+                ),
+                SenderData::SenderUnverified(..) => Ok(()),
+                SenderData::SenderVerified(..) => Ok(()),
+                SenderData::DeviceInfo { legacy_session: true, .. } => Ok(()),
+                SenderData::UnknownDevice { legacy_session: true, .. } => Ok(()),
+                _ => encryption_info_to_error(encryption_info),
+            },
+
+            TrustRequirement::CrossSigned => match &session.sender_data {
+                // Reject if the sender was previously verified, but changed
+                // their identity and is not verified any more.
+                SenderData::SenderUnverifiedButPreviouslyVerified(..) => Err(
+                    MegolmError::SenderIdentityNotTrusted(VerificationLevel::PreviouslyVerified),
+                ),
+                SenderData::SenderUnverified(..) => Ok(()),
+                SenderData::SenderVerified(..) => Ok(()),
+                _ => encryption_info_to_error(encryption_info),
+            },
         }
     }
 

--- a/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
@@ -45,7 +45,8 @@ use crate::{
         CrossSigningKey, EventEncryptionAlgorithm,
     },
     utilities::json_convert,
-    CryptoStoreError, EncryptionSettings, LocalTrust, OlmMachine, UserIdentities,
+    CryptoStoreError, DecryptionSettings, EncryptionSettings, LocalTrust, OlmMachine,
+    TrustRequirement, UserIdentities,
 };
 
 #[async_test]
@@ -110,8 +111,14 @@ async fn test_decryption_verification_state() {
 
     let event = json_convert(&event).unwrap();
 
-    let encryption_info =
-        bob.decrypt_room_event(&event, room_id).await.unwrap().encryption_info.unwrap();
+    let decryption_settings =
+        DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
+    let encryption_info = bob
+        .decrypt_room_event(&event, room_id, &decryption_settings)
+        .await
+        .unwrap()
+        .encryption_info
+        .unwrap();
 
     assert_eq!(
         VerificationState::Unverified(VerificationLevel::UnsignedDevice),

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -70,8 +70,8 @@ use crate::{
     },
     utilities::json_convert,
     verification::tests::bob_id,
-    Account, DeviceData, EncryptionSettings, MegolmError, OlmError, OutgoingRequests,
-    ToDeviceRequest,
+    Account, DecryptionSettings, DeviceData, EncryptionSettings, MegolmError, OlmError,
+    OutgoingRequests, ToDeviceRequest, TrustRequirement,
 };
 
 mod decryption_verification_state;
@@ -552,8 +552,15 @@ async fn test_megolm_encryption() {
 
     let event = json_convert(&event).unwrap();
 
-    let decrypted_event =
-        bob.decrypt_room_event(&event, room_id).await.unwrap().event.deserialize().unwrap();
+    let decryption_settings =
+        DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
+    let decrypted_event = bob
+        .decrypt_room_event(&event, room_id, &decryption_settings)
+        .await
+        .unwrap()
+        .event
+        .deserialize()
+        .unwrap();
 
     if let AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
         MessageLikeEvent::Original(OriginalMessageLikeEvent { sender, content, .. }),
@@ -662,7 +669,9 @@ async fn test_withheld_unverified() {
     });
     let room_event = json_convert(&room_event).unwrap();
 
-    let decrypt_result = bob.decrypt_room_event(&room_event, room_id).await;
+    let decryption_settings =
+        DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
+    let decrypt_result = bob.decrypt_room_event(&room_event, room_id, &decryption_settings).await;
 
     assert_matches!(&decrypt_result, Err(MegolmError::MissingRoomKey(Some(_))));
 
@@ -689,7 +698,12 @@ async fn test_decrypt_unencrypted_event() {
     let event = json_convert(&event).unwrap();
 
     // decrypt_room_event should return an error
-    assert_matches!(bob.decrypt_room_event(&event, room_id).await, Err(MegolmError::JsonError(..)));
+    let decryption_settings =
+        DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
+    assert_matches!(
+        bob.decrypt_room_event(&event, room_id, &decryption_settings).await,
+        Err(MegolmError::JsonError(..))
+    );
 
     // so should get_room_event_encryption_info
     assert_matches!(
@@ -870,7 +884,10 @@ async fn test_query_ratcheted_key() {
 
     let room_event = json_convert(&room_event).unwrap();
 
-    let decrypt_error = bob.decrypt_room_event(&room_event, room_id).await.unwrap_err();
+    let decryption_settings =
+        DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
+    let decrypt_error =
+        bob.decrypt_room_event(&room_event, room_id, &decryption_settings).await.unwrap_err();
 
     if let MegolmError::Decryption(vodo_error) = decrypt_error {
         if let vodozemac::megolm::DecryptionError::UnknownMessageIndex(_, _) = vodo_error {
@@ -999,8 +1016,10 @@ async fn test_room_key_with_fake_identity_keys() {
     });
     let event = json_convert(&event).unwrap();
 
+    let decryption_settings =
+        DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
     assert_matches!(
-        alice.decrypt_room_event(&event, room_id).await,
+        alice.decrypt_room_event(&event, room_id, &decryption_settings).await,
         Err(MegolmError::MismatchedIdentityKeys { .. })
     );
 }
@@ -1265,7 +1284,10 @@ async fn test_unsigned_decryption() {
     let raw_encrypted_event = json_convert(&first_message_encrypted_event).unwrap();
 
     // Bob has the room key, so first message should be decrypted successfully.
-    let raw_decrypted_event = bob.decrypt_room_event(&raw_encrypted_event, room_id).await.unwrap();
+    let decryption_settings =
+        DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
+    let raw_decrypted_event =
+        bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
     assert_matches!(
@@ -1317,7 +1339,8 @@ async fn test_unsigned_decryption() {
 
     // Bob does not have the second room key, so second message should fail to
     // decrypt.
-    let raw_decrypted_event = bob.decrypt_room_event(&raw_encrypted_event, room_id).await.unwrap();
+    let raw_decrypted_event =
+        bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
     assert_matches!(
@@ -1360,7 +1383,8 @@ async fn test_unsigned_decryption() {
     bob.store().save_inbound_group_sessions(&[group_session]).await.unwrap();
 
     // Second message should decrypt now.
-    let raw_decrypted_event = bob.decrypt_room_event(&raw_encrypted_event, room_id).await.unwrap();
+    let raw_decrypted_event =
+        bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
     assert_matches!(
@@ -1424,7 +1448,8 @@ async fn test_unsigned_decryption() {
 
     // Bob does not have the third room key, so third message should fail to
     // decrypt.
-    let raw_decrypted_event = bob.decrypt_room_event(&raw_encrypted_event, room_id).await.unwrap();
+    let raw_decrypted_event =
+        bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
     assert_matches!(
@@ -1471,7 +1496,8 @@ async fn test_unsigned_decryption() {
     bob.store().save_inbound_group_sessions(&[group_session]).await.unwrap();
 
     // Third message should decrypt now.
-    let raw_decrypted_event = bob.decrypt_room_event(&raw_encrypted_event, room_id).await.unwrap();
+    let raw_decrypted_event =
+        bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
     assert_matches!(


### PR DESCRIPTION
Replaces https://github.com/matrix-org/matrix-rust-sdk/pull/3701.  Part of invisible crypto.

The room event decryption function now takes a `DecryptionSetting` which allows you to require that event senders have a certain trust level based on their cross-signing status.  Events that do not meet the required trust level will fail to decrypt with an error.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
