### PR TITLE
http client: don't infinitely retry network failures if there's no retry limit

### DIFF
--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -487,7 +487,10 @@ impl RoomSendQueue {
                     let is_recoverable = match err {
                         crate::Error::Http(ref http_err) => {
                             // All transient errors are recoverable.
-                            matches!(http_err.retry_kind(), RetryKind::Transient { .. })
+                            matches!(
+                                http_err.retry_kind(),
+                                RetryKind::Transient { .. } | RetryKind::NetworkFailure
+                            )
                         }
 
                         // `ConcurrentRequestFailed` typically happens because of an HTTP failure;


### PR DESCRIPTION
Otherwise, this would mean that logged out clients would infinitely repeat network requests failing in the background.

Without this fix, the added test will time out, endlessly reattempting network requests.

Closes #3901.