### PR TITLE
chore: Move lint configuration out of .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,13 +1,3 @@
-# Pass the rustflags specified to host dependencies (build scripts, proc-macros)
-# when a `--target` is passed to Cargo. Historically this was not the case, and
-# because of that, cross-compilation would not set the rustflags configured
-# below in `target.'cfg(...)'` for them, resulting in cache invalidation.
-#
-# Since this is an unstable feature (enabled at the bottom of the file), this
-# setting is unfortunately ignored on stable toolchains, but it's still better
-# to have it apply on nightly than using the old behavior for all toolchains.
-target-applies-to-host = false
-
 [alias]
 xtask = "run --package xtask --"
 uniffi-bindgen = "run --package uniffi-bindgen --"
@@ -15,43 +5,5 @@ uniffi-bindgen = "run --package uniffi-bindgen --"
 [doc.extern-map.registries]
 crates-io = "https://docs.rs/"
 
-# Exclude tarpaulin, android and ios from extra lints since on stable, without
-# the nightly-only target-applies-to-host setting at the top, cross compilation
-# and otherwise changing cfg's can be very bad for caching. These should never
-# be the default either and don't have much target-specific code that would
-# benefit from the extra lints.
-[target.'cfg(not(any(tarpaulin, target_os = "android", target_os = "ios")))']
-rustflags = [
-    "-Wrust_2018_idioms",
-    "-Wsemicolon_in_expressions_from_macros",
-    "-Wunused_extern_crates",
-    "-Wunused_import_braces",
-    "-Wunused_qualifications",
-    "-Wtrivial_casts",
-    "-Wtrivial_numeric_casts",
-    "-Wclippy::cloned_instead_of_copied",
-    "-Wclippy::dbg_macro",
-    "-Wclippy::inefficient_to_string",
-    "-Wclippy::macro_use_imports",
-    "-Wclippy::mut_mut",
-    "-Wclippy::needless_borrow",
-    "-Wclippy::nonstandard_macro_braces",
-    "-Wclippy::str_to_string",
-    "-Wclippy::todo",
-    "-Wclippy::unused_async",
-    "-Wclippy::redundant_clone",
-]
-
-[target.'cfg(target_arch = "wasm32")']
-rustflags = [
-    # We have some types that are !Send and/or !Sync only on wasm, it would be
-    # slightly more efficient, but also pretty annoying, to wrap them in Rc
-    # where we would use Arc on other platforms.
-    "-Aclippy::arc_with_non_send_sync",
-]
-
-# activate the target-applies-to-host feature.
-# Required for `target-applies-to-host` at the top to take effect.
 [unstable]
 rustdoc-map = true
-target-applies-to-host = true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -51,8 +51,6 @@ jobs:
       # Keep in sync with xtask docs
       - name: Build documentation
         env:
-          # Work around https://github.com/rust-lang/cargo/issues/10744
-          CARGO_TARGET_APPLIES_TO_HOST: "true"
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options --cfg docsrs -Dwarnings"
         run:
           cargo doc --no-deps --workspace --features docsrs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,8 +131,26 @@ tracing-appender = { git = "https://github.com/element-hq/tracing.git", rev = "c
 paranoid-android = { git = "https://github.com/element-hq/paranoid-android.git", rev = "69388ac5b4afeed7be4401c70ce17f6d9a2cf19b" }
 
 [workspace.lints.rust]
+rust_2018_idioms = "warn"
+semicolon_in_expressions_from_macros = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
+unused_extern_crates = "warn"
+unused_import_braces = "warn"
+unused_qualifications = "warn"
+trivial_casts = "warn"
+trivial_numeric_casts = "warn"
 
 [workspace.lints.clippy]
 assigning_clones = "allow"
 box_default = "allow"
+cloned_instead_of_copied = "warn"
+dbg_macro = "warn"
+inefficient_to_string = "warn"
+macro_use_imports = "warn"
+mut_mut = "warn"
+needless_borrow = "warn"
+nonstandard_macro_braces = "warn"
+str_to_string = "warn"
+todo = "warn"
+unused_async = "warn"
+redundant_clone = "warn"

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
 #![warn(missing_docs, missing_debug_implementations)]
 
 pub use matrix_sdk_common::*;

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -15,6 +15,7 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs, missing_debug_implementations)]
+#![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
 
 pub mod backups;
 mod ciphers;

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #![doc = include_str!("../README.md")]
 #![warn(missing_debug_implementations, missing_docs)]
+#![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub use async_trait::async_trait;

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -179,8 +179,6 @@ fn check_typos() -> Result<()> {
 
 fn check_clippy() -> Result<()> {
     cmd!("rustup run {NIGHTLY} cargo clippy --all-targets --features testing -- -D warnings")
-        // Work around https://github.com/rust-lang/cargo/issues/10744
-        .env("CARGO_TARGET_APPLIES_TO_HOST", "true")
         .run()?;
 
     cmd!(
@@ -190,14 +188,12 @@ fn check_clippy() -> Result<()> {
             --features native-tls,experimental-sliding-sync,sso-login,testing
             -- -D warnings"
     )
-    .env("CARGO_TARGET_APPLIES_TO_HOST", "true")
     .run()?;
 
     cmd!(
         "rustup run {NIGHTLY} cargo clippy --all-targets -p matrix-sdk-crypto
             --no-default-features -- -D warnings"
     )
-    .env("CARGO_TARGET_APPLIES_TO_HOST", "true")
     .run()?;
 
     Ok(())

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -68,8 +68,6 @@ fn build_docs(
 
     // Keep in sync with .github/workflows/docs.yml
     cmd!("rustup run {NIGHTLY} cargo doc --no-deps --workspace --features docsrs")
-        // Work around https://github.com/rust-lang/cargo/issues/10744
-        .env("CARGO_TARGET_APPLIES_TO_HOST", "true")
         .env("RUSTDOCFLAGS", rustdocflags)
         .args(extra_args)
         .run()?;


### PR DESCRIPTION
This allows removing a lot of hacks to avoid spurious rebuilds.
