### PR TITLE
base: Add media retention policy to EventCacheStore

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "e2e-encryption")]
-use std::ops::Deref;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt, iter,
-    sync::Arc,
 };
+#[cfg(feature = "e2e-encryption")]
+use std::{ops::Deref, sync::Arc};
 
 use eyeball::{SharedObservable, Subscriber};
 #[cfg(not(target_arch = "wasm32"))]
@@ -71,7 +70,7 @@ use crate::RoomMemberships;
 use crate::{
     deserialized_responses::{RawAnySyncOrStrippedTimelineEvent, SyncTimelineEvent},
     error::{Error, Result},
-    event_cache_store::DynEventCacheStore,
+    event_cache_store::EventCacheStoreWrapper,
     rooms::{
         normal::{RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons},
         Room, RoomInfo, RoomState,
@@ -93,7 +92,7 @@ pub struct BaseClient {
     /// Database
     pub(crate) store: Store,
     /// The store used by the event cache.
-    event_cache_store: Arc<DynEventCacheStore>,
+    event_cache_store: EventCacheStoreWrapper,
     /// The store used for encryption.
     ///
     /// This field is only meant to be used for `OlmMachine` initialization.
@@ -147,7 +146,7 @@ impl BaseClient {
 
         BaseClient {
             store: Store::new(config.state_store),
-            event_cache_store: config.event_cache_store,
+            event_cache_store: EventCacheStoreWrapper::new(config.event_cache_store),
             #[cfg(feature = "e2e-encryption")]
             crypto_store: config.crypto_store,
             #[cfg(feature = "e2e-encryption")]
@@ -222,8 +221,8 @@ impl BaseClient {
     }
 
     /// Get a reference to the event cache store.
-    pub fn event_cache_store(&self) -> &DynEventCacheStore {
-        &*self.event_cache_store
+    pub fn event_cache_store(&self) -> &EventCacheStoreWrapper {
+        &self.event_cache_store
     }
 
     /// Is the client logged in.

--- a/crates/matrix-sdk-base/src/event_cache_store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/integration_tests.rs
@@ -14,12 +14,15 @@
 
 //! Trait and macro of integration tests for `EventCacheStore` implementations.
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 use ruma::{
-    api::client::media::get_content_thumbnail::v3::Method, events::room::MediaSource, mxc_uri, uint,
+    api::client::media::get_content_thumbnail::v3::Method, events::room::MediaSource, mxc_uri,
+    owned_mxc_uri, time::SystemTime, uint,
 };
 
-use super::DynEventCacheStore;
+use super::{DynEventCacheStore, MediaRetentionPolicy};
 use crate::media::{MediaFormat, MediaRequest, MediaThumbnailSettings};
 
 /// `EventCacheStore` integration tests.
@@ -31,6 +34,18 @@ use crate::media::{MediaFormat, MediaRequest, MediaThumbnailSettings};
 pub trait EventCacheStoreIntegrationTests {
     /// Test media content storage.
     async fn test_media_content(&self);
+
+    /// Test media retention policy storage.
+    async fn test_store_media_retention_policy(&self);
+
+    /// Test media content's retention policy max file size.
+    async fn test_media_max_file_size(&self);
+
+    /// Test media content's retention policy max file size.
+    async fn test_media_max_cache_size(&self);
+
+    /// Test media content's retention policy expiry.
+    async fn test_media_expiry(&self);
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -49,32 +64,34 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             )),
         };
 
-        let other_uri = mxc_uri!("mxc://localhost/media-other");
-        let request_other_file = MediaRequest {
-            source: MediaSource::Plain(other_uri.to_owned()),
-            format: MediaFormat::File,
-        };
+        let other_uri = owned_mxc_uri!("mxc://localhost/media-other");
+        let request_other_file =
+            MediaRequest { source: MediaSource::Plain(other_uri), format: MediaFormat::File };
 
         let content: Vec<u8> = "hello".into();
         let thumbnail_content: Vec<u8> = "world".into();
         let other_content: Vec<u8> = "foo".into();
+        let time = SystemTime::now();
+        let policy = MediaRetentionPolicy::empty();
 
         // Media isn't present in the cache.
         assert!(
-            self.get_media_content(&request_file).await.unwrap().is_none(),
+            self.get_media_content(&request_file, time).await.unwrap().is_none(),
             "unexpected media found"
         );
         assert!(
-            self.get_media_content(&request_thumbnail).await.unwrap().is_none(),
+            self.get_media_content(&request_thumbnail, time).await.unwrap().is_none(),
             "media not found"
         );
 
         // Let's add the media.
-        self.add_media_content(&request_file, content.clone()).await.expect("adding media failed");
+        self.add_media_content(&request_file, content.clone(), time, policy)
+            .await
+            .expect("adding media failed");
 
         // Media is present in the cache.
         assert_eq!(
-            self.get_media_content(&request_file).await.unwrap().as_ref(),
+            self.get_media_content(&request_file, time).await.unwrap().as_ref(),
             Some(&content),
             "media not found though added"
         );
@@ -84,41 +101,41 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         // Media isn't present in the cache.
         assert!(
-            self.get_media_content(&request_file).await.unwrap().is_none(),
+            self.get_media_content(&request_file, time).await.unwrap().is_none(),
             "media still there after removing"
         );
 
         // Let's add the media again.
-        self.add_media_content(&request_file, content.clone())
+        self.add_media_content(&request_file, content.clone(), time, policy)
             .await
             .expect("adding media again failed");
 
         assert_eq!(
-            self.get_media_content(&request_file).await.unwrap().as_ref(),
+            self.get_media_content(&request_file, time).await.unwrap().as_ref(),
             Some(&content),
             "media not found after adding again"
         );
 
         // Let's add the thumbnail media.
-        self.add_media_content(&request_thumbnail, thumbnail_content.clone())
+        self.add_media_content(&request_thumbnail, thumbnail_content.clone(), time, policy)
             .await
             .expect("adding thumbnail failed");
 
         // Media's thumbnail is present.
         assert_eq!(
-            self.get_media_content(&request_thumbnail).await.unwrap().as_ref(),
+            self.get_media_content(&request_thumbnail, time).await.unwrap().as_ref(),
             Some(&thumbnail_content),
             "thumbnail not found"
         );
 
         // Let's add another media with a different URI.
-        self.add_media_content(&request_other_file, other_content.clone())
+        self.add_media_content(&request_other_file, other_content.clone(), time, policy)
             .await
             .expect("adding other media failed");
 
         // Other file is present.
         assert_eq!(
-            self.get_media_content(&request_other_file).await.unwrap().as_ref(),
+            self.get_media_content(&request_other_file, time).await.unwrap().as_ref(),
             Some(&other_content),
             "other file not found"
         );
@@ -127,22 +144,410 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         self.remove_media_content_for_uri(uri).await.expect("removing all media for uri failed");
 
         assert!(
-            self.get_media_content(&request_file).await.unwrap().is_none(),
+            self.get_media_content(&request_file, time).await.unwrap().is_none(),
             "media wasn't removed"
         );
         assert!(
-            self.get_media_content(&request_thumbnail).await.unwrap().is_none(),
+            self.get_media_content(&request_thumbnail, time).await.unwrap().is_none(),
             "thumbnail wasn't removed"
         );
         assert!(
-            self.get_media_content(&request_other_file).await.unwrap().is_some(),
+            self.get_media_content(&request_other_file, time).await.unwrap().is_some(),
             "other media was removed"
         );
+    }
+
+    async fn test_store_media_retention_policy(&self) {
+        let stored = self.media_retention_policy().await.unwrap();
+        assert!(stored.is_none());
+
+        let policy = MediaRetentionPolicy::default();
+        self.set_media_retention_policy(policy).await.unwrap();
+
+        let stored = self.media_retention_policy().await.unwrap();
+        assert_eq!(stored, Some(policy));
+    }
+
+    async fn test_media_max_file_size(&self) {
+        let time = SystemTime::now();
+
+        // 256 bytes content.
+        let content_big = vec![0; 256];
+        let uri_big = owned_mxc_uri!("mxc://localhost/big-media");
+        let request_big =
+            MediaRequest { source: MediaSource::Plain(uri_big), format: MediaFormat::File };
+
+        // 128 bytes content.
+        let content_avg = vec![0; 128];
+        let uri_avg = owned_mxc_uri!("mxc://localhost/average-media");
+        let request_avg =
+            MediaRequest { source: MediaSource::Plain(uri_avg), format: MediaFormat::File };
+
+        // 64 bytes content.
+        let content_small = vec![0; 64];
+        let uri_small = owned_mxc_uri!("mxc://localhost/small-media");
+        let request_small =
+            MediaRequest { source: MediaSource::Plain(uri_small), format: MediaFormat::File };
+
+        // First, with a policy that doesn't accept the big media.
+        let policy = MediaRetentionPolicy::empty().with_max_file_size(Some(200));
+
+        self.add_media_content(&request_big, content_big.clone(), time, policy).await.unwrap();
+        self.add_media_content(&request_avg, content_avg.clone(), time, policy).await.unwrap();
+        self.add_media_content(&request_small, content_small, time, policy).await.unwrap();
+
+        // The big content was NOT cached but the others were.
+        let stored = self.get_media_content(&request_big, time).await.unwrap();
+        assert!(stored.is_none());
+        let stored = self.get_media_content(&request_avg, time).await.unwrap();
+        assert!(stored.is_some());
+        let stored = self.get_media_content(&request_small, time).await.unwrap();
+        assert!(stored.is_some());
+
+        // A cleanup doesn't have any effect.
+        self.clean_up_media_cache(policy, time).await.unwrap();
+
+        let stored = self.get_media_content(&request_avg, time).await.unwrap();
+        assert!(stored.is_some());
+        let stored = self.get_media_content(&request_small, time).await.unwrap();
+        assert!(stored.is_some());
+
+        // Change to a policy that doesn't accept the average media.
+        let policy = MediaRetentionPolicy::empty().with_max_file_size(Some(100));
+
+        // The cleanup removes the average media.
+        self.clean_up_media_cache(policy, time).await.unwrap();
+
+        let stored = self.get_media_content(&request_avg, time).await.unwrap();
+        assert!(stored.is_none());
+        let stored = self.get_media_content(&request_small, time).await.unwrap();
+        assert!(stored.is_some());
+
+        // Caching big and average media doesn't work.
+        self.add_media_content(&request_big, content_big.clone(), time, policy).await.unwrap();
+        self.add_media_content(&request_avg, content_avg.clone(), time, policy).await.unwrap();
+
+        let stored = self.get_media_content(&request_big, time).await.unwrap();
+        assert!(stored.is_none());
+        let stored = self.get_media_content(&request_avg, time).await.unwrap();
+        assert!(stored.is_none());
+
+        // If there are both a cache size and a file size, the minimum value is used.
+        let policy = MediaRetentionPolicy::empty()
+            .with_max_cache_size(Some(200))
+            .with_max_file_size(Some(1000));
+
+        // Caching big doesn't work.
+        self.add_media_content(&request_big, content_big.clone(), time, policy).await.unwrap();
+        self.add_media_content(&request_avg, content_avg.clone(), time, policy).await.unwrap();
+
+        let stored = self.get_media_content(&request_big, time).await.unwrap();
+        assert!(stored.is_none());
+        let stored = self.get_media_content(&request_avg, time).await.unwrap();
+        assert!(stored.is_some());
+
+        // Change to a policy that doesn't accept the average media.
+        let policy = MediaRetentionPolicy::empty()
+            .with_max_cache_size(Some(100))
+            .with_max_file_size(Some(1000));
+
+        // The cleanup removes the average media.
+        self.clean_up_media_cache(policy, time).await.unwrap();
+
+        let stored = self.get_media_content(&request_avg, time).await.unwrap();
+        assert!(stored.is_none());
+        let stored = self.get_media_content(&request_small, time).await.unwrap();
+        assert!(stored.is_some());
+
+        // Caching big and average media doesn't work.
+        self.add_media_content(&request_big, content_big, time, policy).await.unwrap();
+        self.add_media_content(&request_avg, content_avg, time, policy).await.unwrap();
+
+        let stored = self.get_media_content(&request_big, time).await.unwrap();
+        assert!(stored.is_none());
+        let stored = self.get_media_content(&request_avg, time).await.unwrap();
+        assert!(stored.is_none());
+    }
+
+    async fn test_media_max_cache_size(&self) {
+        // 256 bytes content.
+        let content_big = vec![0; 256];
+        let uri_big = owned_mxc_uri!("mxc://localhost/big-media");
+        let request_big =
+            MediaRequest { source: MediaSource::Plain(uri_big), format: MediaFormat::File };
+
+        // 128 bytes content.
+        let content_avg = vec![0; 128];
+        let uri_avg = owned_mxc_uri!("mxc://localhost/average-media");
+        let request_avg =
+            MediaRequest { source: MediaSource::Plain(uri_avg), format: MediaFormat::File };
+
+        // 64 bytes content.
+        let content_small = vec![0; 64];
+        let uri_small_1 = owned_mxc_uri!("mxc://localhost/small-media-1");
+        let request_small_1 =
+            MediaRequest { source: MediaSource::Plain(uri_small_1), format: MediaFormat::File };
+        let uri_small_2 = owned_mxc_uri!("mxc://localhost/small-media-2");
+        let request_small_2 =
+            MediaRequest { source: MediaSource::Plain(uri_small_2), format: MediaFormat::File };
+        let uri_small_3 = owned_mxc_uri!("mxc://localhost/small-media-3");
+        let request_small_3 =
+            MediaRequest { source: MediaSource::Plain(uri_small_3), format: MediaFormat::File };
+        let uri_small_4 = owned_mxc_uri!("mxc://localhost/small-media-4");
+        let request_small_4 =
+            MediaRequest { source: MediaSource::Plain(uri_small_4), format: MediaFormat::File };
+        let uri_small_5 = owned_mxc_uri!("mxc://localhost/small-media-5");
+        let request_small_5 =
+            MediaRequest { source: MediaSource::Plain(uri_small_5), format: MediaFormat::File };
+
+        // A policy that doesn't accept the big media.
+        let policy = MediaRetentionPolicy::empty().with_max_cache_size(Some(200));
+
+        // Try to add all the content at different times.
+        let mut time = SystemTime::UNIX_EPOCH;
+        self.add_media_content(&request_big, content_big, time, policy).await.unwrap();
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_small_1, content_small.clone(), time, policy)
+            .await
+            .unwrap();
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_small_2, content_small.clone(), time, policy)
+            .await
+            .unwrap();
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_small_3, content_small.clone(), time, policy)
+            .await
+            .unwrap();
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_small_4, content_small.clone(), time, policy)
+            .await
+            .unwrap();
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_small_5, content_small.clone(), time, policy)
+            .await
+            .unwrap();
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_avg, content_avg, time, policy).await.unwrap();
+
+        // The big content was NOT cached but the others were.
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_big, time).await.unwrap();
+        assert!(stored.is_none());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_1, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_2, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_3, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_4, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_5, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_avg, time).await.unwrap();
+        assert!(stored.is_some());
+
+        // Cleanup removes the oldest content first.
+        time += Duration::from_secs(1);
+        self.clean_up_media_cache(policy, time).await.unwrap();
+
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_1, time).await.unwrap();
+        assert!(stored.is_none());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_2, time).await.unwrap();
+        assert!(stored.is_none());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_3, time).await.unwrap();
+        assert!(stored.is_none());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_4, time).await.unwrap();
+        assert!(stored.is_none());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_5, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_avg, time).await.unwrap();
+        assert!(stored.is_some());
+
+        // Reinsert the small medias that were removed.
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_small_1, content_small.clone(), time, policy)
+            .await
+            .unwrap();
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_small_2, content_small.clone(), time, policy)
+            .await
+            .unwrap();
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_small_3, content_small.clone(), time, policy)
+            .await
+            .unwrap();
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_small_4, content_small, time, policy).await.unwrap();
+
+        // Check that they are cached.
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_1, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_2, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_3, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_4, time).await.unwrap();
+        assert!(stored.is_some());
+
+        // Access small_5 too so its last access is updated too.
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_5, time).await.unwrap();
+        assert!(stored.is_some());
+
+        // Cleanup still removes the oldest content first, which is not the same as
+        // before.
+        time += Duration::from_secs(1);
+        self.clean_up_media_cache(policy, time).await.unwrap();
+
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_1, time).await.unwrap();
+        assert!(stored.is_none());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_2, time).await.unwrap();
+        assert!(stored.is_none());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_3, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_4, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_small_5, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_avg, time).await.unwrap();
+        assert!(stored.is_none());
+    }
+
+    async fn test_media_expiry(&self) {
+        // 64 bytes content.
+        let content = vec![0; 64];
+
+        let uri_1 = owned_mxc_uri!("mxc://localhost/media-1");
+        let request_1 =
+            MediaRequest { source: MediaSource::Plain(uri_1), format: MediaFormat::File };
+        let uri_2 = owned_mxc_uri!("mxc://localhost/media-2");
+        let request_2 =
+            MediaRequest { source: MediaSource::Plain(uri_2), format: MediaFormat::File };
+        let uri_3 = owned_mxc_uri!("mxc://localhost/media-3");
+        let request_3 =
+            MediaRequest { source: MediaSource::Plain(uri_3), format: MediaFormat::File };
+        let uri_4 = owned_mxc_uri!("mxc://localhost/media-4");
+        let request_4 =
+            MediaRequest { source: MediaSource::Plain(uri_4), format: MediaFormat::File };
+        let uri_5 = owned_mxc_uri!("mxc://localhost/media-5");
+        let request_5 =
+            MediaRequest { source: MediaSource::Plain(uri_5), format: MediaFormat::File };
+
+        // A policy with 30 seconds expiry.
+        let policy =
+            MediaRetentionPolicy::empty().with_last_access_expiry(Some(Duration::from_secs(30)));
+
+        // Add all the content at different times.
+        let mut time = SystemTime::UNIX_EPOCH;
+        self.add_media_content(&request_1, content.clone(), time, policy).await.unwrap();
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_2, content.clone(), time, policy).await.unwrap();
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_3, content.clone(), time, policy).await.unwrap();
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_4, content.clone(), time, policy).await.unwrap();
+        time += Duration::from_secs(1);
+        self.add_media_content(&request_5, content, time, policy).await.unwrap();
+
+        // The content was cached.
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_1, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_2, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_3, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_4, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_5, time).await.unwrap();
+        assert!(stored.is_some());
+
+        // We are now at UNIX_EPOCH + 10 seconds, the oldest content was accessed 5
+        // seconds ago.
+        time += Duration::from_secs(1);
+        assert_eq!(time, SystemTime::UNIX_EPOCH + Duration::from_secs(10));
+
+        // Cleanup has no effect, nothing has expired.
+        self.clean_up_media_cache(policy, time).await.unwrap();
+
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_1, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_2, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_3, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_4, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_5, time).await.unwrap();
+        assert!(stored.is_some());
+
+        // We are now at UNIX_EPOCH + 16 seconds, the oldest content was accessed 5
+        // seconds ago.
+        time += Duration::from_secs(1);
+        assert_eq!(time, SystemTime::UNIX_EPOCH + Duration::from_secs(16));
+
+        // Jump 26 seconds in the future, so the 2 first media contents are expired.
+        time += Duration::from_secs(26);
+
+        // Cleanup removes the two oldest media contents.
+        self.clean_up_media_cache(policy, time).await.unwrap();
+
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_1, time).await.unwrap();
+        assert!(stored.is_none());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_2, time).await.unwrap();
+        assert!(stored.is_none());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_3, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_4, time).await.unwrap();
+        assert!(stored.is_some());
+        time += Duration::from_secs(1);
+        let stored = self.get_media_content(&request_5, time).await.unwrap();
+        assert!(stored.is_some());
     }
 }
 
 /// Macro building to allow your `EventCacheStore` implementation to run the
 /// entire tests suite locally.
