### PR TITLE
refactor(crypto)!: Remove unused `OneTimeKey::Key` and `SessionCreationError::OneTimeKeyUnknown` variants

### DIFF
--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -305,13 +305,6 @@ pub enum SessionCreationError {
     )]
     OneTimeKeyMissing(OwnedUserId, OwnedDeviceId),
 
-    /// The one-time key algorithm is unsupported.
-    #[error(
-        "Tried to create a new Olm session for {0} {1}, but the one-time \
-        key algorithm is unsupported"
-    )]
-    OneTimeKeyUnknown(OwnedUserId, OwnedDeviceId),
-
     /// Failed to verify the one-time key signatures.
     #[error(
         "Failed to verify the signature of a one-time key, key: {one_time_key:?}, \

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -962,10 +962,6 @@ impl Account {
 
         let result = match first_key {
             OneTimeKey::SignedKey(key) => Ok(PrekeyBundle::Olm3DH { key }),
-            _ => Err(SessionCreationError::OneTimeKeyUnknown(
-                device.user_id().to_owned(),
-                device.device_id().into(),
-            )),
         };
 
         trace!(?result, "Finished searching for a valid pre-key bundle");

--- a/crates/matrix-sdk-crypto/src/types/one_time_keys.rs
+++ b/crates/matrix-sdk-crypto/src/types/one_time_keys.rs
@@ -103,10 +103,6 @@ impl SignedKey {
 pub enum OneTimeKey {
     /// A signed Curve25519 one-time key.
     SignedKey(SignedKey),
-
-    /// An unsigned Curve25519 one-time key.
-    #[serde(serialize_with = "serialize_curve_key")]
-    Key(Curve25519PublicKey),
 }
 
 impl OneTimeKey {
@@ -121,17 +117,7 @@ impl OneTimeKey {
                 let key: SignedKey = key.deserialize_as()?;
                 Ok(OneTimeKey::SignedKey(key))
             }
-            _ => match algorithm.as_str() {
-                "curve25519" => {
-                    let key: String = key.deserialize_as()?;
-                    Ok(OneTimeKey::Key(
-                        Curve25519PublicKey::from_base64(&key).map_err(serde::de::Error::custom)?,
-                    ))
-                }
-                _ => {
-                    Err(serde::de::Error::custom(format!("Unsupported key algorithm {algorithm}")))
-                }
-            },
+            _ => Err(serde::de::Error::custom(format!("Unsupported key algorithm {algorithm}"))),
         }
     }
 }
@@ -141,7 +127,6 @@ impl OneTimeKey {
     pub fn fallback(&self) -> bool {
         match self {
             OneTimeKey::SignedKey(s) => s.fallback(),
-            OneTimeKey::Key(_) => false,
         }
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/matrix-org/matrix-rust-sdk/pull/4171#discussion_r1820767666.