### PR TITLE
SDK: Pass the filename to get_media_file instead of the body.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -414,7 +414,7 @@ impl Client {
     pub async fn get_media_file(
         &self,
         media_source: Arc<MediaSource>,
-        body: Option<String>,
+        filename: Option<String>,
         mime_type: String,
         use_cache: bool,
         temp_dir: Option<String>,
@@ -427,7 +427,7 @@ impl Client {
             .media()
             .get_media_file(
                 &MediaRequest { source, format: MediaFormat::File },
-                body,
+                filename,
                 &mime_type,
                 use_cache,
                 temp_dir,

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -25,6 +25,7 @@ Breaking changes:
 - `Room::event` now takes an optional `RequestConfig` to allow for tweaking the network behavior.
 - The `instant` module was removed, use the `ruma::time` module instead.
 - Add `ClientBuilder::sqlite_store_with_cache_path` to build a client that stores caches in a different directory to state/crypto.
+- The `body` parameter in `get_media_file` has been replaced with a `filename` parameter now that Ruma has a `filename()` method.
 
 Additions:
 


### PR DESCRIPTION
In https://github.com/element-hq/element-x-ios/pull/3375 I noticed that we request a file using the event's `body` which doesn't seem to make sense to me now that #4081 (and https://github.com/ruma/ruma/pull/1921) is available.

This PR updates the `get_media_file` methods in the SDK and FFI to both take the filename instead.