### PR TITLE
tests: increase timeout duration when awaiting a timeline update

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -265,12 +265,11 @@ async fn test_stale_local_echo_time_abort_edit() {
     // It is then sent. The timeline stream can be racy here:
     //
     // - either the local echo is marked as sent *before*, and we receive an update
-    //   for this before
-    // the remote echo.
+    //   for this before the remote echo.
     // - or the remote echo comes up faster.
     //
     // Handle both orderings.
-    while let Ok(Some(vector_diff)) = timeout(Duration::from_secs(1), stream.next()).await {
+    while let Ok(Some(vector_diff)) = timeout(Duration::from_secs(3), stream.next()).await {
         let VectorDiff::Set { index: 0, value: echo } = vector_diff else {
             panic!("unexpected diff: {vector_diff:#?}");
         };


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3931, or so I think: the test waits for a stable state where there aren't any new updates to the timeline, before trying to edit a timeline item, and observe a precise sequence of timeline updates after the item has been edited.

The failures showed that the stable state wasn't reached, because in some occasions, we'd receive the original text as a new timeline update — which could also be the sign of a failing server / duplicated event or other things, but I believe it is just that 1 second timeouts ain't enough for code running under CodeCov.