### PR TITLE
refactor(timeline): fuse `edit_by_id` (resp `redact_by_id`) into their ID-less counterparts

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -496,7 +496,7 @@ impl Timeline {
         new_content: EditedContent,
     ) -> Result<bool, ClientError> {
         self.inner
-            .edit_by_id(&event_or_transaction_id.try_into()?, new_content.try_into()?)
+            .edit(&event_or_transaction_id.try_into()?, new_content.try_into()?)
             .await
             .map_err(Into::into)
     }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -629,11 +629,7 @@ impl Timeline {
         event_or_transaction_id: EventOrTransactionId,
         reason: Option<String>,
     ) -> Result<(), ClientError> {
-        if !self.inner.redact(&(event_or_transaction_id.try_into()?), reason.as_deref()).await? {
-            // TODO make it a hard error instead
-            warn!("Couldn't redact item");
-        }
-        Ok(())
+        Ok(self.inner.redact(&(event_or_transaction_id.try_into()?), reason.as_deref()).await?)
     }
 
     /// Load the reply details for the given event id.

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -500,8 +500,8 @@ impl Timeline {
             .edit(&event_or_transaction_id.clone().try_into()?, new_content.clone().try_into()?)
             .await
         {
-            Ok(true) => Ok(()),
-            Ok(false) | Err(timeline::Error::EventNotInTimeline(_)) => {
+            Ok(()) => Ok(()),
+            Err(timeline::Error::EventNotInTimeline(_)) => {
                 // If we couldn't edit, assume it was an (remote) event that wasn't in the
                 // timeline, and try to edit it via the room itself.
                 let event_id = match event_or_transaction_id {

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -610,10 +610,11 @@ impl Timeline {
         event_or_transaction_id: EventOrTransactionId,
         reason: Option<String>,
     ) -> Result<(), ClientError> {
-        self.inner
-            .redact_by_id(&(event_or_transaction_id.try_into()?), reason.as_deref())
-            .await
-            .map_err(Into::into)
+        if !self.inner.redact(&(event_or_transaction_id.try_into()?), reason.as_deref()).await? {
+            // TODO make it a hard error instead
+            warn!("Couldn't redact item");
+        }
+        Ok(())
     }
 
     /// Load the reply details for the given event id.

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -14,7 +14,6 @@
 
 use matrix_sdk::{
     event_cache::{paginator::PaginatorError, EventCacheError},
-    room::edit::EditError,
     send_queue::RoomSendQueueError,
     HttpError,
 };
@@ -77,6 +76,21 @@ pub enum Error {
     /// An error happened while attempting to redact an event.
     #[error(transparent)]
     RedactError(#[from] RedactError),
+}
+
+#[derive(Error, Debug)]
+pub enum EditError {
+    /// The content types have changed.
+    #[error("the new content type ({new}) doesn't match that of the previous content ({original}")]
+    ContentMismatch { original: String, new: String },
+
+    /// The local echo we tried to edit has been lost.
+    #[error("Invalid state: the local echo we tried to abort has been lost.")]
+    InvalidLocalEchoState,
+
+    /// An error happened at a lower level.
+    #[error(transparent)]
+    RoomError(#[from] matrix_sdk::room::edit::EditError),
 }
 
 #[derive(Error, Debug)]

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -76,7 +76,7 @@ pub enum Error {
 
     /// An error happened while attempting to redact an event.
     #[error(transparent)]
-    RedactError(RedactError),
+    RedactError(#[from] RedactError),
 }
 
 #[derive(Error, Debug)]
@@ -88,6 +88,10 @@ pub enum RedactError {
     /// An error happened while attempting to redact an event.
     #[error(transparent)]
     HttpError(#[from] HttpError),
+
+    /// The local echo we tried to abort has been lost.
+    #[error("Invalid state: the local echo we tried to abort has been lost.")]
+    InvalidLocalEchoState,
 }
 
 #[derive(Error, Debug)]

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -18,7 +18,6 @@ use matrix_sdk::{
     send_queue::RoomSendQueueError,
     HttpError,
 };
-use ruma::OwnedTransactionId;
 use thiserror::Error;
 
 use crate::timeline::{pinned_events_loader::PinnedEventsLoaderError, TimelineEventItemId};
@@ -83,8 +82,8 @@ pub enum Error {
 #[derive(Error, Debug)]
 pub enum RedactError {
     /// Local event to redact wasn't found for transaction id
-    #[error("Local event to redact wasn't found for transaction {0}")]
-    LocalEventNotFound(OwnedTransactionId),
+    #[error("Event to redact wasn't found for item id {0:?}")]
+    ItemNotFound(TimelineEventItemId),
 
     /// An error happened while attempting to redact an event.
     #[error(transparent)]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -276,9 +276,7 @@ async fn test_redact_message() {
     // Redacting a remote event works.
     mock_redaction(event_id!("$42")).mount(&server).await;
 
-    let did_redact =
-        timeline.redact(&first.as_event().unwrap().identifier(), Some("inapprops")).await.unwrap();
-    assert!(did_redact);
+    timeline.redact(&first.as_event().unwrap().identifier(), Some("inapprops")).await.unwrap();
 
     // Redacting a local event works.
     timeline
@@ -300,8 +298,7 @@ async fn test_redact_message() {
     assert_matches!(second.send_state(), Some(EventSendState::SendingFailed { .. }));
 
     // Let's redact the local echo.
-    let did_redact = timeline.redact(&second.identifier(), None).await.unwrap();
-    assert!(did_redact);
+    timeline.redact(&second.identifier(), None).await.unwrap();
 
     // Observe local echo being removed.
     assert_matches!(timeline_stream.next().await, Some(VectorDiff::Remove { index: 2 }));

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -291,7 +291,7 @@ async fn test_stale_local_echo_time_abort_edit() {
     // Now do a crime: try to edit the local echo.
     let did_edit = timeline
         .edit(
-            &local_echo,
+            &local_echo.identifier(),
             EditedContent::RoomMessage(RoomMessageEventContent::text_plain("bonjour").into()),
         )
         .await

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -289,16 +289,14 @@ async fn test_stale_local_echo_time_abort_edit() {
     }
 
     // Now do a crime: try to edit the local echo.
-    let did_edit = timeline
+    // The edit works on the local echo and applies to the remote echo \o/.
+    timeline
         .edit(
             &local_echo.identifier(),
             EditedContent::RoomMessage(RoomMessageEventContent::text_plain("bonjour").into()),
         )
         .await
         .unwrap();
-
-    // The edit works on the local echo and applies to the remote echo \o/.
-    assert!(did_edit);
 
     let vector_diff = timeout(Duration::from_secs(5), stream.next()).await.unwrap().unwrap();
     let remote_echo = assert_matches!(vector_diff, VectorDiff::Set { index: 0, value } => value);


### PR DESCRIPTION
This PR sits on top of #4111 and #4127, and allows us to get rid of the `edit_by_id` / `redact_by_id` variants.

I've added changelog entries \o/

Fixes #4093.