### PR TITLE
Session verification incoming request support

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/verification.rs
@@ -752,7 +752,7 @@ impl VerificationRequest {
             RustVerificationRequestState::Ready {
                 their_methods,
                 our_methods,
-                other_device_id: _,
+                other_device_data: _,
             } => VerificationRequestState::Ready {
                 their_methods: their_methods.iter().map(|m| m.to_string()).collect(),
                 our_methods: our_methods.iter().map(|m| m.to_string()).collect(),

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -213,10 +213,10 @@ impl Client {
         let session_verification_controller: Arc<
             tokio::sync::RwLock<Option<SessionVerificationController>>,
         > = Default::default();
-        let ctrl = session_verification_controller.clone();
+        let controller = session_verification_controller.clone();
 
         sdk_client.add_event_handler(move |ev: AnyToDeviceEvent| async move {
-            if let Some(session_verification_controller) = &*ctrl.clone().read().await {
+            if let Some(session_verification_controller) = &*controller.clone().read().await {
                 session_verification_controller.process_to_device_message(ev).await;
             } else {
                 debug!("received to-device message, but verification controller isn't ready");

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -200,32 +200,29 @@ impl SessionVerificationController {
     }
 
     pub(crate) async fn process_to_device_message(&self, event: AnyToDeviceEvent) {
-        match event {
-            AnyToDeviceEvent::KeyVerificationRequest(event) => {
-                info!("Received verification request: {:}", event.sender);
+        if let AnyToDeviceEvent::KeyVerificationRequest(event) = event {
+            info!("Received verification request: {:}", event.sender);
 
-                let Some(request) = self
-                    .encryption
-                    .get_verification_request(&event.sender, &event.content.transaction_id)
-                    .await
-                else {
-                    error!("Failed retrieving verification request");
-                    return;
-                };
+            let Some(request) = self
+                .encryption
+                .get_verification_request(&event.sender, &event.content.transaction_id)
+                .await
+            else {
+                error!("Failed retrieving verification request");
+                return;
+            };
 
-                if !request.is_self_verification() {
-                    info!("Received non-self verification request. Ignoring.");
-                    return;
-                }
-
-                if let Some(delegate) = &*self.delegate.read().unwrap() {
-                    delegate.did_receive_verification_request(
-                        request.other_user_id().into(),
-                        request.flow_id().into(),
-                    );
-                }
+            if !request.is_self_verification() {
+                info!("Received non-self verification request. Ignoring.");
+                return;
             }
-            _ => (),
+
+            if let Some(delegate) = &*self.delegate.read().unwrap() {
+                delegate.did_receive_verification_request(
+                    request.other_user_id().into(),
+                    request.flow_id().into(),
+                );
+            }
         }
     }
 

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -412,7 +412,13 @@ impl VerificationMachine {
                 };
 
                 if request.flow_id() == &flow_id {
-                    request.receive_ready(event.sender(), c);
+                    if let Some(device_data) =
+                        self.store.get_device(event.sender(), c.from_device()).await?
+                    {
+                        request.receive_ready(event.sender(), c, device_data);
+                    } else {
+                        warn!("Could not retrieve the data for the accepting device, ignoring it");
+                    }
                 } else {
                     flow_id_mismatch();
                 }

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -370,12 +370,20 @@ impl VerificationMachine {
                     return Ok(());
                 }
 
+                let Some(device_data) =
+                    self.store.get_device(event.sender(), r.from_device()).await?
+                else {
+                    warn!("Could not retrieve the device data for the incoming verification request, ignoring it");
+                    return Ok(());
+                };
+
                 let request = VerificationRequest::from_request(
                     self.verifications.clone(),
                     self.store.clone(),
                     event.sender(),
                     flow_id,
                     r,
+                    device_data,
                 );
 
                 self.insert_request(request);

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -341,6 +341,7 @@ impl VerificationMachine {
         match &content {
             AnyVerificationContent::Request(r) => {
                 info!(
+                    sender = ?event.sender(),
                     from_device = r.from_device().as_str(),
                     "Received a new verification request",
                 );
@@ -733,12 +734,12 @@ mod tests {
         let content: OutgoingContent = request.try_into().unwrap();
 
         machine
-            .receive_any_event(&wrap_any_to_device_content(bob_request.other_user(), content))
+            .receive_any_event(&wrap_any_to_device_content(bob_request.own_user_id(), content))
             .await
             .unwrap();
 
         let alice_request =
-            machine.get_request(bob_request.other_user(), bob_request.flow_id().as_str()).unwrap();
+            machine.get_request(bob_request.own_user_id(), bob_request.flow_id().as_str()).unwrap();
 
         // We're not yet cancelled.
         assert!(!alice_request.is_cancelled());
@@ -757,12 +758,12 @@ mod tests {
         let content: OutgoingContent = request.try_into().unwrap();
 
         machine
-            .receive_any_event(&wrap_any_to_device_content(bob_request.other_user(), content))
+            .receive_any_event(&wrap_any_to_device_content(bob_request.own_user_id(), content))
             .await
             .unwrap();
 
         let second_request =
-            machine.get_request(bob_request.other_user(), bob_request.flow_id().as_str()).unwrap();
+            machine.get_request(bob_request.own_user_id(), bob_request.flow_id().as_str()).unwrap();
 
         // Make sure we fetched the new one.
         assert_eq!(second_request.flow_id().as_str(), second_transaction_id);
@@ -795,12 +796,12 @@ mod tests {
         let content: OutgoingContent = request.try_into().unwrap();
 
         machine
-            .receive_any_event(&wrap_any_to_device_content(bob_request.other_user(), content))
+            .receive_any_event(&wrap_any_to_device_content(bob_request.own_user_id(), content))
             .await
             .unwrap();
 
         let first_request =
-            machine.get_request(bob_request.other_user(), bob_request.flow_id().as_str()).unwrap();
+            machine.get_request(bob_request.own_user_id(), bob_request.flow_id().as_str()).unwrap();
 
         // We're not yet cancelled.
         assert!(!first_request.is_cancelled());
@@ -819,12 +820,12 @@ mod tests {
         let content: OutgoingContent = request.try_into().unwrap();
 
         machine
-            .receive_any_event(&wrap_any_to_device_content(bob_request.other_user(), content))
+            .receive_any_event(&wrap_any_to_device_content(bob_request.own_user_id(), content))
             .await
             .unwrap();
 
         let second_request =
-            machine.get_request(bob_request.other_user(), bob_request.flow_id().as_str()).unwrap();
+            machine.get_request(bob_request.own_user_id(), bob_request.flow_id().as_str()).unwrap();
 
         // None of the requests are cancelled
         assert!(!first_request.is_cancelled());

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -819,7 +819,7 @@ pub(crate) mod tests {
     }
 
     pub fn bob_device_id() -> &'static DeviceId {
-        device_id!("BOBDEVCIE")
+        device_id!("BOBDEVICE")
     }
 
     pub(crate) async fn setup_stores() -> (Account, VerificationStore, Account, VerificationStore) {

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -90,9 +90,9 @@ pub enum VerificationRequestState {
         /// The verification methods supported by the us.
         our_methods: Vec<VerificationMethod>,
 
-        /// The device ID of the device that responded to the verification
+        /// The device data of the device that responded to the verification
         /// request.
-        other_device_id: OwnedDeviceId,
+        other_device_data: DeviceData,
     },
     /// The verification request has transitioned into a concrete verification
     /// flow. For example it transitioned into the emoji based SAS
@@ -121,7 +121,7 @@ impl From<&InnerRequest> for VerificationRequestState {
             InnerRequest::Ready(s) => Self::Ready {
                 their_methods: s.state.their_methods.to_owned(),
                 our_methods: s.state.our_methods.to_owned(),
-                other_device_id: s.state.other_device_id.to_owned(),
+                other_device_data: s.state.other_device_data.to_owned(),
             },
             InnerRequest::Transitioned(s) => {
                 Self::Transitioned { verification: s.state.verification.to_owned() }
@@ -282,8 +282,10 @@ impl VerificationRequest {
     pub fn other_device_id(&self) -> Option<OwnedDeviceId> {
         match &*self.inner.read() {
             InnerRequest::Requested(r) => Some(r.state.other_device_data.device_id().to_owned()),
-            InnerRequest::Ready(r) => Some(r.state.other_device_id.to_owned()),
-            InnerRequest::Transitioned(r) => Some(r.state.ready.other_device_id.to_owned()),
+            InnerRequest::Ready(r) => Some(r.state.other_device_data.device_id().to_owned()),
+            InnerRequest::Transitioned(r) => {
+                Some(r.state.ready.other_device_data.device_id().to_owned())
+            }
             InnerRequest::Created(_)
             | InnerRequest::Passive(_)
             | InnerRequest::Done(_)
@@ -666,12 +668,18 @@ impl VerificationRequest {
         Some(ToDeviceRequest::for_recipients(recipient, recip_devices, &c, TransactionId::new()))
     }
 
-    pub(crate) fn receive_ready(&self, sender: &UserId, content: &ReadyContent<'_>) {
+    pub(crate) fn receive_ready(
+        &self,
+        sender: &UserId,
+        content: &ReadyContent<'_>,
+        from_device_data: DeviceData,
+    ) {
         let mut guard = self.inner.write();
 
         match &*guard {
             InnerRequest::Created(s) => {
-                let new_value = InnerRequest::Ready(s.clone().into_ready(sender, content));
+                let new_value =
+                    InnerRequest::Ready(s.clone().into_ready(sender, content, from_device_data));
                 ObservableWriteGuard::set(&mut guard, new_value);
 
                 if let Some(request) =
@@ -900,11 +908,11 @@ impl InnerRequest {
                 DeviceIdOrAllDevices::DeviceId(r.state.other_device_data.device_id().to_owned())
             }
             InnerRequest::Ready(r) => {
-                DeviceIdOrAllDevices::DeviceId(r.state.other_device_id.to_owned())
+                DeviceIdOrAllDevices::DeviceId(r.state.other_device_data.device_id().to_owned())
             }
-            InnerRequest::Transitioned(r) => {
-                DeviceIdOrAllDevices::DeviceId(r.state.ready.other_device_id.to_owned())
-            }
+            InnerRequest::Transitioned(r) => DeviceIdOrAllDevices::DeviceId(
+                r.state.ready.other_device_data.device_id().to_owned(),
+            ),
             InnerRequest::Passive(_) => DeviceIdOrAllDevices::AllDevices,
             InnerRequest::Done(_) => DeviceIdOrAllDevices::AllDevices,
             InnerRequest::Cancelled(_) => DeviceIdOrAllDevices::AllDevices,
@@ -1042,7 +1050,12 @@ impl RequestState<Created> {
         }
     }
 
-    fn into_ready(self, _sender: &UserId, content: &ReadyContent<'_>) -> RequestState<Ready> {
+    fn into_ready(
+        self,
+        _sender: &UserId,
+        content: &ReadyContent<'_>,
+        from_device_data: DeviceData,
+    ) -> RequestState<Ready> {
         // TODO check the flow id, and that the methods match what we suggested.
         RequestState {
             flow_id: self.flow_id,
@@ -1052,7 +1065,7 @@ impl RequestState<Created> {
             state: Ready {
                 their_methods: content.methods().to_owned(),
                 our_methods: self.state.our_methods,
-                other_device_id: content.from_device().into(),
+                other_device_data: from_device_data,
             },
         }
     }
@@ -1115,7 +1128,7 @@ impl RequestState<Requested> {
             state: Ready {
                 their_methods: self.state.their_methods,
                 our_methods: methods.clone(),
-                other_device_id: self.state.other_device_data.device_id().to_owned(),
+                other_device_data: self.state.other_device_data,
             },
         };
 
@@ -1153,8 +1166,9 @@ struct Ready {
     /// The verification methods supported by the us.
     pub our_methods: Vec<VerificationMethod>,
 
-    /// The device ID of the device that responded to the verification request.
-    pub other_device_id: OwnedDeviceId,
+    /// The device data of the device that responded to the verification
+    /// request.
+    pub other_device_data: DeviceData,
 }
 
 #[cfg(feature = "qrcode")]
@@ -1168,7 +1182,7 @@ async fn scan_qr_code<T: Clone>(
     let verification = QrVerification::from_scan(
         request_state.store.to_owned(),
         request_state.other_user_id.to_owned(),
-        state.other_device_id.to_owned(),
+        state.other_device_data.device_id().to_owned(),
         request_state.flow_id.as_ref().to_owned(),
         data,
         we_started,
@@ -1207,21 +1221,7 @@ async fn generate_qr_code<T: Clone>(
         return Ok(None);
     }
 
-    let Some(device) = request_state
-        .store
-        .get_device(&request_state.other_user_id, &state.other_device_id)
-        .await?
-    else {
-        warn!(
-            user_id = ?request_state.other_user_id,
-            device_id = ?state.other_device_id,
-            "Can't create a QR code, the device that accepted the \
-             verification doesn't exist"
-        );
-        return Ok(None);
-    };
-
-    let identities = request_state.store.get_identities(device).await?;
+    let identities = request_state.store.get_identities(state.other_device_data.clone()).await?;
 
     let verification = if let Some(identity) = &identities.identity_being_verified {
         match &identity {
@@ -1240,7 +1240,7 @@ async fn generate_qr_code<T: Clone>(
                         } else {
                             warn!(
                                 user_id = ?request_state.other_user_id,
-                                device_id = ?state.other_device_id,
+                                device_id = ?state.other_device_data.device_id(),
                                 "Can't create a QR code, the other device \
                                  doesn't have a valid device key"
                             );
@@ -1259,7 +1259,7 @@ async fn generate_qr_code<T: Clone>(
                 } else {
                     warn!(
                         user_id = ?request_state.other_user_id,
-                        device_id = ?state.other_device_id,
+                        device_id = ?state.other_device_data.device_id(),
                         "Can't create a QR code, our cross signing identity \
                          doesn't contain a valid master key"
                     );
@@ -1288,7 +1288,7 @@ async fn generate_qr_code<T: Clone>(
                     } else {
                         warn!(
                             user_id = ?request_state.other_user_id,
-                            device_id = ?state.other_device_id,
+                            device_id = ?state.other_device_data.device_id(),
                             "Can't create a QR code, we don't trust our own \
                              master key"
                         );
@@ -1297,7 +1297,7 @@ async fn generate_qr_code<T: Clone>(
                 } else {
                     warn!(
                         user_id = ?request_state.other_user_id,
-                        device_id = ?state.other_device_id,
+                        device_id = ?state.other_device_data.device_id(),
                         "Can't create a QR code, the user's identity \
                          doesn't have a valid master key"
                     );
@@ -1308,7 +1308,7 @@ async fn generate_qr_code<T: Clone>(
     } else {
         warn!(
             user_id = ?request_state.other_user_id,
-            device_id = ?state.other_device_id,
+            device_id = ?state.other_device_data.device_id(),
             "Can't create a QR code, the user doesn't have a valid cross \
              signing identity."
         );
@@ -1478,22 +1478,7 @@ async fn start_sas<T: Clone>(
         return Ok(None);
     }
 
-    // TODO signal why starting the sas flow doesn't work?
-    let Some(device) = request_state
-        .store
-        .get_device(&request_state.other_user_id, &state.other_device_id)
-        .await?
-    else {
-        warn!(
-            user_id = ?request_state.other_user_id,
-            device_id = ?state.other_device_id,
-            "Can't start the SAS verification flow, the device that \
-             accepted the verification doesn't exist"
-        );
-        return Ok(None);
-    };
-
-    let identities = request_state.store.get_identities(device).await?;
+    let identities = request_state.store.get_identities(state.other_device_data.clone()).await?;
 
     let (state, sas, content) = match request_state.flow_id.as_ref() {
         FlowId::ToDevice(t) => {
@@ -1653,7 +1638,10 @@ mod tests {
         let event_id = event_id!("$1234localhost").to_owned();
         let room_id = room_id!("!test:localhost").to_owned();
 
-        let (_alice, alice_store, _bob, bob_store) = setup_stores().await;
+        let (alice, alice_store, bob, bob_store) = setup_stores().await;
+
+        let alice_device_data = DeviceData::from_account(&alice);
+        let bob_device_data = DeviceData::from_account(&bob);
 
         let content = VerificationRequest::request(
             &bob_store.account.user_id,
@@ -1661,12 +1649,6 @@ mod tests {
             alice_id(),
             None,
         );
-
-        let device_data = alice_store
-            .get_device(&bob_store.account.user_id, &bob_store.account.device_id)
-            .await
-            .unwrap()
-            .expect("Missing device data");
 
         let flow_id = FlowId::InRoom(room_id, event_id);
 
@@ -1690,7 +1672,7 @@ mod tests {
             bob_id(),
             flow_id,
             &(&content).into(),
-            device_data,
+            bob_device_data,
         );
 
         assert_matches!(alice_request.state(), VerificationRequestState::Requested { .. });
@@ -1698,7 +1680,7 @@ mod tests {
         let content: OutgoingContent = alice_request.accept().unwrap().try_into().unwrap();
         let content = ReadyContent::try_from(&content).unwrap();
 
-        bob_request.receive_ready(alice_id(), &content);
+        bob_request.receive_ready(alice_id(), &content, alice_device_data);
 
         assert_matches!(bob_request.state(), VerificationRequestState::Ready { .. });
         assert_matches!(alice_request.state(), VerificationRequestState::Ready { .. });
@@ -1748,8 +1730,10 @@ mod tests {
         let event_id = event_id!("$1234localhost");
         let room_id = room_id!("!test:localhost");
 
-        let (_alice, alice_store, bob, bob_store) = setup_stores().await;
-        let bob_device = DeviceData::from_account(&bob);
+        let (alice, alice_store, bob, bob_store) = setup_stores().await;
+
+        let alice_device_data = DeviceData::from_account(&alice);
+        let bob_device_data = DeviceData::from_account(&bob);
 
         let content = VerificationRequest::request(
             &bob_store.account.user_id,
@@ -1757,12 +1741,6 @@ mod tests {
             alice_id(),
             None,
         );
-
-        let device_data = alice_store
-            .get_device(&bob_store.account.user_id, &bob_store.account.device_id)
-            .await
-            .unwrap()
-            .expect("Missing device data");
 
         let flow_id = FlowId::from((room_id, event_id));
 
@@ -1782,19 +1760,19 @@ mod tests {
             bob_id(),
             flow_id,
             &(&content).into(),
-            device_data,
+            bob_device_data.clone(),
         );
 
-        do_accept_request(&alice_request, &bob_request, None);
+        do_accept_request(&alice_request, alice_device_data, &bob_request, None);
 
         let (bob_sas, request) = bob_request.start_sas().await.unwrap().unwrap();
 
         let content: OutgoingContent = request.try_into().unwrap();
         let content = StartContent::try_from(&content).unwrap();
         let flow_id = content.flow_id().to_owned();
-        alice_request.receive_start(bob_device.user_id(), &content).await.unwrap();
+        alice_request.receive_start(bob_device_data.user_id(), &content).await.unwrap();
         let alice_sas =
-            alice_request.verification_cache.get_sas(bob_device.user_id(), &flow_id).unwrap();
+            alice_request.verification_cache.get_sas(bob_device_data.user_id(), &flow_id).unwrap();
 
         assert_matches!(
             alice_request.state(),
@@ -1811,22 +1789,24 @@ mod tests {
 
     #[async_test]
     async fn test_requesting_until_sas_to_device() {
-        let (_alice, alice_store, bob, bob_store) = setup_stores().await;
-        let bob_device = DeviceData::from_account(&bob);
+        let (alice, alice_store, bob, bob_store) = setup_stores().await;
+
+        let alice_device_data = DeviceData::from_account(&alice);
+        let bob_device_data = DeviceData::from_account(&bob);
 
         // Set up the pair of verification requests
         let bob_request = build_test_request(&bob_store, alice_id(), None);
         let alice_request = build_incoming_verification_request(&alice_store, &bob_request).await;
-        do_accept_request(&alice_request, &bob_request, None);
+        do_accept_request(&alice_request, alice_device_data, &bob_request, None);
 
         let (bob_sas, request) = bob_request.start_sas().await.unwrap().unwrap();
 
         let content: OutgoingContent = request.try_into().unwrap();
         let content = StartContent::try_from(&content).unwrap();
         let flow_id = content.flow_id().to_owned();
-        alice_request.receive_start(bob_device.user_id(), &content).await.unwrap();
+        alice_request.receive_start(bob_device_data.user_id(), &content).await.unwrap();
         let alice_sas =
-            alice_request.verification_cache.get_sas(bob_device.user_id(), &flow_id).unwrap();
+            alice_request.verification_cache.get_sas(bob_device_data.user_id(), &flow_id).unwrap();
 
         assert_matches!(
             alice_request.state(),
@@ -1846,7 +1826,9 @@ mod tests {
     #[async_test]
     #[cfg(feature = "qrcode")]
     async fn test_can_scan_another_qr_after_creating_mine() {
-        let (_alice, alice_store, _bob, bob_store) = setup_stores().await;
+        let (alice, alice_store, _bob, bob_store) = setup_stores().await;
+
+        let alice_device_data = DeviceData::from_account(&alice);
 
         // Set up the pair of verification requests
         let bob_request = build_test_request(
@@ -1857,6 +1839,7 @@ mod tests {
         let alice_request = build_incoming_verification_request(&alice_store, &bob_request).await;
         do_accept_request(
             &alice_request,
+            alice_device_data,
             &bob_request,
             Some(vec![VerificationMethod::QrCodeScanV1, VerificationMethod::QrCodeShowV1]),
         );
@@ -1897,12 +1880,14 @@ mod tests {
     #[async_test]
     #[cfg(feature = "qrcode")]
     async fn test_can_start_sas_after_generating_qr_code() {
-        let (_alice, alice_store, _bob, bob_store) = setup_stores().await;
+        let (alice, alice_store, _bob, bob_store) = setup_stores().await;
+
+        let alice_device_data = DeviceData::from_account(&alice);
 
         // Set up the pair of verification requests
         let bob_request = build_test_request(&bob_store, alice_id(), Some(all_methods()));
         let alice_request = build_incoming_verification_request(&alice_store, &bob_request).await;
-        do_accept_request(&alice_request, &bob_request, Some(all_methods()));
+        do_accept_request(&alice_request, alice_device_data, &bob_request, Some(all_methods()));
 
         // Each side can start its own QR verification flow by generating QR code
         let alice_verification = alice_request.generate_qr_code().await.unwrap();
@@ -1942,12 +1927,14 @@ mod tests {
     #[async_test]
     #[cfg(feature = "qrcode")]
     async fn test_start_sas_after_scan_cancels_request() {
-        let (_alice, alice_store, _bob, bob_store) = setup_stores().await;
+        let (alice, alice_store, _bob, bob_store) = setup_stores().await;
+
+        let alice_device_data = DeviceData::from_account(&alice);
 
         // Set up the pair of verification requests
         let bob_request = build_test_request(&bob_store, alice_id(), Some(all_methods()));
         let alice_request = build_incoming_verification_request(&alice_store, &bob_request).await;
-        do_accept_request(&alice_request, &bob_request, Some(all_methods()));
+        do_accept_request(&alice_request, alice_device_data, &bob_request, Some(all_methods()));
 
         // Bob generates a QR code
         let bob_verification = bob_request.generate_qr_code().await.unwrap().unwrap();
@@ -2057,6 +2044,7 @@ mod tests {
     ///   default list of methods will be used.
     fn do_accept_request(
         accepting_request: &VerificationRequest,
+        accepting_device_data: DeviceData,
         initiating_request: &VerificationRequest,
         methods: Option<Vec<VerificationMethod>>,
     ) {
@@ -2066,7 +2054,11 @@ mod tests {
         };
         let content: OutgoingContent = request.unwrap().try_into().unwrap();
         let content = ReadyContent::try_from(&content).unwrap();
-        initiating_request.receive_ready(accepting_request.own_user_id(), &content);
+        initiating_request.receive_ready(
+            accepting_request.own_user_id(),
+            &content,
+            accepting_device_data,
+        );
 
         assert!(initiating_request.is_ready());
         assert!(accepting_request.is_ready());

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -899,7 +899,7 @@ mod tests {
     }
 
     fn bob_device_id() -> &'static DeviceId {
-        device_id!("BOBDEVCIE")
+        device_id!("BOBDEVICE")
     }
 
     fn machine_pair_test_helper() -> (VerificationStore, DeviceData, VerificationStore, DeviceData)

--- a/crates/matrix-sdk/src/encryption/verification/requests.rs
+++ b/crates/matrix-sdk/src/encryption/verification/requests.rs
@@ -226,7 +226,7 @@ impl VerificationRequest {
             Ready { their_methods, our_methods, other_device_data } => {
                 VerificationRequestState::Ready { their_methods, our_methods, other_device_data }
             }
-            Transitioned { verification } => VerificationRequestState::Transitioned {
+            Transitioned { verification, .. } => VerificationRequestState::Transitioned {
                 verification: match verification {
                     matrix_sdk_base::crypto::Verification::SasV1(s) => {
                         Verification::SasV1(SasVerification { inner: s, client })

--- a/crates/matrix-sdk/src/encryption/verification/requests.rs
+++ b/crates/matrix-sdk/src/encryption/verification/requests.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use futures_util::{Stream, StreamExt};
-use matrix_sdk_base::crypto::{CancelInfo, VerificationRequest as BaseVerificationRequest};
+use matrix_sdk_base::crypto::{
+    CancelInfo, DeviceData, VerificationRequest as BaseVerificationRequest,
+};
 use ruma::{events::key::verification::VerificationMethod, OwnedDeviceId, RoomId};
 
 #[cfg(feature = "qrcode")]
@@ -41,9 +43,9 @@ pub enum VerificationRequestState {
         /// The verification methods supported by the sender.
         their_methods: Vec<VerificationMethod>,
 
-        /// The device ID of the device that responded to the verification
+        /// The device data of the device that responded to the verification
         /// request.
-        other_device_id: OwnedDeviceId,
+        other_device_data: DeviceData,
     },
     /// The verification request is ready to start a verification flow.
     Ready {
@@ -218,8 +220,8 @@ impl VerificationRequest {
 
         match state {
             Created { our_methods } => VerificationRequestState::Created { our_methods },
-            Requested { their_methods, other_device_id } => {
-                VerificationRequestState::Requested { their_methods, other_device_id }
+            Requested { their_methods, other_device_data } => {
+                VerificationRequestState::Requested { their_methods, other_device_data }
             }
             Ready { their_methods, our_methods, other_device_id } => {
                 VerificationRequestState::Ready { their_methods, our_methods, other_device_id }

--- a/crates/matrix-sdk/src/encryption/verification/requests.rs
+++ b/crates/matrix-sdk/src/encryption/verification/requests.rs
@@ -16,7 +16,7 @@ use futures_util::{Stream, StreamExt};
 use matrix_sdk_base::crypto::{
     CancelInfo, DeviceData, VerificationRequest as BaseVerificationRequest,
 };
-use ruma::{events::key::verification::VerificationMethod, OwnedDeviceId, RoomId};
+use ruma::{events::key::verification::VerificationMethod, RoomId};
 
 #[cfg(feature = "qrcode")]
 use super::{QrVerification, QrVerificationData};
@@ -55,9 +55,9 @@ pub enum VerificationRequestState {
         /// The verification methods supported by the us.
         our_methods: Vec<VerificationMethod>,
 
-        /// The device ID of the device that responded to the verification
+        /// The device data of the device that responded to the verification
         /// request.
-        other_device_id: OwnedDeviceId,
+        other_device_data: DeviceData,
     },
     /// The verification request has transitioned into a concrete verification
     /// flow. For example it transitioned into the emoji based SAS
@@ -223,8 +223,8 @@ impl VerificationRequest {
             Requested { their_methods, other_device_data } => {
                 VerificationRequestState::Requested { their_methods, other_device_data }
             }
-            Ready { their_methods, our_methods, other_device_id } => {
-                VerificationRequestState::Ready { their_methods, our_methods, other_device_id }
+            Ready { their_methods, our_methods, other_device_data } => {
+                VerificationRequestState::Ready { their_methods, our_methods, other_device_data }
             }
             Transitioned { verification } => VerificationRequestState::Transitioned {
                 verification: match verification {

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
@@ -70,6 +70,7 @@ async fn test_mutual_sas_verification() -> Result<()> {
     bob.get_room(room_id).unwrap().join().await?;
 
     alice.sync_once().await?;
+    bob.sync_once().await?;
 
     warn!("alice and bob are both aware of each other in the e2ee room");
 
@@ -331,6 +332,7 @@ async fn test_mutual_qrcode_verification() -> Result<()> {
     bob.get_room(room_id).unwrap().join().await?;
 
     alice.sync_once().await?;
+    bob.sync_once().await?;
 
     warn!("alice and bob are both aware of each other in the e2ee room");
 
@@ -840,6 +842,9 @@ async fn test_secret_gossip_after_interactive_verification() -> Result<()> {
 
     // The first client is not verified from the point of view of the second client.
     assert!(!seconds_first_device.is_verified());
+
+    // Make the first client aware of the device we're requesting verification for
+    first_client.sync_once().await?;
 
     // Let's send out a request to verify with each other.
     let seconds_verification_request = seconds_first_device.request_verification().await?;


### PR DESCRIPTION
This PR introduced FFI level API support for interacting with incoming session verification requests. Best reviewed commit by commit
- it exposes a new `did_receive_verification_request` `SessionVerificationController` delegate method that includes information about the incoming request/device/sender
- the client can `acknowledge_verification_request` to get informed about it getting accepted somewhere else or cancelled
- the client can also `accept_verification_request` to start interacting with it

This PR also internally switches to the `VerificationRequest::changes` publisher, fixes a couple of invalid VerificationMachine tests and starts storing requesting `DeviceData` directly in `VerificationRequestState. Requested`

Relates to element-hq/element-meta/issues/2464, fixes #3595.