### PR TITLE
base: tidy up processing of global events in sync responses

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -789,17 +789,8 @@ impl BaseClient {
     pub(crate) async fn preprocess_to_device_events(
         &self,
         encryption_sync_changes: EncryptionSyncChanges<'_>,
-        #[cfg(feature = "experimental-sliding-sync")] changes: &mut StateChanges,
-        #[cfg(not(feature = "experimental-sliding-sync"))] _changes: &mut StateChanges,
-        #[cfg(feature = "experimental-sliding-sync")] room_info_notable_updates: &mut BTreeMap<
-            OwnedRoomId,
-            RoomInfoNotableUpdateReasons,
-        >,
-        #[cfg(not(feature = "experimental-sliding-sync"))]
-        _room_info_notable_updates: &mut BTreeMap<
-            OwnedRoomId,
-            RoomInfoNotableUpdateReasons,
-        >,
+        changes: &mut StateChanges,
+        room_info_notable_updates: &mut BTreeMap<OwnedRoomId, RoomInfoNotableUpdateReasons>,
     ) -> Result<Vec<Raw<ruma::events::AnyToDeviceEvent>>> {
         if let Some(o) = self.olm_machine().await.as_ref() {
             // Let the crypto machine handle the sync response, this
@@ -815,8 +806,9 @@ impl BaseClient {
                     self.decrypt_latest_events(&room, changes, room_info_notable_updates).await;
                 }
             }
-            #[cfg(not(feature = "experimental-sliding-sync"))]
-            drop(room_key_updates); // Silence unused variable warning
+
+            #[cfg(not(feature = "experimental-sliding-sync"))] // Silence unused variable warnings.
+            let _ = (room_key_updates, changes, room_info_notable_updates);
 
             Ok(events)
         } else {

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1233,20 +1233,17 @@ impl BaseClient {
         changes: &StateChanges,
         room_info_notable_updates: BTreeMap<OwnedRoomId, RoomInfoNotableUpdateReasons>,
     ) {
-        if changes.account_data.contains_key(&GlobalAccountDataEventType::IgnoredUserList) {
-            if let Some(event) =
-                changes.account_data.get(&GlobalAccountDataEventType::IgnoredUserList)
-            {
-                match event.deserialize_as::<IgnoredUserListEvent>() {
-                    Ok(event) => {
-                        let user_ids: Vec<String> =
-                            event.content.ignored_users.keys().map(|id| id.to_string()).collect();
+        if let Some(event) = changes.account_data.get(&GlobalAccountDataEventType::IgnoredUserList)
+        {
+            match event.deserialize_as::<IgnoredUserListEvent>() {
+                Ok(event) => {
+                    let user_ids: Vec<String> =
+                        event.content.ignored_users.keys().map(|id| id.to_string()).collect();
 
-                        self.ignore_user_list_changes.set(user_ids);
-                    }
-                    Err(error) => {
-                        warn!("Failed to deserialize ignored user list event: {error}")
-                    }
+                    self.ignore_user_list_changes.set(user_ids);
+                }
+                Err(error) => {
+                    warn!("Failed to deserialize ignored user list event: {error}")
                 }
             }
         }

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -31,6 +31,7 @@ pub mod event_cache_store;
 pub mod latest_event;
 pub mod media;
 pub mod notification_settings;
+mod response_processors;
 mod rooms;
 
 pub mod read_receipts;

--- a/crates/matrix-sdk-base/src/response_processors.rs
+++ b/crates/matrix-sdk-base/src/response_processors.rs
@@ -12,15 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeMap, mem};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    mem,
+};
 
 use ruma::{
     events::{AnyGlobalAccountDataEvent, GlobalAccountDataEventType},
     serde::Raw,
+    OwnedUserId, RoomId,
 };
-use tracing::warn;
+use tracing::{debug, instrument, trace, warn};
 
-use crate::StateChanges;
+use crate::{store::Store, StateChanges};
 
 #[must_use]
 pub(crate) struct AccountDataProcessor {
@@ -56,9 +60,96 @@ impl AccountDataProcessor {
         self.raw_by_type.get(&GlobalAccountDataEventType::PushRules)
     }
 
+    /// Processes the direct rooms in a sync response:
+    ///
+    /// Given a [`StateChanges`] instance, processes any direct room info
+    /// from the global account data and adds it to the room infos to
+    /// save.
+    #[instrument(skip_all)]
+    pub(crate) fn process_direct_rooms(
+        &self,
+        events: &[AnyGlobalAccountDataEvent],
+        store: &Store,
+        changes: &mut StateChanges,
+    ) {
+        for event in events {
+            let AnyGlobalAccountDataEvent::Direct(direct_event) = event else { continue };
+
+            let mut new_dms = HashMap::<&RoomId, HashSet<OwnedUserId>>::new();
+            for (user_id, rooms) in direct_event.content.iter() {
+                for room_id in rooms {
+                    new_dms.entry(room_id).or_default().insert(user_id.clone());
+                }
+            }
+
+            let rooms = store.rooms();
+            let mut old_dms = rooms
+                .iter()
+                .filter_map(|r| {
+                    let direct_targets = r.direct_targets();
+                    (!direct_targets.is_empty()).then(|| (r.room_id(), direct_targets))
+                })
+                .collect::<HashMap<_, _>>();
+
+            // Update the direct targets of rooms if they changed.
+            for (room_id, new_direct_targets) in new_dms {
+                if let Some(old_direct_targets) = old_dms.remove(&room_id) {
+                    if old_direct_targets == new_direct_targets {
+                        continue;
+                    }
+                }
+
+                trace!(
+                    ?room_id, targets = ?new_direct_targets,
+                    "Marking room as direct room"
+                );
+
+                if let Some(info) = changes.room_infos.get_mut(room_id) {
+                    info.base_info.dm_targets = new_direct_targets;
+                } else if let Some(room) = store.room(room_id) {
+                    let mut info = room.clone_info();
+                    info.base_info.dm_targets = new_direct_targets;
+                    changes.add_room(info);
+                }
+            }
+
+            // Remove the targets of old direct chats.
+            for room_id in old_dms.keys() {
+                trace!(?room_id, "Unmarking room as direct room");
+
+                if let Some(info) = changes.room_infos.get_mut(*room_id) {
+                    info.base_info.dm_targets.clear();
+                } else if let Some(room) = store.room(room_id) {
+                    let mut info = room.clone_info();
+                    info.base_info.dm_targets.clear();
+                    changes.add_room(info);
+                }
+            }
+        }
+    }
+
     /// Applies the processed data to the state changes.
-    pub fn apply(mut self, changes: &mut StateChanges) -> Vec<AnyGlobalAccountDataEvent> {
+    pub async fn apply(mut self, changes: &mut StateChanges, store: &Store) {
+        // Fill in the content of `changes.account_data`.
         mem::swap(&mut changes.account_data, &mut self.raw_by_type);
-        self.parsed_events
+
+        // Process direct rooms.
+        let has_new_direct_room_data = self
+            .parsed_events
+            .iter()
+            .any(|event| event.event_type() == GlobalAccountDataEventType::Direct);
+
+        if has_new_direct_room_data {
+            self.process_direct_rooms(&self.parsed_events, store, changes);
+        } else if let Ok(Some(direct_account_data)) =
+            store.get_account_data_event(GlobalAccountDataEventType::Direct).await
+        {
+            debug!("Found direct room data in the Store, applying it");
+            if let Ok(direct_account_data) = direct_account_data.deserialize() {
+                self.process_direct_rooms(&[direct_account_data], store, changes);
+            } else {
+                warn!("Failed to deserialize direct room account data");
+            }
+        }
     }
 }

--- a/crates/matrix-sdk-base/src/response_processors.rs
+++ b/crates/matrix-sdk-base/src/response_processors.rs
@@ -1,0 +1,59 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::BTreeMap, mem};
+
+use ruma::{
+    events::{AnyGlobalAccountDataEvent, GlobalAccountDataEventType},
+    serde::Raw,
+};
+use tracing::warn;
+
+use crate::StateChanges;
+
+#[must_use]
+pub(crate) struct AccountDataProcessor {
+    parsed_events: Vec<AnyGlobalAccountDataEvent>,
+    raw_by_type: BTreeMap<GlobalAccountDataEventType, Raw<AnyGlobalAccountDataEvent>>,
+}
+
+impl AccountDataProcessor {
+    /// Creates a new processor for global account data.
+    pub fn process(events: &[Raw<AnyGlobalAccountDataEvent>]) -> Self {
+        let mut raw_by_type = BTreeMap::new();
+        let mut parsed_events = Vec::new();
+
+        for raw_event in events {
+            let event = match raw_event.deserialize() {
+                Ok(e) => e,
+                Err(e) => {
+                    let event_type: Option<String> = raw_event.get_field("type").ok().flatten();
+                    warn!(event_type, "Failed to deserialize a global account data event: {e}");
+                    continue;
+                }
+            };
+
+            raw_by_type.insert(event.event_type(), raw_event.clone());
+            parsed_events.push(event);
+        }
+
+        Self { raw_by_type, parsed_events }
+    }
+
+    /// Applies the processed data to the state changes.
+    pub fn apply(mut self, changes: &mut StateChanges) -> Vec<AnyGlobalAccountDataEvent> {
+        mem::swap(&mut changes.account_data, &mut self.raw_by_type);
+        self.parsed_events
+    }
+}

--- a/crates/matrix-sdk-base/src/response_processors.rs
+++ b/crates/matrix-sdk-base/src/response_processors.rs
@@ -51,6 +51,11 @@ impl AccountDataProcessor {
         Self { raw_by_type, parsed_events }
     }
 
+    /// Returns the push rules found by this processor.
+    pub fn push_rules(&self) -> Option<&Raw<AnyGlobalAccountDataEvent>> {
+        self.raw_by_type.get(&GlobalAccountDataEventType::PushRules)
+    }
+
     /// Applies the processed data to the state changes.
     pub fn apply(mut self, changes: &mut StateChanges) -> Vec<AnyGlobalAccountDataEvent> {
         mem::swap(&mut changes.account_data, &mut self.raw_by_type);

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -45,6 +45,7 @@ use crate::RoomMemberships;
 use crate::{
     error::Result,
     read_receipts::{compute_unread_counts, PreviousEventsProvider},
+    response_processors::AccountDataProcessor,
     rooms::{
         normal::{RoomHero, RoomInfoNotableUpdateReasons},
         RoomState,
@@ -146,7 +147,7 @@ impl BaseClient {
         trace!(
             rooms = rooms.len(),
             lists = lists.len(),
-            extensions = !extensions.is_empty(),
+            has_extensions = !extensions.is_empty(),
             "Processing sliding sync room events"
         );
 
@@ -165,7 +166,7 @@ impl BaseClient {
 
         let account_data = &extensions.account_data;
         let global_account_data_events = if !account_data.is_empty() {
-            self.handle_account_data(&account_data.global, &mut changes).await
+            ProcessAccountData::process(&account_data.global).apply(&mut changes)
         } else {
             Vec::new()
         };

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -161,7 +161,7 @@ impl BaseClient {
         let store = self.store.clone();
         let mut ambiguity_cache = AmbiguityCache::new(store.inner.clone());
 
-        let account_data = AccountDataProcessor::process(&extensions.account_data.global);
+        let account_data_processor = AccountDataProcessor::process(&extensions.account_data.global);
 
         let mut new_rooms = RoomUpdates::default();
         let mut notifications = Default::default();
@@ -174,7 +174,7 @@ impl BaseClient {
                     response_room_data,
                     &mut rooms_account_data,
                     &store,
-                    &account_data,
+                    &account_data_processor,
                     &mut changes,
                     &mut room_info_notable_updates,
                     &mut notifications,
@@ -298,7 +298,7 @@ impl BaseClient {
             }
         }
 
-        account_data.apply(&mut changes, &store).await;
+        account_data_processor.apply(&mut changes, &store).await;
 
         // FIXME not yet supported by sliding sync.
         // changes.presence = presence
@@ -341,7 +341,7 @@ impl BaseClient {
         room_data: &http::response::Room,
         rooms_account_data: &mut BTreeMap<OwnedRoomId, Vec<Raw<AnyRoomAccountDataEvent>>>,
         store: &Store,
-        account_data: &AccountDataProcessor,
+        account_data_processor: &AccountDataProcessor,
         changes: &mut StateChanges,
         room_info_notable_updates: &mut BTreeMap<OwnedRoomId, RoomInfoNotableUpdateReasons>,
         notifications: &mut BTreeMap<OwnedRoomId, Vec<Notification>>,
@@ -427,7 +427,7 @@ impl BaseClient {
             Default::default()
         };
 
-        let push_rules = self.get_push_rules(account_data).await?;
+        let push_rules = self.get_push_rules(account_data_processor).await?;
 
         if let Some(invite_state) = &room_data.invite_state {
             self.handle_invited_state(

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -113,7 +113,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             serde_json::from_value::<Raw<AnyGlobalAccountDataEvent>>(pushrules_json.clone())
                 .unwrap();
         let pushrules_event = pushrules_raw.deserialize().unwrap();
-        changes.add_account_data(pushrules_event, pushrules_raw);
+        changes.account_data.insert(pushrules_event.event_type(), pushrules_raw);
 
         let mut room = RoomInfo::new(room_id, RoomState::Joined);
         room.mark_as_left();

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -360,15 +360,6 @@ impl StateChanges {
         self.room_infos.insert(room.room_id.clone(), room);
     }
 
-    /// Update the `StateChanges` struct with the given `AnyBasicEvent`.
-    pub fn add_account_data(
-        &mut self,
-        event: AnyGlobalAccountDataEvent,
-        raw_event: Raw<AnyGlobalAccountDataEvent>,
-    ) {
-        self.account_data.insert(event.event_type(), raw_event);
-    }
-
     /// Update the `StateChanges` struct with the given room with a new
     /// `AnyBasicEvent`.
     pub fn add_room_account_data(


### PR DESCRIPTION
This tidies up the code by making the data dependencies very explicit, instead of stashing data into `StateChanges` and then relying on it later on during computation. It reduces the amount of duplicated code, streamlines the processing of global account data events, and makes it easier to reason. Also would make it easier to test in isolation, would we need to. Overall, I think this is an improvement, and generalizing this would help commonize more code between sync-v2 and SSS processing.