### PR TITLE
timeline: don't clear the internal counter in presence of local echoes

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -19,18 +19,20 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{
-    config::SyncSettings, executor::spawn, ruma::MilliSecondsSinceUnixEpoch,
-    test_utils::logged_in_client_with_server,
+    assert_next_matches_with_timeout,
+    config::SyncSettings,
+    executor::spawn,
+    ruma::MilliSecondsSinceUnixEpoch,
+    test_utils::{events::EventFactory, logged_in_client_with_server},
 };
 use matrix_sdk_test::{
-    async_test, mocks::mock_encryption_state, sync_timeline_event, JoinedRoomBuilder,
-    SyncResponseBuilder,
+    async_test, mocks::mock_encryption_state, JoinedRoomBuilder, SyncResponseBuilder,
 };
 use matrix_sdk_ui::timeline::{EventSendState, RoomExt, TimelineItemContent};
 use ruma::{
     event_id,
     events::room::message::{MessageType, RoomMessageEventContent},
-    room_id, uint,
+    room_id, uint, user_id,
 };
 use serde_json::json;
 use stream_assert::assert_next_matches;
@@ -99,19 +101,16 @@ async fn test_echo() {
     let item = sent_confirmation.as_event().unwrap();
     assert_matches!(item.send_state(), Some(EventSendState::Sent { .. }));
 
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
-        sync_timeline_event!({
-            "content": {
-                "body": "Hello, World!",
-                "msgtype": "m.text",
-            },
-            "event_id": "$7at8sd:localhost",
-            "origin_server_ts": 152038280,
-            "sender": "@example:localhost",
-            "type": "m.room.message",
-            "unsigned": { "transaction_id": txn_id, },
-        }),
-    ));
+    let f = EventFactory::new();
+    sync_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id).add_timeline_event(
+            f.text_msg("Hello, World!")
+                .sender(user_id!("@example:localhost"))
+                .event_id(event_id!("$7at8sd:localhost"))
+                .server_ts(MilliSecondsSinceUnixEpoch(uint!(152038280)))
+                .unsigned_transaction_id(txn_id),
+        ),
+    );
 
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
@@ -237,50 +236,53 @@ async fn test_dedup_by_event_id_late() {
             ResponseTemplate::new(200)
                 .set_body_json(json!({ "event_id": event_id }))
                 // Not great to use a timer for this, but it's what wiremock gives us right now.
-                // Ideally we'd wait on a channel to produce a value or sth. like that.
-                .set_delay(Duration::from_millis(100)),
+                // Ideally we'd wait on a channel to produce a value or sth. like that, but
+                // wiremock doesn't allow to handle multiple queries at the same time.
+                .set_delay(Duration::from_millis(500)),
         )
         .mount(&server)
         .await;
 
     timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into()).await.unwrap();
 
-    assert_let!(Some(VectorDiff::PushBack { value: local_echo }) = timeline_stream.next().await);
+    // Timeline: [local echo]
+    let local_echo =
+        assert_next_matches_with_timeout!(timeline_stream, VectorDiff::PushBack { value } => value);
     let item = local_echo.as_event().unwrap();
     assert_matches!(item.send_state(), Some(EventSendState::NotSentYet));
 
-    let day_divider =
-        assert_next_matches!( timeline_stream, VectorDiff::PushFront { value } => value);
+    // Timeline: [day-divider, local echo]
+    let day_divider = assert_next_matches_with_timeout!( timeline_stream, VectorDiff::PushFront { value } => value);
     assert!(day_divider.is_day_divider());
 
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
-        sync_timeline_event!({
-            "content": {
-                "body": "Hello, World!",
-                "msgtype": "m.text",
-            },
-            "event_id": event_id,
-            "origin_server_ts": 123456,
-            "sender": "@example:localhost",
-            "type": "m.room.message",
-            // no transaction ID
-        }),
-    ));
+    let f = EventFactory::new();
+    sync_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id).add_timeline_event(
+            // Note: no transaction id.
+            f.text_msg("Hello, World!")
+                .sender(user_id!("@example:localhost"))
+                .event_id(event_id)
+                .server_ts(MilliSecondsSinceUnixEpoch(uint!(123456))),
+        ),
+    );
 
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
 
+    // Timeline: [remote-echo, day-divider, local echo]
     let remote_echo =
         assert_next_matches!(timeline_stream, VectorDiff::PushFront { value } => value);
     let item = remote_echo.as_event().unwrap();
     assert_eq!(item.event_id(), Some(event_id));
 
-    let day_divider =
-        assert_next_matches!(timeline_stream, VectorDiff::PushFront { value } => value);
+    // Timeline: [day-divider, remote-echo, day-divider, local echo]
+    let day_divider = assert_next_matches_with_timeout!(timeline_stream, VectorDiff::PushFront { value } => value);
     assert!(day_divider.is_day_divider());
 
     // Local echo and its day divider are removed.
