### PR TITLE
refactor(base): Remove `impl From` for `SyncTimelineEvent`

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -396,8 +396,10 @@ impl BaseClient {
         let mut timeline = Timeline::new(limited, prev_batch);
         let mut push_context = self.get_push_room_context(room, room_info, changes).await?;
 
-        for event in events {
-            let mut event: SyncTimelineEvent = event.into();
+        for raw_event in events {
+            // Start by assuming we have a plaintext event. We'll replace it with a
+            // decrypted or UTD event below if necessary.
+            let mut event = SyncTimelineEvent::new(raw_event);
 
             match event.raw().deserialize() {
                 Ok(e) => {

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1876,9 +1876,9 @@ mod tests {
             last_prev_batch: Some("pb".to_owned()),
             sync_info: SyncInfo::FullySynced,
             encryption_state_synced: true,
-            latest_event: Some(Box::new(LatestEvent::new(
-                Raw::from_json_string(json!({"sender": "@u:i.uk"}).to_string()).unwrap().into(),
-            ))),
+            latest_event: Some(Box::new(LatestEvent::new(SyncTimelineEvent::new(
+                Raw::from_json_string(json!({"sender": "@u:i.uk"}).to_string()).unwrap(),
+            )))),
             base_info: Box::new(
                 assign!(BaseRoomInfo::new(), { pinned_events: Some(RoomPinnedEventsEventContent::new(vec![owned_event_id!("$a")])) }),
             ),

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -359,12 +359,6 @@ impl SyncTimelineEvent {
     }
 }
 
-impl From<Raw<AnySyncTimelineEvent>> for SyncTimelineEvent {
-    fn from(inner: Raw<AnySyncTimelineEvent>) -> Self {
-        Self::new(inner)
-    }
-}
-
 impl From<TimelineEvent> for SyncTimelineEvent {
     fn from(o: TimelineEvent) -> Self {
         Self { kind: o.kind, push_actions: o.push_actions.unwrap_or_default() }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -1023,7 +1023,7 @@ mod tests {
         formatted_body: &str,
         ts: u64,
     ) -> SyncTimelineEvent {
-        sync_timeline_event!({
+        SyncTimelineEvent::new(sync_timeline_event!({
             "event_id": "$eventid6",
             "sender": user_id,
             "origin_server_ts": ts,
@@ -1035,7 +1035,6 @@ mod tests {
                 "formatted_body": formatted_body,
                 "msgtype": "m.text"
             },
-        })
-        .into()
+        }))
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -16,6 +16,7 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
+use matrix_sdk::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE, BOB, CAROL};
 use ruma::{
     events::{
@@ -112,7 +113,7 @@ async fn test_sticker() {
     let mut stream = timeline.subscribe_events().await;
 
     timeline
-        .handle_live_event(sync_timeline_event!({
+        .handle_live_event(SyncTimelineEvent::new(sync_timeline_event!({
             "content": {
                 "body": "Happy sticker",
                 "info": {
@@ -127,7 +128,7 @@ async fn test_sticker() {
             "origin_server_ts": 143273582,
             "sender": "@alice:server.name",
             "type": "m.sticker",
-        }))
+        })))
         .await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
@@ -278,7 +279,7 @@ async fn test_dedup_pagination() {
     let event = timeline
         .event_builder
         .make_sync_message_event(*ALICE, RoomMessageEventContent::text_plain("o/"));
-    timeline.handle_live_event(event.clone()).await;
+    timeline.handle_live_event(SyncTimelineEvent::new(event.clone())).await;
     // This cast is not actually correct, sync events aren't valid
     // back-paginated events, as they are missing `room_id`. However, the
     // timeline doesn't care about that `room_id` and casts back to

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
+use matrix_sdk::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE, BOB};
 use ruma::events::{
     room::{
@@ -164,26 +165,26 @@ async fn test_hide_failed_to_parse() {
     // m.room.message events must have a msgtype and body in content, so this
     // event with an empty content object should fail to deserialize.
     timeline
-        .handle_live_event(sync_timeline_event!({
+        .handle_live_event(SyncTimelineEvent::new(sync_timeline_event!({
             "content": {},
             "event_id": "$eeG0HA0FAZ37wP8kXlNkxx3I",
             "origin_server_ts": 10,
             "sender": "@alice:example.org",
             "type": "m.room.message",
-        }))
+        })))
         .await;
 
     // Similar to above, the m.room.member state event must also not have an
     // empty content object.
     timeline
-        .handle_live_event(sync_timeline_event!({
+        .handle_live_event(SyncTimelineEvent::new(sync_timeline_event!({
             "content": {},
             "event_id": "$d5G0HA0FAZ37wP8kXlNkxx3I",
             "origin_server_ts": 2179,
             "sender": "@alice:example.org",
             "type": "m.room.member",
             "state_key": "@alice:example.org",
-        }))
+        })))
         .await;
 
     assert_eq!(timeline.controller.items().await.len(), 0);

--- a/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
@@ -14,6 +14,7 @@
 
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
+use matrix_sdk::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE, BOB};
 use ruma::{
     events::{room::message::MessageType, MessageLikeEventType, StateEventType},
@@ -59,13 +60,13 @@ async fn test_invalid_event_content() {
     // m.room.message events must have a msgtype and body in content, so this
     // event with an empty content object should fail to deserialize.
     timeline
-        .handle_live_event(sync_timeline_event!({
+        .handle_live_event(SyncTimelineEvent::new(sync_timeline_event!({
             "content": {},
             "event_id": "$eeG0HA0FAZ37wP8kXlNkxx3I",
             "origin_server_ts": 10,
             "sender": "@alice:example.org",
             "type": "m.room.message",
-        }))
+        })))
         .await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
@@ -78,14 +79,14 @@ async fn test_invalid_event_content() {
     // Similar to above, the m.room.member state event must also not have an
     // empty content object.
     timeline
-        .handle_live_event(sync_timeline_event!({
+        .handle_live_event(SyncTimelineEvent::new(sync_timeline_event!({
             "content": {},
             "event_id": "$d5G0HA0FAZ37wP8kXlNkxx3I",
             "origin_server_ts": 2179,
             "sender": "@alice:example.org",
             "type": "m.room.member",
             "state_key": "@alice:example.org",
-        }))
+        })))
         .await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
@@ -106,7 +107,7 @@ async fn test_invalid_event() {
     // This event is missing the sender field which the homeserver must add to
     // all timeline events. Because the event is malformed, it will be ignored.
     timeline
-        .handle_live_event(sync_timeline_event!({
+        .handle_live_event(SyncTimelineEvent::new(sync_timeline_event!({
             "content": {
                 "body": "hello world",
                 "msgtype": "m.text"
@@ -114,7 +115,7 @@ async fn test_invalid_event() {
             "event_id": "$eeG0HA0FAZ37wP8kXlNkxx3I",
             "origin_server_ts": 10,
             "type": "m.room.message",
-        }))
+        })))
         .await;
     assert_eq!(timeline.controller.items().await.len(), 0);
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -183,7 +183,7 @@ impl TestTimeline {
         C: RedactedMessageLikeEventContent,
     {
         let ev = self.event_builder.make_sync_redacted_message_event(sender, content);
-        self.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
+        self.handle_live_event(SyncTimelineEvent::new(ev)).await;
     }
 
     async fn handle_live_state_event<C>(&self, sender: &UserId, content: C, prev_content: Option<C>)
@@ -191,7 +191,7 @@ impl TestTimeline {
         C: StaticStateEventContent<StateKey = EmptyStateKey>,
     {
         let ev = self.event_builder.make_sync_state_event(sender, "", content, prev_content);
-        self.handle_live_event(ev).await;
+        self.handle_live_event(SyncTimelineEvent::new(ev)).await;
     }
 
     async fn handle_live_state_event_with_state_key<C>(
@@ -209,7 +209,7 @@ impl TestTimeline {
             content,
             prev_content,
         );
-        self.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
+        self.handle_live_event(SyncTimelineEvent::new(ev)).await;
     }
 
     async fn handle_live_redacted_state_event<C>(&self, sender: &UserId, content: C)
@@ -217,7 +217,7 @@ impl TestTimeline {
         C: RedactedStateEventContent<StateKey = EmptyStateKey>,
     {
         let ev = self.event_builder.make_sync_redacted_state_event(sender, "", content);
-        self.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
+        self.handle_live_event(SyncTimelineEvent::new(ev)).await;
     }
 
     async fn handle_live_redacted_state_event_with_state_key<C>(
@@ -230,7 +230,7 @@ impl TestTimeline {
     {
         let ev =
             self.event_builder.make_sync_redacted_state_event(sender, state_key.as_ref(), content);
-        self.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
+        self.handle_live_event(SyncTimelineEvent::new(ev)).await;
     }
 
     async fn handle_live_event(&self, event: impl Into<SyncTimelineEvent>) {

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -1,3 +1,4 @@
+use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_test::{async_test, ALICE, BOB};
 use ruma::{
     events::{
@@ -216,7 +217,7 @@ impl TestTimeline {
         );
         let event =
             self.event_builder.make_sync_message_event_with_id(sender, event_id, event_content);
-        self.handle_live_event(event).await;
+        self.handle_live_event(SyncTimelineEvent::new(event)).await;
     }
 
     async fn send_poll_response(&self, sender: &UserId, answers: Vec<&str>, poll_id: &EventId) {

--- a/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
-use matrix_sdk_base::deserialized_responses::{ShieldState, ShieldStateCode};
+use matrix_sdk_base::deserialized_responses::{ShieldState, ShieldStateCode, SyncTimelineEvent};
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE};
 use ruma::{
     event_id,
@@ -97,7 +97,7 @@ async fn test_local_sent_in_clear_shield() {
 
     // When the remote echo comes in.
     timeline
-        .handle_live_event(sync_timeline_event!({
+        .handle_live_event(SyncTimelineEvent::new(sync_timeline_event!({
             "content": {
                 "body": "Local message",
                 "msgtype": "m.text",
@@ -106,7 +106,7 @@ async fn test_local_sent_in_clear_shield() {
             "event_id": event_id,
             "origin_server_ts": timestamp,
             "type": "m.room.message",
-        }))
+        })))
         .await;
     let item = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
     let event_item = item.as_event().unwrap();

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -320,7 +320,10 @@ mod tests {
         use ruma::room_id;
         use tokio::{spawn, time::sleep};
 
-        use crate::{event_cache::store::Gap, test_utils::logged_in_client};
+        use crate::{
+            deserialized_responses::SyncTimelineEvent, event_cache::store::Gap,
+            test_utils::logged_in_client,
+        };
 
         #[async_test]
         async fn test_wait_no_pagination_token() {
@@ -335,14 +338,15 @@ mod tests {
             let (room_event_cache, _drop_handlers) = event_cache.for_room(room_id).await.unwrap();
 
             // When I only have events in a room,
-            room_event_cache.inner.state.write().await.events.push_events([sync_timeline_event!({
-                "sender": "b@z.h",
-                "type": "m.room.message",
-                "event_id": "$ida",
-                "origin_server_ts": 12344446,
-                "content": { "body":"yolo", "msgtype": "m.text" },
-            })
-            .into()]);
+            room_event_cache.inner.state.write().await.events.push_events([
+                SyncTimelineEvent::new(sync_timeline_event!({
+                    "sender": "b@z.h",
+                    "type": "m.room.message",
+                    "event_id": "$ida",
+                    "origin_server_ts": 12344446,
+                    "content": { "body":"yolo", "msgtype": "m.text" },
+                })),
+            ]);
 
             let pagination = room_event_cache.pagination();
 
@@ -395,14 +399,13 @@ mod tests {
             {
                 let room_events = &mut room_event_cache.inner.state.write().await.events;
                 room_events.push_gap(Gap { prev_token: expected_token.clone() });
-                room_events.push_events([sync_timeline_event!({
+                room_events.push_events([SyncTimelineEvent::new(sync_timeline_event!({
                     "sender": "b@z.h",
                     "type": "m.room.message",
                     "event_id": "$ida",
                     "origin_server_ts": 12344446,
                     "content": { "body":"yolo", "msgtype": "m.text" },
-                })
-                .into()]);
+                }))]);
             }
 
             let pagination = room_event_cache.pagination();

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -36,7 +36,7 @@ use async_stream::stream;
 pub use client::{Version, VersionBuilder};
 use futures_core::stream::Stream;
 pub use matrix_sdk_base::sliding_sync::http;
-use matrix_sdk_common::timer;
+use matrix_sdk_common::{deserialized_responses::SyncTimelineEvent, timer};
 use ruma::{
     api::{client::error::ErrorKind, OutgoingRequest},
     assign, OwnedEventId, OwnedRoomId, RoomId,
@@ -345,7 +345,7 @@ impl SlidingSync {
                         if let Some(joined_room) = sync_response.rooms.join.remove(&room_id) {
                             joined_room.timeline.events
                         } else {
-                            room_data.timeline.drain(..).map(Into::into).collect()
+                            room_data.timeline.drain(..).map(SyncTimelineEvent::new).collect()
                         };
 
                     match rooms_map.get_mut(&room_id) {


### PR DESCRIPTION
I feel like the ability to convert straight from a `Raw<AnySyncTimelineEvent>>` into a `SyncTimelineEvent` is somewhat over-simplified: the two are only occasionally equivalent, and it's better to be explicit.