### PR TITLE
refactor(ffi): remove two fields in `EventTimelineItem`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -1032,7 +1032,7 @@ impl From<SdkShieldState> for ShieldState {
 
 #[derive(Clone, uniffi::Record)]
 pub struct EventTimelineItem {
-    is_local: bool,
+    /// Indicates that an event is remote.
     is_remote: bool,
     event_or_transaction_id: EventOrTransactionId,
     sender: String,
@@ -1072,7 +1072,6 @@ impl From<matrix_sdk_ui::timeline::EventTimelineItem> for EventTimelineItem {
         let read_receipts =
             value.read_receipts().iter().map(|(k, v)| (k.to_string(), v.clone().into())).collect();
         Self {
-            is_local: value.is_local_echo(),
             is_remote: !value.is_local_echo(),
             event_or_transaction_id: value.identifier().into(),
             sender: value.sender().to_string(),

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -237,11 +237,20 @@ impl EventTimelineItem {
     ///
     /// This returns `true` for events created locally, until the server echoes
     /// back the full event as part of a sync response.
+    ///
+    /// This is the opposite of [`Self::is_remote_event`].
     pub fn is_local_echo(&self) -> bool {
         matches!(self.kind, EventTimelineItemKind::Local(_))
     }
 
-    pub(super) fn is_remote_event(&self) -> bool {
+    /// Check whether this item is a remote event.
+    ///
+    /// This returns `true` only for events that have been echoed back from the
+    /// homeserver. A local echo sent but not echoed back yet will return
+    /// `false` here.
+    ///
+    /// This is the opposite of [`Self::is_local_echo`].
+    pub fn is_remote_event(&self) -> bool {
         matches!(self.kind, EventTimelineItemKind::Remote(_))
     }
 


### PR DESCRIPTION
- `is_local` is the opposite of `is_remote`. I hope all foreign languages have a `!` operator :clown_face: 
- the two lazy providers can be unified into a single one, avoiding a bit of boilerplate.

Split from #4100.