### PR TITLE
feat(sdk): Dropping an `UpdatesSubscriber` release its reader token for the garbage collector

### DIFF
--- a/crates/matrix-sdk/src/event_cache/linked_chunk/updates.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/updates.rs
@@ -495,7 +495,7 @@ mod tests {
         // | d | e | f | g | h | i |
         // +---+---+---+---+---+---+
         //
-        // “main” will have its index updated from 3 to 0.
+        // “main” will have its index updated from 0 to 3.
         // “other” will have its index updated from 6 to 3.
         {
             let updates = linked_chunk.updates().unwrap();


### PR DESCRIPTION
The event cache stores its events in a linked chunk. The linked chunk
supports updates (`ObservableUpdates`) via `LinkedChunk::updates()`.
This `ObservableUpdates` receives all updates that are happening inside
the `LinkedChunk`. An `ObservableUpdates` wraps `UpdatesInner`, which
is the real logic to handle multiple update readers. Each reader has a
unique `ReaderToken`. `UpdatesInner` has a garbage collector that drops
all updates that are read by all readers. And here comes the problem.

A category of readers are `UpdatesSubscriber`, returned by
`ObservableUpdates::subscribe()`. When an `UpdatesSubscriber` is
dropped, its reader token was still alive, thus preventing the garbage
collector to clear all its pending updates: they were kept in memory
for the eternity.

This patch implements `Drop` for `UpdatesSubscriber` to correctly remove
its `ReaderToken` from `UpdatesInner`. This patch also adds a test that
runs multiple subscribers, and when one is dropped, its pending updates
are collected by the garbage collector.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280