### PR TITLE
timeline: unify `edit` and `edit_poll` functions

### DIFF
--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -834,7 +834,7 @@ impl From<&RumaFileInfo> for FileInfo {
     }
 }
 
-#[derive(uniffi::Enum)]
+#[derive(Clone, uniffi::Enum)]
 pub enum PollKind {
     Disclosed,
     Undisclosed,

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -1254,18 +1254,18 @@ impl From<ReceiptType> for ruma::api::client::receipt::create_receipt::v3::Recei
 
 #[derive(Clone, uniffi::Enum)]
 pub enum EditContent {
-    RoomMessage(Arc<RoomMessageEventContentWithoutRelation>),
-    PollStart(PollData),
+    RoomMessage { content: Arc<RoomMessageEventContentWithoutRelation> },
+    PollStart { poll_data: PollData },
 }
 
 impl TryFrom<EditContent> for matrix_sdk::room::edit::EditedContent {
     type Error = ClientError;
     fn try_from(value: EditContent) -> Result<Self, Self::Error> {
         match value {
-            EditContent::RoomMessage(content) => {
+            EditContent::RoomMessage { content } => {
                 Ok(matrix_sdk::room::edit::EditedContent::RoomMessage((*content).clone()))
             }
-            EditContent::PollStart(poll_data) => {
+            EditContent::PollStart { poll_data } => {
                 let block: UnstablePollStartContentBlock = poll_data.clone().try_into()?;
                 Ok(matrix_sdk::room::edit::EditedContent::PollStart(
                     poll_data.fallback_text(),

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -490,12 +490,13 @@ impl Timeline {
                                         return Ok(false);
                                     }
                                 }
-                                EditedContent::PollStart(_, poll_start) => {
+                                EditedContent::PollStart { new_content, .. } => {
                                     if matches!(item.content, TimelineItemContent::Poll(_)) {
-                                        let content = UnstablePollStartEventContent::New(
-                                            NewUnstablePollStartEventContent::new(poll_start),
-                                        );
-                                        AnyMessageLikeEventContent::UnstablePollStart(content)
+                                        AnyMessageLikeEventContent::UnstablePollStart(
+                                            UnstablePollStartEventContent::New(
+                                                NewUnstablePollStartEventContent::new(new_content),
+                                            ),
+                                        )
                                     } else {
                                         warn!("New content (poll start) doesn't match previous event content.");
                                         return Ok(false);

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -483,13 +483,23 @@ impl Timeline {
                             // Relations are filled by the editing code itself.
                             let new_content: AnyMessageLikeEventContent = match new_content {
                                 EditedContent::RoomMessage(message) => {
-                                    AnyMessageLikeEventContent::RoomMessage(message.into())
+                                    if matches!(item.content, TimelineItemContent::Message(_)) {
+                                        AnyMessageLikeEventContent::RoomMessage(message.into())
+                                    } else {
+                                        warn!("New content (m.room.message) doesn't match previous event content.");
+                                        return Ok(false);
+                                    }
                                 }
                                 EditedContent::PollStart(_, poll_start) => {
-                                    let content = UnstablePollStartEventContent::New(
-                                        NewUnstablePollStartEventContent::new(poll_start),
-                                    );
-                                    AnyMessageLikeEventContent::UnstablePollStart(content)
+                                    if matches!(item.content, TimelineItemContent::Poll(_)) {
+                                        let content = UnstablePollStartEventContent::New(
+                                            NewUnstablePollStartEventContent::new(poll_start),
+                                        );
+                                        AnyMessageLikeEventContent::UnstablePollStart(content)
+                                    } else {
+                                        warn!("New content (poll start) doesn't match previous event content.");
+                                        return Ok(false);
+                                    }
                                 }
                             };
                             return Ok(handle

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -36,14 +36,11 @@ use pin_project_lite::pin_project;
 use ruma::{
     api::client::receipt::create_receipt::v3::ReceiptType,
     events::{
-        poll::unstable_start::{
-            ReplacementUnstablePollStartEventContent, UnstablePollStartContentBlock,
-            UnstablePollStartEventContent,
-        },
+        poll::unstable_start::{NewUnstablePollStartEventContent, UnstablePollStartEventContent},
         receipt::{Receipt, ReceiptThread},
         room::{
             message::{
-                AddMentions, ForwardThread, OriginalRoomMessageEvent, RoomMessageEventContent,
+                AddMentions, ForwardThread, OriginalRoomMessageEvent,
                 RoomMessageEventContentWithoutRelation,
             },
             pinned_events::RoomPinnedEventsEventContent,
@@ -474,7 +471,7 @@ impl Timeline {
     pub async fn edit(
         &self,
         item: &EventTimelineItem,
-        new_content: RoomMessageEventContentWithoutRelation,
+        new_content: EditedContent,
     ) -> Result<bool, Error> {
         let event_id = match item.identifier() {
             TimelineEventItemId::TransactionId(txn_id) => {
@@ -484,9 +481,19 @@ impl Timeline {
                         TimelineItemHandle::Remote(event_id) => event_id.to_owned(),
                         TimelineItemHandle::Local(handle) => {
                             // Relations are filled by the editing code itself.
-                            let new_content: RoomMessageEventContent = new_content.clone().into();
+                            let new_content: AnyMessageLikeEventContent = match new_content {
+                                EditedContent::RoomMessage(message) => {
+                                    AnyMessageLikeEventContent::RoomMessage(message.into())
+                                }
+                                EditedContent::PollStart(_, poll_start) => {
+                                    let content = UnstablePollStartEventContent::New(
+                                        NewUnstablePollStartEventContent::new(poll_start),
+                                    );
+                                    AnyMessageLikeEventContent::UnstablePollStart(content)
+                                }
+                            };
                             return Ok(handle
-                                .edit(new_content.into())
+                                .edit(new_content)
                                 .await
                                 .map_err(RoomSendQueueError::StorageError)?);
                         }
@@ -500,44 +507,11 @@ impl Timeline {
             TimelineEventItemId::EventId(event_id) => event_id,
         };
 
-        let content =
-            self.room().make_edit_event(&event_id, EditedContent::RoomMessage(new_content)).await?;
+        let content = self.room().make_edit_event(&event_id, new_content).await?;
 
         self.send(content).await?;
 
         Ok(true)
-    }
-
-    pub async fn edit_poll(
-        &self,
-        fallback_text: impl Into<String>,
-        poll: UnstablePollStartContentBlock,
-        edit_item: &EventTimelineItem,
-    ) -> Result<(), SendEventError> {
-        // TODO: refactor this function into [`Self::edit`], there's no good reason to
-        // keep a separate function for this.
-
-        // Early returns here must be in sync with `EventTimelineItem::is_editable`.
-        if !edit_item.is_own() {
-            return Err(UnsupportedEditItem::NotOwnEvent.into());
-        }
-        let Some(event_id) = edit_item.event_id() else {
-            return Err(UnsupportedEditItem::MissingEvent.into());
-        };
-
-        let TimelineItemContent::Poll(_) = edit_item.content() else {
-            return Err(UnsupportedEditItem::NotPollEvent.into());
-        };
-
-        let content = ReplacementUnstablePollStartEventContent::plain_text(
-            fallback_text,
-            poll,
-            event_id.into(),
-        );
-
-        self.send(UnstablePollStartEventContent::from(content).into()).await?;
-
-        Ok(())
     }
 
     /// Toggle a reaction on an event.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -510,7 +510,13 @@ async fn test_send_edit_poll() {
     let edited_poll =
         UnstablePollStartContentBlock::new("Edited Test".to_owned(), edited_poll_answers);
     timeline
-        .edit(&poll_event, EditedContent::PollStart("poll_fallback_text".to_owned(), edited_poll))
+        .edit(
+            &poll_event,
+            EditedContent::PollStart {
+                fallback_text: "poll_fallback_text".to_owned(),
+                new_content: edited_poll,
+            },
+        )
         .await
         .unwrap();
 
@@ -704,8 +710,10 @@ async fn test_edit_local_echo_with_unsupported_content() {
 
     let answers = vec![UnstablePollAnswer::new("A", "Answer A")].try_into().unwrap();
     let poll_content_block = UnstablePollStartContentBlock::new("question", answers);
-    let poll_start_content =
-        EditedContent::PollStart("edited".to_owned(), poll_content_block.clone());
+    let poll_start_content = EditedContent::PollStart {
+        fallback_text: "edited".to_owned(),
+        new_content: poll_content_block.clone(),
+    };
 
     // Let's edit the local echo (message) with an unsupported type (poll start).
     let did_edit = timeline.edit(item, poll_start_content).await.unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -21,6 +21,7 @@ use eyeball_im::VectorDiff;
 use futures_util::{FutureExt, StreamExt};
 use matrix_sdk::{
     config::SyncSettings,
+    room::edit::EditedContent,
     test_utils::{events::EventFactory, logged_in_client_with_server},
     Client,
 };
@@ -233,7 +234,10 @@ async fn test_edit_local_echo() {
 
     // Let's edit the local echo.
     let did_edit = timeline
-        .edit(item, RoomMessageEventContent::text_plain("hello, world").into())
+        .edit(
+            item,
+            EditedContent::RoomMessage(RoomMessageEventContent::text_plain("hello, world").into()),
+        )
         .await
         .unwrap();
 
@@ -317,7 +321,12 @@ async fn test_send_edit() {
         .await;
 
     timeline
-        .edit(&hello_world_item, RoomMessageEventContentWithoutRelation::text_plain("Hello, Room!"))
+        .edit(
+            &hello_world_item,
+            EditedContent::RoomMessage(RoomMessageEventContentWithoutRelation::text_plain(
+                "Hello, Room!",
+            )),
+        )
         .await
         .unwrap();
 
@@ -399,7 +408,12 @@ async fn test_send_reply_edit() {
         .await;
 
     timeline
-        .edit(&reply_item, RoomMessageEventContentWithoutRelation::text_plain("Hello, Room!"))
+        .edit(
+            &reply_item,
+            EditedContent::RoomMessage(RoomMessageEventContentWithoutRelation::text_plain(
+                "Hello, Room!",
+            )),
+        )
         .await
         .unwrap();
 
@@ -494,7 +508,10 @@ async fn test_send_edit_poll() {
     .unwrap();
     let edited_poll =
         UnstablePollStartContentBlock::new("Edited Test".to_owned(), edited_poll_answers);
-    timeline.edit_poll("poll_fallback_text", edited_poll, &poll_event).await.unwrap();
+    timeline
+        .edit(&poll_event, EditedContent::PollStart("poll_fallback_text".to_owned(), edited_poll))
+        .await
+        .unwrap();
 
     // Let the send queue handle the event.
     yield_now().await;
@@ -591,7 +608,12 @@ async fn test_send_edit_when_timeline_is_clear() {
         .await;
 
     timeline
-        .edit(&hello_world_item, RoomMessageEventContentWithoutRelation::text_plain("Hello, Room!"))
+        .edit(
+            &hello_world_item,
+            EditedContent::RoomMessage(RoomMessageEventContentWithoutRelation::text_plain(
+                "Hello, Room!",
+            )),
+        )
         .await
         .unwrap();
 

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -61,8 +61,7 @@ use matrix_sdk_base::{
 use matrix_sdk_common::executor::{spawn, JoinHandle};
 use ruma::{
     events::{
-        reaction::ReactionEventContent, relation::Annotation,
-        room::message::RoomMessageEventContentWithoutRelation, AnyMessageLikeEventContent,
+        reaction::ReactionEventContent, relation::Annotation, AnyMessageLikeEventContent,
         EventContent as _,
     },
     serde::Raw,
@@ -908,30 +907,26 @@ impl QueueStorage {
 
                     // Check the event is one we know how to edit with an edit event.
 
-                    // 1. It must be deserializable…
-                    let content = match new_content.deserialize() {
-                        Ok(c) => c,
+                    // It must be deserializable
+                    let edited_content = match new_content.deserialize() {
+                        Ok(AnyMessageLikeEventContent::RoomMessage(c)) => {
+                            EditedContent::RoomMessage(c.into())
+                        }
+                        Ok(AnyMessageLikeEventContent::UnstablePollStart(c)) => {
+                            let poll_start = c.poll_start().clone();
+                            EditedContent::PollStart(poll_start.question.text.clone(), poll_start)
+                        }
+                        Ok(c) => {
+                            warn!("Unsupported edit content type: {:?}", c.event_type());
+                            return Ok(true);
+                        }
                         Err(err) => {
                             warn!("unable to deserialize: {err}");
                             return Ok(true);
                         }
                     };
 
-                    // 2. …and a room message, at this point.
-                    let AnyMessageLikeEventContent::RoomMessage(room_message_content) = content
-                    else {
-                        warn!("trying to send an edit event for a non-room message: aborting");
-                        return Ok(true);
-                    };
-
-                    // Assume no relation.
-                    let new_content: RoomMessageEventContentWithoutRelation =
-                        room_message_content.into();
-
-                    let edit_event = match room
-                        .make_edit_event(&event_id, EditedContent::RoomMessage(new_content))
-                        .await
-                    {
+                    let edit_event = match room.make_edit_event(&event_id, edited_content).await {
                         Ok(e) => e,
                         Err(err) => {
                             warn!("couldn't create edited event: {err}");

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -907,21 +907,28 @@ impl QueueStorage {
 
                     // Check the event is one we know how to edit with an edit event.
 
-                    // It must be deserializable
+                    // It must be deserializable…
                     let edited_content = match new_content.deserialize() {
                         Ok(AnyMessageLikeEventContent::RoomMessage(c)) => {
+                            // Assume no relationships.
                             EditedContent::RoomMessage(c.into())
                         }
+
                         Ok(AnyMessageLikeEventContent::UnstablePollStart(c)) => {
                             let poll_start = c.poll_start().clone();
-                            EditedContent::PollStart(poll_start.question.text.clone(), poll_start)
+                            EditedContent::PollStart {
+                                fallback_text: poll_start.question.text.clone(),
+                                new_content: poll_start,
+                            }
                         }
+
                         Ok(c) => {
                             warn!("Unsupported edit content type: {:?}", c.event_type());
                             return Ok(true);
                         }
+
                         Err(err) => {
-                            warn!("unable to deserialize: {err}");
+                            warn!("Unable to deserialize: {err}");
                             return Ok(true);
                         }
                     };

--- a/crates/matrix-sdk/src/test_utils/events.rs
+++ b/crates/matrix-sdk/src/test_utils/events.rs
@@ -24,6 +24,10 @@ use ruma::{
             end::PollEndEventContent,
             response::{PollResponseEventContent, SelectionsContentBlock},
             start::{PollAnswer, PollContentBlock, PollStartEventContent},
+            unstable_start::{
+                NewUnstablePollStartEventContent, UnstablePollAnswer,
+                UnstablePollStartContentBlock, UnstablePollStartEventContent,
+            },
         },
         reaction::ReactionEventContent,
         relation::{Annotation, InReplyTo, Replacement, Thread},
@@ -294,6 +298,29 @@ impl EventFactory {
             PollContentBlock::new(TextContentBlock::plain(poll_question.into()), poll_answers),
         );
         self.event(poll_start_content)
+    }
+
+    /// Create an unstable poll start event given a text, the question and the
+    /// possible answers.
+    pub fn unstable_poll_start(
+        &self,
+        content: impl Into<String>,
+        poll_question: impl Into<String>,
+        answers: Vec<impl Into<String>>,
+    ) -> EventBuilder<UnstablePollStartEventContent> {
+        // PollAnswers 'constructor' is not public, so we need to deserialize them
+        let answers: Vec<UnstablePollAnswer> = answers
+            .into_iter()
+            .enumerate()
+            .map(|(idx, answer)| UnstablePollAnswer::new(idx.to_string(), answer.into()))
+            .collect();
+        let poll_answers = answers.try_into().unwrap();
+        let unstable_poll_start_content =
+            UnstablePollStartEventContent::New(NewUnstablePollStartEventContent::plain_text(
+                content,
+                UnstablePollStartContentBlock::new(poll_question, poll_answers),
+            ));
+        self.event(unstable_poll_start_content)
     }
 
     /// Create a poll response with the given answer id and the associated poll

--- a/crates/matrix-sdk/src/test_utils/events.rs
+++ b/crates/matrix-sdk/src/test_utils/events.rs
@@ -23,7 +23,6 @@ use ruma::{
         poll::{
             end::PollEndEventContent,
             response::{PollResponseEventContent, SelectionsContentBlock},
-            start::{PollAnswer, PollContentBlock, PollStartEventContent},
             unstable_start::{
                 NewUnstablePollStartEventContent, UnstablePollAnswer,
                 UnstablePollStartContentBlock, UnstablePollStartEventContent,
@@ -283,44 +282,20 @@ impl EventFactory {
         content: impl Into<String>,
         poll_question: impl Into<String>,
         answers: Vec<impl Into<String>>,
-    ) -> EventBuilder<PollStartEventContent> {
-        // PollAnswers 'constructor' is not public, so we need to deserialize them
-        let answers: Vec<PollAnswer> = answers
-            .into_iter()
-            .enumerate()
-            .map(|(idx, answer)| {
-                PollAnswer::new(idx.to_string(), TextContentBlock::plain(answer.into()))
-            })
-            .collect();
-        let poll_answers = answers.try_into().unwrap();
-        let poll_start_content = PollStartEventContent::new(
-            TextContentBlock::plain(content.into()),
-            PollContentBlock::new(TextContentBlock::plain(poll_question.into()), poll_answers),
-        );
-        self.event(poll_start_content)
-    }
-
-    /// Create an unstable poll start event given a text, the question and the
-    /// possible answers.
-    pub fn unstable_poll_start(
-        &self,
-        content: impl Into<String>,
-        poll_question: impl Into<String>,
-        answers: Vec<impl Into<String>>,
     ) -> EventBuilder<UnstablePollStartEventContent> {
         // PollAnswers 'constructor' is not public, so we need to deserialize them
         let answers: Vec<UnstablePollAnswer> = answers
             .into_iter()
             .enumerate()
-            .map(|(idx, answer)| UnstablePollAnswer::new(idx.to_string(), answer.into()))
+            .map(|(idx, answer)| UnstablePollAnswer::new(idx.to_string(), answer))
             .collect();
         let poll_answers = answers.try_into().unwrap();
-        let unstable_poll_start_content =
+        let poll_start_content =
             UnstablePollStartEventContent::New(NewUnstablePollStartEventContent::plain_text(
                 content,
                 UnstablePollStartContentBlock::new(poll_question, poll_answers),
             ));
-        self.event(unstable_poll_start_content)
+        self.event(poll_start_content)
     }
 
     /// Create a poll response with the given answer id and the associated poll

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -846,10 +846,6 @@ async fn test_edit() {
 
     let (client, server) = logged_in_client_with_server().await;
 
-    // TODO: (#3722) if the event cache isn't available, then making the edit event
-    // will fail.
-    client.event_cache().subscribe().unwrap();
-
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
 
@@ -970,10 +966,6 @@ async fn test_edit() {
 async fn test_edit_with_poll_start() {
     let (client, server) = logged_in_client_with_server().await;
 
-    // TODO: (#3722) if the event cache isn't available, then making the edit event
-    // will fail.
-    client.event_cache().subscribe().unwrap();
-
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
 
@@ -1038,7 +1030,7 @@ async fn test_edit_with_poll_start() {
         .respond_with(
             ResponseTemplate::new(200).set_body_json(
                 EventFactory::new()
-                    .unstable_poll_start("poll_start", "question", vec!["Answer A"])
+                    .poll_start("poll_start", "question", vec!["Answer A"])
                     .sender(client.user_id().unwrap())
                     .room(room_id)
                     .into_raw_timeline()
@@ -1118,10 +1110,6 @@ async fn test_edit_with_poll_start() {
 #[async_test]
 async fn test_edit_while_being_sent_and_fails() {
     let (client, server) = logged_in_client_with_server().await;
-
-    // TODO: (#3722) if the event cache isn't available, then making the edit event
-    // will fail.
-    client.event_cache().subscribe().unwrap();
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -42,7 +42,7 @@ use tokio::{
     time::{sleep, timeout},
 };
 use tracing::{debug, warn};
-
+use matrix_sdk::room::edit::EditedContent;
 use crate::helpers::TestClientBuilder;
 
 /// Checks that there a timeline update, and returns the EventTimelineItem.
@@ -289,7 +289,7 @@ async fn test_stale_local_echo_time_abort_edit() {
 
     // Now do a crime: try to edit the local echo.
     let did_edit = timeline
-        .edit(&local_echo, RoomMessageEventContent::text_plain("bonjour").into())
+        .edit(&local_echo, EditedContent::RoomMessage(RoomMessageEventContent::text_plain("bonjour").into()))
         .await
         .unwrap();
 

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -23,6 +23,7 @@ use futures::pin_mut;
 use futures_util::{FutureExt, StreamExt};
 use matrix_sdk::{
     encryption::{backups::BackupState, EncryptionSettings},
+    room::edit::EditedContent,
     ruma::{
         api::client::room::create_room::v3::Request as CreateRoomRequest,
         events::{
@@ -42,7 +43,7 @@ use tokio::{
     time::{sleep, timeout},
 };
 use tracing::{debug, warn};
-use matrix_sdk::room::edit::EditedContent;
+
 use crate::helpers::TestClientBuilder;
 
 /// Checks that there a timeline update, and returns the EventTimelineItem.
@@ -289,7 +290,10 @@ async fn test_stale_local_echo_time_abort_edit() {
 
     // Now do a crime: try to edit the local echo.
     let did_edit = timeline
-        .edit(&local_echo, EditedContent::RoomMessage(RoomMessageEventContent::text_plain("bonjour").into()))
+        .edit(
+            &local_echo,
+            EditedContent::RoomMessage(RoomMessageEventContent::text_plain("bonjour").into()),
+        )
         .await
         .unwrap();
 


### PR DESCRIPTION
## Changes

Takes care of [this TODO](https://github.com/matrix-org/matrix-rust-sdk/blob/9df1c480795c42afcee39e4c7e553d5a927a2680/crates/matrix-sdk-ui/src/timeline/mod.rs#L520).

- sdk & sdk-ui: unify `Timeline::edit` and `Timeline::edit_polls`, the new fn takes an `EditedContent` parameter now, which includes a `PollStart` case too.
- ffi: also unify the FFI fns there,  using `PollStart` and a new `EditContent` enum that must be passed from the clients like:

```kotlin
val messageContent = MessageEventContent.from(...)
timeline.edit(event, EditedContent.RoomMessage(messageContent))
```

Since the is mainly about changing the fns signatures I've reused the existing tests, including one that used `edit_poll` that now uses the new fn.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
