### PR TITLE
feat(sdk): Add `Client::server`

### DIFF
--- a/crates/matrix-sdk/src/client/builder/homeserver_config.rs
+++ b/crates/matrix-sdk/src/client/builder/homeserver_config.rs
@@ -1,0 +1,216 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ruma::{
+    api::{
+        client::discovery::{discover_homeserver, get_supported_versions},
+        MatrixVersion,
+    },
+    OwnedServerName, ServerName,
+};
+use tracing::debug;
+use url::Url;
+
+use crate::{
+    config::RequestConfig, http_client::HttpClient, sanitize_server_name, ClientBuildError,
+    HttpError,
+};
+
+/// Configuration for the homeserver.
+#[derive(Clone, Debug)]
+pub(super) enum HomeserverConfig {
+    /// A precise URL, including the protocol.
+    Url(String),
+
+    /// A host/port pair representing a server URL.
+    ServerName { server: OwnedServerName, protocol: UrlScheme },
+
+    /// First attempts to build as a server name, then falls back to a URL,
+    /// failing if no valid homeserver is found.
+    ServerNameOrUrl(String),
+}
+
+/// A simple helper to represent `http` or `https` in a URL.
+#[derive(Clone, Copy, Debug)]
+pub(super) enum UrlScheme {
+    Http,
+    Https,
+}
+
+/// The `Ok` result for `HomeserverConfig::discover`.
+pub(super) struct HomeserverDiscoveryResult {
+    pub server: Option<Url>,
+    pub homeserver: Url,
+    pub well_known: Option<discover_homeserver::Response>,
+    pub supported_versions: Option<get_supported_versions::Response>,
+}
+
+impl HomeserverConfig {
+    pub async fn discover(
+        &self,
+        http_client: &HttpClient,
+    ) -> Result<HomeserverDiscoveryResult, ClientBuildError> {
+        Ok(match self {
+            Self::Url(url) => {
+                let homeserver = Url::parse(url)?;
+
+                HomeserverDiscoveryResult {
+                    server: None, // We can't know the `server` if we only have a `homeserver`.
+                    homeserver,
+                    well_known: None,
+                    supported_versions: None,
+                }
+            }
+
+            Self::ServerName { server, protocol } => {
+                let (server, well_known) =
+                    discover_homeserver(server, protocol, http_client).await?;
+
+                HomeserverDiscoveryResult {
+                    server: Some(server),
+                    homeserver: Url::parse(&well_known.homeserver.base_url)?,
+                    well_known: Some(well_known),
+                    supported_versions: None,
+                }
+            }
+
+            Self::ServerNameOrUrl(server_name_or_url) => {
+                let (server, homeserver, well_known, supported_versions) =
+                    discover_homeserver_from_server_name_or_url(
+                        server_name_or_url.to_owned(),
+                        http_client,
+                    )
+                    .await?;
+
+                HomeserverDiscoveryResult {
+                    server: Some(server),
+                    homeserver,
+                    well_known,
+                    supported_versions,
+                }
+            }
+        })
+    }
+}
+
+/// Discovers a homeserver from a server name or a URL.
+///
+/// Tries well-known discovery and checking if the URL points to a homeserver.
+async fn discover_homeserver_from_server_name_or_url(
+    mut server_name_or_url: String,
+    http_client: &HttpClient,
+) -> Result<
+    (Url, Url, Option<discover_homeserver::Response>, Option<get_supported_versions::Response>),
+    ClientBuildError,
+> {
+    let mut discovery_error: Option<ClientBuildError> = None;
+
+    // Attempt discovery as a server name first.
+    let sanitize_result = sanitize_server_name(&server_name_or_url);
+
+    if let Ok(server_name) = sanitize_result.as_ref() {
+        let protocol = if server_name_or_url.starts_with("http://") {
+            UrlScheme::Http
+        } else {
+            UrlScheme::Https
+        };
+
+        match discover_homeserver(server_name, &protocol, http_client).await {
+            Ok((server, well_known)) => {
+                return Ok((
+                    server,
+                    Url::parse(&well_known.homeserver.base_url)?,
+                    Some(well_known),
+                    None,
+                ));
+            }
+            Err(e) => {
+                debug!(error = %e, "Well-known discovery failed.");
+                discovery_error = Some(e);
+
+                // Check if the server name points to a homeserver.
+                server_name_or_url = match protocol {
+                    UrlScheme::Http => format!("http://{server_name}"),
+                    UrlScheme::Https => format!("https://{server_name}"),
+                }
+            }
+        }
+    }
+
+    // When discovery fails, or the input isn't a valid server name, fallback to
+    // trying a homeserver URL.
+    if let Ok(homeserver_url) = Url::parse(&server_name_or_url) {
+        // Make sure the URL is definitely for a homeserver.
+        match get_supported_versions(&homeserver_url, http_client).await {
+            Ok(response) => {
+                return Ok((homeserver_url.clone(), homeserver_url, None, Some(response)));
+            }
+            Err(e) => {
+                debug!(error = %e, "Checking supported versions failed.");
+            }
+        }
+    }
+
+    Err(discovery_error.unwrap_or(ClientBuildError::InvalidServerName))
+}
+
+/// Discovers a homeserver by looking up the well-known at the supplied server
+/// name.
+async fn discover_homeserver(
+    server_name: &ServerName,
+    protocol: &UrlScheme,
+    http_client: &HttpClient,
+) -> Result<(Url, discover_homeserver::Response), ClientBuildError> {
+    debug!("Trying to discover the homeserver");
+
+    let server = Url::parse(&match protocol {
+        UrlScheme::Http => format!("http://{server_name}"),
+        UrlScheme::Https => format!("https://{server_name}"),
+    })?;
+
+    let well_known = http_client
+        .send(
+            discover_homeserver::Request::new(),
+            Some(RequestConfig::short_retry()),
+            server.to_string(),
+            None,
+            &[MatrixVersion::V1_0],
+            Default::default(),
+        )
+        .await
+        .map_err(|e| match e {
+            HttpError::Api(err) => ClientBuildError::AutoDiscovery(err),
+            err => ClientBuildError::Http(err),
+        })?;
+
+    debug!(homeserver_url = well_known.homeserver.base_url, "Discovered the homeserver");
+
+    Ok((server, well_known))
+}
+
+pub(super) async fn get_supported_versions(
+    homeserver_url: &Url,
+    http_client: &HttpClient,
+) -> Result<get_supported_versions::Response, HttpError> {
+    http_client
+        .send(
+            get_supported_versions::Request::new(),
+            Some(RequestConfig::short_retry()),
+            homeserver_url.to_string(),
+            None,
+            &[MatrixVersion::V1_0],
+            Default::default(),
+        )
+        .await
+}

