### PR TITLE
Support for UTD error codes in `[Sync]TimelineEvent`

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -876,7 +876,10 @@ mod tests {
     };
 
     use assert_matches::assert_matches;
-    use matrix_sdk_common::{deserialized_responses::SyncTimelineEvent, ring_buffer::RingBuffer};
+    use matrix_sdk_common::{
+        deserialized_responses::{SyncTimelineEvent, UnableToDecryptInfo, UnableToDecryptReason},
+        ring_buffer::RingBuffer,
+    };
     use matrix_sdk_test::async_test;
     use ruma::{
         api::client::sync::sync_events::UnreadNotificationsCount,
@@ -2494,7 +2497,7 @@ mod tests {
     }
 
     fn make_encrypted_event(id: &str) -> SyncTimelineEvent {
-        SyncTimelineEvent::new(
+        SyncTimelineEvent::new_utd_event(
             Raw::from_json_string(
                 json!({
                     "type": "m.room.encrypted",
@@ -2512,6 +2515,10 @@ mod tests {
                 .to_string(),
             )
             .unwrap(),
+            UnableToDecryptInfo {
+                session_id: Some("".to_owned()),
+                reason: UnableToDecryptReason::MissingMegolmSession,
+            },
         )
     }
 

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -708,6 +708,14 @@ pub enum UnableToDecryptReason {
     SenderIdentityNotTrusted(VerificationLevel),
 }
 
+impl UnableToDecryptReason {
+    /// Returns true if this UTD is due to a missing room key (and hence might
+    /// resolve itself if we wait a bit.)
+    pub fn is_missing_room_key(&self) -> bool {
+        matches!(self, Self::MissingMegolmSession | Self::UnknownMegolmMessageIndex)
+    }
+}
+
 /// Deserialization helper for [`SyncTimelineEvent`], for the modern format.
 ///
 /// This has the exact same fields as [`SyncTimelineEvent`] itself, but has a

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -400,7 +400,8 @@ async fn test_read_receipts_updates_on_message_decryption() {
                 ),
                 None,
             ))
-            .sender(&BOB),
+            .sender(&BOB)
+            .into_utd_sync_timeline_event(),
         )
         .await;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
@@ -151,7 +151,8 @@ async fn test_utd_shield() {
                 ),
                 None,
             ))
-            .sender(&ALICE),
+            .sender(&ALICE)
+            .into_utd_sync_timeline_event(),
         )
         .await;
 


### PR DESCRIPTION
This PR takes the `TimelineEventKind` that was added in https://github.com/matrix-org/matrix-rust-sdk/pull/4082, and adds a third enum variant which is specific to unable-to-decrypt events. We update the two methods which are responsible for decrypting encrypted events that have been received from the network (`decrypt_sync_room_event` and `decrypt_room_event`), and make them return a `[Sync]TimelineEvent` of the relevant kind instead of a megolm error.

Since pretty much everything downstream accesses UTD events via `TimelineEventKind::raw()`, we don't have to change much else to keep things working. 

Part of #4048.