### PR TITLE
chore(ffi): in `Client::account_url` return early when we're not an OIDC session

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -606,6 +606,10 @@ impl Client {
         &self,
         action: Option<AccountManagementAction>,
     ) -> Result<Option<String>, ClientError> {
+        if !matches!(self.inner.auth_api(), Some(AuthApi::Oidc(..))) {
+            return Ok(None);
+        }
+
         match self.inner.oidc().account_management_url(action.map(Into::into)).await {
             Ok(url) => Ok(url.map(|u| u.to_string())),
             Err(e) => {


### PR DESCRIPTION
This avoids one spammy error log for sessions not using oidc.