### PR TITLE
ffi: add async_runtime annotation for impl block with async fun

### DIFF
--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -432,7 +432,7 @@ pub struct UserIdentity {
     inner: matrix_sdk::encryption::identities::UserIdentity,
 }
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl UserIdentity {
     /// Remember this identity, ensuring it does not result in a pin violation.
     ///


### PR DESCRIPTION
What it says on the tin. Fixes crashes when calling this function from the other side of the FFI boundary.