### PR TITLE
refactor(oidc): allow passing a `Prompt` to get an OIDC url

### DIFF
--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -443,10 +443,11 @@ impl Oidc {
     /// webview for a user to login to their account. Call
     /// [`Oidc::login_with_oidc_callback`] to finish the process when the
     /// webview is complete.
-    pub async fn url_for_oidc_login(
+    pub async fn url_for_oidc(
         &self,
         client_metadata: VerifiedClientMetadata,
         registrations: OidcRegistrations,
+        prompt: Prompt,
     ) -> Result<OidcAuthorizationData, OidcError> {
         let issuer = match self.fetch_authentication_issuer().await {
             Ok(issuer) => issuer,
@@ -470,7 +471,7 @@ impl Oidc {
         self.configure(issuer, client_metadata, registrations).await?;
 
         let mut data_builder = self.login(redirect_url.clone(), None)?;
-        data_builder = data_builder.prompt(vec![Prompt::Consent]);
+        data_builder = data_builder.prompt(vec![prompt]);
         let data = data_builder.build().await?;
 
         Ok(data)
@@ -478,7 +479,7 @@ impl Oidc {
 
     /// A higher level wrapper around the methods to complete a login after the
     /// user has logged in through a webview. This method should be used in
-    /// tandem with [`Oidc::url_for_oidc_login`].
+    /// tandem with [`Oidc::url_for_oidc`].
     pub async fn login_with_oidc_callback(
         &self,
         authorization_data: &OidcAuthorizationData,

--- a/crates/matrix-sdk/src/oidc/tests.rs
+++ b/crates/matrix-sdk/src/oidc/tests.rs
@@ -9,6 +9,7 @@ use mas_oidc_client::{
         errors::ClientErrorCode,
         iana::oauth::OAuthClientAuthenticationMethod,
         registration::{ClientMetadata, VerifiedClientMetadata},
+        requests::Prompt,
     },
 };
 use matrix_sdk_base::SessionMeta;
@@ -124,7 +125,7 @@ async fn test_high_level_login() -> anyhow::Result<()> {
 
     // When getting the OIDC login URL.
     let authorization_data =
-        oidc.url_for_oidc_login(metadata.clone(), registrations).await.unwrap();
+        oidc.url_for_oidc(metadata.clone(), registrations, Prompt::Login).await.unwrap();
 
     // Then the client should be configured correctly.
     assert!(oidc.issuer().is_some());
@@ -146,7 +147,7 @@ async fn test_high_level_login_cancellation() -> anyhow::Result<()> {
     // Given a client ready to complete login.
     let (oidc, _server, metadata, registrations) = mock_environment().await.unwrap();
     let authorization_data =
-        oidc.url_for_oidc_login(metadata.clone(), registrations).await.unwrap();
+        oidc.url_for_oidc(metadata.clone(), registrations, Prompt::Login).await.unwrap();
 
     assert!(oidc.issuer().is_some());
     assert!(oidc.client_metadata().is_some());
@@ -170,7 +171,7 @@ async fn test_high_level_login_invalid_state() -> anyhow::Result<()> {
     // Given a client ready to complete login.
     let (oidc, _server, metadata, registrations) = mock_environment().await.unwrap();
     let authorization_data =
-        oidc.url_for_oidc_login(metadata.clone(), registrations).await.unwrap();
+        oidc.url_for_oidc(metadata.clone(), registrations, Prompt::Login).await.unwrap();
 
     assert!(oidc.issuer().is_some());
     assert!(oidc.client_metadata().is_some());


### PR DESCRIPTION
This allows clients to directly open the web page they want: the login one, the registration one, consent, etc. It should improve the UX in the registration flow since we can now skip the login one.

Requested in https://github.com/element-hq/element-x-android/pull/3635.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
