### PR TITLE
timeline: prefer a bundled edit over a pending one

### DIFF
--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -67,9 +67,8 @@ pub fn is_suitable_for_latest_event(event: &AnySyncTimelineEvent) -> PossibleLat
 
                 if is_replacement {
                     return PossibleLatestEvent::NoUnsupportedMessageLikeType;
-                } else {
-                    return PossibleLatestEvent::YesRoomMessage(message);
                 }
+                return PossibleLatestEvent::YesRoomMessage(message);
             }
 
             return PossibleLatestEvent::YesRoomMessage(message);

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -52,8 +52,8 @@ use tracing::{
 };
 
 pub(super) use self::state::{
-    EventMeta, FullEventMeta, PendingEdit, TimelineEnd, TimelineMetadata, TimelineState,
-    TimelineStateTransaction,
+    EventMeta, FullEventMeta, PendingEdit, PendingEditKind, TimelineEnd, TimelineMetadata,
+    TimelineState, TimelineStateTransaction,
 };
 use super::{
     event_handler::TimelineEventKind,

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -947,10 +947,9 @@ impl<P: RoomDataProvider> TimelineController<P> {
 
         // Replace the local-related state (kind) and the content state.
         let new_item = TimelineItem::new(
-            prev_item.with_kind(ti_kind).with_content(
-                TimelineItemContent::message(content, Default::default(), &txn.items),
-                None,
-            ),
+            prev_item
+                .with_kind(ti_kind)
+                .with_content(TimelineItemContent::message(content, None, &txn.items), None),
             prev_item.internal_id.to_owned(),
         );
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -816,6 +816,15 @@ pub(in crate::timeline) enum PendingEdit {
     Poll(Replacement<NewUnstablePollStartEventContentWithoutRelation>),
 }
 
+impl PendingEdit {
+    pub fn edited_event(&self) -> &EventId {
+        match self {
+            PendingEdit::RoomMessage(Replacement { event_id, .. })
+            | PendingEdit::Poll(Replacement { event_id, .. }) => event_id,
+        }
+    }
+}
+
 #[cfg(not(tarpaulin_include))]
 impl std::fmt::Debug for PendingEdit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -869,7 +878,7 @@ pub(in crate::timeline) struct TimelineMetadata {
     pub pending_poll_events: PendingPollEvents,
 
     /// Edit events received before the related event they're editing.
-    pub pending_edits: RingBuffer<(OwnedEventId, PendingEdit)>,
+    pub pending_edits: RingBuffer<PendingEdit>,
 
     /// Identifier of the fully-read event, helping knowing where to introduce
     /// the read marker.

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -201,13 +201,7 @@ impl TimelineState {
         let mut day_divider_adjuster = DayDividerAdjuster::default();
 
         TimelineEventHandler::new(&mut txn, ctx)
-            .handle_event(
-                &mut day_divider_adjuster,
-                content,
-                // Local events are never UTD, so no need to pass in a raw_event - this is only
-                // used to determine the type of UTD if there is one.
-                None,
-            )
+            .handle_event(&mut day_divider_adjuster, content)
             .await;
 
         txn.adjust_day_dividers(day_divider_adjuster);
@@ -586,7 +580,7 @@ impl TimelineStateTransaction<'_> {
             is_highlighted: event.push_actions.iter().any(Action::is_highlight),
             flow: Flow::Remote {
                 event_id: event_id.clone(),
-                raw_event: raw.clone(),
+                raw_event: raw,
                 encryption_info: event.encryption_info,
                 txn_id,
                 position,
@@ -594,9 +588,7 @@ impl TimelineStateTransaction<'_> {
             should_add_new_items: should_add,
         };
 
-        TimelineEventHandler::new(self, ctx)
-            .handle_event(day_divider_adjuster, event_kind, Some(&raw))
-            .await
+        TimelineEventHandler::new(self, ctx).handle_event(day_divider_adjuster, event_kind).await
     }
 
     fn clear(&mut self) {

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::{
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     future::Future,
     num::NonZeroUsize,
     sync::{Arc, RwLock},
@@ -29,8 +29,12 @@ use matrix_sdk_base::deserialized_responses::TimelineEvent;
 use ruma::events::receipt::ReceiptEventContent;
 use ruma::{
     events::{
-        poll::unstable_start::NewUnstablePollStartEventContentWithoutRelation,
-        relation::Replacement, room::message::RoomMessageEventContentWithoutRelation,
+        poll::{
+            unstable_response::UnstablePollResponseEventContent,
+            unstable_start::NewUnstablePollStartEventContentWithoutRelation,
+        },
+        relation::Replacement,
+        room::message::RoomMessageEventContentWithoutRelation,
         AnySyncEphemeralRoomEvent,
     },
     push::Action,
@@ -49,8 +53,7 @@ use crate::{
             Flow, HandleEventResult, TimelineEventContext, TimelineEventHandler, TimelineEventKind,
             TimelineItemPosition,
         },
-        event_item::RemoteEventOrigin,
-        polls::PendingPollEvents,
+        event_item::{PollState, RemoteEventOrigin, ResponseData},
         reactions::Reactions,
         read_receipts::ReadReceipts,
         traits::RoomDataProvider,
@@ -751,6 +754,58 @@ impl TimelineStateTransaction<'_> {
                 let item = item.with_kind(cloned_event);
                 self.items.set(idx, item);
             }
+        }
+    }
+}
+
+/// Cache holding poll response and end events handled before their poll start
+/// event has been handled.
+#[derive(Clone, Debug, Default)]
+pub(in crate::timeline) struct PendingPollEvents {
+    /// Responses to a poll (identified by the poll's start event id).
+    responses: HashMap<OwnedEventId, Vec<ResponseData>>,
+
+    /// Mapping of a poll (identified by its start event's id) to its end date.
+    end_dates: HashMap<OwnedEventId, MilliSecondsSinceUnixEpoch>,
+}
+
+impl PendingPollEvents {
+    pub(crate) fn add_response(
+        &mut self,
+        start_event_id: &EventId,
+        sender: &UserId,
+        timestamp: MilliSecondsSinceUnixEpoch,
+        content: &UnstablePollResponseEventContent,
+    ) {
+        self.responses.entry(start_event_id.to_owned()).or_default().push(ResponseData {
+            sender: sender.to_owned(),
+            timestamp,
+            answers: content.poll_response.answers.clone(),
+        });
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.end_dates.clear();
+        self.responses.clear();
+    }
+
+    /// Mark a poll as finished by inserting its poll date.
+    pub(crate) fn mark_as_ended(
+        &mut self,
+        start_event_id: &EventId,
+        timestamp: MilliSecondsSinceUnixEpoch,
+    ) {
+        self.end_dates.insert(start_event_id.to_owned(), timestamp);
+    }
+
+    /// Dumps all response and end events present in the cache that belong to
+    /// the given start_event_id into the given poll_state.
+    pub(crate) fn apply_pending(&mut self, start_event_id: &EventId, poll_state: &mut PollState) {
+        if let Some(pending_responses) = self.responses.remove(start_event_id) {
+            poll_state.response_data.extend(pending_responses);
+        }
+        if let Some(pending_end) = self.end_dates.remove(start_event_id) {
+            poll_state.end_event_timestamp = Some(pending_end);
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -52,9 +52,9 @@ use super::{
     controller::{PendingEditKind, TimelineMetadata, TimelineStateTransaction},
     day_dividers::DayDividerAdjuster,
     event_item::{
-        extract_edit_content, AnyOtherFullStateEventContent, EventSendState, EventTimelineItemKind,
-        LocalEventTimelineItem, PollState, Profile, ReactionsByKeyBySender, RemoteEventOrigin,
-        RemoteEventTimelineItem, TimelineEventItemId,
+        extract_room_msg_edit_content, AnyOtherFullStateEventContent, EventSendState,
+        EventTimelineItemKind, LocalEventTimelineItem, PollState, Profile, ReactionsByKeyBySender,
+        RemoteEventOrigin, RemoteEventTimelineItem, TimelineEventItemId,
     },
     reactions::FullReactionKey,
     util::{rfind_event_by_id, rfind_event_item},
@@ -346,7 +346,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                                     _ => None,
                                 });
 
-                        let (edit_json, edit_content) = extract_edit_content(relations)
+                        let (edit_json, edit_content) = extract_room_msg_edit_content(relations)
                             .map(|content| {
                                 let edit_json = as_variant!(&self.ctx.flow, Flow::Remote { raw_event, ..} => raw_event).and_then(|raw| {
                                     // Kids, don't do this at home. We're extracting the edit event

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -467,7 +467,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         // don't want to apply another pending edit on top of it.
         let pending_edit = as_variant!(&self.ctx.flow, Flow::Remote { event_id, .. } => event_id)
             .and_then(|event_id| {
-                Self::find_and_remove_pending(&mut self.meta.pending_edits, event_id)
+                Self::maybe_unstash_pending_edit(&mut self.meta.pending_edits, event_id)
             })
             .and_then(|edit| match edit.kind {
                 PendingEditKind::RoomMessage(replacement) => {
@@ -553,15 +553,16 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 // forward-pagination: it's fine to overwrite the previous one, if
                 // available.
                 let edits = &mut self.meta.pending_edits;
-                let _ = Self::find_and_remove_pending(edits, &replaced_event_id);
+                let _ = Self::maybe_unstash_pending_edit(edits, &replaced_event_id);
                 edits.push(replacement);
                 debug!("Timeline item not found, stashing edit");
             }
         }
     }
 
-    /// TODO rename to maybe_unstash_pending_edit?
-    fn find_and_remove_pending(
+    /// Look for a pending edit for the given event, and remove it from the list
+    /// and return it, if found.
+    fn maybe_unstash_pending_edit(
         edits: &mut RingBuffer<PendingEdit>,
         event_id: &EventId,
     ) -> Option<PendingEdit> {
@@ -763,7 +764,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         // don't want to apply another pending edit on top of it.
         let pending_edit = as_variant!(&self.ctx.flow, Flow::Remote { event_id, .. } => event_id)
             .and_then(|event_id| {
-                Self::find_and_remove_pending(&mut self.meta.pending_edits, event_id)
+                Self::maybe_unstash_pending_edit(&mut self.meta.pending_edits, event_id)
             })
             .and_then(|edit| match edit.kind {
                 PendingEditKind::Poll(replacement) => {

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -51,10 +51,9 @@ use super::{
     day_dividers::DayDividerAdjuster,
     event_item::{
         extract_edit_content, AnyOtherFullStateEventContent, EventSendState, EventTimelineItemKind,
-        LocalEventTimelineItem, Profile, ReactionsByKeyBySender, RemoteEventOrigin,
+        LocalEventTimelineItem, PollState, Profile, ReactionsByKeyBySender, RemoteEventOrigin,
         RemoteEventTimelineItem, TimelineEventItemId,
     },
-    polls::PollState,
     reactions::FullReactionKey,
     util::{rfind_event_by_id, rfind_event_item},
     EventTimelineItem, InReplyToDetails, OtherState, Sticker, TimelineDetails, TimelineItem,

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -525,28 +525,28 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         &mut self,
         item: &EventTimelineItem,
     ) -> Option<EventTimelineItem> {
+        let Flow::Remote { event_id, .. } = &self.ctx.flow else {
+            return None;
+        };
+
         let mut find_and_remove_pending = |event_id| {
             let edits = &mut self.meta.pending_edits;
             let pos = edits.iter().position(|(prev_event_id, _)| prev_event_id == event_id)?;
             Some(edits.remove(pos).unwrap().1)
         };
 
-        if let Flow::Remote { event_id, .. } = &self.ctx.flow {
-            match item.content() {
-                TimelineItemContent::Message(..) => {
-                    let pending = find_and_remove_pending(event_id)?;
-                    let edit = as_variant!(pending, PendingEdit::RoomMessage)?;
-                    self.apply_msg_edit(item, edit)
-                }
-                TimelineItemContent::Poll(..) => {
-                    let pending = find_and_remove_pending(event_id)?;
-                    let edit = as_variant!(pending, PendingEdit::Poll)?;
-                    self.apply_poll_edit(item, edit)
-                }
-                _ => None,
+        match item.content() {
+            TimelineItemContent::Message(..) => {
+                let pending = find_and_remove_pending(event_id)?;
+                let edit = as_variant!(pending, PendingEdit::RoomMessage)?;
+                self.apply_msg_edit(item, edit)
             }
-        } else {
-            None
+            TimelineItemContent::Poll(..) => {
+                let pending = find_and_remove_pending(event_id)?;
+                let edit = as_variant!(pending, PendingEdit::Poll)?;
+                self.apply_poll_edit(item, edit)
+            }
+            _ => None,
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -289,7 +289,6 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         mut self,
         day_divider_adjuster: &mut DayDividerAdjuster,
         event_kind: TimelineEventKind,
-        raw_event: Option<&Raw<AnySyncTimelineEvent>>,
     ) -> HandleEventResult {
         let span = tracing::Span::current();
 
@@ -334,6 +333,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
                 AnyMessageLikeEventContent::RoomEncrypted(c) => {
                     // TODO: Handle replacements if the replaced event is also UTD
+                    let raw_event =
+                        as_variant!(&self.ctx.flow, Flow::Remote { raw_event, .. } => raw_event);
                     let cause = UtdCause::determine(raw_event);
                     self.add_item(TimelineItemContent::unable_to_decrypt(c, cause), None);
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -84,6 +84,7 @@ impl Message {
                 e.msgtype.sanitize(DEFAULT_SANITIZER_MODE, RemoveReplyFallback::No);
                 (e.msgtype, e.mentions)
             }
+
             None => {
                 let remove_reply_fallback = if in_reply_to.is_some() {
                     RemoveReplyFallback::Yes

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -164,7 +164,7 @@ impl From<Message> for RoomMessageEventContent {
 
 /// Extracts a replacement for a room message, if present in the bundled
 /// relations.
-pub(crate) fn extract_edit_content(
+pub(crate) fn extract_room_msg_edit_content(
     relations: BundledMessageLikeRelations<AnySyncMessageLikeEvent>,
 ) -> Option<RoomMessageEventContentWithoutRelation> {
     match *relations.replace? {
@@ -320,7 +320,7 @@ impl RepliedToEvent {
 
         let content = TimelineItemContent::Message(Message::from_event(
             c,
-            extract_edit_content(event.relations()),
+            extract_room_msg_edit_content(event.relations()),
             &vector![],
         ));
         let sender = event.sender().to_owned();

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -66,7 +66,7 @@ mod polls;
 
 pub use pinned_events::RoomPinnedEventsChange;
 
-pub(in crate::timeline) use self::{message::extract_edit_content, polls::ResponseData};
+pub(in crate::timeline) use self::{message::extract_room_msg_edit_content, polls::ResponseData};
 pub use self::{
     message::{InReplyToDetails, Message, RepliedToEvent},
     polls::{PollResult, PollState},

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -285,6 +285,12 @@ impl TimelineItemContent {
         as_variant!(self, Self::Message)
     }
 
+    /// If `self` is of the [`Poll`][Self::Poll] variant, return the inner
+    /// [`PollState`].
+    pub fn as_poll(&self) -> Option<&PollState> {
+        as_variant!(self, Self::Poll)
+    }
+
     /// If `self` is of the [`UnableToDecrypt`][Self::UnableToDecrypt] variant,
     /// return the inner [`EncryptedMessage`].
     pub fn as_unable_to_decrypt(&self) -> Option<&EncryptedMessage> {

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -62,6 +62,7 @@ pub(crate) mod pinned_events;
 
 pub use pinned_events::RoomPinnedEventsChange;
 
+pub(crate) use self::message::extract_edit_content;
 pub use self::message::{InReplyToDetails, Message, RepliedToEvent};
 
 /// The content of an [`EventTimelineItem`][super::EventTimelineItem].
@@ -176,7 +177,7 @@ impl TimelineItemContent {
                 // We don't have access to any relations via the `AnySyncTimelineEvent` (I think
                 // - andyb) so we pretend there are none. This might be OK for
                 // the message preview use case.
-                let relations = BundledMessageLikeRelations::new();
+                let edit = None;
 
                 // If this message is a reply, we would look up in this list the message it was
                 // replying to. Since we probably won't show this in the message preview,
@@ -186,7 +187,7 @@ impl TimelineItemContent {
                 let timeline_items = Vector::new();
                 TimelineItemContent::Message(Message::from_event(
                     event_content,
-                    relations,
+                    edit,
                     &timeline_items,
                 ))
             }
@@ -264,7 +265,7 @@ impl TimelineItemContent {
         relations: BundledMessageLikeRelations<AnySyncMessageLikeEvent>,
         timeline_items: &Vector<Arc<TimelineItem>>,
     ) -> Self {
-        Self::Message(Message::from_event(c, relations, timeline_items))
+        Self::Message(Message::from_event(c, extract_edit_content(relations), timeline_items))
     }
 
     #[cfg(not(tarpaulin_include))] // debug-logging functionality

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -58,15 +58,19 @@ use ruma::{
 };
 use tracing::warn;
 
-use crate::timeline::{polls::PollState, TimelineItem};
+use crate::timeline::TimelineItem;
 
 mod message;
 pub(crate) mod pinned_events;
+mod polls;
 
 pub use pinned_events::RoomPinnedEventsChange;
 
-pub(crate) use self::message::extract_edit_content;
-pub use self::message::{InReplyToDetails, Message, RepliedToEvent};
+pub(in crate::timeline) use self::{message::extract_edit_content, polls::ResponseData};
+pub use self::{
+    message::{InReplyToDetails, Message, RepliedToEvent},
+    polls::{PollResult, PollState},
+};
 
 /// The content of an [`EventTimelineItem`][super::EventTimelineItem].
 #[derive(Clone, Debug)]

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -37,7 +37,10 @@ use ruma::{
             history_visibility::RoomHistoryVisibilityEventContent,
             join_rules::RoomJoinRulesEventContent,
             member::{Change, RoomMemberEventContent},
-            message::{Relation, RoomMessageEventContent, SyncRoomMessageEvent},
+            message::{
+                Relation, RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
+                SyncRoomMessageEvent,
+            },
             name::RoomNameEventContent,
             pinned_events::RoomPinnedEventsEventContent,
             power_levels::RoomPowerLevelsEventContent,
@@ -48,8 +51,8 @@ use ruma::{
         },
         space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
         sticker::{StickerEventContent, SyncStickerEvent},
-        AnyFullStateEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
-        BundledMessageLikeRelations, FullStateEventContent, MessageLikeEventType, StateEventType,
+        AnyFullStateEventContent, AnySyncTimelineEvent, FullStateEventContent,
+        MessageLikeEventType, StateEventType,
     },
     OwnedDeviceId, OwnedMxcUri, OwnedUserId, RoomVersionId, UserId,
 };
@@ -272,10 +275,10 @@ impl TimelineItemContent {
     // allow users to call them directly, which should not be supported
     pub(crate) fn message(
         c: RoomMessageEventContent,
-        relations: BundledMessageLikeRelations<AnySyncMessageLikeEvent>,
+        edit: Option<RoomMessageEventContentWithoutRelation>,
         timeline_items: &Vector<Arc<TimelineItem>>,
     ) -> Self {
-        Self::Message(Message::from_event(c, extract_edit_content(relations), timeline_items))
+        Self::Message(Message::from_event(c, edit, timeline_items))
     }
 
     #[cfg(not(tarpaulin_include))] // debug-logging functionality

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/polls.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! This module handles rendering of MSC3381 polls in the timeline.
 
 use std::collections::HashMap;
@@ -13,7 +27,7 @@ use ruma::{
         },
         PollResponseData,
     },
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, UserId,
+    MilliSecondsSinceUnixEpoch, OwnedUserId, UserId,
 };
 
 /// Holds the state of a poll.
@@ -23,21 +37,21 @@ use ruma::{
 /// to the same poll start event.
 #[derive(Clone, Debug)]
 pub struct PollState {
-    pub(super) start_event_content: NewUnstablePollStartEventContent,
-    pub(super) response_data: Vec<ResponseData>,
-    pub(super) end_event_timestamp: Option<MilliSecondsSinceUnixEpoch>,
-    pub(super) has_been_edited: bool,
+    pub(in crate::timeline) start_event_content: NewUnstablePollStartEventContent,
+    pub(in crate::timeline) response_data: Vec<ResponseData>,
+    pub(in crate::timeline) end_event_timestamp: Option<MilliSecondsSinceUnixEpoch>,
+    pub(in crate::timeline) has_been_edited: bool,
 }
 
 #[derive(Clone, Debug)]
-pub(super) struct ResponseData {
-    pub(super) sender: OwnedUserId,
-    pub(super) timestamp: MilliSecondsSinceUnixEpoch,
-    pub(super) answers: Vec<String>,
+pub(in crate::timeline) struct ResponseData {
+    pub sender: OwnedUserId,
+    pub timestamp: MilliSecondsSinceUnixEpoch,
+    pub answers: Vec<String>,
 }
 
 impl PollState {
-    pub(super) fn new(content: NewUnstablePollStartEventContent) -> Self {
+    pub(crate) fn new(content: NewUnstablePollStartEventContent) -> Self {
         Self {
             start_event_content: content,
             response_data: vec![],
@@ -48,7 +62,7 @@ impl PollState {
 
     /// Applies an edit to a poll, returns `None` if the poll was already marked
     /// as finished.
-    pub(super) fn edit(
+    pub(crate) fn edit(
         &self,
         replacement: &NewUnstablePollStartEventContentWithoutRelation,
     ) -> Option<Self> {
@@ -63,7 +77,7 @@ impl PollState {
         }
     }
 
-    pub(super) fn add_response(
+    pub(crate) fn add_response(
         &self,
         sender: &UserId,
         timestamp: MilliSecondsSinceUnixEpoch,
@@ -81,7 +95,7 @@ impl PollState {
     /// Marks the poll as ended.
     ///
     /// If the poll has already ended, returns `Err(())`.
-    pub(super) fn end(&self, timestamp: MilliSecondsSinceUnixEpoch) -> Result<Self, ()> {
+    pub(crate) fn end(&self, timestamp: MilliSecondsSinceUnixEpoch) -> Result<Self, ()> {
         if self.end_event_timestamp.is_none() {
             let mut clone = self.clone();
             clone.end_event_timestamp = Some(timestamp);
@@ -142,58 +156,6 @@ impl From<PollState> for NewUnstablePollStartEventContent {
             NewUnstablePollStartEventContent::plain_text(text, content)
         } else {
             NewUnstablePollStartEventContent::new(content)
-        }
-    }
-}
-
-/// Cache holding poll response and end events handled before their poll start
-/// event has been handled.
-#[derive(Clone, Debug, Default)]
-pub(super) struct PendingPollEvents {
-    /// Responses to a poll (identified by the poll's start event id).
-    responses: HashMap<OwnedEventId, Vec<ResponseData>>,
-
-    /// Mapping of a poll (identified by its start event's id) to its end date.
-    end_dates: HashMap<OwnedEventId, MilliSecondsSinceUnixEpoch>,
-}
-
-impl PendingPollEvents {
-    pub(super) fn add_response(
-        &mut self,
-        start_event_id: &EventId,
-        sender: &UserId,
-        timestamp: MilliSecondsSinceUnixEpoch,
-        content: &UnstablePollResponseEventContent,
-    ) {
-        self.responses.entry(start_event_id.to_owned()).or_default().push(ResponseData {
-            sender: sender.to_owned(),
-            timestamp,
-            answers: content.poll_response.answers.clone(),
-        });
-    }
-
-    pub(super) fn clear(&mut self) {
-        self.end_dates.clear();
-        self.responses.clear();
-    }
-
-    /// Mark a poll as finished by inserting its poll date.
-    pub(super) fn mark_as_ended(
-        &mut self,
-        start_event_id: &EventId,
-        timestamp: MilliSecondsSinceUnixEpoch,
-    ) {
-        self.end_dates.insert(start_event_id.to_owned(), timestamp);
-    }
-
-    /// Dumps all response and end events present in the cache that belong to
-    /// the given start_event_id into the given poll_state.
-    pub(super) fn apply_pending(&mut self, start_event_id: &EventId, poll_state: &mut PollState) {
-        if let Some(pending_responses) = self.responses.remove(start_event_id) {
-            poll_state.response_data.extend(pending_responses);
-        }
-        if let Some(pending_end) = self.end_dates.remove(start_event_id) {
-            poll_state.end_event_timestamp = Some(pending_end);
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -41,6 +41,11 @@ mod content;
 mod local;
 mod remote;
 
+pub(super) use self::{
+    content::extract_edit_content,
+    local::LocalEventTimelineItem,
+    remote::{RemoteEventOrigin, RemoteEventTimelineItem},
+};
 pub use self::{
     content::{
         AnyOtherFullStateEventContent, EncryptedMessage, InReplyToDetails, MemberProfileChange,
@@ -48,10 +53,6 @@ pub use self::{
         RoomPinnedEventsChange, Sticker, TimelineItemContent,
     },
     local::EventSendState,
-};
-pub(super) use self::{
-    local::LocalEventTimelineItem,
-    remote::{RemoteEventOrigin, RemoteEventTimelineItem},
 };
 use super::{RepliedToInfo, ReplyContent, UnsupportedReplyItem};
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -869,7 +869,7 @@ mod tests {
         // Then its properties correctly translate.
         assert_eq!(timeline_item.sender, user_id);
 
-        let poll = timeline_item.poll_state();
+        let poll = timeline_item.content().as_poll().unwrap();
         assert!(poll.has_been_edited);
         assert_eq!(
             poll.start_event_content.poll_start.question.text,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -42,7 +42,7 @@ mod local;
 mod remote;
 
 pub(super) use self::{
-    content::{extract_edit_content, ResponseData},
+    content::{extract_room_msg_edit_content, ResponseData},
     local::LocalEventTimelineItem,
     remote::{RemoteEventOrigin, RemoteEventTimelineItem},
 };

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -733,7 +733,7 @@ mod tests {
         },
         room_id,
         serde::Raw,
-        uint, user_id, MilliSecondsSinceUnixEpoch, RoomId, UInt, UserId,
+        user_id, RoomId, UInt, UserId,
     };
 
     use super::{EventTimelineItem, Profile};
@@ -796,7 +796,7 @@ mod tests {
             .sender(user_id)
             .event_id(original_event_id)
             .bundled_relations(relations)
-            .server_ts(MilliSecondsSinceUnixEpoch(uint!(42)))
+            .server_ts(42)
             .into_sync();
 
         let client = logged_in_client(None).await;

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -42,15 +42,15 @@ mod local;
 mod remote;
 
 pub(super) use self::{
-    content::extract_edit_content,
+    content::{extract_edit_content, ResponseData},
     local::LocalEventTimelineItem,
     remote::{RemoteEventOrigin, RemoteEventTimelineItem},
 };
 pub use self::{
     content::{
         AnyOtherFullStateEventContent, EncryptedMessage, InReplyToDetails, MemberProfileChange,
-        MembershipChange, Message, OtherState, RepliedToEvent, RoomMembershipChange,
-        RoomPinnedEventsChange, Sticker, TimelineItemContent,
+        MembershipChange, Message, OtherState, PollResult, PollState, RepliedToEvent,
+        RoomMembershipChange, RoomPinnedEventsChange, Sticker, TimelineItemContent,
     },
     local::EventSendState,
 };

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -42,7 +42,10 @@ mod local;
 mod remote;
 
 pub(super) use self::{
-    content::{extract_room_msg_edit_content, ResponseData},
+    content::{
+        extract_bundled_edit_event_json, extract_poll_edit_content, extract_room_msg_edit_content,
+        ResponseData,
+    },
     local::LocalEventTimelineItem,
     remote::{RemoteEventOrigin, RemoteEventTimelineItem},
 };

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -68,7 +68,6 @@ pub mod futures;
 mod item;
 mod pagination;
 mod pinned_events_loader;
-mod polls;
 mod reactions;
 mod read_receipts;
 #[cfg(test)]
@@ -85,14 +84,13 @@ pub use self::{
     event_item::{
         AnyOtherFullStateEventContent, EncryptedMessage, EventItemOrigin, EventSendState,
         EventTimelineItem, InReplyToDetails, MemberProfileChange, MembershipChange, Message,
-        OtherState, Profile, ReactionInfo, ReactionStatus, ReactionsByKeyBySender, RepliedToEvent,
-        RoomMembershipChange, RoomPinnedEventsChange, Sticker, TimelineDetails,
+        OtherState, PollResult, Profile, ReactionInfo, ReactionStatus, ReactionsByKeyBySender,
+        RepliedToEvent, RoomMembershipChange, RoomPinnedEventsChange, Sticker, TimelineDetails,
         TimelineEventItemId, TimelineItemContent,
     },
     event_type_filter::TimelineEventTypeFilter,
     item::{TimelineItem, TimelineItemKind},
     pagination::LiveBackPaginationStatus,
-    polls::PollResult,
     traits::RoomExt,
     virtual_item::VirtualTimelineItem,
 };

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -84,9 +84,9 @@ pub use self::{
     event_item::{
         AnyOtherFullStateEventContent, EncryptedMessage, EventItemOrigin, EventSendState,
         EventTimelineItem, InReplyToDetails, MemberProfileChange, MembershipChange, Message,
-        OtherState, PollResult, Profile, ReactionInfo, ReactionStatus, ReactionsByKeyBySender,
-        RepliedToEvent, RoomMembershipChange, RoomPinnedEventsChange, Sticker, TimelineDetails,
-        TimelineEventItemId, TimelineItemContent,
+        OtherState, PollResult, PollState, Profile, ReactionInfo, ReactionStatus,
+        ReactionsByKeyBySender, RepliedToEvent, RoomMembershipChange, RoomPinnedEventsChange,
+        Sticker, TimelineDetails, TimelineEventItemId, TimelineItemContent,
     },
     event_type_filter::TimelineEventTypeFilter,
     item::{TimelineItem, TimelineItemKind},

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -18,7 +18,7 @@
 
 use std::{path::PathBuf, pin::Pin, sync::Arc, task::Poll};
 
-use event_item::{extract_edit_content, EventTimelineItemKind, TimelineItemHandle};
+use event_item::{extract_room_msg_edit_content, EventTimelineItemKind, TimelineItemHandle};
 use eyeball_im::VectorDiff;
 use futures_core::Stream;
 use imbl::Vector;
@@ -431,7 +431,7 @@ impl Timeline {
                 {
                     ReplyContent::Message(Message::from_event(
                         original_message.content.clone(),
-                        extract_edit_content(message_like_event.relations()),
+                        extract_room_msg_edit_content(message_like_event.relations()),
                         &self.items().await,
                     ))
                 } else {

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -18,7 +18,7 @@
 
 use std::{path::PathBuf, pin::Pin, sync::Arc, task::Poll};
 
-use event_item::{EventTimelineItemKind, TimelineItemHandle};
+use event_item::{extract_edit_content, EventTimelineItemKind, TimelineItemHandle};
 use eyeball_im::VectorDiff;
 use futures_core::Stream;
 use imbl::Vector;
@@ -433,7 +433,7 @@ impl Timeline {
                 {
                     ReplyContent::Message(Message::from_event(
                         original_message.content.clone(),
-                        message_like_event.relations(),
+                        extract_edit_content(message_like_event.relations()),
                         &self.items().await,
                     ))
                 } else {

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -24,7 +24,7 @@ use matrix_sdk_test::{async_test, ALICE, BOB};
 use ruma::{
     event_id,
     events::{room::message::RoomMessageEventContent, AnyMessageLikeEventContent},
-    uint, user_id, MilliSecondsSinceUnixEpoch,
+    user_id, MilliSecondsSinceUnixEpoch,
 };
 use stream_assert::assert_next_matches;
 
@@ -164,7 +164,7 @@ async fn test_remote_echo_new_position() {
             f.text_msg("echo")
                 .sender(*ALICE)
                 .event_id(event_id!("$eeG0HA0FAZ37wP8kXlNkxx3I"))
-                .server_ts(MilliSecondsSinceUnixEpoch(uint!(6)))
+                .server_ts(6)
                 .unsigned_transaction_id(&txn_id),
         )
         .await;
@@ -202,11 +202,7 @@ async fn test_day_divider_duplication() {
 
     // … when the second remote event is re-received (day still the same)
     let event_id = items[2].as_event().unwrap().event_id().unwrap();
-    timeline
-        .handle_live_event(
-            f.text_msg("B").event_id(event_id).server_ts(MilliSecondsSinceUnixEpoch(uint!(1))),
-        )
-        .await;
+    timeline.handle_live_event(f.text_msg("B").event_id(event_id).server_ts(1)).await;
 
     // … it should not impact the day dividers.
     let items = timeline.controller.items().await;
@@ -225,11 +221,7 @@ async fn test_day_divider_removed_after_local_echo_disappeared() {
     let f = &timeline.factory;
 
     timeline
-        .handle_live_event(
-            f.text_msg("remote echo")
-                .sender(user_id!("@a:b.c"))
-                .server_ts(MilliSecondsSinceUnixEpoch(0.try_into().unwrap())),
-        )
+        .handle_live_event(f.text_msg("remote echo").sender(user_id!("@a:b.c")).server_ts(0))
         .await;
 
     let items = timeline.controller.items().await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -217,7 +217,7 @@ async fn test_edit_updates_encryption_info() {
 }
 
 #[async_test]
-async fn test_relations_edit_overrides_pending_edit() {
+async fn test_relations_edit_overrides_pending_edit_msg() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 
@@ -272,6 +272,84 @@ async fn test_relations_edit_overrides_pending_edit() {
 
     let text = event.content().as_message().unwrap();
     assert_eq!(text.body(), "edit 2");
+
+    let day_divider = assert_next_matches!(stream, VectorDiff::PushFront { value } => value);
+    assert!(day_divider.is_day_divider());
+
+    assert_pending!(stream);
+}
+
+#[async_test]
+async fn test_relations_edit_overrides_pending_edit_poll() {
+    let timeline = TestTimeline::new();
+    let mut stream = timeline.subscribe().await;
+
+    let f = &timeline.factory;
+
+    let original_event_id = event_id!("$original");
+    let edit1_event_id = event_id!("$edit1");
+    let edit2_event_id = event_id!("$edit2");
+
+    // Pending edit is stashed, nothing comes from the stream.
+    timeline
+        .handle_live_event(
+            f.poll_edit(
+                original_event_id,
+                "Can the fake slim shady please stand up?",
+                vec!["Excuse me?"],
+            )
+            .sender(*ALICE)
+            .event_id(edit1_event_id),
+        )
+        .await;
+    assert_pending!(stream);
+
+    // Now we receive the original event, with a bundled relations group.
+    let mut relations = BundledMessageLikeRelations::new();
+    relations.replace = Some(Box::new(
+        f.poll_edit(
+            original_event_id,
+            "Can the real slim shady please stand up?",
+            vec!["Excuse me?", "Please stand up 🎵", "Please stand up 🎶"],
+        )
+        .sender(*ALICE)
+        .event_id(edit2_event_id)
+        .into(),
+    ));
+
+    let ev = f
+        .poll_start(
+            "Can the fake slim shady please stand down?\nExcuse me?",
+            "Can the fake slim shady please stand down?",
+            vec!["Excuse me?"],
+        )
+        .sender(*ALICE)
+        .event_id(original_event_id)
+        .bundled_relations(relations);
+
+    timeline.handle_live_event(ev).await;
+
+    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+
+    // We receive the latest edit, not the pending one.
+    let event = item.as_event().unwrap();
+    assert_eq!(
+        event
+            .latest_edit_json()
+            .expect("we should have an edit json")
+            .deserialize()
+            .unwrap()
+            .event_id(),
+        edit2_event_id
+    );
+
+    let poll = event.content().as_poll().unwrap();
+    assert!(poll.has_been_edited);
+    assert_eq!(
+        poll.start_event_content.poll_start.question.text,
+        "Can the real slim shady please stand up?"
+    );
+    assert_eq!(poll.start_event_content.poll_start.answers.len(), 3);
 
     let day_divider = assert_next_matches!(stream, VectorDiff::PushFront { value } => value);
     assert!(day_divider.is_day_divider());

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -259,7 +259,18 @@ async fn test_relations_edit_overrides_pending_edit() {
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
 
     // We receive the latest edit, not the pending one.
-    let text = item.as_event().unwrap().content().as_message().unwrap();
+    let event = item.as_event().unwrap();
+    assert_eq!(
+        event
+            .latest_edit_json()
+            .expect("we should have an edit json")
+            .deserialize()
+            .unwrap()
+            .event_id(),
+        edit2_event_id
+    );
+
+    let text = event.content().as_message().unwrap();
     assert_eq!(text.body(), "edit 2");
 
     let day_divider = assert_next_matches!(stream, VectorDiff::PushFront { value } => value);

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -15,7 +15,7 @@ use ruma::{
 };
 
 use crate::timeline::{
-    polls::PollState, tests::TestTimeline, EventTimelineItem, TimelineItemContent,
+    event_item::PollState, tests::TestTimeline, EventTimelineItem, TimelineItemContent,
 };
 
 #[async_test]

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -252,7 +252,7 @@ impl TestTimeline {
 }
 
 impl EventTimelineItem {
-    fn poll_state(self) -> PollState {
+    pub(crate) fn poll_state(self) -> PollState {
         match self.content() {
             TimelineItemContent::Poll(poll_state) => poll_state.clone(),
             _ => panic!("Not a poll state"),

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -14,9 +14,7 @@ use ruma::{
     server_name, EventId, OwnedEventId, UserId,
 };
 
-use crate::timeline::{
-    event_item::PollState, tests::TestTimeline, EventTimelineItem, TimelineItemContent,
-};
+use crate::timeline::{event_item::PollState, tests::TestTimeline, EventTimelineItem};
 
 #[async_test]
 async fn test_poll_is_displayed() {
@@ -37,7 +35,7 @@ async fn test_edited_poll_is_displayed() {
     let event = timeline.poll_event().await;
     let event_id = event.event_id().unwrap();
     timeline.send_poll_edit(&ALICE, event_id, fakes::poll_b()).await;
-    let poll_state = event.poll_state();
+    let poll_state = event.content().as_poll().unwrap();
     let edited_poll_state = timeline.poll_state().await;
 
     assert_poll_start_eq(&poll_state.start_event_content.poll_start, &fakes::poll_a());
@@ -197,7 +195,7 @@ impl TestTimeline {
     }
 
     async fn poll_state(&self) -> PollState {
-        self.event_items().await[0].clone().poll_state()
+        self.event_items().await[0].content().as_poll().unwrap().clone()
     }
 
     async fn send_poll_start(&self, sender: &UserId, content: UnstablePollStartContentBlock) {
@@ -248,15 +246,6 @@ impl TestTimeline {
             ReplacementUnstablePollStartEventContent::new(content, original_id.to_owned());
         let event_content = AnyMessageLikeEventContent::UnstablePollStart(content.into());
         self.handle_live_event(self.factory.event(event_content).sender(sender)).await
-    }
-}
-
-impl EventTimelineItem {
-    pub(crate) fn poll_state(self) -> PollState {
-        match self.content() {
-            TimelineItemContent::Poll(poll_state) => poll_state.clone(),
-            _ => panic!("Not a poll state"),
-        }
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -209,7 +209,7 @@ async fn test_initial_reaction_timestamp_is_stored() {
     let reactions = items.last().unwrap().as_event().unwrap().reactions();
     let entry = reactions.get(&REACTION_KEY.to_owned()).unwrap();
 
-    assert_eq!(reaction_timestamp, entry.values().next().unwrap().timestamp);
+    assert_eq!(entry.values().next().unwrap().timestamp, reaction_timestamp);
 }
 
 /// Returns the unique item id, the event id, and position of the message.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -107,7 +107,7 @@ async fn test_echo() {
             f.text_msg("Hello, World!")
                 .sender(user_id!("@example:localhost"))
                 .event_id(event_id!("$7at8sd:localhost"))
-                .server_ts(MilliSecondsSinceUnixEpoch(uint!(152038280)))
+                .server_ts(152038280)
                 .unsigned_transaction_id(txn_id),
         ),
     );
@@ -262,7 +262,7 @@ async fn test_dedup_by_event_id_late() {
             f.text_msg("Hello, World!")
                 .sender(user_id!("@example:localhost"))
                 .event_id(event_id)
-                .server_ts(MilliSecondsSinceUnixEpoch(uint!(123456))),
+                .server_ts(123456),
         ),
     );
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -851,7 +851,12 @@ async fn test_pending_edit() {
 
     // Then I get the edited content immediately.
     assert_let!(Some(VectorDiff::PushBack { value }) = timeline_stream.next().await);
-    let msg = value.as_event().unwrap().content().as_message().unwrap();
+
+    let event = value.as_event().unwrap();
+    let latest_edit_json = event.latest_edit_json().expect("we should have an edit json");
+    assert_eq!(latest_edit_json.deserialize().unwrap().event_id(), edit_event_id);
+
+    let msg = event.content().as_message().unwrap();
     assert!(msg.is_edited());
     assert_eq!(msg.body(), "[edit]");
 

--- a/crates/matrix-sdk/src/test_utils/events.rs
+++ b/crates/matrix-sdk/src/test_utils/events.rs
@@ -38,10 +38,26 @@ use ruma::{
     },
     serde::Raw,
     server_name, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
-    OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
+    OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UInt, UserId,
 };
 use serde::Serialize;
 use serde_json::json;
+
+pub trait TimestampArg {
+    fn to_milliseconds_since_unix_epoch(self) -> MilliSecondsSinceUnixEpoch;
+}
+
+impl TimestampArg for MilliSecondsSinceUnixEpoch {
+    fn to_milliseconds_since_unix_epoch(self) -> MilliSecondsSinceUnixEpoch {
+        self
+    }
+}
+
+impl TimestampArg for u64 {
+    fn to_milliseconds_since_unix_epoch(self) -> MilliSecondsSinceUnixEpoch {
+        MilliSecondsSinceUnixEpoch(UInt::try_from(self).unwrap())
+    }
+}
 
 #[derive(Debug, Default)]
 struct Unsigned {
@@ -80,8 +96,8 @@ where
         self
     }
 
-    pub fn server_ts(mut self, ts: MilliSecondsSinceUnixEpoch) -> Self {
-        self.server_ts = ts;
+    pub fn server_ts(mut self, ts: impl TimestampArg) -> Self {
+        self.server_ts = ts.to_milliseconds_since_unix_epoch();
         self
     }
 

--- a/crates/matrix-sdk/src/test_utils/events.rs
+++ b/crates/matrix-sdk/src/test_utils/events.rs
@@ -59,9 +59,11 @@ impl TimestampArg for u64 {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize)]
 struct Unsigned {
+    #[serde(skip_serializing_if = "Option::is_none")]
     transaction_id: Option<OwnedTransactionId>,
+    #[serde(rename = "m.relations", skip_serializing_if = "Option::is_none")]
     relations: Option<BundledMessageLikeRelations<Raw<AnySyncTimelineEvent>>>,
 }
 
@@ -156,19 +158,7 @@ where
         }
 
         if let Some(unsigned) = self.unsigned {
-            let mut unsigned_json = json!({});
-
-            // We can't plain serialize `Unsigned`, otherwise this would result in some
-            // `null` fields when options are set to none, which Ruma rejects.
-            let unsigned_obj = unsigned_json.as_object_mut().unwrap();
-            if let Some(transaction_id) = unsigned.transaction_id {
-                unsigned_obj.insert("transaction_id".to_owned(), json!(transaction_id));
-            }
-            if let Some(relations) = unsigned.relations {
-                unsigned_obj.insert("m.relations".to_owned(), json!(relations));
-            }
-
-            map.insert("unsigned".to_owned(), unsigned_json);
+            map.insert("unsigned".to_owned(), json!(unsigned));
         }
 
         if let Some(state_key) = self.state_key {


### PR DESCRIPTION
When adding a new event, we might also receive a bundled edit as part of `m.relations`; this is guaranteed to be the most up-to-date (if received from sync), so we should prefer this bundled edit over any pending edit we might have found.

Consider the following scenario:

- received pending edit $2 for event $1
- another edit $3 happens to $1
- when receiving $1, we may receive $3 as a bundled edit, but might have seen $2 before. In that case, it's preferable to use $3 rather than $2.

It's not clear it's the absolute fix, since we don't know the relative ordering of $2 and $3: if getting the event from cache, it might have bundled relations that are now outdated. I wonder if we should get rid of the bundled relations when storing them in the event cache :eyes: A question for another day.

This also fixes an issue where we'd not include the `latest_edit_json` for bundled edits of a room message. This is now included and properly tested. As such, this fixes #2848.

This contains a few extra refactorings, tests, etc. In particular, it also includes bundled relations when considering a latest event preview, and as such it might help displaying the edit rather than the original in more cases.

Part of #3905.