### PR TITLE
sdk-ui & sdk: add a relationship type filter to `load_event_with_relations`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -41,7 +41,7 @@ use ruma::{
     events::{
         reaction::ReactionEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
-        relation::Annotation,
+        relation::{Annotation, RelationType},
         AnyMessageLikeEventContent, AnyTimelineEvent, EmptyStateKey,
         RedactedMessageLikeEventContent, RedactedStateEventContent, StaticStateEventContent,
     },
@@ -345,6 +345,7 @@ impl PinnedEventsRoom for TestRoomDataProvider {
         &'a self,
         _event_id: &'a EventId,
         _request_config: Option<RequestConfig>,
+        _related_event_filters: Option<Vec<RelationType>>,
     ) -> BoxFuture<'a, Result<(SyncTimelineEvent, Vec<SyncTimelineEvent>), PaginatorError>> {
         unimplemented!();
     }


### PR DESCRIPTION
We need this for pinned events where we want reactions, edits and redactions, but we don't want replies or threaded replies.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
