### PR TITLE
ffi: Add Python bindings UniFFI config

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -10,10 +10,11 @@ license = "Apache-2.0"
 publish = false
 
 [lib]
+name = "matrix_sdk_crypto_ffi"
 crate-type = ["cdylib", "staticlib"]
 
 [[bin]]
-name = "matrix_sdk_crypto_ffi"
+name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
 [features]

--- a/bindings/matrix-sdk-crypto-ffi/pyproject.toml
+++ b/bindings/matrix-sdk-crypto-ffi/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"

--- a/bindings/matrix-sdk-crypto-ffi/uniffi.toml
+++ b/bindings/matrix-sdk-crypto-ffi/uniffi.toml
@@ -4,3 +4,6 @@ cdylib_name = "matrix_sdk_crypto_ffi"
 
 [bindings.swift]
 module_name = "MatrixSDKCrypto"
+
+[bindings.python]
+cdylib_name = "matrix_sdk_crypto_ffi"

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -10,7 +10,12 @@ rust-version = { workspace = true }
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 
 [lib]
+name = "matrix_sdk_ffi"
 crate-type = ["cdylib", "staticlib"]
+
+[[bin]]
+name = "uniffi-bindgen"
+path = "uniffi-bindgen.rs"
 
 [features]
 default = ["bundled-sqlite"]
@@ -41,7 +46,7 @@ tracing-core = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-appender = { version = "0.2.2" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
-uniffi = { workspace = true, features = ["tokio"] }
+uniffi = { workspace = true, features = ["cli", "tokio"] }
 url = { workspace = true }
 zeroize = { workspace = true }
 uuid = { version = "1.4.1", features = ["v4"] }

--- a/bindings/matrix-sdk-ffi/pyproject.toml
+++ b/bindings/matrix-sdk-ffi/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"

--- a/bindings/matrix-sdk-ffi/uniffi-bindgen.rs
+++ b/bindings/matrix-sdk-ffi/uniffi-bindgen.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}

--- a/bindings/matrix-sdk-ffi/uniffi.toml
+++ b/bindings/matrix-sdk-ffi/uniffi.toml
@@ -2,3 +2,6 @@
 package_name = "org.matrix.rustcomponents.sdk"
 cdylib_name = "matrix_sdk_ffi"
 android_cleaner = true
+
+[bindings.python]
+cdylib_name = "matrix_sdk_ffi"


### PR DESCRIPTION
Those changes allow to build functional Python wheel of the crypto FFI layer using [maturin](https://github.com/PyO3/maturin).
Something is still not right for the full SDK FFI, I am looking into it but it should be a change on maturin side.

Currently depends on a [change](https://github.com/PyO3/maturin/pull/2208) in maturin.

- [ ] Public API changes documented in changelogs (optional)

Signed-off-by: Mathieu Velten <mathieu@velten.xyz>
