### PR TITLE
Timeline: Extend UtdCause with new reason codes

### DIFF
--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -120,6 +120,8 @@ pub enum MegolmError {
     /// An encrypted message wasn't decrypted, because the sender's
     /// cross-signing identity did not satisfy the requested
     /// [`crate::TrustRequirement`].
+    ///
+    /// The nested value is the sender's current verification level.
     #[error("decryption failed because trust requirement not satisfied: {0}")]
     SenderIdentityNotTrusted(VerificationLevel),
 }

--- a/crates/matrix-sdk-crypto/src/types/events/utd_cause.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/utd_cause.rs
@@ -117,7 +117,7 @@ mod tests {
     use crate::types::events::UtdCause;
 
     #[test]
-    fn a_missing_raw_event_means_we_guess_unknown() {
+    fn test_a_missing_raw_event_means_we_guess_unknown() {
         // When we don't provide any JSON to check for membership, then we guess the UTD
         // is unknown.
         assert_eq!(
@@ -133,7 +133,7 @@ mod tests {
     }
 
     #[test]
-    fn if_there_is_no_membership_info_we_guess_unknown() {
+    fn test_if_there_is_no_membership_info_we_guess_unknown() {
         // If our JSON contains no membership info, then we guess the UTD is unknown.
         assert_eq!(
             UtdCause::determine(
@@ -148,7 +148,7 @@ mod tests {
     }
 
     #[test]
-    fn if_membership_info_cant_be_parsed_we_guess_unknown() {
+    fn test_if_membership_info_cant_be_parsed_we_guess_unknown() {
         // If our JSON contains a membership property but not the JSON we expected, then
         // we guess the UTD is unknown.
         assert_eq!(
@@ -164,7 +164,7 @@ mod tests {
     }
 
     #[test]
-    fn if_membership_is_invite_we_guess_unknown() {
+    fn test_if_membership_is_invite_we_guess_unknown() {
         // If membership=invite then we expected to be sent the keys so the cause of the
         // UTD is unknown.
         assert_eq!(
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn if_membership_is_join_we_guess_unknown() {
+    fn test_if_membership_is_join_we_guess_unknown() {
         // If membership=join then we expected to be sent the keys so the cause of the
         // UTD is unknown.
         assert_eq!(
@@ -196,7 +196,7 @@ mod tests {
     }
 
     #[test]
-    fn if_membership_is_leave_we_guess_membership() {
+    fn test_if_membership_is_leave_we_guess_membership() {
         // If membership=leave then we have an explanation for why we can't decrypt,
         // until we have MSC3061.
         assert_eq!(
@@ -212,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn if_reason_is_not_missing_key_we_guess_unknown_even_if_membership_is_leave() {
+    fn test_if_reason_is_not_missing_key_we_guess_unknown_even_if_membership_is_leave() {
         // If the UnableToDecryptReason is other than MissingMegolmSession or
         // UnknownMegolmMessageIndex, we do not know the reason for the failure
         // even if membership=leave.
@@ -229,7 +229,7 @@ mod tests {
     }
 
     #[test]
-    fn if_unstable_prefix_membership_is_leave_we_guess_membership() {
+    fn test_if_unstable_prefix_membership_is_leave_we_guess_membership() {
         // Before MSC4115 is merged, we support the unstable prefix too.
         assert_eq!(
             UtdCause::determine(
@@ -246,7 +246,7 @@ mod tests {
     }
 
     #[test]
-    fn verification_violation_is_passed_through() {
+    fn test_verification_violation_is_passed_through() {
         assert_eq!(
             UtdCause::determine(
                 Some(&raw_event(json!({}))),
@@ -262,7 +262,7 @@ mod tests {
     }
 
     #[test]
-    fn unsigned_device_is_passed_through() {
+    fn test_unsigned_device_is_passed_through() {
         assert_eq!(
             UtdCause::determine(
                 Some(&raw_event(json!({}))),
@@ -278,7 +278,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_device_is_passed_through() {
+    fn test_unknown_device_is_passed_through() {
         assert_eq!(
             UtdCause::determine(
                 Some(&raw_event(json!({}))),

--- a/crates/matrix-sdk-crypto/src/types/events/utd_cause.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/utd_cause.rs
@@ -24,9 +24,9 @@ pub enum UtdCause {
     #[default]
     Unknown = 0,
 
-    /// This event was sent when we were not a member of the room (or invited),
-    /// so it is impossible to decrypt (without MSC3061).
-    Membership = 1,
+    /// We are missing the keys for this event, and the event was sent when we
+    /// were not a member of the room (or invited).
+    SentBeforeWeJoined = 1,
     //
     // TODO: Other causes for UTDs. For example, this message is device-historical, information
     // extracted from the WithheldCode in the MissingRoomKey object, or various types of Olm
@@ -64,7 +64,7 @@ impl UtdCause {
             if let Ok(Some(unsigned)) = raw_event.get_field::<UnsignedWithMembership>("unsigned") {
                 if let Membership::Leave = unsigned.membership {
                     // We were not a member - this is the cause of the UTD
-                    return UtdCause::Membership;
+                    return UtdCause::SentBeforeWeJoined;
                 }
             }
         }
@@ -132,7 +132,7 @@ mod tests {
         // until we have MSC3061.
         assert_eq!(
             UtdCause::determine(Some(&raw_event(json!({ "unsigned": { "membership": "leave" } })))),
-            UtdCause::Membership
+            UtdCause::SentBeforeWeJoined
         );
     }
 
@@ -143,7 +143,7 @@ mod tests {
             UtdCause::determine(Some(&raw_event(
                 json!({ "unsigned": { "io.element.msc4115.membership": "leave" } })
             ))),
-            UtdCause::Membership
+            UtdCause::SentBeforeWeJoined
         );
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -416,10 +416,10 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 }
             },
 
-            TimelineEventKind::UnableToDecrypt { content, .. } => {
+            TimelineEventKind::UnableToDecrypt { content, unable_to_decrypt_info } => {
                 // TODO: Handle replacements if the replaced event is also UTD
                 let raw_event = self.ctx.flow.raw_event();
-                let cause = UtdCause::determine(raw_event);
+                let cause = UtdCause::determine(raw_event, &unable_to_decrypt_info);
                 self.add_item(TimelineItemContent::unable_to_decrypt(content, cause), None);
 
                 // Let the hook know that we ran into an unable-to-decrypt that is added to the

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -493,7 +493,7 @@ async fn test_utd_cause_for_nonmember_event_is_found() {
         TimelineItemContent::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 { cause, .. }) =
             event.content()
     );
-    assert_eq!(*cause, UtdCause::Membership);
+    assert_eq!(*cause, UtdCause::SentBeforeWeJoined);
 }
 
 #[async_test]
@@ -516,7 +516,7 @@ async fn test_utd_cause_for_nonmember_event_is_found_unstable_prefix() {
         TimelineItemContent::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 { cause, .. }) =
             event.content()
     );
-    assert_eq!(*cause, UtdCause::Membership);
+    assert_eq!(*cause, UtdCause::SentBeforeWeJoined);
 }
 
 #[async_test]


### PR DESCRIPTION
This PR is the final part of the epic of making unable-to-decrypt information available in the timeline. As of #4070, the UTD info is now available in the `[Sync]TimelineEvent` created by the network code: now, we just need to copy that information into the items that are added to the timeline itself.

To do this, we add a new variant to `matrix_sdk_ui::event_handler::TimelineEventKind` (not to be confused with `matrix_sdk_common::deserialized_responses::TimelineEventKind` which was recently added in #4082) to hold the relevant data, and then add a bunch of new reason codes to the `UtdCause` which is derived from the decryption failure.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/4048.
~~Based on https://github.com/matrix-org/matrix-rust-sdk/pull/4070.~~