### PR TITLE
sdk-ui: make room encryption optional to create a timeline

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
@@ -643,7 +643,13 @@ mod tests {
     }
 
     fn test_metadata() -> TimelineMetadata {
-        TimelineMetadata::new(owned_user_id!("@a:b.c"), ruma::RoomVersionId::V11, None, None, false)
+        TimelineMetadata::new(
+            owned_user_id!("@a:b.c"),
+            ruma::RoomVersionId::V11,
+            None,
+            None,
+            Some(false),
+        )
     }
 
     #[test]

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -402,6 +402,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             }
 
             TimelineEventKind::OtherState { state_key, content } => {
+                // Update room encryption if a `m.room.encryption` event is found in the
+                // timeline
                 if should_add {
                     self.add_item(TimelineItemContent::OtherState(OtherState {
                         state_key,
@@ -955,7 +957,11 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             }
         };
 
-        let is_room_encrypted = self.meta.is_room_encrypted;
+        let is_room_encrypted = if let Ok(is_room_encrypted) = self.meta.is_room_encrypted.read() {
+            is_room_encrypted.unwrap_or_default()
+        } else {
+            false
+        };
 
         let mut item = EventTimelineItem::new(
             sender,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -839,6 +839,7 @@ struct TimelineDropHandle {
     room_key_backup_enabled_join_handle: JoinHandle<()>,
     local_echo_listener_handle: JoinHandle<()>,
     _event_cache_drop_handle: Arc<EventCacheDropHandles>,
+    encryption_changes_handle: JoinHandle<()>,
 }
 
 impl Drop for TimelineDropHandle {
@@ -855,6 +856,7 @@ impl Drop for TimelineDropHandle {
         self.room_update_join_handle.abort();
         self.room_key_from_backups_join_handle.abort();
         self.room_key_backup_enabled_join_handle.abort();
+        self.encryption_changes_handle.abort();
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -20,6 +20,7 @@ use std::{
     sync::Arc,
 };
 
+use eyeball::{SharedObservable, Subscriber};
 use eyeball_im::VectorDiff;
 use futures_core::Stream;
 use futures_util::FutureExt as _;
@@ -33,8 +34,8 @@ use matrix_sdk::{
     test_utils::events::EventFactory,
     BoxFuture,
 };
-use matrix_sdk_base::latest_event::LatestEvent;
-use matrix_sdk_test::{EventBuilder, ALICE, BOB};
+use matrix_sdk_base::{latest_event::LatestEvent, RoomInfo, RoomState};
+use matrix_sdk_test::{EventBuilder, ALICE, BOB, DEFAULT_TEST_ROOM_ID};
 use ruma::{
     event_id,
     events::{
@@ -103,7 +104,7 @@ impl TestTimeline {
                 TimelineFocus::Live,
                 Some(prefix),
                 None,
-                false,
+                Some(false),
             ),
             event_builder: EventBuilder::new(),
             factory: EventFactory::new(),
@@ -117,7 +118,7 @@ impl TestTimeline {
                 TimelineFocus::Live,
                 None,
                 None,
-                false,
+                Some(false),
             ),
             event_builder: EventBuilder::new(),
             factory: EventFactory::new(),
@@ -131,7 +132,7 @@ impl TestTimeline {
                 TimelineFocus::Live,
                 None,
                 Some(hook),
-                true,
+                Some(true),
             ),
             event_builder: EventBuilder::new(),
             factory: EventFactory::new(),
@@ -146,7 +147,7 @@ impl TestTimeline {
                 TimelineFocus::Live,
                 None,
                 None,
-                encrypted,
+                Some(encrypted),
             ),
             event_builder: EventBuilder::new(),
             factory: EventFactory::new(),
@@ -443,5 +444,10 @@ impl RoomDataProvider for TestRoomDataProvider {
             Ok(())
         }
         .boxed()
+    }
+
+    fn room_info(&self) -> Subscriber<RoomInfo> {
+        let info = RoomInfo::new(*DEFAULT_TEST_ROOM_ID, RoomState::Joined);
+        SharedObservable::new(info).subscribe()
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -14,6 +14,7 @@
 
 use std::future::Future;
 
+use eyeball::Subscriber;
 use futures_util::FutureExt as _;
 use indexmap::IndexMap;
 #[cfg(test)]
@@ -22,7 +23,7 @@ use matrix_sdk::{
     deserialized_responses::TimelineEvent, event_cache::paginator::PaginableRoom, BoxFuture,
     Result, Room,
 };
-use matrix_sdk_base::latest_event::LatestEvent;
+use matrix_sdk_base::{latest_event::LatestEvent, RoomInfo};
 use ruma::{
     events::{
         fully_read::FullyReadEventContent,
@@ -107,6 +108,8 @@ pub(super) trait RoomDataProvider:
         reason: Option<&'a str>,
         transaction_id: Option<OwnedTransactionId>,
     ) -> BoxFuture<'a, Result<(), super::Error>>;
+
+    fn room_info(&self) -> Subscriber<RoomInfo>;
 }
 
 impl RoomDataProvider for Room {
@@ -270,6 +273,10 @@ impl RoomDataProvider for Room {
             Ok(())
         }
         .boxed()
+    }
+
+    fn room_info(&self) -> Subscriber<RoomInfo> {
+        self.subscribe_info()
     }
 }
 

--- a/crates/matrix-sdk/src/test_utils/events.rs
+++ b/crates/matrix-sdk/src/test_utils/events.rs
@@ -57,6 +57,7 @@ pub struct EventBuilder<E: EventContent> {
     content: E,
     server_ts: MilliSecondsSinceUnixEpoch,
     unsigned: Option<Unsigned>,
+    state_key: Option<String>,
 }
 
 impl<E: EventContent> EventBuilder<E>
@@ -89,6 +90,11 @@ where
         self
     }
 
+    pub fn state_key(mut self, state_key: impl Into<String>) -> Self {
+        self.state_key = Some(state_key.into());
+        self
+    }
+
     #[inline(always)]
     fn construct_json<T>(self, requires_room: bool) -> Raw<T> {
         let event_id = self
@@ -118,6 +124,9 @@ where
         }
         if let Some(unsigned) = self.unsigned {
             map.insert("unsigned".to_owned(), json!(unsigned));
+        }
+        if let Some(state_key) = self.state_key {
+            map.insert("state_key".to_owned(), json!(state_key));
         }
 
         Raw::new(map).unwrap().cast()
@@ -237,6 +246,7 @@ impl EventFactory {
             redacts: None,
             content,
             unsigned: None,
+            state_key: None,
         }
     }
 


### PR DESCRIPTION
Instead of forcing the room encryption to be known when the timeline is created and failing if it's not known, take the latest room encryption info as a base value and update it when processing timeline events.

At the time of writing this PR, the encryption info is only used to decide whether shields should be calculated for timeline items or not.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3850 (I hope).

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
