### PR TITLE
chore(timeline): instrument timeline tasks with their focus and internal id prefix

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -163,7 +163,7 @@ impl TimelineBuilder {
         let controller = TimelineController::new(
             room,
             focus.clone(),
-            internal_id_prefix,
+            internal_id_prefix.clone(),
             unable_to_decrypt_hook,
             is_room_encrypted,
         )
@@ -206,8 +206,13 @@ impl TimelineBuilder {
             let room_event_cache = room_event_cache.clone();
             let inner = controller.clone();
 
-            let span =
-                info_span!(parent: Span::none(), "room_update_handler", room_id = ?room.room_id());
+            let span = info_span!(
+                parent: Span::none(),
+                "live_update_handler",
+                room_id = ?room.room_id(),
+                focus = focus.debug_string(),
+                prefix = internal_id_prefix
+            );
             span.follows_from(Span::current());
 
             async move {
@@ -307,7 +312,13 @@ impl TimelineBuilder {
                     timeline.handle_local_echo(echo).await;
                 }
 
-                let span = info_span!(parent: Span::none(), "local_echo_handler", room_id = ?room.room_id());
+                let span = info_span!(
+                    parent: Span::none(),
+                    "local_echo_handler",
+                    room_id = ?room.room_id(),
+                    focus = focus.debug_string(),
+                    prefix = internal_id_prefix
+                );
                 span.follows_from(Span::current());
 
                 // React to future local echoes too.

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -171,6 +171,16 @@ pub enum TimelineFocus {
     PinnedEvents { max_events_to_load: u16, max_concurrent_requests: u16 },
 }
 
+impl TimelineFocus {
+    pub(super) fn debug_string(&self) -> String {
+        match self {
+            TimelineFocus::Live => "live".to_owned(),
+            TimelineFocus::Event { target, .. } => format!("permalink:{target}"),
+            TimelineFocus::PinnedEvents { .. } => "pinned-events".to_owned(),
+        }
+    }
+}
+
 impl Timeline {
     /// Create a new [`TimelineBuilder`] for the given room.
     pub fn builder(room: &Room) -> TimelineBuilder {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -60,7 +60,13 @@ async fn test_echo() {
     mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await.unwrap());
+    let timeline = Arc::new(
+        room.timeline_builder()
+            .with_internal_id_prefix("le_prefix".to_owned())
+            .build()
+            .await
+            .unwrap(),
+    );
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     Mock::given(method("PUT"))


### PR DESCRIPTION
This would have avoided a few hours of debugging where we thought there was an issue with multiple timelines spawned at the same time, and then realized it was expected because of the existence of the pinned timeline in EX apps.