### PR TITLE
ffi: Add the registration helper URL to the ElementWellKnown file.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/element.rs
+++ b/bindings/matrix-sdk-ffi/src/element.rs
@@ -11,7 +11,8 @@ pub struct ElementCallWellKnown {
 /// Element specific well-known settings
 #[derive(Deserialize, uniffi::Record)]
 pub struct ElementWellKnown {
-    call: ElementCallWellKnown,
+    call: Option<ElementCallWellKnown>,
+    registration_helper_url: Option<String>,
 }
 
 /// Helper function to parse a string into a ElementWellKnown struct


### PR DESCRIPTION
There's a new field to handle in the well-known file.