### PR TITLE
indexeddb: Reinstate crypto store integration tests

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -1704,12 +1704,7 @@ mod wasm_unit_tests {
 
 #[cfg(all(test, target_arch = "wasm32"))]
 mod tests {
-    use matrix_sdk_crypto::{
-        cryptostore_integration_tests,
-        store::{Changes, CryptoStore as _, DeviceChanges, PendingChanges},
-        DeviceData,
-    };
-    use matrix_sdk_test::async_test;
+    use matrix_sdk_crypto::cryptostore_integration_tests;
 
     use super::IndexeddbCryptoStore;
 
@@ -1732,6 +1727,8 @@ mod tests {
                 .expect("Can't create store without passphrase"),
         }
     }
+
+    cryptostore_integration_tests!();
 }
 
 #[cfg(all(test, target_arch = "wasm32"))]


### PR DESCRIPTION
We are supposed to run the cryptostore integ tests twice for indexeddb: once with encryption enabled, and once without.

We are no longer running the tests without encryption. I think this was accidentally removed in [#3799](https://github.com/matrix-org/matrix-rust-sdk/pull/3799/commits/3dae56d34338086aa681e3a5a932a9f4c9d86570#diff-a6cc12d0312753050af771b6007b12f02f0997e8578eeb0a11a17df87f79817aL1804).