### PR TITLE
Retry the decryption of events in the timeline if backups were enabled

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -16,6 +16,7 @@ use std::{collections::BTreeSet, sync::Arc};
 
 use futures_util::{pin_mut, StreamExt};
 use matrix_sdk::{
+    encryption::backups::BackupState,
     event_cache::{EventsOrigin, RoomEventCacheUpdate},
     executor::spawn,
     Room,
@@ -370,6 +371,44 @@ impl TimelineBuilder {
             })
         };
 
+        let room_key_backup_enabled_join_handle = {
+            let inner = controller.clone();
+            let stream = client.encryption().backups().state_stream();
+
+            spawn(async move {
+                pin_mut!(stream);
+
+                while let Some(update) = stream.next().await {
+                    match update {
+                        // If the backup got enabled, or we lagged and thus missed that the backup
+                        // might be enabled, retry to decrypt all the events. Please note, depending
+                        // on the backup download strategy, this might do two things under the
+                        // assumption that the backup contains the relevant room keys:
+                        //
+                        // 1. It will decrypt the events, if `BackupDownloadStrategy` has been set
+                        //    to `OneShot`.
+                        // 2. It will fail to decrypt the event, but try to download the room key to
+                        //    decrypt it if the `BackupDownloadStrategy` has been set to
+                        //    `AfterDecryptionFailure`.
+                        Ok(BackupState::Enabled) | Err(_) => {
+                            let room = inner.room();
+                            inner.retry_event_decryption(room, None).await;
+                        }
+                        // The other states aren't interesting since they are either still enabling
+                        // the backup or have the backup in the disabled state.
+                        Ok(
+                            BackupState::Unknown
+                            | BackupState::Creating
+                            | BackupState::Resuming
+                            | BackupState::Disabling
+                            | BackupState::Downloading
+                            | BackupState::Enabling,
+                        ) => (),
+                    }
+                }
+            })
+        };
+
         let timeline = Timeline {
             controller,
             event_cache: room_event_cache,
@@ -379,6 +418,7 @@ impl TimelineBuilder {
                 room_update_join_handle,
                 pinned_events_join_handle,
                 room_key_from_backups_join_handle,
+                room_key_backup_enabled_join_handle,
                 local_echo_listener_handle,
                 _event_cache_drop_handle: event_cache_drop,
             }),

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -851,6 +851,7 @@ struct TimelineDropHandle {
     room_update_join_handle: JoinHandle<()>,
     pinned_events_join_handle: Option<JoinHandle<()>>,
     room_key_from_backups_join_handle: JoinHandle<()>,
+    room_key_backup_enabled_join_handle: JoinHandle<()>,
     local_echo_listener_handle: JoinHandle<()>,
     _event_cache_drop_handle: Arc<EventCacheDropHandles>,
 }
@@ -860,12 +861,15 @@ impl Drop for TimelineDropHandle {
         for handle in self.event_handler_handles.drain(..) {
             self.client.remove_event_handler(handle);
         }
+
         if let Some(handle) = self.pinned_events_join_handle.take() {
             handle.abort()
         };
+
         self.local_echo_listener_handle.abort();
         self.room_update_join_handle.abort();
         self.room_key_from_backups_join_handle.abort();
+        self.room_key_backup_enabled_join_handle.abort();
     }
 }
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -45,6 +45,14 @@ Additions:
 - WidgetDriver: Support the `"delay"` field in the `send_event` widget actions.
 This allows to send delayed events, as defined in [MSC4157](https://github.com/matrix-org/matrix-spec-proposals/pull/4157)
 
+Bug fixes:
+
+- Fix a bug where room keys were considered to be downloaded before backups were
+  enabled. This bug only affects the
+  `BackupDownloadStrategy::AfterDecryptionFailure`, where no attempt would be
+  made to download a room key, if a decryption failure with a given room key
+  would have been encountered before the backups were enabled.
+
 # 0.7.0
 
 Breaking changes:

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -445,7 +445,16 @@ impl Backups {
     }
 
     /// Download a single room key from the server-side key backup.
-    pub async fn download_room_key(&self, room_id: &RoomId, session_id: &str) -> Result<(), Error> {
+    ///
+    /// Returns `true` if we managed to download a room key, `false` or an error
+    /// if we failed to download it. `false` indicates that there was no
+    /// error, we just don't have backups enabled so we can't download a
+    /// room key.
+    pub async fn download_room_key(
+        &self,
+        room_id: &RoomId,
+        session_id: &str,
+    ) -> Result<bool, Error> {
         let olm_machine = self.client.olm_machine().await;
         let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
 
@@ -471,10 +480,14 @@ impl Backups {
 
                 self.handle_downloaded_room_keys(response, decryption_key, &version, olm_machine)
                     .await?;
-            }
-        }
 
-        Ok(())
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        } else {
+            Ok(false)
+        }
     }
 
     /// Set the state of the backup.

--- a/crates/matrix-sdk/src/encryption/tasks.rs
+++ b/crates/matrix-sdk/src/encryption/tasks.rs
@@ -344,6 +344,16 @@ impl BackupDownloadTaskListenerState {
             return false;
         };
 
+        // If backups aren't enabled, there's no point in trying to download a room key.
+        if !client.encryption().backups().are_enabled().await {
+            debug!(
+                ?download_request,
+                "Not performing backup download because backups are not enabled"
+            );
+
+            return false;
+        }
+
         // Check if the keys for this message have arrived in the meantime.
         // If we get a StoreError doing the lookup, we assume the keys haven't arrived
         // (though if the store is returning errors, probably something else is


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/matrix-org/matrix-rust-sdk/issues/3768 and subsequently https://github.com/element-hq/element-x-ios/issues/3055. A review commit by commit is advised.

There are two issues that I have discovered:

1. Like #3768 theorized, enabling a backup doesn't trigger a decryption retry in the timeline.
2. The background task which is supposed to download the room keys upon a decryption failure happens has logic to deduplicate downloads and to stop the download if the backup does not contain the room key. This logic incorrectly marks a room key as downloaded if a backup was not yet enabled and thus no actual download attempt happened.

The first two commits add regression tests for these two issues, then we fix the actual issues, and lastly we address a TODO item in the vicinity of the room key download task, and do some renames. 

If this is too much to handle, please feel free to push for separate PRs for these tasks. 

This closes: https://github.com/matrix-org/matrix-rust-sdk/issues/3768.

- [x] Public API changes documented in changelogs (optional)
