### PR TITLE
feat(ui): `all_rooms` in `RoomListService` requires `m.room.canonical_name`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -150,6 +150,7 @@ impl RoomListService {
                         (StateEventType::RoomMember, "$LAZY".to_owned()),
                         (StateEventType::RoomMember, "$ME".to_owned()),
                         (StateEventType::RoomName, "".to_owned()),
+                        (StateEventType::RoomCanonicalAlias, "".to_owned()),
                         (StateEventType::RoomPowerLevels, "".to_owned()),
                     ])
                     .include_heroes(Some(true))

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -327,6 +327,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
                         ["m.room.member", "$LAZY"],
                         ["m.room.member", "$ME"],
                         ["m.room.name", ""],
+                        ["m.room.canonical_alias", ""],
                         ["m.room.power_levels", ""],
                     ],
                     "include_heroes": true,


### PR DESCRIPTION
This patch adds `m.room.canonical_name` in the `required_state` of the `all_rooms` list defined by `RoomListService`.

This is useful to better compute the room name in a more robust way.
