### PR TITLE
crypto: Sort IdentityStatusChanges when providing them via subscribe_to_identity_status_changes

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/room_identity_state.rs
+++ b/crates/matrix-sdk-crypto/src/identities/room_identity_state.rs
@@ -204,7 +204,7 @@ fn state_of(user_identity: &UserIdentity) -> IdentityState {
 /// A change in the status of the identity of a member of the room. Returned by
 /// [`RoomIdentityState::process_change`] to indicate that something changed in
 /// this room and we should either show or hide a warning.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct IdentityStatusChange {
     /// The user ID of the user whose identity status changed
     pub user_id: OwnedUserId,
@@ -214,7 +214,7 @@ pub struct IdentityStatusChange {
 }
 
 /// The state of an identity - verified, pinned etc.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum IdentityState {
     /// The user is verified with us

--- a/crates/matrix-sdk/src/room/identity_status_changes.rs
+++ b/crates/matrix-sdk/src/room/identity_status_changes.rs
@@ -88,17 +88,21 @@ impl IdentityStatusChanges {
         };
 
         Ok(stream!({
-            let current_state =
+            let mut current_state =
                 filter_non_self(state.room_identity_state.current_state(), &own_user_id);
+
             if !current_state.is_empty() {
+                current_state.sort();
                 yield current_state;
             }
+
             while let Some(item) = unprocessed_stream.next().await {
-                let update = filter_non_self(
+                let mut update = filter_non_self(
                     state.room_identity_state.process_change(item).await,
                     &own_user_id,
                 );
                 if !update.is_empty() {
+                    update.sort();
                     yield update;
                 }
             }


### PR DESCRIPTION
A specific test for this case will need quite involved changes to `IdentityChangeDataSet` so I am working on that as a separate change.

Fixes https://github.com/element-hq/element-meta/issues/2566