--- a/crates/matrix-sdk/src/client/builder/homeserver_config.rs
+++ b/crates/matrix-sdk/src/client/builder/homeserver_config.rs
@@ -30,14 +30,14 @@ use crate::{
 /// Configuration for the homeserver.
 #[derive(Clone, Debug)]
 pub(super) enum HomeserverConfig {
-    /// A precise URL, including the protocol.
+    /// A homeserver name URL, including the protocol.
     Url(String),
 
-    /// A host/port pair representing a server URL.
+    /// A server name, with the protocol put apart.
     ServerName { server: OwnedServerName, protocol: UrlScheme },
 
-    /// First attempts to build as a server URL, then falls back to a
-    /// homeserver URL, failing if no valid homeserver is found.
+    /// A server name with or without the protocol (it will fallback to `https`
+    /// if absent), or a homeserver URL.
     ServerNameOrUrl(String),
 }
 

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -13,21 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod homeserver_config;
+
 use std::{fmt, sync::Arc};
 
+use homeserver_config::*;
 use matrix_sdk_base::{store::StoreConfig, BaseClient};
 use ruma::{
-    api::{
-        client::discovery::{discover_homeserver, get_supported_versions},
-        error::FromHttpResponseError,
-        MatrixVersion,
-    },
+    api::{error::FromHttpResponseError, MatrixVersion},
     OwnedServerName, ServerName,
 };
 use thiserror::Error;
 use tokio::sync::{broadcast, Mutex, OnceCell};
 use tracing::{debug, field::debug, instrument, Span};
-use url::Url;
 
 use super::{Client, ClientInner};
 #[cfg(feature = "e2e-encryption")]
@@ -527,67 +525,6 @@ impl ClientBuilder {
     }
 }
 
