### PR TITLE
sdk: Fixes to `Room::forget`

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1403,6 +1403,17 @@ impl BaseClient {
         self.store.room(room_id)
     }
 
+    /// Forget the room with the given room ID.
+    ///
+    /// The room will be dropped from the room list and the store.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room that should be forgotten.
+    pub async fn forget_room(&self, room_id: &RoomId) -> StoreResult<()> {
+        self.store.forget_room(room_id).await
+    }
+
     /// Get the olm machine.
     #[cfg(feature = "e2e-encryption")]
     pub async fn olm_machine(&self) -> RwLockReadGuard<'_, Option<OlmMachine>> {

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -304,6 +304,17 @@ impl Store {
             })
             .clone()
     }
+
+    /// Forget the room with the given room ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room that should be forgotten.
+    pub(crate) async fn forget_room(&self, room_id: &RoomId) -> Result<()> {
+        self.inner.remove_room(room_id).await?;
+        self.rooms.write().unwrap().remove(room_id);
+        Ok(())
+    }
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2663,7 +2663,7 @@ impl Room {
             }
         }
 
-        self.client.store().remove_room(self.inner.room_id()).await?;
+        self.client.base_client().forget_room(self.inner.room_id()).await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk/tests/integration/room/left.rs
+++ b/crates/matrix-sdk/tests/integration/room/left.rs
@@ -1,25 +1,41 @@
 use std::time::Duration;
 
+use assert_matches2::assert_matches;
 use matrix_sdk::config::SyncSettings;
 use matrix_sdk_base::RoomState;
-use matrix_sdk_test::{async_test, test_json, DEFAULT_TEST_ROOM_ID};
-use ruma::OwnedRoomOrAliasId;
+use matrix_sdk_test::{
+    async_test, test_json, GlobalAccountDataTestEvent, LeftRoomBuilder, SyncResponseBuilder,
+    DEFAULT_TEST_ROOM_ID,
+};
+use ruma::{events::direct::DirectEventContent, user_id, OwnedRoomOrAliasId};
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path_regex},
+    matchers::{header, method, path, path_regex},
     Mock, ResponseTemplate,
 };
 
 use crate::{logged_in_client_with_server, mock_sync};
 
 #[async_test]
-async fn test_forget_room() {
+async fn test_forget_non_direct_room() {
     let (client, server) = logged_in_client_with_server().await;
+    let user_id = client.user_id().unwrap();
 
     Mock::given(method("POST"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/forget$"))
         .and(header("authorization", "Bearer 1234"))
         .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EMPTY))
+        .named("forget")
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path(format!("/_matrix/client/r0/user/{user_id}/account_data/m.direct")))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EMPTY))
+        .named("set_mdirect")
+        .expect(0)
         .mount(&server)
         .await;
 
@@ -30,6 +46,58 @@ async fn test_forget_room() {
 
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
     assert_eq!(room.state(), RoomState::Left);
+
+    room.forget().await.unwrap();
+}
+
+#[async_test]
+async fn test_forget_direct_room() {
+    let (client, server) = logged_in_client_with_server().await;
+    let user_id = client.user_id().unwrap();
+    let invited_user_id = user_id!("@invited:localhost");
+
+    // Initialize the direct room.
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_left_room(LeftRoomBuilder::default());
+    sync_builder.add_global_account_data_event(GlobalAccountDataTestEvent::Direct);
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
+
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let _response = client.sync_once(sync_settings).await.unwrap();
+
+    let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
+    assert_eq!(room.state(), RoomState::Left);
+    assert!(room.is_direct().await.unwrap());
+    assert!(room.direct_targets().contains(invited_user_id));
+
+    let direct_account_data = client
+        .account()
+        .account_data::<DirectEventContent>()
+        .await
+        .expect("getting m.direct account data failed")
+        .expect("no m.direct account data")
+        .deserialize()
+        .expect("failed to deserialize m.direct account data");
+    assert_matches!(direct_account_data.get(invited_user_id), Some(invited_user_dms));
+    assert_eq!(invited_user_dms, &[DEFAULT_TEST_ROOM_ID.to_owned()]);
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/forget$"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EMPTY))
+        .named("forget")
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path(format!("/_matrix/client/r0/user/{user_id}/account_data/m.direct")))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EMPTY))
+        .named("set_mdirect")
+        .expect(1)
+        .mount(&server)
+        .await;
 
     room.forget().await.unwrap();
 }

--- a/crates/matrix-sdk/tests/integration/room/left.rs
+++ b/crates/matrix-sdk/tests/integration/room/left.rs
@@ -48,6 +48,8 @@ async fn test_forget_non_direct_room() {
     assert_eq!(room.state(), RoomState::Left);
 
     room.forget().await.unwrap();
+
+    assert!(client.get_room(&DEFAULT_TEST_ROOM_ID).is_none());
 }
 
 #[async_test]
@@ -100,6 +102,8 @@ async fn test_forget_direct_room() {
         .await;
 
     room.forget().await.unwrap();
+
+    assert!(client.get_room(&DEFAULT_TEST_ROOM_ID).is_none());
 }
 
 #[async_test]


### PR DESCRIPTION
When forgetting rooms:
- Remove direct rooms from the `m.direct` account data,
- Remove rooms from the in-memory list.

Fixes #4078.\
Fixes #4079.