### PR TITLE
test(integration): Enable `test_notification`

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -99,6 +99,7 @@ async fn test_notification() -> Result<()> {
 
         assert_matches!(notification.event, NotificationEvent::Invite(_));
         assert_eq!(notification.event.sender(), alice.user_id().unwrap());
+        assert_eq!(notification.joined_members_count, 0);
         assert_eq!(notification.is_room_encrypted, None);
         assert!(notification.is_direct_message_room);
 

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -31,7 +31,6 @@ use tracing::warn;
 use crate::helpers::TestClientBuilder;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore]
 async fn test_notification() -> Result<()> {
     // Create new users for each test run, to avoid conflicts with invites existing
     // from previous runs.
@@ -61,14 +60,16 @@ async fn test_notification() -> Result<()> {
     let room_id = alice_room.room_id().to_owned();
 
     // Bob receives a notification about it.
-
     let bob_invite_response = bob.sync_once(Default::default()).await?;
     let sync_token = bob_invite_response.next_batch;
 
-    let mut invited_rooms = bob_invite_response.rooms.invite.into_iter();
+    let mut invited_rooms = bob_invite_response.rooms.invite;
 
-    let (_, invited_room) = invited_rooms.next().expect("must be invited to one room");
-    assert!(invited_rooms.next().is_none(), "no more invited rooms: {invited_rooms:#?}");
+    assert_eq!(invited_rooms.len(), 1, "must be only one invitation");
+
+    let Some(invited_room) = invited_rooms.get(&room_id) else {
+        panic!("bob is invited in an unexpected room");
+    };
 
     if let Some(event_id) = invited_room.invite_state.events.iter().find_map(|event| {
         let Ok(AnyStrippedStateEvent::RoomMember(room_member_ev)) = event.deserialize() else {
@@ -90,6 +91,7 @@ async fn test_notification() -> Result<()> {
         // Try with sliding sync first.
         let notification_client =
             NotificationClient::new(bob.clone(), process_setup.clone()).await.unwrap();
+
         assert_let!(
             NotificationStatus::Event(notification) =
                 notification_client.get_notification_with_sliding_sync(&room_id, &event_id).await?
@@ -97,8 +99,8 @@ async fn test_notification() -> Result<()> {
 
         warn!("sliding_sync: checking invite notification");
 
+        assert_matches!(notification.event, NotificationEvent::Invite(_));
         assert_eq!(notification.event.sender(), alice.user_id().unwrap());
-        assert_eq!(notification.joined_members_count, 1);
         assert_eq!(notification.is_room_encrypted, None);
         assert!(notification.is_direct_message_room);
 
@@ -109,8 +111,10 @@ async fn test_notification() -> Result<()> {
         assert_eq!(notification.sender_display_name.as_deref(), Some(ALICE_NAME));
 
         // In theory, the room name ought to be ROOM_NAME here, but the sliding sync
-        // proxy returns the other person's name as the room's name (as of
+        // server returns the other person's name as the room's name (as of
         // 2023-08-04).
+        //
+        // See https://github.com/element-hq/synapse/issues/17763.
         assert!(notification.room_computed_display_name != ROOM_NAME);
         assert_eq!(notification.room_computed_display_name, ALICE_NAME);
 
@@ -125,7 +129,7 @@ async fn test_notification() -> Result<()> {
         warn!("Couldn't get the invite event.");
     }
 
-    // Bob accepts the invite, joins the room.
+    // Bob inspects the invite room.
     {
         let room = bob.get_room(&room_id).expect("bob doesn't know about the room");
         ensure!(
@@ -137,13 +141,16 @@ async fn test_notification() -> Result<()> {
         assert_eq!(sender.user_id(), alice.user_id().expect("alice has a user_id"));
     }
 
-    // Bob joins the room.
-    bob.get_room(alice_room.room_id()).unwrap().join().await?;
+    bob.get_room(alice_room.room_id())
+        .unwrap()
+        // Bob joins the room.
+        .join()
+        .await?;
 
     // Now Alice sends a message to Bob.
     alice_room.send(RoomMessageEventContent::text_plain("Hello world!")).await?;
 
-    // In this sync, bob receives the message from Alice.
+    // In this sync, Bob receives the message from Alice.
     let bob_response = bob.sync_once(SyncSettings::default().token(sync_token)).await?;
 
     let mut joined_rooms = bob_response.rooms.join.into_iter();
@@ -201,6 +208,7 @@ async fn test_notification() -> Result<()> {
         assert_eq!(notification.room_computed_display_name, ROOM_NAME);
     };
 
+    // Check with sliding sync.
     let notification_client =
         NotificationClient::new(bob.clone(), process_setup.clone()).await.unwrap();
     assert_let!(
@@ -209,6 +217,7 @@ async fn test_notification() -> Result<()> {
     );
     check_notification(true, notification);
 
+    // Check with `/context`.
     let notification_client = NotificationClient::new(bob.clone(), process_setup).await.unwrap();
     let notification = notification_client
         .get_notification_with_context(&room_id, &event_id)


### PR DESCRIPTION
This test was failing since the migration from the sliding sync proxy
to Synapse.

This patch fixes the test. The failing part was:

```rust
assert_eq!(notification.joined_members_count, 1);
```

This patch removes this assertion for the moment. In Synapse 1.115,
Synapse doesn't share this data for the sake of privacy because the
room is not joined. But the CI runs 1.114 and it seems to be different.
I'm investigating that. Edit: https://github.com/matrix-org/matrix-rust-sdk/pull/4030
fixes the CI to use 1.115, and the test now passes correctly \o/.

A comment has been made on MSC4186 to precise this behaviour:
https://github.com/matrix-org/matrix-spec-proposals/pull/4186#discussion_r1774775560.

Moreover, this test was asserting a bug (which is alright), <del>but now
a bug report has been made. The patch contains the link to this bug
report.</del>. Turns out, it wasn't a bug, and a patch fixes the test.

The code has been a bit rewritten to make it simpler, and more comments
have been added.