+    // Timeline: [day-divider, remote-echo, day-divider]
     assert_matches!(timeline_stream.next().await, Some(VectorDiff::Remove { index: 3 }));
+    // Timeline: [day-divider, remote-echo]
     assert_matches!(timeline_stream.next().await, Some(VectorDiff::Remove { index: 2 }));
 }
 

--- a/crates/matrix-sdk/src/test_utils/events.rs
+++ b/crates/matrix-sdk/src/test_utils/events.rs
@@ -17,7 +17,6 @@
 use std::sync::atomic::{AtomicU64, Ordering::SeqCst};
 
 use matrix_sdk_base::deserialized_responses::{SyncTimelineEvent, TimelineEvent};
-use matrix_sdk_test::{sync_timeline_event, timeline_event};
 use ruma::{
     events::{
         message::TextContentBlock,
@@ -35,10 +34,16 @@ use ruma::{
         AnySyncTimelineEvent, AnyTimelineEvent, EventContent,
     },
     serde::Raw,
-    server_name, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId,
-    RoomId, UserId,
+    server_name, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
+    OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
 };
 use serde::Serialize;
+use serde_json::json;
+
+#[derive(Debug, Default, Serialize)]
+struct Unsigned {
+    transaction_id: Option<OwnedTransactionId>,
+}
 
 #[derive(Debug)]
 pub struct EventBuilder<E: EventContent> {
@@ -48,6 +53,7 @@ pub struct EventBuilder<E: EventContent> {
     redacts: Option<OwnedEventId>,
     content: E,
     server_ts: MilliSecondsSinceUnixEpoch,
+    unsigned: Option<Unsigned>,
 }
 
 impl<E: EventContent> EventBuilder<E>
@@ -74,20 +80,48 @@ where
         self
     }
 
-    pub fn into_raw_timeline(self) -> Raw<AnyTimelineEvent> {
-        let room_id = self.room.expect("we should have a room id at this point");
-        let event_id =
-            self.event_id.unwrap_or_else(|| EventId::new(room_id.server_name().unwrap()));
+    pub fn unsigned_transaction_id(mut self, transaction_id: &TransactionId) -> Self {
+        self.unsigned.get_or_insert_with(Default::default).transaction_id =
+            Some(transaction_id.to_owned());
+        self
+    }
 
-        timeline_event!({
+    #[inline(always)]
+    fn construct_json<T>(self, requires_room: bool) -> Raw<T> {
+        let event_id = self
+            .event_id
+            .or_else(|| {
+                self.room.as_ref().map(|room_id| EventId::new(room_id.server_name().unwrap()))
+            })
+            .unwrap_or_else(|| EventId::new(server_name!("dummy.org")));
+
+        let mut json = json!({
             "type": self.content.event_type(),
             "content": self.content,
             "event_id": event_id,
             "sender": self.sender.expect("we should have a sender user id at this point"),
-            "room_id": room_id,
             "origin_server_ts": self.server_ts,
-            "redacts": self.redacts,
-        })
+        });
+
+        let map = json.as_object_mut().unwrap();
+
+        if requires_room {
+            let room_id = self.room.expect("TimelineEvent requires a room id");
+            map.insert("room_id".to_owned(), json!(room_id));
+        }
+
+        if let Some(redacts) = self.redacts {
+            map.insert("redacts".to_owned(), json!(redacts));
+        }
+        if let Some(unsigned) = self.unsigned {
+            map.insert("unsigned".to_owned(), json!(unsigned));
+        }
+
+        Raw::new(map).unwrap().cast()
+    }
+
+    pub fn into_raw_timeline(self) -> Raw<AnyTimelineEvent> {
+        self.construct_json(true)
     }
 
     pub fn into_timeline(self) -> TimelineEvent {
@@ -95,19 +129,7 @@ where
     }
 
     pub fn into_raw_sync(self) -> Raw<AnySyncTimelineEvent> {
-        let event_id = self
-            .event_id
-            .or_else(|| self.room.map(|room_id| EventId::new(room_id.server_name().unwrap())))
-            .unwrap_or_else(|| EventId::new(server_name!("dummy.org")));
-
-        sync_timeline_event!({
-            "type": self.content.event_type(),
-            "content": self.content,
-            "event_id": event_id,
-            "sender": self.sender.expect("we should have a sender user id at this point"),
-            "origin_server_ts": self.server_ts,
-            "redacts": self.redacts,
-        })
+        self.construct_json(false)
     }
 
     pub fn into_sync(self) -> SyncTimelineEvent {
@@ -211,6 +233,7 @@ impl EventFactory {
             event_id: None,
             redacts: None,
             content,
+            unsigned: None,
         }
     }
 


### PR DESCRIPTION
Might fix issues like https://github.com/element-hq/element-x-android-rageshakes/issues/2585 or items morphing into other items as in https://github.com/element-hq/element-x-ios/issues/3206.