### PR TITLE
timeline: small cleanups (doc polls + use event factory more)

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -36,7 +36,7 @@ use crate::{
             TimelineItemPosition,
         },
         event_item::RemoteEventOrigin,
-        polls::PollPendingEvents,
+        polls::PendingPollEvents,
         reactions::Reactions,
         read_receipts::ReadReceipts,
         traits::RoomDataProvider,
@@ -701,7 +701,7 @@ pub(in crate::timeline) struct TimelineMetadata {
     pub all_events: VecDeque<EventMeta>,
 
     pub reactions: Reactions,
-    pub poll_pending_events: PollPendingEvents,
+    pub pending_poll_events: PendingPollEvents,
     pub fully_read_event: Option<OwnedEventId>,
 
     /// Whether we have a fully read-marker item in the timeline, that's up to
@@ -726,7 +726,7 @@ impl TimelineMetadata {
             all_events: Default::default(),
             next_internal_id: Default::default(),
             reactions: Default::default(),
-            poll_pending_events: Default::default(),
+            pending_poll_events: Default::default(),
             fully_read_event: Default::default(),
             // It doesn't make sense to set this to false until we fill the `fully_read_event`
             // field, otherwise we'll keep on exiting early in `Self::update_read_marker`.
@@ -745,7 +745,7 @@ impl TimelineMetadata {
         }
         self.all_events.clear();
         self.reactions.clear();
-        self.poll_pending_events.clear();
+        self.pending_poll_events.clear();
         self.fully_read_event = None;
         // We forgot about the fully read marker right above, so wait for a new one
         // before attempting to update it for each new timeline item.

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -639,7 +639,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         if let Flow::Remote { event_id, .. } = &self.ctx.flow {
             // Applying the cache to remote events only because local echoes
             // don't have an event ID that could be referenced by responses yet.
-            self.meta.poll_pending_events.apply(event_id, &mut poll_state);
+            self.meta.pending_poll_events.apply_pending(event_id, &mut poll_state);
         }
 
         if should_add {
@@ -649,7 +649,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
     fn handle_poll_response(&mut self, c: UnstablePollResponseEventContent) {
         let Some((item_pos, item)) = rfind_event_by_id(self.items, &c.relates_to.event_id) else {
-            self.meta.poll_pending_events.add_response(
+            self.meta.pending_poll_events.add_response(
                 &c.relates_to.event_id,
                 &self.ctx.sender,
                 self.ctx.timestamp,
@@ -678,7 +678,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
     fn handle_poll_end(&mut self, c: UnstablePollEndEventContent) {
         let Some((item_pos, item)) = rfind_event_by_id(self.items, &c.relates_to.event_id) else {
-            self.meta.poll_pending_events.add_end(&c.relates_to.event_id, self.ctx.timestamp);
+            self.meta.pending_poll_events.mark_as_ended(&c.relates_to.event_id, self.ctx.timestamp);
             return;
         };
 


### PR DESCRIPTION
What it says on the tin. I was looking how poll events stash pending related events, will probably do something similar for edits later.