### PR TITLE
feat: Implement cross-process lock for the `EventCache`

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "e2e-encryption")]
-use std::ops::Deref;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt, iter,
+    ops::Deref,
     sync::Arc,
 };
 
@@ -252,12 +251,12 @@ impl BaseClient {
     /// Get a reference to the store.
     #[allow(unknown_lints, clippy::explicit_auto_deref)]
     pub fn store(&self) -> &DynStateStore {
-        &*self.store
+        self.store.deref()
     }
 
     /// Get a reference to the event cache store.
     pub fn event_cache_store(&self) -> &DynEventCacheStore {
-        &*self.event_cache_store
+        self.event_cache_store.as_ref()
     }
 
     /// Is the client logged in.

--- a/crates/matrix-sdk-base/src/event_cache_store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/integration_tests.rs
@@ -233,3 +233,79 @@ macro_rules! event_cache_store_integration_tests {
         }
     };
 }
+
+/// Macro generating tests for the event cache store, related to time (mostly
+/// for the cross-process lock).
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! event_cache_store_integration_tests_time {
+    () => {
+        #[cfg(not(target_arch = "wasm32"))]
+        mod event_cache_store_integration_tests_time {
+            use std::time::Duration;
+
+            use matrix_sdk_test::async_test;
+            use $crate::event_cache_store::IntoEventCacheStore;
+
+            use super::get_event_cache_store;
+
+            #[async_test]
+            async fn test_lease_locks() {
+                let store = get_event_cache_store().await.unwrap().into_event_cache_store();
+
+                let acquired0 = store.try_take_leased_lock(0, "key", "alice").await.unwrap();
+                assert!(acquired0);
+
+                // Should extend the lease automatically (same holder).
+                let acquired2 = store.try_take_leased_lock(300, "key", "alice").await.unwrap();
+                assert!(acquired2);
+
+                // Should extend the lease automatically (same holder + time is ok).
+                let acquired3 = store.try_take_leased_lock(300, "key", "alice").await.unwrap();
+                assert!(acquired3);
+
+                // Another attempt at taking the lock should fail, because it's taken.
+                let acquired4 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();
+                assert!(!acquired4);
+
+                // Even if we insist.
+                let acquired5 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();
+                assert!(!acquired5);
+
+                // That's a nice test we got here, go take a little nap.
+                tokio::time::sleep(Duration::from_millis(50)).await;
+
+                // Still too early.
+                let acquired55 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();
+                assert!(!acquired55);
+
+                // Ok you can take another nap then.
+                tokio::time::sleep(Duration::from_millis(250)).await;
+
+                // At some point, we do get the lock.
+                let acquired6 = store.try_take_leased_lock(0, "key", "bob").await.unwrap();
+                assert!(acquired6);
+
+                tokio::time::sleep(Duration::from_millis(1)).await;
+
+                // The other gets it almost immediately too.
+                let acquired7 = store.try_take_leased_lock(0, "key", "alice").await.unwrap();
+                assert!(acquired7);
+
+                tokio::time::sleep(Duration::from_millis(1)).await;
+
+                // But when we take a longer lease...
+                let acquired8 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();
+                assert!(acquired8);
+
+                // It blocks the other user.
+                let acquired9 = store.try_take_leased_lock(300, "key", "alice").await.unwrap();
+                assert!(!acquired9);
+
+                // We can hold onto our lease.
+                let acquired10 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();
+                assert!(acquired10);
+            }
+        }
+    };
+}

