### PR TITLE
client builder: return a `ClientBuildError` when failing to build, instead of filtering out unexpected errors

### DIFF
--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -709,19 +709,6 @@ pub enum ClientBuildError {
     SqliteStore(#[from] matrix_sdk_sqlite::OpenStoreError),
 }
 
-impl ClientBuildError {
-    /// Assert that a valid homeserver URL was given to the builder and no other
-    /// invalid options were specified, which means the only possible error
-    /// case is [`Self::Http`].
-    #[doc(hidden)]
-    pub fn assert_valid_builder_args(self) -> HttpError {
-        match self {
-            ClientBuildError::Http(e) => e,
-            other => unreachable!("homeserver URL was asserted to be valid: {other:?}"),
-        }
-    }
-}
-
 // The http mocking library is not supported for wasm32
 #[cfg(all(test, not(target_arch = "wasm32")))]
 pub(crate) mod tests {

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -717,7 +717,7 @@ impl ClientBuildError {
     pub fn assert_valid_builder_args(self) -> HttpError {
         match self {
             ClientBuildError::Http(e) => e,
-            _ => unreachable!("homeserver URL was asserted to be valid"),
+            other => unreachable!("homeserver URL was asserted to be valid: {other:?}"),
         }
     }
 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -386,12 +386,8 @@ impl Client {
     /// # Arguments
     ///
     /// * `homeserver_url` - The homeserver that the client should connect to.
-    pub async fn new(homeserver_url: Url) -> Result<Self, HttpError> {
-        Self::builder()
-            .homeserver_url(homeserver_url)
-            .build()
-            .await
-            .map_err(ClientBuildError::assert_valid_builder_args)
+    pub async fn new(homeserver_url: Url) -> Result<Self, ClientBuildError> {
+        Self::builder().homeserver_url(homeserver_url).build().await
     }
 
     /// Returns a subscriber that publishes an event every time the ignore user


### PR DESCRIPTION
This old method was checking invariants that were
spooky-action-at-a-distance: these invariants have changed since then,
so this would panic instead of returning a proper error to the caller.

Signed-off-by: oliverw@element.io
