### PR TITLE
feat: add fn to await a synced room from `Client`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1002,6 +1002,16 @@ impl Client {
 
         Ok(RoomPreview::from_sdk(sdk_room_preview))
     }
+
+    /// Waits until an at least partially synced room is received, and returns
+    /// it.
+    ///
+    /// **Note: this function will loop endlessly until either it finds the room
+    /// or an externally set timeout happens.**
+    pub async fn await_room_remote_echo(&self, room_id: String) -> Result<Arc<Room>, ClientError> {
+        let room_id = RoomId::parse(room_id)?;
+        Ok(Arc::new(Room::new(self.inner.await_room_remote_echo(&room_id).await)))
+    }
 }
 
 #[uniffi::export(callback_interface)]

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -347,6 +347,13 @@ impl Room {
         self.inner.read().sync_info == SyncInfo::FullySynced
     }
 
+    /// Check if the room state has been at least partially synced.
+    ///
+    /// See [`Room::is_state_fully_synced`] for more info.
+    pub fn is_state_partially_or_fully_synced(&self) -> bool {
+        self.inner.read().sync_info != SyncInfo::NoState
+    }
+
     /// Check if the room has its encryption event synced.
     ///
     /// The encryption event can be missing when the room hasn't appeared in

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -20,6 +20,7 @@ use std::{ops::Deref, sync::Arc};
 use async_once_cell::OnceCell as AsyncOnceCell;
 use matrix_sdk::SlidingSync;
 use ruma::RoomId;
