### PR TITLE
CI: Build the Swift framework under dbg to re-use the library artefacts.

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -175,7 +175,7 @@ jobs:
         run: swift test
 
       - name: Build Framework
-        run: target/debug/xtask swift build-framework --target=aarch64-apple-ios
+        run: target/debug/xtask swift build-framework --target=aarch64-apple-ios --profile=dbg
 
   complement-crypto:
     name: "Run Complement Crypto tests"


### PR DESCRIPTION
Looking at a previous [run](https://github.com/matrix-org/matrix-rust-sdk/actions/runs/11214737650/job/31170627200) of the bindings tests, we build the library with no profile specified in 3m 39s. Then we build the XCFramework which [falls back to `reldbg`](https://github.com/matrix-org/matrix-rust-sdk/blob/a12a46b77706bf9ff4f034c50668b06d079dd296/xtask/src/swift.rs#L70) when no profile is specified, it then takes a further 16m30s. Using `dbg` for both should hopefully reuse most of what was already built and basically prove that the xtask is able to assemble the framework correctly 🤞