### PR TITLE
chore(ci): run tarpaulin in release mode

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -98,6 +98,7 @@ jobs:
         env:
           CARGO_PROFILE_COV_INHERITS: 'dev'
           CARGO_PROFILE_COV_DEBUG: 1
+          CARGO_PROFILE_COV_OPT_LEVEL: 1
           HOMESERVER_URL: "http://localhost:8008"
           HOMESERVER_DOMAIN: "synapse"
           SLIDING_SYNC_PROXY_URL: "http://localhost:8118"

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1371,10 +1371,12 @@ impl BaseClient {
     pub async fn share_room_key(&self, room_id: &RoomId) -> Result<Vec<Arc<ToDeviceRequest>>> {
         match self.olm_machine().await.as_ref() {
             Some(o) => {
-                let (history_visibility, settings) = self
-                    .get_room(room_id)
+                let room = self.get_room(room_id);
+                tracing::warn!("BNJBVR: room found? {:?}", room.is_some());
+                let (history_visibility, settings) = room
                     .map(|r| (r.history_visibility(), r.encryption_settings()))
                     .unwrap_or((HistoryVisibility::Joined, None));
+                tracing::warn!("BNJBVR: encryption settings: {settings:?}");
 
                 // Don't share the group session with members that are invited
                 // if the history visibility is set to `Joined`

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1238,6 +1238,7 @@ impl RoomInfo {
 
     /// Set the encryption event content in this room.
     pub fn set_encryption_event(&mut self, event: Option<RoomEncryptionEventContent>) {
+        tracing::warn!("BNJBVR: set_encryption_event: {event:?}");
         self.base_info.encryption = event;
     }
 

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -227,6 +227,7 @@ impl Store {
                 );
                 let new_room_id = new_room.room_id().to_owned();
 
+                tracing::warn!(room_id = %new_room_id, "BNJBVR: restoring room");
                 rooms.insert(new_room_id, new_room);
             }
         }
@@ -294,6 +295,7 @@ impl Store {
             .write()
             .unwrap()
             .get_or_create(room_id, || {
+                tracing::warn!(%room_id, "BNJBVR: creating a new room in store");
                 Room::new(
                     user_id,
                     self.inner.clone(),
@@ -312,6 +314,7 @@ impl Store {
     /// * `room_id` - The id of the room that should be forgotten.
     pub(crate) async fn forget_room(&self, room_id: &RoomId) -> Result<()> {
         self.inner.remove_room(room_id).await?;
+        tracing::warn!(%room_id, "BNJBVR: removing room");
         self.rooms.write().unwrap().remove(room_id);
         Ok(())
     }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -564,6 +564,7 @@ impl Room {
 
                 // Persist the event and the fact that we requested it from the server in
                 // `RoomInfo`.
+                tracing::warn!("BNJBVR: done request_encryption_state: {response:?}");
                 let mut room_info = self.clone_info();
                 room_info.mark_encryption_state_synced();
                 room_info.set_encryption_event(response.clone());


### PR DESCRIPTION
This is a small experiment: it turns out compiling is relatively quick, on a PR I just did (3 minutes), but running the tarpaulin build took around 8 minutes. I'm wondering if increasing the compile times and lowering the run time is worth it, hence this experiment.