### PR TITLE
ffi: Allow recovery to be enabled using a passphrase

### DIFF
--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -315,6 +315,7 @@ impl Encryption {
     pub async fn enable_recovery(
         &self,
         wait_for_backups_to_upload: bool,
+        mut passphrase: Option<String>,
         progress_listener: Box<dyn EnableRecoveryProgressListener>,
     ) -> Result<String> {
         let recovery = self.inner.recovery();
@@ -323,6 +324,12 @@ impl Encryption {
             recovery.enable().wait_for_backups_to_upload()
         } else {
             recovery.enable()
+        };
+
+        let enable = if let Some(passphrase) = &passphrase {
+            enable.with_passphrase(passphrase)
+        } else {
+            enable
         };
 
         let mut progress_stream = enable.subscribe_to_progress();
@@ -337,6 +344,7 @@ impl Encryption {
         let ret = enable.await?;
 
         task.abort();
+        passphrase.zeroize();
 
         Ok(ret)
     }


### PR DESCRIPTION
Some people might want to use the recovery module using a passphrase, please note EX should just pass `None` as the `passphrase` argument.