### PR TITLE
Do not log full keys query response which can be very large

### DIFF
--- a/crates/matrix-sdk/src/encryption/recovery/mod.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/mod.rs
@@ -629,7 +629,7 @@ impl Recovery {
         }
     }
 
-    #[instrument(skip(self, response))]
+    #[instrument(skip_all)]
     pub(crate) async fn update_state_after_keys_query(&self, response: &get_keys::v3::Response) {
         if let Some(user_id) = self.client.user_id() {
             if response.master_keys.contains_key(user_id) {

--- a/crates/matrix-sdk/src/encryption/recovery/mod.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/mod.rs
@@ -629,7 +629,7 @@ impl Recovery {
         }
     }
 
-    #[instrument]
+    #[instrument(skip(self, response))]
     pub(crate) async fn update_state_after_keys_query(&self, response: &get_keys::v3::Response) {
         if let Some(user_id) = self.client.user_id() {
             if response.master_keys.contains_key(user_id) {


### PR DESCRIPTION
Noticed this while looking at the logs, where I saw a log line of ~1.26MB