### PR TITLE
ffi: use the send queue for out-of-timeline edits

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -734,7 +734,7 @@ impl Room {
             .make_edit_event(&event_id, EditedContent::RoomMessage((*new_content).clone()))
             .await?;
 
-        self.inner.send(replacement_event).await?;
+        self.inner.send_queue().send(replacement_event).await?;
         Ok(())
     }
 }

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -569,12 +569,6 @@ struct RoomSendQueueInner {
     /// When an event has been sent to the server, it is removed from that queue
     /// *after* being sent. That way, we will retry sending upon failure, in
     /// the same order events have been inserted in the first place.
-    ///
-    /// In the future, this will be replaced by a database, and this field may
-    /// be removed. Instead of appending to that queue / updating its
-    /// content / deleting entries, all that will be required will be to
-    /// manipulate the on-disk storage. In other words, the storage will become
-    /// the one source of truth.
     queue: QueueStorage,
 
     /// A notifier that's updated any time common data is touched (stopped or


### PR DESCRIPTION
Tiny commits, see their descriptions.