### PR TITLE
crypto: New return type for `decrypt_room_event`

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -38,7 +38,7 @@ use ruma::{
     },
     events::{
         key::verification::VerificationMethod, room::message::MessageType, AnyMessageLikeEvent,
-        AnySyncMessageLikeEvent, AnyTimelineEvent, MessageLikeEvent,
+        AnySyncMessageLikeEvent, MessageLikeEvent,
     },
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
@@ -891,7 +891,7 @@ impl OlmMachine {
         ))?;
 
         if handle_verification_events {
-            if let Ok(AnyTimelineEvent::MessageLike(e)) = decrypted.event.deserialize() {
+            if let Ok(e) = decrypted.event.deserialize() {
                 match &e {
                     AnyMessageLikeEvent::RoomMessage(MessageLikeEvent::Original(
                         original_event,
@@ -909,8 +909,7 @@ impl OlmMachine {
             }
         }
 
-        let encryption_info =
-            decrypted.encryption_info.expect("Decrypted event didn't contain any encryption info");
+        let encryption_info = decrypted.encryption_info;
 
         let event_json: Event<'_> = serde_json::from_str(decrypted.event.json().get())?;
 

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -15,7 +15,7 @@
 use std::{collections::BTreeMap, fmt};
 
 use ruma::{
-    events::{AnySyncTimelineEvent, AnyTimelineEvent},
+    events::{AnyMessageLikeEvent, AnySyncTimelineEvent, AnyTimelineEvent},
     push::Action,
     serde::{JsonObject, Raw},
     DeviceKeyAlgorithm, OwnedDeviceId, OwnedEventId, OwnedUserId,
@@ -380,6 +380,13 @@ impl From<TimelineEvent> for SyncTimelineEvent {
     }
 }
 
+impl From<DecryptedRoomEvent> for SyncTimelineEvent {
+    fn from(decrypted: DecryptedRoomEvent) -> Self {
+        let timeline_event: TimelineEvent = decrypted.into();
+        timeline_event.into()
+    }
+}
+
 #[derive(Clone)]
 pub struct TimelineEvent {
     /// The actual event.
@@ -406,6 +413,20 @@ impl TimelineEvent {
     }
 }
 
+impl From<DecryptedRoomEvent> for TimelineEvent {
+    fn from(decrypted: DecryptedRoomEvent) -> Self {
+        Self {
+            // Casting from the more specific `AnyMessageLikeEvent` (i.e. an event without a
+            // `state_key`) to a more generic `AnyTimelineEvent` (i.e. one that may contain
+            // a `state_key`) is safe.
+            event: decrypted.event.cast(),
+            encryption_info: Some(decrypted.encryption_info),
+            push_actions: None,
+            unsigned_encryption_info: decrypted.unsigned_encryption_info,
+        }
+    }
+}
+
 #[cfg(not(tarpaulin_include))]
 impl fmt::Debug for TimelineEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -420,6 +441,35 @@ impl fmt::Debug for TimelineEvent {
         }
         s.maybe_field("unsigned_encryption_info", unsigned_encryption_info);
         s.finish()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+/// A successfully-decrypted encrypted event.
+pub struct DecryptedRoomEvent {
+    /// The decrypted event.
+    pub event: Raw<AnyMessageLikeEvent>,
+
+    /// The encryption info about the event.
+    pub encryption_info: EncryptionInfo,
+
+    /// The encryption info about the events bundled in the `unsigned`
+    /// object.
+    ///
+    /// Will be `None` if no bundled event was encrypted.
+    pub unsigned_encryption_info: Option<BTreeMap<UnsignedEventLocation, UnsignedDecryptionResult>>,
+}
+
+#[cfg(not(tarpaulin_include))]
+impl fmt::Debug for DecryptedRoomEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let DecryptedRoomEvent { event, encryption_info, unsigned_encryption_info } = self;
+
+        f.debug_struct("DecryptedRoomEvent")
+            .field("event", &DebugRawEvent(event))
+            .field("encryption_info", encryption_info)
+            .maybe_field("unsigned_encryption_info", unsigned_encryption_info)
+            .finish()
     }
 }
 

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -53,7 +53,10 @@ Changes:
 
 Breaking changes:
 
-  **NOTE**: this version causes changes to the format of the serialised data in
+- `OlmMachine::decrypt_room_event` now returns a `DecryptedRoomEvent` type,
+  instead of the more generic `TimelineEvent` type.
+
+- **NOTE**: this version causes changes to the format of the serialised data in
   the CryptoStore, meaning that, once upgraded, it will not be possible to roll
   back applications to earlier versions without breaking user sessions.
 

--- a/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
@@ -117,8 +117,7 @@ async fn test_decryption_verification_state() {
         .decrypt_room_event(&event, room_id, &decryption_settings)
         .await
         .unwrap()
-        .encryption_info
-        .unwrap();
+        .encryption_info;
 
     assert_eq!(
         VerificationState::Unverified(VerificationLevel::UnsignedDevice),

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -31,8 +31,8 @@ use ruma::{
         room::message::{
             AddMentions, MessageType, Relation, ReplyWithinThread, RoomMessageEventContent,
         },
-        AnyMessageLikeEvent, AnyMessageLikeEventContent, AnyTimelineEvent, AnyToDeviceEvent,
-        MessageLikeEvent, OriginalMessageLikeEvent,
+        AnyMessageLikeEvent, AnyMessageLikeEventContent, AnyToDeviceEvent, MessageLikeEvent,
+        OriginalMessageLikeEvent,
     },
     room_id,
     serde::Raw,
@@ -563,8 +563,8 @@ async fn test_megolm_encryption() {
         .deserialize()
         .unwrap();
 
-    if let AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
-        MessageLikeEvent::Original(OriginalMessageLikeEvent { sender, content, .. }),
+    if let AnyMessageLikeEvent::RoomMessage(MessageLikeEvent::Original(
+        OriginalMessageLikeEvent { sender, content, .. },
     )) = decrypted_event
     {
         assert_eq!(&sender, alice.user_id());
@@ -1291,16 +1291,12 @@ async fn test_unsigned_decryption() {
         bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
-    assert_matches!(
-        decrypted_event,
-        AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(first_message))
-    );
+    assert_matches!(decrypted_event, AnyMessageLikeEvent::RoomMessage(first_message));
 
     let first_message = first_message.as_original().unwrap();
     assert_eq!(first_message.content.body(), first_message_text);
     assert!(first_message.unsigned.relations.is_empty());
 
-    assert!(raw_decrypted_event.encryption_info.is_some());
     assert!(raw_decrypted_event.unsigned_encryption_info.is_none());
 
     // Get a new room key, but don't give it to Bob yet.
@@ -1344,10 +1340,7 @@ async fn test_unsigned_decryption() {
         bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
-    assert_matches!(
-        decrypted_event,
-        AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(first_message))
-    );
+    assert_matches!(decrypted_event, AnyMessageLikeEvent::RoomMessage(first_message));
 
     let first_message = first_message.as_original().unwrap();
     assert_eq!(first_message.content.body(), first_message_text);
@@ -1355,7 +1348,6 @@ async fn test_unsigned_decryption() {
     assert!(first_message.unsigned.relations.replace.is_none());
     assert!(first_message.unsigned.relations.has_replacement());
 
-    assert!(raw_decrypted_event.encryption_info.is_some());
     let unsigned_encryption_info = raw_decrypted_event.unsigned_encryption_info.unwrap();
     assert_eq!(unsigned_encryption_info.len(), 1);
     let replace_encryption_result =
@@ -1388,10 +1380,7 @@ async fn test_unsigned_decryption() {
         bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
-    assert_matches!(
-        decrypted_event,
-        AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(first_message))
-    );
+    assert_matches!(decrypted_event, AnyMessageLikeEvent::RoomMessage(first_message));
 
     let first_message = first_message.as_original().unwrap();
     assert_eq!(first_message.content.body(), first_message_text);
@@ -1399,7 +1388,6 @@ async fn test_unsigned_decryption() {
     assert_matches!(&replace.content.relates_to, Some(Relation::Replacement(replace_content)));
     assert_eq!(replace_content.new_content.msgtype.body(), second_message_text);
 
-    assert!(raw_decrypted_event.encryption_info.is_some());
     let unsigned_encryption_info = raw_decrypted_event.unsigned_encryption_info.unwrap();
     assert_eq!(unsigned_encryption_info.len(), 1);
     let replace_encryption_result =
@@ -1453,10 +1441,7 @@ async fn test_unsigned_decryption() {
         bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
-    assert_matches!(
-        decrypted_event,
-        AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(first_message))
-    );
+    assert_matches!(decrypted_event, AnyMessageLikeEvent::RoomMessage(first_message));
 
     let first_message = first_message.as_original().unwrap();
     assert_eq!(first_message.content.body(), first_message_text);
@@ -1465,7 +1450,6 @@ async fn test_unsigned_decryption() {
     let thread = first_message.unsigned.relations.thread.as_ref().unwrap();
     assert_matches!(thread.latest_event.deserialize(), Ok(AnyMessageLikeEvent::RoomEncrypted(_)));
 
-    assert!(raw_decrypted_event.encryption_info.is_some());
     let unsigned_encryption_info = raw_decrypted_event.unsigned_encryption_info.unwrap();
     assert_eq!(unsigned_encryption_info.len(), 2);
     let replace_encryption_result =
@@ -1501,10 +1485,7 @@ async fn test_unsigned_decryption() {
         bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
-    assert_matches!(
-        decrypted_event,
-        AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(first_message))
-    );
+    assert_matches!(decrypted_event, AnyMessageLikeEvent::RoomMessage(first_message));
 
     let first_message = first_message.as_original().unwrap();
     assert_eq!(first_message.content.body(), first_message_text);
@@ -1517,7 +1498,6 @@ async fn test_unsigned_decryption() {
     let third_message = third_message.as_original().unwrap();
     assert_eq!(third_message.content.body(), third_message_text);
 
-    assert!(raw_decrypted_event.encryption_info.is_some());
     let unsigned_encryption_info = raw_decrypted_event.unsigned_encryption_info.unwrap();
     assert_eq!(unsigned_encryption_info.len(), 2);
     let replace_encryption_result =

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -304,6 +304,6 @@ impl Decryptor for (matrix_sdk_base::crypto::OlmMachine, ruma::OwnedRoomId) {
             DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
         let event =
             olm_machine.decrypt_room_event(raw.cast_ref(), room_id, &decryption_settings).await?;
-        Ok(event)
+        Ok(event.into())
     }
 }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1186,7 +1186,7 @@ impl Room {
         let decryption_settings = DecryptionSettings {
             sender_device_trust_requirement: self.client.base_client().decryption_trust_requirement,
         };
-        let mut event = match machine
+        let decrypted = match machine
             .decrypt_room_event(event.cast_ref(), self.inner.room_id(), &decryption_settings)
             .await
         {
@@ -1201,6 +1201,7 @@ impl Room {
             }
         };
 
+        let mut event: TimelineEvent = decrypted.into();
         event.push_actions = self.event_push_actions(&event.event).await?;
 
         Ok(event)


### PR DESCRIPTION
I need to do a bit of a refactoring on `TimelineEvent`, so let's start by giving `decrypt_room_event` its own return type.

(some groundwork for https://github.com/matrix-org/matrix-rust-sdk/issues/4048)

- [x] Public API changes documented in changelogs (optional)
