### PR TITLE
test: Don't use the matrix.org server for the sliding sync version discovery tests

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -467,10 +467,10 @@ mod tests {
             .and(path("/.well-known/matrix/client"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "m.homeserver": {
-                    "base_url": "https://matrix.org",
+                    "base_url": server.uri(),
                 },
                 "org.matrix.msc3575.proxy": {
-                    "url": "https://proxy.matrix.org",
+                    "url": server.uri(),
                 },
             })))
             .mount(&server)


### PR DESCRIPTION
Since the well-known lookup will modify the homeserver you are using, we need to set the homeserver URL to our own mocked server as well.