### PR TITLE
feat(knocking): process knocked rooms separately during sync

### DIFF
--- a/crates/matrix-sdk-base/src/debug.rs
+++ b/crates/matrix-sdk-base/src/debug.rs
@@ -17,7 +17,10 @@
 use std::fmt;
 
 pub use matrix_sdk_common::debug::*;
-use ruma::{api::client::sync::sync_events::v3::InvitedRoom, serde::Raw};
+use ruma::{
+    api::client::sync::sync_events::v3::{InvitedRoom, KnockedRoom},
+    serde::Raw,
+};
 
 /// A wrapper around a slice of `Raw` events that implements `Debug` in a way
 /// that only prints the event type of each item.
@@ -42,6 +45,20 @@ impl<'a> fmt::Debug for DebugInvitedRoom<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("InvitedRoom")
             .field("invite_state", &DebugListOfRawEvents(&self.0.invite_state.events))
+            .finish()
+    }
+}
+
+/// A wrapper around a knocked on room as found in `/sync` responses that
+/// implements `Debug` in a way that only prints the event ID and event type for
+/// the raw events contained in `knock_state`.
+pub struct DebugKnockedRoom<'a>(pub &'a KnockedRoom);
+
+#[cfg(not(tarpaulin_include))]
+impl<'a> fmt::Debug for DebugKnockedRoom<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KnockedRoom")
+            .field("knock_state", &DebugListOfRawEvents(&self.0.knock_state.events))
             .finish()
     }
 }

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -15,7 +15,10 @@ use matrix_sdk_test::{
     async_test, sync_state_event,
     test_json::{
         self,
-        sync::{MIXED_INVITED_ROOM_ID, MIXED_JOINED_ROOM_ID, MIXED_LEFT_ROOM_ID, MIXED_SYNC},
+        sync::{
+            MIXED_INVITED_ROOM_ID, MIXED_JOINED_ROOM_ID, MIXED_KNOCKED_ROOM_ID, MIXED_LEFT_ROOM_ID,
+            MIXED_SYNC,
+        },
         sync_events::PINNED_EVENTS,
         TAG,
     },
@@ -340,7 +343,7 @@ async fn test_subscribe_all_room_updates() {
     client.sync_once(sync_settings).await.unwrap();
 
     let room_updates = rx.recv().now_or_never().unwrap().unwrap();
-    assert_let!(RoomUpdates { leave, join, invite } = room_updates);
+    assert_let!(RoomUpdates { leave, join, invite, knocked } = room_updates);
 
     // Check the left room updates.
     {
@@ -382,6 +385,16 @@ async fn test_subscribe_all_room_updates() {
 
         assert_eq!(room_id, *MIXED_INVITED_ROOM_ID);
         assert_eq!(update.invite_state.events.len(), 2);
+    }
+
+    // Check the knocked room updates.
+    {
+        assert_eq!(knocked.len(), 1);
+
+        let (room_id, update) = knocked.iter().next().unwrap();
+
+        assert_eq!(room_id, *MIXED_KNOCKED_ROOM_ID);
+        assert_eq!(update.knock_state.events.len(), 2);
     }
 }
 

--- a/testing/matrix-sdk-test/src/test_json/sync.rs
+++ b/testing/matrix-sdk-test/src/test_json/sync.rs
@@ -1240,8 +1240,11 @@ pub static MIXED_LEFT_ROOM_ID: Lazy<&RoomId> =
 /// In the [`MIXED_SYNC`], the room id of the invited room.
 pub static MIXED_INVITED_ROOM_ID: Lazy<&RoomId> =
     Lazy::new(|| room_id!("!SVkFJHzfwvuaIEawgE:localhost"));
+/// In the [`MIXED_SYNC`], the room id of the knocked room.
+pub static MIXED_KNOCKED_ROOM_ID: Lazy<&RoomId> =
+    Lazy::new(|| room_id!("!SVkFJHzfwvuaIEawgF:localhost"));
 
-/// A sync that contains updates to joined/invited/left rooms.
+/// A sync that contains updates to joined/invited/knocked/left rooms.
 pub static MIXED_SYNC: Lazy<JsonValue> = Lazy::new(|| {
     json!({
         "account_data": {
@@ -1351,6 +1354,30 @@ pub static MIXED_SYNC: Lazy<JsonValue> = Lazy::new(|| {
                         "state_key": "@bob:example.com",
                         "content": {
                           "membership": "invite"
+                        }
+                      }
+                    ]
+                  }
+                }
+            },
+            "knock": {
+                *MIXED_KNOCKED_ROOM_ID: {
+                  "knock_state": {
+                    "events": [
+                      {
+                        "sender": "@alice:example.com",
+                        "type": "m.room.name",
+                        "state_key": "",
+                        "content": {
+                          "name": "My Room Name"
+                        }
+                      },
+                      {
+                        "sender": "@bob:example.com",
+                        "type": "m.room.member",
+                        "state_key": "@bob:example.com",
+                        "content": {
+                          "membership": "knock"
                         }
                       }
                     ]


### PR DESCRIPTION
## Changes

This PR contains 2 commits:

1. The first one processes the membership state events in `process_sliding_sync_room_membership`, deserializes them and decides whether the resulting room should be a knock or invite one default to invite if not sure. Then it propagates the changes up the flow.
2. Since we already have `handle_stripped_state` to parse the contents of the `invite_state` stripped state events it seemed better to reuse this and deserialize the events only once, then mark the room as invited or knocked in this method. Ideally this should be part of the inner `fn BaseRoomInfo::handle_stripped_state_event`, but that doesn't have access to the `Room::state` property.

Both solutions work AFAICT, the 1st one centralises the membership processing in a single point but it's more inefficient, the 2nd one does only one round of deserialization but hides the membership change a bit lower in the sliding sync processing flow. Let me know if you have any preferences and I'll use one of those versions, or propose a better alternative.

Existing tests have been extended to check the invite vs knock room state processing.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
