### PR TITLE
Process name changes that come back on the sync api

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -42,6 +42,7 @@ use ruma::{
             history_visibility::HistoryVisibility,
             join_rules::JoinRule,
             member::{MembershipState, RoomMemberEventContent},
+            name::RoomNameEventContent,
             pinned_events::RoomPinnedEventsEventContent,
             redaction::SyncRoomRedactionEvent,
             tombstone::RoomTombstoneEventContent,
@@ -1496,6 +1497,14 @@ impl RoomInfo {
             Some(MinimalStateEvent::Original(ev)) => &ev.content.join_rule,
             _ => &JoinRule::Public,
         }
+    }
+
+    /// Update the room name.
+    pub fn update_name(&mut self, name: String) {
+        self.base_info.name = Some(MinimalStateEvent::Original(OriginalMinimalStateEvent {
+            content: RoomNameEventContent::new(name),
+            event_id: None,
+        }))
     }
 
     /// Get the name of this room.


### PR DESCRIPTION
In debugging code, we found that the 'name' that comes back on Room responses in sliding sync was seemingly not being processed.  This caused name changes to not be reflected in the client.

- [ ] Public API changes documented in changelogs (optional)

Signed-off-by: Daniel Salinas
