### PR TITLE
ci: detect unused dependencies

### DIFF
--- a/.github/workflows/detect-unused-dependencies.yml
+++ b/.github/workflows/detect-unused-dependencies.yml
@@ -1,0 +1,12 @@
+name: Detects unused dependencies
+on:
+  pull_request: { branches: "*" }
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Machete
+        uses: bnjbvr/cargo-machete@main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,26 +996,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const_format"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "const_panic"
 version = "0.2.8"
 source = "git+https://github.com/jplatte/const_panic?rev=9024a4cb3eac45c1d2d980f17aaee287b17be498#9024a4cb3eac45c1d2d980f17aaee287b17be498"
@@ -1691,7 +1671,6 @@ dependencies = [
  "clap",
  "futures-util",
  "matrix-sdk",
- "qrcode",
  "tokio",
  "tracing-subscriber",
  "url",
@@ -3243,7 +3222,6 @@ dependencies = [
  "async-trait",
  "bs58",
  "byteorder",
- "cbc",
  "cfg-if",
  "ctr",
  "eyeball",
@@ -3331,7 +3309,6 @@ dependencies = [
  "once_cell",
  "paranoid-android",
  "ruma",
- "sanitize-filename-reader-friendly",
  "serde",
  "serde_json",
  "thiserror",
@@ -5239,15 +5216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sanitize-filename-reader-friendly"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b750e71aac86f4b238844ac9416e7339a8de1225eb1ebe5fba89890f634c46bf"
-dependencies = [
- "const_format",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6344,12 +6312,6 @@ name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "uniffi"

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -33,7 +33,6 @@ matrix-sdk-ui = { workspace = true, features = ["uniffi"] }
 mime = "0.3.16"
 once_cell = { workspace = true }
 ruma = { workspace = true, features = ["html", "unstable-unspecified", "unstable-msc3488", "compat-unset-avatar", "unstable-msc3245-v1-compat"] }
-sanitize-filename-reader-friendly = "2.2.1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -35,7 +35,6 @@ as_variant = { workspace = true }
 async-trait = { workspace = true }
 bs58 = { version = "0.5.0" }
 byteorder = { workspace = true }
-cbc = { version = "0.1.2", features = ["std"] }
 cfg-if = "1.0"
 ctr = "0.9.1"
 eyeball = { workspace = true }

--- a/crates/matrix-sdk-store-encryption/Cargo.toml
+++ b/crates/matrix-sdk-store-encryption/Cargo.toml
@@ -33,3 +33,6 @@ anyhow = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["getrandom"] # We do manually enable a feature for it.

--- a/examples/qr-login/Cargo.toml
+++ b/examples/qr-login/Cargo.toml
@@ -13,7 +13,6 @@ test = false
 anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
-qrcode = { version = "0.14.1" }
 futures-util = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = "2.3.1"


### PR DESCRIPTION
I've noticed there were a few unused dependencies; this removes them, and introduces a new check that will fail if there are any unused dependencies detected with `cargo-machete`. Also marks one false positive that the tool can't detect.