### PR TITLE
feat(ui): Revisit `required_state` for `RoomListService`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -57,7 +57,7 @@ mod room_list;
 pub mod sorters;
 mod state;
 
-use std::{iter::once, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use async_stream::stream;
 use eyeball::Subscriber;
@@ -89,6 +89,11 @@ const DEFAULT_REQUIRED_STATE: &[(StateEventType, &str)] = &[
     (StateEventType::RoomPowerLevels, ""),
     (StateEventType::CallMember, ""),
 ];
+
+/// The default `required_state` constant value for sliding sync room
+/// subscriptions that must be added to `DEFAULT_REQUIRED_STATE`.
+const DEFAULT_ROOM_SUBSCRIPTION_EXTRA_REQUIRED_STATE: &[(StateEventType, &str)] =
+    &[(StateEventType::RoomCreate, ""), (StateEventType::RoomPinnedEvents, "")];
 
 /// The default `timeline_limit` value when used with room subscriptions.
 const DEFAULT_ROOM_SUBSCRIPTION_TIMELINE_LIMIT: u32 = 20;
@@ -398,8 +403,11 @@ impl RoomListService {
             required_state: DEFAULT_REQUIRED_STATE.iter().map(|(state_event, value)| {
                 (state_event.clone(), (*value).to_owned())
             })
-            .chain(once((StateEventType::RoomCreate, "".to_owned())))
-            .chain(once((StateEventType::RoomPinnedEvents, "".to_owned())))
+            .chain(
+                DEFAULT_ROOM_SUBSCRIPTION_EXTRA_REQUIRED_STATE.iter().map(|(state_event, value)| {
+                    (state_event.clone(), (*value).to_owned())
+                })
+            )
             .collect(),
             timeline_limit: UInt::from(DEFAULT_ROOM_SUBSCRIPTION_TIMELINE_LIMIT),
         });

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -146,12 +146,14 @@ impl RoomListService {
                     )
                     .timeline_limit(1)
                     .required_state(vec![
+                        (StateEventType::RoomName, "".to_owned()),
                         (StateEventType::RoomEncryption, "".to_owned()),
                         (StateEventType::RoomMember, "$LAZY".to_owned()),
                         (StateEventType::RoomMember, "$ME".to_owned()),
-                        (StateEventType::RoomName, "".to_owned()),
+                        (StateEventType::RoomTopic, "".to_owned()),
                         (StateEventType::RoomCanonicalAlias, "".to_owned()),
                         (StateEventType::RoomPowerLevels, "".to_owned()),
+                        (StateEventType::RoomPinnedEvents, "".to_owned()),
                         (StateEventType::CallMember, "".to_owned()),
                     ])
                     .include_heroes(Some(true))

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -151,8 +151,8 @@ impl RoomListService {
                         (StateEventType::RoomMember, "$ME".to_owned()),
                         (StateEventType::RoomName, "".to_owned()),
                         (StateEventType::RoomCanonicalAlias, "".to_owned()),
-                        (StateEventType::RoomAvatar, "".to_owned()),
                         (StateEventType::RoomPowerLevels, "".to_owned()),
+                        (StateEventType::CallMember, "".to_owned()),
                     ])
                     .include_heroes(Some(true))
                     .filters(Some(assign!(http::request::ListFilters::default(), {

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -334,6 +334,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
                         ["m.room.canonical_alias", ""],
                         ["m.room.avatar", ""],
                         ["m.room.power_levels", ""],
+                        ["m.call.member", ""],
                     ],
                     "include_heroes": true,
                     "filters": {

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -7,9 +7,7 @@ use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use futures_util::{pin_mut, FutureExt, StreamExt};
 use matrix_sdk::{test_utils::logged_in_client_with_server, Client};
-use matrix_sdk_base::{
-    sliding_sync::http::request::RoomSubscription, sync::UnreadNotificationsCount,
-};
+use matrix_sdk_base::sync::UnreadNotificationsCount;
 use matrix_sdk_test::{async_test, mocks::mock_encryption_state};
 use matrix_sdk_ui::{
     room_list_service::{
@@ -20,10 +18,8 @@ use matrix_sdk_ui::{
     RoomListService,
 };
 use ruma::{
-    api::client::room::create_room::v3::Request as CreateRoomRequest,
-    assign, event_id,
-    events::{room::message::RoomMessageEventContent, StateEventType},
-    mxc_uri, room_id, uint,
+    api::client::room::create_room::v3::Request as CreateRoomRequest, event_id,
+    events::room::message::RoomMessageEventContent, mxc_uri, room_id,
 };
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
@@ -334,7 +330,6 @@ async fn test_sync_all_states() -> Result<(), Error> {
                         ["m.room.topic", ""],
                         ["m.room.canonical_alias", ""],
                         ["m.room.power_levels", ""],
-                        ["m.room.pinned_events", ""],
                         ["org.matrix.msc3401.call.member", ""],
                     ],
                     "include_heroes": true,
@@ -2083,18 +2078,7 @@ async fn test_room_subscription() -> Result<(), Error> {
 
     // Subscribe.
 
-    room_list.subscribe_to_rooms(
-        &[room_id_1],
-        Some(assign!(RoomSubscription::default(), {
-            required_state: vec![
-                (StateEventType::RoomName, "".to_owned()),
-                (StateEventType::RoomTopic, "".to_owned()),
-                (StateEventType::RoomAvatar, "".to_owned()),
-                (StateEventType::RoomCanonicalAlias, "".to_owned()),
-            ],
-            timeline_limit: uint!(30),
-        })),
-    );
+    room_list.subscribe_to_rooms(&[room_id_1]);
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
@@ -2109,12 +2093,17 @@ async fn test_room_subscription() -> Result<(), Error> {
                 room_id_1: {
                     "required_state": [
                         ["m.room.name", ""],
+                        ["m.room.encryption", ""],
+                        ["m.room.member", "$LAZY"],
+                        ["m.room.member", "$ME"],
                         ["m.room.topic", ""],
-                        ["m.room.avatar", ""],
                         ["m.room.canonical_alias", ""],
+                        ["m.room.power_levels", ""],
+                        ["org.matrix.msc3401.call.member", ""],
                         ["m.room.create", ""],
+                        ["m.room.pinned_events", ""],
                     ],
-                    "timeline_limit": 30,
+                    "timeline_limit": 20,
                 },
             },
         },
@@ -2127,18 +2116,7 @@ async fn test_room_subscription() -> Result<(), Error> {
 
     // Subscribe to another room.
 
-    room_list.subscribe_to_rooms(
-        &[room_id_2],
-        Some(assign!(RoomSubscription::default(), {
-            required_state: vec![
-                (StateEventType::RoomName, "".to_owned()),
-                (StateEventType::RoomTopic, "".to_owned()),
-                (StateEventType::RoomAvatar, "".to_owned()),
-                (StateEventType::RoomCanonicalAlias, "".to_owned()),
-            ],
-            timeline_limit: uint!(30),
-        })),
-    );
+    room_list.subscribe_to_rooms(&[room_id_2]);
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
@@ -2153,12 +2131,17 @@ async fn test_room_subscription() -> Result<(), Error> {
                 room_id_2: {
                     "required_state": [
                         ["m.room.name", ""],
+                        ["m.room.encryption", ""],
+                        ["m.room.member", "$LAZY"],
+                        ["m.room.member", "$ME"],
                         ["m.room.topic", ""],
-                        ["m.room.avatar", ""],
                         ["m.room.canonical_alias", ""],
+                        ["m.room.power_levels", ""],
+                        ["org.matrix.msc3401.call.member", ""],
                         ["m.room.create", ""],
+                        ["m.room.pinned_events", ""],
                     ],
-                    "timeline_limit": 30,
+                    "timeline_limit": 20,
                 },
             },
         },
@@ -2171,18 +2154,7 @@ async fn test_room_subscription() -> Result<(), Error> {
 
     // Subscribe to an already subscribed room. Nothing happens.
 
-    room_list.subscribe_to_rooms(
-        &[room_id_1],
-        Some(assign!(RoomSubscription::default(), {
-            required_state: vec![
-                (StateEventType::RoomName, "".to_owned()),
-                (StateEventType::RoomTopic, "".to_owned()),
-                (StateEventType::RoomAvatar, "".to_owned()),
-                (StateEventType::RoomCanonicalAlias, "".to_owned()),
-            ],
-            timeline_limit: uint!(30),
-        })),
-    );
+    room_list.subscribe_to_rooms(&[room_id_1]);
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -327,14 +327,15 @@ async fn test_sync_all_states() -> Result<(), Error> {
                 ALL_ROOMS: {
                     "ranges": [[0, 19]],
                     "required_state": [
+                        ["m.room.name", ""],
                         ["m.room.encryption", ""],
                         ["m.room.member", "$LAZY"],
                         ["m.room.member", "$ME"],
-                        ["m.room.name", ""],
+                        ["m.room.topic", ""],
                         ["m.room.canonical_alias", ""],
-                        ["m.room.avatar", ""],
                         ["m.room.power_levels", ""],
-                        ["m.call.member", ""],
+                        ["m.room.pinned_events", ""],
+                        ["org.matrix.msc3401.call.member", ""],
                     ],
                     "include_heroes": true,
                     "filters": {

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -23,9 +23,8 @@ use matrix_sdk::{
     ruma::{
         api::client::receipt::create_receipt::v3::ReceiptType,
         events::room::message::{MessageType, RoomMessageEventContent},
-        uint, MilliSecondsSinceUnixEpoch, OwnedRoomId, RoomId,
+        MilliSecondsSinceUnixEpoch, OwnedRoomId, RoomId,
     },
-    sliding_sync::http::request::RoomSubscription,
     AuthSession, Client, ServerName, SqliteCryptoStore, SqliteStateStore,
 };
 use matrix_sdk_ui::{
@@ -445,10 +444,7 @@ impl App {
             .get_selected_room_id(Some(selected))
             .and_then(|room_id| self.ui_rooms.lock().unwrap().get(&room_id).cloned())
         {
-            let mut sub = RoomSubscription::default();
-            sub.timeline_limit = uint!(30);
-
-            self.sync_service.room_list_service().subscribe_to_rooms(&[room.room_id()], Some(sub));
+            self.sync_service.room_list_service().subscribe_to_rooms(&[room.room_id()]);
             self.current_room_subscription = Some(room);
         }
     }


### PR DESCRIPTION
This patch updates `matrix_sdk_ui::room_list_service`, and is twofold:

First off, it adds `m.call.member`, `m.room.topic` and `m.room.pinned_events` to
`required_state` of the `all_rooms` sliding sync list.

Second, this `required_state` sliding sync list value is easily out-of-sync with
the `required_state` sliding sync room subscription value. Thus, this patch
removes the `settings` argument of `RoomListService::subscribe_to_rooms` and
computes its own `RoomSubscription` instance. For `required_state`, it uses the
same `required_state` used by the `all_rooms` list, plus the `m.room.create`
state event. For `timeline_limit`, it uses 20 by default (this is not the
default value we were using in our tests, but that's the default value most
Matrix clients use).
