### PR TITLE
Revert "chore(ui,ffi): Remove the `RoomList::entries` method"

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -182,6 +182,33 @@ impl RoomList {
         })
     }
 
+    fn entries(&self, listener: Box<dyn RoomListEntriesListener>) -> Arc<TaskHandle> {
+        let this = self.inner.clone();
+        let utd_hook = self.room_list_service.utd_hook.clone();
+
+        Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
+            let (entries, entries_stream) = this.entries();
+
+            pin_mut!(entries_stream);
+
+            listener.on_update(vec![RoomListEntriesUpdate::Append {
+                values: entries
+                    .into_iter()
+                    .map(|room| Arc::new(RoomListItem::from(room, utd_hook.clone())))
+                    .collect(),
+            }]);
+
+            while let Some(diffs) = entries_stream.next().await {
+                listener.on_update(
+                    diffs
+                        .into_iter()
+                        .map(|diff| RoomListEntriesUpdate::from(diff, utd_hook.clone()))
+                        .collect(),
+                );
+            }
+        })))
+    }
+
     fn entries_with_dynamic_adapters(
         self: Arc<Self>,
         page_size: u32,

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -44,9 +44,9 @@
 //! fluid user experience for a Matrix client.
 //!
 //! [`RoomListService::all_rooms`] provides a way to get a [`RoomList`] for all
-//! the rooms. From that, calling [`RoomList::entries_with_dynamic_adapters`]
-//! provides a way to get a stream of rooms. This stream is sorted, can be
-//! filtered, and the filter can be changed over time.
+//! the rooms. From that, calling [`RoomList::entries`] provides a way to get a
+//! stream of room list entry. This stream can be filtered, and the filter can
+//! be changed over time.
 //!
 //! [`RoomListService::state`] provides a way to get a stream of the state
 //! machine's state, which can be pretty helpful for the client app.

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -115,8 +115,8 @@ impl RoomList {
         self.loading_state.subscribe()
     }
 
-    /// Get a stream of rooms.
-    fn entries(&self) -> (Vector<Room>, impl Stream<Item = Vec<VectorDiff<Room>>> + '_) {
+    /// Get all previous rooms, in addition to a [`Stream`] to rooms' updates.
+    pub fn entries(&self) -> (Vector<Room>, impl Stream<Item = Vec<VectorDiff<Room>>> + '_) {
         let (rooms, stream) = self.client.rooms_stream();
 
         let map_room = |room| Room::new(room, &self.sliding_sync);
@@ -127,11 +127,9 @@ impl RoomList {
         )
     }
 
-    /// Get a configurable stream of rooms.
-    ///
-    /// It's possible to provide a filter that will filter out room list
-    /// entries, and that it's also possible to “paginate” over the entries by
-    /// `page_size`. The rooms are also sorted.
+    /// Similar to [`Self::entries`] except that it's possible to provide a
+    /// filter that will filter out room list entries, and that it's also
+    /// possible to “paginate” over the entries by `page_size`.
     ///
     /// The returned stream will only start yielding diffs once a filter is set
     /// through the returned [`RoomListDynamicEntriesController`]. For every


### PR DESCRIPTION
Reverts matrix-org/matrix-rust-sdk#3999

Complement crypto was failing but CI configuration has failed to catch that, let's revert this patch quickly.