### PR TITLE
sdk: tiny refactorings

### DIFF
--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -443,7 +443,9 @@ impl ClientBuilder {
             let mut client =
                 BaseClient::with_store_config(build_store_config(self.store_config).await?);
             #[cfg(feature = "e2e-encryption")]
-            (client.room_key_recipient_strategy = self.room_key_recipient_strategy.clone());
+            {
+                client.room_key_recipient_strategy = self.room_key_recipient_strategy;
+            }
             client
         };
 

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -352,7 +352,6 @@ mod tests {
             event_cache.subscribe().unwrap();
 
             let (room_event_cache, _drop_handlers) = event_cache.for_room(room_id).await.unwrap();
-            let room_event_cache = room_event_cache.unwrap();
 
             // When I only have events in a room,
             {
@@ -405,7 +404,6 @@ mod tests {
             event_cache.subscribe().unwrap();
 
             let (room_event_cache, _drop_handlers) = event_cache.for_room(room_id).await.unwrap();
-            let room_event_cache = room_event_cache.unwrap();
 
             let expected_token = "old".to_owned();
 
@@ -460,7 +458,6 @@ mod tests {
             event_cache.subscribe().unwrap();
 
             let (room_event_cache, _drop_handles) = event_cache.for_room(room_id).await.unwrap();
-            let room_event_cache = room_event_cache.unwrap();
 
             let expected_token = "old".to_owned();
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2769,13 +2769,7 @@ impl Room {
     pub async fn event_cache(
         &self,
     ) -> event_cache::Result<(RoomEventCache, Arc<EventCacheDropHandles>)> {
-        let global_event_cache = self.client.event_cache();
-
-        global_event_cache.for_room(self.room_id()).await.map(|(maybe_room, drop_handles)| {
-            // SAFETY: the `RoomEventCache` must always been found, since we're constructing
-            // from a `Room`.
-            (maybe_room.unwrap(), drop_handles)
-        })
+        self.client.event_cache().for_room(self.room_id()).await
     }
 
     /// This will only send a call notification event if appropriate.


### PR DESCRIPTION
These were found while looking at rageshakes involving missing initial local echoes, but I didn't get my head around it this time. Oh well.