### PR TITLE
ui: Remove the e2e-encryption feature from the matrix-sdk-ui crate

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -28,7 +28,7 @@ eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-util = { workspace = true }
 log-panics = { version = "2", features = ["with-backtrace"] }
-matrix-sdk-ui = { workspace = true, features = ["e2e-encryption", "uniffi"] }
+matrix-sdk-ui = { workspace = true, features = ["uniffi"] }
 mime = "0.3.16"
 once_cell = { workspace = true }
 ruma = { workspace = true, features = ["html", "unstable-unspecified", "unstable-msc3488", "compat-unset-avatar", "unstable-msc3245-v1-compat"] }

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -8,9 +8,7 @@ license = "Apache-2.0"
 rust-version = { workspace = true }
 
 [features]
-default = ["e2e-encryption", "native-tls"]
-
-e2e-encryption = ["matrix-sdk/e2e-encryption"]
+default = ["native-tls"]
 
 native-tls = ["matrix-sdk/native-tls"]
 rustls-tls = ["matrix-sdk/rustls-tls"]
@@ -37,7 +35,7 @@ growable-bloom-filter = { workspace = true }
 imbl = { workspace = true, features = ["serde"] }
 indexmap = "2.0.0"
 itertools = { workspace = true }
-matrix-sdk = { workspace = true, features = ["experimental-sliding-sync"] }
+matrix-sdk = { workspace = true, features = ["experimental-sliding-sync", "e2e-encryption"] }
 matrix-sdk-base = { workspace = true }
 mime = "0.3.16"
 once_cell = { workspace = true }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -198,7 +198,6 @@ impl TimelineState {
         txn.commit();
     }
 
-    #[cfg(feature = "e2e-encryption")]
     pub(super) async fn retry_event_decryption<P: RoomDataProvider, Fut>(
         &mut self,
         retry_one: impl Fn(Arc<TimelineItem>) -> Fut,
@@ -635,7 +634,6 @@ impl TimelineStateTransaction<'_> {
                 self.meta.all_events.push_back(event_meta.base_meta());
             }
 
-            #[cfg(feature = "e2e-encryption")]
             TimelineItemPosition::Update(_) => {
                 if let Some(event) =
                     self.meta.all_events.iter_mut().find(|e| e.event_id == event_meta.event_id)

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -234,7 +234,6 @@ pub(super) enum TimelineItemPosition {
     /// A single item is updated.
     ///
     /// This only happens when a UTD must be replaced with the decrypted event.
-    #[cfg(feature = "e2e-encryption")]
     Update(usize),
 }
 
@@ -249,7 +248,6 @@ pub(super) struct HandleEventResult {
     ///
     /// This can happen only if there was a UTD item that has been decrypted
     /// into an item that was filtered out with the event filter.
-    #[cfg(feature = "e2e-encryption")]
     pub(super) item_removed: bool,
 
     /// How many items were updated?
@@ -433,7 +431,6 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         if !self.result.item_added {
             trace!("No new item added");
 
-            #[cfg(feature = "e2e-encryption")]
             if let Flow::Remote { position: TimelineItemPosition::Update(idx), .. } = self.ctx.flow
             {
                 // If add was not called, that means the UTD event is one that
@@ -821,7 +818,6 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     | TimelineItemPosition::End { origin } => origin,
 
                     // For updates, reuse the origin of the encrypted event.
-                    #[cfg(feature = "e2e-encryption")]
                     TimelineItemPosition::Update(idx) => self.items[idx]
                         .as_event()
                         .and_then(|ev| Some(ev.as_remote()?.origin))
@@ -966,7 +962,6 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 }
             }
 
-            #[cfg(feature = "e2e-encryption")]
             Flow::Remote { position: TimelineItemPosition::Update(idx), .. } => {
                 trace!("Updating timeline item at position {idx}");
                 let id = self.items[*idx].internal_id.clone();

--- a/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
@@ -89,7 +89,6 @@ pub(in crate::timeline) enum RemoteEventOrigin {
     /// The event came from pagination.
     Pagination,
     /// We don't know.
-    #[cfg(feature = "e2e-encryption")]
     Unknown,
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -76,7 +76,6 @@ mod reactions;
 mod read_receipts;
 #[cfg(test)]
 mod tests;
-#[cfg(feature = "e2e-encryption")]
 mod to_device;
 mod traits;
 mod util;
@@ -217,7 +216,6 @@ impl Timeline {
     /// }
     /// # anyhow::Ok(()) };
     /// ```
-    #[cfg(feature = "e2e-encryption")]
     pub async fn retry_decryption<S: Into<String>>(
         &self,
         session_ids: impl IntoIterator<Item = S>,
@@ -230,7 +228,6 @@ impl Timeline {
             .await;
     }
 
-    #[cfg(feature = "e2e-encryption")]
     #[tracing::instrument(skip(self))]
     async fn retry_decryption_for_all_events(&self) {
         self.controller.retry_event_decryption(self.room(), None).await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -68,7 +68,6 @@ use crate::{
 mod basic;
 mod echo;
 mod edit;
-#[cfg(feature = "e2e-encryption")]
 mod encryption;
 mod event_filter;
 mod invalid;

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -329,7 +329,6 @@ async fn test_read_receipts_updates_on_back_paginated_filtered_events() {
     assert_pending!(stream);
 }
 
-#[cfg(feature = "e2e-encryption")]
 #[async_test]
 async fn test_read_receipts_updates_on_message_decryption() {
     use std::{io::Cursor, iter};

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use futures_util::{pin_mut, StreamExt as _};
 use matrix_sdk::test_utils::logged_in_client_with_server;
+use matrix_sdk_base::crypto::store::Changes;
 use matrix_sdk_test::async_test;
 use matrix_sdk_ui::encryption_sync_service::{
     EncryptionSyncPermit, EncryptionSyncService, WithLocking,
@@ -291,18 +292,14 @@ async fn test_encryption_sync_always_reloads_todevice_token() -> anyhow::Result<
     // This encryption sync now conceptually goes to sleep, and another encryption
     // sync starts in another process, runs a sync and changes the to-device
     // token cached on disk.
-    #[cfg(feature = "e2e-encryption")]
-    {
-        use matrix_sdk_base::crypto::store::Changes;
-        if let Some(olm_machine) = &*client.olm_machine_for_testing().await {
-            olm_machine
-                .store()
-                .save_changes(Changes {
-                    next_batch_token: Some("nb2".to_owned()),
-                    ..Default::default()
-                })
-                .await?;
-        }
+    if let Some(olm_machine) = &*client.olm_machine_for_testing().await {
+        olm_machine
+            .store()
+            .save_changes(Changes {
+                next_batch_token: Some("nb2".to_owned()),
+                ..Default::default()
+            })
+            .await?;
     }
 
     // Next iteration must have reloaded the latest to-device token.


### PR DESCRIPTION
It does not make much sense to create an UI client that does not support end-to-end encryption, besides disabling the feature was broken for quite some time.
