### PR TITLE
crypto: expose new method `OlmMachine::try_decrypt_room_event`

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Changes:
 
+- Add new method `OlmMachine::try_decrypt_room_event`.
+  ([#4116](https://github.com/matrix-org/matrix-rust-sdk/pull/4116))
+
+- Add reason code to `matrix_sdk_common::deserialized_responses::UnableToDecryptInfo`.
+  ([#4116](https://github.com/matrix-org/matrix-rust-sdk/pull/4116))
+
 - The `UserIdentity` struct has been renamed to `OtherUserIdentity`
   ([#4036](https://github.com/matrix-org/matrix-rust-sdk/pull/4036]))
 

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -89,6 +89,7 @@ pub use identities::{
     OwnUserIdentityData, UserDevices, UserIdentity, UserIdentityData,
 };
 pub use machine::{CrossSigningBootstrapRequests, EncryptionSyncChanges, OlmMachine};
+use matrix_sdk_common::deserialized_responses::{DecryptedRoomEvent, UnableToDecryptInfo};
 #[cfg(feature = "qrcode")]
 pub use matrix_sdk_qrcode;
 pub use olm::{Account, CrossSigningStatus, EncryptionSettings, Session};
@@ -141,4 +142,15 @@ pub struct DecryptionSettings {
     /// event. If the sender's device is not sufficiently trusted,
     /// [`MegolmError::SenderIdentityNotTrusted`] will be returned.
     pub sender_device_trust_requirement: TrustRequirement,
+}
+
+/// The result of an attempt to decrypt a room event: either a successful
+/// decryption, or information on a failure.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum RoomEventDecryptionResult {
+    /// A successfully-decrypted encrypted event.
+    Decrypted(DecryptedRoomEvent),
+
+    /// We were unable to decrypt the event
+    UnableToDecrypt(UnableToDecryptInfo),
 }

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -18,7 +18,7 @@ use assert_matches2::assert_matches;
 use futures_util::{pin_mut, FutureExt, StreamExt};
 use itertools::Itertools;
 use matrix_sdk_common::deserialized_responses::{
-    UnableToDecryptInfo, UnsignedDecryptionResult, UnsignedEventLocation,
+    UnableToDecryptInfo, UnableToDecryptReason, UnsignedDecryptionResult, UnsignedEventLocation,
 };
 use matrix_sdk_test::{async_test, message_like_event_content, ruma_response_from_json, test_json};
 use ruma::{
@@ -1355,7 +1355,8 @@ async fn test_unsigned_decryption() {
     assert_matches!(
         replace_encryption_result,
         UnsignedDecryptionResult::UnableToDecrypt(UnableToDecryptInfo {
-            session_id: Some(second_room_key_session_id)
+            session_id: Some(second_room_key_session_id),
+            reason: UnableToDecryptReason::MissingMegolmSession,
         })
     );
 
@@ -1460,7 +1461,8 @@ async fn test_unsigned_decryption() {
     assert_matches!(
         thread_encryption_result,
         UnsignedDecryptionResult::UnableToDecrypt(UnableToDecryptInfo {
-            session_id: Some(third_room_key_session_id)
+            session_id: Some(third_room_key_session_id),
+            reason: UnableToDecryptReason::MissingMegolmSession,
         })
     );
 


### PR DESCRIPTION
... which returns an enum which encodes decryption failure information, rather than returning `MegolmError`

To make this work, we also extend the existing `UnableToDecryptInfo` to include a reason code for the failure.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/4048