### PR TITLE
test: Update Synapse from 1.115 to 1.117

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
       # tests need a synapse: this is a service and not michaelkaye/setup-matrix-synapse@main as the
       # latter does not provide networking for services to communicate with it.
       synapse:
-        image: ghcr.io/matrix-org/synapse-service:v1.115.0 # keep in sync with ./coverage.yml
+        image: ghcr.io/matrix-org/synapse-service:v1.117.0 # keep in sync with ./coverage.yml
         env:
             SYNAPSE_COMPLEMENT_DATABASE: sqlite
             SERVER_NAME: synapse

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,7 +49,7 @@ jobs:
       # tests need a synapse: this is a service and not michaelkaye/setup-matrix-synapse@main as the
       # latter does not provide networking for services to communicate with it.
       synapse:
-        image: ghcr.io/matrix-org/synapse-service:v1.115.0 # keep in sync with ./ci.yml
+        image: ghcr.io/matrix-org/synapse-service:v1.117.0 # keep in sync with ./ci.yml
         env:
             SYNAPSE_COMPLEMENT_DATABASE: sqlite
             SERVER_NAME: synapse

--- a/testing/matrix-sdk-integration-testing/assets/Dockerfile
+++ b/testing/matrix-sdk-integration-testing/assets/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/matrixdotorg/synapse:v1.115.0
+FROM docker.io/matrixdotorg/synapse:v1.117.0
 ADD ci-start.sh /ci-start.sh
 RUN chmod 770 /ci-start.sh
 ENTRYPOINT /ci-start.sh


### PR DESCRIPTION
This patch updates Synapse in our CI infrastructure and in the `matrix-sdk-integration-testing` crate.