--- a/crates/matrix-sdk-base/src/event_cache_store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/memory_store.rs
@@ -51,6 +51,15 @@ impl MemoryStore {
 impl EventCacheStore for MemoryStore {
     type Error = EventCacheStoreError;
 
+    async fn try_take_leased_lock(
+        &self,
+        lease_duration_ms: u32,
+        key: &str,
+        holder: &str,
+    ) -> Result<bool, Self::Error> {
+        todo!()
+    }
+
     async fn add_media_content(&self, request: &MediaRequest, data: Vec<u8>) -> Result<()> {
         // Avoid duplication. Let's try to remove it first.
         self.remove_media_content(request).await?;

--- a/crates/matrix-sdk-base/src/event_cache_store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/memory_store.rs
@@ -185,4 +185,5 @@ mod tests {
     }
 
     event_cache_store_integration_tests!();
+    event_cache_store_integration_tests_time!();
 }

--- a/crates/matrix-sdk-base/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/mod.rs
@@ -40,6 +40,7 @@ pub use self::{
 };
 
 /// The high-level public type to represent an `EventCacheStore` lock.
+#[derive(Clone)]
 pub struct EventCacheStoreLock {
     /// The inner cross process lock that is used to lock the `EventCacheStore`.
     cross_process_lock: CrossProcessStoreLock<LockableEventCacheStore>,
@@ -50,6 +51,7 @@ pub struct EventCacheStoreLock {
     store: Arc<DynEventCacheStore>,
 }
 
+#[cfg(not(tarpaulin_include))]
 impl fmt::Debug for EventCacheStoreLock {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.debug_struct("EventCacheStoreLock").finish_non_exhaustive()
@@ -94,6 +96,7 @@ pub struct EventCacheStoreLockGuard<'a> {
     store: &'a DynEventCacheStore,
 }
 
+#[cfg(not(tarpaulin_include))]
 impl<'a> fmt::Debug for EventCacheStoreLockGuard<'a> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.debug_struct("EventCacheStoreLockGuard").finish_non_exhaustive()

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -531,6 +531,9 @@ impl StoreConfig {
     }
 
     /// Set a custom implementation of an `EventCacheStore`.
+    ///
+    /// The `key` and `holder` arguments represent the key and holder inside the
+    /// [`CrossProcessStoreLock::new`][matrix_sdk_common::store_locks::CrossProcessStoreLock::new].
     pub fn event_cache_store<S>(mut self, event_cache_store: S, key: String, holder: String) -> Self
     where
         S: event_cache_store::IntoEventCacheStore,

--- a/crates/matrix-sdk-common/src/store_locks.rs
+++ b/crates/matrix-sdk-common/src/store_locks.rs
@@ -338,7 +338,7 @@ pub enum LockStoreError {
 mod tests {
     use std::{
         collections::HashMap,
-        sync::{atomic, Arc, Mutex},
+        sync::{atomic, Arc, RwLock},
         time::Instant,
     };
 
@@ -350,47 +350,18 @@ mod tests {
     };
 
     use super::{
-        BackingStore, CrossProcessStoreLock, CrossProcessStoreLockGuard, LockStoreError,
-        EXTEND_LEASE_EVERY_MS,
+        memory_store_helper::try_take_leased_lock, BackingStore, CrossProcessStoreLock,
+        CrossProcessStoreLockGuard, LockStoreError, EXTEND_LEASE_EVERY_MS,
     };
 
     #[derive(Clone, Default)]
     struct TestStore {
-        leases: Arc<Mutex<HashMap<String, (String, Instant)>>>,
+        leases: Arc<RwLock<HashMap<String, (String, Instant)>>>,
     }
 
     impl TestStore {
         fn try_take_leased_lock(&self, lease_duration_ms: u32, key: &str, holder: &str) -> bool {
-            let now = Instant::now();
-            let expiration = now + Duration::from_millis(lease_duration_ms.into());
-            let mut leases = self.leases.lock().unwrap();
-            if let Some(prev) = leases.get_mut(key) {
-                if prev.0 == holder {
-                    // We had the lease before, extend it.
-                    prev.1 = expiration;
-                    true
-                } else {
-                    // We didn't have it.
-                    if prev.1 < now {
-                        // Steal it!
-                        prev.0 = holder.to_owned();
-                        prev.1 = expiration;
-                        true
-                    } else {
-                        // We tried our best.
-                        false
-                    }
-                }
-            } else {
-                leases.insert(
-                    key.to_owned(),
-                    (
-                        holder.to_owned(),
-                        Instant::now() + Duration::from_millis(lease_duration_ms.into()),
-                    ),
-                );
-                true
-            }
+            try_take_leased_lock(&self.leases, lease_duration_ms, key, holder)
         }
     }
 
@@ -523,5 +494,61 @@ mod tests {
         assert_matches!(lock1.spin_lock(Some(200)).await, Err(LockStoreError::LockTimeout));
 
         Ok(())
+    }
+}
+
+/// Some code that is shared by almost all `MemoryStore` implementations out
+/// there.
+pub mod memory_store_helper {
+    use std::{
+        collections::{hash_map::Entry, HashMap},
+        sync::RwLock,
+        time::{Duration, Instant},
+    };
+
+    pub fn try_take_leased_lock(
+        leases: &RwLock<HashMap<String, (String, Instant)>>,
+        lease_duration_ms: u32,
+        key: &str,
+        holder: &str,
+    ) -> bool {
+        let now = Instant::now();
+        let expiration = now + Duration::from_millis(lease_duration_ms.into());
+
+        match leases.write().unwrap().entry(key.to_owned()) {
+            // There is an existing holder.
+            Entry::Occupied(mut entry) => {
+                let (current_holder, current_expiration) = entry.get_mut();
+
+                if current_holder == holder {
+                    // We had the lease before, extend it.
+                    *current_expiration = expiration;
+
+                    true
+                } else {
+                    // We didn't have it.
+                    if *current_expiration < now {
+                        // Steal it!
+                        *current_holder = holder.to_owned();
+                        *current_expiration = expiration;
+
+                        true
+                    } else {
+                        // We tried our best.
+                        false
+                    }
+                }
+            }
+
+            // There is no holder, easy.
+            Entry::Vacant(entry) => {
+                entry.insert((
+                    holder.to_owned(),
+                    Instant::now() + Duration::from_millis(lease_duration_ms.into()),
+                ));
+
+                true
+            }
+        }
     }
 }

--- a/crates/matrix-sdk-common/src/store_locks.rs
+++ b/crates/matrix-sdk-common/src/store_locks.rs
@@ -58,7 +58,7 @@ use crate::{
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait BackingStore {
-    type Error: Error + Send + Sync;
+    type LockError: Error + Send + Sync;
 
     /// Try to take a lock using the given store.
     async fn try_lock(
@@ -66,7 +66,7 @@ pub trait BackingStore {
         lease_duration_ms: u32,
         key: &str,
         holder: &str,
-    ) -> Result<bool, Self::Error>;
+    ) -> Result<bool, Self::LockError>;
 }
 
 /// Small state machine to handle wait times.
@@ -400,7 +400,7 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
     #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
     impl BackingStore for TestStore {
-        type Error = DummyError;
+        type LockError = DummyError;
 
         /// Try to take a lock using the given store.
         async fn try_lock(
@@ -408,7 +408,7 @@ mod tests {
             lease_duration_ms: u32,
             key: &str,
             holder: &str,
-        ) -> Result<bool, Self::Error> {
+        ) -> Result<bool, Self::LockError> {
             Ok(self.try_take_leased_lock(lease_duration_ms, key, holder))
         }
     }

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -1925,14 +1925,14 @@ pub struct LockableCryptoStore(Arc<dyn CryptoStore<Error = CryptoStoreError>>);
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl matrix_sdk_common::store_locks::BackingStore for LockableCryptoStore {
-    type Error = CryptoStoreError;
+    type LockError = CryptoStoreError;
 
     async fn try_lock(
         &self,
         lease_duration_ms: u32,
         key: &str,
         holder: &str,
-    ) -> std::result::Result<bool, Self::Error> {
+    ) -> std::result::Result<bool, Self::LockError> {
         self.0.try_take_leased_lock(lease_duration_ms, key, holder).await
     }
 }

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/002_lease_locks.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/002_lease_locks.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "lease_locks" (
+    "key" TEXT PRIMARY KEY NOT NULL,
+    "holder" TEXT NOT NULL,
+    "expiration" REAL NOT NULL
+);

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -140,6 +140,15 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
 impl EventCacheStore for SqliteEventCacheStore {
     type Error = Error;
 
+    async fn try_take_leased_lock(
+        &self,
+        lease_duration_ms: u32,
+        key: &str,
+        holder: &str,
+    ) -> Result<bool, Self::Error> {
+        todo!()
+    }
+
     async fn add_media_content(&self, request: &MediaRequest, content: Vec<u8>) -> Result<()> {
         let uri = self.encode_key(keys::MEDIA, request.source.unique_key());
         let format = self.encode_key(keys::MEDIA, request.format.unique_key());

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -276,7 +276,7 @@ mod tests {
 
     use matrix_sdk_base::{
         event_cache_store::{EventCacheStore, EventCacheStoreError},
-        event_cache_store_integration_tests,
+        event_cache_store_integration_tests, event_cache_store_integration_tests_time,
         media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
     };
     use matrix_sdk_test::async_test;
@@ -300,6 +300,7 @@ mod tests {
     }
 
     event_cache_store_integration_tests!();
+    event_cache_store_integration_tests_time!();
 
     async fn get_event_cache_store_content_sorted_by_last_access(
         event_cache_store: &SqliteEventCacheStore,
@@ -381,6 +382,7 @@ mod encrypted_tests {
 
     use matrix_sdk_base::{
         event_cache_store::EventCacheStoreError, event_cache_store_integration_tests,
+        event_cache_store_integration_tests_time,
     };
     use once_cell::sync::Lazy;
     use tempfile::{tempdir, TempDir};
@@ -405,4 +407,5 @@ mod encrypted_tests {
     }
 
     event_cache_store_integration_tests!();
+    event_cache_store_integration_tests_time!();
 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -33,7 +33,7 @@ use imbl::Vector;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::store::LockableCryptoStore;
 use matrix_sdk_base::{
-    event_cache_store::DynEventCacheStore,
+    event_cache_store::EventCacheStoreLock,
     store::{DynStateStore, ServerCapabilities},
     sync::{Notification, RoomUpdates},
     BaseClient, RoomInfoNotableUpdate, RoomState, RoomStateFilter, SendOutsideWasm, SessionMeta,
@@ -590,7 +590,7 @@ impl Client {
     }
 
     /// Get a reference to the event cache store.
-    pub(crate) fn event_cache_store(&self) -> &DynEventCacheStore {
+    pub(crate) fn event_cache_store(&self) -> &EventCacheStoreLock {
         self.base_client().event_cache_store()
     }
 

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -377,7 +377,7 @@ impl Media {
         // Read from the cache.
         if use_cache {
             if let Some(content) =
-                self.client.event_cache_store().get_media_content(request).await?
+                self.client.event_cache_store().lock().await?.get_media_content(request).await?
             {
                 return Ok(content);
             }
@@ -477,7 +477,12 @@ impl Media {
         };
 
         if use_cache {
-            self.client.event_cache_store().add_media_content(request, content.clone()).await?;
+            self.client
+                .event_cache_store()
+                .lock()
+                .await?
+                .add_media_content(request, content.clone())
+                .await?;
         }
 
         Ok(content)
@@ -489,7 +494,7 @@ impl Media {
     ///
     /// * `request` - The `MediaRequest` of the content.
     pub async fn remove_media_content(&self, request: &MediaRequest) -> Result<()> {
-        Ok(self.client.event_cache_store().remove_media_content(request).await?)
+        Ok(self.client.event_cache_store().lock().await?.remove_media_content(request).await?)
     }
 
     /// Delete all the media content corresponding to the given
@@ -499,7 +504,7 @@ impl Media {
     ///
     /// * `uri` - The `MxcUri` of the files.
     pub async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<()> {
-        Ok(self.client.event_cache_store().remove_media_content_for_uri(uri).await?)
+        Ok(self.client.event_cache_store().lock().await?.remove_media_content_for_uri(uri).await?)
     }
 
     /// Get the file of the given media event content.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1986,14 +1986,15 @@ impl Room {
             .await?;
 
         if store_in_cache {
-            let cache_store = self.client.event_cache_store();
+            let cache_store_lock_guard = self.client.event_cache_store().lock().await?;
 
             // A failure to cache shouldn't prevent the whole upload from finishing
             // properly, so only log errors during caching.
 
             debug!("caching the media");
             let request = MediaRequest { source: media_source.clone(), format: MediaFormat::File };
-            if let Err(err) = cache_store.add_media_content(&request, data).await {
+
+            if let Err(err) = cache_store_lock_guard.add_media_content(&request, data).await {
                 warn!("unable to cache the media after uploading it: {err}");
             }
 
@@ -2016,7 +2017,7 @@ impl Room {
                     }),
                 };
 
-                if let Err(err) = cache_store.add_media_content(&request, data).await {
+                if let Err(err) = cache_store_lock_guard.add_media_content(&request, data).await {
                     warn!("unable to cache the media after uploading it: {err}");
                 }
             }


### PR DESCRIPTION
This PR must be reviewed commit-by-commit.

It introduces the `LockableEventCacheStore` type, which wraps `DynEventCacheStore`, and that implements `BackingStore` so that it can be used inside the `CrossProcessStoreLock`.

It then introduces the `EventCacheStoreLock` type, which glue all pieces together: the `CrossProcessStoreLock` and the `LockableEventCacheStore`. It exposes a single method: `lock(&'a self) -> Result<EventCacheStoreLockGuard<'a>, _>`, which allows to take the lock. The guard derefs to `DynEventCacheStore`. The resulting API is straightforward to use according to me: `client.event_cache_store().lock().await?`, pretty Rust idiomatic.

Finally, the PR replaces all uses of `DynEventCacheStore` by `EventCacheStoreLock`. There is no more public `DynEventCacheStore`, expect via `EventCacheStoreLock`.

A follow-up patch must update `matrix_sdk::event_cache` to refresh the in-memory data of the event cache when the lock holder has changed. I believe it's nice to introduce that in another PR instead of increasing the number of patches in this one.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280
