### PR TITLE
feat(ffi): Add `RoomInfo::creator`.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -11,6 +11,7 @@ use crate::{
 #[derive(uniffi::Record)]
 pub struct RoomInfo {
     id: String,
+    creator: Option<String>,
     /// The room's name from the room state event if received from sync, or one
     /// that's been computed otherwise.
     display_name: Option<String>,
@@ -70,6 +71,7 @@ impl RoomInfo {
 
         Ok(Self {
             id: room.room_id().to_string(),
+            creator: room.creator().as_ref().map(ToString::to_string),
             display_name: room.cached_display_name().map(|name| name.to_string()),
             raw_name: room.name(),
             topic: room.topic(),

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -120,8 +120,12 @@ impl Default for RoomInfoNotableUpdateReasons {
 /// invited rooms.
 #[derive(Debug, Clone)]
 pub struct Room {
+    /// The room ID.
     room_id: OwnedRoomId,
+
+    /// Our own user ID.
     own_user_id: OwnedUserId,
+
     inner: SharedObservable<RoomInfo>,
     room_info_notable_update_sender: broadcast::Sender<RoomInfoNotableUpdate>,
     store: Arc<DynStateStore>,
@@ -251,6 +255,11 @@ impl Room {
     /// Get the unique room id of the room.
     pub fn room_id(&self) -> &RoomId {
         &self.room_id
+    }
+
+    /// Get a copy of the room creator.
+    pub fn creator(&self) -> Option<OwnedUserId> {
+        self.inner.read().creator().map(ToOwned::to_owned)
     }
 
     /// Get our own user id.


### PR DESCRIPTION
This patch adds the `matrix_sdk_ffi::RoomInfo::creator` field
as an `Option<String>`. This value comes from the new method
`matrix_sdk_base::Room::creator()`, which simply forwards the value from the
existing `matrix_sdk_base::RoomInfo::creator()`.

---

* Addresses https://github.com/element-hq/customer-success/issues/347#issuecomment-2312062942
