### PR TITLE
FFI : Added a method for login using JWT

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -60,7 +60,7 @@ use ruma::{
     OwnedServerName, RoomAliasId, RoomOrAliasId, ServerName,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Value, Map};
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, error};
 use url::Url;
@@ -291,6 +291,31 @@ impl Client {
         if let Some(device_id) = device_id.as_ref() {
             builder = builder.device_id(device_id);
         }
+        builder.send().await?;
+        Ok(())
+    }
+
+    /// Login with JWT
+    pub async fn login_with_jwt(
+        &self,
+        jwt: String,
+        initial_device_name: Option<String>
+    ) -> Result<(), ClientError> {
+
+        let data: Map<String, Value> = [("token".to_owned(), jwt.into())]
+            .into_iter()
+            .collect();
+
+        let mut builder = self.inner.matrix_auth().login_custom("org.matrix.login.jwt", data)?;
+
+        if let Some(initial_device_name) = initial_device_name.as_ref() {
+            builder = builder.initial_device_display_name(initial_device_name);
+        }
+        
+        if let Some(device_id) = device_id.as_ref() {
+            builder = builder.device_id(device_id);
+        }
+        
         builder.send().await?;
         Ok(())
     }


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Matrix auth exposes a method to login with JWT, but this was not available in the kotlin bindings to be used by element app. 
This change adds the method for the same. 

This would help the users to use third party auth libraries that provide access token, to be used for logging in to synapse.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
Pratik Deshpande <prattspective@gmail.com>