### PR TITLE
tests: increase timeout duration for await_room_remote_echo

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2866,7 +2866,7 @@ pub(crate) mod tests {
         });
 
         let room =
-            timeout(Duration::from_secs(1), client.await_room_remote_echo(room_id)).await.unwrap();
+            timeout(Duration::from_secs(10), client.await_room_remote_echo(room_id)).await.unwrap();
         assert_eq!(room.room_id(), room_id);
     }
 


### PR DESCRIPTION
Fixes #4003, or so I suspect. The integration tests run in code coverage can be quite slow, so we can't put timeouts this low.