### PR TITLE
ffi: expose method to allow user account deactivate for `m.login.password` based accounts

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -74,6 +74,7 @@ use crate::{
     notification_settings::NotificationSettings,
     room_directory_search::RoomDirectorySearch,
     room_preview::RoomPreview,
+    ruma::AuthData,
     sync_service::{SyncService, SyncServiceBuilder},
     task_handle::TaskHandle,
     ClientError,
@@ -1026,6 +1027,30 @@ impl Client {
     pub async fn await_room_remote_echo(&self, room_id: String) -> Result<Arc<Room>, ClientError> {
         let room_id = RoomId::parse(room_id)?;
         Ok(Arc::new(Room::new(self.inner.await_room_remote_echo(&room_id).await)))
+    }
+
+    /// Deactivate this account definitively.
+    /// Similarly to `encryption::reset_identity` this
+    /// will only work with password-based authentication (`m.login.password`)
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_data` - This request uses the [User-Interactive Authentication
+    ///   API][uiaa]. The first request needs to set this to `None` and will
+    ///   always fail and the same request needs to be made but this time with
+    ///   some `auth_data` provided.
+    pub async fn deactivate_account(
+        &self,
+        auth_data: Option<AuthData>,
+        erase_data: bool,
+    ) -> Result<(), ClientError> {
+        if let Some(auth_data) = auth_data {
+            _ = self.inner.account().deactivate(None, Some(auth_data.into()), erase_data).await?;
+        } else {
+            _ = self.inner.account().deactivate(None, None, erase_data).await?;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -360,6 +360,9 @@ impl Account {
     ///   information for the interactive auth and the same request needs to be
     ///   made but this time with some `auth_data` provided.
     ///
+    /// * `erase` - Whether the user would like their content to be erased as
+    ///   much as possible from the server.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -376,7 +379,7 @@ impl Account {
     /// # let homeserver = Url::parse("http://localhost:8080")?;
     /// # let client = Client::new(homeserver).await?;
     /// # let account = client.account();
-    /// let response = account.deactivate(None, None).await;
+    /// let response = account.deactivate(None, None, false).await;
     ///
     /// // Proceed with UIAA.
     /// # anyhow::Ok(()) };
@@ -388,10 +391,12 @@ impl Account {
         &self,
         id_server: Option<&str>,
         auth_data: Option<AuthData>,
+        erase_data: bool,
     ) -> Result<deactivate::v3::Response> {
         let request = assign!(deactivate::v3::Request::new(), {
             id_server: id_server.map(ToOwned::to_owned),
             auth: auth_data,
+            erase: erase_data,
         });
         Ok(self.client.send(request, None).await?)
     }


### PR DESCRIPTION
Expose the Account method but restrict it to the types we were already using for user interactive authorization on the identity reset flows.