### PR TITLE
ffi: use fork of `tracing` crate with a fix for Android logs rotation

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -82,3 +82,10 @@ features = [
 
 [lints]
 workspace = true
+
+[patch.crates-io]
+tracing = { git = "https://github.com/element-hq/tracing.git", rev = "ca9431f74d37c9d3b5e6a9f35b2c706711dab7dd", default-features = false, features = ["std"] }
+tracing-core = { git = "https://github.com/element-hq/tracing.git", rev = "ca9431f74d37c9d3b5e6a9f35b2c706711dab7dd" }
+tracing-subscriber = { git = "https://github.com/element-hq/tracing.git", rev = "ca9431f74d37c9d3b5e6a9f35b2c706711dab7dd" }
+tracing-appender = { git = "https://github.com/element-hq/tracing.git", rev = "ca9431f74d37c9d3b5e6a9f35b2c706711dab7dd" }
+paranoid-android = { git = "https://github.com/element-hq/paranoid-android.git", rev = "69388ac5b4afeed7be4401c70ce17f6d9a2cf19b" }


### PR DESCRIPTION
The `tracing` library has [an issue](https://github.com/tokio-rs/tracing/issues/2937) that prevents the configured log rotation from working on Android. While there has been [a proposed fix](https://github.com/tokio-rs/tracing/pull/3000) for some time, it hasn't been merged yet.

We recently discovered some cases of users who had hundreds of log files, several times our current max limit, and today I confirmed old logs weren't being deleted.

My proposed solution is to use [a forked tracing library](https://github.com/element-hq/tracing) in the meantime, along with [a forked paranoid-android one](https://github.com/element-hq/paranoid-android), which needs to use this former fork.

I tested this on an Android client and I saw the old logs being removed, as expected.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
