### PR TITLE
fix(sdk): Sliding sync discovers the proxy on the server, not the homeserver

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -474,7 +474,7 @@ impl Client {
     /// The server used by the client.
     ///
     /// See `Self::server` to learn more.
-    fn server(&self) -> Option<&Url> {
+    pub fn server(&self) -> Option<&Url> {
         self.inner.server.as_ref()
     }
 


### PR DESCRIPTION
The `.well-known` file is located on the server, not the homeserver. This patch fixes that along with the associated tests.
