### PR TITLE
timeline: factor out inner part of `[Sync]TimelineEvent`

### DIFF
--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -561,9 +561,12 @@ mod tests {
             json!({
                 "latest_event": {
                     "event": {
-                        "encryption_info": null,
-                        "event": {
-                            "event_id": "$1"
+                        "kind": {
+                            "PlainText": {
+                                "event": {
+                                    "event_id": "$1"
+                                }
+                            }
                         }
                     },
                 }
@@ -577,6 +580,23 @@ mod tests {
         assert!(deserialized.latest_event.sender_name_is_ambiguous.is_none());
 
         // The previous format can also be deserialized.
+        let serialized = json!({
+                "latest_event": {
+                    "event": {
+                        "encryption_info": null,
+                        "event": {
+                            "event_id": "$1"
+                        }
+                    },
+                }
+        });
+
+        let deserialized: TestStruct = serde_json::from_value(serialized).unwrap();
+        assert_eq!(deserialized.latest_event.event().event_id().unwrap(), "$1");
+        assert!(deserialized.latest_event.sender_profile.is_none());
+        assert!(deserialized.latest_event.sender_name_is_ambiguous.is_none());
+
+        // The even older format can also be deserialized.
         let serialized = json!({
             "latest_event": event
         });

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -203,7 +203,7 @@ impl RoomReadReceipts {
     /// Returns whether a new event triggered a new unread/notification/mention.
     #[inline(always)]
     fn process_event(&mut self, event: &SyncTimelineEvent, user_id: &UserId) {
-        if marks_as_unread(&event.event, user_id) {
+        if marks_as_unread(event.raw(), user_id) {
             self.num_unread += 1;
         }
 
@@ -408,7 +408,7 @@ impl ReceiptSelector {
     fn try_match_implicit(&mut self, user_id: &UserId, new_events: &[SyncTimelineEvent]) {
         for ev in new_events {
             // Get the `sender` field, if any, or skip this event.
-            let Ok(Some(sender)) = ev.event.get_field::<OwnedUserId>("sender") else { continue };
+            let Ok(Some(sender)) = ev.raw().get_field::<OwnedUserId>("sender") else { continue };
             if sender == user_id {
                 // Get the event id, if any, or skip this event.
                 let Some(event_id) = ev.event_id() else { continue };

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1880,10 +1880,7 @@ mod tests {
             "encryption_state_synced": true,
             "latest_event": {
                 "event": {
-                    "encryption_info": null,
-                    "event": {
-                        "sender": "@u:i.uk",
-                    },
+                    "kind": {"PlainText": {"event": {"sender": "@u:i.uk"}}},
                 },
             },
             "base_info": {

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1261,9 +1261,9 @@ impl RoomInfo {
         if let Some(latest_event) = &mut self.latest_event {
             tracing::trace!("Checking if redaction applies to latest event");
             if latest_event.event_id().as_deref() == Some(redacts) {
-                match apply_redaction(&latest_event.event().event, _raw, room_version) {
+                match apply_redaction(latest_event.event().raw(), _raw, room_version) {
                     Some(redacted) => {
-                        latest_event.event_mut().event = redacted;
+                        latest_event.event_mut().set_raw(redacted);
                         debug!("Redacted latest event");
                     }
                     None => {

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -677,7 +677,7 @@ async fn cache_latest_events(
         Vec::with_capacity(room.latest_encrypted_events.read().unwrap().capacity());
 
     for event in events.iter().rev() {
-        if let Ok(timeline_event) = event.event.deserialize() {
+        if let Ok(timeline_event) = event.raw().deserialize() {
             match is_suitable_for_latest_event(&timeline_event) {
                 PossibleLatestEvent::YesRoomMessage(_)
                 | PossibleLatestEvent::YesPoll(_)
@@ -757,7 +757,7 @@ async fn cache_latest_events(
                     // Check how many encrypted events we have seen. Only store another if we
                     // haven't already stored the maximum number.
                     if encrypted_events.len() < encrypted_events.capacity() {
-                        encrypted_events.push(event.event.clone());
+                        encrypted_events.push(event.raw().clone());
                     }
                 }
                 _ => {
@@ -1683,7 +1683,7 @@ mod tests {
 
         // But it's now redacted
         assert_matches!(
-            latest_event.event().event.deserialize().unwrap(),
+            latest_event.event().raw().deserialize().unwrap(),
             AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
                 SyncRoomMessageEvent::Redacted(_)
             ))

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -297,8 +297,11 @@ pub struct EncryptionInfo {
     pub verification_state: VerificationState,
 }
 
-/// A customized version of a room event coming from a sync that holds optional
-/// encryption info.
+/// Represents a matrix room event that has been returned from `/sync`,
+/// after initial processing.
+///
+/// This is almost identical to [`TimelineEvent`], but wraps an
+/// [`AnySyncTimelineEvent`] instead of [`AnyTimelineEvent`].
 #[derive(Clone, Deserialize, Serialize)]
 pub struct SyncTimelineEvent {
     /// The actual event.
@@ -388,6 +391,16 @@ impl From<DecryptedRoomEvent> for SyncTimelineEvent {
     }
 }
 
+/// Represents a matrix room event that has been returned from a Matrix
+/// client-server API endpoint such as `/messages`, after initial processing.
+///
+/// The "initial processing" includes an attempt to decrypt encrypted events, so
+/// the main thing this adds over [`AnyTimelineEvent`] is information on
+/// encryption.
+///
+/// See also [`SyncTimelineEvent`] which is almost identical, but is used for
+/// results from the `/sync` endpoint (which lack a `room_id` property) and
+/// hence wraps an [`AnySyncTimelineEvent`] instead of [`AnyTimelineEvent`].
 #[derive(Clone)]
 pub struct TimelineEvent {
     /// The actual event.

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -474,8 +474,9 @@ impl TimelineEvent {
 
     /// Returns a reference to the (potentially decrypted) Matrix event inside
     /// this `TimelineEvent`.
-    pub fn raw(&self) -> &Raw<AnyTimelineEvent> {
-        &self.inner_event
+    pub fn raw(&self) -> &Raw<AnySyncTimelineEvent> {
+        // TODO: make `inner_event` an AnySyncTimelineEvent instead.
+        self.inner_event.cast_ref()
     }
 
     /// If the event was a decrypted event that was successfully decrypted, get

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -487,8 +487,9 @@ impl TimelineEvent {
 
     /// Takes ownership of this `TimelineEvent`, returning the (potentially
     /// decrypted) Matrix event within.
-    pub fn into_raw(self) -> Raw<AnyTimelineEvent> {
-        self.inner_event
+    pub fn into_raw(self) -> Raw<AnySyncTimelineEvent> {
+        // TODO: make `inner_event` an AnySyncTimelineEvent instead.
+        self.inner_event.cast()
     }
 }
 

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -303,7 +303,7 @@ pub struct EncryptionInfo {
 /// Previously, this differed from [`TimelineEvent`] by wrapping an
 /// [`AnySyncTimelineEvent`] instead of an [`AnyTimelineEvent`], but nowadays
 /// they are essentially identical, and one of them should probably be removed.
-#[derive(Clone, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct SyncTimelineEvent {
     /// The event itself, together with any information on decryption.
     pub kind: TimelineEventKind,
@@ -361,19 +361,6 @@ impl SyncTimelineEvent {
     /// Replace the Matrix event within this event. Used to handle redaction.
     pub fn set_raw(&mut self, event: Raw<AnySyncTimelineEvent>) {
         self.kind = TimelineEventKind::PlainText { event };
-    }
-}
-
-#[cfg(not(tarpaulin_include))]
-impl fmt::Debug for SyncTimelineEvent {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let SyncTimelineEvent { kind, push_actions } = self;
-        let mut s = f.debug_struct("SyncTimelineEvent");
-        s.field("kind", &kind);
-        if !push_actions.is_empty() {
-            s.field("push_actions", push_actions);
-        }
-        s.finish()
     }
 }
 
@@ -448,7 +435,7 @@ impl<'de> Deserialize<'de> for SyncTimelineEvent {
 /// Previously, this differed from [`SyncTimelineEvent`] by wrapping an
 /// [`AnyTimelineEvent`] instead of an [`AnySyncTimelineEvent`], but nowadays
 /// they are essentially identical, and one of them should probably be removed.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TimelineEvent {
     /// The event itself, together with any information on decryption.
     pub kind: TimelineEventKind,
@@ -496,21 +483,6 @@ impl TimelineEvent {
 impl From<DecryptedRoomEvent> for TimelineEvent {
     fn from(decrypted: DecryptedRoomEvent) -> Self {
         Self { kind: TimelineEventKind::Decrypted(decrypted), push_actions: None }
-    }
-}
-
-#[cfg(not(tarpaulin_include))]
-impl fmt::Debug for TimelineEvent {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let TimelineEvent { kind, push_actions } = self;
-        let mut s = f.debug_struct("TimelineEvent");
-        s.field("kind", &kind);
-        if let Some(push_actions) = &push_actions {
-            if !push_actions.is_empty() {
-                s.field("push_actions", push_actions);
-            }
-        }
-        s.finish()
     }
 }
 

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -357,11 +357,6 @@ impl SyncTimelineEvent {
     pub fn into_raw(self) -> Raw<AnySyncTimelineEvent> {
         self.kind.into_raw()
     }
-
-    /// Replace the Matrix event within this event. Used to handle redaction.
-    pub fn set_raw(&mut self, event: Raw<AnySyncTimelineEvent>) {
-        self.kind = TimelineEventKind::PlainText { event };
-    }
 }
 
 impl From<Raw<AnySyncTimelineEvent>> for SyncTimelineEvent {

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -552,9 +552,7 @@ impl NotificationClient {
         let mut timeline_event = response.event.ok_or(Error::ContextMissingEvent)?;
         let state_events = response.state;
 
-        if let Some(decrypted_event) =
-            self.retry_decryption(&room, timeline_event.raw().cast_ref()).await?
-        {
+        if let Some(decrypted_event) = self.retry_decryption(&room, timeline_event.raw()).await? {
             timeline_event = decrypted_event;
         }
 

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -500,7 +500,7 @@ impl NotificationClient {
                     self.retry_decryption(&room, timeline_event).await?
                 {
                     let push_actions = timeline_event.push_actions.take();
-                    raw_event = RawNotificationEvent::Timeline(timeline_event.into_raw().cast());
+                    raw_event = RawNotificationEvent::Timeline(timeline_event.into_raw());
                     push_actions
                 } else {
                     room.event_push_actions(timeline_event).await?
@@ -566,7 +566,7 @@ impl NotificationClient {
         Ok(Some(
             NotificationItem::new(
                 &room,
-                RawNotificationEvent::Timeline(timeline_event.into_raw().cast()),
+                RawNotificationEvent::Timeline(timeline_event.into_raw()),
                 push_actions.as_deref(),
                 state_events,
             )

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -421,7 +421,7 @@ impl TimelineStateTransaction<'_> {
         settings: &TimelineSettings,
         day_divider_adjuster: &mut DayDividerAdjuster,
     ) -> HandleEventResult {
-        let raw = event.event;
+        let raw = event.raw();
         let (event_id, sender, timestamp, txn_id, event_kind, should_add) = match raw.deserialize()
         {
             Ok(event) => {
@@ -580,8 +580,8 @@ impl TimelineStateTransaction<'_> {
             is_highlighted: event.push_actions.iter().any(Action::is_highlight),
             flow: Flow::Remote {
                 event_id: event_id.clone(),
-                raw_event: raw,
-                encryption_info: event.encryption_info,
+                raw_event: raw.clone(),
+                encryption_info: event.encryption_info().cloned(),
                 txn_id,
                 position,
             },

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -234,7 +234,7 @@ impl TimelineState {
             };
 
             event.push_actions = push_rules_context.as_ref().map(|(push_rules, push_context)| {
-                push_rules.get_actions(&event.event, push_context).to_owned()
+                push_rules.get_actions(event.raw(), push_context).to_owned()
             });
 
             let handle_one_res = txn

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -351,7 +351,7 @@ impl RepliedToEvent {
         timeline_event: TimelineEvent,
         room_data_provider: &P,
     ) -> Result<Self, TimelineError> {
-        let event = match timeline_event.event.deserialize() {
+        let event = match timeline_event.raw().deserialize() {
             Ok(AnyTimelineEvent::MessageLike(event)) => event,
             _ => {
                 return Err(TimelineError::UnsupportedEvent);

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -31,7 +31,7 @@ use ruma::{
             SyncRoomMessageEvent,
         },
         AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
-        AnyTimelineEvent, BundledMessageLikeRelations, Mentions,
+        BundledMessageLikeRelations, Mentions,
     },
     html::RemoveReplyFallback,
     serde::Raw,
@@ -352,7 +352,7 @@ impl RepliedToEvent {
         room_data_provider: &P,
     ) -> Result<Self, TimelineError> {
         let event = match timeline_event.raw().deserialize() {
-            Ok(AnyTimelineEvent::MessageLike(event)) => event,
+            Ok(AnySyncTimelineEvent::MessageLike(event)) => event,
             _ => {
                 return Err(TimelineError::UnsupportedEvent);
             }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -25,7 +25,7 @@ use matrix_sdk::{
     Client, Error,
 };
 use matrix_sdk_base::{
-    deserialized_responses::{ShieldStateCode, SyncTimelineEvent, SENT_IN_CLEAR},
+    deserialized_responses::{ShieldStateCode, SENT_IN_CLEAR},
     latest_event::LatestEvent,
 };
 use once_cell::sync::Lazy;
@@ -161,8 +161,8 @@ impl EventTimelineItem {
         // potential footgun which could one day turn into a security issue.
         use super::traits::RoomDataProvider;
 
-        let SyncTimelineEvent { event: raw_sync_event, encryption_info, .. } =
-            latest_event.event().clone();
+        let raw_sync_event = latest_event.event().raw().clone();
+        let encryption_info = latest_event.event().encryption_info().cloned();
 
         let Ok(event) = raw_sync_event.deserialize_as::<AnySyncTimelineEvent>() else {
             warn!("Unable to deserialize latest_event as an AnySyncTimelineEvent!");

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -413,11 +413,7 @@ impl Timeline {
             UnsupportedReplyItem::MissingEvent
         })?;
 
-        // We need to get the content and we can do that by casting the event as a
-        // `AnySyncTimelineEvent` which is the same as a `AnyTimelineEvent`, but without
-        // the `room_id` field. The cast is valid because we are just losing
-        // track of such field.
-        let raw_sync_event: Raw<AnySyncTimelineEvent> = event.into_raw().cast();
+        let raw_sync_event = event.into_raw();
         let sync_event = raw_sync_event.deserialize().map_err(|error| {
             error!("Failed to deserialize event with ID {event_id} with error: {error}");
             UnsupportedReplyItem::FailedToDeserializeEvent

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -417,7 +417,7 @@ impl Timeline {
         // `AnySyncTimelineEvent` which is the same as a `AnyTimelineEvent`, but without
         // the `room_id` field. The cast is valid because we are just losing
         // track of such field.
-        let raw_sync_event: Raw<AnySyncTimelineEvent> = event.event.cast();
+        let raw_sync_event: Raw<AnySyncTimelineEvent> = event.into_raw().cast();
         let sync_event = raw_sync_event.deserialize().map_err(|error| {
             error!("Failed to deserialize event with ID {event_id} with error: {error}");
             UnsupportedReplyItem::FailedToDeserializeEvent

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -109,7 +109,7 @@ impl PinnedEventsLoader {
 
         // Sort using chronological ordering (oldest -> newest)
         loaded_events.sort_by_key(|item| {
-            item.event
+            item.raw()
                 .deserialize()
                 .map(|e| e.origin_server_ts())
                 .unwrap_or_else(|_| MilliSecondsSinceUnixEpoch::now())

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -71,9 +71,9 @@ async fn mock_context(
         .and(path(format!("/_matrix/client/r0/rooms/{room_id}/context/{event_id}")))
         .and(header("authorization", "Bearer 1234"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "events_before": events_before.into_iter().rev().map(|ev| ev.event).collect_vec(),
-            "event": event.event,
-            "events_after": events_after.into_iter().map(|ev| ev.event).collect_vec(),
+            "events_before": events_before.into_iter().rev().map(|ev| ev.into_raw()).collect_vec(),
+            "event": event.into_raw(),
+            "events_after": events_after.into_iter().map(|ev| ev.into_raw()).collect_vec(),
             "state": state,
             "start": prev_batch_token,
             "end": next_batch_token
@@ -93,7 +93,7 @@ async fn mock_event(
     Mock::given(method("GET"))
         .and(path(format!("/_matrix/client/r0/rooms/{room_id}/event/{event_id}")))
         .and(header("authorization", "Bearer 1234"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(event.event.json()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(event.into_raw().json()))
         .mount(server)
         .await;
 }
@@ -116,7 +116,7 @@ async fn mock_messages(
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "start": start,
             "end": end,
-            "chunk": chunk.into_iter().map(|ev| ev.event).collect_vec(),
+            "chunk": chunk.into_iter().map(|ev| ev.into_raw()).collect_vec(),
             "state": state,
         })))
         .expect(1)

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -731,7 +731,7 @@ impl TestHelper {
 
             if add_to_timeline {
                 joined_room_builder =
-                    joined_room_builder.add_timeline_event(timeline_event.into_raw().cast());
+                    joined_room_builder.add_timeline_event(timeline_event.into_raw());
             }
         }
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -720,7 +720,7 @@ impl TestHelper {
     ) -> Result<SyncResponse, matrix_sdk::Error> {
         let mut joined_room_builder = JoinedRoomBuilder::new(&self.room_id);
         for (timeline_event, add_to_timeline) in text_messages {
-            let deserialized_event = timeline_event.event.deserialize()?;
+            let deserialized_event = timeline_event.raw().deserialize()?;
             mock_event(
                 &self.server,
                 &self.room_id,
@@ -731,7 +731,7 @@ impl TestHelper {
 
             if add_to_timeline {
                 joined_room_builder =
-                    joined_room_builder.add_timeline_event(timeline_event.event.cast());
+                    joined_room_builder.add_timeline_event(timeline_event.into_raw().cast());
             }
         }
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2110,7 +2110,7 @@ impl Client {
     /// while let Some(Ok(response)) = sync_stream.next().await {
     ///     for room in response.rooms.join.values() {
     ///         for e in &room.timeline.events {
-    ///             if let Ok(event) = e.event.deserialize() {
+    ///             if let Ok(event) = e.raw().deserialize() {
     ///                 println!("Received event {:?}", event);
     ///             }
     ///         }

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -820,7 +820,7 @@ impl RoomEventCacheInner {
         event: &SyncTimelineEvent,
     ) {
         // Handle and cache events and relations.
-        if let Ok(AnySyncTimelineEvent::MessageLike(ev)) = event.event.deserialize() {
+        if let Ok(AnySyncTimelineEvent::MessageLike(ev)) = event.raw().deserialize() {
             // Handle redactions separately, as their logic is slightly different.
             if let AnySyncMessageLikeEvent::RoomRedaction(SyncRoomRedactionEvent::Original(ev)) =
                 &ev

--- a/crates/matrix-sdk/src/event_cache/paginator.rs
+++ b/crates/matrix-sdk/src/event_cache/paginator.rs
@@ -736,7 +736,7 @@ mod tests {
         }
 
         assert_event_matches_msg(&context.events[10], "fetch_from");
-        assert_eq!(context.events[10].event.deserialize().unwrap().event_id(), event_id);
+        assert_eq!(context.events[10].raw().deserialize().unwrap().event_id(), event_id);
 
         for i in 0..10 {
             assert_event_matches_msg(&context.events[i + 11], &format!("after-{i}"));
@@ -800,7 +800,7 @@ mod tests {
         // And I get the events I expected.
         assert_eq!(context.events.len(), 1);
         assert_event_matches_msg(&context.events[0], "initial");
-        assert_eq!(context.events[0].event.deserialize().unwrap().event_id(), event_id);
+        assert_eq!(context.events[0].raw().deserialize().unwrap().event_id(), event_id);
 
         // There's a previous batch, but no next batch.
         assert!(context.has_prev);
@@ -865,7 +865,7 @@ mod tests {
         // And I get the events I expected.
         assert_eq!(context.events.len(), 1);
         assert_event_matches_msg(&context.events[0], "initial");
-        assert_eq!(context.events[0].event.deserialize().unwrap().event_id(), event_id);
+        assert_eq!(context.events[0].raw().deserialize().unwrap().event_id(), event_id);
 
         // There's a previous batch.
         assert!(context.has_prev);
@@ -915,7 +915,7 @@ mod tests {
         // And I get the events I expected.
         assert_eq!(context.events.len(), 1);
         assert_event_matches_msg(&context.events[0], "initial");
-        assert_eq!(context.events[0].event.deserialize().unwrap().event_id(), event_id);
+        assert_eq!(context.events[0].raw().deserialize().unwrap().event_id(), event_id);
 
         // There's a next batch, but no previous batch (i.e. we've hit the start of the
         // timeline).

--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -388,7 +388,7 @@ impl Client {
 
         for item in timeline_events {
             let TimelineEventDetails { event_type, state_key, unsigned } =
-                item.event.deserialize_as()?;
+                item.raw().deserialize_as()?;
 
             let redacted = unsigned.and_then(|u| u.redacted_because).is_some();
             let (handler_kind_g, handler_kind_r) = match state_key {
@@ -396,8 +396,8 @@ impl Client {
                 None => (HandlerKind::MessageLike, HandlerKind::message_like_redacted(redacted)),
             };
 
-            let raw_event = item.event.json();
-            let encryption_info = item.encryption_info.as_ref();
+            let raw_event = item.raw().json();
+            let encryption_info = item.encryption_info();
             let push_actions = &item.push_actions;
 
             // Event handlers for possibly-redacted timeline events

--- a/crates/matrix-sdk/src/room/edit.rs
+++ b/crates/matrix-sdk/src/room/edit.rs
@@ -142,7 +142,7 @@ async fn make_edit_event<S: EventSource>(
 ) -> Result<AnyMessageLikeEventContent, EditError> {
     let target = source.get_event(event_id).await?;
 
-    let event = target.event.deserialize().map_err(EditError::Deserialize)?;
+    let event = target.raw().deserialize().map_err(EditError::Deserialize)?;
 
     // The event must be message-like.
     let AnySyncTimelineEvent::MessageLike(message_like_event) = event else {
@@ -186,7 +186,7 @@ async fn make_edit_event<S: EventSource>(
             let replied_to_original_room_msg = replied_to_sync_timeline_event
                 .and_then(|sync_timeline_event| {
                     sync_timeline_event
-                        .event
+                        .raw()
                         .deserialize()
                         .map_err(|err| warn!("unable to deserialize replied-to event: {err}"))
                         .ok()

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -315,7 +315,7 @@ impl Room {
 
             for event in &mut response.chunk {
                 event.push_actions =
-                    Some(push_rules.get_actions(&event.event, &push_context).to_owned());
+                    Some(push_rules.get_actions(event.raw(), &push_context).to_owned());
             }
         }
 
@@ -420,7 +420,7 @@ impl Room {
         }
 
         let mut event = TimelineEvent::new(event);
-        event.push_actions = self.event_push_actions(&event.event).await?;
+        event.push_actions = self.event_push_actions(event.raw()).await?;
 
         Ok(event)
     }
@@ -1238,7 +1238,7 @@ impl Room {
         };
 
         let mut event: TimelineEvent = decrypted.into();
-        event.push_actions = self.event_push_actions(&event.event).await?;
+        event.push_actions = self.event_push_actions(event.raw()).await?;
 
         Ok(event)
     }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -2303,7 +2303,7 @@ mod tests {
         let no_local_events = room_id!("!crepe:example.org");
         let already_limited = room_id!("!paris:example.org");
 
-        let response_timeline = vec![event_c.event.clone(), event_d.event.clone()];
+        let response_timeline = vec![event_c.raw().clone(), event_d.raw().clone()];
 
         let local_rooms = BTreeMap::from_iter([
             (
@@ -2386,21 +2386,21 @@ mod tests {
                 no_overlap.to_owned(),
                 assign!(http::response::Room::default(), {
                     initial: Some(true),
-                    timeline: vec![event_c.event.clone(), event_d.event.clone()],
+                    timeline: vec![event_c.raw().clone(), event_d.raw().clone()],
                 }),
             ),
             (
                 partial_overlap.to_owned(),
                 assign!(http::response::Room::default(), {
                     initial: Some(true),
-                    timeline: vec![event_c.event.clone(), event_d.event.clone()],
+                    timeline: vec![event_c.raw().clone(), event_d.raw().clone()],
                 }),
             ),
             (
                 complete_overlap.to_owned(),
                 assign!(http::response::Room::default(), {
                     initial: Some(true),
-                    timeline: vec![event_c.event.clone(), event_d.event.clone()],
+                    timeline: vec![event_c.raw().clone(), event_d.raw().clone()],
                 }),
             ),
             (
@@ -2414,7 +2414,7 @@ mod tests {
                 no_local_events.to_owned(),
                 assign!(http::response::Room::default(), {
                     initial: Some(true),
-                    timeline: vec![event_c.event.clone(), event_d.event.clone()],
+                    timeline: vec![event_c.raw().clone(), event_d.raw().clone()],
                 }),
             ),
             (
@@ -2422,7 +2422,7 @@ mod tests {
                 assign!(http::response::Room::default(), {
                     initial: Some(true),
                     limited: true,
-                    timeline: vec![event_c.event, event_d.event],
+                    timeline: vec![event_c.into_raw(), event_d.into_raw()],
                 }),
             ),
         ]);

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -363,7 +363,7 @@ mod tests {
             let timeline = & $( $timeline_queue ).*;
 
             $(
-                assert_eq!(timeline[ $nth ].event.deserialize().unwrap().event_id(), $event_id);
+                assert_eq!(timeline[ $nth ].raw().deserialize().unwrap().event_id(), $event_id);
             )*
         };
     }
@@ -714,7 +714,7 @@ mod tests {
             // Check that the last event is the last event of the timeline, i.e. we only
             // keep the _latest_ events, not the _first_ events.
             assert_eq!(
-                frozen_room.timeline_queue.last().unwrap().event.deserialize().unwrap().event_id(),
+                frozen_room.timeline_queue.last().unwrap().raw().deserialize().unwrap().event_id(),
                 &format!("$x{max}:baz.org")
             );
         }
@@ -755,7 +755,7 @@ mod tests {
             // Check that the last event is the last event of the timeline, i.e. we only
             // keep the _latest_ events, not the _first_ events.
             assert_eq!(
-                frozen_room.timeline_queue.last().unwrap().event.deserialize().unwrap().event_id(),
+                frozen_room.timeline_queue.last().unwrap().raw().deserialize().unwrap().event_id(),
                 &format!("$x{max}:baz.org")
             );
         }

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -657,7 +657,7 @@ mod tests {
                 "prev_batch": "foo",
                 "timeline": [
                     {
-                        "event": {
+                        "kind": { "PlainText": { "event": {
                             "content": {
                                 "body": "let it gooo!",
                                 "msgtype": "m.text"
@@ -667,8 +667,7 @@ mod tests {
                             "room_id": "!someroom:example.com",
                             "sender": "@bob:example.com",
                             "type": "m.room.message"
-                        },
-                        "encryption_info": null
+                        }}}
                     }
                 ]
             })

--- a/crates/matrix-sdk/src/test_utils.rs
+++ b/crates/matrix-sdk/src/test_utils.rs
@@ -24,7 +24,7 @@ use crate::{
 #[track_caller]
 pub fn assert_event_matches_msg<E: Clone + Into<SyncTimelineEvent>>(event: &E, expected: &str) {
     let event: SyncTimelineEvent = event.clone().into();
-    let event = event.event.deserialize().unwrap();
+    let event = event.raw().deserialize().unwrap();
     assert_let!(
         AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(message)) = event
     );

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -73,7 +73,7 @@ impl MatrixDriver {
         });
 
         let messages = self.room.messages(options).await?;
-        Ok(messages.chunk.into_iter().map(|ev| ev.event.cast()).collect())
+        Ok(messages.chunk.into_iter().map(|ev| ev.into_raw().cast()).collect())
     }
 
     pub(crate) async fn read_state_events(

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -750,7 +750,7 @@ async fn test_encrypt_room_event() {
         .expect("We should be able to decrypt an event that we ourselves have encrypted");
 
     let event = timeline_event
-        .event
+        .raw()
         .deserialize()
         .expect("We should be able to deserialize the decrypted event");
 

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -755,8 +755,8 @@ async fn test_encrypt_room_event() {
         .expect("We should be able to deserialize the decrypted event");
 
     assert_let!(
-        ruma::events::AnyTimelineEvent::MessageLike(
-            ruma::events::AnyMessageLikeEvent::RoomMessage(message_event)
+        ruma::events::AnySyncTimelineEvent::MessageLike(
+            ruma::events::AnySyncMessageLikeEvent::RoomMessage(message_event)
         ) = event
     );
 

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -972,7 +972,7 @@ async fn test_enable_from_secret_storage() {
         room.event(event_id, None).await.expect("We should be able to fetch our encrypted event");
 
     assert_matches!(
-        event.encryption_info,
+        event.encryption_info(),
         None,
         "We should not be able to decrypt our encrypted event before we import the room keys from \
          the backup"
@@ -1042,9 +1042,9 @@ async fn test_enable_from_secret_storage() {
     let event =
         room.event(event_id, None).await.expect("We should be able to fetch our encrypted event");
 
-    assert_matches!(event.encryption_info, Some(..), "The event should now be decrypted");
+    assert_matches!(event.encryption_info(), Some(..), "The event should now be decrypted");
     let event: RoomMessageEvent =
-        event.event.deserialize_as().expect("We should be able to deserialize the event");
+        event.raw().deserialize_as().expect("We should be able to deserialize the event");
     let event = event.as_original().unwrap();
     assert_eq!(event.content.body(), "tt");
 
@@ -1392,7 +1392,7 @@ async fn test_enable_from_secret_storage_and_download_after_utd() {
         room.event(event_id, None).await.expect("We should be able to fetch our encrypted event");
 
     assert_matches!(
-        event.encryption_info,
+        event.encryption_info(),
         None,
         "We should not be able to decrypt the event right away"
     );
@@ -1412,9 +1412,9 @@ async fn test_enable_from_secret_storage_and_download_after_utd() {
     let event =
         room.event(event_id, None).await.expect("We should be able to fetch our encrypted event");
 
-    assert_matches!(event.encryption_info, Some(..), "The event should now be decrypted");
+    assert_matches!(event.encryption_info(), Some(..), "The event should now be decrypted");
     let event: RoomMessageEvent =
-        event.event.deserialize_as().expect("We should be able to deserialize the event");
+        event.raw().deserialize_as().expect("We should be able to deserialize the event");
     let event = event.as_original().unwrap();
     assert_eq!(event.content.body(), "tt");
 
@@ -1522,7 +1522,7 @@ async fn test_enable_from_secret_storage_and_download_after_utd_from_old_message
         room.event(event_id, None).await.expect("We should be able to fetch our encrypted event");
 
     assert_matches!(
-        event.encryption_info,
+        event.encryption_info(),
         None,
         "We should not be able to decrypt the event right away"
     );
@@ -1542,9 +1542,9 @@ async fn test_enable_from_secret_storage_and_download_after_utd_from_old_message
     let event =
         room.event(event_id, None).await.expect("We should be able to fetch our encrypted event");
 
-    assert_matches!(event.encryption_info, Some(..), "The event should now be decrypted");
+    assert_matches!(event.encryption_info(), Some(..), "The event should now be decrypted");
     let event: RoomMessageEvent =
-        event.event.deserialize_as().expect("We should be able to deserialize the event");
+        event.raw().deserialize_as().expect("We should be able to deserialize the event");
     let event = event.as_original().unwrap();
     assert_eq!(event.content.body(), "tt");
 

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -19,7 +19,7 @@ use ruma::{
             member::MembershipState,
             message::RoomMessageEventContent,
         },
-        AnyStateEvent, AnySyncStateEvent, AnyTimelineEvent, StateEventType,
+        AnySyncStateEvent, AnySyncTimelineEvent, StateEventType,
     },
     mxc_uri, room_id,
 };
@@ -671,7 +671,7 @@ async fn test_event() {
 
     let timeline_event = room.event(event_id, None).await.unwrap();
     assert_let!(
-        AnyTimelineEvent::State(AnyStateEvent::RoomTombstone(event)) =
+        AnySyncTimelineEvent::State(AnySyncStateEvent::RoomTombstone(event)) =
             timeline_event.raw().deserialize().unwrap()
     );
     assert_eq!(event.event_id(), event_id);

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -672,7 +672,7 @@ async fn test_event() {
     let timeline_event = room.event(event_id, None).await.unwrap();
     assert_let!(
         AnyTimelineEvent::State(AnyStateEvent::RoomTombstone(event)) =
-            timeline_event.event.deserialize().unwrap()
+            timeline_event.raw().deserialize().unwrap()
     );
     assert_eq!(event.event_id(), event_id);
 
@@ -734,15 +734,15 @@ async fn test_event_with_context() {
     let context_ret = room.event_with_context(event_id, false, uint!(1), None).await.unwrap();
 
     assert_let!(Some(timeline_event) = context_ret.event);
-    assert_let!(Ok(event) = timeline_event.event.deserialize());
+    assert_let!(Ok(event) = timeline_event.raw().deserialize());
     assert_eq!(event.event_id(), event_id);
 
     assert_eq!(1, context_ret.events_before.len());
-    assert_let!(Ok(event) = context_ret.events_before[0].event.deserialize());
+    assert_let!(Ok(event) = context_ret.events_before[0].raw().deserialize());
     assert_eq!(event.event_id(), prev_event_id);
 
     assert_eq!(1, context_ret.events_after.len());
-    assert_let!(Ok(event) = context_ret.events_after[0].event.deserialize());
+    assert_let!(Ok(event) = context_ret.events_after[0].raw().deserialize());
     assert_eq!(event.event_id(), next_event_id);
 
     // Requested event and their context ones were saved to the cache

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -729,7 +729,7 @@ impl App {
 
                         let rendered_events = events
                             .into_iter()
-                            .map(|sync_timeline_item| sync_timeline_item.event.json().to_string())
+                            .map(|sync_timeline_item| sync_timeline_item.raw().json().to_string())
                             .collect::<Vec<_>>()
                             .join("\n\n");
 

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
@@ -950,11 +950,11 @@ async fn test_secret_gossip_after_interactive_verification() -> Result<()> {
 
     let timeline_event = room.event(&event_id, None).await?;
     timeline_event
-        .encryption_info
+        .encryption_info()
         .expect("The event should have been encrypted and successfully decrypted.");
 
     let event: OriginalSyncMessageLikeEvent<RoomMessageEventContent> =
-        timeline_event.event.deserialize_as()?;
+        timeline_event.raw().deserialize_as()?;
     let message = event.content.msgtype;
 
     assert_let!(MessageType::Text(message) = message);

--- a/testing/matrix-sdk-integration-testing/src/tests/nse.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/nse.rs
@@ -423,7 +423,7 @@ async fn decrypt_event(
         return None;
     };
 
-    let Ok(deserialized) = decrypted.event.deserialize() else { return None };
+    let Ok(deserialized) = decrypted.raw().deserialize() else { return None };
 
     let AnyTimelineEvent::MessageLike(message) = &deserialized else { return None };
 

--- a/testing/matrix-sdk-integration-testing/src/tests/nse.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/nse.rs
@@ -18,8 +18,7 @@ use matrix_sdk::{
                 message::{MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent},
             },
             room_key::ToDeviceRoomKeyEvent,
-            AnyMessageLikeEventContent, AnySyncTimelineEvent, AnyTimelineEvent,
-            OriginalSyncMessageLikeEvent,
+            AnyMessageLikeEventContent, AnySyncTimelineEvent, OriginalSyncMessageLikeEvent,
         },
         serde::Raw,
         EventEncryptionAlgorithm, OwnedEventId, OwnedRoomId, RoomId,
@@ -425,7 +424,7 @@ async fn decrypt_event(
 
     let Ok(deserialized) = decrypted.raw().deserialize() else { return None };
 
-    let AnyTimelineEvent::MessageLike(message) = &deserialized else { return None };
+    let AnySyncTimelineEvent::MessageLike(message) = &deserialized else { return None };
 
     let Some(AnyMessageLikeEventContent::RoomMessage(content)) = message.original_content() else {
         return None;

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -8,8 +8,8 @@ use matrix_sdk::{
         api::client::room::create_room::v3::Request as CreateRoomRequest,
         assign, event_id, events,
         events::{
-            room::message::RoomMessageEventContent, AnyRoomAccountDataEventContent, AnyStateEvent,
-            AnyTimelineEvent, EventContent,
+            room::message::RoomMessageEventContent, AnyRoomAccountDataEventContent,
+            AnySyncStateEvent, AnySyncTimelineEvent, EventContent,
         },
         serde::Raw,
         uint,
@@ -180,7 +180,7 @@ async fn test_event_with_context() -> Result<()> {
 
         // Last event is the m.room.encryption event.
         let event = prev_events[9].raw().deserialize().unwrap();
-        assert_matches!(event, AnyTimelineEvent::State(AnyStateEvent::RoomEncryption(_)));
+        assert_matches!(event, AnySyncTimelineEvent::State(AnySyncStateEvent::RoomEncryption(_)));
 
         // There are other events before that (room creation, alice joining).
         assert!(prev_messages.end.is_some());

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -99,7 +99,7 @@ async fn test_event_with_context() -> Result<()> {
         let target = response
             .event
             .expect("there should be an event")
-            .event
+            .raw()
             .deserialize()
             .expect("it should be deserializable");
         assert_eq!(target.event_id(), &event_id);
@@ -129,7 +129,7 @@ async fn test_event_with_context() -> Result<()> {
         let target = response
             .event
             .expect("there should be an event")
-            .event
+            .raw()
             .deserialize()
             .expect("it should be deserializable");
         assert_eq!(target.event_id(), &event_id);
@@ -179,7 +179,7 @@ async fn test_event_with_context() -> Result<()> {
         assert_event_matches_msg(&prev_events[8], "0");
 
         // Last event is the m.room.encryption event.
-        let event = prev_events[9].event.deserialize().unwrap();
+        let event = prev_events[9].raw().deserialize().unwrap();
         assert_matches!(event, AnyTimelineEvent::State(AnyStateEvent::RoomEncryption(_)));
 
         // There are other events before that (room creation, alice joining).

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -154,7 +154,7 @@ async fn test_notification() -> Result<()> {
         .events
         .iter()
         .find_map(|event| {
-            let event = event.event.deserialize().ok()?;
+            let event = event.raw().deserialize().ok()?;
             (event.event_type() == TimelineEventType::RoomMessage)
                 .then(|| event.event_id().to_owned())
         })


### PR DESCRIPTION
As [previously discussed](https://github.com/matrix-org/matrix-rust-sdk/pull/4053#issuecomment-2385782287), we'd like to replace the innards of `SyncTimelineEvent` and `TimelineEvent` with a new enum, so that we can accurately represent the three possible states of (Unencrypted, Decrypted, UnableToDecrypt).

This PR lays the groundwork for that change by pulling out the enum. For now it only supports the Decrypted and PlainText cases: the UTD case is still mapped onto PlainText, and will change in a followup PR. It is essentially a reworking of https://github.com/matrix-org/matrix-rust-sdk/issues/4053.

One potential point of contention is that I've used the same inner type for both `TimelineEvent` and `SyncTimelineEvent`: it seems to me that we never rely on the different type information, so having two implementations felt redundant. (It does mean that `TimelineEvent` and `SyncTimelineEvent` become essentially identical, but replacing one with the other felt like a job for another day.) Anyway, I'm happy to revisit this and add a separate `SyncTimelineEventKind` or somesuch instead.

~~Speaking of which, I'm also not entirely happy with the name `TimelineEventInner`. When we discussed this, poljar spoke of `TimelineFoo` and I've not felt much more inspired since. If we could think of a decent name, I think the struct could usefully be exposed as a public type which might clean up some other bits of code. Suggestions welcome.~~ Now renamed to `TimelineEventKind`.

Unfortunately, this PR is necessarily somewhat large. I've tried to structure it in a way to make it easily reviewable, but let me know if I can help with review.

Part of #4048.