### PR TITLE
crypto: Log the received device keys on an encrypted olm message

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -1109,7 +1109,11 @@ impl OlmMachine {
         decrypted: &mut OlmDecryptionInfo,
         changes: &mut Changes,
     ) -> OlmResult<()> {
-        debug!("Received a decrypted to-device event");
+        debug!(
+            sender_device_keys =
+                ?decrypted.result.event.sender_device_keys().map(|k| (k.curve25519_key(), k.ed25519_key())).unwrap_or((None, None)),
+            "Received a decrypted to-device event",
+        );
 
         match &*decrypted.result.event {
             AnyDecryptedOlmEvent::RoomKey(e) => {

--- a/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
@@ -148,6 +148,17 @@ impl AnyDecryptedOlmEvent {
             AnyDecryptedOlmEvent::Dummy(e) => e.content.event_type(),
         }
     }
+
+    /// The sender's device keys, if supplied in the message as per MSC4147
+    pub fn sender_device_keys(&self) -> Option<&DeviceKeys> {
+        match self {
+            AnyDecryptedOlmEvent::Custom(_) => None,
+            AnyDecryptedOlmEvent::RoomKey(e) => e.device_keys.as_ref(),
+            AnyDecryptedOlmEvent::ForwardedRoomKey(e) => e.device_keys.as_ref(),
+            AnyDecryptedOlmEvent::SecretSend(e) => e.device_keys.as_ref(),
+            AnyDecryptedOlmEvent::Dummy(e) => e.device_keys.as_ref(),
+        }
+    }
 }
 
 /// An `m.olm.v1.curve25519-aes-sha2` decrypted to-device event.


### PR DESCRIPTION
MSC4147 adds a `device_keys` property to the plaintext content of encrypted to-device events, and support for picking this out was added in #3556/#3633.

Turns out it's quite handy to log this information.

The output of this is something like:

```
2024-08-30T14:40:27.061681Z DEBUG receive_sync_changes:receive_to_device_event{sender="@alice:example.org" event_type="m.room.encrypted" message_id="01J6HVNZXBPF860R0TBH3H75KZ"}:handle_decrypted_to_device_event{sender_key="curve25519:CpEg1cKt2OiASokDD23L9/buqT7LAkcUEVaFXaBSCFU" event_type="m.room_key"}: matrix_sdk_crypto::machine: Received a decrypted to-device event sender_device_keys=(Some("curve25519:CpEg1cKt2OiASokDD23L9/buqT7LAkcUEVaFXaBSCFU"), Some("ed25519:aEMaB1+jf3tzIRdyNzI514m1czCra9W23JwYXho27iw"))
```



