### PR TITLE
misc: Remove deprecated apis

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -809,20 +809,6 @@ impl Room {
         self.inner.read().heroes().to_vec()
     }
 
-    /// Get the list of `RoomMember`s that are considered to be joined members
-    /// of this room.
-    #[deprecated = "Use members with RoomMemberships::JOIN instead"]
-    pub async fn joined_members(&self) -> StoreResult<Vec<RoomMember>> {
-        self.members(RoomMemberships::JOIN).await
-    }
-
-    /// Get the list of `RoomMember`s that are considered to be joined or
-    /// invited members of this room.
-    #[deprecated = "Use members with RoomMemberships::ACTIVE instead"]
-    pub async fn active_members(&self) -> StoreResult<Vec<RoomMember>> {
-        self.members(RoomMemberships::ACTIVE).await
-    }
-
     /// Returns the number of members who have joined or been invited to the
     /// room.
     pub fn active_members_count(&self) -> u64 {

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -71,8 +71,6 @@ pub trait StateStoreIntegrationTests {
     async fn test_receipts_saving(&self);
     /// Test custom storage.
     async fn test_custom_storage(&self) -> Result<()>;
-    /// Test invited room saving.
-    async fn test_persist_invited_room(&self) -> Result<()>;
     /// Test stripped and non-stripped room member saving.
     async fn test_stripped_non_stripped(&self) -> Result<()>;
     /// Test room removal.
@@ -259,9 +257,6 @@ impl StateStoreIntegrationTests for DynStateStore {
         assert!(self.get_kv_data(StateStoreDataKey::SyncToken).await?.is_some());
         assert!(self.get_presence_event(user_id).await?.is_some());
         assert_eq!(self.get_room_infos().await?.len(), 2, "Expected to find 2 room infos");
-        #[allow(deprecated)]
-        let stripped_rooms = self.get_stripped_room_infos().await?;
-        assert_eq!(stripped_rooms.len(), 1, "Expected to find 1 stripped room info");
         assert!(self
             .get_account_data_event(GlobalAccountDataEventType::PushRules)
             .await?
@@ -918,25 +913,12 @@ impl StateStoreIntegrationTests for DynStateStore {
         Ok(())
     }
 
-    async fn test_persist_invited_room(&self) -> Result<()> {
-        self.populate().await?;
-
-        #[allow(deprecated)]
-        let stripped_rooms = self.get_stripped_room_infos().await?;
-        assert_eq!(stripped_rooms.len(), 1);
-
-        Ok(())
-    }
-
     async fn test_stripped_non_stripped(&self) -> Result<()> {
         let room_id = room_id!("!test_stripped_non_stripped:localhost");
         let user_id = user_id();
 
         assert!(self.get_member_event(room_id, user_id).await.unwrap().is_none());
         assert_eq!(self.get_room_infos().await.unwrap().len(), 0);
-        #[allow(deprecated)]
-        let stripped_rooms = self.get_stripped_room_infos().await?;
-        assert_eq!(stripped_rooms.len(), 0);
 
         let mut changes = StateChanges::default();
         changes
@@ -953,9 +935,6 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_member_event(room_id, user_id).await.unwrap().unwrap().deserialize().unwrap();
         assert!(matches!(member_event, MemberEvent::Sync(_)));
         assert_eq!(self.get_room_infos().await.unwrap().len(), 1);
-        #[allow(deprecated)]
-        let stripped_rooms = self.get_stripped_room_infos().await?;
-        assert_eq!(stripped_rooms.len(), 0);
 
         let members = self.get_user_ids(room_id, RoomMemberships::empty()).await.unwrap();
         assert_eq!(members, vec![user_id.to_owned()]);
@@ -969,9 +948,6 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_member_event(room_id, user_id).await.unwrap().unwrap().deserialize().unwrap();
         assert!(matches!(member_event, MemberEvent::Stripped(_)));
         assert_eq!(self.get_room_infos().await.unwrap().len(), 1);
-        #[allow(deprecated)]
-        let stripped_rooms = self.get_stripped_room_infos().await?;
-        assert_eq!(stripped_rooms.len(), 1);
 
         let members = self.get_user_ids(room_id, RoomMemberships::empty()).await.unwrap();
         assert_eq!(members, vec![user_id.to_owned()]);
@@ -989,9 +965,6 @@ impl StateStoreIntegrationTests for DynStateStore {
         self.remove_room(room_id).await?;
 
         assert_eq!(self.get_room_infos().await?.len(), 1, "room is still there");
-        #[allow(deprecated)]
-        let stripped_rooms = self.get_stripped_room_infos().await?;
-        assert_eq!(stripped_rooms.len(), 1);
 
         assert!(self.get_state_event(room_id, StateEventType::RoomName, "").await?.is_none());
         assert!(
@@ -1044,9 +1017,6 @@ impl StateStoreIntegrationTests for DynStateStore {
         self.remove_room(stripped_room_id).await?;
 
         assert!(self.get_room_infos().await?.is_empty(), "still room info found");
-        #[allow(deprecated)]
-        let stripped_rooms = self.get_stripped_room_infos().await?;
-        assert!(stripped_rooms.is_empty(), "still stripped room info found");
         Ok(())
     }
 
@@ -1582,12 +1552,6 @@ macro_rules! statestore_integration_tests {
             async fn test_custom_storage() -> StoreResult<()> {
                 let store = get_store().await?.into_state_store();
                 store.test_custom_storage().await
-            }
-
-            #[async_test]
-            async fn test_persist_invited_room() -> StoreResult<()> {
-                let store = get_store().await?.into_state_store();
-                store.test_persist_invited_room().await
             }
 
             #[async_test]

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -45,7 +45,7 @@ use super::{
 };
 use crate::{
     deserialized_responses::RawAnySyncOrStrippedState, MinimalRoomMemberEvent, RoomMemberships,
-    RoomState, StateStoreDataKey, StateStoreDataValue,
+    StateStoreDataKey, StateStoreDataValue,
 };
 
 /// In-memory, non-persistent implementation of the `StateStore`.
@@ -696,27 +696,8 @@ impl StateStore for MemoryStore {
         Ok(get_user_ids_inner(&self.members.read().unwrap(), room_id, memberships))
     }
 
-    async fn get_invited_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>> {
-        StateStore::get_user_ids(self, room_id, RoomMemberships::INVITE).await
-    }
-
-    async fn get_joined_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>> {
-        StateStore::get_user_ids(self, room_id, RoomMemberships::JOIN).await
-    }
-
     async fn get_room_infos(&self) -> Result<Vec<RoomInfo>> {
         Ok(self.room_info.read().unwrap().values().cloned().collect())
-    }
-
-    async fn get_stripped_room_infos(&self) -> Result<Vec<RoomInfo>> {
-        Ok(self
-            .room_info
-            .read()
-            .unwrap()
-            .values()
-            .filter(|r| matches!(r.state(), RoomState::Invited))
-            .cloned()
-            .collect())
     }
 
     async fn get_users_with_display_name(

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -190,23 +190,8 @@ pub trait StateStore: AsyncTraitDeps {
         memberships: RoomMemberships,
     ) -> Result<Vec<OwnedUserId>, Self::Error>;
 
-    /// Get all the user ids of members that are in the invited state for a
-    /// given room, for stripped and regular rooms alike.
-    #[deprecated = "Use get_user_ids with RoomMemberships::INVITE instead."]
-    async fn get_invited_user_ids(&self, room_id: &RoomId)
-        -> Result<Vec<OwnedUserId>, Self::Error>;
-
-    /// Get all the user ids of members that are in the joined state for a
-    /// given room, for stripped and regular rooms alike.
-    #[deprecated = "Use get_user_ids with RoomMemberships::JOIN instead."]
-    async fn get_joined_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>, Self::Error>;
-
     /// Get all the pure `RoomInfo`s the store knows about.
     async fn get_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error>;
-
-    /// Get all the pure `RoomInfo`s the store knows about.
-    #[deprecated = "Use get_room_infos instead and filter by RoomState"]
-    async fn get_stripped_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error>;
 
     /// Get all the users that use the given display name in the given room.
     ///
@@ -559,24 +544,8 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         self.0.get_user_ids(room_id, memberships).await.map_err(Into::into)
     }
 
-    async fn get_invited_user_ids(
-        &self,
-        room_id: &RoomId,
-    ) -> Result<Vec<OwnedUserId>, Self::Error> {
-        self.0.get_user_ids(room_id, RoomMemberships::INVITE).await.map_err(Into::into)
-    }
-
-    async fn get_joined_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>, Self::Error> {
-        self.0.get_user_ids(room_id, RoomMemberships::JOIN).await.map_err(Into::into)
-    }
-
     async fn get_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error> {
         self.0.get_room_infos().await.map_err(Into::into)
-    }
-
-    #[allow(deprecated)]
-    async fn get_stripped_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error> {
-        self.0.get_stripped_room_infos().await.map_err(Into::into)
     }
 
     async fn get_users_with_display_name(

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -582,60 +582,6 @@ impl Room {
         }
     }
 
-    /// Get active members for this room, includes invited, joined members.
-    ///
-    /// *Note*: This method will fetch the members from the homeserver if the
-    /// member list isn't synchronized due to member lazy loading. Because of
-    /// that, it might panic if it isn't run on a tokio thread.
-    ///
-    /// Use [active_members_no_sync()](#method.active_members_no_sync) if you
-    /// want a method that doesn't do any requests.
-    #[deprecated = "Use members with RoomMemberships::ACTIVE instead"]
-    pub async fn active_members(&self) -> Result<Vec<RoomMember>> {
-        self.sync_members().await?;
-        self.members_no_sync(RoomMemberships::ACTIVE).await
-    }
-
-    /// Get active members for this room, includes invited, joined members.
-    ///
-    /// *Note*: This method will not fetch the members from the homeserver if
-    /// the member list isn't synchronized due to member lazy loading. Thus,
-    /// members could be missing from the list.
-    ///
-    /// Use [active_members()](#method.active_members) if you want to ensure to
-    /// always get the full member list.
-    #[deprecated = "Use members_no_sync with RoomMemberships::ACTIVE instead"]
-    pub async fn active_members_no_sync(&self) -> Result<Vec<RoomMember>> {
-        self.members_no_sync(RoomMemberships::ACTIVE).await
-    }
-
-    /// Get all the joined members of this room.
-    ///
-    /// *Note*: This method will fetch the members from the homeserver if the
-    /// member list isn't synchronized due to member lazy loading. Because of
-    /// that it might panic if it isn't run on a tokio thread.
-    ///
-    /// Use [joined_members_no_sync()](#method.joined_members_no_sync) if you
-    /// want a method that doesn't do any requests.
-    #[deprecated = "Use members with RoomMemberships::JOIN instead"]
-    pub async fn joined_members(&self) -> Result<Vec<RoomMember>> {
-        self.sync_members().await?;
-        self.members_no_sync(RoomMemberships::JOIN).await
-    }
-
-    /// Get all the joined members of this room.
-    ///
-    /// *Note*: This method will not fetch the members from the homeserver if
-    /// the member list isn't synchronized due to member lazy loading. Thus,
-    /// members could be missing from the list.
-    ///
-    /// Use [joined_members()](#method.joined_members) if you want to ensure to
-    /// always get the full member list.
-    #[deprecated = "Use members_no_sync with RoomMemberships::JOIN instead"]
-    pub async fn joined_members_no_sync(&self) -> Result<Vec<RoomMember>> {
-        self.members_no_sync(RoomMemberships::JOIN).await
-    }
-
     /// Get a specific member of this room.
     ///
     /// *Note*: This method will fetch the members from the homeserver if the


### PR DESCRIPTION
The APIs have been deprecated for a year and a half, and the deprecations were released in 0.7.0.