### PR TITLE
fix(experimental-algorithms) Add missing argument to handle_supported_key_request

### DIFF
--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -510,7 +510,8 @@ impl GossipMachine {
                     }
                     #[cfg(feature = "experimental-algorithms")]
                     RequestedKeyInfo::MegolmV2AesSha2(i) => {
-                        self.handle_supported_key_request(event, &i.room_id, &i.session_id).await
+                        self.handle_supported_key_request(cache, event, &i.room_id, &i.session_id)
+                            .await
                     }
                     RequestedKeyInfo::Unknown(i) => {
                         debug!(


### PR DESCRIPTION
This fixes the build

Before this change:

```
$ cargo check --features=experimental-algorithms
error[E0061]: this method takes 4 arguments but 3 arguments were supplied
   --> crates/matrix-sdk-crypto/src/gossiping/machine.rs:513:30
    |
513 |                         self.handle_supported_key_request(event, &i.room_id, &i.session_id).await
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ----- argument #1 of type `&StoreCache` is missing
```