### PR TITLE
testing: enforce a `test_` prefix for tests

### DIFF
--- a/crates/matrix-sdk-common/src/timeout.rs
+++ b/crates/matrix-sdk-common/src/timeout.rs
@@ -70,14 +70,14 @@ pub(crate) mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[async_test]
-    async fn without_timeout() {
+    async fn test_without_timeout() {
         timeout(future::ready(()), Duration::from_millis(100))
             .await
             .expect("future should have completed without ElapsedError");
     }
 
     #[async_test]
-    async fn with_timeout() {
+    async fn test_with_timeout() {
         timeout(future::pending::<()>(), Duration::from_millis(100))
             .await
             .expect_err("future should return an ElapsedError");

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -745,7 +745,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn memory_store_backups() -> Result<(), OlmError> {
+    async fn test_memory_store_backups() -> Result<(), OlmError> {
         let machine = OlmMachine::new(alice_id(), alice_device_id()).await;
 
         backup_flow(machine).await
@@ -831,7 +831,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn import_backed_up_room_keys() {
+    async fn test_import_backed_up_room_keys() {
         let machine = OlmMachine::new(alice_id(), alice_device_id()).await;
         let backup_machine = machine.backup_machine();
 
@@ -880,7 +880,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn sign_backup_info() {
+    async fn test_sign_backup_info() {
         let machine = OlmMachine::new(alice_id(), alice_device_id()).await;
         let backup_machine = machine.backup_machine();
 

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1359,14 +1359,14 @@ mod tests {
     }
 
     #[async_test]
-    async fn create_machine() {
+    async fn test_create_machine() {
         let machine = get_machine_test_helper().await;
 
         assert!(machine.outgoing_to_device_requests().await.unwrap().is_empty());
     }
 
     #[async_test]
-    async fn re_request_keys() {
+    async fn test_re_request_keys() {
         let machine = get_machine_test_helper().await;
         let account = account();
 
@@ -1389,7 +1389,7 @@ mod tests {
 
     #[async_test]
     #[cfg(feature = "automatic-room-key-forwarding")]
-    async fn create_key_request() {
+    async fn test_create_key_request() {
         let machine = get_machine_test_helper().await;
         let account = account();
         let second_account = alice_2_account();
@@ -1422,7 +1422,7 @@ mod tests {
     /// We should *not* request keys if that has been disabled
     #[async_test]
     #[cfg(feature = "automatic-room-key-forwarding")]
-    async fn create_key_request_requests_disabled() {
+    async fn test_create_key_request_requests_disabled() {
         let machine = get_machine_test_helper().await;
         let account = account();
         let second_account = alice_2_account();
@@ -1450,7 +1450,7 @@ mod tests {
 
     #[async_test]
     #[cfg(feature = "automatic-room-key-forwarding")]
-    async fn receive_forwarded_key() {
+    async fn test_receive_forwarded_key() {
         let machine = get_machine_test_helper().await;
         let account = account();
 

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1425,7 +1425,7 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn own_device_with_private_identity() {
+    async fn test_own_device_with_private_identity() {
         let response = own_key_query();
         let (_, device) = device(&response);
 
@@ -1542,7 +1542,7 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn resolve_identity_pin_violation_with_verification() {
+    async fn test_resolve_identity_pin_violation_with_verification() {
         use test_json::keys_query_sets::IdentityChangeDataSet as DataSet;
 
         let my_user_id = user_id!("@me:localhost");
@@ -1610,7 +1610,7 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn resolve_identity_verification_violation_with_withdraw() {
+    async fn test_resolve_identity_verification_violation_with_withdraw() {
         use test_json::keys_query_sets::PreviouslyVerifiedTestData as DataSet;
 
         let machine = OlmMachine::new(DataSet::own_id(), device_id!("LOCAL")).await;
@@ -1650,7 +1650,7 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn reset_own_keys_creates_verification_violation() {
+    async fn test_reset_own_keys_creates_verification_violation() {
         use test_json::keys_query_sets::PreviouslyVerifiedTestData as DataSet;
 
         let machine = OlmMachine::new(DataSet::own_id(), device_id!("LOCAL")).await;
@@ -1691,7 +1691,7 @@ pub(crate) mod tests {
     /// Test that receiving new public keys for our own identity causes a
     /// verification violation on our own identity.
     #[async_test]
-    async fn own_keys_update_creates_own_identity_verification_violation() {
+    async fn test_own_keys_update_creates_own_identity_verification_violation() {
         use test_json::keys_query_sets::PreviouslyVerifiedTestData as DataSet;
 
         let machine = OlmMachine::new(DataSet::own_id(), device_id!("LOCAL")).await;

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -1006,7 +1006,7 @@ async fn test_room_key_with_fake_identity_keys() {
 }
 
 #[async_test]
-async fn importing_private_cross_signing_keys_verifies_the_public_identity() {
+async fn test_importing_private_cross_signing_keys_verifies_the_public_identity() {
     async fn create_additional_machine(machine: &OlmMachine) -> OlmMachine {
         let second_machine = OlmMachine::new(machine.user_id(), "ADDITIONAL_MACHINE".into()).await;
 

--- a/crates/matrix-sdk-crypto/src/machine/tests/room_settings.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/room_settings.rs
@@ -10,14 +10,14 @@ use crate::{
 };
 
 #[async_test]
-async fn room_settings_returns_none_for_unknown_room() {
+async fn test_room_settings_returns_none_for_unknown_room() {
     let machine = OlmMachine::new(tests::user_id(), tests::alice_device_id()).await;
     let settings = machine.room_settings(room_id!("!test2:localhost")).await.unwrap();
     assert!(settings.is_none());
 }
 
 #[async_test]
-async fn stores_and_returns_room_settings() {
+async fn test_stores_and_returns_room_settings() {
     let machine = OlmMachine::new(tests::user_id(), tests::alice_device_id()).await;
     let room_id = room_id!("!test:localhost");
 
@@ -33,7 +33,7 @@ async fn stores_and_returns_room_settings() {
 }
 
 #[async_test]
-async fn set_room_settings_rejects_invalid_algorithms() {
+async fn test_set_room_settings_rejects_invalid_algorithms() {
     let machine = OlmMachine::new(tests::user_id(), tests::alice_device_id()).await;
     let room_id = room_id!("!test:localhost");
 
@@ -51,7 +51,7 @@ async fn set_room_settings_rejects_invalid_algorithms() {
 }
 
 #[async_test]
-async fn set_room_settings_rejects_changes() {
+async fn test_set_room_settings_rejects_changes() {
     let machine = OlmMachine::new(tests::user_id(), tests::alice_device_id()).await;
     let room_id = room_id!("!test:localhost");
 
@@ -77,7 +77,7 @@ async fn set_room_settings_rejects_changes() {
 }
 
 #[async_test]
-async fn set_room_settings_accepts_noop_changes() {
+async fn test_set_room_settings_accepts_noop_changes() {
     let machine = OlmMachine::new(tests::user_id(), tests::alice_device_id()).await;
     let room_id = room_id!("!test:localhost");
 

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -1667,7 +1667,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn fallback_key_signature_verification() -> Result<()> {
+    async fn test_fallback_key_signature_verification() -> Result<()> {
         let fallback_key = json!({
             "fallback": true,
             "key": "XPFqtLvBepBmW6jSAbBuJbhEpprBhQOX1IjUu+cnMF4",

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -840,7 +840,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn session_comparison() {
+    async fn test_session_comparison() {
         let alice = Account::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
 

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -833,7 +833,7 @@ mod tests {
         const TWO_HOURS: Duration = Duration::from_secs(60 * 60 * 2);
 
         #[async_test]
-        async fn session_is_not_expired_if_no_messages_sent_and_no_time_passed() {
+        async fn test_session_is_not_expired_if_no_messages_sent_and_no_time_passed() {
             // Given a session that expires after one message
             let session = create_session(EncryptionSettings {
                 rotation_period_msgs: 1,
@@ -848,7 +848,7 @@ mod tests {
         }
 
         #[async_test]
-        async fn session_is_expired_if_we_rotate_every_message_and_one_was_sent(
+        async fn test_session_is_expired_if_we_rotate_every_message_and_one_was_sent(
         ) -> Result<(), MegolmError> {
             // Given a session that expires after one message
             let session = create_session(EncryptionSettings {
@@ -872,7 +872,7 @@ mod tests {
         }
 
         #[async_test]
-        async fn session_with_rotation_period_is_not_expired_after_no_time() {
+        async fn test_session_with_rotation_period_is_not_expired_after_no_time() {
             // Given a session with a 2h expiration
             let session = create_session(EncryptionSettings {
                 rotation_period: TWO_HOURS,
@@ -887,7 +887,7 @@ mod tests {
         }
 
         #[async_test]
-        async fn session_is_expired_after_rotation_period() {
+        async fn test_session_is_expired_after_rotation_period() {
             // Given a session with a 2h expiration
             let mut session = create_session(EncryptionSettings {
                 rotation_period: TWO_HOURS,
@@ -905,7 +905,7 @@ mod tests {
 
         #[async_test]
         #[cfg(not(feature = "_disable-minimum-rotation-period-ms"))]
-        async fn session_does_not_expire_under_one_hour_even_if_we_ask_for_shorter() {
+        async fn test_session_does_not_expire_under_one_hour_even_if_we_ask_for_shorter() {
             // Given a session with a 100ms expiration
             let mut session = create_session(EncryptionSettings {
                 rotation_period: Duration::from_millis(100),
@@ -929,7 +929,7 @@ mod tests {
 
         #[async_test]
         #[cfg(feature = "_disable-minimum-rotation-period-ms")]
-        async fn with_disable_minrotperiod_feature_sessions_can_expire_quickly() {
+        async fn test_with_disable_minrotperiod_feature_sessions_can_expire_quickly() {
             // Given a session with a 100ms expiration
             let mut session = create_session(EncryptionSettings {
                 rotation_period: Duration::from_millis(100),
@@ -947,7 +947,7 @@ mod tests {
         }
 
         #[async_test]
-        async fn session_with_zero_msgs_rotation_is_not_expired_initially() {
+        async fn test_session_with_zero_msgs_rotation_is_not_expired_initially() {
             // Given a session that is supposed to expire after zero messages
             let session = create_session(EncryptionSettings {
                 rotation_period_msgs: 0,
@@ -963,7 +963,7 @@ mod tests {
         }
 
         #[async_test]
-        async fn session_with_zero_msgs_rotation_expires_after_one_message(
+        async fn test_session_with_zero_msgs_rotation_expires_after_one_message(
         ) -> Result<(), MegolmError> {
             // Given a session that is supposed to expire after zero messages
             let session = create_session(EncryptionSettings {
@@ -988,7 +988,7 @@ mod tests {
         }
 
         #[async_test]
-        async fn session_expires_after_10k_messages_even_if_we_ask_for_more() {
+        async fn test_session_expires_after_10k_messages_even_if_we_ask_for_more() {
             // Given we asked to expire after 100K messages
             let session = create_session(EncryptionSettings {
                 rotation_period_msgs: 100_000,

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -205,7 +205,7 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn edit_decryption() {
+    async fn test_edit_decryption() {
         let alice = Account::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
         let event_id = event_id!("$1234adfad:asdf");
@@ -265,7 +265,7 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn relates_to_decryption() {
+    async fn test_relates_to_decryption() {
         let alice = Account::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
         let event_id = event_id!("$1234adfad:asdf");
@@ -337,7 +337,7 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn group_session_export() {
+    async fn test_group_session_export() {
         let alice = Account::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
 

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
@@ -1047,7 +1047,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn ratcheted_sharing() {
+    async fn test_ratcheted_sharing() {
         let machine = machine_with_shared_room_key_test_helper().await;
 
         let room_id = room_id!("!test:localhost");
@@ -1075,7 +1075,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn changing_encryption_settings() {
+    async fn test_changing_encryption_settings() {
         let machine = machine_with_shared_room_key_test_helper().await;
         let room_id = room_id!("!test:localhost");
         let keys_claim = keys_claim_response();

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -892,7 +892,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn failure_handling() {
+    async fn test_failure_handling() {
         let alice = user_id!("@alice:example.org");
         let alice_account = Account::with_device_id(alice, "DEVICEID".into());
         let alice_device = DeviceData::from_account(&alice_account);
@@ -919,7 +919,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn failed_devices_handling() {
+    async fn test_failed_devices_handling() {
         // Alice is missing altogether
         test_invalid_claim_response(json!({
             "one_time_keys": {},

--- a/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
+++ b/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
@@ -365,7 +365,7 @@ mod test {
     use crate::machine::test_helpers::get_machine_pair_with_setup_sessions_test_helper;
 
     #[async_test]
-    async fn cache_cleared_after_device_update() {
+    async fn test_cache_cleared_after_device_update() {
         let user_id = user_id!("@alice:example.com");
         let (first, second) =
             get_machine_pair_with_setup_sessions_test_helper(user_id, user_id, false).await;

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -123,7 +123,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn save_account_via_generic_save() {
+            async fn test_save_account_via_generic_save() {
                 let store = get_store("save_account_via_generic", None, true).await;
                 assert!(store.get_static_account().is_none());
                 assert!(store.load_account().await.unwrap().is_none());
@@ -137,7 +137,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn save_account() {
+            async fn test_save_account() {
                 let store = get_store("save_account", None, true).await;
                 assert!(store.get_static_account().is_none());
                 assert!(store.load_account().await.unwrap().is_none());
@@ -151,7 +151,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn load_account() {
+            async fn test_load_account() {
                 let store = get_store("load_account", None, true).await;
                 let account = get_account();
 
@@ -167,7 +167,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn load_account_with_passphrase() {
+            async fn test_load_account_with_passphrase() {
                 let passphrase = Some("secret_passphrase");
                 let store = get_store("load_account_with_passphrase", passphrase, true).await;
                 let account = get_account();
@@ -184,7 +184,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn save_and_share_account() {
+            async fn test_save_and_share_account() {
                 let store = get_store("save_and_share_account", None, true).await;
                 let mut account = get_account();
 
@@ -209,7 +209,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn load_sessions() {
+            async fn test_load_sessions() {
                 let store = get_store("load_sessions", None, true).await;
                 let (account, session) = get_account_and_session().await;
                 store
@@ -236,7 +236,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn add_and_save_session() {
+            async fn test_add_and_save_session() {
                 let store_name = "add_and_save_session";
 
                 // Given we created a session and saved it in the store
@@ -288,7 +288,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn load_outbound_group_session() {
+            async fn test_load_outbound_group_session() {
                 let dir = "load_outbound_group_session";
                 let room_id = room_id!("!test:localhost");
 
@@ -338,7 +338,7 @@ macro_rules! cryptostore_integration_tests {
 
             /// Test that we can import an inbound group session via [`CryptoStore::save_changes`]
             #[async_test]
-            async fn save_changes_save_inbound_group_session() {
+            async fn test_save_changes_save_inbound_group_session() {
                 let (account, store) = get_loaded_store("save_inbound_group_session").await;
 
                 let room_id = &room_id!("!test:localhost");
@@ -353,7 +353,7 @@ macro_rules! cryptostore_integration_tests {
             /// Test that we can import a backed-up group session via
             /// [`CryptoStore::save_inbound_group_sessions`]
             #[async_test]
-            async fn save_inbound_group_session_from_backup() {
+            async fn test_save_inbound_group_session_from_backup() {
                 let (account, store) =
                     get_loaded_store("save_inbound_group_session_from_backup").await;
 
@@ -390,7 +390,7 @@ macro_rules! cryptostore_integration_tests {
             /// are waiting for more work on https://github.com/element-hq/element-web/issues/26892.
             #[ignore]
             #[async_test]
-            async fn save_inbound_group_session_from_old_backup() {
+            async fn test_save_inbound_group_session_from_old_backup() {
                 let (account, store) =
                     get_loaded_store("save_inbound_group_session_from_old_backup").await;
 
@@ -415,7 +415,7 @@ macro_rules! cryptostore_integration_tests {
             /// Test that we can import a not-backed-up group session via
             /// [`CryptoStore::save_inbound_group_sessions`]
             #[async_test]
-            async fn save_inbound_group_session_from_import() {
+            async fn test_save_inbound_group_session_from_import() {
                 let (account, store) =
                     get_loaded_store("save_inbound_group_session_from_import").await;
 
@@ -443,7 +443,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn mark_inbound_group_sessions_as_backed_up() {
+            async fn test_mark_inbound_group_sessions_as_backed_up() {
                 // Given a store exists with multiple unbacked-up sessions
                 let (account, store) =
                     get_loaded_store("mark_inbound_group_sessions_as_backed_up").await;
@@ -486,7 +486,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn reset_inbound_group_session_for_backup() {
+            async fn test_reset_inbound_group_session_for_backup() {
                 // Given a store exists where all sessions are backed up to backup_1
                 let (account, store) =
                     get_loaded_store("reset_inbound_group_session_for_backup").await;
@@ -526,7 +526,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn load_inbound_group_session() {
+            async fn test_load_inbound_group_session() {
                 let dir = "load_inbound_group_session";
                 let (account, store) = get_loaded_store(dir).await;
                 assert_eq!(store.get_inbound_group_sessions().await.unwrap().len(), 0);
@@ -679,7 +679,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn device_deleting() {
+            async fn test_device_deleting() {
                 let dir = "device_deleting";
                 let (_account, store) = get_loaded_store(dir.clone()).await;
                 let device = get_device();
@@ -785,7 +785,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn private_identity_saving() {
+            async fn test_private_identity_saving() {
                 let (_, store) = get_loaded_store("private_identity_saving").await;
                 assert!(store.load_identity().await.unwrap().is_none());
                 let identity = PrivateCrossSigningIdentity::new(alice_id().to_owned());
@@ -799,7 +799,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn olm_hash_saving() {
+            async fn test_olm_hash_saving() {
                 let (_, store) = get_loaded_store("olm_hash_saving").await;
 
                 let hash = OlmMessageHash {
@@ -816,7 +816,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn key_request_saving() {
+            async fn test_key_request_saving() {
                 let (account, store) = get_loaded_store("key_request_saving").await;
                 let sender_key =
                     Curve25519PublicKey::from_base64("Nn0L2hkcCMFKqynTjyGsJbth7QrVmX3lbrksMkrGOAw")
@@ -878,7 +878,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn gossipped_secret_saving() {
+            async fn test_gossipped_secret_saving() {
                 let (account, store) = get_loaded_store("gossipped_secret_saving").await;
 
                 let secret = "It is a secret to everybody";
@@ -955,7 +955,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn withheld_info_storage() {
+            async fn test_withheld_info_storage() {
                 let (account, store) = get_loaded_store("withheld_info_storage").await;
 
                 let mut info_list: BTreeMap<_, BTreeMap<_, _>> = BTreeMap::new();
@@ -1033,7 +1033,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn room_settings_saving() {
+            async fn test_room_settings_saving() {
                 let (_, store) = get_loaded_store("room_settings_saving").await;
 
                 let room_1 = room_id!("!test_1:localhost");
@@ -1074,7 +1074,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn backup_keys_saving() {
+            async fn test_backup_keys_saving() {
                 let (_account, store) = get_loaded_store("backup_keys_saving").await;
 
                 let restored = store.load_backup_keys().await.unwrap();
@@ -1098,7 +1098,7 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            async fn custom_value_saving() {
+            async fn test_custom_value_saving() {
                 let (_, store) = get_loaded_store("custom_value_saving").await;
                 store.set_custom_value("A", "Hello".as_bytes().to_vec()).await.unwrap();
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -1944,7 +1944,7 @@ mod tests {
     use crate::{machine::test_helpers::get_machine_pair, types::EventEncryptionAlgorithm};
 
     #[async_test]
-    async fn import_room_keys_notifies_stream() {
+    async fn test_import_room_keys_notifies_stream() {
         use futures_util::FutureExt;
 
         let (alice, bob, _) =
@@ -1967,7 +1967,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn export_room_keys_provides_selected_keys() {
+    async fn test_export_room_keys_provides_selected_keys() {
         // Given an OlmMachine with room keys in it
         let (alice, _, _) = get_machine_pair(user_id!("@a:s.co"), user_id!("@b:s.co"), false).await;
         let room1_id = room_id!("!room1:localhost");
@@ -1995,7 +1995,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn export_room_keys_stream_can_provide_all_keys() {
+    async fn test_export_room_keys_stream_can_provide_all_keys() {
         // Given an OlmMachine with room keys in it
         let (alice, _, _) = get_machine_pair(user_id!("@a:s.co"), user_id!("@b:s.co"), false).await;
         let room1_id = room_id!("!room1:localhost");
@@ -2023,7 +2023,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn export_room_keys_stream_can_provide_a_subset_of_keys() {
+    async fn test_export_room_keys_stream_can_provide_a_subset_of_keys() {
         // Given an OlmMachine with room keys in it
         let (alice, _, _) = get_machine_pair(user_id!("@a:s.co"), user_id!("@b:s.co"), false).await;
         let room1_id = room_id!("!room1:localhost");
@@ -2049,7 +2049,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn export_secrets_bundle() {
+    async fn test_export_secrets_bundle() {
         let user_id = user_id!("@alice:example.com");
         let (first, second, _) = get_machine_pair(user_id, user_id, false).await;
 

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/mod.rs
@@ -101,7 +101,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn partial_eq_cross_signing_keys() {
+    async fn test_partial_eq_cross_signing_keys() {
         macro_rules! test_partial_eq {
             ($key_type:ident, $key_field:ident, $field:ident, $usage:expr) => {
                 let user_id = user_id!("@example:localhost");

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -572,7 +572,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn create() {
+    async fn test_create() {
         let alice = Account::with_device_id(alice_id(), alice_device_id());
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let _ = VerificationMachine::new(
@@ -583,7 +583,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn full_flow() {
+    async fn test_full_flow() {
         let (alice_machine, bob) = setup_verification_machine().await;
 
         let alice = alice_machine.get_sas(bob.user_id(), bob.flow_id().as_str()).unwrap();
@@ -639,7 +639,7 @@ mod tests {
     #[cfg(not(target_os = "macos"))]
     #[allow(unknown_lints, clippy::unchecked_duration_subtraction)]
     #[async_test]
-    async fn timing_out() {
+    async fn test_timing_out() {
         use std::time::Duration;
 
         use ruma::time::Instant;
@@ -663,7 +663,7 @@ mod tests {
     /// Test to ensure that we cancel both verifications if a second one gets
     /// started while another one is going on.
     #[async_test]
-    async fn double_verification_cancellation() {
+    async fn test_double_verification_cancellation() {
         let (machine, bob_store) = verification_machine().await;
 
         let alice_device =
@@ -705,7 +705,7 @@ mod tests {
     /// Test to ensure that we cancel both verification requests if a second one
     /// gets started while another one is going on.
     #[async_test]
-    async fn double_verification_request_cancellation() {
+    async fn test_double_verification_request_cancellation() {
         let (machine, bob_store) = verification_machine().await;
 
         // Start the first verification request.
@@ -767,7 +767,7 @@ mod tests {
     /// flow_id) the existing request is not cancelled and the new one is
     /// ignored
     #[async_test]
-    async fn ignore_identical_verification_request() {
+    async fn test_ignore_identical_verification_request() {
         let (machine, bob_store) = verification_machine().await;
 
         // Start the first verification request.

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -1828,7 +1828,7 @@ mod tests {
 
     #[async_test]
     #[cfg(feature = "qrcode")]
-    async fn can_scan_another_qr_after_creating_mine() {
+    async fn test_can_scan_another_qr_after_creating_mine() {
         let (_alice, alice_store, _bob, bob_store) = setup_stores().await;
 
         // Set up the pair of verification requests
@@ -1879,7 +1879,7 @@ mod tests {
 
     #[async_test]
     #[cfg(feature = "qrcode")]
-    async fn can_start_sas_after_generating_qr_code() {
+    async fn test_can_start_sas_after_generating_qr_code() {
         let (_alice, alice_store, _bob, bob_store) = setup_stores().await;
 
         // Set up the pair of verification requests
@@ -1924,7 +1924,7 @@ mod tests {
 
     #[async_test]
     #[cfg(feature = "qrcode")]
-    async fn start_sas_after_scan_cancels_request() {
+    async fn test_start_sas_after_scan_cancels_request() {
         let (_alice, alice_store, _bob, bob_store) = setup_stores().await;
 
         // Set up the pair of verification requests

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -933,7 +933,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn sas_wrapper_full() {
+    async fn test_sas_wrapper_full() {
         let (alice_store, alice_device, bob_store, bob_device) = machine_pair_test_helper();
 
         let identities = alice_store.get_identities(bob_device).await.unwrap();
@@ -1007,7 +1007,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn sas_with_restricted_methods() {
+    async fn test_sas_with_restricted_methods() {
         let (alice_store, alice_device, bob_store, bob_device) = machine_pair_test_helper();
         let identities = alice_store.get_identities(bob_device).await.unwrap();
 

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
@@ -256,7 +256,7 @@ mod tests {
 
     /// Make lots of sessions and see how long it takes to count them in v8
     #[async_test]
-    async fn count_lots_of_sessions_v8() {
+    async fn test_count_lots_of_sessions_v8() {
         let cipher = Arc::new(StoreCipher::new().unwrap());
         let serializer = IndexeddbSerializer::new(Some(cipher.clone()));
         // Session keys are slow to create, so make one upfront and use it for every
@@ -294,7 +294,7 @@ mod tests {
 
     /// Make lots of sessions and see how long it takes to count them in v10
     #[async_test]
-    async fn count_lots_of_sessions_v10() {
+    async fn test_count_lots_of_sessions_v10() {
         let serializer = IndexeddbSerializer::new(Some(Arc::new(StoreCipher::new().unwrap())));
 
         // Session keys are slow to create, so make one upfront and use it for every
@@ -693,7 +693,7 @@ mod tests {
     /// Opening a db that has been upgraded to MAX_SUPPORTED_SCHEMA_VERSION
     /// should be ok
     #[async_test]
-    async fn can_open_max_supported_schema_version() {
+    async fn test_can_open_max_supported_schema_version() {
         let _ = make_tracing_subscriber(None).try_init();
 
         let db_prefix = "test_can_open_max_supported_schema_version";
@@ -707,7 +707,7 @@ mod tests {
     /// Opening a db that has been upgraded beyond MAX_SUPPORTED_SCHEMA_VERSION
     /// should throw an error
     #[async_test]
-    async fn can_not_open_too_new_db() {
+    async fn test_can_not_open_too_new_db() {
         let _ = make_tracing_subscriber(None).try_init();
 
         let db_prefix = "test_can_not_open_too_new_db";

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -1683,7 +1683,7 @@ mod wasm_unit_tests {
     }
 
     #[async_test]
-    fn needs_backup_is_serialized_as_a_u8_in_js() {
+    fn test_needs_backup_is_serialized_as_a_u8_in_js() {
         let session_needs_backup = super::unit_tests::backup_test_session(true);
 
         let js_value = serde_wasm_bindgen::to_value(&session_needs_backup).unwrap();
@@ -1693,7 +1693,7 @@ mod wasm_unit_tests {
     }
 
     #[async_test]
-    fn doesnt_need_backup_is_serialized_with_missing_field_in_js() {
+    fn test_doesnt_need_backup_is_serialized_with_missing_field_in_js() {
         let session_backed_up = super::unit_tests::backup_test_session(false);
 
         let js_value = serde_wasm_bindgen::to_value(&session_backed_up).unwrap();
@@ -1765,7 +1765,7 @@ mod encrypted_tests {
     /// Test that we can migrate a store created with a passphrase, to being
     /// encrypted with a key instead.
     #[async_test]
-    async fn migrate_passphrase_to_key() {
+    async fn test_migrate_passphrase_to_key() {
         let store_name = "test_migrate_passphrase_to_key";
         let passdata: [u8; 32] = rand::random();
         let b64_passdata = base64_encode(passdata);

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -1336,7 +1336,7 @@ mod tests {
     /// Test that we didn't regress in our storage layer by loading data from a
     /// pre-filled database, or in other words use a test vector for this.
     #[async_test]
-    async fn open_test_vector_store() {
+    async fn test_open_test_vector_store() {
         let TestDb { dir: _, database } = get_test_db().await;
 
         let account = database

--- a/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
@@ -25,7 +25,7 @@ use super::TestTimeline;
 use crate::timeline::TimelineItemContent;
 
 #[async_test]
-async fn invalid_edit() {
+async fn test_invalid_edit() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
@@ -52,7 +52,7 @@ async fn invalid_edit() {
 }
 
 #[async_test]
-async fn invalid_event_content() {
+async fn test_invalid_event_content() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
@@ -100,7 +100,7 @@ async fn invalid_event_content() {
 }
 
 #[async_test]
-async fn invalid_event() {
+async fn test_invalid_event() {
     let timeline = TestTimeline::new();
 
     // This event is missing the sender field which the homeserver must add to

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -19,7 +19,7 @@ use crate::timeline::{
 };
 
 #[async_test]
-async fn poll_is_displayed() {
+async fn test_poll_is_displayed() {
     let timeline = TestTimeline::new();
 
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
@@ -30,7 +30,7 @@ async fn poll_is_displayed() {
 }
 
 #[async_test]
-async fn edited_poll_is_displayed() {
+async fn test_edited_poll_is_displayed() {
     let timeline = TestTimeline::new();
 
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
@@ -47,7 +47,7 @@ async fn edited_poll_is_displayed() {
 }
 
 #[async_test]
-async fn voting_adds_the_vote_to_the_results() {
+async fn test_voting_adds_the_vote_to_the_results() {
     let timeline = TestTimeline::new();
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let poll_id = timeline.poll_event().await.event_id().unwrap().to_owned();
@@ -61,7 +61,7 @@ async fn voting_adds_the_vote_to_the_results() {
 }
 
 #[async_test]
-async fn ending_a_poll_sets_end_time_to_results() {
+async fn test_ending_a_poll_sets_end_time_to_results() {
     let timeline = TestTimeline::new();
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let poll_id = timeline.poll_event().await.event_id().unwrap().to_owned();
@@ -74,7 +74,7 @@ async fn ending_a_poll_sets_end_time_to_results() {
 }
 
 #[async_test]
-async fn only_the_last_vote_from_a_user_is_counted() {
+async fn test_only_the_last_vote_from_a_user_is_counted() {
     let timeline = TestTimeline::new();
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let poll_id = timeline.poll_event().await.event_id().unwrap().to_owned();
@@ -91,7 +91,7 @@ async fn only_the_last_vote_from_a_user_is_counted() {
 }
 
 #[async_test]
-async fn votes_after_end_are_discarded() {
+async fn test_votes_after_end_are_discarded() {
     let timeline = TestTimeline::new();
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let poll_id = timeline.poll_event().await.event_id().unwrap().to_owned();
@@ -108,7 +108,7 @@ async fn votes_after_end_are_discarded() {
 }
 
 #[async_test]
-async fn multiple_end_events_are_discarded() {
+async fn test_multiple_end_events_are_discarded() {
     let timeline = TestTimeline::new();
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let poll_id = timeline.poll_event().await.event_id().unwrap().to_owned();
@@ -128,7 +128,7 @@ async fn multiple_end_events_are_discarded() {
 }
 
 #[async_test]
-async fn a_somewhat_complex_voting_session_yields_the_expected_outcome() {
+async fn test_a_somewhat_complex_voting_session_yields_the_expected_outcome() {
     let timeline = TestTimeline::new();
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let poll_id = timeline.poll_event().await.event_id().unwrap().to_owned();
@@ -160,7 +160,7 @@ async fn a_somewhat_complex_voting_session_yields_the_expected_outcome() {
 }
 
 #[async_test]
-async fn events_received_before_start_are_not_lost() {
+async fn test_events_received_before_start_are_not_lost() {
     let timeline = TestTimeline::new();
     let poll_id: OwnedEventId = EventId::new(server_name!("dummy.server"));
 

--- a/crates/matrix-sdk/src/authentication/qrcode/rendezvous_channel.rs
+++ b/crates/matrix-sdk/src/authentication/qrcode/rendezvous_channel.rs
@@ -315,7 +315,7 @@ mod test {
     }
 
     #[async_test]
-    async fn creation() {
+    async fn test_creation() {
         let server = MockServer::start().await;
         let url =
             Url::parse(&server.uri()).expect("We should be able to parse the example homeserver");
@@ -436,7 +436,7 @@ mod test {
     }
 
     #[async_test]
-    async fn retry_mechanism() {
+    async fn test_retry_mechanism() {
         let server = MockServer::start().await;
         let url =
             Url::parse(&server.uri()).expect("We should be able to parse the example homeserver");
@@ -493,7 +493,7 @@ mod test {
     }
 
     #[async_test]
-    async fn receive_error() {
+    async fn test_receive_error() {
         let server = MockServer::start().await;
         let url =
             Url::parse(&server.uri()).expect("We should be able to parse the example homeserver");

--- a/crates/matrix-sdk/src/authentication/qrcode/secure_channel.rs
+++ b/crates/matrix-sdk/src/authentication/qrcode/secure_channel.rs
@@ -347,7 +347,7 @@ pub(super) mod test {
     }
 
     #[async_test]
-    async fn creation() {
+    async fn test_creation() {
         let server = MockServer::start().await;
         let rendezvous_server = MockedRendezvousServer::new(&server, "abcdEFG12345").await;
 

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -1064,7 +1064,7 @@ mod test {
     }
 
     #[async_test]
-    async fn backup_disabling_after_remote_deletion() {
+    async fn test_backup_disabling_after_remote_deletion() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 
@@ -1104,7 +1104,7 @@ mod test {
     }
 
     #[async_test]
-    async fn exists_on_server() {
+    async fn test_exists_on_server() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 
@@ -1194,7 +1194,7 @@ mod test {
     }
 
     #[async_test]
-    async fn waiting_for_steady_state_resets_the_delay() {
+    async fn test_waiting_for_steady_state_resets_the_delay() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 

--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -602,7 +602,7 @@ mod tests {
     });
 
     #[async_test]
-    async fn add_event_handler() -> crate::Result<()> {
+    async fn test_add_event_handler() -> crate::Result<()> {
         let client = logged_in_client(None).await;
 
         let member_count = Arc::new(AtomicU8::new(0));
@@ -693,7 +693,7 @@ mod tests {
 
     #[async_test]
     #[allow(dependency_on_unit_never_type_fallback)]
-    async fn add_room_event_handler() -> crate::Result<()> {
+    async fn test_add_room_event_handler() -> crate::Result<()> {
         let client = logged_in_client(None).await;
 
         let room_id_a = room_id!("!foo:example.org");
@@ -755,7 +755,7 @@ mod tests {
 
     #[async_test]
     #[allow(dependency_on_unit_never_type_fallback)]
-    async fn remove_event_handler() -> crate::Result<()> {
+    async fn test_remove_event_handler() -> crate::Result<()> {
         let client = logged_in_client(None).await;
 
         let member_count = Arc::new(AtomicU8::new(0));
@@ -800,7 +800,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn event_handler_drop_guard() {
+    async fn test_event_handler_drop_guard() {
         let client = no_retry_test_client(None).await;
 
         let handle = client.add_event_handler(|_ev: OriginalSyncRoomMemberEvent| async {});
@@ -816,7 +816,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn use_client_in_handler() {
+    async fn test_use_client_in_handler() {
         // This used to not work because we were requiring `Send` of event
         // handler futures even on WASM, where practically all futures that do
         // I/O aren't.
@@ -832,7 +832,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn raw_event_handler() -> crate::Result<()> {
+    async fn test_raw_event_handler() -> crate::Result<()> {
         let client = logged_in_client(None).await;
         let counter = Arc::new(AtomicU8::new(0));
         client.add_event_handler_context(counter.clone());
@@ -852,7 +852,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn enum_event_handler() -> crate::Result<()> {
+    async fn test_enum_event_handler() -> crate::Result<()> {
         let client = logged_in_client(None).await;
         let counter = Arc::new(AtomicU8::new(0));
         client.add_event_handler_context(counter.clone());

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -308,7 +308,7 @@ mod tests {
     };
 
     #[async_test]
-    async fn ensure_concurrent_request_limit_is_observed() {
+    async fn test_ensure_concurrent_request_limit_is_observed() {
         let (client_builder, server) = test_client_builder_with_server().await;
         let client = client_builder
             .request_config(RequestConfig::default().max_concurrent_requests(NonZeroUsize::new(5)))
@@ -353,7 +353,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn ensure_no_max_concurrent_request_does_not_limit() {
+    async fn test_ensure_no_max_concurrent_request_does_not_limit() {
         let (client_builder, server) = test_client_builder_with_server().await;
         let client = client_builder
             .request_config(RequestConfig::default().max_concurrent_requests(None))

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -575,7 +575,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn subscribe_to_changes() {
+    async fn test_subscribe_to_changes() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
         let settings = client.notification_settings().await;
@@ -1281,7 +1281,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn list_keywords() {
+    async fn test_list_keywords() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 
@@ -1339,7 +1339,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn add_keyword_missing() {
+    async fn test_add_keyword_missing() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
         let settings = client.notification_settings().await;
@@ -1365,7 +1365,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn add_keyword_disabled() {
+    async fn test_add_keyword_disabled() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 
@@ -1421,7 +1421,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn add_keyword_noop() {
+    async fn test_add_keyword_noop() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 
@@ -1468,7 +1468,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn remove_keyword_all() {
+    async fn test_remove_keyword_all() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 
@@ -1528,7 +1528,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn remove_keyword_noop() {
+    async fn test_remove_keyword_noop() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
         let settings = client.notification_settings().await;

--- a/crates/matrix-sdk/src/room_directory_search.rs
+++ b/crates/matrix-sdk/src/room_directory_search.rs
@@ -293,7 +293,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn search_success() {
+    async fn test_search_success() {
         let (server, client) = new_server_and_client().await;
 
         let mut room_directory_search = RoomDirectorySearch::new(client);
@@ -312,7 +312,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn search_success_paginated() {
+    async fn test_search_success_paginated() {
         let (server, client) = new_server_and_client().await;
 
         let mut room_directory_search = RoomDirectorySearch::new(client);
@@ -348,7 +348,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn search_fails() {
+    async fn test_search_fails() {
         let (server, client) = new_server_and_client().await;
 
         let mut room_directory_search = RoomDirectorySearch::new(client);
@@ -367,7 +367,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn search_fails_when_paginating() {
+    async fn test_search_fails_when_paginating() {
         let (server, client) = new_server_and_client().await;
 
         let mut room_directory_search = RoomDirectorySearch::new(client);
@@ -401,7 +401,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn search_success_paginated_with_filter() {
+    async fn test_search_success_paginated_with_filter() {
         let (server, client) = new_server_and_client().await;
 
         let mut room_directory_search = RoomDirectorySearch::new(client);
@@ -441,7 +441,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn search_followed_by_another_search_with_filter() {
+    async fn test_search_followed_by_another_search_with_filter() {
         let (server, client) = new_server_and_client().await;
 
         let mut room_directory_search = RoomDirectorySearch::new(client);

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -88,7 +88,7 @@ async fn mount_once(
 }
 
 #[async_test]
-async fn create() {
+async fn test_create() {
     let user_id = user_id!("@example:morpheus.localhost");
 
     let session = MatrixSession {
@@ -164,7 +164,7 @@ async fn create() {
 }
 
 #[async_test]
-async fn creation_failure() {
+async fn test_creation_failure() {
     let user_id = user_id!("@example:morpheus.localhost");
 
     let session = MatrixSession {
@@ -245,7 +245,7 @@ async fn creation_failure() {
 }
 
 #[async_test]
-async fn disabling() {
+async fn test_disabling() {
     let user_id = user_id!("@example:morpheus.localhost");
 
     let session = MatrixSession {
@@ -332,7 +332,7 @@ async fn disabling() {
 }
 
 #[async_test]
-async fn disable_if_only_enabled_remotely() {
+async fn test_disable_if_only_enabled_remotely() {
     let user_id = user_id!("@example:morpheus.localhost");
 
     let session = MatrixSession {
@@ -364,7 +364,7 @@ async fn disable_if_only_enabled_remotely() {
 
 #[async_test]
 #[cfg(feature = "sqlite")]
-async fn backup_resumption() {
+async fn test_backup_resumption() {
     use tempfile::tempdir;
 
     let dir = tempdir().unwrap();
@@ -458,7 +458,7 @@ async fn setup_backups(client: &Client, server: &wiremock::MockServer) {
 }
 
 #[async_test]
-async fn steady_state_waiting() {
+async fn test_steady_state_waiting() {
     let user_id = user_id!("@example:morpheus.localhost");
 
     let session = MatrixSession {
@@ -642,7 +642,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
 /// outbound room key is created. But it would work for a key received via a to
 /// device event as well.
 #[async_test]
-async fn incremental_upload_of_keys() -> Result<()> {
+async fn test_incremental_upload_of_keys() -> Result<()> {
     let user_id = user_id!("@example:morpheus.localhost");
 
     let session = MatrixSession {
@@ -715,7 +715,7 @@ async fn incremental_upload_of_keys() -> Result<()> {
 
 #[async_test]
 #[cfg(feature = "experimental-sliding-sync")]
-async fn incremental_upload_of_keys_sliding_sync() -> Result<()> {
+async fn test_incremental_upload_of_keys_sliding_sync() -> Result<()> {
     let user_id = user_id!("@example:morpheus.localhost");
 
     let session = MatrixSession {
@@ -822,7 +822,7 @@ async fn incremental_upload_of_keys_sliding_sync() -> Result<()> {
 }
 
 #[async_test]
-async fn steady_state_waiting_errors() {
+async fn test_steady_state_waiting_errors() {
     let user_id = user_id!("@example:morpheus.localhost");
 
     let session = MatrixSession {
@@ -904,7 +904,7 @@ async fn steady_state_waiting_errors() {
 }
 
 #[async_test]
-async fn enable_from_secret_storage() {
+async fn test_enable_from_secret_storage() {
     const SECRET_STORE_KEY: &str = "mypassphrase";
     const KEY_ID: &str = "yJWwBm2Ts8jHygTBslKpABFyykavhhfA";
 
@@ -1047,7 +1047,7 @@ async fn enable_from_secret_storage() {
 }
 
 #[async_test]
-async fn enable_from_secret_storage_no_existing_backup() {
+async fn test_enable_from_secret_storage_no_existing_backup() {
     let user_id = user_id!("@example2:morpheus.localhost");
 
     let session = MatrixSession {
@@ -1090,7 +1090,7 @@ async fn enable_from_secret_storage_no_existing_backup() {
 }
 
 #[async_test]
-async fn enable_from_secret_storage_mismatched_key() {
+async fn test_enable_from_secret_storage_mismatched_key() {
     let user_id = user_id!("@example2:morpheus.localhost");
 
     let session = MatrixSession {
@@ -1142,7 +1142,7 @@ async fn enable_from_secret_storage_mismatched_key() {
 }
 
 #[async_test]
-async fn enable_from_secret_storage_manual_download() {
+async fn test_enable_from_secret_storage_manual_download() {
     let user_id = user_id!("@example2:morpheus.localhost");
 
     let session = MatrixSession {
@@ -1173,7 +1173,7 @@ async fn enable_from_secret_storage_manual_download() {
 }
 
 #[async_test]
-async fn enable_from_secret_storage_and_manual_download() {
+async fn test_enable_from_secret_storage_and_manual_download() {
     let user_id = user_id!("@example2:morpheus.localhost");
     let room_id = room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost");
 
@@ -1294,7 +1294,7 @@ async fn enable_from_secret_storage_and_manual_download() {
 }
 
 #[async_test]
-async fn enable_from_secret_storage_and_download_after_utd() {
+async fn test_enable_from_secret_storage_and_download_after_utd() {
     let user_id = user_id!("@example2:morpheus.localhost");
     let room_id = room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost");
     let event_id = event_id!("$JbFHtZpEJiH8uaajZjPLz0QUZc1xtBR9rPGBOjF6WFM");
@@ -1409,7 +1409,7 @@ async fn enable_from_secret_storage_and_download_after_utd() {
 /// Even if we have a key to the session, we should still attempt a backup
 /// download if the UTD message has a lower megolm ratchet index than we have.
 #[async_test]
-async fn enable_from_secret_storage_and_download_after_utd_from_old_message_index() {
+async fn test_enable_from_secret_storage_and_download_after_utd_from_old_message_index() {
     let user_id = user_id!("@example2:morpheus.localhost");
     let room_id = room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost");
     let event_id = event_id!("$JbFHtZpEJiH8uaajZjPLz0QUZc1xtBR9rPGBOjF6WFM");

--- a/crates/matrix-sdk/tests/integration/encryption/recovery.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/recovery.rs
@@ -155,14 +155,14 @@ async fn mock_put_new_default_secret_storage_key(user_id: &UserId, server: &wire
 }
 
 #[async_test]
-async fn recovery_status_server_unavailable() {
+async fn test_recovery_status_server_unavailable() {
     let (client, _) = logged_in_client_with_server().await;
     client.encryption().wait_for_e2ee_initialization_tasks().await;
     assert_eq!(client.encryption().recovery().state(), RecoveryState::Unknown);
 }
 
 #[async_test]
-async fn recovery_status_secret_storage_set_up() {
+async fn test_recovery_status_secret_storage_set_up() {
     const KEY_ID: &str = "yJWwBm2Ts8jHygTBslKpABFyykavhhfA";
     let user_id = user_id!("@example:morpheus.localhost");
 
@@ -184,7 +184,7 @@ async fn recovery_status_secret_storage_set_up() {
 }
 
 #[async_test]
-async fn recovery_status_secret_storage_not_set_up() {
+async fn test_recovery_status_secret_storage_not_set_up() {
     let user_id = user_id!("@example:morpheus.localhost");
 
     let session = MatrixSession {
@@ -444,7 +444,7 @@ async fn enable(
 }
 
 #[async_test]
-async fn recovery_setup() {
+async fn test_recovery_setup() {
     let user_id = user_id!("@example:morpheus.localhost");
     let (client, server) = test_client(user_id).await;
 
@@ -457,7 +457,7 @@ async fn recovery_setup() {
 }
 
 #[async_test]
-async fn recovery_setup_without_wait() {
+async fn test_recovery_setup_without_wait() {
     let user_id = user_id!("@example:morpheus.localhost");
     let (client, server) = test_client(user_id).await;
 
@@ -470,7 +470,7 @@ async fn recovery_setup_without_wait() {
 }
 
 #[async_test]
-async fn backups_enabling() {
+async fn test_backups_enabling() {
     let user_id = user_id!("@example:morpheus.localhost");
     let (client, server) = test_client(user_id).await;
 
@@ -529,7 +529,7 @@ async fn backups_enabling() {
 }
 
 #[async_test]
-async fn backups_enabling_already_enabled() {
+async fn test_backups_enabling_already_enabled() {
     let user_id = user_id!("@example:morpheus.localhost");
     let (client, server) = test_client(user_id).await;
 
@@ -564,7 +564,7 @@ async fn backups_enabling_already_enabled() {
 }
 
 #[async_test]
-async fn recovery_disabling() {
+async fn test_recovery_disabling() {
     let user_id = user_id!("@example:morpheus.localhost");
     let (client, server) = test_client(user_id).await;
 
@@ -656,7 +656,7 @@ async fn recovery_disabling() {
 }
 
 #[async_test]
-async fn reset_recovery_key() {
+async fn test_reset_recovery_key() {
     let user_id = user_id!("@example:morpheus.localhost");
     let (client, server) = test_client(user_id).await;
 
@@ -702,7 +702,7 @@ async fn reset_recovery_key() {
 }
 
 #[async_test]
-async fn recover_and_reset() {
+async fn test_recover_and_reset() {
     let user_id = user_id!("@example:morpheus.localhost");
     const SECRET_STORE_KEY: &str = "mypassphrase";
     const KEY_ID: &str = "yJWwBm2Ts8jHygTBslKpABFyykavhhfA";

--- a/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
@@ -65,7 +65,7 @@ async fn mock_secret_store_key(
 }
 
 #[async_test]
-async fn secret_store_create_default_key() {
+async fn test_secret_store_create_default_key() {
     let (client, server) = logged_in_client_with_server().await;
 
     let user_id = client.user_id().expect("We should know our user ID by now");
@@ -140,7 +140,7 @@ async fn secret_store_create_default_key() {
 }
 
 #[async_test]
-async fn secret_store_missing_key_info() {
+async fn test_secret_store_missing_key_info() {
     let (client, server) = logged_in_client_with_server().await;
 
     let user_id = client.user_id().expect("We should know our user ID by now");
@@ -190,7 +190,7 @@ async fn secret_store_missing_key_info() {
 }
 
 #[async_test]
-async fn secret_store_not_setup() {
+async fn test_secret_store_not_setup() {
     let (client, server) = logged_in_client_with_server().await;
 
     let user_id = client.user_id().expect("We should know our user ID by now");
@@ -221,7 +221,7 @@ async fn secret_store_not_setup() {
 }
 
 #[async_test]
-async fn secret_store_opening() {
+async fn test_secret_store_opening() {
     let (client, server) = logged_in_client_with_server().await;
 
     mock_secret_store_key(
@@ -269,7 +269,7 @@ async fn secret_store_opening() {
 }
 
 #[async_test]
-async fn set_in_secret_store() {
+async fn test_set_in_secret_store() {
     let (client, server) = logged_in_client_with_server().await;
 
     mock_secret_store_key(
@@ -366,7 +366,7 @@ async fn set_in_secret_store() {
 }
 
 #[async_test]
-async fn restore_cross_signing_from_secret_store() {
+async fn test_restore_cross_signing_from_secret_store() {
     let user_id = user_id!("@example:morpheus.localhost");
 
     let session = MatrixSession {
@@ -567,7 +567,7 @@ async fn restore_cross_signing_from_secret_store() {
 }
 
 #[async_test]
-async fn is_secret_storage_enabled() {
+async fn test_is_secret_storage_enabled() {
     let user_id = user_id!("@example:morpheus.localhost");
 
     let session = MatrixSession {

--- a/crates/matrix-sdk/tests/integration/notification.rs
+++ b/crates/matrix-sdk/tests/integration/notification.rs
@@ -18,7 +18,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use crate::{logged_in_client_with_server, mock_sync};
 
 #[async_test]
-async fn notifications_joined() {
+async fn test_notifications_joined() {
     let (client, server) = logged_in_client_with_server().await;
     let room_id = room_id!("!joined_room:localhost");
     let user_id = client.user_id().unwrap();
@@ -102,7 +102,7 @@ async fn notifications_joined() {
 }
 
 #[async_test]
-async fn notifications_invite() {
+async fn test_notifications_invite() {
     let (client, server) = logged_in_client_with_server().await;
     let room_id = room_id!("!invited_room:localhost");
     let user_id = client.user_id().unwrap();

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -75,7 +75,7 @@ async fn test_login_username_refresh_token() {
 
 #[async_test]
 #[cfg(feature = "sso-login")]
-async fn login_sso_refresh_token() {
+async fn test_login_sso_refresh_token() {
     let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("POST"))
@@ -119,7 +119,7 @@ async fn login_sso_refresh_token() {
 }
 
 #[async_test]
-async fn register_refresh_token() {
+async fn test_register_refresh_token() {
     let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("POST"))
@@ -148,7 +148,7 @@ async fn register_refresh_token() {
 }
 
 #[async_test]
-async fn no_refresh_token() {
+async fn test_no_refresh_token() {
     let (client, server) = logged_in_client_with_server().await;
 
     // Refresh token doesn't change.
@@ -238,7 +238,7 @@ async fn test_refresh_token() {
 }
 
 #[async_test]
-async fn refresh_token_not_handled() {
+async fn test_refresh_token_not_handled() {
     let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
@@ -272,7 +272,7 @@ async fn refresh_token_not_handled() {
 }
 
 #[async_test]
-async fn refresh_token_handled_success() {
+async fn test_refresh_token_handled_success() {
     let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
@@ -332,7 +332,7 @@ async fn refresh_token_handled_success() {
 }
 
 #[async_test]
-async fn refresh_token_handled_failure() {
+async fn test_refresh_token_handled_failure() {
     let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
@@ -382,7 +382,7 @@ async fn refresh_token_handled_failure() {
 }
 
 #[async_test]
-async fn refresh_token_handled_multi_success() {
+async fn test_refresh_token_handled_multi_success() {
     let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
@@ -455,7 +455,7 @@ async fn refresh_token_handled_multi_success() {
 }
 
 #[async_test]
-async fn refresh_token_handled_multi_failure() {
+async fn test_refresh_token_handled_multi_failure() {
     let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
@@ -528,7 +528,7 @@ async fn refresh_token_handled_multi_failure() {
 }
 
 #[async_test]
-async fn refresh_token_handled_other_error() {
+async fn test_refresh_token_handled_other_error() {
     let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())

--- a/crates/matrix-sdk/tests/integration/room/left.rs
+++ b/crates/matrix-sdk/tests/integration/room/left.rs
@@ -12,7 +12,7 @@ use wiremock::{
 use crate::{logged_in_client_with_server, mock_sync};
 
 #[async_test]
-async fn forget_room() {
+async fn test_forget_room() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
@@ -34,7 +34,7 @@ async fn forget_room() {
 }
 
 #[async_test]
-async fn rejoin_room() {
+async fn test_rejoin_room() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))

--- a/crates/matrix-sdk/tests/integration/room/spaces.rs
+++ b/crates/matrix-sdk/tests/integration/room/spaces.rs
@@ -152,7 +152,7 @@ async fn sync_space(
 }
 
 #[async_test]
-async fn no_parent_space() {
+async fn test_no_parent_space() {
     let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::SYNC, None).await;
@@ -169,7 +169,7 @@ async fn no_parent_space() {
 }
 
 #[async_test]
-async fn parent_space_undeserializable() {
+async fn test_parent_space_undeserializable() {
     let (client, server) = logged_in_client_with_server().await;
 
     let mut sync = PARENT_SPACE_SYNC.clone();
@@ -185,7 +185,7 @@ async fn parent_space_undeserializable() {
 }
 
 #[async_test]
-async fn parent_space_redacted() {
+async fn test_parent_space_redacted() {
     let (client, server) = logged_in_client_with_server().await;
 
     let mut sync = PARENT_SPACE_SYNC.clone();
@@ -214,7 +214,7 @@ async fn parent_space_redacted() {
 }
 
 #[async_test]
-async fn parent_space_unverifiable() {
+async fn test_parent_space_unverifiable() {
     let (client, server) = logged_in_client_with_server().await;
 
     initial_sync_with_m_space_parent(&client, &server, &PARENT_SPACE_SYNC).await;
@@ -229,7 +229,7 @@ async fn parent_space_unverifiable() {
 }
 
 #[async_test]
-async fn parent_space_illegitimate() {
+async fn test_parent_space_illegitimate() {
     let (client, server) = logged_in_client_with_server().await;
 
     mock_members(&server).await;
@@ -248,7 +248,7 @@ async fn parent_space_illegitimate() {
 }
 
 #[async_test]
-async fn parent_space_reciprocal() {
+async fn test_parent_space_reciprocal() {
     let (client, server) = logged_in_client_with_server().await;
 
     let sync_token = initial_sync_with_m_space_parent(&client, &server, &PARENT_SPACE_SYNC).await;
@@ -285,7 +285,7 @@ async fn parent_space_reciprocal() {
 }
 
 #[async_test]
-async fn parent_space_redacted_reciprocal() {
+async fn test_parent_space_redacted_reciprocal() {
     let (client, server) = logged_in_client_with_server().await;
 
     mock_members(&server).await;
@@ -373,7 +373,7 @@ async fn setup_parent_member(
 }
 
 #[async_test]
-async fn parent_space_powerlevel() {
+async fn test_parent_space_powerlevel() {
     let (client, server) = logged_in_client_with_server().await;
 
     let sync_token = initial_sync_with_m_space_parent(&client, &server, &PARENT_SPACE_SYNC).await;
@@ -390,7 +390,7 @@ async fn parent_space_powerlevel() {
 }
 
 #[async_test]
-async fn parent_space_powerlevel_too_low() {
+async fn test_parent_space_powerlevel_too_low() {
     let (client, server) = logged_in_client_with_server().await;
 
     let sync_token = initial_sync_with_m_space_parent(&client, &server, &PARENT_SPACE_SYNC).await;

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -144,7 +144,7 @@ async fn send_response(
 }
 
 #[async_test]
-async fn negotiate_capabilities_immediately() {
+async fn test_negotiate_capabilities_immediately() {
     let (_, _, driver_handle) = run_test_driver(false).await;
 
     let caps = json!(["org.matrix.msc2762.receive.event:m.room.message"]);
@@ -198,7 +198,7 @@ async fn negotiate_capabilities_immediately() {
 }
 
 #[async_test]
-async fn read_messages() {
+async fn test_read_messages() {
     let (_, mock_server, driver_handle) = run_test_driver(true).await;
 
     {
@@ -287,7 +287,7 @@ async fn read_messages() {
 }
 
 #[async_test]
-async fn read_messages_with_msgtype_capabilities() {
+async fn test_read_messages_with_msgtype_capabilities() {
     let (_, mock_server, driver_handle) = run_test_driver(true).await;
 
     {
@@ -384,7 +384,7 @@ async fn read_messages_with_msgtype_capabilities() {
 }
 
 #[async_test]
-async fn read_room_members() {
+async fn test_read_room_members() {
     let (_, mock_server, driver_handle) = run_test_driver(false).await;
 
     negotiate_capabilities(
@@ -422,7 +422,7 @@ async fn read_room_members() {
 }
 
 #[async_test]
-async fn receive_live_events() {
+async fn test_receive_live_events() {
     let (client, mock_server, driver_handle) = run_test_driver(false).await;
 
     negotiate_capabilities(
@@ -521,7 +521,7 @@ async fn receive_live_events() {
 }
 
 #[async_test]
-async fn send_room_message() {
+async fn test_send_room_message() {
     let (_, mock_server, driver_handle) = run_test_driver(false).await;
 
     negotiate_capabilities(&driver_handle, json!(["org.matrix.msc2762.send.event:m.room.message"]))
@@ -560,7 +560,7 @@ async fn send_room_message() {
 }
 
 #[async_test]
-async fn send_room_name() {
+async fn test_send_room_name() {
     let (_, mock_server, driver_handle) = run_test_driver(false).await;
 
     negotiate_capabilities(
@@ -602,7 +602,7 @@ async fn send_room_name() {
 }
 
 #[async_test]
-async fn send_delayed_message_event() {
+async fn test_send_delayed_message_event() {
     let (_, mock_server, driver_handle) = run_test_driver(false).await;
 
     negotiate_capabilities(
@@ -650,7 +650,7 @@ async fn send_delayed_message_event() {
 }
 
 #[async_test]
-async fn send_delayed_state_event() {
+async fn test_send_delayed_state_event() {
     let (_, mock_server, driver_handle) = run_test_driver(false).await;
 
     negotiate_capabilities(
@@ -698,7 +698,7 @@ async fn send_delayed_state_event() {
 }
 
 #[async_test]
-async fn try_send_delayed_state_event_without_permission() {
+async fn test_try_send_delayed_state_event_without_permission() {
     let (_, _mock_server, driver_handle) = run_test_driver(false).await;
 
     negotiate_capabilities(
@@ -734,7 +734,7 @@ async fn try_send_delayed_state_event_without_permission() {
 }
 
 #[async_test]
-async fn update_delayed_event() {
+async fn test_update_delayed_event() {
     let (_, mock_server, driver_handle) = run_test_driver(false).await;
 
     negotiate_capabilities(&driver_handle, json!(["org.matrix.msc4157.update_delayed_event",]))
@@ -770,7 +770,7 @@ async fn update_delayed_event() {
 }
 
 #[async_test]
-async fn try_update_delayed_event_without_permission() {
+async fn test_try_update_delayed_event_without_permission() {
     let (_, _mock_server, driver_handle) = run_test_driver(false).await;
 
     negotiate_capabilities(&driver_handle, json!([])).await;
@@ -798,7 +798,7 @@ async fn try_update_delayed_event_without_permission() {
 }
 
 #[async_test]
-async fn try_update_delayed_event_without_permission_negotiate() {
+async fn test_try_update_delayed_event_without_permission_negotiate() {
     let (_, _mock_server, driver_handle) = run_test_driver(false).await;
 
     send_request(

--- a/testing/matrix-sdk-test-macros/src/lib.rs
+++ b/testing/matrix-sdk-test-macros/src/lib.rs
@@ -7,6 +7,11 @@ use syn::parse_macro_input;
 #[proc_macro_attribute]
 pub fn async_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let fun = parse_macro_input!(item as syn::ItemFn);
+
+    if !fun.sig.ident.to_string().starts_with("test_") {
+        panic!("test function names must start with test_");
+    }
+
     // on the regular return-case, we can just use cfg_attr and quit early
     if fun.sig.output == syn::ReturnType::Default {
         let attrs = r#"


### PR DESCRIPTION
This will only apply to `async_test` functions, but I think this is a win:

1. for consistency within the codebase, since I've started doing so in many places,
2. because these function names will clearly identify these functions as tests, in the call tree interfaces, when rendered using the LSP show-callers/show-callees functionality.