### PR TITLE
Media: Add support for media captions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff6858c1f7e2a470c5403091866fa95b36fe0dbac5d771f932c15e5ff1ee501"
+checksum = "2e15626aaf9c351bc696217cbe29cb9b5e86c43f8a46b5e2f5c6c5cf7cb904ce"
 dependencies = [
  "log",
  "mac",
@@ -2950,9 +2950,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d581ff8be69d08a2efa23a959d81aa22b739073f749f067348bd4f4ba4b69195"
+checksum = "82c88c6129bd24319e62a0359cb6b958fa7e8be6e19bb1663bc396b90883aca5"
 dependencies = [
  "log",
  "phf",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
 dependencies = [
  "assign",
  "js_int",
@@ -4982,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.18.0"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
 dependencies = [
  "as_variant",
  "assign",
@@ -5005,7 +5005,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -5037,7 +5037,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.28.1"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
 dependencies = [
  "as_variant",
  "indexmap 2.6.0",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
 dependencies = [
  "http",
  "js_int",
@@ -5076,7 +5076,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.2.0"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.5"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
 dependencies = [
  "js_int",
  "thiserror",
@@ -5097,7 +5097,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5113,7 +5113,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=1ae98db9c44f46a590f4c76baf5cef70ebb6970d#1ae98db9c44f46a590f4c76baf5cef70ebb6970d"
+source = "git+https://github.com/ruma/ruma?rev=b1c9a32f26f7aa76e20f96dbbb113250ed979112#b1c9a32f26f7aa76e20f96dbbb113250ed979112"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ once_cell = "1.16.0"
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "1ae98db9c44f46a590f4c76baf5cef70ebb6970d", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "b1c9a32f26f7aa76e20f96dbbb113250ed979112", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -61,7 +61,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "1ae98db9c44f46a590f4c76baf
     "unstable-msc4075",
     "unstable-msc4140",
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "1ae98db9c44f46a590f4c76baf5cef70ebb6970d" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "b1c9a32f26f7aa76e20f96dbbb113250ed979112" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"
@@ -123,7 +123,7 @@ opt-level = 3
 async-compat = { git = "https://github.com/jplatte/async-compat", rev = "16dc8597ec09a6102d58d4e7b67714a35dd0ecb8" }
 const_panic = { git = "https://github.com/jplatte/const_panic", rev = "9024a4cb3eac45c1d2d980f17aaee287b17be498" }
 # Needed to fix rotation log issue on Android (https://github.com/tokio-rs/tracing/issues/2937)
-tracing = { git = "https://github.com/element-hq/tracing.git", rev = "ca9431f74d37c9d3b5e6a9f35b2c706711dab7dd"}
+tracing = { git = "https://github.com/element-hq/tracing.git", rev = "ca9431f74d37c9d3b5e6a9f35b2c706711dab7dd" }
 tracing-core = { git = "https://github.com/element-hq/tracing.git", rev = "ca9431f74d37c9d3b5e6a9f35b2c706711dab7dd" }
 tracing-subscriber = { git = "https://github.com/element-hq/tracing.git", rev = "ca9431f74d37c9d3b5e6a9f35b2c706711dab7dd" }
 tracing-appender = { git = "https://github.com/element-hq/tracing.git", rev = "ca9431f74d37c9d3b5e6a9f35b2c706711dab7dd" }

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -716,7 +716,7 @@ pub struct RequiredState {
 #[derive(uniffi::Record)]
 pub struct RoomSubscription {
     pub required_state: Option<Vec<RequiredState>>,
-    pub timeline_limit: Option<u32>,
+    pub timeline_limit: u32,
     pub include_heroes: Option<bool>,
 }
 
@@ -726,7 +726,7 @@ impl From<RoomSubscription> for http::request::RoomSubscription {
             required_state: val.required_state.map(|r|
                 r.into_iter().map(|s| (s.key.into(), s.value)).collect()
             ).unwrap_or_default(),
-            timeline_limit: val.timeline_limit.map(|u| u.into()),
+            timeline_limit: val.timeline_limit.into(),
             include_heroes: val.include_heroes,
         })
     }

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -425,7 +425,7 @@ impl NotificationClient {
             &[room_id],
             Some(assign!(http::request::RoomSubscription::default(), {
                 required_state,
-                timeline_limit: Some(uint!(16))
+                timeline_limit: uint!(16)
             })),
             true,
         );

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -376,6 +376,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 99]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -400,6 +401,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 199]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -424,6 +426,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 299]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -448,6 +451,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 399]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -483,6 +487,7 @@ async fn test_sync_resumes_from_previous_state() -> Result<(), Error> {
                 "lists": {
                     ALL_ROOMS: {
                         "ranges": [[0, 19]],
+                        "timeline_limit": 1,
                     },
                 },
             },
@@ -510,6 +515,7 @@ async fn test_sync_resumes_from_previous_state() -> Result<(), Error> {
                 "lists": {
                     ALL_ROOMS: {
                         "ranges": [[0, 9]],
+                        "timeline_limit": 0,
                     },
                 },
             },
@@ -537,6 +543,7 @@ async fn test_sync_resumes_from_previous_state() -> Result<(), Error> {
                 "lists": {
                     ALL_ROOMS: {
                         "ranges": [[0, 9]],
+                        "timeline_limit": 0,
                     },
                 },
             },
@@ -571,6 +578,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The default range, in selective sync-mode.
                     "ranges": [[0, 19]],
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -595,6 +603,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Still the default range, in selective sync-mode.
                     "ranges": [[0, 19]],
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -618,6 +627,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The sync-mode has changed to growing, with its initial range.
                     "ranges": [[0, 99]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -642,6 +652,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Due to previous error, the sync-mode is back to selective, with its initial range.
                     "ranges": [[0, 19]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -664,6 +675,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Sync-mode is now growing.
                     "ranges": [[0, 99]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -687,6 +699,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The sync-mode is still growing, and the range has made progress.
                     "ranges": [[0, 199]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -711,6 +724,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Due to previous error, the sync-mode is back to selective, with its initial range.
                     "ranges": [[0, 19]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -733,6 +747,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The sync-mode is now growing.
                     "ranges": [[0, 99]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -755,6 +770,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // No error. The range is making progress.
                     "ranges": [[0, 199]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -779,6 +795,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                     // Range is making progress and is even reaching the maximum
                     // number of rooms.
                     "ranges": [[0, 209]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -803,6 +820,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Due to previous error, the sync-mode is back to selective, with its initial range.
                     "ranges": [[0, 19]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -825,6 +843,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Sync-mode is now growing.
                     "ranges": [[0, 99]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -863,6 +882,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The default range, in selective sync-mode.
                     "ranges": [[0, 19]],
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -893,6 +913,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The sync-mode is still selective, with its initial range.
                     "ranges": [[0, 19]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -916,6 +937,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The sync-mode is now growing, with its initial range.
                     "ranges": [[0, 99]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -947,6 +969,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The sync-mode is back to selective.
                     "ranges": [[0, 19]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -970,6 +993,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Sync-mode is growing, with its initial range.
                     "ranges": [[0, 99]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -993,6 +1017,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Range is making progress, and has reached its maximum.
                     "ranges": [[0, 149]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -1033,6 +1058,7 @@ async fn test_loading_states() -> Result<(), Error> {
                 "lists": {
                     ALL_ROOMS: {
                         "ranges": [[0, 19]],
+                        "timeline_limit": 1,
                     },
                 },
             },
@@ -1063,6 +1089,7 @@ async fn test_loading_states() -> Result<(), Error> {
                 "lists": {
                     ALL_ROOMS: {
                         "ranges": [[0, 9]],
+                        "timeline_limit": 0,
                     },
                 },
             },
@@ -1093,6 +1120,7 @@ async fn test_loading_states() -> Result<(), Error> {
                 "lists": {
                     ALL_ROOMS: {
                         "ranges": [[0, 11]],
+                        "timeline_limit": 0,
                     },
                 },
             },
@@ -1140,6 +1168,7 @@ async fn test_loading_states() -> Result<(), Error> {
                 "lists": {
                     ALL_ROOMS: {
                         "ranges": [[0, 19]],
+                        "timeline_limit": 1,
                     },
                 },
             },
@@ -1186,6 +1215,7 @@ async fn test_entries_stream() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 19]],
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -1229,6 +1259,7 @@ async fn test_entries_stream() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 9]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -1277,6 +1308,7 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 19]],
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -1331,6 +1363,7 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 9]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -1440,6 +1473,7 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 9]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -1606,6 +1640,7 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 9]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -1676,6 +1711,7 @@ async fn test_room_sorting() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 19]],
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -1774,6 +1810,7 @@ async fn test_room_sorting() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 4]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -1859,6 +1896,7 @@ async fn test_room_sorting() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 4]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -1933,6 +1971,7 @@ async fn test_room_sorting() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 5]],
+                    "timeline_limit": 0,
                 },
             },
         },
