### PR TITLE
chore(cargo): Update `ruma`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
+source = "git+https://github.com/ruma/ruma?rev=26165b23fc2ae9928c5497a21db3d31f4b44cc2a#26165b23fc2ae9928c5497a21db3d31f4b44cc2a"
 dependencies = [
  "assign",
  "js_int",
@@ -4982,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.18.0"
-source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
+source = "git+https://github.com/ruma/ruma?rev=26165b23fc2ae9928c5497a21db3d31f4b44cc2a#26165b23fc2ae9928c5497a21db3d31f4b44cc2a"
 dependencies = [
  "as_variant",
  "assign",
@@ -5005,7 +5005,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
+source = "git+https://github.com/ruma/ruma?rev=26165b23fc2ae9928c5497a21db3d31f4b44cc2a#26165b23fc2ae9928c5497a21db3d31f4b44cc2a"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -5037,7 +5037,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.28.1"
-source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
+source = "git+https://github.com/ruma/ruma?rev=26165b23fc2ae9928c5497a21db3d31f4b44cc2a#26165b23fc2ae9928c5497a21db3d31f4b44cc2a"
 dependencies = [
  "as_variant",
  "indexmap 2.6.0",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
+source = "git+https://github.com/ruma/ruma?rev=26165b23fc2ae9928c5497a21db3d31f4b44cc2a#26165b23fc2ae9928c5497a21db3d31f4b44cc2a"
 dependencies = [
  "http",
  "js_int",
@@ -5076,7 +5076,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.2.0"
-source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
+source = "git+https://github.com/ruma/ruma?rev=26165b23fc2ae9928c5497a21db3d31f4b44cc2a#26165b23fc2ae9928c5497a21db3d31f4b44cc2a"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.5"
-source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
+source = "git+https://github.com/ruma/ruma?rev=26165b23fc2ae9928c5497a21db3d31f4b44cc2a#26165b23fc2ae9928c5497a21db3d31f4b44cc2a"
 dependencies = [
  "js_int",
  "thiserror",
@@ -5097,7 +5097,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
+source = "git+https://github.com/ruma/ruma?rev=26165b23fc2ae9928c5497a21db3d31f4b44cc2a#26165b23fc2ae9928c5497a21db3d31f4b44cc2a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5113,7 +5113,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
+source = "git+https://github.com/ruma/ruma?rev=26165b23fc2ae9928c5497a21db3d31f4b44cc2a#26165b23fc2ae9928c5497a21db3d31f4b44cc2a"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ once_cell = "1.16.0"
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "b1c9a32f26f7aa76e20f96dbbb113250ed979112", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "26165b23fc2ae9928c5497a21db3d31f4b44cc2a", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -61,7 +61,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "b1c9a32f26f7aa76e20f96dbbb
     "unstable-msc4075",
     "unstable-msc4140",
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "b1c9a32f26f7aa76e20f96dbbb113250ed979112" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "26165b23fc2ae9928c5497a21db3d31f4b44cc2a" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -376,7 +376,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 99]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -401,7 +401,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 199]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -426,7 +426,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 299]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -451,7 +451,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 399]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -515,7 +515,7 @@ async fn test_sync_resumes_from_previous_state() -> Result<(), Error> {
                 "lists": {
                     ALL_ROOMS: {
                         "ranges": [[0, 9]],
-                        "timeline_limit": 0,
+                        "timeline_limit": 1,
                     },
                 },
             },
@@ -543,7 +543,7 @@ async fn test_sync_resumes_from_previous_state() -> Result<(), Error> {
                 "lists": {
                     ALL_ROOMS: {
                         "ranges": [[0, 9]],
-                        "timeline_limit": 0,
+                        "timeline_limit": 1,
                     },
                 },
             },
@@ -627,7 +627,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The sync-mode has changed to growing, with its initial range.
                     "ranges": [[0, 99]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -652,7 +652,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Due to previous error, the sync-mode is back to selective, with its initial range.
                     "ranges": [[0, 19]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -675,7 +675,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Sync-mode is now growing.
                     "ranges": [[0, 99]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -699,7 +699,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The sync-mode is still growing, and the range has made progress.
                     "ranges": [[0, 199]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -724,7 +724,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Due to previous error, the sync-mode is back to selective, with its initial range.
                     "ranges": [[0, 19]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -747,7 +747,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The sync-mode is now growing.
                     "ranges": [[0, 99]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -770,7 +770,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // No error. The range is making progress.
                     "ranges": [[0, 199]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -795,7 +795,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                     // Range is making progress and is even reaching the maximum
                     // number of rooms.
                     "ranges": [[0, 209]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -820,7 +820,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Due to previous error, the sync-mode is back to selective, with its initial range.
                     "ranges": [[0, 19]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -843,7 +843,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Sync-mode is now growing.
                     "ranges": [[0, 99]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -913,7 +913,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The sync-mode is still selective, with its initial range.
                     "ranges": [[0, 19]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -937,7 +937,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The sync-mode is now growing, with its initial range.
                     "ranges": [[0, 99]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -969,7 +969,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The sync-mode is back to selective.
                     "ranges": [[0, 19]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -993,7 +993,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Sync-mode is growing, with its initial range.
                     "ranges": [[0, 99]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -1017,7 +1017,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Range is making progress, and has reached its maximum.
                     "ranges": [[0, 149]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -1089,7 +1089,7 @@ async fn test_loading_states() -> Result<(), Error> {
                 "lists": {
                     ALL_ROOMS: {
                         "ranges": [[0, 9]],
-                        "timeline_limit": 0,
+                        "timeline_limit": 1,
                     },
                 },
             },
@@ -1120,7 +1120,7 @@ async fn test_loading_states() -> Result<(), Error> {
                 "lists": {
                     ALL_ROOMS: {
                         "ranges": [[0, 11]],
-                        "timeline_limit": 0,
+                        "timeline_limit": 1,
                     },
                 },
             },
@@ -1271,7 +1271,7 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 9]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -1381,7 +1381,7 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 9]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -1548,7 +1548,7 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 9]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -1718,7 +1718,7 @@ async fn test_room_sorting() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 4]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -1804,7 +1804,7 @@ async fn test_room_sorting() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 4]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -1879,7 +1879,7 @@ async fn test_room_sorting() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 5]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -2099,7 +2099,7 @@ async fn test_room_subscription() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 2]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
             "room_subscriptions": {
@@ -2143,7 +2143,7 @@ async fn test_room_subscription() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 2]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
             "room_subscriptions": {
@@ -2190,7 +2190,7 @@ async fn test_room_subscription() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 2]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
             // NO `room_subscriptions`!
@@ -2257,7 +2257,7 @@ async fn test_room_unread_notifications() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 0]],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
         },

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -177,9 +177,9 @@ impl SlidingSyncListBuilder {
                         self.required_state,
                         self.include_heroes,
                         self.filters,
-                        self.timeline_limit,
                     ),
                 )),
+                timeline_limit: StdRwLock::new(self.timeline_limit),
                 name: self.name,
                 cache_policy: self.cache_policy,
 

--- a/crates/matrix-sdk/src/sliding_sync/list/sticky.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/sticky.rs
@@ -1,7 +1,6 @@
 use matrix_sdk_base::sliding_sync::http;
 use ruma::events::StateEventType;
 
-use super::Bound;
 use crate::sliding_sync::sticky_parameters::StickyData;
 
 /// The set of `SlidingSyncList` request parameters that are *sticky*, as
@@ -17,9 +16,6 @@ pub(super) struct SlidingSyncListStickyParameters {
 
     /// Any filters to apply to the query.
     filters: Option<http::request::ListFilters>,
-
-    /// The maximum number of timeline events to query for.
-    timeline_limit: Bound,
 }
 
 impl SlidingSyncListStickyParameters {
@@ -27,21 +23,10 @@ impl SlidingSyncListStickyParameters {
         required_state: Vec<(StateEventType, String)>,
         include_heroes: Option<bool>,
         filters: Option<http::request::ListFilters>,
-        timeline_limit: Bound,
     ) -> Self {
         // Consider that each list will have at least one parameter set, so invalidate
         // it by default.
-        Self { required_state, include_heroes, filters, timeline_limit }
-    }
-}
-
-impl SlidingSyncListStickyParameters {
-    pub(super) fn timeline_limit(&self) -> Bound {
-        self.timeline_limit
-    }
-
-    pub(super) fn set_timeline_limit(&mut self, timeline: Bound) {
-        self.timeline_limit = timeline;
+        Self { required_state, include_heroes, filters }
     }
 }
 
@@ -50,7 +35,6 @@ impl StickyData for SlidingSyncListStickyParameters {
 
     fn apply(&self, request: &mut Self::Request) {
         request.room_details.required_state = self.required_state.to_vec();
-        request.room_details.timeline_limit = self.timeline_limit.into();
         request.include_heroes = self.include_heroes;
         request.filters = self.filters.clone();
     }


### PR DESCRIPTION
This patch updates `ruma` to include:

* https://github.com/ruma/ruma/pull/1913
* https://github.com/ruma/ruma/pull/1914