### PR TITLE
timeline: stash edits around until we see the original event

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -52,7 +52,7 @@ use tracing::{
 };
 
 pub(super) use self::state::{
-    EventMeta, FullEventMeta, TimelineEnd, TimelineMetadata, TimelineState,
+    EventMeta, FullEventMeta, PendingEdit, TimelineEnd, TimelineMetadata, TimelineState,
     TimelineStateTransaction,
 };
 use super::{

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -733,6 +733,11 @@ pub(in crate::timeline) struct TimelineMetadata {
     /// This value is constant over the lifetime of the metadata.
     pub(crate) unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
 
+    /// A boolean indicating whether the room the timeline is attached to is
+    /// actually encrypted or not.
+    /// TODO: this is misplaced, it should be part of the room provider as this
+    /// value can change over time when a room switches from non-encrypted
+    /// to encrypted, see also #3850.
     pub(crate) is_room_encrypted: bool,
 
     /// Matrix room version of the timeline's room, or a sensible default.
@@ -752,11 +757,18 @@ pub(in crate::timeline) struct TimelineMetadata {
     /// are discarded in the timeline items.
     pub all_events: VecDeque<EventMeta>,
 
+    /// State helping matching reactions to their associated events, and
+    /// stashing pending reactions.
     pub reactions: Reactions,
 
+    /// Associated poll events received before their original poll start event.
     pub pending_poll_events: PendingPollEvents,
+
+    /// Edit events received before the related event they're editing.
     pub pending_edits: HashMap<OwnedEventId, PendingEdit>,
 
+    /// Identifier of the fully-read event, helping knowing where to introduce
+    /// the read marker.
     pub fully_read_event: Option<OwnedEventId>,
 
     /// Whether we have a fully read-marker item in the timeline, that's up to
@@ -767,6 +779,9 @@ pub(in crate::timeline) struct TimelineMetadata {
     /// - The fully-read marker item would be the last item in the timeline.
     pub has_up_to_date_read_marker_item: bool,
 
+    /// Read receipts related state.
+    ///
+    /// TODO: move this over to the event cache (see also #3058).
     pub read_receipts: ReadReceipts,
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -26,6 +26,7 @@ use matrix_sdk_base::deserialized_responses::TimelineEvent;
 use ruma::events::receipt::ReceiptEventContent;
 use ruma::{
     events::{
+        poll::unstable_start::NewUnstablePollStartEventContentWithoutRelation,
         relation::Replacement, room::message::RoomMessageEventContentWithoutRelation,
         AnySyncEphemeralRoomEvent,
     },
@@ -702,6 +703,22 @@ impl TimelineStateTransaction<'_> {
     }
 }
 
+#[derive(Clone)]
+pub(in crate::timeline) enum PendingEdit {
+    RoomMessage(Replacement<RoomMessageEventContentWithoutRelation>),
+    Poll(Replacement<NewUnstablePollStartEventContentWithoutRelation>),
+}
+
+#[cfg(not(tarpaulin_include))]
+impl std::fmt::Debug for PendingEdit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RoomMessage(_) => f.debug_struct("RoomMessage").finish_non_exhaustive(),
+            Self::Poll(_) => f.debug_struct("Poll").finish_non_exhaustive(),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(in crate::timeline) struct TimelineMetadata {
     // **** CONSTANT FIELDS ****
@@ -738,7 +755,7 @@ pub(in crate::timeline) struct TimelineMetadata {
     pub reactions: Reactions,
 
     pub pending_poll_events: PendingPollEvents,
-    pub pending_edits: HashMap<OwnedEventId, Replacement<RoomMessageEventContentWithoutRelation>>,
+    pub pending_edits: HashMap<OwnedEventId, PendingEdit>,
 
     pub fully_read_event: Option<OwnedEventId>,
 

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -352,7 +352,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
                 AnyMessageLikeEventContent::UnstablePollStart(
                     UnstablePollStartEventContent::Replacement(c),
-                ) => self.handle_poll_start_edit(c.relates_to),
+                ) => self.handle_poll_edit(c.relates_to),
 
                 AnyMessageLikeEventContent::UnstablePollStart(
                     UnstablePollStartEventContent::New(c),
@@ -639,7 +639,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
     }
 
     #[instrument(skip_all, fields(replacement_event_id = ?replacement.event_id))]
-    fn handle_poll_start_edit(
+    fn handle_poll_edit(
         &mut self,
         replacement: Replacement<NewUnstablePollStartEventContentWithoutRelation>,
     ) {
@@ -662,9 +662,9 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         };
 
         let new_content = match poll_state.edit(&replacement.new_content) {
-            Ok(edited_poll_state) => TimelineItemContent::Poll(edited_poll_state),
-            Err(e) => {
-                info!("Failed to apply poll edit: {e:?}");
+            Some(edited_poll_state) => TimelineItemContent::Poll(edited_poll_state),
+            None => {
+                info!("Not applying edit to a poll that's already ended");
                 return;
             }
         };

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -46,18 +46,20 @@ impl PollState {
         }
     }
 
+    /// Applies an edit to a poll, returns `None` if the poll was already marked
+    /// as finished.
     pub(super) fn edit(
         &self,
         replacement: &NewUnstablePollStartEventContentWithoutRelation,
-    ) -> Result<Self, ()> {
+    ) -> Option<Self> {
         if self.end_event_timestamp.is_none() {
             let mut clone = self.clone();
             clone.start_event_content.poll_start = replacement.poll_start.clone();
             clone.start_event_content.text = replacement.text.clone();
             clone.has_been_edited = true;
-            Ok(clone)
+            Some(clone)
         } else {
-            Err(())
+            None
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -125,6 +125,11 @@ impl PollState {
             has_been_edited: self.has_been_edited,
         }
     }
+
+    /// Returns true whether this poll has been edited.
+    pub fn is_edit(&self) -> bool {
+        self.has_been_edited
+    }
 }
 
 impl From<PollState> for NewUnstablePollStartEventContent {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -652,20 +652,14 @@ async fn test_pending_edit() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    // Then I get the content as original first…
+    // Then I get the edited content immediately.
     assert_let!(Some(VectorDiff::PushBack { value }) = timeline_stream.next().await);
     let item = value.as_event().unwrap();
     assert!(item.event_id().is_some());
     assert!(!item.is_own());
-    assert_eq!(item.content().as_message().unwrap().body(), "hi");
-
-    // And then the edit.
-    assert_next_matches!(timeline_stream, VectorDiff::Set { index: 0, value } => {
-        let item = value.as_event().unwrap();
-        assert!(item.event_id().is_some());
-        assert!(!item.is_own());
-        assert_eq!(item.content().as_message().unwrap().body(), "[edit]");
-    });
+    let msg = item.content().as_message().unwrap();
+    assert!(msg.is_edited());
+    assert_eq!(msg.body(), "[edit]");
 
     // The day divider.
     assert_next_matches!(timeline_stream, VectorDiff::PushFront { value } => {


### PR DESCRIPTION
What it says on the tin. Built on top of #https://github.com/matrix-org/matrix-rust-sdk/pull/3947. Needs a bit extra work/thinking:

- [x] is it ok that we receive an update for the original event *and then* an update for the edit?
- [x] add test for back-pagination, it should not be reverting to a previous edit of an event
- [x] add test for multiple stashed edits override each other (added to the back, in a live timeline)

The idea is that if we receive an edit for an event we hadn't seen in the timeline, then we'll keep the edit around, in case we see the event later. The number of pending edits event is bounded, by virtue of using a `RingBuffer` for each timeline.

This PR will stash pending edits for room messages and polls, as these two kinds of edits are handled in the code base.

Part of #3905.