### PR TITLE
timeline: allow all foci to handle local echoes

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -267,7 +267,7 @@ pub(super) struct TimelineEventHandler<'a, 'o> {
 }
 
 /// Types of live updates expected in this timeline.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum LiveTimelineUpdatesAllowed {
     All,
     PinnedEvents,
@@ -284,7 +284,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             items,
             meta,
             ctx,
-            live_timeline_updates_type: live_timeline_updates_type.clone(),
+            live_timeline_updates_type: *live_timeline_updates_type,
             result: HandleEventResult::default(),
         }
     }
@@ -312,8 +312,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 span.record("txn_id", debug(txn_id));
                 debug!("Handling local event");
 
-                // Only add new timeline items if we're in the live mode, i.e. not in the
-                // event-focused mode.
+                // Only add new timeline items if we're in the live mode.
                 matches!(self.live_timeline_updates_type, LiveTimelineUpdatesAllowed::All)
             }
 

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -242,8 +242,9 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
         is_room_encrypted: bool,
     ) -> Self {
-        let (focus_data, is_live) = match focus {
+        let (focus_data, allowed_live_updates) = match focus {
             TimelineFocus::Live => (TimelineFocusData::Live, LiveTimelineUpdatesAllowed::All),
+
             TimelineFocus::Event { target, num_context_events } => {
                 let paginator = Paginator::new(room_data_provider.clone());
                 (
@@ -251,6 +252,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
                     LiveTimelineUpdatesAllowed::None,
                 )
             }
+
             TimelineFocus::PinnedEvents { max_events_to_load } => (
                 TimelineFocusData::PinnedEvents {
                     loader: PinnedEventsLoader::new(
@@ -264,7 +266,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 
         let state = TimelineInnerState::new(
             room_data_provider.room_version(),
-            is_live,
+            allowed_live_updates,
             internal_id_prefix,
             unable_to_decrypt_hook,
             is_room_encrypted,

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -271,7 +271,7 @@ impl TimelineInnerState {
             items,
             previous_meta: &mut self.meta,
             meta,
-            live_timeline_updates_type: self.live_timeline_updates_type.clone(),
+            live_timeline_updates_type: self.live_timeline_updates_type,
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -858,7 +858,7 @@ struct TimelineDropHandle {
     room_update_join_handle: JoinHandle<()>,
     pinned_events_join_handle: Option<JoinHandle<()>>,
     room_key_from_backups_join_handle: JoinHandle<()>,
-    local_echo_listener_handle: Option<JoinHandle<()>>,
+    local_echo_listener_handle: JoinHandle<()>,
     _event_cache_drop_handle: Arc<EventCacheDropHandles>,
 }
 
@@ -867,12 +867,10 @@ impl Drop for TimelineDropHandle {
         for handle in self.event_handler_handles.drain(..) {
             self.client.remove_event_handler(handle);
         }
-        if let Some(handle) = self.local_echo_listener_handle.take() {
-            handle.abort()
-        };
         if let Some(handle) = self.pinned_events_join_handle.take() {
             handle.abort()
         };
+        self.local_echo_listener_handle.abort();
         self.room_update_join_handle.abort();
         self.room_key_from_backups_join_handle.abort();
     }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -20,7 +20,7 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{
-    assert_let_timeout,
+    assert_next_matches_with_timeout,
     config::SyncSettings,
     test_utils::{events::EventFactory, logged_in_client_with_server},
 };
@@ -30,6 +30,7 @@ use matrix_sdk_test::{
 use matrix_sdk_ui::{timeline::TimelineFocus, Timeline};
 use ruma::{event_id, events::room::message::RoomMessageEventContent, room_id};
 use stream_assert::assert_pending;
+use tokio::time::sleep;
 
 use crate::{mock_context, mock_messages, mock_sync};
 
@@ -249,7 +250,7 @@ async fn test_focused_timeline_reacts() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let_timeout!(Some(VectorDiff::Set { index: 1, value: item }) = timeline_stream.next());
+    let item = assert_next_matches_with_timeout!(timeline_stream, VectorDiff::Set { index: 1, value: item } => item);
 
     let event_item = item.as_event().unwrap();
     // Text hasn't changed.
@@ -258,6 +259,82 @@ async fn test_focused_timeline_reacts() {
     assert_eq!(event_item.reactions().len(), 1);
 
     // And nothing more.
+    assert_pending!(timeline_stream);
+}
+
+#[async_test]
+async fn test_focused_timeline_local_echoes() {
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let (client, server) = logged_in_client_with_server().await;
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    let mut sync_response_builder = SyncResponseBuilder::new();
+    sync_response_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+
+    // Mark the room as joined.
+    mock_sync(&server, sync_response_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    // Start a focused timeline.
+    let f = EventFactory::new().room(room_id);
+    let target_event = event_id!("$1");
+
+    mock_context(
+        &server,
+        room_id,
+        target_event,
+        None,
+        vec![],
+        f.text_msg("yolo").event_id(target_event).sender(*BOB).into_timeline(),
+        vec![],
+        None,
+        vec![],
+    )
+    .await;
+
+    mock_encryption_state(&server, false).await;
+
+    let room = client.get_room(room_id).unwrap();
+    let timeline = Timeline::builder(&room)
+        .with_focus(TimelineFocus::Event {
+            target: target_event.to_owned(),
+            num_context_events: 20,
+        })
+        .build()
+        .await
+        .unwrap();
+
+    server.reset().await;
+
+    let (items, mut timeline_stream) = timeline.subscribe().await;
+
+    assert_eq!(items.len(), 1 + 1); // event items + a day divider
+    assert!(items[0].is_day_divider());
+
+    let event_item = items[1].as_event().unwrap();
+    assert_eq!(event_item.content().as_message().unwrap().body(), "yolo");
+    assert_eq!(event_item.reactions().len(), 0);
+
+    sleep(Duration::from_millis(100)).await;
+    assert_pending!(timeline_stream);
+
+    // Add a reaction to the focused event, which will cause a local echo to happen.
+    timeline.toggle_reaction(items[1].unique_id(), "✨").await.unwrap();
+
+    // We immediately get the local echo for the reaction.
+    let item = assert_next_matches_with_timeout!(timeline_stream, VectorDiff::Set { index: 1, value: item } => item);
+
+    let event_item = item.as_event().unwrap();
+    // Text hasn't changed.
+    assert_eq!(event_item.content().as_message().unwrap().body(), "yolo");
+    // But now there's one reaction to the event.
+    let reactions = event_item.reactions();
+    assert_eq!(reactions.len(), 1);
+    assert!(reactions.get("✨").unwrap().get(client.user_id().unwrap()).is_some());
+
+    // And nothing more.
+    sleep(Duration::from_millis(100)).await;
     assert_pending!(timeline_stream);
 }
 
@@ -321,7 +398,7 @@ async fn test_focused_timeline_doesnt_show_local_echoes() {
     timeline.send(RoomMessageEventContent::text_plain("h4xx0r").into()).await.unwrap();
 
     // Let a bit of time for the send queue to process the event.
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    sleep(Duration::from_millis(300)).await;
 
     // And nothing more.
     assert_pending!(timeline_stream);


### PR DESCRIPTION
There's already the right logic to not *add* new timeline items to a non-live timeline, so adding a message etc. will not show it in a pinned / permalinked timeline. On the other hand, *updating* a timeline item (reaction/redaction/edit) will affect it, no matter the type. So we can handle local echoes of those types for those timeline items, such that they're displayed in real-time on all foci.

The added test would fail before the patch.