### PR TITLE
fix(ffi): don't panic when running into an unknown membership state

### DIFF
--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -217,3 +217,8 @@ impl From<matrix_sdk::Error> for NotificationSettingsError {
         Self::Generic { msg: e.to_string() }
     }
 }
+
+/// Something has not been implemented yet.
+#[derive(thiserror::Error, Debug)]
+#[error("not implemented yet")]
+pub struct NotYetImplemented;

--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -105,7 +105,7 @@ impl TryFrom<AnySyncStateEvent> for StateEventContent {
                 let original_content = get_state_event_original_content(content)?;
                 StateEventContent::RoomMemberContent {
                     user_id: state_key,
-                    membership_state: original_content.membership.into(),
+                    membership_state: original_content.membership.try_into()?,
                 }
             }
             AnySyncStateEvent::RoomName(_) => StateEventContent::RoomName,

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -90,7 +90,10 @@ impl RoomInfo {
                     .await
                     .ok()
                     .and_then(|details| details.inviter)
-                    .map(Into::into),
+                    .map(TryInto::try_into)
+                    .transpose()
+                    .ok()
+                    .flatten(),
                 _ => None,
             },
             heroes: room.heroes().into_iter().map(Into::into).collect(),

--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -19,6 +19,9 @@ pub enum MembershipState {
 
     /// The user has left.
     Leave,
+
+    /// A custom membership state value.
+    Custom { value: String },
 }
 
 impl TryFrom<matrix_sdk::ruma::events::room::member::MembershipState> for MembershipState {
@@ -42,6 +45,9 @@ impl TryFrom<matrix_sdk::ruma::events::room::member::MembershipState> for Member
             }
             matrix_sdk::ruma::events::room::member::MembershipState::Leave => {
                 Ok(MembershipState::Leave)
+            }
+            matrix_sdk::ruma::events::room::member::MembershipState::_Custom(_) => {
+                Ok(MembershipState::Custom { value: m.to_string() })
             }
             _ => {
                 tracing::warn!("Other membership state change not yet implemented");


### PR DESCRIPTION
Fixes #1254. This adds a bandaid in the form of converting `Into` impl to `TryInto`, and then will happily ignore errors in multiple places; unknown states are logged in warnings, so we can still get some information about it, would they become an issue in the future.