### PR TITLE
chore(knocking): Add `reason` and `server_names` to `Client::knock`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -977,9 +977,16 @@ impl Client {
     }
 
     /// Knock on a room to join it using its ID or alias.
-    pub async fn knock(&self, room_id_or_alias: String) -> Result<Arc<Room>, ClientError> {
+    pub async fn knock(
+        &self,
+        room_id_or_alias: String,
+        reason: Option<String>,
+        server_names: Vec<String>,
+    ) -> Result<Arc<Room>, ClientError> {
         let room_id = RoomOrAliasId::parse(&room_id_or_alias)?;
-        let room = self.inner.knock(room_id).await?;
+        let server_names =
+            server_names.iter().map(ServerName::parse).collect::<Result<Vec<_>, _>>()?;
+        let room = self.inner.knock(room_id, reason, server_names).await?;
         Ok(Arc::new(Room::new(room)))
     }
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2243,8 +2243,14 @@ impl Client {
 
     /// Knock on a room given its `room_id_or_alias` to ask for permission to
     /// join it.
-    pub async fn knock(&self, room_id_or_alias: OwnedRoomOrAliasId) -> Result<Room> {
-        let request = knock_room::v3::Request::new(room_id_or_alias);
+    pub async fn knock(
+        &self,
+        room_id_or_alias: OwnedRoomOrAliasId,
+        reason: Option<String>,
+        server_names: Vec<OwnedServerName>,
+    ) -> Result<Room> {
+        let request =
+            assign!(knock_room::v3::Request::new(room_id_or_alias), { reason, via: server_names });
         let response = self.send(request, None).await?;
         let base_room = self.inner.base_client.room_knocked(&response.room_id).await?;
         Ok(Room::new(self.clone(), base_room))

--- a/crates/matrix-sdk/tests/integration/room/left.rs
+++ b/crates/matrix-sdk/tests/integration/room/left.rs
@@ -150,7 +150,7 @@ async fn test_knocking() {
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
     assert_eq!(room.state(), RoomState::Left);
 
-    let room =
-        client.knock(OwnedRoomOrAliasId::from((*DEFAULT_TEST_ROOM_ID).to_owned())).await.unwrap();
+    let room_id = OwnedRoomOrAliasId::from((*DEFAULT_TEST_ROOM_ID).to_owned());
+    let room = client.knock(room_id, None, Vec::new()).await.unwrap();
     assert_eq!(room.state(), RoomState::Knocked);
 }


### PR DESCRIPTION
These are needed parts of the API 😬 .

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
