### PR TITLE
chore(sdk): Replace “simplified sliding sync” by “MSC4186”

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2286,9 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+checksum = "0ff6858c1f7e2a470c5403091866fa95b36fe0dbac5d771f932c15e5ff1ee501"
 dependencies = [
  "log",
  "mac",
@@ -2972,9 +2972,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+checksum = "d581ff8be69d08a2efa23a959d81aa22b739073f749f067348bd4f4ba4b69195"
 dependencies = [
  "log",
  "phf",
@@ -4522,9 +4522,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8746739f11d39ce5ad5c2520a9b75285310dbfe78c541ccf832d38615765aec0"
+checksum = "666f0f59e259aea2d72e6012290c09877a780935cc3c18b1ceded41f3890d59c"
 dependencies = [
  "bitflags 2.6.0",
  "memchr",
@@ -4997,7 +4997,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.10.1"
-source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
+source = "git+https://github.com/matrix-org/ruma?rev=bb6d4c531aebb571fed4b1948df0118244762741#bb6d4c531aebb571fed4b1948df0118244762741"
 dependencies = [
  "assign",
  "js_int",
@@ -5014,7 +5014,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.18.0"
-source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
+source = "git+https://github.com/matrix-org/ruma?rev=bb6d4c531aebb571fed4b1948df0118244762741#bb6d4c531aebb571fed4b1948df0118244762741"
 dependencies = [
  "as_variant",
  "assign",
@@ -5037,7 +5037,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.13.0"
-source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
+source = "git+https://github.com/matrix-org/ruma?rev=bb6d4c531aebb571fed4b1948df0118244762741#bb6d4c531aebb571fed4b1948df0118244762741"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -5069,7 +5069,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.28.1"
-source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
+source = "git+https://github.com/matrix-org/ruma?rev=bb6d4c531aebb571fed4b1948df0118244762741#bb6d4c531aebb571fed4b1948df0118244762741"
 dependencies = [
  "as_variant",
  "indexmap 2.2.6",
@@ -5094,7 +5094,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.9.0"
-source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
+source = "git+https://github.com/matrix-org/ruma?rev=bb6d4c531aebb571fed4b1948df0118244762741#bb6d4c531aebb571fed4b1948df0118244762741"
 dependencies = [
  "http",
  "js_int",
@@ -5108,7 +5108,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.2.0"
-source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
+source = "git+https://github.com/matrix-org/ruma?rev=bb6d4c531aebb571fed4b1948df0118244762741#bb6d4c531aebb571fed4b1948df0118244762741"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5120,7 +5120,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.5"
-source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
+source = "git+https://github.com/matrix-org/ruma?rev=bb6d4c531aebb571fed4b1948df0118244762741#bb6d4c531aebb571fed4b1948df0118244762741"
 dependencies = [
  "js_int",
  "thiserror",
@@ -5129,8 +5129,9 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.13.0"
-source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
+source = "git+https://github.com/matrix-org/ruma?rev=bb6d4c531aebb571fed4b1948df0118244762741#bb6d4c531aebb571fed4b1948df0118244762741"
 dependencies = [
+ "cfg-if",
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
@@ -5144,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.9.0"
-source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
+source = "git+https://github.com/matrix-org/ruma?rev=bb6d4c531aebb571fed4b1948df0118244762741#bb6d4c531aebb571fed4b1948df0118244762741"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ once_cell = "1.16.0"
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { git = "https://github.com/matrix-org/ruma", rev = "17f6e555528512319e706bb2cfe68a12ec5603b6", features = [
+ruma = { git = "https://github.com/matrix-org/ruma", rev = "bb6d4c531aebb571fed4b1948df0118244762741", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -61,7 +61,7 @@ ruma = { git = "https://github.com/matrix-org/ruma", rev = "17f6e555528512319e70
     "unstable-msc4075",
     "unstable-msc4140",
 ] }
-ruma-common = { git = "https://github.com/matrix-org/ruma", rev = "17f6e555528512319e706bb2cfe68a12ec5603b6" }
+ruma-common = { git = "https://github.com/matrix-org/ruma", rev = "bb6d4c531aebb571fed4b1948df0118244762741" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -23,7 +23,7 @@ qrcode = ["matrix-sdk-crypto?/qrcode"]
 automatic-room-key-forwarding = ["matrix-sdk-crypto?/automatic-room-key-forwarding"]
 experimental-sliding-sync = [
     "ruma/unstable-msc3575",
-    "ruma/unstable-simplified-msc3575",
+    "ruma/unstable-msc4186",
 ]
 uniffi = ["dep:uniffi", "matrix-sdk-crypto?/uniffi", "matrix-sdk-common/uniffi"]
 

--- a/crates/matrix-sdk-base/src/sliding_sync/http.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/http.rs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! HTTP types for (Simplified) MSC3575.
+//! HTTP types for MSC4186 or MSC3585.
 //!
 //! This module provides unified namings for types from MSC3575 and
-//! Simplified MSC3575, in addition to provide conversion from one
-//! format to another.
+//! MSC4186.
 
-/// HTTP types from MSC3575, renamed to match the Simplified MSC3575 namings.
+/// HTTP types from MSC3575, renamed to match the MSC4186 namings.
 pub mod msc3575 {
     use ruma::api::client::sync::sync_events::v4;
     pub use v4::{Request, Response};
@@ -42,9 +41,9 @@ pub mod msc3575 {
     }
 }
 
-/// HTTP types from Simplified MSC3575.
-pub mod simplified_msc3575 {
+/// HTTP types from MSC4186.
+pub mod msc4186 {
     pub use ruma::api::client::sync::sync_events::v5::*;
 }
 
-pub use simplified_msc3575::*;
+pub use msc4186::*;

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -119,15 +119,14 @@ impl BaseClient {
     ///   sync.
     /// * `previous_events_provider` - Timeline events prior to the current
     ///   sync.
-    /// * `from_simplified_sliding_sync` - Whether the `response` comes from
-    ///   simplified sliding sync (Simplified MSC3575), or sliding sync
-    ///   (MSC3575).
+    /// * `from_msc4186` - Whether the `response` comes from simplified sliding
+    ///   sync (MSC4186) or sliding sync (MSC3575).
     #[instrument(skip_all, level = "trace")]
     pub async fn process_sliding_sync<PEP: PreviousEventsProvider>(
         &self,
         response: &http::Response,
         previous_events_provider: &PEP,
-        from_simplified_sliding_sync: bool,
+        from_msc4186: bool,
     ) -> Result<SyncResponse> {
         let http::Response {
             // FIXME not yet supported by sliding sync. see
@@ -181,7 +180,7 @@ impl BaseClient {
                     &mut room_info_notable_updates,
                     &mut notifications,
                     &mut ambiguity_cache,
-                    from_simplified_sliding_sync,
+                    from_msc4186,
                 )
                 .await?;
 
@@ -353,7 +352,7 @@ impl BaseClient {
         room_info_notable_updates: &mut BTreeMap<OwnedRoomId, RoomInfoNotableUpdateReasons>,
         notifications: &mut BTreeMap<OwnedRoomId, Vec<Notification>>,
         ambiguity_cache: &mut AmbiguityCache,
-        from_simplified_sliding_sync: bool,
+        from_msc4186: bool,
     ) -> Result<(RoomInfo, Option<JoinedRoomUpdate>, Option<LeftRoomUpdate>, Option<InvitedRoom>)>
     {
         // This method may change `room_data` (see the terrible hack describes below)
@@ -381,10 +380,10 @@ impl BaseClient {
         // `timestamp` despites having `m.room.create` in `bump_event_types`. The result
         // of this is that an invite cannot be sorted. This horrible hack will fix that.
         //
-        // The SDK manipulates Simplified MSC3575 `Request` and `Response` though. In
-        // Simplified MSC3575, `bump_stamp` replaces `timestamp`, which does NOT
-        // represent a time! This hack must really, only, apply to the proxy, so to
-        // MSC3575 strictly (hence the `from_simplified_sliding_sync` argument).
+        // The SDK manipulates MSC4186 `Request` and `Response` though. In MSC4186,
+        // `bump_stamp` replaces `timestamp`, which does NOT represent a time! This
+        // hack must really, only, apply to the proxy, so to MSC3575 strictly (hence
+        // the `from_msc4186` argument).
         //
         // The proxy uses the `origin_server_ts` event's value to fill the `timestamp`
         // room's value (which is a bad idea[^1]). If `timestamp` is `None`, let's find
@@ -392,9 +391,8 @@ impl BaseClient {
         //
         // [^1]: using `origin_server_ts` for `timestamp` is a bad idea because
         // this value can be forged by a malicious user. Anyway, that's how it works
-        // in the proxy. Simplified MSC3575 has another mechanism which fixes the
-        // problem.
-        if !from_simplified_sliding_sync && room_data.bump_stamp.is_none() {
+        // in the proxy. MSC4186 has another mechanism which fixes the problem.
+        if !from_msc4186 && room_data.bump_stamp.is_none() {
             if let Some(invite_state) = &room_data.invite_state {
                 room_data.to_mut().bump_stamp =
                     invite_state.iter().rev().find_map(|invite_state| {
@@ -1432,7 +1430,7 @@ mod tests {
 
     #[async_test]
     async fn test_invitation_room_receive_a_default_timestamp_on_not_simplified_sliding_sync() {
-        const NOT_SIMPLIFIED_SLIDING_SYNC: bool = false;
+        const NOT_MSC4186: bool = false;
 
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
@@ -1445,7 +1443,7 @@ mod tests {
         set_room_invited(&mut room, user_id, user_id);
         let response = response_with_room(room_id, room);
         let _sync_resp = client
-            .process_sliding_sync(&response, &(), NOT_SIMPLIFIED_SLIDING_SYNC)
+            .process_sliding_sync(&response, &(), NOT_MSC4186)
             .await
             .expect("Failed to process sync");
 
@@ -1491,7 +1489,7 @@ mod tests {
 
         let response = response_with_room(room_id, room);
         let _sync_resp = client
-            .process_sliding_sync(&response, &(), NOT_SIMPLIFIED_SLIDING_SYNC)
+            .process_sliding_sync(&response, &(), NOT_MSC4186)
             .await
             .expect("Failed to process sync");
 

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -27,6 +27,7 @@ use matrix_sdk_base::{
 };
 use ruma::{
     assign,
+    directory::RoomTypeFilter,
     events::{
         room::{member::StrippedRoomMemberEvent, message::SyncRoomMessageEvent},
         AnyFullStateEventContent, AnyStateEvent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
@@ -358,7 +359,7 @@ impl NotificationClient {
             .required_state(required_state.clone())
             .filters(Some(assign!(http::request::ListFilters::default(), {
                 is_invite: Some(true),
-                not_room_types: vec!["m.space".to_owned()],
+                not_room_types: vec![RoomTypeFilter::Space],
             })));
 
         let sync = self

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -69,7 +69,7 @@ use matrix_sdk::{
 use matrix_sdk_base::sliding_sync::http;
 pub use room::*;
 pub use room_list::*;
-use ruma::{assign, events::StateEventType, OwnedRoomId, RoomId};
+use ruma::{assign, directory::RoomTypeFilter, events::StateEventType, OwnedRoomId, RoomId};
 pub use state::*;
 use thiserror::Error;
 use tokio::time::timeout;
@@ -158,7 +158,7 @@ impl RoomListService {
                         // If unset, both invited and joined rooms are returned. If false, no invited rooms are
                         // returned. If true, only invited rooms are returned.
                         is_invite: None,
-                        not_room_types: vec!["m.space".to_owned()],
+                        not_room_types: vec![RoomTypeFilter::Space],
                     }))),
             )
             .await

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -32,7 +32,7 @@ pub enum Version {
     },
 
     /// Use the version of the sliding sync implementation inside Synapse, i.e.
-    /// Simplified MSC3575.
+    /// MSC4186.
     Native,
 }
 
@@ -268,7 +268,7 @@ impl<'a> SlidingSyncResponseProcessor<'a> {
     pub async fn handle_room_response(
         &mut self,
         response: &http::Response,
-        from_simplified_sliding_sync: bool,
+        from_msc4186: bool,
     ) -> Result<()> {
         self.response = Some(
             self.client
@@ -276,7 +276,7 @@ impl<'a> SlidingSyncResponseProcessor<'a> {
                 .process_sliding_sync(
                     response,
                     &SlidingSyncPreviousEventsProvider(self.rooms),
-                    from_simplified_sliding_sync,
+                    from_msc4186,
                 )
                 .await?,
         );

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -268,7 +268,7 @@ impl<'a> SlidingSyncResponseProcessor<'a> {
     pub async fn handle_room_response(
         &mut self,
         response: &http::Response,
-        from_msc4186: bool,
+        with_msc4186: bool,
     ) -> Result<()> {
         self.response = Some(
             self.client
@@ -276,7 +276,7 @@ impl<'a> SlidingSyncResponseProcessor<'a> {
                 .process_sliding_sync(
                     response,
                     &SlidingSyncPreviousEventsProvider(self.rooms),
-                    from_msc4186,
+                    with_msc4186,
                 )
                 .await?,
         );

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -682,8 +682,8 @@ impl SlidingSync {
             self.generate_sync_request(&mut LazyTransactionId::new()).await?;
 
         // The code manipulates `Request` and `Response` from MSC4186 because it's
-        // the future standard. Let's check if the generated request must be
-        // transformed into an MSC3575 `Request`.
+        // the future standard (at the time of writing: 2024-09-09). Let's check if
+        // the generated request must be transformed into an MSC3575 `Request`.
         if !self.inner.version.is_native() {
             self.send_sync_request(
                 Into::<http::msc3575::Request>::into(request),

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -531,7 +531,7 @@ impl SlidingSync {
     /// Send a sliding sync request.
     ///
     /// This method contains the sending logic. It takes a generic `Request`
-    /// because it can be a Simplified MSC3575 or a MSC3575 `Request`.
+    /// because it can be an MSC4186 or an MSC3575 `Request`.
     async fn send_sync_request<Request>(
         &self,
         request: Request,
@@ -543,7 +543,7 @@ impl SlidingSync {
         Request::IncomingResponse: Send
             + Sync
             +
-            // This is required to get back a Simplified MSC3575 `Response` whatever the
+            // This is required to get back an MSC4186 `Response` whatever the
             // `Request` type.
             Into<http::Response>,
         HttpError: From<ruma::api::error::FromHttpResponseError<Request::EndpointError>>,
@@ -613,11 +613,10 @@ impl SlidingSync {
         #[cfg(not(feature = "e2e-encryption"))]
         let response = request.await?;
 
-        // The code manipulates `Request` and `Response` from Simplified MSC3575 because
-        // it's the future standard. But this function may have received a `Request`
-        // from Simplified MSC3575 or MSC3575. We need to get back a
-        // Simplified MSC3575 `Response`.
-        let response = Into::<http::simplified_msc3575::Response>::into(response);
+        // The code manipulates `Request` and `Response` from MSC4186 because it's the
+        // future standard. But this function may have received a `Request` from MSC4186
+        // or MSC3575. We need to get back an MSC4186 `Response`.
+        let response = Into::<http::msc4186::Response>::into(response);
 
         debug!("Received response");
 
@@ -682,10 +681,9 @@ impl SlidingSync {
         let (request, request_config, position_guard) =
             self.generate_sync_request(&mut LazyTransactionId::new()).await?;
 
-        // The code manipulates `Request` and `Response` from Simplified MSC3575
-        // because it's the future standard. If
-        // `Client::is_simplified_sliding_sync_enabled` is turned off, the
-        // Simplified MSC3575 `Request` must be transformed into a MSC3575 `Request`.
+        // The code manipulates `Request` and `Response` from MSC4186 because it's
+        // the future standard. Let's check if the generated request must be
+        // transformed into an MSC3575 `Request`.
         if !self.inner.version.is_native() {
             self.send_sync_request(
                 Into::<http::msc3575::Request>::into(request),

--- a/testing/matrix-sdk-integration-testing/src/helpers.rs
+++ b/testing/matrix-sdk-integration-testing/src/helpers.rs
@@ -84,8 +84,8 @@ impl TestClientBuilder {
         let mut client_builder = Client::builder()
             .user_agent("matrix-sdk-integration-tests")
             .homeserver_url(homeserver_url)
-            // Disable Simplified MSC3575 for the integration tests as, at the time of writing
-            // (2024-07-15), we use a Synapse version that doesn't support Simplified MSC3575.
+            // Disable MSC4186 for the integration tests as, at the time of writing
+            // (2024-07-15), we use a Synapse version that doesn't support MSC4186.
             .sliding_sync_version_builder(VersionBuilder::Proxy {
                 url: Url::parse(&sliding_sync_proxy_url)
                     .expect("Sliding sync proxy URL is invalid"),


### PR DESCRIPTION
Simplified sliding sync now has an MSC number: 4186. Let's use it to clarify our code. I've done the same on Ruma side, and I've updated our `matrix-org/ruma` fork with its `feat-sss` branch.