### PR TITLE
chore(ffi): introduce `AsyncRuntimeDropped` helper

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -1,12 +1,6 @@
 #![allow(deprecated)]
 
-use std::{
-    fmt::Debug,
-    mem::{ManuallyDrop, MaybeUninit},
-    ptr::addr_of_mut,
-    sync::Arc,
-    time::Duration,
-};
+use std::{fmt::Debug, mem::MaybeUninit, ptr::addr_of_mut, sync::Arc, time::Duration};
 
 use eyeball_im::VectorDiff;
 use futures_util::{pin_mut, StreamExt, TryFutureExt};
@@ -34,6 +28,7 @@ use crate::{
     room_preview::RoomPreview,
     timeline::{EventTimelineItem, Timeline},
     timeline_event_filter::TimelineEventTypeFilter,
+    utils::AsyncRuntimeDropped,
     TaskHandle, RUNTIME,
 };
 
@@ -635,7 +630,7 @@ impl RoomListItem {
 
         let room_preview = client.get_room_preview(&room_or_alias_id, server_names).await?;
 
-        Ok(Arc::new(RoomPreview::new(ManuallyDrop::new(client), room_preview)))
+        Ok(Arc::new(RoomPreview::new(AsyncRuntimeDropped::new(client), room_preview)))
     }
 
     /// Build a full `Room` FFI object, filling its associated timeline.


### PR DESCRIPTION
This avoids proliferation of `ManuallyDrop` in the code base, by having
a single type that's used for dropping under an async runtime.

---

I actually saw three uses of `ManuallyDrop` on the FFI layer, but failed to notice that two of them were in the crypto FFI crate. Should I introduce a new FFI helper crate just for sharing this code across the two other crates?