### PR TITLE
ci: use macos-14 runners for the swift related tasks

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -131,7 +131,7 @@ jobs:
   test-apple:
     name: matrix-rust-components-swift
     needs: xtask
-    runs-on: macos-12
+    runs-on: macos-14
     if: github.event_name == 'push' || !github.event.pull_request.draft
 
     steps:
@@ -186,7 +186,7 @@ jobs:
 
   test-crypto-apple-framework-generation:
     name: Generate Crypto FFI Apple XCFramework
-    runs-on: macos-12
+    runs-on: macos-14
     if: github.event_name == 'push' || !github.event.pull_request.draft
 
     steps:

--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -175,7 +175,7 @@ jobs:
         run: swift test
 
       - name: Build Framework
-        run: target/debug/xtask swift build-framework --target=aarch64-apple-ios
+        run: target/debug/xtask swift build-framework --target=aarch64-apple-ios --profile=dev
 
   complement-crypto:
     name: "Run Complement Crypto tests"

--- a/.github/workflows/xtask.yml
+++ b/.github/workflows/xtask.yml
@@ -35,7 +35,7 @@ jobs:
             os-name: 🐧
             cachekey-id: linux
 
-          - os: macos-12
+          - os: macos-14
             os-name: 🍏
             cachekey-id: macos
 


### PR DESCRIPTION
macos-12 runners are going [to be deprecated](https://github.com/actions/runner-images/issues/10721), so we should try to upgrade any time soon.

cc @stefanceriu @pixlwave 