### PR TITLE
ui: Do not warn when no reaction to redact was found

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -906,7 +906,6 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             }
         }
 
-        warn!("Reaction to redact was missing from the reaction or user map");
         false
     }
 


### PR DESCRIPTION
The `handle_reaction_redaction` method is called by `handle_redaction` for every single redaction event that we receive as a first step to check if the redaction matches a reaction.
It means that not finding a reaction to redact is perfectly fine and is not worthy of a warning.

