### PR TITLE
chore(ffi): move the `store_in_cache` timeline media upload parameter before the `progress_watcher` closure

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -103,8 +103,8 @@ impl Timeline {
         filename: String,
         mime_type: Option<String>,
         attachment_config: AttachmentConfig,
-        progress_watcher: Option<Box<dyn ProgressWatcher>>,
         store_in_cache: bool,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Result<(), RoomError> {
         let mime_str = mime_type.as_ref().ok_or(RoomError::InvalidAttachmentMimeType)?;
         let mime_type =
@@ -284,8 +284,8 @@ impl Timeline {
         image_info: ImageInfo,
         caption: Option<String>,
         formatted_caption: Option<FormattedBody>,
-        progress_watcher: Option<Box<dyn ProgressWatcher>>,
         store_in_cache: bool,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Arc<SendAttachmentJoinHandle> {
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
             let base_image_info = BaseImageInfo::try_from(&image_info)
@@ -301,8 +301,8 @@ impl Timeline {
                 url,
                 image_info.mimetype,
                 attachment_config,
-                progress_watcher,
                 store_in_cache,
+                progress_watcher,
             )
             .await
         }))
@@ -316,8 +316,8 @@ impl Timeline {
         video_info: VideoInfo,
         caption: Option<String>,
         formatted_caption: Option<FormattedBody>,
-        progress_watcher: Option<Box<dyn ProgressWatcher>>,
         store_in_cache: bool,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Arc<SendAttachmentJoinHandle> {
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
             let base_video_info: BaseVideoInfo = BaseVideoInfo::try_from(&video_info)
@@ -333,8 +333,8 @@ impl Timeline {
                 url,
                 video_info.mimetype,
                 attachment_config,
-                progress_watcher,
                 store_in_cache,
+                progress_watcher,
             )
             .await
         }))
@@ -346,8 +346,8 @@ impl Timeline {
         audio_info: AudioInfo,
         caption: Option<String>,
         formatted_caption: Option<FormattedBody>,
-        progress_watcher: Option<Box<dyn ProgressWatcher>>,
         store_in_cache: bool,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Arc<SendAttachmentJoinHandle> {
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
             let base_audio_info: BaseAudioInfo = BaseAudioInfo::try_from(&audio_info)
@@ -363,8 +363,8 @@ impl Timeline {
                 url,
                 audio_info.mimetype,
                 attachment_config,
-                progress_watcher,
                 store_in_cache,
+                progress_watcher,
             )
             .await
         }))
@@ -378,8 +378,8 @@ impl Timeline {
         waveform: Vec<u16>,
         caption: Option<String>,
         formatted_caption: Option<FormattedBody>,
-        progress_watcher: Option<Box<dyn ProgressWatcher>>,
         store_in_cache: bool,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Arc<SendAttachmentJoinHandle> {
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
             let base_audio_info: BaseAudioInfo = BaseAudioInfo::try_from(&audio_info)
@@ -396,8 +396,8 @@ impl Timeline {
                 url,
                 audio_info.mimetype,
                 attachment_config,
-                progress_watcher,
                 store_in_cache,
+                progress_watcher,
             )
             .await
         }))
@@ -407,8 +407,8 @@ impl Timeline {
         self: Arc<Self>,
         url: String,
         file_info: FileInfo,
-        progress_watcher: Option<Box<dyn ProgressWatcher>>,
         store_in_cache: bool,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Arc<SendAttachmentJoinHandle> {
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
             let base_file_info: BaseFileInfo =
@@ -421,8 +421,8 @@ impl Timeline {
                 url,
                 file_info.mimetype,
                 attachment_config,
-                progress_watcher,
                 store_in_cache,
+                progress_watcher,
             )
             .await
         }))


### PR DESCRIPTION
… for aesthetic reasons