### PR TITLE
crypto: expose `SenderDataFinder::find_using_device_data`

### DIFF
--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
@@ -392,9 +392,9 @@ impl GroupSessionManager {
             // InboundGroupSession that we create as a pair to the OutboundGroupSession we
             // are sending out.
             let own_sender_data = if let Some(device) = own_device {
-                SenderDataFinder::find_using_device_keys(
+                SenderDataFinder::find_using_device_data(
                     &self.store,
-                    device.as_device_keys().clone(),
+                    device.inner.clone(),
                     &inbound,
                 )
                 .await?
@@ -668,9 +668,9 @@ impl GroupSessionManager {
             // InboundGroupSession that we create as a pair to the OutboundGroupSession we
             // are sending out.
             let own_sender_data = if let Some(device) = &device {
-                SenderDataFinder::find_using_device_keys(
+                SenderDataFinder::find_using_device_data(
                     &self.store,
-                    device.as_device_keys().clone(),
+                    device.inner.clone(),
                     &inbound,
                 )
                 .await?


### PR DESCRIPTION
Turns out that most of the places we call `find_using_device_keys`, we already have a DeviceData. So we might as well pass that in directly, rather than extracting the device keys and then rebuilding a DeviceData.