@@ -2106,6 +2145,7 @@ async fn test_room_subscription() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 19]],
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -2141,7 +2181,7 @@ async fn test_room_subscription() -> Result<(), Error> {
                 (StateEventType::RoomAvatar, "".to_owned()),
                 (StateEventType::RoomCanonicalAlias, "".to_owned()),
             ],
-            timeline_limit: Some(uint!(30)),
+            timeline_limit: uint!(30),
         })),
     );
 
@@ -2151,6 +2191,7 @@ async fn test_room_subscription() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 2]],
+                    "timeline_limit": 0,
                 },
             },
             "room_subscriptions": {
@@ -2184,7 +2225,7 @@ async fn test_room_subscription() -> Result<(), Error> {
                 (StateEventType::RoomAvatar, "".to_owned()),
                 (StateEventType::RoomCanonicalAlias, "".to_owned()),
             ],
-            timeline_limit: Some(uint!(30)),
+            timeline_limit: uint!(30),
         })),
     );
 
@@ -2194,6 +2235,7 @@ async fn test_room_subscription() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 2]],
+                    "timeline_limit": 0,
                 },
             },
             "room_subscriptions": {
@@ -2227,7 +2269,7 @@ async fn test_room_subscription() -> Result<(), Error> {
                 (StateEventType::RoomAvatar, "".to_owned()),
                 (StateEventType::RoomCanonicalAlias, "".to_owned()),
             ],
-            timeline_limit: Some(uint!(30)),
+            timeline_limit: uint!(30),
         })),
     );
 
