### PR TITLE
indexeddb: simplify construction of `InboundGroupSessionIndexedDbObject`

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
@@ -99,11 +99,8 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
             );
 
             // Serialize the session in the new format
-            // This is much the same as [`IndexeddbStore::serialize_inbound_group_session`].
-            let new_value = InboundGroupSessionIndexedDbObject::new(
-                serializer.maybe_encrypt_value(session.pickle().await)?,
-                !session.backed_up(),
-            );
+            let new_value =
+                InboundGroupSessionIndexedDbObject::from_session(&session, serializer).await?;
 
             // Write it to the new store
             inbound_group_sessions3

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -1584,7 +1584,7 @@ struct GossipRequestIndexedDbObject {
     unsent: bool,
 }
 
-/// The objects we store in the inbound_group_sessions2 indexeddb object store
+/// The objects we store in the inbound_group_sessions3 indexeddb object store
 #[derive(serde::Serialize, serde::Deserialize)]
 struct InboundGroupSessionIndexedDbObject {
     /// Possibly encrypted


### PR DESCRIPTION
This PR has no functional changes -- it's just refactoring in preparation for later functional changes.

I'm soon going to be adding three more fields to `InboundGroupSessionIndexedDbObject`. Rather than keep adding more and more arguments to `InboundGroupSessionIndexedDbObject::new`, we might as well construct the object directly.

Futher, there are two copies of the same code to construct an `InboundGroupSessionIndexedDbObject` from an `InboundGroupSession`. Let's factor the common logic into a new function called `InboundGroupSessionIndexedDbObject::from_session`.