### PR TITLE
timeline: use a `TimelineEventItemId` for reacting to something

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -495,7 +495,7 @@ impl Timeline {
         new_content: EditedContent,
     ) -> Result<bool, ClientError> {
         self.inner
-            .edit_by_id(&(event_or_transaction_id.try_into()?), new_content.try_into()?)
+            .edit_by_id(&event_or_transaction_id.try_into()?, new_content.try_into()?)
             .await
             .map_err(Into::into)
     }
@@ -530,19 +530,21 @@ impl Timeline {
 
     /// Toggle a reaction on an event.
     ///
-    /// The `unique_id` parameter is a string returned by
-    /// the `TimelineItem::unique_id()` method. As such, this method works both
-    /// on local echoes and remote items.
-    ///
     /// Adds or redacts a reaction based on the state of the reaction at the
     /// time it is called.
+    ///
+    /// This method works both on local echoes and remote items.
     ///
     /// When redacting a previous reaction, the redaction reason is not set.
     ///
     /// Ensures that only one reaction is sent at a time to avoid race
     /// conditions and spamming the homeserver with requests.
-    pub async fn toggle_reaction(&self, unique_id: String, key: String) -> Result<(), ClientError> {
-        self.inner.toggle_reaction(&unique_id, &key).await?;
+    pub async fn toggle_reaction(
+        &self,
+        item_id: EventOrTransactionId,
+        key: String,
+    ) -> Result<(), ClientError> {
+        self.inner.toggle_reaction(&item_id.try_into()?, &key).await?;
         Ok(())
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -70,7 +70,7 @@ use crate::{
         event_item::EventTimelineItemKind,
         pinned_events_loader::{PinnedEventsLoader, PinnedEventsLoaderError},
         reactions::FullReactionKey,
-        util::rfind_event_by_uid,
+        util::rfind_event_by_item_id,
         TimelineEventFilterFn,
     },
     unable_to_decrypt_hook::UtdHookManager,
@@ -484,12 +484,12 @@ impl<P: RoomDataProvider> TimelineController<P> {
     #[instrument(skip_all)]
     pub(super) async fn toggle_reaction_local(
         &self,
-        unique_id: &str,
+        item_id: &TimelineEventItemId,
         key: &str,
     ) -> Result<bool, Error> {
         let mut state = self.state.write().await;
 
-        let Some((item_pos, item)) = rfind_event_by_uid(&state.items, unique_id) else {
+        let Some((item_pos, item)) = rfind_event_by_item_id(&state.items, item_id) else {
             warn!("Timeline item not found, can't add reaction");
             return Err(Error::FailedToToggleReaction);
         };
@@ -502,7 +502,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
             .map(|reaction_info| reaction_info.status.clone());
 
         let Some(prev_status) = prev_status else {
-            match &item.inner.kind {
+            match &item.kind {
                 EventTimelineItemKind::Local(local) => {
                     if let Some(send_handle) = local.send_handle.clone() {
                         if send_handle

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -735,7 +735,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
     ///
     /// If the corresponding local timeline item is missing, a warning is
     /// raised.
-    #[instrument(skip_all, fields(txn_id))]
+    #[instrument(skip(self))]
     pub(super) async fn update_event_send_state(
         &self,
         txn_id: &TransactionId,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -103,22 +103,6 @@ pub enum TimelineEventItemId {
     EventId(OwnedEventId),
 }
 
-impl From<String> for TimelineEventItemId {
-    fn from(value: String) -> Self {
-        value.as_str().into()
-    }
-}
-
-impl From<&str> for TimelineEventItemId {
-    fn from(value: &str) -> Self {
-        if let Ok(event_id) = EventId::parse(value) {
-            TimelineEventItemId::EventId(event_id)
-        } else {
-            TimelineEventItemId::TransactionId(value.into())
-        }
-    }
-}
-
 /// An handle that usually allows to perform an action on a timeline event.
 ///
 /// If the item represents a remote item, then the event id is usually
@@ -749,7 +733,7 @@ mod tests {
     };
 
     use super::{EventTimelineItem, Profile};
-    use crate::timeline::{TimelineDetails, TimelineEventItemId};
+    use crate::timeline::TimelineDetails;
 
     #[async_test]
     async fn test_latest_message_event_can_be_wrapped_as_a_timeline_item() {
@@ -972,20 +956,6 @@ mod tests {
                 avatar_url: Some(owned_mxc_uri!("mxc://e.org/SEs"))
             }
         );
-    }
-
-    #[test]
-    fn test_raw_event_id_into_timeline_event_item_id_gets_event_id() {
-        let raw_id = "$123:example.com";
-        let id: TimelineEventItemId = raw_id.into();
-        assert_matches!(id, TimelineEventItemId::EventId(_));
-    }
-
-    #[test]
-    fn test_raw_str_into_timeline_event_item_id_gets_transaction_id() {
-        let raw_id = "something something";
-        let id: TimelineEventItemId = raw_id.into();
-        assert_matches!(id, TimelineEventItemId::TransactionId(_));
     }
 
     fn member_event(

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -547,9 +547,6 @@ impl Timeline {
 
     /// Toggle a reaction on an event.
     ///
-    /// The `unique_id` parameter is a string returned by
-    /// [`TimelineItem::unique_id()`].
-    ///
     /// Adds or redacts a reaction based on the state of the reaction at the
     /// time it is called.
     ///
@@ -557,8 +554,12 @@ impl Timeline {
     ///
     /// Ensures that only one reaction is sent at a time to avoid race
     /// conditions and spamming the homeserver with requests.
-    pub async fn toggle_reaction(&self, unique_id: &str, reaction_key: &str) -> Result<(), Error> {
-        self.controller.toggle_reaction_local(unique_id, reaction_key).await?;
+    pub async fn toggle_reaction(
+        &self,
+        item_id: &TimelineEventItemId,
+        reaction_key: &str,
+    ) -> Result<(), Error> {
+        self.controller.toggle_reaction_local(item_id, reaction_key).await?;
         Ok(())
     }
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -320,7 +320,7 @@ async fn test_focused_timeline_local_echoes() {
     assert_pending!(timeline_stream);
 
     // Add a reaction to the focused event, which will cause a local echo to happen.
-    timeline.toggle_reaction(items[1].unique_id(), "✨").await.unwrap();
+    timeline.toggle_reaction(&event_item.identifier(), "✨").await.unwrap();
 
     // We immediately get the local echo for the reaction.
     let item = assert_next_matches_with_timeout!(timeline_stream, VectorDiff::Set { index: 1, value: item } => item);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
@@ -75,7 +75,7 @@ async fn test_abort_before_being_sent() {
 
     assert_let!(Some(VectorDiff::PushBack { value: first }) = stream.next().await);
     let item = first.as_event().unwrap();
-    let unique_id = first.unique_id();
+    let item_id = item.identifier();
     assert_eq!(item.content().as_message().unwrap().body(), "hello");
 
     assert_let!(Some(VectorDiff::PushFront { value: day_divider }) = stream.next().await);
@@ -102,7 +102,7 @@ async fn test_abort_before_being_sent() {
     mock_redaction(event_id!("$3")).mount(&server).await;
 
     // We add the reaction…
-    timeline.toggle_reaction(unique_id, "👍").await.unwrap();
+    timeline.toggle_reaction(&item_id, "👍").await.unwrap();
 
     // First toggle (local echo).
     {
@@ -119,7 +119,7 @@ async fn test_abort_before_being_sent() {
     }
 
     // We toggle another reaction at the same time…
-    timeline.toggle_reaction(unique_id, "🥰").await.unwrap();
+    timeline.toggle_reaction(&item_id, "🥰").await.unwrap();
 
     {
         assert_let!(Some(VectorDiff::Set { index: 1, value: item }) = stream.next().await);
@@ -140,7 +140,7 @@ async fn test_abort_before_being_sent() {
 
     // Then we remove the first one; because it was being sent, it should lead to a
     // redaction event.
-    timeline.toggle_reaction(unique_id, "👍").await.unwrap();
+    timeline.toggle_reaction(&item_id, "👍").await.unwrap();
 
     {
         assert_let!(Some(VectorDiff::Set { index: 1, value: item }) = stream.next().await);
@@ -157,7 +157,7 @@ async fn test_abort_before_being_sent() {
 
     // But because the first one was being sent, this one won't and the local echo
     // could be discarded.
-    timeline.toggle_reaction(unique_id, "🥰").await.unwrap();
+    timeline.toggle_reaction(&item_id, "🥰").await.unwrap();
 
     {
         assert_let!(Some(VectorDiff::Set { index: 1, value: item }) = stream.next().await);
@@ -214,12 +214,11 @@ async fn test_redact_failed() {
     let _response = client.sync_once(Default::default()).await.unwrap();
     server.reset().await;
 
-    let unique_id = assert_next_matches_with_timeout!(stream, VectorDiff::PushBack { value: item } => {
-        let unique_id = item.unique_id().to_owned();
+    let item_id = assert_next_matches_with_timeout!(stream, VectorDiff::PushBack { value: item } => {
         let item = item.as_event().unwrap();
         assert_eq!(item.content().as_message().unwrap().body(), "hello");
         assert!(item.reactions().is_empty());
-        unique_id
+        item.identifier()
     });
 
     assert_next_matches_with_timeout!(stream, VectorDiff::Set { index: 0, value: item } => {
@@ -242,7 +241,7 @@ async fn test_redact_failed() {
         .await;
 
     // We toggle the reaction, which fails with an error.
-    timeline.toggle_reaction(&unique_id, "😆").await.unwrap_err();
+    timeline.toggle_reaction(&item_id, "😆").await.unwrap_err();
 
     // The local echo is removed (assuming the redaction works)…
     assert_next_matches_with_timeout!(stream, VectorDiff::Set { index: 1, value: item } => {
@@ -310,13 +309,12 @@ async fn test_local_reaction_to_local_echo() {
     let _ = timeline.send(RoomMessageEventContent::text_plain("lol").into()).await.unwrap();
 
     // Receive a local echo.
-    let unique_id = assert_next_matches_with_timeout!(stream, VectorDiff::PushBack { value: item } => {
-        let unique_id = item.unique_id().to_owned();
+    let item_id = assert_next_matches_with_timeout!(stream, VectorDiff::PushBack { value: item } => {
         let item = item.as_event().unwrap();
         assert!(item.is_local_echo());
         assert_eq!(item.content().as_message().unwrap().body(), "lol");
         assert!(item.reactions().is_empty());
-        unique_id
+        item.identifier()
     });
 
     // Good ol' day divider.
@@ -326,7 +324,7 @@ async fn test_local_reaction_to_local_echo() {
 
     // Add a reaction before the remote echo comes back.
     let key1 = "🤣";
-    timeline.toggle_reaction(&unique_id, key1).await.unwrap();
+    timeline.toggle_reaction(&item_id, key1).await.unwrap();
 
     // The reaction is added to the local echo.
     assert_next_matches_with_timeout!(stream, VectorDiff::Set { index: 1, value: item } => {
@@ -338,7 +336,7 @@ async fn test_local_reaction_to_local_echo() {
 
     // Add another reaction.
     let key2 = "😈";
-    timeline.toggle_reaction(&unique_id, key2).await.unwrap();
+    timeline.toggle_reaction(&item_id, key2).await.unwrap();
 
     // Also comes as a local echo.
     assert_next_matches_with_timeout!(stream, VectorDiff::Set { index: 1, value: item } => {
@@ -350,7 +348,7 @@ async fn test_local_reaction_to_local_echo() {
 
     // Remove second reaction. It's immediately removed, since it was a local echo,
     // and it wasn't being sent.
-    timeline.toggle_reaction(&unique_id, key2).await.unwrap();
+    timeline.toggle_reaction(&item_id, key2).await.unwrap();
 
     assert_next_matches_with_timeout!(stream, VectorDiff::Set { index: 1, value: item } => {
         let reactions = item.as_event().unwrap().reactions();


### PR DESCRIPTION
New preamble to https://github.com/matrix-org/matrix-rust-sdk/pull/4111.