### PR TITLE
sdk-base: add `RoomInfo::prev_room_state` property

### DIFF
--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -114,6 +114,7 @@ impl RoomInfoV1 {
             version: 0,
             room_id,
             room_state: room_type,
+            prev_room_state: None,
             notification_counts,
             summary,
             members_synced,


### PR DESCRIPTION
This is useful for the knocking feature since we'll be able to differentiate between rooms that you were just invited from rooms that you knocked and then were granted access, or rooms that you left and rooms where your knocking attempt was rejected.

The `mark_room_as_*` functions have been updated so they reuse the same `set_state` function underneath, which only updates the previous state if the new one doesn't match.

Needs https://github.com/matrix-org/matrix-rust-sdk/pull/4080.
<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
