### PR TITLE
send queue: allow unwedging and retry after recipient trust changes

### DIFF
--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -134,14 +134,14 @@ impl From<EventCacheError> for ClientError {
     }
 }
 
-impl From<RoomSendQueueError> for ClientError {
-    fn from(e: RoomSendQueueError) -> Self {
+impl From<EditError> for ClientError {
+    fn from(e: EditError) -> Self {
         Self::new(e)
     }
 }
 
-impl From<EditError> for ClientError {
-    fn from(e: EditError) -> Self {
+impl From<RoomSendQueueError> for ClientError {
+    fn from(e: RoomSendQueueError) -> Self {
         Self::new(e)
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1331,6 +1331,10 @@ impl<P: RoomDataProvider> TimelineController<P> {
                 .await;
             }
 
+            RoomSendQueueUpdate::RetryEvent { transaction_id } => {
+                self.update_event_send_state(&transaction_id, EventSendState::NotSentYet).await;
+            }
+
             RoomSendQueueUpdate::SentEvent { transaction_id, event_id } => {
                 self.update_event_send_state(&transaction_id, EventSendState::Sent { event_id })
                     .await;

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -15,7 +15,7 @@
 use std::collections::BTreeMap;
 
 use matrix_sdk_base::{
-    crypto::{types::MasterPubkey, UserIdentities as CryptoUserIdentities},
+    crypto::{types::MasterPubkey, CryptoStoreError, UserIdentities as CryptoUserIdentities},
     RoomMemberships,
 };
 use ruma::{
@@ -351,6 +351,15 @@ impl UserIdentity {
     /// ```
     pub fn is_verified(&self) -> bool {
         self.inner.identity.is_verified()
+    }
+
+    /// Remove the requirement for this identity to be verified.
+    ///
+    /// If an identity was previously verified and is not any more it will be
+    /// reported to the user. In order to remove this notice users have to
+    /// verify again or to withdraw the verification requirement.
+    pub async fn withdraw_verification(&self) -> Result<(), CryptoStoreError> {
+        self.inner.identity.withdraw_verification().await
     }
 
     /// Get the public part of the Master key of this user identity.

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -568,6 +568,11 @@ impl RoomSendQueue {
 
         self.inner.notifier.notify_one();
 
+        let _ = self
+            .inner
+            .updates
+            .send(RoomSendQueueUpdate::RetryEvent { transaction_id: transaction_id.to_owned() });
+
         Ok(())
     }
 }
@@ -1192,6 +1197,12 @@ pub enum RoomSendQueueUpdate {
         /// while an unrecoverable error will be parked, until the user
         /// decides to cancel sending it.
         is_recoverable: bool,
+    },
+
+    /// The event has been unwedged and sending is now being retried.
+    RetryEvent {
+        /// Transaction id used to identify this event.
+        transaction_id: OwnedTransactionId,
     },
 
     /// The event has been sent to the server, and the query returned

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -566,6 +566,7 @@ impl RoomSendQueue {
             .await
             .map_err(RoomSendQueueError::StorageError)?;
 
+        // Wake up the queue, in case the room was asleep before unwedging the event.
         self.inner.notifier.notify_one();
 
         let _ = self
@@ -693,7 +694,7 @@ impl QueueStorage {
     }
 
     /// Marks an event identified with the given transaction id as being now
-    /// unwedged and adds it back to the queue
+    /// unwedged and adds it back to the queue.
     async fn mark_as_unwedged(
         &self,
         transaction_id: &TransactionId,

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1490,7 +1490,7 @@ async fn test_unwedge_unrecoverable_errors() {
     assert!(client.send_queue().is_enabled());
 
     // Unwedge the previously failed message and try sending it again
-    let _ = q.unwedge(&txn1).await;
+    q.unwedge(&txn1).await.unwrap();
 
     // The message should be retried
     assert_update!(watch => retry { txn=txn1 });


### PR DESCRIPTION
* add a generic mechanism for unwedging and resending requests based on their transaction identifier
* expose methods for manually withdrawing certain users' verification or trusting their devices and resending failed messages

This will be used in conjunction with the send errors introduced in https://github.com/matrix-org/matrix-rust-sdk/pull/3866 to allow the user to force resend failed messages after manually resolving trust issues.

Fixes #3839, fixes #3838, fixes #3837.