### PR TITLE
chore(ruma): Update Ruma to support negative `bump_stamp`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4934,7 +4934,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/Hywan/ruma?rev=beb6d1b4145d7197203eddd72d4c2b3834b9b429#beb6d1b4145d7197203eddd72d4c2b3834b9b429"
 dependencies = [
  "assign",
  "js_int",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.18.0"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/Hywan/ruma?rev=beb6d1b4145d7197203eddd72d4c2b3834b9b429#beb6d1b4145d7197203eddd72d4c2b3834b9b429"
 dependencies = [
  "as_variant",
  "assign",
@@ -4974,7 +4974,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/Hywan/ruma?rev=beb6d1b4145d7197203eddd72d4c2b3834b9b429#beb6d1b4145d7197203eddd72d4c2b3834b9b429"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -5006,7 +5006,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.28.1"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/Hywan/ruma?rev=beb6d1b4145d7197203eddd72d4c2b3834b9b429#beb6d1b4145d7197203eddd72d4c2b3834b9b429"
 dependencies = [
  "as_variant",
  "indexmap 2.2.6",
@@ -5031,7 +5031,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/Hywan/ruma?rev=beb6d1b4145d7197203eddd72d4c2b3834b9b429#beb6d1b4145d7197203eddd72d4c2b3834b9b429"
 dependencies = [
  "http",
  "js_int",
@@ -5045,7 +5045,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.2.0"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/Hywan/ruma?rev=beb6d1b4145d7197203eddd72d4c2b3834b9b429#beb6d1b4145d7197203eddd72d4c2b3834b9b429"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5057,7 +5057,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.5"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/Hywan/ruma?rev=beb6d1b4145d7197203eddd72d4c2b3834b9b429#beb6d1b4145d7197203eddd72d4c2b3834b9b429"
 dependencies = [
  "js_int",
  "thiserror",
@@ -5066,7 +5066,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/Hywan/ruma?rev=beb6d1b4145d7197203eddd72d4c2b3834b9b429#beb6d1b4145d7197203eddd72d4c2b3834b9b429"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5082,7 +5082,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/Hywan/ruma?rev=beb6d1b4145d7197203eddd72d4c2b3834b9b429#beb6d1b4145d7197203eddd72d4c2b3834b9b429"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ once_cell = "1.16.0"
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "1ae98db9c44f46a590f4c76baf5cef70ebb6970d", features = [
+ruma = { git = "https://github.com/Hywan/ruma", rev = "beb6d1b4145d7197203eddd72d4c2b3834b9b429", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -61,7 +61,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "1ae98db9c44f46a590f4c76baf
     "unstable-msc4075",
     "unstable-msc4140",
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "1ae98db9c44f46a590f4c76baf5cef70ebb6970d" }
+ruma-common = { git = "https://github.com/Hywan/ruma", rev = "beb6d1b4145d7197203eddd72d4c2b3834b9b429" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -990,7 +990,7 @@ impl Room {
     ///
     /// Please read `RoomInfo::recency_stamp` to learn more.
     #[cfg(feature = "experimental-sliding-sync")]
-    pub fn recency_stamp(&self) -> Option<u64> {
+    pub fn recency_stamp(&self) -> Option<i64> {
         self.inner.read().recency_stamp
     }
 
@@ -1094,7 +1094,7 @@ pub struct RoomInfo {
     /// more accurate than relying on the latest event.
     #[cfg(feature = "experimental-sliding-sync")]
     #[serde(default)]
-    pub(crate) recency_stamp: Option<u64>,
+    pub(crate) recency_stamp: Option<i64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -1547,7 +1547,7 @@ impl RoomInfo {
     ///
     /// Please read [`Self::recency_stamp`] to learn more.
     #[cfg(feature = "experimental-sliding-sync")]
-    pub(crate) fn update_recency_stamp(&mut self, stamp: u64) {
+    pub(crate) fn update_recency_stamp(&mut self, stamp: i64) {
         self.recency_stamp = Some(stamp);
     }
 

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -31,7 +31,7 @@ use ruma::{
         GlobalAccountDataEventType,
     },
     serde::Raw,
-    JsOption, OwnedRoomId, RoomId, UInt,
+    Int, JsOption, OwnedRoomId, RoomId,
 };
 use tracing::{debug, error, instrument, trace, warn};
 
@@ -413,7 +413,7 @@ impl BaseClient {
             if let Some(invite_state) = &room_data.invite_state {
                 room_data.to_mut().bump_stamp =
                     invite_state.iter().rev().find_map(|invite_state| {
-                        invite_state.get_field::<UInt>("origin_server_ts").ok().flatten()
+                        invite_state.get_field::<Int>("origin_server_ts").ok().flatten()
                     });
 
                 debug!(
@@ -851,7 +851,7 @@ fn process_room_properties(
     }
 
     if let Some(recency_stamp) = &room_data.bump_stamp {
-        let recency_stamp: u64 = (*recency_stamp).into();
+        let recency_stamp: i64 = (*recency_stamp).into();
 
         if room_info.recency_stamp.as_ref() != Some(&recency_stamp) {
             room_info.update_recency_stamp(recency_stamp);

--- a/crates/matrix-sdk-ui/src/room_list_service/sorters/recency.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/sorters/recency.rs
@@ -18,14 +18,14 @@ use super::{Room, Sorter};
 
 struct RecencyMatcher<F>
 where
-    F: Fn(&Room, &Room) -> (Option<u64>, Option<u64>),
+    F: Fn(&Room, &Room) -> (Option<i64>, Option<i64>),
 {
     recency_stamps: F,
 }
 
 impl<F> RecencyMatcher<F>
 where
-    F: Fn(&Room, &Room) -> (Option<u64>, Option<u64>),
+    F: Fn(&Room, &Room) -> (Option<i64>, Option<i64>),
 {
     fn matches(&self, left: &Room, right: &Room) -> Ordering {
         if left.id() == right.id() {


### PR DESCRIPTION
Blocked by https://github.com/ruma/ruma/pull/1912.

This is a draft patch to check we can support negative `bump_stamp` from Synapse.