### PR TITLE
event cache: reset paginator state when receiving a limited timeline

### DIFF
--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -53,6 +53,7 @@ use matrix_sdk_base::{
     sync::{JoinedRoomUpdate, LeftRoomUpdate, RoomUpdates, Timeline},
 };
 use matrix_sdk_common::executor::{spawn, JoinHandle};
+use paginator::PaginatorState;
 use ruma::{
     events::{
         room::{message::Relation, redaction::SyncRoomRedactionEvent},
@@ -766,11 +767,16 @@ impl RoomEventCacheInner {
         self.append_events_locked_impl(
             room_events,
             sync_timeline_events,
-            prev_batch,
+            prev_batch.clone(),
             ephemeral_events,
             ambiguity_changes,
         )
-        .await
+        .await?;
+
+        // Reset the paginator status to initial.
+        self.pagination.paginator.set_idle_state(PaginatorState::Initial, prev_batch, None)?;
+
+        Ok(())
     }
 
     /// Append a set of events to the room cache and storage, notifying

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -133,12 +133,11 @@ impl RoomPagination {
     }
 
     async fn run_backwards_impl(&self, batch_size: u16) -> Result<Option<BackPaginationOutcome>> {
-        // Make sure there's at most one back-pagination request.
         let prev_token = self.get_or_wait_for_token().await;
 
         let paginator = &self.inner.pagination.paginator;
 
-        paginator.set_idle_state(prev_token.clone(), None)?;
+        paginator.set_idle_state(PaginatorState::Idle, prev_token.clone(), None)?;
 
         // Run the actual pagination.
         let PaginationResult { events, hit_end_of_timeline: reached_start } =


### PR DESCRIPTION
Before this patch, we did reset the paginator state just a bit too late, that is: at the beginning of running the next back-pagination. Resetting the state would trigger an update of the paginator status, which would reflect at the timeline paginator status level too.

But we have a bit of a conundrum here. Imagine the following sequence of events:

- back-pagination => at some point the paginator from the event cache hits the start of the timeline
- it reflects that at the timeline level, setting `hit_start_of_timeline` to true
- we received a limited/gappy sync via (simplified?) sliding sync, which resets the internal back-pagination token to None in the room event cache (not the associated paginator)
- this clears the timeline

Now, calling the paginator's `run_backwards()` method (or equivalently, the timeline's `live_paginate_backwards` method) would reset the pagination token as intended. But an API consumer would not see a status update there, so they're not aware that they can run back-pagination, because the previous status indicated that pagination hit the start of the timeline (and it hasn't changed since then, b/o absence of status update). Kaboom, we're stuck.

The resolution consists in resetting the paginator's state a bit earlier, i.e. just after receiving a limited timeline. In that case, we can even forward the pagination token a bit ahead of time, if it was already available.

Includes a regression test, that failed when checking `!hit_start_of_timeline()` after the timeline reset, before the patch.

Should fix https://github.com/element-hq/element-x-ios/issues/2024, @pixlwave can you confirm please?