### PR TITLE
indexeddb: Pass the db transaction into do_schema_upgrade closures

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v0_to_v5.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v0_to_v5.rs
@@ -26,7 +26,7 @@ use crate::crypto_store::{
 
 /// Perform schema migrations as needed, up to schema version 5.
 pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 5, |db, old_version| {
+    do_schema_upgrade(name, 5, |db, _, old_version| {
         // An old_version of 1 could either mean actually the first version of the
         // schema, or a completely empty schema that has been created with a
         // call to `IdbDatabase::open` with no explicit "version". So, to determine

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v10_to_v11.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v10_to_v11.rs
@@ -57,5 +57,5 @@ pub(crate) async fn data_migrate(
 pub(crate) async fn schema_bump(name: &str) -> crate::crypto_store::Result<(), DomException> {
     // Just bump the version number to 11 to demonstrate that we have run the data
     // changes from data_migrate.
-    do_schema_upgrade(name, 11, |_, _| Ok(())).await
+    do_schema_upgrade(name, 11, |_, _, _| Ok(())).await
 }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v5_to_v7.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v5_to_v7.rs
@@ -36,7 +36,7 @@ use crate::{
 
 /// Perform the schema upgrade v5 to v6, creating `inbound_group_sessions2`.
 pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 6, |db, _| {
+    do_schema_upgrade(name, 6, |db, _, _| {
         let object_store = db.create_object_store(old_keys::INBOUND_GROUP_SESSIONS_V2)?;
 
         add_nonunique_index(
@@ -109,7 +109,7 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
 
 /// Perform the schema upgrade v6 to v7, deleting `inbound_group_sessions`.
 pub(crate) async fn schema_delete(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 7, |db, _| {
+    do_schema_upgrade(name, 7, |db, _, _| {
         db.delete_object_store(old_keys::INBOUND_GROUP_SESSIONS_V1)?;
         Ok(())
     })

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v7_to_v8.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v7_to_v8.rs
@@ -113,7 +113,7 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
 
 /// Perform the schema upgrade v7 to v8, Just bumping the schema version.
 pub(crate) async fn schema_bump(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 8, |_, _| {
+    do_schema_upgrade(name, 8, |_, _, _| {
         // Just bump the version number to 8 to demonstrate that we have run the data
         // changes from prepare_data_for_v8.
         Ok(())

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
@@ -35,7 +35,7 @@ use crate::{
 
 /// Perform the schema upgrade v8 to v9, creating `inbound_group_sessions3`.
 pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 9, |db, _| {
+    do_schema_upgrade(name, 9, |db, _, _| {
         let object_store = db.create_object_store(keys::INBOUND_GROUP_SESSIONS_V3)?;
 
         add_nonunique_index(
@@ -128,7 +128,7 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
 
 /// Perform the schema upgrade v8 to v10, deleting `inbound_group_sessions2`.
 pub(crate) async fn schema_delete(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 10, |db, _| {
+    do_schema_upgrade(name, 10, |db, _, _| {
         db.delete_object_store(old_keys::INBOUND_GROUP_SESSIONS_V2)?;
         Ok(())
     })


### PR DESCRIPTION
For some operations (notably: adding an index to an existing object store), we need access to the database transation during the upgrade operation.

This isn't used yet, but I wanted to pull it out to a separate PR to slim down https://github.com/matrix-org/matrix-rust-sdk/pull/3806 a bit.