+///
+/// Can be run with the `with_media_size_tests` argument to include more tests
+/// about the media cache retention policy based on content size. It is not
+/// recommended to run those in encrypted stores because the size of the
+/// encrypted content may vary compared to what the tests expect.
 ///
 /// You need to provide a `async fn get_event_cache_store() ->
 /// EventCacheStoreResult<impl EventCacheStore>` providing a fresh event cache
@@ -171,19 +576,53 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 #[allow(unused_macros, unused_extern_crates)]
 #[macro_export]
 macro_rules! event_cache_store_integration_tests {
-    () => {
+    (with_media_size_tests) => {
         mod event_cache_store_integration_tests {
-            use matrix_sdk_test::async_test;
-            use $crate::event_cache_store::{EventCacheStoreIntegrationTests, IntoEventCacheStore};
-
-            use super::get_event_cache_store;
+            $crate::event_cache_store_integration_tests!(@inner);
 
             #[async_test]
-            async fn test_media_content() {
-                let event_cache_store =
-                    get_event_cache_store().await.unwrap().into_event_cache_store();
-                event_cache_store.test_media_content().await;
+            async fn test_media_max_file_size() {
+                let event_cache_store = get_event_cache_store().await.unwrap().into_event_cache_store();
+                event_cache_store.test_media_max_file_size().await;
             }
+
+            #[async_test]
+            async fn test_media_max_cache_size() {
+                let event_cache_store = get_event_cache_store().await.unwrap().into_event_cache_store();
+                event_cache_store.test_media_max_cache_size().await;
+            }
+        }
+    };
+
+    () => {
+        mod event_cache_store_integration_tests {
+            $crate::event_cache_store_integration_tests!(@inner);
+        }
+    };
+
+    (@inner) => {
+        use matrix_sdk_test::async_test;
+        use $crate::event_cache_store::{EventCacheStoreIntegrationTests, IntoEventCacheStore};
+
+        use super::get_event_cache_store;
+
+        #[async_test]
+        async fn test_media_content() {
+            let event_cache_store =
+                get_event_cache_store().await.unwrap().into_event_cache_store();
+            event_cache_store.test_media_content().await;
+        }
+
+        #[async_test]
+        async fn test_store_media_retention_policy() {
+            let event_cache_store = get_event_cache_store().await.unwrap().into_event_cache_store();
+            event_cache_store.test_store_media_retention_policy().await;
+        }
+
+        #[async_test]
+        async fn test_media_expiry() {
+            let event_cache_store = get_event_cache_store().await.unwrap().into_event_cache_store();
+            event_cache_store.test_media_expiry().await;
         }
     };
 }

--- a/crates/matrix-sdk-base/src/event_cache_store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/memory_store.rs
@@ -16,9 +16,9 @@ use std::{num::NonZeroUsize, sync::RwLock as StdRwLock};
 
 use async_trait::async_trait;
 use matrix_sdk_common::ring_buffer::RingBuffer;
-use ruma::{MxcUri, OwnedMxcUri};
+use ruma::{time::SystemTime, MxcUri, OwnedMxcUri};
 
-use super::{EventCacheStore, EventCacheStoreError, Result};
+use super::{EventCacheStore, EventCacheStoreError, MediaRetentionPolicy, Result};
 use crate::media::{MediaRequest, UniqueKey as _};
 
 /// In-memory, non-persistent implementation of the `EventCacheStore`.
@@ -27,15 +27,41 @@ use crate::media::{MediaRequest, UniqueKey as _};
 #[allow(clippy::type_complexity)]
 #[derive(Debug)]
 pub struct MemoryStore {
-    media: StdRwLock<RingBuffer<(OwnedMxcUri, String /* unique key */, Vec<u8>)>>,
+    inner: StdRwLock<MemoryStoreInner>,
+}
+
+#[derive(Debug)]
+struct MemoryStoreInner {
+    /// The media retention policy to use on cleanups.
+    media_retention_policy: Option<MediaRetentionPolicy>,
+    /// Media content.
+    media: RingBuffer<MediaContent>,
 }
 
 // SAFETY: `new_unchecked` is safe because 20 is not zero.
 const NUMBER_OF_MEDIAS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(20) };
 
+/// A media content.
+#[derive(Debug, Clone)]
+struct MediaContent {
+    /// The Matrix URI of the media.
+    uri: OwnedMxcUri,
+    /// The unique key of the media request.
+    key: String,
+    /// The content of the media.
+    data: Vec<u8>,
+    /// The last access time of the media.
+    last_access: SystemTime,
+}
+
 impl Default for MemoryStore {
     fn default() -> Self {
-        Self { media: StdRwLock::new(RingBuffer::new(NUMBER_OF_MEDIAS)) }
+        let inner = MemoryStoreInner {
+            media_retention_policy: Default::default(),
+            media: RingBuffer::new(NUMBER_OF_MEDIAS),
+        };
+
+        Self { inner: StdRwLock::new(inner) }
     }
 }
 
@@ -51,53 +77,178 @@ impl MemoryStore {
 impl EventCacheStore for MemoryStore {
     type Error = EventCacheStoreError;
 
-    async fn add_media_content(&self, request: &MediaRequest, data: Vec<u8>) -> Result<()> {
-        // Avoid duplication. Let's try to remove it first.
-        self.remove_media_content(request).await?;
-        // Now, let's add it.
-        self.media.write().unwrap().push((request.uri().to_owned(), request.unique_key(), data));
+    async fn media_retention_policy(&self) -> Result<Option<MediaRetentionPolicy>, Self::Error> {
+        Ok(self.inner.read().unwrap().media_retention_policy)
+    }
+
+    async fn set_media_retention_policy(
+        &self,
+        policy: MediaRetentionPolicy,
+    ) -> Result<(), Self::Error> {
+        let mut inner = self.inner.write().unwrap();
+        inner.media_retention_policy = Some(policy);
 
         Ok(())
     }
 
-    async fn get_media_content(&self, request: &MediaRequest) -> Result<Option<Vec<u8>>> {
-        let media = self.media.read().unwrap();
+    async fn add_media_content(
+        &self,
+        request: &MediaRequest,
+        data: Vec<u8>,
+        current_time: SystemTime,
+        policy: MediaRetentionPolicy,
+    ) -> Result<()> {
+        // Avoid duplication. Let's try to remove it first.
+        self.remove_media_content(request).await?;
+
+        if policy.exceeds_max_file_size(data.len()) {
+            // The content is too big to be cached.
+            return Ok(());
+        }
+
+        // Now, let's add it.
+        let content = MediaContent {
+            uri: request.uri().to_owned(),
+            key: request.unique_key(),
+            data,
+            last_access: current_time,
+        };
+        self.inner.write().unwrap().media.push(content);
+
+        Ok(())
+    }
+
+    async fn get_media_content(
+        &self,
+        request: &MediaRequest,
+        current_time: SystemTime,
+    ) -> Result<Option<Vec<u8>>> {
+        let mut inner = self.inner.write().unwrap();
         let expected_key = request.unique_key();
 
-        Ok(media.iter().find_map(|(_media_uri, media_key, media_content)| {
-            (media_key == &expected_key).then(|| media_content.to_owned())
-        }))
+        // First get the content out of the buffer.
+        let Some(index) = inner.media.iter().position(|media| media.key == expected_key) else {
+            return Ok(None);
+        };
+        let Some(mut content) = inner.media.remove(index) else {
+            return Ok(None);
+        };
+
+        // Clone the data.
+        let data = content.data.clone();
+
+        // Update the last access time.
+        content.last_access = current_time;
+
+        // Put it back in the buffer.
+        inner.media.push(content);
+
+        Ok(Some(data))
     }
 
     async fn remove_media_content(&self, request: &MediaRequest) -> Result<()> {
-        let mut media = self.media.write().unwrap();
+        let mut inner = self.inner.write().unwrap();
+
         let expected_key = request.unique_key();
-        let Some(index) = media
-            .iter()
-            .position(|(_media_uri, media_key, _media_content)| media_key == &expected_key)
-        else {
+        let Some(index) = inner.media.iter().position(|media| media.key == expected_key) else {
             return Ok(());
         };
 
-        media.remove(index);
+        inner.media.remove(index);
 
         Ok(())
     }
 
     async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<()> {
-        let mut media = self.media.write().unwrap();
-        let expected_key = uri.to_owned();
-        let positions = media
+        let mut inner = self.inner.write().unwrap();
+        let positions = inner
+            .media
             .iter()
             .enumerate()
-            .filter_map(|(position, (media_uri, _media_key, _media_content))| {
-                (media_uri == &expected_key).then_some(position)
-            })
+            .filter_map(|(position, media)| (media.uri == uri).then_some(position))
             .collect::<Vec<_>>();
 
         // Iterate in reverse-order so that positions stay valid after first removals.
         for position in positions.into_iter().rev() {
-            media.remove(position);
+            inner.media.remove(position);
+        }
+
+        Ok(())
+    }
+
+    async fn clean_up_media_cache(
+        &self,
+        policy: MediaRetentionPolicy,
+        current_time: SystemTime,
+    ) -> Result<(), Self::Error> {
+        if !policy.has_limitations() {
+            // We can safely skip all the checks.
+            return Ok(());
+        }
+
+        let mut inner = self.inner.write().unwrap();
+
+        // First, check media content that exceed the max filesize.
+        if policy.max_file_size.is_some() || policy.max_cache_size.is_some() {
+            inner.media.retain(|content| !policy.exceeds_max_file_size(content.data.len()));
+        }
+
+        // Then, clean up expired media content.
+        if policy.last_access_expiry.is_some() {
+            inner
+                .media
+                .retain(|content| !policy.has_content_expired(current_time, content.last_access));
+        }
+
+        // Finally, if the cache size is too big, remove old items until it fits.
+        if let Some(max_cache_size) = policy.max_cache_size {
+            // Reverse the iterator because in case the cache size is overflowing, we want
+            // to count the number of old items to remove, and old items are at
+            // the start.
+            let (cache_size, overflowing_count) = inner.media.iter().rev().fold(
+                (0usize, 0u8),
+                |(cache_size, overflowing_count), content| {
+                    if overflowing_count > 0 {
+                        // Assume that all data is overflowing now. Overflowing count cannot
+                        // overflow because the number of items is limited to 20.
+                        (cache_size, overflowing_count + 1)
+                    } else {
+                        match cache_size.checked_add(content.data.len()) {
+                            Some(cache_size) => (cache_size, 0),
+                            // The cache size is overflowing, let's count the number of overflowing
+                            // items to be able to remove them, since the max cache size cannot be
+                            // bigger than usize::MAX.
+                            None => (cache_size, 1),
+                        }
+                    }
+                },
+            );
+
+            // If the cache size is overflowing, remove the number of old items we counted.
+            for _position in 0..overflowing_count {
+                inner.media.pop();
+            }
+
+            if cache_size > max_cache_size {
+                let difference = cache_size - max_cache_size;
+
+                // Count the number of old items to remove to reach the difference.
+                let mut accumulated_items_size = 0usize;
+                let mut remove_items_count = 0u8;
+                for content in inner.media.iter() {
+                    remove_items_count += 1;
+                    // Cannot overflow since we already removed overflowing items.
+                    accumulated_items_size += content.data.len();
+
+                    if accumulated_items_size >= difference {
+                        break;
+                    }
+                }
+
+                for _position in 0..remove_items_count {
+                    inner.media.pop();
+                }
+            }
         }
 
         Ok(())
@@ -112,5 +263,5 @@ mod tests {
         Ok(MemoryStore::new())
     }
 
-    event_cache_store_integration_tests!();
+    event_cache_store_integration_tests!(with_media_size_tests);
 }

--- a/crates/matrix-sdk-base/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/mod.rs
@@ -19,21 +19,25 @@
 //! into the event cache for the actual storage. By default this brings an
 //! in-memory store.
 
-use std::str::Utf8Error;
+use std::{str::Utf8Error, time::Duration};
 
 #[cfg(any(test, feature = "testing"))]
 #[macro_use]
 pub mod integration_tests;
 mod memory_store;
 mod traits;
+mod wrapper;
 
 pub use matrix_sdk_store_encryption::Error as StoreEncryptionError;
+use ruma::time::SystemTime;
+use serde::{Deserialize, Serialize};
 
 #[cfg(any(test, feature = "testing"))]
 pub use self::integration_tests::EventCacheStoreIntegrationTests;
 pub use self::{
     memory_store::MemoryStore,
     traits::{DynEventCacheStore, EventCacheStore, IntoEventCacheStore},
+    wrapper::EventCacheStoreWrapper,
 };
 
 /// Event cache store specific error type.
@@ -83,3 +87,162 @@ impl EventCacheStoreError {
 
 /// An `EventCacheStore` specific result type.
 pub type Result<T, E = EventCacheStoreError> = std::result::Result<T, E>;
+
+/// The retention policy for media content used by the `EventCacheStore`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MediaRetentionPolicy {
+    /// The maximum authorized size of the overall media cache, in bytes.
+    ///
+    /// The cache size is defined as the sum of the sizes of all the (possibly
+    /// encrypted) media contents in the cache, excluding any metadata
+    /// associated with them.
+    ///
+    /// If this is set and the cache size is bigger than this value, the oldest
+    /// media contents in the cache will be removed during a cleanup until the
+    /// cache size is below this threshold.
+    ///
+    /// Note that it is possible for the cache size to temporarily exceed this
+    /// value between two cleanups.
+    ///
+    /// Defaults to 400 MiB.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_cache_size: Option<usize>,
+    /// The maximum authorized size of a single media content, in bytes.
+    ///
+    /// The size of a media content is the size taken by the content in the
+    /// database, after it was possibly encrypted, so it might differ from the
+    /// initial size of the content.
+    ///
+    /// The maximum authorized size of a single media content is actually the
+    /// lowest value between `max_cache_size` and `max_file_size`.
+    ///
+    /// If it is set, media content bigger than the maximum size will not be
+    /// cached. If the maximum size changed after media content that exceeds the
+    /// new value was cached, the corresponding content will be removed
+    /// during a cleanup.
+    ///
+    /// Defaults to 20 MiB.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_file_size: Option<usize>,
+    /// The duration after which unaccessed media content is considered
+    /// expired.
+    ///
+    /// If this is set, media content whose last access is older than this
+    /// duration will be removed from the media cache during a cleanup.
+    ///
+    /// Defaults to 30 days.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_access_expiry: Option<Duration>,
+}
+
+impl MediaRetentionPolicy {
+    /// Create a `MediaRetentionPolicy` with the default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create an empty `MediaRetentionPolicy`.
+    ///
+    /// This means that all media will be cached and cleanups have no effect.
+    pub fn empty() -> Self {
+        Self { max_cache_size: None, max_file_size: None, last_access_expiry: None }
+    }
+
+    /// Set the maximum authorized size of the overall media cache, in bytes.
+    pub fn with_max_cache_size(mut self, size: Option<usize>) -> Self {
+        self.max_cache_size = size;
+        self
+    }
+
+    /// Set the maximum authorized size of a single media content, in bytes.
+    pub fn with_max_file_size(mut self, size: Option<usize>) -> Self {
+        self.max_file_size = size;
+        self
+    }
+
+    /// Set the duration before which unaccessed media content is considered
+    /// expired.
+    pub fn with_last_access_expiry(mut self, duration: Option<Duration>) -> Self {
+        self.last_access_expiry = duration;
+        self
+    }
+
+    /// Whether this policy has limitations.
+    ///
+    /// If this policy has no limitations, a cleanup job would have no effect.
+    ///
+    /// Returns `true` if at least one limitation is set.
+    pub fn has_limitations(&self) -> bool {
+        self.max_cache_size.is_some()
+            || self.max_file_size.is_some()
+            || self.last_access_expiry.is_some()
+    }
+
+    /// Whether the given size exceeds the maximum authorized size of the media
+    /// cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The overall size of the media cache to check, in bytes.
+    pub fn exceeds_max_cache_size(&self, size: usize) -> bool {
+        self.max_cache_size.is_some_and(|max_size| size > max_size)
+    }
+
+    /// The computed maximum authorized size of a single media content, in
+    /// bytes.
+    ///
+    /// This is the lowest value between `max_cache_size` and `max_file_size`.
+    pub fn computed_max_file_size(&self) -> Option<usize> {
+        match (self.max_cache_size, self.max_file_size) {
+            (None, None) => None,
+            (None, Some(size)) => Some(size),
+            (Some(size), None) => Some(size),
+            (Some(max_cache_size), Some(max_file_size)) => Some(max_cache_size.min(max_file_size)),
+        }
+    }
+
+    /// Whether the given size, in bytes, exceeds the computed maximum
+    /// authorized size of a single media content.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The size of the media content to check, in bytes.
+    pub fn exceeds_max_file_size(&self, size: usize) -> bool {
+        self.computed_max_file_size().is_some_and(|max_size| size > max_size)
+    }
+
+    /// Whether a content whose last access was at the given time has expired.
+    ///
+    /// # Arguments
+    ///
+    /// * `current_time` - The current time.
+    ///
+    /// * `last_access_time` - The time when the media content to check was last
+    ///   accessed.
+    pub fn has_content_expired(
+        &self,
+        current_time: SystemTime,
+        last_access_time: SystemTime,
+    ) -> bool {
+        self.last_access_expiry.is_some_and(|max_duration| {
+            current_time
+                .duration_since(last_access_time)
+                // If this returns an error, the last access time is newer than the current time.
+                // This shouldn't happen but in this case the content cannot be expired.
+                .is_ok_and(|elapsed| elapsed >= max_duration)
+        })
+    }
+}
+
+impl Default for MediaRetentionPolicy {
+    fn default() -> Self {
+        Self {
+            // 400 MiB.
+            max_cache_size: Some(400 * 1024 * 1024),
+            // 20 MiB.
+            max_file_size: Some(20 * 1024 * 1024),
+            // 30 days.
+            last_access_expiry: Some(Duration::from_secs(30 * 24 * 60 * 60)),
+        }
+    }
+}

--- a/crates/matrix-sdk-base/src/event_cache_store/wrapper.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/wrapper.rs
@@ -1,0 +1,130 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, Mutex as StdMutex};
+
+use ruma::{time::SystemTime, MxcUri};
+use tokio::sync::Mutex as AsyncMutex;
+
+use super::{DynEventCacheStore, MediaRetentionPolicy, Result};
+use crate::media::MediaRequest;
+
+/// A wrapper around an [`EventCacheStore`] implementation to abstract common
+/// operations.
+///
+/// [`EventCacheStore`]: super::EventCacheStore
+#[derive(Debug, Clone)]
+pub struct EventCacheStoreWrapper {
+    /// The inner store implementation.
+    store: Arc<DynEventCacheStore>,
+    /// The media retention policy.
+    media_retention_policy: Arc<StdMutex<Option<MediaRetentionPolicy>>>,
+    /// Guard to only have a single media cleanup at a time.
+    media_cleanup_guard: Arc<AsyncMutex<()>>,
+}
+
+impl EventCacheStoreWrapper {
+    /// Create a new `EventCacheStoreWrapper` around the given store.
+    pub(crate) fn new(store: Arc<DynEventCacheStore>) -> Self {
+        Self {
+            store,
+            media_retention_policy: Default::default(),
+            media_cleanup_guard: Default::default(),
+        }
+    }
+
+    /// The media retention policy.
+    pub async fn media_retention_policy(&self) -> Result<MediaRetentionPolicy> {
+        if let Some(policy) = *self.media_retention_policy.lock().unwrap() {
+            return Ok(policy);
+        }
+
+        let policy = self.store.media_retention_policy().await?.unwrap_or_default();
+        *self.media_retention_policy.lock().unwrap() = Some(policy);
+
+        Ok(policy)
+    }
+
+    /// Set the media retention policy.
+    pub async fn set_media_retention_policy(&self, policy: MediaRetentionPolicy) -> Result<()> {
+        self.store.set_media_retention_policy(policy).await?;
+
+        *self.media_retention_policy.lock().unwrap() = Some(policy);
+        Ok(())
+    }
+
+    /// Add a media file's content in the media cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The `MediaRequest` of the file.
+    /// * `content` - The content of the file.
+    pub async fn add_media_content(&self, request: &MediaRequest, content: Vec<u8>) -> Result<()> {
+        let policy = self.media_retention_policy().await?;
+
+        if policy.exceeds_max_file_size(content.len()) {
+            // The media content should not be cached.
+            return Ok(());
+        }
+
+        // We let the store implementation check the max file size again because the
+        // size of the content should change if it is encrypted.
+        self.store.add_media_content(request, content, SystemTime::now(), policy).await
+    }
+
+    /// Get a media file's content out of the media cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The `MediaRequest` of the file.
+    pub async fn get_media_content(&self, request: &MediaRequest) -> Result<Option<Vec<u8>>> {
+        self.store.get_media_content(request, SystemTime::now()).await
+    }
+
+    /// Remove a media file's content from the media cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The `MediaRequest` of the file.
+    pub async fn remove_media_content(&self, request: &MediaRequest) -> Result<()> {
+        self.store.remove_media_content(request).await
+    }
+
+    /// Remove all the media files' content associated to an `MxcUri` from the
+    /// media cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `uri` - The `MxcUri` of the media files.
+    pub async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<()> {
+        self.store.remove_media_content_for_uri(uri).await
+    }
+
+    /// Clean up the media cache with the current media retention policy.
+    ///
+    /// This is a noop if another cleanup is ongoing.
+    pub async fn clean_up_media_cache(&self) -> Result<()> {
+        let Ok(_guard) = self.media_cleanup_guard.try_lock() else {
+            return Ok(());
+        };
+
+        let policy = self.media_retention_policy().await?;
+        if !policy.has_limitations() {
+            // We can safely skip all the checks.
+            return Ok(());
+        }
+
+        self.store.clean_up_media_cache(policy, SystemTime::now()).await
+    }
+}

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -33,7 +33,7 @@ use imbl::Vector;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::store::LockableCryptoStore;
 use matrix_sdk_base::{
-    event_cache_store::DynEventCacheStore,
+    event_cache_store::EventCacheStoreWrapper,
     store::{DynStateStore, ServerCapabilities},
     sync::{Notification, RoomUpdates},
     BaseClient, RoomInfoNotableUpdate, RoomState, RoomStateFilter, SendOutsideWasm, SessionMeta,
@@ -584,7 +584,7 @@ impl Client {
     }
 
     /// Get a reference to the event cache store.
-    pub(crate) fn event_cache_store(&self) -> &DynEventCacheStore {
+    pub fn event_cache_store(&self) -> &EventCacheStoreWrapper {
         self.base_client().event_cache_store()
     }
 


### PR DESCRIPTION
Allows to prevent the media cache from growing indefinitely by setting different limitations like size or last access time. I tried to select sensible defaults for those values.

Currently cleanups must be triggered manually, a future PR will add the possibility to run a regular cleanup task so they happen automatically.