@@ -2240,6 +2282,7 @@ async fn test_room_subscription() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 2]],
+                    "timeline_limit": 0,
                 },
             },
             // NO `room_subscriptions`!
@@ -2274,6 +2317,7 @@ async fn test_room_unread_notifications() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 19]],
+                    "timeline_limit": 1,
                 },
             },
         },
@@ -2305,6 +2349,7 @@ async fn test_room_unread_notifications() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "ranges": [[0, 0]],
+                    "timeline_limit": 0,
                 },
             },
         },

--- a/crates/matrix-sdk/src/sliding_sync/list/sticky.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/sticky.rs
@@ -50,7 +50,7 @@ impl StickyData for SlidingSyncListStickyParameters {
 
     fn apply(&self, request: &mut Self::Request) {
         request.room_details.required_state = self.required_state.to_vec();
-        request.room_details.timeline_limit = Some(self.timeline_limit.into());
+        request.room_details.timeline_limit = self.timeline_limit.into();
         request.include_heroes = self.include_heroes;
         request.filters = self.filters.clone();
     }

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -411,7 +411,7 @@ impl App {
             .and_then(|room_id| self.ui_rooms.lock().unwrap().get(&room_id).cloned())
         {
             let mut sub = RoomSubscription::default();
-            sub.timeline_limit = Some(uint!(30));
+            sub.timeline_limit = uint!(30);
 
             self.sync_service.room_list_service().subscribe_to_rooms(&[room.room_id()], Some(sub));
             self.current_room_subscription = Some(room);


### PR DESCRIPTION
This PR makes 2 changes:

- Update Ruma to include https://github.com/ruma/ruma/pull/1919 and https://github.com/ruma/ruma/pull/1921 so that computed filenames/captions are available for audio, file, image and video messages.
- Update the FFI mappings to include captions and use the computed filename.