+use tracing::info;
 
 use super::Error;
 use crate::{
@@ -150,27 +151,32 @@ impl Room {
     }
 
     /// Create a new [`TimelineBuilder`] with the default configuration.
+    ///
+    /// If the room was synced before some initial events will be added to the
+    /// [`TimelineBuilder`].
     pub async fn default_room_timeline_builder(&self) -> Result<TimelineBuilder, Error> {
         // TODO we can remove this once the event cache handles his own cache.
 
-        let sliding_sync_room =
-            self.inner
-                .sliding_sync
-                .get_room(self.inner.room.room_id())
-                .await
-                .ok_or_else(|| Error::RoomNotFound(self.inner.room.room_id().to_owned()))?;
+        let sliding_sync_room = self.inner.sliding_sync.get_room(self.inner.room.room_id()).await;
 
-        self.inner
-            .room
-            .client()
-            .event_cache()
-            .add_initial_events(
-                self.inner.room.room_id(),
-                sliding_sync_room.timeline_queue().iter().cloned().collect(),
-                sliding_sync_room.prev_batch(),
-            )
-            .await
-            .map_err(Error::EventCache)?;
+        if let Some(sliding_sync_room) = sliding_sync_room {
+            self.inner
+                .room
+                .client()
+                .event_cache()
+                .add_initial_events(
+                    self.inner.room.room_id(),
+                    sliding_sync_room.timeline_queue().iter().cloned().collect(),
+                    sliding_sync_room.prev_batch(),
+                )
+                .await
+                .map_err(Error::EventCache)?;
+        } else {
+            info!(
+                "No cached sliding sync room found for `{}`, the timeline will be empty.",
+                self.room_id()
+            );
+        }
 
         Ok(Timeline::builder(&self.inner.room).track_read_marker_and_receipts())
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -652,7 +652,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
         // now we may want to replace a populated timeline with an empty one.
         if !state.items.is_empty() || !events.is_empty() {
             state
-                .replace_with_remove_events(
+                .replace_with_remote_events(
                     events,
                     TimelineEnd::Back,
                     origin,

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -279,7 +279,7 @@ impl TimelineState {
     /// Note: when the `position` is [`TimelineEnd::Front`], prepended events
     /// should be ordered in *reverse* topological order, that is, `events[0]`
     /// is the most recent.
-    pub(super) async fn replace_with_remove_events<P: RoomDataProvider>(
+    pub(super) async fn replace_with_remote_events<P: RoomDataProvider>(
         &mut self,
         events: Vec<SyncTimelineEvent>,
         position: TimelineEnd,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2240,6 +2240,28 @@ impl Client {
         // SAFETY: always initialized in the `Client` ctor.
         self.inner.event_cache.get().unwrap()
     }
+
+    /// Waits until an at least partially synced room is received, and returns
+    /// it.
+    ///
+    /// **Note: this function will loop endlessly until either it finds the room
+    /// or an externally set timeout happens.**
+    pub async fn await_room_remote_echo(&self, room_id: &RoomId) -> Room {
+        loop {
+            if let Some(room) = self.get_room(room_id) {
+                if room.is_state_partially_or_fully_synced() {
+                    debug!("Found just created room!");
+                    return room;
+                } else {
+                    warn!("Room wasn't partially synced, waiting for sync beat to try again");
+                }
+            } else {
+                warn!("Room wasn't found, waiting for sync beat to try again");
+            }
+            self.inner.sync_beat.listen().await;
+            debug!("New sync beat found");
+        }
+    }
 }
 
 /// A weak reference to the inner client, useful when trying to get a handle
@@ -2300,12 +2322,15 @@ pub(crate) mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     use ruma::{
-        api::MatrixVersion, events::ignored_user_list::IgnoredUserListEventContent, owned_room_id,
-        room_id, RoomId, ServerName, UserId,
+        api::{client::room::create_room::v3::Request as CreateRoomRequest, MatrixVersion},
+        assign,
+        events::ignored_user_list::IgnoredUserListEventContent,
+        owned_room_id, room_id, RoomId, ServerName, UserId,
     };
+    use serde_json::json;
     use url::Url;
     use wiremock::{
-        matchers::{body_json, header, method, path},
+        matchers::{body_json, header, method, path, query_param_is_missing},
         Mock, MockServer, ResponseTemplate,
     };
 
@@ -2315,6 +2340,7 @@ pub(crate) mod tests {
         config::{RequestConfig, SyncSettings},
         test_utils::{
             logged_in_client, no_retry_test_client, set_client_session, test_client_builder,
+            test_client_builder_with_server,
         },
         Error,
     };
@@ -2772,5 +2798,127 @@ pub(crate) mod tests {
         // We don't define a mock server on purpose here, so that the error is really a
         // network error.
         client.whoami().await.unwrap_err();
+    }
+
+    #[async_test]
+    async fn test_await_room_remote_echo_returns_the_room_if_it_was_already_synced() {
+        let (client_builder, server) = test_client_builder_with_server().await;
+        let client = client_builder.request_config(RequestConfig::new()).build().await.unwrap();
+        set_client_session(&client).await;
+
+        let builder = Mock::given(method("GET"))
+            .and(path("/_matrix/client/r0/sync"))
+            .and(header("authorization", "Bearer 1234"))
+            .and(query_param_is_missing("since"));
+
+        let room_id = room_id!("!room:example.org");
+        let joined_room_builder = JoinedRoomBuilder::new(room_id);
+        let mut sync_response_builder = SyncResponseBuilder::new();
+        sync_response_builder.add_joined_room(joined_room_builder);
+        let response_body = sync_response_builder.build_json_sync_response();
+
+        builder
+            .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+            .mount(&server)
+            .await;
+
+        client.sync_once(SyncSettings::default()).await.unwrap();
+
+        let room =
+            tokio::time::timeout(Duration::from_secs(1), client.await_room_remote_echo(room_id))
+                .await
+                .unwrap();
+        assert_eq!(room.room_id(), room_id);
+    }
+
+    #[async_test]
+    async fn test_await_room_remote_echo_returns_the_room_when_it_is_ready() {
+        let (client_builder, server) = test_client_builder_with_server().await;
+        let client = client_builder.request_config(RequestConfig::new()).build().await.unwrap();
+        set_client_session(&client).await;
+
+        let builder = Mock::given(method("GET"))
+            .and(path("/_matrix/client/r0/sync"))
+            .and(header("authorization", "Bearer 1234"))
+            .and(query_param_is_missing("since"));
+
+        let room_id = room_id!("!room:example.org");
+        let joined_room_builder = JoinedRoomBuilder::new(room_id);
+        let mut sync_response_builder = SyncResponseBuilder::new();
+        sync_response_builder.add_joined_room(joined_room_builder);
+        let response_body = sync_response_builder.build_json_sync_response();
+
+        builder
+            .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+            .mount(&server)
+            .await;
+
+        let client = Arc::new(client);
+
+        // Perform the /sync request with a delay so it starts after the
+        // `await_room_remote_echo` call has happened
+        tokio::spawn({
+            let client = client.clone();
+            async move {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                client.sync_once(SyncSettings::default()).await.unwrap();
+            }
+        });
+
+        let room =
+            tokio::time::timeout(Duration::from_secs(1), client.await_room_remote_echo(room_id))
+                .await
+                .unwrap();
+        assert_eq!(room.room_id(), room_id);
+    }
+
+    #[async_test]
+    async fn test_await_room_remote_echo_will_timeout_if_no_room_is_found() {
+        let (client_builder, _) = test_client_builder_with_server().await;
+        let client = client_builder.request_config(RequestConfig::new()).build().await.unwrap();
+        set_client_session(&client).await;
+
+        let room_id = room_id!("!room:example.org");
+        // Room is not present so the client won't be able to find it. The call will
+        // timeout.
+        let err =
+            tokio::time::timeout(Duration::from_secs(1), client.await_room_remote_echo(room_id))
+                .await
+                .err();
+        assert!(err.is_some());
+    }
+
+    #[async_test]
+    async fn test_await_room_remote_echo_will_timeout_if_room_is_found_but_not_synced() {
+        let (client_builder, server) = test_client_builder_with_server().await;
+        let client = client_builder.request_config(RequestConfig::new()).build().await.unwrap();
+        set_client_session(&client).await;
+
+        Mock::given(method("POST"))
+            .and(path("_matrix/client/r0/createRoom"))
+            .and(header("authorization", "Bearer 1234"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "room_id": "!room:example.org"})),
+            )
+            .mount(&server)
+            .await;
+
+        // Create a room in the internal store
+        let room = client
+            .create_room(assign!(CreateRoomRequest::new(), {
+                invite: vec![],
+                is_direct: false,
+            }))
+            .await
+            .unwrap();
+
+        // Room is locally present, but not synced, the call will timeout
+        let err = tokio::time::timeout(
+            Duration::from_secs(1),
+            client.await_room_remote_echo(room.room_id()),
+        )
+        .await
+        .err();
+        assert!(err.is_some());
     }
 }


### PR DESCRIPTION
## Changes

- Add `fn sdk_base::Room::is_state_partially_or_fully_synced()`. I was planning to reuse `Room::is_state_fully_synced()`, but this apparently doesn't work with SSS.
- Add `fn Client::await_room_remote_echo(&RoomId)`, which will loop indefinitely until it finds a room with the provided room id, using `ClientInner::sync_beat` to delay the checks. This is the core of the changes, and an FFI fn has been created to access it.
- `SlidingSyncRoom` is no longer needed in `fn RoomListItem::default_room_timeline_builder()`. It was mandatory, and used only to pre-fill the timeline with initial items. After discussing this behavior we decided we can make it non-mandatory so timelines can be created for rooms that haven't been synced yet, which was a source of pain in the clients.
- Fix dumb typo in `TimelineState`.

## Motivation

After using `Client::create_room` in the clients we found some cases where we were trying to create a timeline for the just created room while it still hadn't been synced and this resulted in an error and the full room not being returned to the clients. The new `await_room_remote_echo` fn will let us wait until the room has been synced, fixing this issue.

Also, there may be some cases where a room is in the local DB but it hasn't been synced yet. The behaviour change in `default_room_timeline_builder` should fix that.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
