### PR TITLE
chore(sdk): Rename `HomeserverConfig` variants

### DIFF
--- a/crates/matrix-sdk/src/client/builder/homeserver_config.rs
+++ b/crates/matrix-sdk/src/client/builder/homeserver_config.rs
@@ -31,14 +31,14 @@ use crate::{
 #[derive(Clone, Debug)]
 pub(super) enum HomeserverConfig {
     /// A homeserver name URL, including the protocol.
-    Url(String),
+    HomeserverUrl(String),
 
     /// A server name, with the protocol put apart.
     ServerName { server: OwnedServerName, protocol: UrlScheme },
 
     /// A server name with or without the protocol (it will fallback to `https`
     /// if absent), or a homeserver URL.
-    ServerNameOrUrl(String),
+    ServerNameOrHomeserverUrl(String),
 }
 
 /// A simple helper to represent `http` or `https` in a URL.
@@ -62,7 +62,7 @@ impl HomeserverConfig {
         http_client: &HttpClient,
     ) -> Result<HomeserverDiscoveryResult, ClientBuildError> {
         Ok(match self {
-            Self::Url(url) => {
+            Self::HomeserverUrl(url) => {
                 let homeserver = Url::parse(url)?;
 
                 HomeserverDiscoveryResult {
@@ -85,7 +85,7 @@ impl HomeserverConfig {
                 }
             }
 
-            Self::ServerNameOrUrl(server_name_or_url) => {
+            Self::ServerNameOrHomeserverUrl(server_name_or_url) => {
                 let (server, homeserver, well_known, supported_versions) =
                     discover_homeserver_from_server_name_or_url(
                         server_name_or_url.to_owned(),
@@ -233,7 +233,7 @@ mod tests {
         let http_client =
             HttpClient::new(HttpSettings::default().make_client().unwrap(), Default::default());
 
-        let result = HomeserverConfig::Url("https://matrix-client.matrix.org".to_owned())
+        let result = HomeserverConfig::HomeserverUrl("https://matrix-client.matrix.org".to_owned())
             .discover(&http_client)
             .await
             .unwrap();
@@ -294,7 +294,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let result = HomeserverConfig::ServerNameOrUrl(server.uri().to_string())
+        let result = HomeserverConfig::ServerNameOrHomeserverUrl(server.uri().to_string())
             .discover(&http_client)
             .await
             .unwrap();
@@ -320,7 +320,7 @@ mod tests {
             .mount(&homeserver)
             .await;
 
-        let result = HomeserverConfig::ServerNameOrUrl(homeserver.uri().to_string())
+        let result = HomeserverConfig::ServerNameOrHomeserverUrl(homeserver.uri().to_string())
             .discover(&http_client)
             .await
             .unwrap();

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -123,24 +123,12 @@ impl ClientBuilder {
 
     /// Set the homeserver URL to use.
     ///
-    /// The following methods are mutually exclusive:
-    /// [`homeserver_url()`][Self::homeserver_url]
-    /// [`server_name()`][Self::server_name]
-    /// [`insecure_server_name_no_tls()`][Self::insecure_server_name_no_tls]
-    /// [`server_name_or_homeserver_url()`][Self::server_name_or_homeserver_url],
+    /// The following methods are mutually exclusive: [`Self::homeserver_url`],
+    /// [`Self::server_name`] [`Self::insecure_server_name_no_tls`],
+    /// [`Self::server_name_or_homeserver_url`].
     /// If you set more than one, then whatever was set last will be used.
     pub fn homeserver_url(mut self, url: impl AsRef<str>) -> Self {
-        self.homeserver_cfg = Some(HomeserverConfig::Url(url.as_ref().to_owned()));
-        self
-    }
-
-    /// Set sliding sync to a specific version.
-    #[cfg(feature = "experimental-sliding-sync")]
-    pub fn sliding_sync_version_builder(
-        mut self,
-        version_builder: SlidingSyncVersionBuilder,
-    ) -> Self {
-        self.sliding_sync_version_builder = version_builder;
+        self.homeserver_cfg = Some(HomeserverConfig::HomeserverUrl(url.as_ref().to_owned()));
         self
     }
 
@@ -149,11 +137,9 @@ impl ClientBuilder {
     /// We assume we can connect in HTTPS to that server. If that's not the
     /// case, prefer using [`Self::insecure_server_name_no_tls`].
     ///
-    /// The following methods are mutually exclusive:
-    /// [`homeserver_url()`][Self::homeserver_url]
-    /// [`server_name()`][Self::server_name]
-    /// [`insecure_server_name_no_tls()`][Self::insecure_server_name_no_tls]
-    /// [`server_name_or_homeserver_url()`][Self::server_name_or_homeserver_url],
+    /// The following methods are mutually exclusive: [`Self::homeserver_url`],
+    /// [`Self::server_name`] [`Self::insecure_server_name_no_tls`],
+    /// [`Self::server_name_or_homeserver_url`].
     /// If you set more than one, then whatever was set last will be used.
     pub fn server_name(mut self, server_name: &ServerName) -> Self {
         self.homeserver_cfg = Some(HomeserverConfig::ServerName {
@@ -168,11 +154,9 @@ impl ClientBuilder {
     /// (not secured) scheme. This also relaxes OIDC discovery checks to allow
     /// HTTP schemes.
     ///
-    /// The following methods are mutually exclusive:
-    /// [`homeserver_url()`][Self::homeserver_url]
-    /// [`server_name()`][Self::server_name]
-    /// [`insecure_server_name_no_tls()`][Self::insecure_server_name_no_tls]
-    /// [`server_name_or_homeserver_url()`][Self::server_name_or_homeserver_url],
+    /// The following methods are mutually exclusive: [`Self::homeserver_url`],
+    /// [`Self::server_name`] [`Self::insecure_server_name_no_tls`],
+    /// [`Self::server_name_or_homeserver_url`].
     /// If you set more than one, then whatever was set last will be used.
     pub fn insecure_server_name_no_tls(mut self, server_name: &ServerName) -> Self {
         self.homeserver_cfg = Some(HomeserverConfig::ServerName {
@@ -185,18 +169,27 @@ impl ClientBuilder {
     /// Set the server name to discover the homeserver from, falling back to
     /// using it as a homeserver URL if discovery fails. When falling back to a
     /// homeserver URL, a check is made to ensure that the server exists (unlike
-    /// [`homeserver_url()`][Self::homeserver_url]), so you can guarantee that
-    /// the client is ready to use.
+    /// [`Self::homeserver_url`], so you can guarantee that the client is ready
+    /// to use.
     ///
-    /// The following methods are mutually exclusive:
-    /// [`homeserver_url()`][Self::homeserver_url]
-    /// [`server_name()`][Self::server_name]
-    /// [`insecure_server_name_no_tls()`][Self::insecure_server_name_no_tls]
-    /// [`server_name_or_homeserver_url()`][Self::server_name_or_homeserver_url],
+    /// The following methods are mutually exclusive: [`Self::homeserver_url`],
+    /// [`Self::server_name`] [`Self::insecure_server_name_no_tls`],
+    /// [`Self::server_name_or_homeserver_url`].
     /// If you set more than one, then whatever was set last will be used.
     pub fn server_name_or_homeserver_url(mut self, server_name_or_url: impl AsRef<str>) -> Self {
-        self.homeserver_cfg =
-            Some(HomeserverConfig::ServerNameOrUrl(server_name_or_url.as_ref().to_owned()));
+        self.homeserver_cfg = Some(HomeserverConfig::ServerNameOrHomeserverUrl(
+            server_name_or_url.as_ref().to_owned(),
+        ));
+        self
+    }
+
+    /// Set sliding sync to a specific version.
+    #[cfg(feature = "experimental-sliding-sync")]
+    pub fn sliding_sync_version_builder(
+        mut self,
+        version_builder: SlidingSyncVersionBuilder,
+    ) -> Self {
+        self.sliding_sync_version_builder = version_builder;
         self
     }
 


### PR DESCRIPTION
This patch renames `HomeserverConfig::Url` to `HomeserverUrl`, and `HomeserverConfig::ServerNameOrUrl` to `ServerNameOrHomeserverUrl`. Funnily, the methods on `ClientBuilder` doesn't need to be renamed to match the new naming since they already use this naming!