### PR TITLE
feat(event cache store): add ability to rename a media cache key

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache_store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/traits.rs
@@ -42,6 +42,28 @@ pub trait EventCacheStore: AsyncTraitDeps {
         content: Vec<u8>,
     ) -> Result<(), Self::Error>;
 
+    /// Replaces the given media's content key with another one.
+    ///
+    /// This should be used whenever a temporary (local) MXID has been used, and
+    /// it must now be replaced with its actual remote counterpart (after
+    /// uploading some content, or creating an empty MXC URI).
+    ///
+    /// ⚠ No check is performed to ensure that the media formats are consistent,
+    /// i.e. it's possible to update with a thumbnail key a media that was
+    /// keyed as a file before. The caller is responsible of ensuring that
+    /// the replacement makes sense, according to their use case.
+    ///
+    /// # Arguments
+    ///
+    /// * `from` - The previous `MediaRequest` of the file.
+    ///
+    /// * `to` - The new `MediaRequest` of the file.
+    async fn replace_media_key(
+        &self,
+        from: &MediaRequest,
+        to: &MediaRequest,
+    ) -> Result<(), Self::Error>;
+
     /// Get a media file's content out of the media store.
     ///
     /// # Arguments
@@ -89,6 +111,14 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
         content: Vec<u8>,
     ) -> Result<(), Self::Error> {
         self.0.add_media_content(request, content).await.map_err(Into::into)
+    }
+
+    async fn replace_media_key(
+        &self,
+        from: &MediaRequest,
+        to: &MediaRequest,
+    ) -> Result<(), Self::Error> {
+        self.0.replace_media_key(from, to).await.map_err(Into::into)
     }
 
     async fn get_media_content(

--- a/crates/matrix-sdk-common/src/ring_buffer.rs
+++ b/crates/matrix-sdk-common/src/ring_buffer.rs
@@ -14,7 +14,7 @@
 
 use std::{
     collections::{
-        vec_deque::{Drain, Iter},
+        vec_deque::{Drain, Iter, IterMut},
         VecDeque,
     },
     num::NonZeroUsize,
@@ -86,6 +86,13 @@ impl<T> RingBuffer<T> {
     /// the same order you would get if you repeatedly called pop().
     pub fn iter(&self) -> Iter<'_, T> {
         self.inner.iter()
+    }
+
+    /// Returns a mutable iterator that provides elements in front-to-back
+    /// order, i.e. the same order you would get if you repeatedly called
+    /// pop().
+    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+        self.inner.iter_mut()
     }
 
     /// Returns an iterator that drains its items.
@@ -219,6 +226,24 @@ mod tests {
 
         assert_eq!(ring_buffer.remove(1), None);
         assert_eq!(ring_buffer.remove(10), None);
+    }
+
+    #[test]
+    fn test_iter() {
+        let mut ring_buffer = RingBuffer::new(NonZeroUsize::new(5).unwrap());
+
+        ring_buffer.push(1);
+        ring_buffer.push(2);
+        ring_buffer.push(3);
+
+        let as_vec = ring_buffer.iter().copied().collect::<Vec<_>>();
+        assert_eq!(as_vec, [1, 2, 3]);
+
+        let first_entry = ring_buffer.iter_mut().next().unwrap();
+        *first_entry = 42;
+
+        let as_vec = ring_buffer.iter().copied().collect::<Vec<_>>();
+        assert_eq!(as_vec, [42, 2, 3]);
     }
 
     #[test]

--- a/crates/matrix-sdk-common/src/ring_buffer.rs
+++ b/crates/matrix-sdk-common/src/ring_buffer.rs
@@ -268,14 +268,14 @@ mod tests {
     }
 
     #[test]
-    fn clear_on_empty_buffer_is_a_noop() {
+    fn test_clear_on_empty_buffer_is_a_noop() {
         let mut ring_buffer: RingBuffer<u8> = RingBuffer::new(NonZeroUsize::new(3).unwrap());
         ring_buffer.clear();
         assert_eq!(ring_buffer.len(), 0);
     }
 
     #[test]
-    fn clear_removes_all_items() {
+    fn test_clear_removes_all_items() {
         // Given a RingBuffer that has been used
         let mut ring_buffer = RingBuffer::new(NonZeroUsize::new(3).unwrap());
         ring_buffer.push(4);
@@ -295,7 +295,7 @@ mod tests {
     }
 
     #[test]
-    fn clear_does_not_affect_capacity() {
+    fn test_clear_does_not_affect_capacity() {
         // Given a RingBuffer that has been used
         let mut ring_buffer = RingBuffer::new(NonZeroUsize::new(3).unwrap());
         ring_buffer.push(4);
@@ -313,7 +313,7 @@ mod tests {
     }
 
     #[test]
-    fn capacity_is_what_we_passed_to_new() {
+    fn test_capacity_is_what_we_passed_to_new() {
         // Given a RingBuffer
         let ring_buffer = RingBuffer::<i32>::new(NonZeroUsize::new(13).unwrap());
         // When I ask for its capacity I get what I provided at the start
@@ -321,7 +321,7 @@ mod tests {
     }
 
     #[test]
-    fn capacity_is_not_affected_by_overflowing() {
+    fn test_capacity_is_not_affected_by_overflowing() {
         // Given a RingBuffer that has been used
         let mut ring_buffer = RingBuffer::new(NonZeroUsize::new(3).unwrap());
         ring_buffer.push(4);
@@ -343,7 +343,7 @@ mod tests {
     }
 
     #[test]
-    fn roundtrip_serialization() {
+    fn test_roundtrip_serialization() {
         // Given a RingBuffer
         let mut ring_buffer = RingBuffer::new(NonZeroUsize::new(3).unwrap());
         ring_buffer.push("1".to_owned());
@@ -363,7 +363,7 @@ mod tests {
     }
 
     #[test]
-    fn extending_an_empty_ringbuffer_adds_the_items() {
+    fn test_extending_an_empty_ringbuffer_adds_the_items() {
         // Given a RingBuffer
         let mut ring_buffer = RingBuffer::new(NonZeroUsize::new(5).unwrap());
 
@@ -375,7 +375,7 @@ mod tests {
     }
 
     #[test]
-    fn extend_adds_items_to_the_end() {
+    fn test_extend_adds_items_to_the_end() {
         // Given a RingBuffer with something in it
         let mut ring_buffer = RingBuffer::new(NonZeroUsize::new(5).unwrap());
         ring_buffer.push("1".to_owned());
@@ -392,7 +392,7 @@ mod tests {
     }
 
     #[test]
-    fn extend_does_not_overflow_max_length() {
+    fn test_extend_does_not_overflow_max_length() {
         // Given a RingBuffer with something in it
         let mut ring_buffer = RingBuffer::new(NonZeroUsize::new(5).unwrap());
         ring_buffer.push("1".to_owned());
@@ -415,7 +415,7 @@ mod tests {
     }
 
     #[test]
-    fn extending_a_full_ringbuffer_preserves_max_length() {
+    fn test_extending_a_full_ringbuffer_preserves_max_length() {
         // Given a full RingBuffer with something in it
         let mut ring_buffer = RingBuffer::new(NonZeroUsize::new(2).unwrap());
         ring_buffer.push("1".to_owned());


### PR DESCRIPTION
What it says on the tin. Will allow caching medias before they're sent to a remote, when used with the send queue.

Part of #1732.