### PR TITLE
chore: Configure dependabot to notify us about outdated github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
This was tested out in vodozemac, works nicely: https://github.com/matrix-org/vodozemac/pull/188 and https://github.com/matrix-org/vodozemac/pull/190.