### PR TITLE
MatrixRTC: Fix different devices from the same user overwriting the room info state event.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4934,7 +4934,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=92a35381b56ffa3c2a611287bb5011f574271478#92a35381b56ffa3c2a611287bb5011f574271478"
+source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
 dependencies = [
  "assign",
  "js_int",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.18.0"
-source = "git+https://github.com/ruma/ruma?rev=92a35381b56ffa3c2a611287bb5011f574271478#92a35381b56ffa3c2a611287bb5011f574271478"
+source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
 dependencies = [
  "as_variant",
  "assign",
@@ -4974,7 +4974,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=92a35381b56ffa3c2a611287bb5011f574271478#92a35381b56ffa3c2a611287bb5011f574271478"
+source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -5006,7 +5006,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.28.1"
-source = "git+https://github.com/ruma/ruma?rev=92a35381b56ffa3c2a611287bb5011f574271478#92a35381b56ffa3c2a611287bb5011f574271478"
+source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
 dependencies = [
  "as_variant",
  "indexmap 2.2.6",
@@ -5031,7 +5031,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=92a35381b56ffa3c2a611287bb5011f574271478#92a35381b56ffa3c2a611287bb5011f574271478"
+source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
 dependencies = [
  "http",
  "js_int",
@@ -5045,7 +5045,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.2.0"
-source = "git+https://github.com/ruma/ruma?rev=92a35381b56ffa3c2a611287bb5011f574271478#92a35381b56ffa3c2a611287bb5011f574271478"
+source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5057,7 +5057,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.5"
-source = "git+https://github.com/ruma/ruma?rev=92a35381b56ffa3c2a611287bb5011f574271478#92a35381b56ffa3c2a611287bb5011f574271478"
+source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
 dependencies = [
  "js_int",
  "thiserror",
@@ -5066,7 +5066,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=92a35381b56ffa3c2a611287bb5011f574271478#92a35381b56ffa3c2a611287bb5011f574271478"
+source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5082,7 +5082,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=92a35381b56ffa3c2a611287bb5011f574271478#92a35381b56ffa3c2a611287bb5011f574271478"
+source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ once_cell = "1.16.0"
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "92a35381b56ffa3c2a611287bb5011f574271478", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "1ae98db9c44f46a590f4c76baf5cef70ebb6970d", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -61,7 +61,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "92a35381b56ffa3c2a611287bb
     "unstable-msc4075",
     "unstable-msc4140",
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "92a35381b56ffa3c2a611287bb5011f574271478" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "1ae98db9c44f46a590f4c76baf5cef70ebb6970d" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -30,7 +30,7 @@ use ruma::events::AnySyncTimelineEvent;
 use ruma::{
     api::client::sync::sync_events::v3::RoomSummary as RumaSummary,
     events::{
-        call::member::MembershipData,
+        call::member::{CallMemberStateKey, MembershipData},
         ignored_user_list::IgnoredUserListEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::{
@@ -1485,10 +1485,10 @@ impl RoomInfo {
     /// associated UserId's in this room.
     ///
     /// The vector is ordered by oldest membership to newest.
-    fn active_matrix_rtc_memberships(&self) -> Vec<(OwnedUserId, MembershipData<'_>)> {
+    fn active_matrix_rtc_memberships(&self) -> Vec<(CallMemberStateKey, MembershipData<'_>)> {
         let mut v = self
             .base_info
-            .rtc_member
+            .rtc_member_events
             .iter()
             .filter_map(|(user_id, ev)| {
                 ev.as_original().map(|ev| {
@@ -1509,7 +1509,7 @@ impl RoomInfo {
     /// returns Memberships with application "m.call" and scope "m.room".
     ///
     /// The vector is ordered by oldest membership user to newest.
-    fn active_room_call_memberships(&self) -> Vec<(OwnedUserId, MembershipData<'_>)> {
+    fn active_room_call_memberships(&self) -> Vec<(CallMemberStateKey, MembershipData<'_>)> {
         self.active_matrix_rtc_memberships()
             .into_iter()
             .filter(|(_user_id, m)| m.is_room_call())
@@ -1531,7 +1531,10 @@ impl RoomInfo {
     ///
     /// The vector is ordered by oldest membership user to newest.
     pub fn active_room_call_participants(&self) -> Vec<OwnedUserId> {
-        self.active_room_call_memberships().iter().map(|(user_id, _)| user_id.clone()).collect()
+        self.active_room_call_memberships()
+            .iter()
+            .map(|(call_member_state_key, _)| call_member_state_key.user_id().to_owned())
+            .collect()
     }
 
     /// Returns the latest (decrypted) event recorded for this room.
@@ -1701,11 +1704,12 @@ mod tests {
     use matrix_sdk_test::{async_test, ALICE, BOB, CAROL};
     use ruma::{
         api::client::sync::sync_events::v3::RoomSummary as RumaSummary,
+        device_id, event_id,
         events::{
             call::member::{
-                Application, CallApplicationContent, CallMemberEventContent, CallMemberStateKey,
-                Focus, LegacyMembershipData, LegacyMembershipDataInit, LivekitFocus,
-                OriginalSyncCallMemberEvent,
+                ActiveFocus, ActiveLivekitFocus, Application, CallApplicationContent,
+                CallMemberEventContent, CallMemberStateKey, Focus, LegacyMembershipData,
+                LegacyMembershipDataInit, LivekitFocus, OriginalSyncCallMemberEvent,
             },
             room::{
                 canonical_alias::RoomCanonicalAliasEventContent,
@@ -1722,8 +1726,8 @@ mod tests {
         owned_event_id, room_alias_id, room_id,
         serde::Raw,
         time::SystemTime,
-        user_id, EventEncryptionAlgorithm, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId,
-        UserId,
+        user_id, DeviceId, EventEncryptionAlgorithm, EventId, MilliSecondsSinceUnixEpoch,
+        OwnedEventId, OwnedUserId, UserId,
     };
     use serde_json::json;
     use stream_assert::{assert_pending, assert_ready};
@@ -2729,51 +2733,101 @@ mod tests {
         .expect("date out of range")
     }
 
-    fn call_member_state_event(
+    fn legacy_membership_for_my_call(
+        device_id: &DeviceId,
+        membership_id: &str,
+        minutes_ago: u32,
+    ) -> LegacyMembershipData {
+        let (application, foci) = foci_and_application();
+        assign!(
+            LegacyMembershipData::from(LegacyMembershipDataInit {
+                application,
+                device_id: device_id.to_owned(),
+                expires: Duration::from_millis(3_600_000),
+                foci_active: foci,
+                membership_id: membership_id.to_owned(),
+            }),
+            { created_ts: Some(timestamp(minutes_ago)) }
+        )
+    }
+
+    fn legacy_member_state_event(
         memberships: Vec<LegacyMembershipData>,
-        ev_id: &str,
+        ev_id: &EventId,
         user_id: &UserId,
     ) -> AnySyncStateEvent {
         let content = CallMemberEventContent::new_legacy(memberships);
 
         AnySyncStateEvent::CallMember(SyncStateEvent::Original(OriginalSyncCallMemberEvent {
             content,
-            event_id: OwnedEventId::from_str(ev_id).unwrap(),
+            event_id: ev_id.to_owned(),
             sender: user_id.to_owned(),
             // we can simply use now here since this will be dropped when using a MinimalStateEvent
             // in the roomInfo
             origin_server_ts: timestamp(0),
-            state_key: CallMemberStateKey::from_str(user_id.as_str())
-                // SAFETY: `user_id` is a valid `UserId` and cannot fail to be transformed into a
-                // `CallMemberStateKey`.
-                .expect("Failed to transform a `UserId` into a `CallMemberStateKey`"),
+            state_key: CallMemberStateKey::new(user_id.to_owned(), None, false),
             unsigned: StateUnsigned::new(),
         }))
     }
 
-    fn membership_for_my_call(
-        device_id: &str,
-        membership_id: &str,
+    struct InitData<'a> {
+        device_id: &'a DeviceId,
         minutes_ago: u32,
-    ) -> LegacyMembershipData {
+    }
+
+    fn session_member_state_event(
+        ev_id: &EventId,
+        user_id: &UserId,
+        init_data: Option<InitData<'_>>,
+    ) -> AnySyncStateEvent {
         let application = Application::Call(CallApplicationContent::new(
             "my_call_id_1".to_owned(),
             ruma::events::call::member::CallScope::Room,
         ));
-        let foci_active = vec![Focus::Livekit(LivekitFocus::new(
+        let foci_preferred = vec![Focus::Livekit(LivekitFocus::new(
             "my_call_foci_alias".to_owned(),
             "https://lk.org".to_owned(),
         ))];
+        let focus_active = ActiveFocus::Livekit(ActiveLivekitFocus::new());
+        let (content, state_key) = match init_data {
+            Some(InitData { device_id, minutes_ago }) => (
+                CallMemberEventContent::new(
+                    application,
+                    device_id.to_owned(),
+                    focus_active,
+                    foci_preferred,
+                    Some(timestamp(minutes_ago)),
+                ),
+                CallMemberStateKey::new(user_id.to_owned(), Some(device_id.to_owned()), false),
+            ),
+            None => (
+                CallMemberEventContent::new_empty(None),
+                CallMemberStateKey::new(user_id.to_owned(), None, false),
+            ),
+        };
 
-        assign!(
-            LegacyMembershipData::from(LegacyMembershipDataInit {
-                application,
-                device_id: device_id.to_owned(),
-                expires: Duration::from_millis(3_600_000),
-                foci_active,
-                membership_id: membership_id.to_owned(),
-            }),
-            { created_ts: Some(timestamp(minutes_ago)) }
+        AnySyncStateEvent::CallMember(SyncStateEvent::Original(OriginalSyncCallMemberEvent {
+            content,
+            event_id: ev_id.to_owned(),
+            sender: user_id.to_owned(),
+            // we can simply use now here since this will be dropped when using a MinimalStateEvent
+            // in the roomInfo
+            origin_server_ts: timestamp(0),
+            state_key,
+            unsigned: StateUnsigned::new(),
+        }))
+    }
+
+    fn foci_and_application() -> (Application, Vec<Focus>) {
+        (
+            Application::Call(CallApplicationContent::new(
+                "my_call_id_1".to_owned(),
+                ruma::events::call::member::CallScope::Room,
+            )),
+            vec![Focus::Livekit(LivekitFocus::new(
+                "my_call_foci_alias".to_owned(),
+                "https://lk.org".to_owned(),
+            ))],
         )
     }
 
@@ -2790,20 +2844,20 @@ mod tests {
     /// `user_a`: empty memberships
     /// `user_b`: one membership
     /// `user_c`: two memberships (two devices)
-    fn create_call_with_member_events_for_user(a: &UserId, b: &UserId, c: &UserId) -> Room {
+    fn legacy_create_call_with_member_events_for_user(a: &UserId, b: &UserId, c: &UserId) -> Room {
         let (_, room) = make_room_test_helper(RoomState::Joined);
 
-        let a_empty = call_member_state_event(Vec::new(), "$1234", a);
+        let a_empty = legacy_member_state_event(Vec::new(), event_id!("$1234"), a);
 
         // make b 10min old
-        let m_init_b = membership_for_my_call("0", "0", 1);
-        let b_one = call_member_state_event(vec![m_init_b], "$12345", b);
+        let m_init_b = legacy_membership_for_my_call(device_id!("DEVICE_0"), "0", 1);
+        let b_one = legacy_member_state_event(vec![m_init_b], event_id!("$12345"), b);
 
         // c1 1min old
-        let m_init_c1 = membership_for_my_call("0", "0", 10);
+        let m_init_c1 = legacy_membership_for_my_call(device_id!("DEVICE_0"), "0", 10);
         // c2 20min old
-        let m_init_c2 = membership_for_my_call("1", "0", 20);
-        let c_two = call_member_state_event(vec![m_init_c1, m_init_c2], "$123456", c);
+        let m_init_c2 = legacy_membership_for_my_call(device_id!("DEVICE_1"), "0", 20);
+        let c_two = legacy_member_state_event(vec![m_init_c1, m_init_c2], event_id!("$123456"), c);
 
         // Intentionally use a non time sorted receive order.
         receive_state_events(&room, vec![&c_two, &a_empty, &b_one]);
@@ -2811,26 +2865,65 @@ mod tests {
         room
     }
 
+    /// `user_a`: empty memberships
+    /// `user_b`: one membership
+    /// `user_c`: two memberships (two devices)
+    fn session_create_call_with_member_events_for_user(a: &UserId, b: &UserId, c: &UserId) -> Room {
+        let (_, room) = make_room_test_helper(RoomState::Joined);
+
+        let a_empty = session_member_state_event(event_id!("$1234"), a, None);
+
+        // make b 10min old
+        let b_one = session_member_state_event(
+            event_id!("$12345"),
+            b,
+            Some(InitData { device_id: "DEVICE_0".into(), minutes_ago: 1 }),
+        );
+
+        let m_c1 = session_member_state_event(
+            event_id!("$123456_0"),
+            c,
+            Some(InitData { device_id: "DEVICE_0".into(), minutes_ago: 10 }),
+        );
+        let m_c2 = session_member_state_event(
+            event_id!("$123456_1"),
+            c,
+            Some(InitData { device_id: "DEVICE_1".into(), minutes_ago: 20 }),
+        );
+        // Intentionally use a non time sorted receive order1
+        receive_state_events(&room, vec![&m_c1, &m_c2, &a_empty, &b_one]);
+
+        room
+    }
+
     #[test]
     fn test_show_correct_active_call_state() {
-        let room = create_call_with_member_events_for_user(&ALICE, &BOB, &CAROL);
+        let room_legacy = legacy_create_call_with_member_events_for_user(&ALICE, &BOB, &CAROL);
 
         // This check also tests the ordering.
         // We want older events to be in the front.
         // user_b (Bob) is 1min old, c1 (CAROL) 10min old, c2 (CAROL) 20min old
         assert_eq!(
             vec![CAROL.to_owned(), CAROL.to_owned(), BOB.to_owned()],
-            room.active_room_call_participants()
+            room_legacy.active_room_call_participants()
         );
-        assert!(room.has_active_room_call());
+        assert!(room_legacy.has_active_room_call());
+
+        let room_session = session_create_call_with_member_events_for_user(&ALICE, &BOB, &CAROL);
+        assert_eq!(
+            vec![CAROL.to_owned(), CAROL.to_owned(), BOB.to_owned()],
+            room_session.active_room_call_participants()
+        );
+        assert!(room_session.has_active_room_call());
     }
 
     #[test]
     fn test_active_call_is_false_when_everyone_left() {
-        let room = create_call_with_member_events_for_user(&ALICE, &BOB, &CAROL);
+        let room = legacy_create_call_with_member_events_for_user(&ALICE, &BOB, &CAROL);
 
-        let b_empty_membership = call_member_state_event(Vec::new(), "$1234_1", &BOB);
-        let c_empty_membership = call_member_state_event(Vec::new(), "$12345_1", &CAROL);
+        let b_empty_membership = legacy_member_state_event(Vec::new(), event_id!("$1234_1"), &BOB);
+        let c_empty_membership =
+            legacy_member_state_event(Vec::new(), event_id!("$12345_1"), &CAROL);
 
         receive_state_events(&room, vec![&b_empty_membership, &c_empty_membership]);
 

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -212,7 +212,7 @@ impl BaseRoomInfoV1 {
             name,
             tombstone,
             topic,
-            rtc_member: BTreeMap::new(),
+            rtc_member_events: BTreeMap::new(),
             is_marked_unread: false,
             notable_tags: RoomNotableTags::empty(),
             pinned_events: None,


### PR DESCRIPTION
This PR is best reviewed with the background from: https://github.com/matrix-org/matrix-rust-sdk/pull/3998
The main change in this PR is the transition from using a UserId as the index for call member events in the room info to using the newly introduced `CallMemberStateKey` that is a combination of UserId and device id.

This is important since otherwise the room state could only store one event per user (but a user can join with multiple devices)

It also adds tests for session membership events (which is the new state event format for call member state events we need for reliable state events)


<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
