### PR TITLE
crypto: Include megolm ratchet index in logging span fields

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Changes:
 
+- Improve logging for undecryptable Megolm events.
+  ([#3989](https://github.com/matrix-org/matrix-rust-sdk/pull/3989))
+
 - Miscellaneous improvements to logging for verification and `OwnUserIdentity`
   updates.
   ([#3949](https://github.com/matrix-org/matrix-rust-sdk/pull/3949))

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -1747,7 +1747,7 @@ impl OlmMachine {
         self.decrypt_room_event_inner(event, room_id, true, decryption_settings).await
     }
 
-    #[instrument(name = "decrypt_room_event", skip_all, fields(?room_id, event_id, origin_server_ts, sender, algorithm, session_id, sender_key))]
+    #[instrument(name = "decrypt_room_event", skip_all, fields(?room_id, event_id, origin_server_ts, sender, algorithm, session_id, message_index, sender_key))]
     async fn decrypt_room_event_inner(
         &self,
         event: &Raw<EncryptedEvent>,
@@ -1781,6 +1781,8 @@ impl OlmMachine {
         };
 
         Span::current().record("session_id", content.session_id());
+        Span::current().record("message_index", content.message_index());
+
         let result =
             self.decrypt_megolm_events(room_id, &event, &content, decryption_settings).await;
 

--- a/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
@@ -268,6 +268,15 @@ impl SupportedEventEncryptionSchemes<'_> {
             SupportedEventEncryptionSchemes::MegolmV2AesSha2(c) => &c.session_id,
         }
     }
+
+    /// The index of the Megolm ratchet that was used to encrypt the message.
+    pub fn message_index(&self) -> u32 {
+        match self {
+            SupportedEventEncryptionSchemes::MegolmV1AesSha2(c) => c.ciphertext.message_index(),
+            #[cfg(feature = "experimental-algorithms")]
+            SupportedEventEncryptionSchemes::MegolmV2AesSha2(c) => c.ciphertext.message_index(),
+        }
+    }
 }
 
 impl<'a> From<&'a MegolmV1AesSha2Content> for SupportedEventEncryptionSchemes<'a> {


### PR DESCRIPTION
This field is helpful as it tells us the sequence number of the message in the megolm session, which gives us a clue about how long it will have been since the session should have been shared with us.

[Question: an alternative would be just to attach the whole of `content` to the span, instead of separate fields for `sender_key`, `session_id`, `message_index`. The Debug defintion for `MegolmV1AesSha2Content` looks like it contains the right things, so the code might be simpler. On the other hand, I think the output would be less readable. Thoughts?]