### PR TITLE
refactor(send queue): refactor in preparation for media local echoes

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -503,7 +503,7 @@ impl Client {
         Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
             // Respawn tasks for rooms that had unsent events. At this point we've just
             // created the subscriber, so it'll be notified about errors.
-            q.respawn_tasks_for_rooms_with_unsent_events().await;
+            q.respawn_tasks_for_rooms_with_unsent_requests().await;
 
             loop {
                 match subscriber.recv().await {

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -36,10 +36,7 @@ use serde_json::{json, value::Value as JsonValue};
 use super::{DependentQueuedEventKind, DynStateStore, ServerCapabilities};
 use crate::{
     deserialized_responses::MemberEvent,
-    store::{
-        traits::ChildTransactionId, QueueWedgeError, Result, SerializableEventContent,
-        StateStoreExt,
-    },
+    store::{ChildTransactionId, QueueWedgeError, Result, SerializableEventContent, StateStoreExt},
     RoomInfo, RoomMemberships, RoomState, StateChanges, StateStoreDataKey, StateStoreDataValue,
 };
 

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -1219,7 +1219,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         {
             assert_eq!(pending[0].transaction_id, txn0);
 
-            let deserialized = pending[0].event.deserialize().unwrap();
+            let deserialized = pending[0].as_event().unwrap().deserialize().unwrap();
             assert_let!(AnyMessageLikeEventContent::RoomMessage(content) = deserialized);
             assert_eq!(content.body(), "msg0");
 
@@ -1246,7 +1246,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         assert_eq!(pending[0].transaction_id, txn0);
 
         for i in 0..4 {
-            let deserialized = pending[i].event.deserialize().unwrap();
+            let deserialized = pending[i].as_event().unwrap().deserialize().unwrap();
             assert_let!(AnyMessageLikeEventContent::RoomMessage(content) = deserialized);
             assert_eq!(content.body(), format!("msg{i}"));
             assert!(!pending[i].is_wedged());
@@ -1293,7 +1293,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         {
             assert_eq!(pending[2].transaction_id, *txn2);
 
-            let deserialized = pending[2].event.deserialize().unwrap();
+            let deserialized = pending[2].as_event().unwrap().deserialize().unwrap();
             assert_let!(AnyMessageLikeEventContent::RoomMessage(content) = deserialized);
             assert_eq!(content.body(), "wow that's a cool test");
 
@@ -1301,7 +1301,7 @@ impl StateStoreIntegrationTests for DynStateStore {
 
             for i in 0..4 {
                 if i != 2 {
-                    let deserialized = pending[i].event.deserialize().unwrap();
+                    let deserialized = pending[i].as_event().unwrap().deserialize().unwrap();
                     assert_let!(AnyMessageLikeEventContent::RoomMessage(content) = deserialized);
                     assert_eq!(content.body(), format!("msg{i}"));
 

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -1369,7 +1369,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         self.save_send_queue_event(room_id, txn0.clone(), event0).await.unwrap();
 
         // No dependents, to start with.
-        assert!(self.list_dependent_send_queue_events(room_id).await.unwrap().is_empty());
+        assert!(self.load_dependent_send_queue_events(room_id).await.unwrap().is_empty());
 
         // Save a redaction for that event.
         let child_txn = ChildTransactionId::new();
@@ -1383,7 +1383,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         .unwrap();
 
         // It worked.
-        let dependents = self.list_dependent_send_queue_events(room_id).await.unwrap();
+        let dependents = self.load_dependent_send_queue_events(room_id).await.unwrap();
         assert_eq!(dependents.len(), 1);
         assert_eq!(dependents[0].parent_transaction_id, txn0);
         assert_eq!(dependents[0].own_transaction_id, child_txn);
@@ -1397,7 +1397,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         assert_eq!(num_updated, 1);
 
         // It worked.
-        let dependents = self.list_dependent_send_queue_events(room_id).await.unwrap();
+        let dependents = self.load_dependent_send_queue_events(room_id).await.unwrap();
         assert_eq!(dependents.len(), 1);
         assert_eq!(dependents[0].parent_transaction_id, txn0);
         assert_eq!(dependents[0].own_transaction_id, child_txn);
@@ -1412,7 +1412,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         assert!(removed);
 
         // It worked.
-        assert!(self.list_dependent_send_queue_events(room_id).await.unwrap().is_empty());
+        assert!(self.load_dependent_send_queue_events(room_id).await.unwrap().is_empty());
 
         // Now, inserting a dependent event and removing the original send queue event
         // will NOT remove the dependent event.
@@ -1430,7 +1430,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         )
         .await
         .unwrap();
-        assert_eq!(self.list_dependent_send_queue_events(room_id).await.unwrap().len(), 1);
+        assert_eq!(self.load_dependent_send_queue_events(room_id).await.unwrap().len(), 1);
 
         self.save_dependent_send_queue_event(
             room_id,
@@ -1445,14 +1445,14 @@ impl StateStoreIntegrationTests for DynStateStore {
         )
         .await
         .unwrap();
-        assert_eq!(self.list_dependent_send_queue_events(room_id).await.unwrap().len(), 2);
+        assert_eq!(self.load_dependent_send_queue_events(room_id).await.unwrap().len(), 2);
 
         // Remove event0 / txn0.
         let removed = self.remove_send_queue_event(room_id, &txn0).await.unwrap();
         assert!(removed);
 
         // This has removed none of the dependent events.
-        let dependents = self.list_dependent_send_queue_events(room_id).await.unwrap();
+        let dependents = self.load_dependent_send_queue_events(room_id).await.unwrap();
         assert_eq!(dependents.len(), 2);
     }
 }

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -949,7 +949,7 @@ impl StateStore for MemoryStore {
     ///
     /// This returns absolutely all the dependent send queue events, whether
     /// they have an event id or not.
-    async fn list_dependent_send_queue_events(
+    async fn load_dependent_send_queue_events(
         &self,
         room: &RoomId,
     ) -> Result<Vec<DependentQueuedEvent>, Self::Error> {

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -36,10 +36,8 @@ use ruma::{
 use tracing::{debug, instrument, trace, warn};
 
 use super::{
-    traits::{
-        ChildTransactionId, ComposerDraft, QueuedEvent, SerializableEventContent,
-        ServerCapabilities,
-    },
+    send_queue::{ChildTransactionId, QueuedEvent, SerializableEventContent},
+    traits::{ComposerDraft, ServerCapabilities},
     DependentQueuedEvent, DependentQueuedEventKind, Result, RoomInfo, StateChanges, StateStore,
     StoreError,
 };

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -76,7 +76,7 @@ pub use self::{
     memory_store::MemoryStore,
     send_queue::{
         ChildTransactionId, DependentQueuedEvent, DependentQueuedEventKind, QueueWedgeError,
-        QueuedEvent, SerializableEventContent,
+        QueuedEvent, QueuedRequestKind, SerializableEventContent,
     },
     traits::{
         ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, ServerCapabilities,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -68,16 +68,19 @@ use crate::{
 pub(crate) mod ambiguity_map;
 mod memory_store;
 pub mod migration_helpers;
+mod send_queue;
 
 #[cfg(any(test, feature = "testing"))]
 pub use self::integration_tests::StateStoreIntegrationTests;
 pub use self::{
     memory_store::MemoryStore,
+    send_queue::{
+        ChildTransactionId, DependentQueuedEvent, DependentQueuedEventKind, QueueWedgeError,
+        QueuedEvent, SerializableEventContent,
+    },
     traits::{
-        ChildTransactionId, ComposerDraft, ComposerDraftType, DependentQueuedEvent,
-        DependentQueuedEventKind, DynStateStore, IntoStateStore, QueueWedgeError, QueuedEvent,
-        SerializableEventContent, ServerCapabilities, StateStore, StateStoreDataKey,
-        StateStoreDataValue, StateStoreExt,
+        ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, ServerCapabilities,
+        StateStore, StateStoreDataKey, StateStoreDataValue, StateStoreExt,
     },
 };
 

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -75,8 +75,8 @@ pub use self::integration_tests::StateStoreIntegrationTests;
 pub use self::{
     memory_store::MemoryStore,
     send_queue::{
-        ChildTransactionId, DependentQueuedEvent, DependentQueuedEventKind, QueueWedgeError,
-        QueuedEvent, QueuedRequestKind, SerializableEventContent,
+        ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind, QueueWedgeError,
+        QueuedRequest, QueuedRequestKind, SerializableEventContent,
     },
     traits::{
         ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, ServerCapabilities,

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -1,0 +1,228 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! All data types related to the send queue.
+
+use std::{collections::BTreeMap, fmt, ops::Deref};
+
+use ruma::{
+    events::{AnyMessageLikeEventContent, EventContent as _, RawExt as _},
+    serde::Raw,
+    OwnedDeviceId, OwnedEventId, OwnedTransactionId, OwnedUserId, TransactionId,
+};
+use serde::{Deserialize, Serialize};
+
+/// A thin wrapper to serialize a `AnyMessageLikeEventContent`.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SerializableEventContent {
+    event: Raw<AnyMessageLikeEventContent>,
+    event_type: String,
+}
+
+#[cfg(not(tarpaulin_include))]
+impl fmt::Debug for SerializableEventContent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Don't include the event in the debug display.
+        f.debug_struct("SerializedEventContent")
+            .field("event_type", &self.event_type)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SerializableEventContent {
+    /// Create a [`SerializableEventContent`] from a raw
+    /// [`AnyMessageLikeEventContent`] along with its type.
+    pub fn from_raw(event: Raw<AnyMessageLikeEventContent>, event_type: String) -> Self {
+        Self { event_type, event }
+    }
+
+    /// Create a [`SerializableEventContent`] from an
+    /// [`AnyMessageLikeEventContent`].
+    pub fn new(event: &AnyMessageLikeEventContent) -> Result<Self, serde_json::Error> {
+        Ok(Self::from_raw(Raw::new(event)?, event.event_type().to_string()))
+    }
+
+    /// Convert a [`SerializableEventContent`] back into a
+    /// [`AnyMessageLikeEventContent`].
+    pub fn deserialize(&self) -> Result<AnyMessageLikeEventContent, serde_json::Error> {
+        self.event.deserialize_with_type(self.event_type.clone().into())
+    }
+
+    /// Returns the raw event content along with its type.
+    ///
+    /// Useful for callers manipulating custom events.
+    pub fn raw(self) -> (Raw<AnyMessageLikeEventContent>, String) {
+        (self.event, self.event_type)
+    }
+}
+
+/// An event to be sent with a send queue.
+#[derive(Clone)]
+pub struct QueuedEvent {
+    /// The content of the message-like event we'd like to send.
+    pub event: SerializableEventContent,
+
+    /// Unique transaction id for the queued event, acting as a key.
+    pub transaction_id: OwnedTransactionId,
+
+    /// Set when the event couldn't be sent because of an unrecoverable API
+    /// error. `None` if the event is in queue for being sent.
+    pub error: Option<QueueWedgeError>,
+}
+
+impl QueuedEvent {
+    /// True if the event couldn't be sent because of an unrecoverable API
+    /// error. See [`Self::error`] for more details on the reason.
+    pub fn is_wedged(&self) -> bool {
+        self.error.is_some()
+    }
+}
+
+/// Represents a failed to send unrecoverable error of an event sent via the
+/// send queue.
+///
+/// It is a serializable representation of a client error, see
+/// `From` implementation for more details. These errors can not be
+/// automatically retried, but yet some manual action can be taken before retry
+/// sending. If not the only solution is to delete the local event.
+#[derive(Clone, Debug, Serialize, Deserialize, thiserror::Error)]
+pub enum QueueWedgeError {
+    /// This error occurs when there are some insecure devices in the room, and
+    /// the current encryption setting prohibits sharing with them.
+    #[error("There are insecure devices in the room")]
+    InsecureDevices {
+        /// The insecure devices as a Map of userID to deviceID.
+        user_device_map: BTreeMap<OwnedUserId, Vec<OwnedDeviceId>>,
+    },
+
+    /// This error occurs when a previously verified user is not anymore, and
+    /// the current encryption setting prohibits sharing when it happens.
+    #[error("Some users that were previously verified are not anymore")]
+    IdentityViolations {
+        /// The users that are expected to be verified but are not.
+        users: Vec<OwnedUserId>,
+    },
+
+    /// It is required to set up cross-signing and properly verify the current
+    /// session before sending.
+    #[error("Own verification is required")]
+    CrossVerificationRequired,
+
+    /// Other errors.
+    #[error("Other unrecoverable error: {msg}")]
+    GenericApiError {
+        /// Description of the error.
+        msg: String,
+    },
+}
+
+/// The specific user intent that characterizes a [`DependentQueuedEvent`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum DependentQueuedEventKind {
+    /// The event should be edited.
+    Edit {
+        /// The new event for the content.
+        new_content: SerializableEventContent,
+    },
+
+    /// The event should be redacted/aborted/removed.
+    Redact,
+
+    /// The event should be reacted to, with the given key.
+    React {
+        /// Key used for the reaction.
+        key: String,
+    },
+}
+
+/// A transaction id identifying a [`DependentQueuedEvent`] rather than its
+/// parent [`QueuedEvent`].
+///
+/// This thin wrapper adds some safety to some APIs, making it possible to
+/// distinguish between the parent's `TransactionId` and the dependent event's
+/// own `TransactionId`.
+#[repr(transparent)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ChildTransactionId(OwnedTransactionId);
+
+impl ChildTransactionId {
+    /// Returns a new [`ChildTransactionId`].
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self(TransactionId::new())
+    }
+}
+
+impl Deref for ChildTransactionId {
+    type Target = TransactionId;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<String> for ChildTransactionId {
+    fn from(val: String) -> Self {
+        Self(val.into())
+    }
+}
+
+impl From<ChildTransactionId> for OwnedTransactionId {
+    fn from(val: ChildTransactionId) -> Self {
+        val.0
+    }
+}
+
+/// An event to be sent, depending on a [`QueuedEvent`] to be sent first.
+///
+/// Depending on whether the event has been sent or not, this will either update
+/// the local echo in the storage, or send an event equivalent to the user
+/// intent to the homeserver.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DependentQueuedEvent {
+    /// Unique identifier for this dependent queued event.
+    ///
+    /// Useful for deletion.
+    pub own_transaction_id: ChildTransactionId,
+
+    /// The kind of user intent.
+    pub kind: DependentQueuedEventKind,
+
+    /// Transaction id for the parent's local echo / used in the server request.
+    ///
+    /// Note: this is the transaction id used for the depended-on event, i.e.
+    /// the one that was originally sent and that's being modified with this
+    /// dependent event.
+    pub parent_transaction_id: OwnedTransactionId,
+
+    /// If the parent event has been sent, the parent's event identifier
+    /// returned by the server once the local echo has been sent out.
+    ///
+    /// Note: this is the event id used for the depended-on event after it's
+    /// been sent, not for a possible event that could have been sent
+    /// because of this [`DependentQueuedEvent`].
+    pub event_id: Option<OwnedEventId>,
+}
+
+#[cfg(not(tarpaulin_include))]
+impl fmt::Debug for QueuedEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Hide the content from the debug log.
+        f.debug_struct("QueuedEvent")
+            .field("transaction_id", &self.transaction_id)
+            .field("is_wedged", &self.is_wedged())
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -439,7 +439,7 @@ pub trait StateStore: AsyncTraitDeps {
     ///
     /// This returns absolutely all the dependent send queue events, whether
     /// they have an event id or not. They must be returned in insertion order.
-    async fn list_dependent_send_queue_events(
+    async fn load_dependent_send_queue_events(
         &self,
         room: &RoomId,
     ) -> Result<Vec<DependentQueuedEvent>, Self::Error>;
@@ -710,11 +710,11 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         self.0.remove_dependent_send_queue_event(room_id, own_txn_id).await.map_err(Into::into)
     }
 
-    async fn list_dependent_send_queue_events(
+    async fn load_dependent_send_queue_events(
         &self,
         room_id: &RoomId,
     ) -> Result<Vec<DependentQueuedEvent>, Self::Error> {
-        self.0.list_dependent_send_queue_events(room_id).await.map_err(Into::into)
+        self.0.load_dependent_send_queue_events(room_id).await.map_err(Into::into)
     }
 }
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -16,7 +16,6 @@ use std::{
     borrow::Borrow,
     collections::{BTreeMap, BTreeSet},
     fmt,
-    ops::Deref,
     sync::Arc,
 };
 
@@ -29,20 +28,22 @@ use ruma::{
     events::{
         presence::PresenceEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
-        AnyGlobalAccountDataEvent, AnyMessageLikeEventContent, AnyRoomAccountDataEvent,
-        EmptyStateKey, EventContent as _, GlobalAccountDataEvent, GlobalAccountDataEventContent,
-        GlobalAccountDataEventType, RawExt as _, RedactContent, RedactedStateEventContent,
-        RoomAccountDataEvent, RoomAccountDataEventContent, RoomAccountDataEventType,
-        StateEventType, StaticEventContent, StaticStateEventContent,
+        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, EmptyStateKey, GlobalAccountDataEvent,
+        GlobalAccountDataEventContent, GlobalAccountDataEventType, RedactContent,
+        RedactedStateEventContent, RoomAccountDataEvent, RoomAccountDataEventContent,
+        RoomAccountDataEventType, StateEventType, StaticEventContent, StaticStateEventContent,
     },
     serde::Raw,
     time::SystemTime,
-    EventId, OwnedDeviceId, OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedTransactionId,
-    OwnedUserId, RoomId, TransactionId, UserId,
+    EventId, OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId,
+    TransactionId, UserId,
 };
 use serde::{Deserialize, Serialize};
 
-use super::{StateChanges, StoreError};
+use super::{
+    ChildTransactionId, DependentQueuedEvent, DependentQueuedEventKind, QueueWedgeError,
+    QueuedEvent, SerializableEventContent, StateChanges, StoreError,
+};
 use crate::{
     deserialized_responses::{RawAnySyncOrStrippedState, RawMemberEvent, RawSyncOrStrippedState},
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships,
@@ -1101,210 +1102,6 @@ impl StateStoreDataKey<'_> {
     /// Key prefix to use for the [`ComposerDraft`][Self::ComposerDraft]
     /// variant.
     pub const COMPOSER_DRAFT: &'static str = "composer_draft";
-}
-
-/// A thin wrapper to serialize a `AnyMessageLikeEventContent`.
-#[derive(Clone, Serialize, Deserialize)]
-pub struct SerializableEventContent {
-    event: Raw<AnyMessageLikeEventContent>,
-    event_type: String,
-}
-
-#[cfg(not(tarpaulin_include))]
-impl fmt::Debug for SerializableEventContent {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Don't include the event in the debug display.
-        f.debug_struct("SerializedEventContent")
-            .field("event_type", &self.event_type)
-            .finish_non_exhaustive()
-    }
-}
-
-impl SerializableEventContent {
-    /// Create a [`SerializableEventContent`] from a raw
-    /// [`AnyMessageLikeEventContent`] along with its type.
-    pub fn from_raw(event: Raw<AnyMessageLikeEventContent>, event_type: String) -> Self {
-        Self { event_type, event }
-    }
-
-    /// Create a [`SerializableEventContent`] from an
-    /// [`AnyMessageLikeEventContent`].
-    pub fn new(event: &AnyMessageLikeEventContent) -> Result<Self, serde_json::Error> {
-        Ok(Self::from_raw(Raw::new(event)?, event.event_type().to_string()))
-    }
-
-    /// Convert a [`SerializableEventContent`] back into a
-    /// [`AnyMessageLikeEventContent`].
-    pub fn deserialize(&self) -> Result<AnyMessageLikeEventContent, serde_json::Error> {
-        self.event.deserialize_with_type(self.event_type.clone().into())
-    }
-
-    /// Returns the raw event content along with its type.
-    ///
-    /// Useful for callers manipulating custom events.
-    pub fn raw(self) -> (Raw<AnyMessageLikeEventContent>, String) {
-        (self.event, self.event_type)
-    }
-}
-
-/// An event to be sent with a send queue.
-#[derive(Clone)]
-pub struct QueuedEvent {
-    /// The content of the message-like event we'd like to send.
-    pub event: SerializableEventContent,
-
-    /// Unique transaction id for the queued event, acting as a key.
-    pub transaction_id: OwnedTransactionId,
-
-    /// Set when the event couldn't be sent because of an unrecoverable API
-    /// error. `None` if the event is in queue for being sent.
-    pub error: Option<QueueWedgeError>,
-}
-
-impl QueuedEvent {
-    /// True if the event couldn't be sent because of an unrecoverable API
-    /// error. See [`Self::error`] for more details on the reason.
-    pub fn is_wedged(&self) -> bool {
-        self.error.is_some()
-    }
-}
-
-/// Represents a failed to send unrecoverable error of an event sent via the
-/// send_queue.
-///
-/// It is a serializable representation of a client error, see
-/// `From` implementation for more details. These errors can not be
-/// automatically retried, but yet some manual action can be taken before retry
-/// sending. If not the only solution is to delete the local event.
-#[derive(Clone, Debug, Serialize, Deserialize, thiserror::Error)]
-pub enum QueueWedgeError {
-    /// This error occurs when there are some insecure devices in the room, and
-    /// the current encryption setting prohibits sharing with them.
-    #[error("There are insecure devices in the room")]
-    InsecureDevices {
-        /// The insecure devices as a Map of userID to deviceID.
-        user_device_map: BTreeMap<OwnedUserId, Vec<OwnedDeviceId>>,
-    },
-
-    /// This error occurs when a previously verified user is not anymore, and
-    /// the current encryption setting prohibits sharing when it happens.
-    #[error("Some users that were previously verified are not anymore")]
-    IdentityViolations {
-        /// The users that are expected to be verified but are not.
-        users: Vec<OwnedUserId>,
-    },
-
-    /// It is required to set up cross-signing and properly verify the current
-    /// session before sending.
-    #[error("Own verification is required")]
-    CrossVerificationRequired,
-
-    /// Other errors.
-    #[error("Other unrecoverable error: {msg}")]
-    GenericApiError {
-        /// Description of the error.
-        msg: String,
-    },
-}
-
-/// The specific user intent that characterizes a [`DependentQueuedEvent`].
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum DependentQueuedEventKind {
-    /// The event should be edited.
-    Edit {
-        /// The new event for the content.
-        new_content: SerializableEventContent,
-    },
-
-    /// The event should be redacted/aborted/removed.
-    Redact,
-
-    /// The event should be reacted to, with the given key.
-    React {
-        /// Key used for the reaction.
-        key: String,
-    },
-}
-
-/// A transaction id identifying a [`DependentQueuedEvent`] rather than its
-/// parent [`QueuedEvent`].
-///
-/// This thin wrapper adds some safety to some APIs, making it possible to
-/// distinguish between the parent's `TransactionId` and the dependent event's
-/// own `TransactionId`.
-#[repr(transparent)]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct ChildTransactionId(OwnedTransactionId);
-
-impl ChildTransactionId {
-    /// Returns a new [`ChildTransactionId`].
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        Self(TransactionId::new())
-    }
-}
-
-impl Deref for ChildTransactionId {
-    type Target = TransactionId;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl From<String> for ChildTransactionId {
-    fn from(val: String) -> Self {
-        Self(val.into())
-    }
-}
-
-impl From<ChildTransactionId> for OwnedTransactionId {
-    fn from(val: ChildTransactionId) -> Self {
-        val.0
-    }
-}
-
-/// An event to be sent, depending on a [`QueuedEvent`] to be sent first.
-///
-/// Depending on whether the event has been sent or not, this will either update
-/// the local echo in the storage, or send an event equivalent to the user
-/// intent to the homeserver.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct DependentQueuedEvent {
-    /// Unique identifier for this dependent queued event.
-    ///
-    /// Useful for deletion.
-    pub own_transaction_id: ChildTransactionId,
-
-    /// The kind of user intent.
-    pub kind: DependentQueuedEventKind,
-
-    /// Transaction id for the parent's local echo / used in the server request.
-    ///
-    /// Note: this is the transaction id used for the depended-on event, i.e.
-    /// the one that was originally sent and that's being modified with this
-    /// dependent event.
-    pub parent_transaction_id: OwnedTransactionId,
-
-    /// If the parent event has been sent, the parent's event identifier
-    /// returned by the server once the local echo has been sent out.
-    ///
-    /// Note: this is the event id used for the depended-on event after it's
-    /// been sent, not for a possible event that could have been sent
-    /// because of this [`DependentQueuedEvent`].
-    pub event_id: Option<OwnedEventId>,
-}
-
-#[cfg(not(tarpaulin_include))]
-impl fmt::Debug for QueuedEvent {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Hide the content from the debug log.
-        f.debug_struct("QueuedEvent")
-            .field("transaction_id", &self.transaction_id)
-            .field("is_wedged", &self.is_wedged())
-            .finish_non_exhaustive()
-    }
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -1618,7 +1618,7 @@ impl_state_store!({
         Ok(false)
     }
 
-    async fn list_dependent_send_queue_events(
+    async fn load_dependent_send_queue_events(
         &self,
         room_id: &RoomId,
     ) -> Result<Vec<DependentQueuedEvent>> {

--- a/crates/matrix-sdk-sqlite/migrations/state_store/005_send_queue_dependent_events.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/005_send_queue_dependent_events.sql
@@ -14,6 +14,6 @@ CREATE TABLE "dependent_send_queue_events" (
     -- Used as a value (thus encrypted/decrypted), can be null.
     "event_id" BLOB NULL,
 
-    -- Serialized `DependentQueuedEventKind`, used as a value (thus encrypted/decrypted).
+    -- Serialized `DependentQueuedRequestKind`, used as a value (thus encrypted/decrypted).
     "content" BLOB NOT NULL
 );

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1896,7 +1896,7 @@ impl StateStore for SqliteStateStore {
         Ok(num_deleted > 0)
     }
 
-    async fn list_dependent_send_queue_events(
+    async fn load_dependent_send_queue_events(
         &self,
         room_id: &RoomId,
     ) -> Result<Vec<DependentQueuedEvent>> {

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -12,7 +12,8 @@ use matrix_sdk_base::{
     deserialized_responses::{RawAnySyncOrStrippedState, SyncOrStrippedState},
     store::{
         migration_helpers::RoomInfoV1, ChildTransactionId, DependentQueuedEvent,
-        DependentQueuedEventKind, QueueWedgeError, QueuedEvent, SerializableEventContent,
+        DependentQueuedEventKind, QueueWedgeError, QueuedEvent, QueuedRequestKind,
+        SerializableEventContent,
     },
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, RoomState, StateChanges, StateStore,
     StateStoreDataKey, StateStoreDataValue,
@@ -1767,7 +1768,7 @@ impl StateStore for SqliteStateStore {
         for entry in res {
             queued_events.push(QueuedEvent {
                 transaction_id: entry.0.into(),
-                event: self.deserialize_json(&entry.1)?,
+                kind: QueuedRequestKind::Event { content: self.deserialize_json(&entry.1)? },
                 error: entry.2.map(|v| self.deserialize_value(&v)).transpose()?,
             });
         }

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -893,7 +893,7 @@ impl QueueStorage {
             });
 
         let local_reactions = store
-            .list_dependent_send_queue_events(&self.room_id)
+            .load_dependent_send_queue_events(&self.room_id)
             .await?
             .into_iter()
             .filter_map(|dep| match dep.kind {
@@ -1078,7 +1078,7 @@ impl QueueStorage {
         let store = client.store();
 
         let dependent_events = store
-            .list_dependent_send_queue_events(&self.room_id)
+            .load_dependent_send_queue_events(&self.room_id)
             .await
             .map_err(RoomSendQueueStorageError::StorageError)?;
 

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1799,7 +1799,7 @@ async fn test_reloading_rooms_with_unsent_events() {
         .unwrap();
     set_client_session(&client).await;
 
-    client.send_queue().respawn_tasks_for_rooms_with_unsent_events().await;
+    client.send_queue().respawn_tasks_for_rooms_with_unsent_requests().await;
 
     // Let the sending queues process events.
     sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
This refactors the send queue so that it can apply sending more abstract requests, instead of only sending plain events. This will generalize to media uploads soon, but in the future might also generalize to [sending redactions](https://github.com/matrix-org/matrix-rust-sdk/issues/4162), etc. So we now queue requests, update requests, and so on; which leads to some fun renaming in a massive patch, but no changes in functionality. Those would come in subsequent pull requests.

Indexeddb has a database format change, that is gently handled the same way we did for is_wedged vs wedged errors, that is: the migration applies at the reading boundary (we can't use the `#[serde(untagged)]` enum trick because we're storing a raw JSON value, and this is known to be [buggy](https://github.com/serde-rs/json/issues/497) in serde). Sqlite hasn't been modified yet.

Part of #1732.