### PR TITLE
ffi & sdk: add room knocking to `Client`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -972,6 +972,13 @@ impl Client {
         Ok(Arc::new(Room::new(room)))
     }
 
+    /// Knock on a room to join it using its ID or alias.
+    pub async fn knock(&self, room_id_or_alias: String) -> Result<Arc<Room>, ClientError> {
+        let room_id = RoomOrAliasId::parse(&room_id_or_alias)?;
+        let room = self.inner.knock(room_id).await?;
+        Ok(Arc::new(Room::new(room)))
+    }
+
     pub async fn get_recently_visited_rooms(&self) -> Result<Vec<String>, ClientError> {
         Ok(self
             .inner

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -50,6 +50,7 @@ pub enum Membership {
     Invited,
     Joined,
     Left,
+    Knocked,
 }
 
 impl From<RoomState> for Membership {
@@ -58,6 +59,7 @@ impl From<RoomState> for Membership {
             RoomState::Invited => Membership::Invited,
             RoomState::Joined => Membership::Joined,
             RoomState::Left => Membership::Left,
+            RoomState::Knocked => Membership::Knocked,
         }
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -189,8 +189,10 @@ pub enum RoomState {
     Joined,
     /// The room is in a left state.
     Left,
-    /// The room is in a invited state.
+    /// The room is in an invited state.
     Invited,
+    /// The room is in a knocked state.
+    Knocked,
 }
 
 impl From<&MembershipState> for RoomState {
@@ -201,7 +203,7 @@ impl From<&MembershipState> for RoomState {
             MembershipState::Ban => Self::Left,
             MembershipState::Invite => Self::Invited,
             MembershipState::Join => Self::Joined,
-            MembershipState::Knock => Self::Left,
+            MembershipState::Knock => Self::Knocked,
             MembershipState::Leave => Self::Left,
             _ => panic!("Unexpected MembershipState: {}", membership_state),
         }
@@ -436,6 +438,9 @@ impl Room {
                     },
                 }
             }
+
+            // TODO: implement logic once we have the stripped events as we'd have with an Invite
+            RoomState::Knocked => Ok(false),
         }
     }
 
@@ -1150,6 +1155,11 @@ impl RoomInfo {
         self.room_state = RoomState::Invited;
     }
 
+    /// Mark this Room as knocked.
+    pub fn mark_as_knocked(&mut self) {
+        self.room_state = RoomState::Knocked;
+    }
+
     /// Set the membership RoomState of this Room
     pub fn set_state(&mut self, room_state: RoomState) {
         self.room_state = room_state;
@@ -1685,6 +1695,8 @@ bitflags! {
         const INVITED  = 0b00000010;
         /// The room is in a left state.
         const LEFT     = 0b00000100;
+        /// The room is in a knocked state.
+        const KNOCKED  = 0b00001000;
     }
 }
 
@@ -1699,6 +1711,7 @@ impl RoomStateFilter {
             RoomState::Joined => Self::JOINED,
             RoomState::Left => Self::LEFT,
             RoomState::Invited => Self::INVITED,
+            RoomState::Knocked => Self::KNOCKED,
         };
 
         self.contains(bit_state)

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -260,7 +260,7 @@ impl BaseClient {
                         .or_insert_with(LeftRoomUpdate::default)
                         .account_data
                         .append(&mut raw.to_vec()),
-                    RoomState::Invited => {}
+                    RoomState::Invited | RoomState::Knocked => {}
                 }
             }
         }
@@ -528,6 +528,9 @@ impl BaseClient {
             )),
 
             RoomState::Invited => Ok((room_info, None, None, invited_room)),
+
+            // TODO: implement special logic for retrieving the knocked room info
+            RoomState::Knocked => Ok((room_info, None, None, None)),
         }
     }
 


### PR DESCRIPTION
## Changes

- Add `Client::knock` to both the binding and the SDK.
- Add `Client::room_knocked` to mark a room as knocked. I more or less copied the implementation from `room_joined`, so I'm not sure if some of the internal operations are not needed.
- Added `RoomState::Knocked` and `RoomStateFilter::KNOCKED` enum cases.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
