### PR TITLE
sdk: Add support for authenticated media stable feature

### DIFF
--- a/crates/matrix-sdk/src/config/request.rs
+++ b/crates/matrix-sdk/src/config/request.rs
@@ -19,6 +19,7 @@ use std::{
 };
 
 use matrix_sdk_common::debug::DebugStructExt;
+use ruma::api::MatrixVersion;
 
 use crate::http_client::DEFAULT_REQUEST_TIMEOUT;
 
@@ -47,19 +48,27 @@ pub struct RequestConfig {
     pub(crate) retry_timeout: Option<Duration>,
     pub(crate) max_concurrent_requests: Option<NonZeroUsize>,
     pub(crate) force_auth: bool,
+    pub(crate) force_matrix_version: Option<MatrixVersion>,
 }
 
 #[cfg(not(tarpaulin_include))]
 impl Debug for RequestConfig {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { timeout, retry_limit, retry_timeout, force_auth, max_concurrent_requests } =
-            self;
+        let Self {
+            timeout,
+            retry_limit,
+            retry_timeout,
+            force_auth,
+            max_concurrent_requests,
+            force_matrix_version,
+        } = self;
 
         let mut res = fmt.debug_struct("RequestConfig");
         res.field("timeout", timeout)
             .maybe_field("retry_limit", retry_limit)
             .maybe_field("retry_timeout", retry_timeout)
-            .maybe_field("max_concurrent_requests", max_concurrent_requests);
+            .maybe_field("max_concurrent_requests", max_concurrent_requests)
+            .maybe_field("force_matrix_version", force_matrix_version);
 
         if *force_auth {
             res.field("force_auth", &true);
@@ -77,6 +86,7 @@ impl Default for RequestConfig {
             retry_timeout: Default::default(),
             max_concurrent_requests: Default::default(),
             force_auth: false,
+            force_matrix_version: Default::default(),
         }
     }
 }
