### PR TITLE
ci: speed up iOS bindings tests by building them on the `dev` profile

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -175,7 +175,7 @@ jobs:
         run: swift test
 
       - name: Build Framework
-        run: target/debug/xtask swift build-framework --target=aarch64-apple-ios
+        run: target/debug/xtask swift build-framework --target=aarch64-apple-ios --profile=dev
 
   complement-crypto:
     name: "Run Complement Crypto tests"


### PR DESCRIPTION
- speed regression introduced when switching the default bindings profile to `reldbg` in #4020