### PR TITLE
crypto: Rename PreviouslyVerified to VerificationViolation

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -57,6 +57,9 @@ Breaking changes:
   the CryptoStore, meaning that, once upgraded, it will not be possible to roll
   back applications to earlier versions without breaking user sessions.
 
+- Renamed `VerificationLevel::PreviouslyVerified` to
+  `VerificationLevel::VerificationViolation`.
+
 - `OlmMachine::decrypt_room_event` now takes a `DecryptionSettings` argument,
   which includes a `TrustRequirement` indicating the required trust level for
   the sending device.  When it is called with `TrustRequirement` other than

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -2200,7 +2200,7 @@ pub(crate) mod tests {
     // Set up a machine do initial own key query and import cross-signing secret to
     // make the current session verified.
     async fn common_verified_identity_changes_machine_setup() -> OlmMachine {
-        use test_json::keys_query_sets::PreviouslyVerifiedTestData as DataSet;
+        use test_json::keys_query_sets::VerificationViolationTestData as DataSet;
 
         let machine = OlmMachine::new(DataSet::own_id(), device_id!("LOCAL")).await;
 
@@ -2220,7 +2220,7 @@ pub(crate) mod tests {
     }
     #[async_test]
     async fn test_manager_verified_latch_setup_on_new_identities() {
-        use test_json::keys_query_sets::PreviouslyVerifiedTestData as DataSet;
+        use test_json::keys_query_sets::VerificationViolationTestData as DataSet;
 
         let machine = common_verified_identity_changes_machine_setup().await;
 
@@ -2276,7 +2276,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_manager_verified_identity_changes_setup_on_updated_identities() {
-        use test_json::keys_query_sets::PreviouslyVerifiedTestData as DataSet;
+        use test_json::keys_query_sets::VerificationViolationTestData as DataSet;
 
         let machine = common_verified_identity_changes_machine_setup().await;
 
@@ -2318,7 +2318,7 @@ pub(crate) mod tests {
     // The cross signing secrets are not yet uploaded.
     // Then query keys for carol and bob (both signed by own identity)
     async fn common_verified_identity_changes_own_trust_change_machine_setup() -> OlmMachine {
-        use test_json::keys_query_sets::PreviouslyVerifiedTestData as DataSet;
+        use test_json::keys_query_sets::VerificationViolationTestData as DataSet;
 
         // Start on a non-verified session
         let machine = OlmMachine::new(DataSet::own_id(), device_id!("LOCAL")).await;
@@ -2352,7 +2352,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_manager_verified_identity_changes_setup_on_own_identity_trust_change() {
-        use test_json::keys_query_sets::PreviouslyVerifiedTestData as DataSet;
+        use test_json::keys_query_sets::VerificationViolationTestData as DataSet;
         let machine = common_verified_identity_changes_own_trust_change_machine_setup().await;
 
         let own_identity =
@@ -2389,7 +2389,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_manager_verified_identity_change_setup_on_import_secrets() {
-        use test_json::keys_query_sets::PreviouslyVerifiedTestData as DataSet;
+        use test_json::keys_query_sets::VerificationViolationTestData as DataSet;
         let machine = common_verified_identity_changes_own_trust_change_machine_setup().await;
 
         let own_identity =

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -1477,7 +1477,7 @@ impl OlmMachine {
                 sender_data,
                 SenderData::UnknownDevice { .. }
                     | SenderData::DeviceInfo { .. }
-                    | SenderData::SenderUnverifiedButPreviouslyVerified { .. }
+                    | SenderData::VerificationViolation { .. }
             )
         }
 
@@ -1689,8 +1689,8 @@ impl OlmMachine {
             TrustRequirement::CrossSignedOrLegacy => match &session.sender_data {
                 // Reject if the sender was previously verified, but changed
                 // their identity and is not verified any more.
-                SenderData::SenderUnverifiedButPreviouslyVerified(..) => Err(
-                    MegolmError::SenderIdentityNotTrusted(VerificationLevel::PreviouslyVerified),
+                SenderData::VerificationViolation(..) => Err(
+                    MegolmError::SenderIdentityNotTrusted(VerificationLevel::VerificationViolation),
                 ),
                 SenderData::SenderUnverified(..) => Ok(()),
                 SenderData::SenderVerified(..) => Ok(()),
@@ -1702,8 +1702,8 @@ impl OlmMachine {
             TrustRequirement::CrossSigned => match &session.sender_data {
                 // Reject if the sender was previously verified, but changed
                 // their identity and is not verified any more.
-                SenderData::SenderUnverifiedButPreviouslyVerified(..) => Err(
-                    MegolmError::SenderIdentityNotTrusted(VerificationLevel::PreviouslyVerified),
+                SenderData::VerificationViolation(..) => Err(
+                    MegolmError::SenderIdentityNotTrusted(VerificationLevel::VerificationViolation),
                 ),
                 SenderData::SenderUnverified(..) => Ok(()),
                 SenderData::SenderVerified(..) => Ok(()),
@@ -2493,9 +2493,9 @@ fn sender_data_to_verification_state(
             VerificationState::Unverified(VerificationLevel::UnsignedDevice),
             Some(device_keys.device_id),
         ),
-        SenderData::SenderUnverifiedButPreviouslyVerified(KnownSenderData {
-            device_id, ..
-        }) => (VerificationState::Unverified(VerificationLevel::PreviouslyVerified), device_id),
+        SenderData::VerificationViolation(KnownSenderData { device_id, .. }) => {
+            (VerificationState::Unverified(VerificationLevel::VerificationViolation), device_id)
+        }
         SenderData::SenderUnverified(KnownSenderData { device_id, .. }) => {
             (VerificationState::Unverified(VerificationLevel::UnverifiedIdentity), device_id)
         }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
@@ -267,7 +267,7 @@ impl<'a> SenderDataFinder<'a> {
                 .expect("User with master key must have identity")
                 .was_previously_verified()
             {
-                SenderData::SenderUnverifiedButPreviouslyVerified(known_sender_data)
+                SenderData::VerificationViolation(known_sender_data)
             } else {
                 SenderData::SenderUnverified(known_sender_data)
             }

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -521,7 +521,7 @@ mod tests {
         async_test, test_json,
         test_json::keys_query_sets::{
             IdentityChangeDataSet, KeyDistributionTestData, MaloIdentityChangeDataSet,
-            PreviouslyVerifiedTestData,
+            VerificationViolationTestData,
         },
     };
     use ruma::{
@@ -710,7 +710,7 @@ mod tests {
     /// `error_on_verified_user_problem` is set.
     #[async_test]
     async fn test_error_on_unsigned_of_verified_users() {
-        use PreviouslyVerifiedTestData as DataSet;
+        use VerificationViolationTestData as DataSet;
 
         // We start with Bob, who is verified and has one unsigned device.
         let machine = unsigned_of_verified_setup().await;
@@ -766,7 +766,7 @@ mod tests {
     /// device.
     #[async_test]
     async fn test_error_on_unsigned_of_verified_resolve_by_whitelisting() {
-        use PreviouslyVerifiedTestData as DataSet;
+        use VerificationViolationTestData as DataSet;
 
         let machine = unsigned_of_verified_setup().await;
 
@@ -802,7 +802,7 @@ mod tests {
     /// device.
     #[async_test]
     async fn test_error_on_unsigned_of_verified_resolve_by_blacklisting() {
-        use PreviouslyVerifiedTestData as DataSet;
+        use VerificationViolationTestData as DataSet;
 
         let machine = unsigned_of_verified_setup().await;
 
@@ -846,7 +846,7 @@ mod tests {
     /// is verified and we have unsigned devices.
     #[async_test]
     async fn test_error_on_unsigned_of_verified_owner_is_us() {
-        use PreviouslyVerifiedTestData as DataSet;
+        use VerificationViolationTestData as DataSet;
 
         let machine = unsigned_of_verified_setup().await;
 
@@ -891,7 +891,7 @@ mod tests {
     /// error.
     #[async_test]
     async fn test_should_not_error_on_unsigned_of_unverified() {
-        use PreviouslyVerifiedTestData as DataSet;
+        use VerificationViolationTestData as DataSet;
 
         let machine = OlmMachine::new(DataSet::own_id(), device_id!("LOCAL")).await;
 
@@ -941,7 +941,7 @@ mod tests {
     /// error, when we have not verified our own identity.
     #[async_test]
     async fn test_should_not_error_on_unsigned_of_signed_but_unverified() {
-        use PreviouslyVerifiedTestData as DataSet;
+        use VerificationViolationTestData as DataSet;
 
         let machine = OlmMachine::new(DataSet::own_id(), device_id!("LOCAL")).await;
 
@@ -989,7 +989,7 @@ mod tests {
     /// withdrawing verification
     #[async_test]
     async fn test_verified_user_changed_identity() {
-        use test_json::keys_query_sets::PreviouslyVerifiedTestData as DataSet;
+        use test_json::keys_query_sets::VerificationViolationTestData as DataSet;
 
         // We start with Bob, who is verified and has one unsigned device. We have also
         // verified our own identity.
@@ -1039,7 +1039,7 @@ mod tests {
     /// withdrawing verification
     #[async_test]
     async fn test_own_verified_identity_changed() {
-        use test_json::keys_query_sets::PreviouslyVerifiedTestData as DataSet;
+        use test_json::keys_query_sets::VerificationViolationTestData as DataSet;
 
         // We start with a verified identity.
         let machine = unsigned_of_verified_setup().await;
@@ -1497,10 +1497,10 @@ mod tests {
     ///
     /// Returns an `OlmMachine` which is properly configured with trusted
     /// cross-signing keys. Also imports a set of keys for
-    /// Bob ([`PreviouslyVerifiedTestData::bob_id`]), where Bob is verified and
-    /// has 2 devices, one signed and the other not.
+    /// Bob ([`VerificationViolationTestData::bob_id`]), where Bob is verified
+    /// and has 2 devices, one signed and the other not.
     async fn unsigned_of_verified_setup() -> OlmMachine {
-        use test_json::keys_query_sets::PreviouslyVerifiedTestData as DataSet;
+        use test_json::keys_query_sets::VerificationViolationTestData as DataSet;
 
         let machine = OlmMachine::new(DataSet::own_id(), device_id!("LOCAL")).await;
 

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -1247,8 +1247,7 @@ macro_rules! cryptostore_integration_tests {
                         device_keys: account.device_keys().clone(),
                         legacy_session: false,
                     },
-                    SenderDataType::SenderUnverifiedButPreviouslyVerified =>
-                        panic!("SenderUnverifiedButPreviouslyVerified not supported"),
+                    SenderDataType::VerificationViolation => panic!("VerificationViolation not supported"),
                     SenderDataType::SenderUnverified=> panic!("SenderUnverified not supported"),
                     SenderDataType::SenderVerified => panic!("SenderVerified not supported"),
                 };

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Breaking changes:
 
+- Renamed `VerificationLevel::PreviouslyVerified` to `VerificationLevel::VerificationViolation`.
 - Add a `PreviouslyVerified` variant to `VerificationLevel` indicating that the identity is unverified and previously it was verified.
 - Replace the `Notification` type from Ruma in `SyncResponse` and `Client::register_notification_handler`
   by a custom one

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -653,10 +653,10 @@ impl IdentityChangeDataSet {
 /// A set of `/keys/query` responses that were initially created to simulate
 /// when a user that was verified reset his keys and became unverified.
 ///
-/// The local user (as returned by [`PreviouslyVerifiedTestData::own_id`]) is
+/// The local user (as returned by [`VerificationViolationTestData::own_id`]) is
 /// `@alice:localhost`. There are 2 other users: `@bob:localhost` (returned by
-/// [`PreviouslyVerifiedTestData::bob_id`]), and `@carol:localhost` (returned by
-/// [`PreviouslyVerifiedTestData::carol_id`]).
+/// [`VerificationViolationTestData::bob_id`]), and `@carol:localhost` (returned
+/// by [`VerificationViolationTestData::carol_id`]).
 ///
 /// We provide two `/keys/query` responses for each of Bob and Carol: one signed
 /// by Alice, and one not signed.
@@ -665,10 +665,10 @@ impl IdentityChangeDataSet {
 /// another one not cross-signed.
 ///
 /// The `/keys/query` responses were generated using a local synapse.
-pub struct PreviouslyVerifiedTestData {}
+pub struct VerificationViolationTestData {}
 
 #[allow(dead_code)]
-impl PreviouslyVerifiedTestData {
+impl VerificationViolationTestData {
     /// Secret part of Alice's master cross-signing key.
     ///
     /// Exported from Element-Web with the following console snippet:


### PR DESCRIPTION
Part of https://github.com/element-hq/element-meta/issues/2526

For consistency with other places, we have now settled on `VerificationViolation` as the best way to express this situation.

- [x] Public API changes documented in changelogs (optional)
