### PR TITLE
base: Do not warn when room in m.direct account data is missing

### DIFF
--- a/crates/matrix-sdk-base/src/response_processors.rs
+++ b/crates/matrix-sdk-base/src/response_processors.rs
@@ -41,7 +41,7 @@ fn map_info<F: FnOnce(&mut RoomInfo)>(
         f(&mut info);
         changes.add_room(info);
     } else {
-        warn!(room = %room_id, "couldn't find room in state changes or store");
+        debug!(room = %room_id, "couldn't find room in state changes or store");
     }
 }
 


### PR DESCRIPTION
It can occur that the data is partly outdated and contains rooms that were forgotten. Given that we now update that data after every sync, that creates a lot of noise in the logs for something that is not really a problem.

I demoted it to the DEBUG level, in case someone needs it for debugging purposes, but it would also be fine not to log anything, imo.