### PR TITLE
timeline: simplify `should_add` management, and document it better

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -105,6 +105,12 @@ pub(super) struct TimelineEventContext {
     pub(super) read_receipts: IndexMap<OwnedUserId, Receipt>,
     pub(super) is_highlighted: bool,
     pub(super) flow: Flow,
+
+    /// If the event represents a new item, should it be added to the timeline?
+    ///
+    /// This controls whether a new timeline *may* be added. If the update kind
+    /// is about an update to an existing timeline item (redaction, edit,
+    /// reaction, etc.), it's always handled by default.
     pub(super) should_add_new_items: bool,
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -263,14 +263,6 @@ pub(super) struct TimelineEventHandler<'a, 'o> {
     result: HandleEventResult,
 }
 
-/// Types of live updates expected in this timeline.
-#[derive(Debug, Clone, Copy)]
-pub enum LiveTimelineUpdatesAllowed {
-    All,
-    PinnedEvents,
-    None,
-}
-
 impl<'a, 'o> TimelineEventHandler<'a, 'o> {
     pub(super) fn new(
         state: &'a mut TimelineInnerStateTransaction<'o>,

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -691,16 +691,12 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         let sender = self.room_data_provider.own_user_id().to_owned();
         let profile = self.room_data_provider.profile_from_user_id(&sender).await;
 
+        // Only add new items if the timeline is live.
+        let should_add_new_items = self.is_live().await;
+
         let mut state = self.state.write().await;
         state
-            .handle_local_event(
-                sender,
-                profile,
-                txn_id,
-                send_handle,
-                content,
-                &self.room_data_provider,
-            )
+            .handle_local_event(sender, profile, should_add_new_items, txn_id, send_handle, content)
             .await;
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -24,8 +24,6 @@ use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedEventId};
 use thiserror::Error;
 use tracing::{debug, warn};
 
-use crate::timeline::event_handler::TimelineEventKind;
-
 const MAX_CONCURRENT_REQUESTS: usize = 10;
 
 /// Utility to load the pinned events in a room.
@@ -130,22 +128,6 @@ pub trait PinnedEventsRoom: SendOutsideWasm + SyncOutsideWasm {
     /// It avoids having to clone the whole list of event ids to check a single
     /// value.
     fn is_pinned_event(&self, event_id: &EventId) -> bool;
-
-    /// Returns whether the passed `event_kind` is either an edit or a redaction
-    /// of a pinned event.
-    fn is_replacement_for_pinned_event(&self, event_kind: &TimelineEventKind) -> bool {
-        match event_kind {
-            TimelineEventKind::Message { relations, .. } => {
-                if let Some(orig_ev) = &relations.replace {
-                    self.is_pinned_event(orig_ev.event_id())
-                } else {
-                    false
-                }
-            }
-            TimelineEventKind::Redaction { redacts } => self.is_pinned_event(redacts),
-            _ => false,
-        }
-    }
 }
 
 impl PinnedEventsRoom for Room {


### PR DESCRIPTION
Tidying up and resolves potential bugs around handling of read receipts in theory.