-/// Discovers a homeserver from a server name or a URL.
-///
-/// Tries well-known discovery and checking if the URL points to a homeserver.
-async fn discover_homeserver_from_server_name_or_url(
-    mut server_name_or_url: String,
-    http_client: &HttpClient,
-) -> Result<
-    (Url, Url, Option<discover_homeserver::Response>, Option<get_supported_versions::Response>),
-    ClientBuildError,
-> {
-    let mut discovery_error: Option<ClientBuildError> = None;
-
-    // Attempt discovery as a server name first.
-    let sanitize_result = sanitize_server_name(&server_name_or_url);
-
-    if let Ok(server_name) = sanitize_result.as_ref() {
-        let protocol = if server_name_or_url.starts_with("http://") {
-            UrlScheme::Http
-        } else {
-            UrlScheme::Https
-        };
-
-        match discover_homeserver(server_name, &protocol, http_client).await {
-            Ok((server, well_known)) => {
-                return Ok((
-                    server,
-                    Url::parse(&well_known.homeserver.base_url)?,
-                    Some(well_known),
-                    None,
-                ));
-            }
-            Err(e) => {
-                debug!(error = %e, "Well-known discovery failed.");
-                discovery_error = Some(e);
-
-                // Check if the server name points to a homeserver.
-                server_name_or_url = match protocol {
-                    UrlScheme::Http => format!("http://{server_name}"),
-                    UrlScheme::Https => format!("https://{server_name}"),
-                }
-            }
-        }
-    }
-
-    // When discovery fails, or the input isn't a valid server name, fallback to
-    // trying a homeserver URL.
-    if let Ok(homeserver_url) = Url::parse(&server_name_or_url) {
-        // Make sure the URL is definitely for a homeserver.
-        match get_supported_versions(&homeserver_url, http_client).await {
-            Ok(response) => {
-                return Ok((homeserver_url.clone(), homeserver_url, None, Some(response)));
-            }
-            Err(e) => {
-                debug!(error = %e, "Checking supported versions failed.");
-            }
-        }
-    }
-
-    Err(discovery_error.unwrap_or(ClientBuildError::InvalidServerName))
-}
-
 /// Creates a server name from a user supplied string. The string is first
 /// sanitized by removing whitespace, the http(s) scheme and any trailing
 /// slashes before being parsed.
@@ -595,56 +532,6 @@ pub fn sanitize_server_name(s: &str) -> crate::Result<OwnedServerName, IdParseEr
     ServerName::parse(
         s.trim().trim_start_matches("http://").trim_start_matches("https://").trim_end_matches('/'),
     )
