### PR TITLE
refactor(event cache): simplify the locking situation

### DIFF
--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -18,26 +18,12 @@
 //! doesn't require subscribing to a specific room to get access to this
 //! information.
 //!
-//! It's intended to be fast, robust and easy to maintain.
+//! It's intended to be fast, robust and easy to maintain, having learned from
+//! previous endeavours at implementing middle to high level features elsewhere
+//! in the SDK, notably in the UI's Timeline object.
 //!
-//! See the [github issue](https://github.com/matrix-org/matrix-rust-sdk/issues/3058) for more details about the historical reasons that led us to start writing this.
-//!
-//! Most of it is still a work-in-progress, as of 2024-01-22.
-//!
-//! The desired set of features it may eventually implement is the following:
-//!
-//! - [ ] compute proper unread room counts, and use backpagination to get
-//!   missing messages/notifications/mentions, if needs be.
-//! - [ ] expose that information with a new data structure similar to the
-//!   `RoomInfo`, and that may update a `RoomListService`.
-//! - [ ] provide read receipts for each message.
-//! - [x] backwards pagination
-//! - [~] forward pagination
-//! - [ ] reconcile results with cached timelines.
-//! - [ ] retry decryption upon receiving new keys (from an encryption sync
-//!   service or from a key backup).
-//! - [ ] expose the latest event for a given room.
-//! - [ ] caching of events on-disk.
+//! See the [github issue](https://github.com/matrix-org/matrix-rust-sdk/issues/3058) for more
+//! details about the historical reasons that led us to start writing this.
 
 #![forbid(missing_docs)]
 

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -339,7 +339,7 @@ async fn test_backpaginate_once() {
         // Then if I backpaginate,
         let pagination = room_event_cache.pagination();
 
-        assert!(pagination.get_or_wait_for_token().await.is_some());
+        assert!(pagination.get_or_wait_for_token(None).await.is_some());
 
         pagination.run_backwards(20, once).await.unwrap()
     };
@@ -428,7 +428,7 @@ async fn test_backpaginate_many_times_with_many_iterations() {
 
     // Then if I backpaginate in a loop,
     let pagination = room_event_cache.pagination();
-    while pagination.get_or_wait_for_token().await.is_some() {
+    while pagination.get_or_wait_for_token(None).await.is_some() {
         pagination
             .run_backwards(20, |outcome, timeline_has_been_reset| {
                 num_paginations += 1;
@@ -544,7 +544,7 @@ async fn test_backpaginate_many_times_with_one_iteration() {
 
     // Then if I backpaginate in a loop,
     let pagination = room_event_cache.pagination();
-    while pagination.get_or_wait_for_token().await.is_some() {
+    while pagination.get_or_wait_for_token(None).await.is_some() {
         pagination
             .run_backwards(20, |outcome, timeline_has_been_reset| {
                 num_paginations += 1;
@@ -691,7 +691,7 @@ async fn test_reset_while_backpaginating() {
     // Run the pagination!
     let pagination = room_event_cache.pagination();
 
-    let first_token = pagination.get_or_wait_for_token().await;
+    let first_token = pagination.get_or_wait_for_token(None).await;
     assert!(first_token.is_some());
 
     let backpagination = spawn({
@@ -721,7 +721,7 @@ async fn test_reset_while_backpaginating() {
     assert!(!events.is_empty());
 
     // Now if we retrieve the oldest token, it's set to something else.
-    let second_token = pagination.get_or_wait_for_token().await.unwrap();
+    let second_token = pagination.get_or_wait_for_token(None).await.unwrap();
     assert!(first_token.unwrap() != second_token);
     assert_eq!(second_token, "third_backpagination");
 }
@@ -774,7 +774,7 @@ async fn test_backpaginating_without_token() {
 
     // We don't have a token.
     let pagination = room_event_cache.pagination();
-    assert!(pagination.get_or_wait_for_token().await.is_none());
+    assert!(pagination.get_or_wait_for_token(None).await.is_none());
 
     // If we try to back-paginate with a token, it will hit the end of the timeline
     // and give us the resulting event.


### PR DESCRIPTION
This simplifies the locking situation, in particular it would've made the bug fixed by https://github.com/matrix-org/matrix-rust-sdk/pull/3501 impossible to happen in the first place (or at least, way more obvious).

Fixes #3502. Thanks @Hywan for the technical discussion we had about it.