### PR TITLE
chore: Enable the proper feature of tower

### DIFF
--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -106,7 +106,7 @@ sha2 = { workspace = true, optional = true }
 tempfile = "3.3.0"
 thiserror = { workspace = true }
 tokio-stream = { workspace = true, features = ["sync"] }
-tower = { version = "0.4.13", features = ["make"], optional = true }
+tower = { version = "0.4.13", features = ["util"], optional = true }
 tracing = { workspace = true, features = ["attributes"] }
 uniffi = { workspace = true, optional = true }
 url = { workspace = true, features = ["serde"] }

--- a/examples/oidc_cli/Cargo.toml
+++ b/examples/oidc_cli/Cargo.toml
@@ -18,7 +18,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-tower = { version = "0.4.13", features = ["make"] }
+tower = { version = "0.4.13", features = ["util"] }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 


### PR DESCRIPTION
I noticed that when running `cargo update` on a downstream project. `axum` released a new minor version that updated their version of tower to a new major version, and that made the SDK fail to compile.

That's because axum enables the `util` feature and we don't. And we only use `service_fn`, which is behind the `util` feature, not the `make` feature.