### PR TITLE
test(integration): Enable `test_room_notification_count`

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -37,7 +37,7 @@ pub struct SlidingSyncListBuilder {
     required_state: Vec<(StateEventType, String)>,
     include_heroes: Option<bool>,
     filters: Option<http::request::ListFilters>,
-    timeline_limit: Option<Bound>,
+    timeline_limit: Bound,
     pub(crate) name: String,
 
     /// Should this list be cached and reloaded from the cache?
@@ -76,7 +76,7 @@ impl SlidingSyncListBuilder {
             ],
             include_heroes: None,
             filters: None,
-            timeline_limit: None,
+            timeline_limit: 1,
             name: name.into(),
             reloaded_cached_data: None,
             cache_policy: SlidingSyncListCachePolicy::Disabled,
@@ -123,14 +123,13 @@ impl SlidingSyncListBuilder {
 
     /// Set the limit of regular events to fetch for the timeline.
     pub fn timeline_limit(mut self, timeline_limit: Bound) -> Self {
-        self.timeline_limit = Some(timeline_limit);
+        self.timeline_limit = timeline_limit;
         self
     }
 
-    /// Reset the limit of regular events to fetch for the timeline. It is left
-    /// to the server to decide how many to send back
+    /// Set the limit of regular events to fetch for the timeline to 0.
     pub fn no_timeline_limit(mut self) -> Self {
-        self.timeline_limit = Default::default();
+        self.timeline_limit = 0;
         self
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -132,12 +132,12 @@ impl SlidingSyncList {
     }
 
     /// Get the timeline limit.
-    pub fn timeline_limit(&self) -> Option<Bound> {
+    pub fn timeline_limit(&self) -> Bound {
         self.inner.sticky.read().unwrap().data().timeline_limit()
     }
 
     /// Set timeline limit.
-    pub fn set_timeline_limit(&self, timeline: Option<Bound>) {
+    pub fn set_timeline_limit(&self, timeline: Bound) {
         self.inner.sticky.write().unwrap().data_mut().set_timeline_limit(timeline);
     }
 
@@ -594,13 +594,10 @@ mod tests {
             .timeline_limit(7)
             .build(sender);
 
-        assert_eq!(list.inner.sticky.read().unwrap().data().timeline_limit(), Some(7));
+        assert_eq!(list.inner.sticky.read().unwrap().data().timeline_limit(), 7);
 
-        list.set_timeline_limit(Some(42));
-        assert_eq!(list.inner.sticky.read().unwrap().data().timeline_limit(), Some(42));
-
-        list.set_timeline_limit(None);
-        assert_eq!(list.inner.sticky.read().unwrap().data().timeline_limit(), None);
+        list.set_timeline_limit(42);
+        assert_eq!(list.inner.sticky.read().unwrap().data().timeline_limit(), 42);
     }
 
     macro_rules! assert_ranges {

--- a/crates/matrix-sdk/src/sliding_sync/list/sticky.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/sticky.rs
@@ -19,7 +19,7 @@ pub(super) struct SlidingSyncListStickyParameters {
     filters: Option<http::request::ListFilters>,
 
     /// The maximum number of timeline events to query for.
-    timeline_limit: Option<Bound>,
+    timeline_limit: Bound,
 }
 
 impl SlidingSyncListStickyParameters {
@@ -27,7 +27,7 @@ impl SlidingSyncListStickyParameters {
         required_state: Vec<(StateEventType, String)>,
         include_heroes: Option<bool>,
         filters: Option<http::request::ListFilters>,
-        timeline_limit: Option<Bound>,
+        timeline_limit: Bound,
     ) -> Self {
         // Consider that each list will have at least one parameter set, so invalidate
         // it by default.
@@ -36,11 +36,11 @@ impl SlidingSyncListStickyParameters {
 }
 
 impl SlidingSyncListStickyParameters {
-    pub(super) fn timeline_limit(&self) -> Option<Bound> {
+    pub(super) fn timeline_limit(&self) -> Bound {
         self.timeline_limit
     }
 
-    pub(super) fn set_timeline_limit(&mut self, timeline: Option<Bound>) {
+    pub(super) fn set_timeline_limit(&mut self, timeline: Bound) {
         self.timeline_limit = timeline;
     }
 }
@@ -50,7 +50,7 @@ impl StickyData for SlidingSyncListStickyParameters {
 
     fn apply(&self, request: &mut Self::Request) {
         request.room_details.required_state = self.required_state.to_vec();
-        request.room_details.timeline_limit = self.timeline_limit.map(Into::into);
+        request.room_details.timeline_limit = Some(self.timeline_limit.into());
         request.include_heroes = self.include_heroes;
         request.filters = self.filters.clone();
     }

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -359,7 +359,6 @@ impl UpdateObserver {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_room_notification_count() -> Result<()> {
     use tokio::time::timeout;
 
@@ -488,20 +487,6 @@ async fn test_room_notification_count() -> Result<()> {
         assert_eq!(alice_room.num_unread_notifications(), 1);
         assert_eq!(alice_room.num_unread_mentions(), 0);
 
-        // If the server hasn't updated the server-side notification count yet, wait for
-        // it and reassert.
-        if alice_room.unread_notification_counts().notification_count != 1 {
-            update_observer
-                .next()
-                .await
-                .expect("server should update server-side notification count");
-            assert_eq!(alice_room.unread_notification_counts().notification_count, 1);
-
-            assert_eq!(alice_room.num_unread_messages(), 1);
-            assert_eq!(alice_room.num_unread_notifications(), 1);
-            assert_eq!(alice_room.num_unread_mentions(), 0);
-        }
-
         update_observer.assert_is_pending();
     }
 
@@ -524,20 +509,6 @@ async fn test_room_notification_count() -> Result<()> {
         assert_eq!(alice_room.num_unread_messages(), 2);
         assert_eq!(alice_room.num_unread_notifications(), 2);
         assert_eq!(alice_room.num_unread_mentions(), 1);
-
-        // If the server hasn't updated the server-side notification count yet, wait for
-        // it and reassert.
-        if alice_room.unread_notification_counts().notification_count != 2 {
-            update_observer
-                .next()
-                .await
-                .expect("server should update server-side notification count");
-            assert_eq!(alice_room.unread_notification_counts().notification_count, 2);
-
-            assert_eq!(alice_room.num_unread_messages(), 2);
-            assert_eq!(alice_room.num_unread_notifications(), 2);
-            assert_eq!(alice_room.num_unread_mentions(), 1);
-        }
 
         update_observer.assert_is_pending();
     }


### PR DESCRIPTION
This test was failing since the migration from the sliding sync proxy
to Synapse.

This patch fixes the test. The failing parts were:

1. The `timeline_limit` wasn't set, so Synapse was returning an error,
2. The `unread_notifications` was set to 0 and could not be set to 1
   because that's an encrypted room.

The fact `timeline_limit` is now mandatory has been mentioned in the MSC:
https://github.com/matrix-org/matrix-spec-proposals/pull/4186/files#r1775138458
A patch in Ruma has been created. The previous patch in this repository
also contains the fix for the SDK side.

The assertions around `unread_notifications` have been removed. We no
longer use this API anymore (and it should be deprecated by the way).