-}
-
-/// Discovers a homeserver by looking up the well-known at the supplied server
-/// name.
-async fn discover_homeserver(
-    server_name: &ServerName,
-    protocol: &UrlScheme,
-    http_client: &HttpClient,
-) -> Result<(Url, discover_homeserver::Response), ClientBuildError> {
-    debug!("Trying to discover the homeserver");
-
-    let server = Url::parse(&match protocol {
-        UrlScheme::Http => format!("http://{server_name}"),
-        UrlScheme::Https => format!("https://{server_name}"),
-    })?;
-
-    let well_known = http_client
-        .send(
-            discover_homeserver::Request::new(),
-            Some(RequestConfig::short_retry()),
-            server.to_string(),
-            None,
-            &[MatrixVersion::V1_0],
-            Default::default(),
-        )
-        .await
-        .map_err(|e| match e {
-            HttpError::Api(err) => ClientBuildError::AutoDiscovery(err),
-            err => ClientBuildError::Http(err),
-        })?;
-
-    debug!(homeserver_url = well_known.homeserver.base_url, "Discovered the homeserver");
-
-    Ok((server, well_known))
-}
-
-async fn get_supported_versions(
-    homeserver_url: &Url,
-    http_client: &HttpClient,
-) -> Result<get_supported_versions::Response, HttpError> {
-    http_client
-        .send(
-            get_supported_versions::Request::new(),
-            Some(RequestConfig::short_retry()),
-            homeserver_url.to_string(),
-            None,
-            &[MatrixVersion::V1_0],
-            Default::default(),
-        )
-        .await
 }
 
 #[allow(clippy::unused_async)] // False positive when building with !sqlite & !indexeddb
@@ -719,80 +606,6 @@ async fn build_indexeddb_store_config(
     _passphrase: Option<&str>,
 ) -> Result<StoreConfig, ClientBuildError> {
     panic!("the IndexedDB is only available on the 'wasm32' arch")
-}
-
-#[derive(Clone, Copy, Debug)]
-enum UrlScheme {
-    Http,
-    Https,
-}
-
-#[derive(Clone, Debug)]
-enum HomeserverConfig {
-    /// A precise URL, including the protocol.
-    Url(String),
-
-    /// A host/port pair representing a server URL.
-    ServerName { server: OwnedServerName, protocol: UrlScheme },
-
-    /// First attempts to build as a server name, then falls back to a URL,
-    /// failing if no valid homeserver is found.
-    ServerNameOrUrl(String),
-}
-
-struct HomeserverDiscoveryResult {
-    server: Option<Url>,
-    homeserver: Url,
-    well_known: Option<discover_homeserver::Response>,
-    supported_versions: Option<get_supported_versions::Response>,
-}
-
-impl HomeserverConfig {
-    async fn discover(
-        &self,
-        http_client: &HttpClient,
-    ) -> Result<HomeserverDiscoveryResult, ClientBuildError> {
-        Ok(match self {
-            Self::Url(url) => {
-                let homeserver = Url::parse(url)?;
-
-                HomeserverDiscoveryResult {
-                    server: None, // We can't know the `server` if we only have a `homeserver`.
-                    homeserver,
-                    well_known: None,
-                    supported_versions: None,
-                }
-            }
-
-            Self::ServerName { server, protocol } => {
-                let (server, well_known) =
-                    discover_homeserver(server, protocol, http_client).await?;
-
-                HomeserverDiscoveryResult {
-                    server: Some(server),
-                    homeserver: Url::parse(&well_known.homeserver.base_url)?,
-                    well_known: Some(well_known),
-                    supported_versions: None,
-                }
-            }
-
-            Self::ServerNameOrUrl(server_name_or_url) => {
-                let (server, homeserver, well_known, supported_versions) =
-                    discover_homeserver_from_server_name_or_url(
-                        server_name_or_url.to_owned(),
-                        http_client,
-                    )
-                    .await?;
-
-                HomeserverDiscoveryResult {
-                    server: Some(server),
-                    homeserver,
-                    well_known,
-                    supported_versions,
-                }
-            }
-        })
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -920,6 +733,7 @@ pub(crate) mod tests {
     use assert_matches::assert_matches;
     use matrix_sdk_test::{async_test, test_json};
     use serde_json::{json_internal, Value as JsonValue};
+    use url::Url;
     use wiremock::{
         matchers::{method, path},
         Mock, MockServer, ResponseTemplate,


### PR DESCRIPTION
This patch adds `Client::server` as an `Option<Url>`. This should not be confused with the `homeserver`. For example, in the case of Matrix, `matrix.org` is the server, and `matrix-client.matrix.org` is the homeserver.

This patch should be reviewed commit-by-commit for the sake of simplicity. Code is moved into their own module for clarity.