### PR TITLE
feat(base): Increase the `room_info_notable_update_sender` capacity

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -143,7 +143,7 @@ impl BaseClient {
     ///   previous login call.
     pub fn with_store_config(config: StoreConfig) -> Self {
         let (room_info_notable_update_sender, _room_info_notable_update_receiver) =
-            broadcast::channel(100);
+            broadcast::channel(u16::MAX as usize);
 
         BaseClient {
             store: Store::new(config.state_store),


### PR DESCRIPTION
This broadcast channel can easily be overflowed if more than 100 updates arrive
at the time. This patch extends the capacity to 2^16 - 1.

This patch also adds more logs to detect lagged on this channel from the room
list point of view.