@@ -140,6 +150,17 @@ impl RequestConfig {
     #[must_use]
     pub fn force_auth(mut self) -> Self {
         self.force_auth = true;
+        self
+    }
+
+    /// Force the Matrix version used to select which version of the endpoint to
+    /// use.
+    ///
+    /// Can be used to force the use of a stable endpoint when the versions
+    /// advertised by the homeserver do not support it.
+    #[must_use]
+    pub(crate) fn force_matrix_version(mut self, version: MatrixVersion) -> Self {
+        self.force_matrix_version = Some(version);
         self
     }
 }

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -108,6 +108,12 @@ impl HttpClient {
     {
         trace!(request_type = type_name::<R>(), "Serializing request");
 
+        let server_versions = if config.force_matrix_version.is_some() {
+            config.force_matrix_version.as_slice()
+        } else {
+            server_versions
+        };
+
         let send_access_token = match access_token {
             Some(access_token) => {
                 if config.force_auth {

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -22,6 +22,17 @@ use wiremock::{
 async fn test_get_media_content_no_auth() {
     let (client, server) = logged_in_client_with_server().await;
 
+    // The client will call this endpoint to get the list of unstable features.
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/versions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "versions": ["r0.6.1"],
+        })))
+        .named("versions")
+        .expect(1)
+        .mount(&server)
+        .await;
+
     let media = client.media();
 
     let request = MediaRequest {
@@ -98,6 +109,17 @@ async fn test_get_media_content_no_auth() {
 async fn test_get_media_file_no_auth() {
     let (client, server) = logged_in_client_with_server().await;
 
+    // The client will call this endpoint to get the list of unstable features.
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/versions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "versions": ["r0.6.1"],
+        })))
+        .named("versions")
+        .expect(1)
+        .mount(&server)
+        .await;
+
     let event_content = ImageMessageEventContent::plain(
         "filename.jpg".into(),
         mxc_uri!("mxc://example.org/image").to_owned(),
@@ -168,7 +190,7 @@ async fn test_get_media_file_no_auth() {
 }
 
 #[async_test]
-async fn test_get_media_file_with_auth() {
+async fn test_get_media_file_with_auth_matrix_1_11() {
     // The server must advertise support for v1.11 for authenticated media support,
     // so we make the request instead of assuming.
     let server = wiremock::MockServer::start().await;
@@ -177,6 +199,119 @@ async fn test_get_media_file_with_auth() {
         .and(path("/_matrix/client/versions"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "versions": ["v1.7", "v1.8", "v1.9", "v1.10", "v1.11"],
+        })))
+        .named("versions")
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Build client.
+    let client = Client::builder()
+        .homeserver_url(server.uri())
+        .request_config(RequestConfig::new().disable_retry())
+        .build()
+        .await
+        .unwrap();
+
+    // Restore session.
+    client
+        .matrix_auth()
+        .restore_session(MatrixSession {
+            meta: SessionMeta {
+                user_id: user_id!("@example:localhost").to_owned(),
+                device_id: device_id!("DEVICEID").to_owned(),
+            },
+            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+        })
+        .await
+        .unwrap();
+
+    // Build event content.
+    let event_content = ImageMessageEventContent::plain(
+        "filename.jpg".into(),
+        mxc_uri!("mxc://example.org/image").to_owned(),
+    )
+    .info(Box::new(assign!(ImageInfo::new(), {
+        height: Some(uint!(398)),
+        width: Some(uint!(394)),
+        mimetype: Some("image/jpeg".into()),
+        size: Some(uint!(31037)),
+    })));
+
+    // Get the full file.
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/v1/media/download/example.org/image"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("binaryjpegdata", "image/jpeg"))
+        .named("get_file")
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    client.media().get_file(&event_content, false).await.unwrap();
+
+    // Get a thumbnail, not animated.
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/v1/media/thumbnail/example.org/image"))
+        .and(query_param("method", "scale"))
+        .and(query_param("width", "100"))
+        .and(query_param("height", "100"))
+        .and(query_param("animated", "false"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw("smallerbinaryjpegdata", "image/jpeg"),
+        )
+        .expect(1)
+        .named("get_thumbnail_no_animated")
+        .mount(&server)
+        .await;
+
+    client
+        .media()
+        .get_thumbnail(
+            &event_content,
+            MediaThumbnailSettings::new(Method::Scale, uint!(100), uint!(100)),
+            true,
+        )
+        .await
+        .unwrap();
+
+    // Get a thumbnail, animated.
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/v1/media/thumbnail/example.org/image"))
+        .and(query_param("method", "crop"))
+        .and(query_param("width", "100"))
+        .and(query_param("height", "100"))
+        .and(query_param("animated", "true"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw("smallerbinaryjpegdata", "image/jpeg"),
+        )
+        .expect(1)
+        .named("get_thumbnail_animated_true")
+        .mount(&server)
+        .await;
+
+    let settings = MediaThumbnailSettings {
+        size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
+        animated: true,
+    };
+    client.media().get_thumbnail(&event_content, settings, true).await.unwrap();
+}
+
+#[async_test]
+async fn test_get_media_file_with_auth_matrix_stable_feature() {
+    // The server must advertise support for the stable feature for authenticated
+    // media support, so we make the request instead of assuming.
+    let server = wiremock::MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/versions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "versions": ["v1.7", "v1.8", "v1.9", "v1.10"],
+            "unstable_features": {
+                "org.matrix.msc3916.stable": true,
+            },
         })))
         .named("versions")
         .expect(1)


### PR DESCRIPTION
Was added post-merge to the MSC in https://github.com/matrix-org/matrix-spec-proposals/pull/4180 for servers that support authenticated media but do not support all of Matrix 1.11 yet.

Requires a kind of hack to force Ruma to select the stable endpoint by ignoring the real versions advertised by the homeserver for this particular endpoint.