### PR TITLE
doc(contributing): Recommend --interactive for git rebase --autosquash

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,7 +193,7 @@ requested.
    commits, the [autosquash] option can help with this.
 
 ```bash
-git rebase main --autosquash
+git rebase main --interactive --autosquash
 ```
 
 [fixup]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupamendrewordltcommitgt


### PR DESCRIPTION
Older versions of Git require --interactive when we supply --autosquash, and it's also probably a good idea generally.

See https://stackoverflow.com/a/77663575/22610 for more info.