### PR TITLE
feat(send queue): send attachments with the send queue

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -717,6 +717,7 @@ impl Client {
     ) -> Result<Vec<u8>, ClientError> {
         let source = (*media_source).clone();
 
+        debug!(?source, "requesting media file");
         Ok(self
             .inner
             .media()
@@ -732,6 +733,7 @@ impl Client {
     ) -> Result<Vec<u8>, ClientError> {
         let source = (*media_source).clone();
 
+        debug!(source = ?media_source, width, height, "requesting media thumbnail");
         Ok(self
             .inner
             .media()

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -8,7 +8,8 @@ use std::{
 use anyhow::{anyhow, Context as _};
 use matrix_sdk::{
     media::{
-        MediaFileHandle as SdkMediaFileHandle, MediaFormat, MediaRequest, MediaThumbnailSettings,
+        MediaFileHandle as SdkMediaFileHandle, MediaFormat, MediaRequestParameters,
+        MediaThumbnailSettings,
     },
     oidc::{
         registrations::{ClientId, OidcRegistrations},
@@ -442,7 +443,7 @@ impl Client {
             .inner
             .media()
             .get_media_file(
-                &MediaRequest { source, format: MediaFormat::File },
+                &MediaRequestParameters { source, format: MediaFormat::File },
                 filename,
                 &mime_type,
                 use_cache,
@@ -721,7 +722,7 @@ impl Client {
         Ok(self
             .inner
             .media()
-            .get_media_content(&MediaRequest { source, format: MediaFormat::File }, true)
+            .get_media_content(&MediaRequestParameters { source, format: MediaFormat::File }, true)
             .await?)
     }
 
@@ -738,7 +739,7 @@ impl Client {
             .inner
             .media()
             .get_media_content(
-                &MediaRequest {
+                &MediaRequestParameters {
                     source,
                     format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
                         Method::Scale,

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -183,6 +183,12 @@ pub enum QueueWedgeError {
     /// session before sending.
     CrossVerificationRequired,
 
+    /// Some media content to be sent has disappeared from the cache.
+    MissingMediaContent,
+
+    /// Some mime type couldn't be parsed.
+    InvalidMimeType { mime_type: String },
+
     /// Other errors.
     GenericApiError { msg: String },
 }
@@ -201,10 +207,17 @@ impl Display for QueueWedgeError {
             QueueWedgeError::CrossVerificationRequired => {
                 f.write_str("Own verification is required")
             }
+            QueueWedgeError::MissingMediaContent => {
+                f.write_str("Media to be sent disappeared from local storage")
+            }
+            QueueWedgeError::InvalidMimeType { mime_type } => {
+                write!(f, "Invalid mime type '{mime_type}' for media upload")
+            }
             QueueWedgeError::GenericApiError { msg } => f.write_str(msg),
         }
     }
 }
+
 impl From<SdkQueueWedgeError> for QueueWedgeError {
     fn from(value: SdkQueueWedgeError) -> Self {
         match value {
@@ -223,6 +236,10 @@ impl From<SdkQueueWedgeError> for QueueWedgeError {
                 users: users.iter().map(ruma::OwnedUserId::to_string).collect(),
             },
             SdkQueueWedgeError::CrossVerificationRequired => Self::CrossVerificationRequired,
+            SdkQueueWedgeError::MissingMediaContent => Self::MissingMediaContent,
+            SdkQueueWedgeError::InvalidMimeType { mime_type } => {
+                Self::InvalidMimeType { mime_type }
+            }
             SdkQueueWedgeError::GenericApiError { msg } => Self::GenericApiError { msg },
         }
     }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -105,18 +105,13 @@ impl Timeline {
         filename: String,
         mime_type: Option<String>,
         attachment_config: AttachmentConfig,
-        store_in_cache: bool,
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Result<(), RoomError> {
         let mime_str = mime_type.as_ref().ok_or(RoomError::InvalidAttachmentMimeType)?;
         let mime_type =
             mime_str.parse::<Mime>().map_err(|_| RoomError::InvalidAttachmentMimeType)?;
 
-        let mut request = self.inner.send_attachment(filename, mime_type, attachment_config);
-
-        if store_in_cache {
-            request.store_in_cache();
-        }
+        let request = self.inner.send_attachment(filename, mime_type, attachment_config);
 
         if let Some(progress_watcher) = progress_watcher {
             let mut subscriber = request.subscribe_to_send_progress();
@@ -278,7 +273,6 @@ impl Timeline {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn send_image(
         self: Arc<Self>,
         url: String,
@@ -286,7 +280,6 @@ impl Timeline {
         image_info: ImageInfo,
         caption: Option<String>,
         formatted_caption: Option<FormattedBody>,
-        store_in_cache: bool,
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Arc<SendAttachmentJoinHandle> {
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
@@ -299,18 +292,11 @@ impl Timeline {
                 .caption(caption)
                 .formatted_caption(formatted_caption.map(Into::into));
 
-            self.send_attachment(
-                url,
-                image_info.mimetype,
-                attachment_config,
-                store_in_cache,
-                progress_watcher,
-            )
-            .await
+            self.send_attachment(url, image_info.mimetype, attachment_config, progress_watcher)
+                .await
         }))
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn send_video(
         self: Arc<Self>,
         url: String,
@@ -318,7 +304,6 @@ impl Timeline {
         video_info: VideoInfo,
         caption: Option<String>,
         formatted_caption: Option<FormattedBody>,
-        store_in_cache: bool,
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Arc<SendAttachmentJoinHandle> {
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
@@ -331,14 +316,8 @@ impl Timeline {
                 .caption(caption)
                 .formatted_caption(formatted_caption.map(Into::into));
 
-            self.send_attachment(
-                url,
-                video_info.mimetype,
-                attachment_config,
-                store_in_cache,
-                progress_watcher,
-            )
-            .await
+            self.send_attachment(url, video_info.mimetype, attachment_config, progress_watcher)
+                .await
         }))
     }
 
@@ -348,7 +327,6 @@ impl Timeline {
         audio_info: AudioInfo,
         caption: Option<String>,
         formatted_caption: Option<FormattedBody>,
-        store_in_cache: bool,
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Arc<SendAttachmentJoinHandle> {
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
@@ -361,14 +339,8 @@ impl Timeline {
                 .caption(caption)
                 .formatted_caption(formatted_caption.map(Into::into));
 
-            self.send_attachment(
-                url,
-                audio_info.mimetype,
-                attachment_config,
-                store_in_cache,
-                progress_watcher,
-            )
-            .await
+            self.send_attachment(url, audio_info.mimetype, attachment_config, progress_watcher)
+                .await
         }))
     }
 
@@ -380,7 +352,6 @@ impl Timeline {
         waveform: Vec<u16>,
         caption: Option<String>,
         formatted_caption: Option<FormattedBody>,
-        store_in_cache: bool,
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Arc<SendAttachmentJoinHandle> {
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
@@ -394,14 +365,8 @@ impl Timeline {
                 .caption(caption)
                 .formatted_caption(formatted_caption.map(Into::into));
 
-            self.send_attachment(
-                url,
-                audio_info.mimetype,
-                attachment_config,
-                store_in_cache,
-                progress_watcher,
-            )
-            .await
+            self.send_attachment(url, audio_info.mimetype, attachment_config, progress_watcher)
+                .await
         }))
     }
 
@@ -409,7 +374,6 @@ impl Timeline {
         self: Arc<Self>,
         url: String,
         file_info: FileInfo,
-        store_in_cache: bool,
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Arc<SendAttachmentJoinHandle> {
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
@@ -419,14 +383,7 @@ impl Timeline {
 
             let attachment_config = AttachmentConfig::new().info(attachment_info);
 
-            self.send_attachment(
-                url,
-                file_info.mimetype,
-                attachment_config,
-                store_in_cache,
-                progress_watcher,
-            )
-            .await
+            self.send_attachment(url, file_info.mimetype, attachment_config, progress_watcher).await
         }))
     }
 

--- a/crates/matrix-sdk-base/src/event_cache_store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/integration_tests.rs
@@ -20,7 +20,7 @@ use ruma::{
 };
 
 use super::DynEventCacheStore;
-use crate::media::{MediaFormat, MediaRequest, MediaThumbnailSettings};
+use crate::media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings};
 
 /// `EventCacheStore` integration tests.
 ///
@@ -41,9 +41,11 @@ pub trait EventCacheStoreIntegrationTests {
 impl EventCacheStoreIntegrationTests for DynEventCacheStore {
     async fn test_media_content(&self) {
         let uri = mxc_uri!("mxc://localhost/media");
-        let request_file =
-            MediaRequest { source: MediaSource::Plain(uri.to_owned()), format: MediaFormat::File };
-        let request_thumbnail = MediaRequest {
+        let request_file = MediaRequestParameters {
+            source: MediaSource::Plain(uri.to_owned()),
+            format: MediaFormat::File,
+        };
+        let request_thumbnail = MediaRequestParameters {
             source: MediaSource::Plain(uri.to_owned()),
             format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
                 Method::Crop,
@@ -53,7 +55,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         };
 
         let other_uri = mxc_uri!("mxc://localhost/media-other");
-        let request_other_file = MediaRequest {
+        let request_other_file = MediaRequestParameters {
             source: MediaSource::Plain(other_uri.to_owned()),
             format: MediaFormat::File,
         };
@@ -145,8 +147,10 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
     async fn test_replace_media_key(&self) {
         let uri = mxc_uri!("mxc://sendqueue.local/tr4n-s4ct-10n1-d");
-        let req =
-            MediaRequest { source: MediaSource::Plain(uri.to_owned()), format: MediaFormat::File };
+        let req = MediaRequestParameters {
+            source: MediaSource::Plain(uri.to_owned()),
+            format: MediaFormat::File,
+        };
 
         let content = "hello".as_bytes().to_owned();
 
@@ -161,7 +165,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         // Replacing a media request works.
         let new_uri = mxc_uri!("mxc://matrix.org/tr4n-s4ct-10n1-d");
-        let new_req = MediaRequest {
+        let new_req = MediaRequestParameters {
             source: MediaSource::Plain(new_uri.to_owned()),
             format: MediaFormat::File,
         };

--- a/crates/matrix-sdk-base/src/event_cache_store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/memory_store.rs
@@ -21,7 +21,7 @@ use matrix_sdk_common::{
 use ruma::{MxcUri, OwnedMxcUri};
 
 use super::{EventCacheStore, EventCacheStoreError, Result};
-use crate::media::{MediaRequest, UniqueKey as _};
+use crate::media::{MediaRequestParameters, UniqueKey as _};
 
 /// In-memory, non-persistent implementation of the `EventCacheStore`.
 ///
@@ -66,7 +66,11 @@ impl EventCacheStore for MemoryStore {
         Ok(try_take_leased_lock(&self.leases, lease_duration_ms, key, holder))
     }
 
-    async fn add_media_content(&self, request: &MediaRequest, data: Vec<u8>) -> Result<()> {
+    async fn add_media_content(
+        &self,
+        request: &MediaRequestParameters,
+        data: Vec<u8>,
+    ) -> Result<()> {
         // Avoid duplication. Let's try to remove it first.
         self.remove_media_content(request).await?;
         // Now, let's add it.
@@ -77,8 +81,8 @@ impl EventCacheStore for MemoryStore {
 
     async fn replace_media_key(
         &self,
-        from: &MediaRequest,
-        to: &MediaRequest,
+        from: &MediaRequestParameters,
+        to: &MediaRequestParameters,
     ) -> Result<(), Self::Error> {
         let expected_key = from.unique_key();
 
@@ -91,7 +95,7 @@ impl EventCacheStore for MemoryStore {
         Ok(())
     }
 
-    async fn get_media_content(&self, request: &MediaRequest) -> Result<Option<Vec<u8>>> {
+    async fn get_media_content(&self, request: &MediaRequestParameters) -> Result<Option<Vec<u8>>> {
         let expected_key = request.unique_key();
 
         let media = self.media.read().unwrap();
@@ -100,7 +104,7 @@ impl EventCacheStore for MemoryStore {
         }))
     }
 
-    async fn remove_media_content(&self, request: &MediaRequest) -> Result<()> {
+    async fn remove_media_content(&self, request: &MediaRequestParameters) -> Result<()> {
         let expected_key = request.unique_key();
 
         let mut media = self.media.write().unwrap();

--- a/crates/matrix-sdk-base/src/event_cache_store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/traits.rs
@@ -19,7 +19,7 @@ use matrix_sdk_common::AsyncTraitDeps;
 use ruma::MxcUri;
 
 use super::EventCacheStoreError;
-use crate::media::MediaRequest;
+use crate::media::MediaRequestParameters;
 
 /// An abstract trait that can be used to implement different store backends
 /// for the event cache of the SDK.
@@ -46,7 +46,7 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// * `content` - The content of the file.
     async fn add_media_content(
         &self,
-        request: &MediaRequest,
+        request: &MediaRequestParameters,
         content: Vec<u8>,
     ) -> Result<(), Self::Error>;
 
@@ -71,8 +71,8 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// * `to` - The new `MediaRequest` of the file.
     async fn replace_media_key(
         &self,
-        from: &MediaRequest,
-        to: &MediaRequest,
+        from: &MediaRequestParameters,
+        to: &MediaRequestParameters,
     ) -> Result<(), Self::Error>;
 
     /// Get a media file's content out of the media store.
@@ -82,7 +82,7 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// * `request` - The `MediaRequest` of the file.
     async fn get_media_content(
         &self,
-        request: &MediaRequest,
+        request: &MediaRequestParameters,
     ) -> Result<Option<Vec<u8>>, Self::Error>;
 
     /// Remove a media file's content from the media store.
@@ -90,7 +90,10 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// # Arguments
     ///
     /// * `request` - The `MediaRequest` of the file.
-    async fn remove_media_content(&self, request: &MediaRequest) -> Result<(), Self::Error>;
+    async fn remove_media_content(
+        &self,
+        request: &MediaRequestParameters,
+    ) -> Result<(), Self::Error>;
 
     /// Remove all the media files' content associated to an `MxcUri` from the
     /// media store.
@@ -127,7 +130,7 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
 
     async fn add_media_content(
         &self,
-        request: &MediaRequest,
+        request: &MediaRequestParameters,
         content: Vec<u8>,
     ) -> Result<(), Self::Error> {
         self.0.add_media_content(request, content).await.map_err(Into::into)
@@ -135,20 +138,23 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
 
     async fn replace_media_key(
         &self,
-        from: &MediaRequest,
-        to: &MediaRequest,
+        from: &MediaRequestParameters,
+        to: &MediaRequestParameters,
     ) -> Result<(), Self::Error> {
         self.0.replace_media_key(from, to).await.map_err(Into::into)
     }
 
     async fn get_media_content(
         &self,
-        request: &MediaRequest,
+        request: &MediaRequestParameters,
     ) -> Result<Option<Vec<u8>>, Self::Error> {
         self.0.get_media_content(request).await.map_err(Into::into)
     }
 
-    async fn remove_media_content(&self, request: &MediaRequest) -> Result<(), Self::Error> {
+    async fn remove_media_content(
+        &self,
+        request: &MediaRequestParameters,
+    ) -> Result<(), Self::Error> {
         self.0.remove_media_content(request).await.map_err(Into::into)
     }
 

--- a/crates/matrix-sdk-base/src/event_cache_store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/traits.rs
@@ -61,6 +61,9 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// keyed as a file before. The caller is responsible of ensuring that
     /// the replacement makes sense, according to their use case.
     ///
+    /// This should not raise an error when the `from` parameter points to an
+    /// unknown media, and it should silently continue in this case.
+    ///
     /// # Arguments
     ///
     /// * `from` - The previous `MediaRequest` of the file.

--- a/crates/matrix-sdk-base/src/media.rs
+++ b/crates/matrix-sdk-base/src/media.rs
@@ -97,9 +97,11 @@ impl UniqueKey for MediaSource {
     }
 }
 
-/// A request for media data.
+/// Parameters for a request for retrieve media data.
+///
+/// This is used as a key in the media cache too.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MediaRequest {
+pub struct MediaRequestParameters {
     /// The source of the media file.
     pub source: MediaSource,
 
@@ -107,7 +109,7 @@ pub struct MediaRequest {
     pub format: MediaFormat,
 }
 
-impl MediaRequest {
+impl MediaRequestParameters {
     /// Get the [`MxcUri`] from `Self`.
     pub fn uri(&self) -> &MxcUri {
         match &self.source {
@@ -117,7 +119,7 @@ impl MediaRequest {
     }
 }
 
-impl UniqueKey for MediaRequest {
+impl UniqueKey for MediaRequestParameters {
     fn unique_key(&self) -> String {
         format!("{}{UNIQUE_SEPARATOR}{}", self.source.unique_key(), self.format.unique_key())
     }
@@ -213,14 +215,14 @@ mod tests {
     fn test_media_request_url() {
         let mxc_uri = mxc_uri!("mxc://homeserver/media");
 
-        let plain = MediaRequest {
+        let plain = MediaRequestParameters {
             source: MediaSource::Plain(mxc_uri.to_owned()),
             format: MediaFormat::File,
         };
 
         assert_eq!(plain.uri(), mxc_uri);
 
-        let file = MediaRequest {
+        let file = MediaRequestParameters {
             source: MediaSource::Encrypted(Box::new(
                 serde_json::from_value(json!({
                     "url": mxc_uri,

--- a/crates/matrix-sdk-base/src/media.rs
+++ b/crates/matrix-sdk-base/src/media.rs
@@ -14,6 +14,7 @@ use ruma::{
     },
     MxcUri, UInt,
 };
+use serde::{Deserialize, Serialize};
 
 const UNIQUE_SEPARATOR: &str = "_";
 
@@ -25,7 +26,7 @@ pub trait UniqueKey {
 }
 
 /// The requested format of a media file.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum MediaFormat {
     /// The file that was uploaded.
     File,
@@ -44,7 +45,7 @@ impl UniqueKey for MediaFormat {
 }
 
 /// The requested size of a media thumbnail.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MediaThumbnailSize {
     /// The desired resizing method.
     pub method: Method,
@@ -65,7 +66,7 @@ impl UniqueKey for MediaThumbnailSize {
 }
 
 /// The desired settings of a media thumbnail.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MediaThumbnailSettings {
     /// The desired size of the thumbnail.
     pub size: MediaThumbnailSize,
@@ -110,7 +111,7 @@ impl UniqueKey for MediaSource {
 }
 
 /// A request for media data.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MediaRequest {
     /// The source of the media file.
     pub source: MediaSource,

--- a/crates/matrix-sdk-base/src/media.rs
+++ b/crates/matrix-sdk-base/src/media.rs
@@ -44,9 +44,9 @@ impl UniqueKey for MediaFormat {
     }
 }
 
-/// The requested size of a media thumbnail.
+/// The desired settings of a media thumbnail.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MediaThumbnailSize {
+pub struct MediaThumbnailSettings {
     /// The desired resizing method.
     pub method: Method,
 
@@ -57,19 +57,6 @@ pub struct MediaThumbnailSize {
     /// The desired height of the thumbnail. The actual thumbnail may not match
     /// the size specified.
     pub height: UInt,
-}
-
-impl UniqueKey for MediaThumbnailSize {
-    fn unique_key(&self) -> String {
-        format!("{}{UNIQUE_SEPARATOR}{}x{}", self.method, self.width, self.height)
-    }
-}
-
-/// The desired settings of a media thumbnail.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MediaThumbnailSettings {
-    /// The desired size of the thumbnail.
-    pub size: MediaThumbnailSize,
 
     /// If we want to request an animated thumbnail from the homeserver.
     ///
@@ -84,13 +71,13 @@ impl MediaThumbnailSettings {
     /// Constructs a new `MediaThumbnailSettings` with the given method, width
     /// and height.
     pub fn new(method: Method, width: UInt, height: UInt) -> Self {
-        Self { size: MediaThumbnailSize { method, width, height }, animated: false }
+        Self { method, width, height, animated: false }
     }
 }
 
 impl UniqueKey for MediaThumbnailSettings {
     fn unique_key(&self) -> String {
-        let mut key = self.size.unique_key();
+        let mut key = format!("{}{UNIQUE_SEPARATOR}{}x{}", self.method, self.width, self.height);
 
         if self.animated {
             key.push_str(UNIQUE_SEPARATOR);

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -1406,7 +1406,9 @@ impl StateStoreIntegrationTests for DynStateStore {
         assert_eq!(dependents.len(), 1);
         assert_eq!(dependents[0].parent_transaction_id, txn0);
         assert_eq!(dependents[0].own_transaction_id, child_txn);
-        assert_eq!(dependents[0].parent_key.as_ref(), Some(&SentRequestKey::Event(event_id)));
+        assert_matches!(dependents[0].parent_key.as_ref(), Some(SentRequestKey::Event(eid)) => {
+            assert_eq!(*eid, event_id);
+        });
         assert_matches!(dependents[0].kind, DependentQueuedRequestKind::RedactEvent);
 
         // Now remove it.

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -75,8 +75,9 @@ pub use self::integration_tests::StateStoreIntegrationTests;
 pub use self::{
     memory_store::MemoryStore,
     send_queue::{
-        ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind, QueueWedgeError,
-        QueuedRequest, QueuedRequestKind, SentRequestKey, SerializableEventContent,
+        ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind,
+        FinishUploadThumbnailInfo, QueueWedgeError, QueuedRequest, QueuedRequestKind,
+        SentRequestKey, SerializableEventContent,
     },
     traits::{
         ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, ServerCapabilities,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -77,7 +77,7 @@ pub use self::{
     send_queue::{
         ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind,
         FinishUploadThumbnailInfo, QueueWedgeError, QueuedRequest, QueuedRequestKind,
-        SentRequestKey, SerializableEventContent,
+        SentMediaInfo, SentRequestKey, SerializableEventContent,
     },
     traits::{
         ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, ServerCapabilities,

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -86,7 +86,7 @@ pub enum QueuedRequestKind {
     ///
     /// The bytes must be stored in the media cache, and are identified by the
     /// cache key.
-    Upload {
+    MediaUpload {
         /// Content type of the media to be uploaded.
         ///
         /// Stored as a `String` because `Mime` which we'd really want to use

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -292,6 +292,22 @@ impl From<OwnedTransactionId> for ChildTransactionId {
     }
 }
 
+/// Information about a media (and its thumbnail) that have been sent to an
+/// homeserver.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SentMediaInfo {
+    /// File that was uploaded by this request.
+    ///
+    /// If the request related to a thumbnail upload, this contains the
+    /// thumbnail media source.
+    pub file: MediaSource,
+
+    /// Optional thumbnail previously uploaded, when uploading a file.
+    ///
+    /// When uploading a thumbnail, this is set to `None`.
+    pub thumbnail: Option<MediaSource>,
+}
+
 /// A unique key (identifier) indicating that a transaction has been
 /// successfully sent to the server.
 ///
@@ -302,24 +318,19 @@ pub enum SentRequestKey {
     Event(OwnedEventId),
 
     /// The parent transaction returned an uploaded resource URL.
-    Media {
-        /// File that was uploaded by this request.
-        ///
-        /// If the request related to a thumbnail upload, this contains the
-        /// thumbnail media source.
-        file: MediaSource,
-
-        /// Optional thumbnail previously uploaded, when uploading a file.
-        ///
-        /// When uploading a thumbnail, this is set to `None`.
-        thumbnail: Option<MediaSource>,
-    },
+    Media(SentMediaInfo),
 }
 
 impl SentRequestKey {
     /// Converts the current parent key into an event id, if possible.
     pub fn into_event_id(self) -> Option<OwnedEventId> {
         as_variant!(self, Self::Event)
+    }
+
+    /// Converts the current parent key into information about a sent media, if
+    /// possible.
+    pub fn into_media(self) -> Option<SentMediaInfo> {
+        as_variant!(self, Self::Media)
     }
 }
 

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -27,7 +27,7 @@ use ruma::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::media::MediaRequest;
+use crate::media::MediaRequestParameters;
 
 /// A thin wrapper to serialize a `AnyMessageLikeEventContent`.
 #[derive(Clone, Serialize, Deserialize)]
@@ -95,7 +95,7 @@ pub enum QueuedRequestKind {
 
         /// The cache key used to retrieve the media's bytes in the event cache
         /// store.
-        cache_key: MediaRequest,
+        cache_key: MediaRequestParameters,
 
         /// An optional media source for a thumbnail already uploaded.
         thumbnail_source: Option<MediaSource>,
@@ -216,7 +216,7 @@ pub enum DependentQueuedRequestKind {
 
         /// Media request necessary to retrieve the file itself (not the
         /// thumbnail).
-        cache_key: MediaRequest,
+        cache_key: MediaRequestParameters,
 
         /// To which media transaction id does this upload relate to?
         related_to: OwnedTransactionId,

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1359,6 +1359,11 @@ impl<P: RoomDataProvider> TimelineController<P> {
                 self.update_event_send_state(&transaction_id, EventSendState::Sent { event_id })
                     .await;
             }
+
+            RoomSendQueueUpdate::UploadedMedia { related_to, .. } => {
+                // TODO(bnjbvr): Do something else?
+                info!(txn_id = %related_to, "some media for a media event has been uploaded");
+            }
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/futures.rs
+++ b/crates/matrix-sdk-ui/src/timeline/futures.rs
@@ -15,7 +15,6 @@ pub struct SendAttachment<'a> {
     config: AttachmentConfig,
     tracing_span: Span,
     pub(crate) send_progress: SharedObservable<TransmissionProgress>,
-    store_in_cache: bool,
 }
 
 impl<'a> SendAttachment<'a> {
@@ -32,7 +31,6 @@ impl<'a> SendAttachment<'a> {
             config,
             tracing_span: Span::current(),
             send_progress: Default::default(),
-            store_in_cache: false,
         }
     }
 
@@ -42,14 +40,6 @@ impl<'a> SendAttachment<'a> {
     pub fn subscribe_to_send_progress(&self) -> Subscriber<TransmissionProgress> {
         self.send_progress.subscribe()
     }
-
-    /// Whether the sent attachment should be stored in the cache or not.
-    ///
-    /// If set to true, then retrieving the data for the attachment will result
-    /// in a cache hit immediately after upload.
-    pub fn store_in_cache(&mut self) {
-        self.store_in_cache = true;
-    }
 }
 
 impl<'a> IntoFuture for SendAttachment<'a> {
@@ -57,8 +47,7 @@ impl<'a> IntoFuture for SendAttachment<'a> {
     boxed_into_future!(extra_bounds: 'a);
 
     fn into_future(self) -> Self::IntoFuture {
-        let Self { timeline, path, mime_type, config, tracing_span, send_progress, store_in_cache } =
-            self;
+        let Self { timeline, path, mime_type, config, tracing_span, send_progress: _ } = self;
 
         let fut = async move {
             let filename = path
@@ -68,15 +57,8 @@ impl<'a> IntoFuture for SendAttachment<'a> {
                 .ok_or(Error::InvalidAttachmentFileName)?;
             let data = fs::read(&path).map_err(|_| Error::InvalidAttachmentData)?;
 
-            let mut fut = timeline
-                .room()
-                .send_attachment(filename, &mime_type, data, config)
-                .with_send_progress_observable(send_progress);
-
-            if store_in_cache {
-                fut = fut.store_in_cache();
-            }
-
+            let send_queue = timeline.room().send_queue();
+            let fut = send_queue.send_attachment(filename, mime_type, data, config);
             fut.await.map_err(|_| Error::FailedSendingAttachment)?;
 
             Ok(())

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 use matrix_sdk_base::{
-    media::{MediaFormat, MediaRequest},
+    media::{MediaFormat, MediaRequestParameters},
     store::StateStoreExt,
     StateStoreDataKey, StateStoreDataValue,
 };
@@ -217,7 +217,7 @@ impl Account {
     /// ```
     pub async fn get_avatar(&self, format: MediaFormat) -> Result<Option<Vec<u8>>> {
         if let Some(url) = self.get_avatar_url().await? {
-            let request = MediaRequest { source: MediaSource::Plain(url), format };
+            let request = MediaRequestParameters { source: MediaSource::Plain(url), format };
             Ok(Some(self.client.media().get_media_content(&request, true).await?))
         } else {
             Ok(None)

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -296,7 +296,7 @@ impl Media {
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn get_media_file(
         &self,
-        request: &MediaRequest,
+        request: &MediaRequestParameters,
         filename: Option<String>,
         content_type: &Mime,
         use_cache: bool,
@@ -371,7 +371,7 @@ impl Media {
     /// * `use_cache` - If we should use the media cache for this request.
     pub async fn get_media_content(
         &self,
-        request: &MediaRequest,
+        request: &MediaRequestParameters,
         use_cache: bool,
     ) -> Result<Vec<u8>> {
         // Read from the cache.
@@ -494,7 +494,7 @@ impl Media {
     /// # Arguments
     ///
     /// * `request` - The `MediaRequest` of the content.
-    pub async fn remove_media_content(&self, request: &MediaRequest) -> Result<()> {
+    pub async fn remove_media_content(&self, request: &MediaRequestParameters) -> Result<()> {
         Ok(self.client.event_cache_store().lock().await?.remove_media_content(request).await?)
     }
 
@@ -530,7 +530,10 @@ impl Media {
     ) -> Result<Option<Vec<u8>>> {
         let Some(source) = event_content.source() else { return Ok(None) };
         let file = self
-            .get_media_content(&MediaRequest { source, format: MediaFormat::File }, use_cache)
+            .get_media_content(
+                &MediaRequestParameters { source, format: MediaFormat::File },
+                use_cache,
+            )
             .await?;
         Ok(Some(file))
     }
@@ -545,7 +548,11 @@ impl Media {
     /// * `event_content` - The media event content.
     pub async fn remove_file(&self, event_content: &impl MediaEventContent) -> Result<()> {
         if let Some(source) = event_content.source() {
-            self.remove_media_content(&MediaRequest { source, format: MediaFormat::File }).await?;
+            self.remove_media_content(&MediaRequestParameters {
+                source,
+                format: MediaFormat::File,
+            })
+            .await?;
         }
 
         Ok(())
@@ -578,7 +585,7 @@ impl Media {
         let Some(source) = event_content.thumbnail_source() else { return Ok(None) };
         let thumbnail = self
             .get_media_content(
-                &MediaRequest { source, format: MediaFormat::Thumbnail(settings) },
+                &MediaRequestParameters { source, format: MediaFormat::Thumbnail(settings) },
                 use_cache,
             )
             .await?;
@@ -602,7 +609,7 @@ impl Media {
         settings: MediaThumbnailSettings,
     ) -> Result<()> {
         if let Some(source) = event_content.source() {
-            self.remove_media_content(&MediaRequest {
+            self.remove_media_content(&MediaRequestParameters {
                 source,
                 format: MediaFormat::Thumbnail(settings),
             })

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -437,16 +437,17 @@ impl Media {
 
                 content
             }
+
             MediaSource::Plain(uri) => {
                 if let MediaFormat::Thumbnail(settings) = &request.format {
                     if use_auth {
                         let mut request =
                             authenticated_media::get_content_thumbnail::v1::Request::from_uri(
                                 uri,
-                                settings.size.width,
-                                settings.size.height,
+                                settings.width,
+                                settings.height,
                             )?;
-                        request.method = Some(settings.size.method.clone());
+                        request.method = Some(settings.method.clone());
                         request.animated = Some(settings.animated);
 
                         self.client.send(request, request_config).await?.file
@@ -455,10 +456,10 @@ impl Media {
                         let request = {
                             let mut request = media::get_content_thumbnail::v3::Request::from_url(
                                 uri,
-                                settings.size.width,
-                                settings.size.height,
+                                settings.width,
+                                settings.height,
                             )?;
-                            request.method = Some(settings.size.method.clone());
+                            request.method = Some(settings.method.clone());
                             request.animated = Some(settings.animated);
                             request
                         };

--- a/crates/matrix-sdk/src/room/member.rs
+++ b/crates/matrix-sdk/src/room/member.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use ruma::events::room::MediaSource;
 
 use crate::{
-    media::{MediaFormat, MediaRequest},
+    media::{MediaFormat, MediaRequestParameters},
     BaseRoomMember, Client, Result,
 };
 
@@ -61,7 +61,7 @@ impl RoomMember {
     /// ```
     pub async fn avatar(&self, format: MediaFormat) -> Result<Option<Vec<u8>>> {
         let Some(url) = self.avatar_url() else { return Ok(None) };
-        let request = MediaRequest { source: MediaSource::Plain(url.to_owned()), format };
+        let request = MediaRequestParameters { source: MediaSource::Plain(url.to_owned()), format };
         Ok(Some(self.client.media().get_media_content(&request, true).await?))
     }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -132,7 +132,7 @@ use crate::{
     error::{BeaconError, WrongRoomState},
     event_cache::{self, EventCacheDropHandles, RoomEventCache},
     event_handler::{EventHandler, EventHandlerDropGuard, EventHandlerHandle, SyncEvent},
-    media::{MediaFormat, MediaRequest},
+    media::{MediaFormat, MediaRequestParameters},
     notification_settings::{IsEncrypted, IsOneToOne, RoomNotificationMode},
     room::power_levels::{RoomPowerLevelChanges, RoomPowerLevelsExt},
     sync::RoomUpdate,
@@ -264,7 +264,7 @@ impl Room {
     /// ```
     pub async fn avatar(&self, format: MediaFormat) -> Result<Option<Vec<u8>>> {
         let Some(url) = self.avatar_url() else { return Ok(None) };
-        let request = MediaRequest { source: MediaSource::Plain(url.to_owned()), format };
+        let request = MediaRequestParameters { source: MediaSource::Plain(url.to_owned()), format };
         Ok(Some(self.client.media().get_media_content(&request, true).await?))
     }
 
@@ -1994,7 +1994,8 @@ impl Room {
             // properly, so only log errors during caching.
 
             debug!("caching the media");
-            let request = MediaRequest { source: media_source.clone(), format: MediaFormat::File };
+            let request =
+                MediaRequestParameters { source: media_source.clone(), format: MediaFormat::File };
 
             if let Err(err) = cache_store_lock_guard.add_media_content(&request, data).await {
                 warn!("unable to cache the media after uploading it: {err}");
@@ -2007,7 +2008,7 @@ impl Room {
 
                 // Do a best guess at figuring the media request: not animated, cropped
                 // thumbnail of the original size.
-                let request = MediaRequest {
+                let request = MediaRequestParameters {
                     source: source.clone(),
                     format: MediaFormat::Thumbnail(MediaThumbnailSettings {
                         method: ruma::media::Method::Scale,

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2048,7 +2048,7 @@ impl Room {
     /// Creates the inner [`MessageType`] for an already-uploaded media file
     /// provided by its source.
     #[allow(clippy::too_many_arguments)]
-    fn make_attachment_type(
+    pub(crate) fn make_attachment_type(
         &self,
         content_type: &Mime,
         filename: &str,
@@ -2134,7 +2134,7 @@ impl Room {
 
     /// Creates the [`RoomMessageEventContent`] based on the message type and
     /// mentions.
-    fn make_attachment_event(
+    pub(crate) fn make_attachment_event(
         msg_type: MessageType,
         mentions: Option<Mentions>,
     ) -> RoomMessageEventContent {

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -41,7 +41,7 @@ use matrix_sdk_base::{
     deserialized_responses::{
         RawAnySyncOrStrippedState, RawSyncOrStrippedState, SyncOrStrippedState, TimelineEvent,
     },
-    media::{MediaThumbnailSettings, MediaThumbnailSize},
+    media::MediaThumbnailSettings,
     store::StateStoreExt,
     ComposerDraft, RoomInfoNotableUpdateReasons, RoomMemberships, StateChanges, StateStoreDataKey,
     StateStoreDataValue,
@@ -2010,11 +2010,9 @@ impl Room {
                 let request = MediaRequest {
                     source: source.clone(),
                     format: MediaFormat::Thumbnail(MediaThumbnailSettings {
-                        size: MediaThumbnailSize {
-                            method: ruma::media::Method::Scale,
-                            width,
-                            height,
-                        },
+                        method: ruma::media::Method::Scale,
+                        width,
+                        height,
                         animated: false,
                     }),
                 };

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -139,7 +139,7 @@ use std::{
 use as_variant::as_variant;
 use matrix_sdk_base::{
     event_cache_store::EventCacheStoreError,
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings, MediaThumbnailSize},
+    media::MediaRequest,
     store::{
         ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind,
         FinishUploadThumbnailInfo, QueueWedgeError, QueuedRequest, QueuedRequestKind,
@@ -150,33 +150,29 @@ use matrix_sdk_base::{
 use matrix_sdk_common::executor::{spawn, JoinHandle};
 use mime::Mime;
 use ruma::{
-    assign,
     events::{
         reaction::ReactionEventContent,
         relation::Annotation,
-        room::{
-            message::{MessageType, RoomMessageEventContent},
-            MediaSource, ThumbnailInfo,
-        },
+        room::{message::RoomMessageEventContent, MediaSource},
         AnyMessageLikeEventContent, EventContent as _,
     },
-    media::Method,
     serde::Raw,
-    uint, OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedTransactionId, TransactionId, UInt,
+    OwnedEventId, OwnedRoomId, OwnedTransactionId, TransactionId,
 };
 use tokio::sync::{broadcast, Notify, RwLock};
-use tracing::{debug, error, info, instrument, trace, warn, Span};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 #[cfg(feature = "e2e-encryption")]
 use crate::crypto::{OlmError, SessionRecipientCollectionError};
 use crate::{
-    attachment::AttachmentConfig,
     client::WeakClient,
     config::RequestConfig,
     error::RetryKind,
     room::{edit::EditedContent, WeakRoom},
     Client, Room,
 };
+
+mod upload;
 
 /// A client-wide send queue, for all the rooms known by a client.
 pub struct SendQueue {
@@ -491,226 +487,6 @@ impl RoomSendQueue {
         .await
     }
 
-    /// Queues an attachment to be sent to the room, using the send queue.
-    ///
-    /// This returns quickly (without sending or uploading anything), and will
-    /// push the event to be sent into a queue, handled in the background.
-    ///
-    /// Callers are expected to consume [`RoomSendQueueUpdate`] via calling
-    /// the [`Self::subscribe()`] method to get updates about the sending of
-    /// that event.
-    ///
-    /// By default, if sending failed on the first attempt, it will be retried a
-    /// few times. If sending failed after those retries, the entire
-    /// client's sending queue will be disabled, and it will need to be
-    /// manually re-enabled by the caller (e.g. after network is back, or when
-    /// something has been done about the faulty requests).
-    #[instrument(skip_all, fields(event_txn))]
-    pub async fn send_attachment(
-        &self,
-        filename: &str,
-        content_type: Mime,
-        data: Vec<u8>,
-        mut config: AttachmentConfig,
-    ) -> Result<SendAttachmentHandle, RoomSendQueueError> {
-        let Some(room) = self.inner.room.get() else {
-            return Err(RoomSendQueueError::RoomDisappeared);
-        };
-        if room.state() != RoomState::Joined {
-            return Err(RoomSendQueueError::RoomNotJoined);
-        }
-
-        let upload_file_txn = TransactionId::new();
-        let send_event_txn = config.txn_id.map_or_else(ChildTransactionId::new, Into::into);
-
-        Span::current().record("event_txn", tracing::field::display(&*send_event_txn));
-        debug!(filename, %content_type, %upload_file_txn, "sending an attachment");
-
-        // Cache the file itself in the cache store.
-        let file_media_request = Self::make_local_file_media_request(&upload_file_txn);
-        room.client()
-            .event_cache_store()
-            .add_media_content(&file_media_request, data.clone())
-            .await
-            .map_err(|err| RoomSendQueueError::StorageError(err.into()))?;
-
-        // Process the thumbnail, if it's been provided.
-        let (upload_thumbnail_txn, event_thumbnail_info, queue_thumbnail_info) = if let Some(
-            thumbnail,
-        ) =
-            config.thumbnail.take()
-        {
-            // Normalize information to retrieve the thumbnail in the cache store.
-            let info = thumbnail.info.as_ref();
-            let height = info.and_then(|info| info.height).unwrap_or_else(|| {
-                trace!("thumbnail height is unknown, using 0 for the cache entry");
-                uint!(0)
-            });
-            let width = info.and_then(|info| info.width).unwrap_or_else(|| {
-                trace!("thumbnail width is unknown, using 0 for the cache entry");
-                uint!(0)
-            });
-
-            let txn = TransactionId::new();
-            trace!(upload_thumbnail_txn = %txn, thumbnail_size = ?(height, width), "attachment has a thumbnail");
-
-            // Cache thumbnail in the cache store.
-            let thumbnail_media_request =
-                Self::make_local_thumbnail_media_request(&txn, height, width);
-            room.client()
-                .event_cache_store()
-                .add_media_content(&thumbnail_media_request, thumbnail.data.clone())
-                .await
-                .map_err(|err| RoomSendQueueError::StorageError(err.into()))?;
-
-            // Create the information required for filling the thumbnail section of the
-            // media event.
-            let thumbnail_info =
-                Box::new(assign!(thumbnail.info.map(ThumbnailInfo::from).unwrap_or_default(), {
-                    mimetype: Some(thumbnail.content_type.as_ref().to_owned())
-                }));
-
-            (
-                Some(txn.clone()),
-                Some((thumbnail_media_request.source.clone(), thumbnail_info)),
-                Some((
-                    FinishUploadThumbnailInfo { txn, width, height },
-                    thumbnail_media_request,
-                    thumbnail.content_type,
-                )),
-            )
-        } else {
-            Default::default()
-        };
-
-        // Create the content for the media event.
-        let event_content = Room::make_attachment_event(
-            room.make_attachment_type(
-                &content_type,
-                filename,
-                file_media_request.source.clone(),
-                config.caption,
-                config.formatted_caption,
-                config.info,
-                event_thumbnail_info,
-            ),
-            config.mentions,
-        );
-
-        // Save requests in the queue storage.
-        self.inner
-            .queue
-            .push_media(
-                event_content.clone(),
-                content_type,
-                send_event_txn.clone().into(),
-                upload_file_txn.clone(),
-                file_media_request,
-                queue_thumbnail_info,
-            )
-            .await?;
-
-        trace!("manager sends a media to the background task");
-
-        self.inner.notifier.notify_one();
-
-        let _ = self.inner.updates.send(RoomSendQueueUpdate::NewLocalEvent(LocalEcho {
-            transaction_id: send_event_txn.clone().into(),
-            content: LocalEchoContent::Event {
-                serialized_event: SerializableEventContent::new(&event_content.into())
-                    .map_err(RoomSendQueueStorageError::JsonSerialization)?,
-                // TODO: this should be a `SendAttachmentHandle`!
-                send_handle: SendHandle {
-                    room: self.clone(),
-                    transaction_id: send_event_txn.clone().into(),
-                    is_upload: true,
-                },
-                send_error: None,
-            },
-        }));
-
-        Ok(SendAttachmentHandle {
-            _room: self.clone(),
-            _transaction_id: send_event_txn.into(),
-            _file_upload: upload_file_txn,
-            _thumbnail_transaction_id: upload_thumbnail_txn,
-        })
-    }
-
-    /// Create a [`MediaRequest`] for a file we want to store locally before
-    /// sending it.
-    ///
-    /// This uses a MXC ID that is only locally valid.
-    fn make_local_file_media_request(txn_id: &TransactionId) -> MediaRequest {
-        // .local is guaranteed to be on the local network. It would be a shame that
-        // `send-queue.local` resolves to an actual Synapse media server, we don't
-        // expect this to be likely though.
-        MediaRequest {
-            source: MediaSource::Plain(OwnedMxcUri::from(format!(
-                "mxc://send-queue.local/{txn_id}"
-            ))),
-            format: MediaFormat::File,
-        }
-    }
-
-    /// Create a [`MediaRequest`] for a file we want to store locally before
-    /// sending it.
-    ///
-    /// This uses a MXC ID that is only locally valid.
-    fn make_local_thumbnail_media_request(
-        txn_id: &TransactionId,
-        height: UInt,
-        width: UInt,
-    ) -> MediaRequest {
-        // See comment in [`Self::make_local_file_media_request`].
-        let source =
-            MediaSource::Plain(OwnedMxcUri::from(format!("mxc://send-queue.local/{}", txn_id)));
-        let format = MediaFormat::Thumbnail(MediaThumbnailSettings {
-            size: MediaThumbnailSize { method: Method::Scale, width, height },
-            animated: false,
-        });
-        MediaRequest { source, format }
-    }
-
-    /// Replace the source by the final ones in all the media types handled by
-    /// [`Room::make_attachment_type()`].
-    fn update_media_event_after_upload(echo: &mut RoomMessageEventContent, sent: SentMediaInfo) {
-        // Some variants look eerily similar below, but the `event` and `info` are all
-        // different types…
-        match &mut echo.msgtype {
-            MessageType::Audio(event) => {
-                event.source = sent.file;
-            }
-            MessageType::File(event) => {
-                event.source = sent.file;
-                if let Some(info) = event.info.as_mut() {
-                    info.thumbnail_source = sent.thumbnail;
-                }
-            }
-            MessageType::Image(event) => {
-                event.source = sent.file;
-                if let Some(info) = event.info.as_mut() {
-                    info.thumbnail_source = sent.thumbnail;
-                }
-            }
-            MessageType::Video(event) => {
-                event.source = sent.file;
-                if let Some(info) = event.info.as_mut() {
-                    info.thumbnail_source = sent.thumbnail;
-                }
-            }
-
-            _ => {
-                // All `MessageType` created by `Room::make_attachment_type` should be
-                // handled here. The only way to end up here is that a message type has
-                // been tampered with in the database.
-                error!("Invalid message type in database: {}", echo.msgtype());
-                // Only crash debug builds.
-                debug_assert!(false, "invalid message type in database");
-            }
-        }
-    }
-
     /// Returns the current local requests as well as a receiver to listen to
     /// the send queue updates, as defined in [`RoomSendQueueUpdate`].
     pub async fn subscribe(
@@ -916,13 +692,10 @@ impl RoomSendQueue {
                     })
                 })?;
 
-                let Some(data) =
-                    room.client().event_cache_store().get_media_content(&cache_key).await?
-                else {
-                    return Err(crate::Error::SendQueueWedgeError(
-                        QueueWedgeError::MissingMediaContent,
-                    ));
-                };
+                let data =
+                    room.client().event_cache_store().get_media_content(&cache_key).await?.ok_or(
+                        crate::Error::SendQueueWedgeError(QueueWedgeError::MissingMediaContent),
+                    )?;
 
                 #[cfg(feature = "e2e-encryption")]
                 let media_source = if room.is_encrypted().await? {
@@ -1643,45 +1416,19 @@ impl QueueStorage {
                     // Not finished yet, we should retry later => false.
                     return Ok(false);
                 };
-
-                // The thumbnail has been sent, now transform the dependent file upload request
-                // into a ready one.
-                let sent_media = parent_key.into_media().ok_or(
-                    RoomSendQueueError::StorageError(RoomSendQueueStorageError::InvalidParentKey),
-                )?;
-
-                // The media we just uploaded was a thumbnail, so the thumbnail shouldn't have
-                // a thumbnail itself.
-                debug_assert!(sent_media.thumbnail.is_none());
-                if sent_media.thumbnail.is_some() {
-                    warn!("unexpected thumbnail for a thumbnail!");
-                }
-
-                trace!(
-                    %related_to,
-                    "done uploading thumbnail, now queuing a request to send the media file itself"
-                );
-
-                let request = QueuedRequestKind::Upload {
+                self.handle_dependent_file_upload_with_thumbnail(
+                    client,
+                    dependent_request.own_transaction_id.into(),
+                    parent_key,
                     content_type,
                     cache_key,
-                    // The thumbnail for the next upload is the file we just uploaded here.
-                    thumbnail_source: Some(sent_media.file),
                     related_to,
-                };
-
-                store
-                    .save_send_queue_request(
-                        &self.room_id,
-                        dependent_request.own_transaction_id.into(),
-                        request,
-                    )
-                    .await
-                    .map_err(RoomSendQueueStorageError::StateStoreError)?;
+                )
+                .await?;
             }
 
             DependentQueuedRequestKind::FinishUpload {
-                mut local_echo,
+                local_echo,
                 file_upload,
                 thumbnail_info,
             } => {
@@ -1689,80 +1436,16 @@ impl QueueStorage {
                     // Not finished yet, we should retry later => false.
                     return Ok(false);
                 };
-
-                // Both uploads are ready: enqueue the event with its final data.
-                let sent_media = parent_key.into_media().ok_or(
-                    RoomSendQueueError::StorageError(RoomSendQueueStorageError::InvalidParentKey),
-                )?;
-
-                // Update cache keys in the cache store.
-                {
-                    // Do it for the file itself.
-                    let from_req = RoomSendQueue::make_local_file_media_request(&file_upload);
-                    trace!(from = ?from_req.source, to = ?sent_media.file, "renaming media file key in cache store");
-                    client
-                        .event_cache_store()
-                        .replace_media_key(
-                            &from_req,
-                            &MediaRequest {
-                                source: sent_media.file.clone(),
-                                format: MediaFormat::File,
-                            },
-                        )
-                        .await
-                        .map_err(RoomSendQueueStorageError::EventCacheStoreError)?;
-
-                    // Rename the thumbnail too, if needs be.
-                    if let Some((info, new_source)) =
-                        thumbnail_info.as_ref().zip(sent_media.thumbnail.clone())
-                    {
-                        let from_req = RoomSendQueue::make_local_thumbnail_media_request(
-                            &info.txn,
-                            info.height,
-                            info.width,
-                        );
-
-                        trace!( from = ?from_req.source, to = ?new_source, "renaming thumbnail file key in cache store");
-
-                        // Reuse the same format for the cached thumbnail with the final MXC ID.
-                        let new_format = from_req.format.clone();
-
-                        client
-                            .event_cache_store()
-                            .replace_media_key(
-                                &from_req,
-                                &MediaRequest { source: new_source, format: new_format },
-                            )
-                            .await
-                            .map_err(RoomSendQueueStorageError::EventCacheStoreError)?;
-                    }
-                }
-
-                RoomSendQueue::update_media_event_after_upload(&mut local_echo, sent_media);
-
-                let new_content = SerializableEventContent::new(&local_echo.into())
-                    .map_err(RoomSendQueueStorageError::JsonSerialization)?;
-
-                // Indicates observers that the upload finished, by editing the local echo for
-                // the event into its final form before sending.
-                new_updates.push(RoomSendQueueUpdate::ReplacedLocalEvent {
-                    transaction_id: dependent_request.own_transaction_id.clone().into(),
-                    new_content: new_content.clone(),
-                });
-
-                trace!(
-                    event_txn = %&*dependent_request.own_transaction_id,
-                    "queueing media event after successfully uploading the media (and maybe a thumbnail)"
-                );
-
-                store
-                    .save_send_queue_request(
-                        &self.room_id,
-                        dependent_request.own_transaction_id.into(),
-                        new_content.into(),
-                    )
-                    .await
-                    .map_err(RoomSendQueueStorageError::StateStoreError)?;
+                self.handle_dependent_finish_upload(
+                    client,
+                    dependent_request.own_transaction_id.into(),
+                    parent_key,
+                    local_echo,
+                    file_upload,
+                    thumbnail_info,
+                    new_updates,
+                )
+                .await?;
             }
         }
 

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -140,7 +140,7 @@ use std::{
 use as_variant::as_variant;
 use matrix_sdk_base::{
     event_cache_store::EventCacheStoreError,
-    media::MediaRequest,
+    media::MediaRequestParameters,
     store::{
         ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind,
         FinishUploadThumbnailInfo, QueueWedgeError, QueuedRequest, QueuedRequestKind,
@@ -1034,8 +1034,8 @@ impl QueueStorage {
         content_type: Mime,
         send_event_txn: OwnedTransactionId,
         upload_file_txn: OwnedTransactionId,
-        file_media_request: MediaRequest,
-        thumbnail: Option<(FinishUploadThumbnailInfo, MediaRequest, Mime)>,
+        file_media_request: MediaRequestParameters,
+        thumbnail: Option<(FinishUploadThumbnailInfo, MediaRequestParameters, Mime)>,
     ) -> Result<(), RoomSendQueueStorageError> {
         // Keep the lock until we're done touching the storage.
         // TODO refactor to make the relationship between being_sent and the store more

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -15,7 +15,7 @@
 //! Private implementations of the media upload mechanism.
 
 use matrix_sdk_base::{
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings, MediaThumbnailSize},
+    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
     store::{
         ChildTransactionId, FinishUploadThumbnailInfo, QueuedRequestKind, SentMediaInfo,
         SentRequestKey, SerializableEventContent,
@@ -76,7 +76,9 @@ fn make_local_thumbnail_media_request(
     let source =
         MediaSource::Plain(OwnedMxcUri::from(format!("mxc://send-queue.localhost/{}", txn_id)));
     let format = MediaFormat::Thumbnail(MediaThumbnailSettings {
-        size: MediaThumbnailSize { method: Method::Scale, width, height },
+        method: Method::Scale,
+        width,
+        height,
         animated: false,
     });
     MediaRequest { source, format }

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -1,0 +1,386 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Private implementations of the media upload mechanism.
+
+use matrix_sdk_base::{
+    media::{MediaFormat, MediaRequest, MediaThumbnailSettings, MediaThumbnailSize},
+    store::{
+        ChildTransactionId, FinishUploadThumbnailInfo, QueuedRequestKind, SentMediaInfo,
+        SentRequestKey, SerializableEventContent,
+    },
+    RoomState,
+};
+use mime::Mime;
+use ruma::{
+    assign,
+    events::room::{
+        message::{MessageType, RoomMessageEventContent},
+        MediaSource, ThumbnailInfo,
+    },
+    media::Method,
+    uint, OwnedMxcUri, OwnedTransactionId, TransactionId, UInt,
+};
+use tracing::{debug, error, instrument, trace, warn, Span};
+
+use super::{QueueStorage, RoomSendQueue, RoomSendQueueError, SendAttachmentHandle};
+use crate::{
+    attachment::AttachmentConfig,
+    send_queue::{
+        LocalEcho, LocalEchoContent, RoomSendQueueStorageError, RoomSendQueueUpdate, SendHandle,
+    },
+    Client, Room,
+};
+
+/// Create a [`MediaRequest`] for a file we want to store locally before
+/// sending it.
+///
+/// This uses a MXC ID that is only locally valid.
+fn make_local_file_media_request(txn_id: &TransactionId) -> MediaRequest {
+    // .local is guaranteed to be on the local network. It would be a shame that
+    // `send-queue.local` resolves to an actual Synapse media server, we don't
+    // expect this to be likely though.
+    MediaRequest {
+        source: MediaSource::Plain(OwnedMxcUri::from(format!("mxc://send-queue.local/{txn_id}"))),
+        format: MediaFormat::File,
+    }
+}
+
+/// Create a [`MediaRequest`] for a file we want to store locally before
+/// sending it.
+///
+/// This uses a MXC ID that is only locally valid.
+fn make_local_thumbnail_media_request(
+    txn_id: &TransactionId,
+    height: UInt,
+    width: UInt,
+) -> MediaRequest {
+    // See comment in [`Self::make_local_file_media_request`].
+    let source =
+        MediaSource::Plain(OwnedMxcUri::from(format!("mxc://send-queue.local/{}", txn_id)));
+    let format = MediaFormat::Thumbnail(MediaThumbnailSettings {
+        size: MediaThumbnailSize { method: Method::Scale, width, height },
+        animated: false,
+    });
+    MediaRequest { source, format }
+}
+
+/// Replace the source by the final ones in all the media types handled by
+/// [`Room::make_attachment_type()`].
+fn update_media_event_after_upload(echo: &mut RoomMessageEventContent, sent: SentMediaInfo) {
+    // Some variants look eerily similar below, but the `event` and `info` are all
+    // different types…
+    match &mut echo.msgtype {
+        MessageType::Audio(event) => {
+            event.source = sent.file;
+        }
+        MessageType::File(event) => {
+            event.source = sent.file;
+            if let Some(info) = event.info.as_mut() {
+                info.thumbnail_source = sent.thumbnail;
+            }
+        }
+        MessageType::Image(event) => {
+            event.source = sent.file;
+            if let Some(info) = event.info.as_mut() {
+                info.thumbnail_source = sent.thumbnail;
+            }
+        }
+        MessageType::Video(event) => {
+            event.source = sent.file;
+            if let Some(info) = event.info.as_mut() {
+                info.thumbnail_source = sent.thumbnail;
+            }
+        }
+
+        _ => {
+            // All `MessageType` created by `Room::make_attachment_type` should be
+            // handled here. The only way to end up here is that a message type has
+            // been tampered with in the database.
+            error!("Invalid message type in database: {}", echo.msgtype());
+            // Only crash debug builds.
+            debug_assert!(false, "invalid message type in database");
+        }
+    }
+}
+
+impl RoomSendQueue {
+    /// Queues an attachment to be sent to the room, using the send queue.
+    ///
+    /// This returns quickly (without sending or uploading anything), and will
+    /// push the event to be sent into a queue, handled in the background.
+    ///
+    /// Callers are expected to consume [`RoomSendQueueUpdate`] via calling
+    /// the [`Self::subscribe()`] method to get updates about the sending of
+    /// that event.
+    ///
+    /// By default, if sending failed on the first attempt, it will be retried a
+    /// few times. If sending failed after those retries, the entire
+    /// client's sending queue will be disabled, and it will need to be
+    /// manually re-enabled by the caller (e.g. after network is back, or when
+    /// something has been done about the faulty requests).
+    #[instrument(skip_all, fields(event_txn))]
+    pub async fn send_attachment(
+        &self,
+        filename: &str,
+        content_type: Mime,
+        data: Vec<u8>,
+        mut config: AttachmentConfig,
+    ) -> Result<SendAttachmentHandle, RoomSendQueueError> {
+        let Some(room) = self.inner.room.get() else {
+            return Err(RoomSendQueueError::RoomDisappeared);
+        };
+        if room.state() != RoomState::Joined {
+            return Err(RoomSendQueueError::RoomNotJoined);
+        }
+
+        let upload_file_txn = TransactionId::new();
+        let send_event_txn = config.txn_id.map_or_else(ChildTransactionId::new, Into::into);
+
+        Span::current().record("event_txn", tracing::field::display(&*send_event_txn));
+        debug!(filename, %content_type, %upload_file_txn, "sending an attachment");
+
+        // Cache the file itself in the cache store.
+        let file_media_request = make_local_file_media_request(&upload_file_txn);
+        room.client()
+            .event_cache_store()
+            .add_media_content(&file_media_request, data.clone())
+            .await
+            .map_err(|err| RoomSendQueueError::StorageError(err.into()))?;
+
+        // Process the thumbnail, if it's been provided.
+        let (upload_thumbnail_txn, event_thumbnail_info, queue_thumbnail_info) = if let Some(
+            thumbnail,
+        ) =
+            config.thumbnail.take()
+        {
+            // Normalize information to retrieve the thumbnail in the cache store.
+            let info = thumbnail.info.as_ref();
+            let height = info.and_then(|info| info.height).unwrap_or_else(|| {
+                trace!("thumbnail height is unknown, using 0 for the cache entry");
+                uint!(0)
+            });
+            let width = info.and_then(|info| info.width).unwrap_or_else(|| {
+                trace!("thumbnail width is unknown, using 0 for the cache entry");
+                uint!(0)
+            });
+
+            let txn = TransactionId::new();
+            trace!(upload_thumbnail_txn = %txn, thumbnail_size = ?(height, width), "attachment has a thumbnail");
+
+            // Cache thumbnail in the cache store.
+            let thumbnail_media_request = make_local_thumbnail_media_request(&txn, height, width);
+            room.client()
+                .event_cache_store()
+                .add_media_content(&thumbnail_media_request, thumbnail.data.clone())
+                .await
+                .map_err(|err| RoomSendQueueError::StorageError(err.into()))?;
+
+            // Create the information required for filling the thumbnail section of the
+            // media event.
+            let thumbnail_info =
+                Box::new(assign!(thumbnail.info.map(ThumbnailInfo::from).unwrap_or_default(), {
+                    mimetype: Some(thumbnail.content_type.as_ref().to_owned())
+                }));
+
+            (
+                Some(txn.clone()),
+                Some((thumbnail_media_request.source.clone(), thumbnail_info)),
+                Some((
+                    FinishUploadThumbnailInfo { txn, width, height },
+                    thumbnail_media_request,
+                    thumbnail.content_type,
+                )),
+            )
+        } else {
+            Default::default()
+        };
+
+        // Create the content for the media event.
+        let event_content = Room::make_attachment_event(
+            room.make_attachment_type(
+                &content_type,
+                filename,
+                file_media_request.source.clone(),
+                config.caption,
+                config.formatted_caption,
+                config.info,
+                event_thumbnail_info,
+            ),
+            config.mentions,
+        );
+
+        // Save requests in the queue storage.
+        self.inner
+            .queue
+            .push_media(
+                event_content.clone(),
+                content_type,
+                send_event_txn.clone().into(),
+                upload_file_txn.clone(),
+                file_media_request,
+                queue_thumbnail_info,
+            )
+            .await?;
+
+        trace!("manager sends a media to the background task");
+
+        self.inner.notifier.notify_one();
+
+        let _ = self.inner.updates.send(RoomSendQueueUpdate::NewLocalEvent(LocalEcho {
+            transaction_id: send_event_txn.clone().into(),
+            content: LocalEchoContent::Event {
+                serialized_event: SerializableEventContent::new(&event_content.into())
+                    .map_err(RoomSendQueueStorageError::JsonSerialization)?,
+                // TODO: this should be a `SendAttachmentHandle`!
+                send_handle: SendHandle {
+                    room: self.clone(),
+                    transaction_id: send_event_txn.clone().into(),
+                    is_upload: true,
+                },
+                send_error: None,
+            },
+        }));
+
+        Ok(SendAttachmentHandle {
+            _room: self.clone(),
+            _transaction_id: send_event_txn.into(),
+            _file_upload: upload_file_txn,
+            _thumbnail_transaction_id: upload_thumbnail_txn,
+        })
+    }
+}
+
+impl QueueStorage {
+    /// Consumes a finished upload and queues sending of the final media event.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn handle_dependent_finish_upload(
+        &self,
+        client: &Client,
+        event_txn: OwnedTransactionId,
+        parent_key: SentRequestKey,
+        mut local_echo: RoomMessageEventContent,
+        file_upload_txn: OwnedTransactionId,
+        thumbnail_info: Option<FinishUploadThumbnailInfo>,
+        new_updates: &mut Vec<RoomSendQueueUpdate>,
+    ) -> Result<(), RoomSendQueueError> {
+        // Both uploads are ready: enqueue the event with its final data.
+        let sent_media = parent_key
+            .into_media()
+            .ok_or(RoomSendQueueError::StorageError(RoomSendQueueStorageError::InvalidParentKey))?;
+
+        // Update cache keys in the cache store.
+        {
+            // Do it for the file itself.
+            let from_req = make_local_file_media_request(&file_upload_txn);
+
+            trace!(from = ?from_req.source, to = ?sent_media.file, "renaming media file key in cache store");
+
+            client
+                .event_cache_store()
+                .replace_media_key(
+                    &from_req,
+                    &MediaRequest { source: sent_media.file.clone(), format: MediaFormat::File },
+                )
+                .await
+                .map_err(RoomSendQueueStorageError::EventCacheStoreError)?;
+
+            // Rename the thumbnail too, if needs be.
+            if let Some((info, new_source)) =
+                thumbnail_info.as_ref().zip(sent_media.thumbnail.clone())
+            {
+                let from_req =
+                    make_local_thumbnail_media_request(&info.txn, info.height, info.width);
+
+                trace!( from = ?from_req.source, to = ?new_source, "renaming thumbnail file key in cache store");
+
+                // Reuse the same format for the cached thumbnail with the final MXC ID.
+                let new_format = from_req.format.clone();
+
+                client
+                    .event_cache_store()
+                    .replace_media_key(
+                        &from_req,
+                        &MediaRequest { source: new_source, format: new_format },
+                    )
+                    .await
+                    .map_err(RoomSendQueueStorageError::EventCacheStoreError)?;
+            }
+        }
+
+        update_media_event_after_upload(&mut local_echo, sent_media);
+
+        let new_content = SerializableEventContent::new(&local_echo.into())
+            .map_err(RoomSendQueueStorageError::JsonSerialization)?;
+
+        // Indicates observers that the upload finished, by editing the local echo for
+        // the event into its final form before sending.
+        new_updates.push(RoomSendQueueUpdate::ReplacedLocalEvent {
+            transaction_id: event_txn.clone(),
+            new_content: new_content.clone(),
+        });
+
+        trace!(%event_txn, "queueing media event after successfully uploading media(s)");
+
+        client
+            .store()
+            .save_send_queue_request(&self.room_id, event_txn, new_content.into())
+            .await
+            .map_err(RoomSendQueueStorageError::StateStoreError)?;
+
+        Ok(())
+    }
+
+    /// Consumes a finished upload of a thumbnail and queues the file upload.
+    pub(super) async fn handle_dependent_file_upload_with_thumbnail(
+        &self,
+        client: &Client,
+        next_upload_txn: OwnedTransactionId,
+        parent_key: SentRequestKey,
+        content_type: String,
+        cache_key: MediaRequest,
+        event_txn: OwnedTransactionId,
+    ) -> Result<(), RoomSendQueueError> {
+        // The thumbnail has been sent, now transform the dependent file upload request
+        // into a ready one.
+        let sent_media = parent_key
+            .into_media()
+            .ok_or(RoomSendQueueError::StorageError(RoomSendQueueStorageError::InvalidParentKey))?;
+
+        // The media we just uploaded was a thumbnail, so the thumbnail shouldn't have
+        // a thumbnail itself.
+        debug_assert!(sent_media.thumbnail.is_none());
+        if sent_media.thumbnail.is_some() {
+            warn!("unexpected thumbnail for a thumbnail!");
+        }
+
+        trace!(related_to = %event_txn, "done uploading thumbnail, now queuing a request to send the media file itself");
+
+        let request = QueuedRequestKind::Upload {
+            content_type,
+            cache_key,
+            // The thumbnail for the next upload is the file we just uploaded here.
+            thumbnail_source: Some(sent_media.file),
+            related_to: event_txn,
+        };
+
+        client
+            .store()
+            .save_send_queue_request(&self.room_id, next_upload_txn, request)
+            .await
+            .map_err(RoomSendQueueStorageError::StateStoreError)?;
+
+        Ok(())
+    }
+}

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -1,7 +1,7 @@
 use matrix_sdk::{
     config::RequestConfig,
     matrix_auth::{MatrixSession, MatrixSessionTokens},
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
+    media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings},
     test_utils::logged_in_client_with_server,
     Client, SessionMeta,
 };
@@ -35,7 +35,7 @@ async fn test_get_media_content_no_auth() {
 
     let media = client.media();
 
-    let request = MediaRequest {
+    let request = MediaRequestParameters {
         source: MediaSource::Plain(mxc_uri!("mxc://localhost/textfile").to_owned()),
         format: MediaFormat::File,
     };

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -1,7 +1,7 @@
 use matrix_sdk::{
     config::RequestConfig,
     matrix_auth::{MatrixSession, MatrixSessionTokens},
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings, MediaThumbnailSize},
+    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
     test_utils::logged_in_client_with_server,
     Client, SessionMeta,
 };
@@ -183,7 +183,9 @@ async fn test_get_media_file_no_auth() {
         .await;
 
     let settings = MediaThumbnailSettings {
-        size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
+        method: Method::Crop,
+        width: uint!(100),
+        height: uint!(100),
         animated: true,
     };
     client.media().get_thumbnail(&event_content, settings, true).await.unwrap();
@@ -293,7 +295,9 @@ async fn test_get_media_file_with_auth_matrix_1_11() {
         .await;
 
     let settings = MediaThumbnailSettings {
-        size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
+        method: Method::Crop,
+        width: uint!(100),
+        height: uint!(100),
         animated: true,
     };
     client.media().get_thumbnail(&event_content, settings, true).await.unwrap();
@@ -406,7 +410,9 @@ async fn test_get_media_file_with_auth_matrix_stable_feature() {
         .await;
 
     let settings = MediaThumbnailSettings {
-        size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
+        method: Method::Crop,
+        width: uint!(100),
+        height: uint!(100),
         animated: true,
     };
     client.media().get_thumbnail(&event_content, settings, true).await.unwrap();

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -6,7 +6,7 @@ use matrix_sdk::{
         Thumbnail,
     },
     config::SyncSettings,
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
+    media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings},
     test_utils::logged_in_client_with_server,
 };
 use matrix_sdk_test::{async_test, mocks::mock_encryption_state, test_json, DEFAULT_TEST_ROOM_ID};
@@ -245,8 +245,8 @@ async fn test_room_attachment_send_info_thumbnail() {
 
     // Preconditions: nothing is found in the cache.
     let media_request =
-        MediaRequest { source: MediaSource::Plain(media_mxc), format: MediaFormat::File };
-    let thumbnail_request = MediaRequest {
+        MediaRequestParameters { source: MediaSource::Plain(media_mxc), format: MediaFormat::File };
+    let thumbnail_request = MediaRequestParameters {
         source: MediaSource::Plain(thumbnail_mxc.clone()),
         format: MediaFormat::Thumbnail(MediaThumbnailSettings {
             method: ruma::media::Method::Scale,
@@ -297,7 +297,7 @@ async fn test_room_attachment_send_info_thumbnail() {
     let _ = client
         .media()
         .get_media_content(
-            &MediaRequest {
+            &MediaRequestParameters {
                 source: MediaSource::Plain(thumbnail_mxc.clone()),
                 format: MediaFormat::File,
             },
@@ -307,7 +307,7 @@ async fn test_room_attachment_send_info_thumbnail() {
         .unwrap_err();
 
     // But it is not found when requesting it as a thumbnail with a different size.
-    let thumbnail_request = MediaRequest {
+    let thumbnail_request = MediaRequestParameters {
         source: MediaSource::Plain(thumbnail_mxc),
         format: MediaFormat::Thumbnail(MediaThumbnailSettings {
             method: ruma::media::Method::Scale,

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -6,7 +6,7 @@ use matrix_sdk::{
         Thumbnail,
     },
     config::SyncSettings,
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings, MediaThumbnailSize},
+    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
     test_utils::logged_in_client_with_server,
 };
 use matrix_sdk_test::{async_test, mocks::mock_encryption_state, test_json, DEFAULT_TEST_ROOM_ID};
@@ -249,11 +249,9 @@ async fn test_room_attachment_send_info_thumbnail() {
     let thumbnail_request = MediaRequest {
         source: MediaSource::Plain(thumbnail_mxc.clone()),
         format: MediaFormat::Thumbnail(MediaThumbnailSettings {
-            size: MediaThumbnailSize {
-                method: ruma::media::Method::Scale,
-                width: uint!(480),
-                height: uint!(360),
-            },
+            method: ruma::media::Method::Scale,
+            width: uint!(480),
+            height: uint!(360),
             animated: false,
         }),
     };
@@ -312,11 +310,9 @@ async fn test_room_attachment_send_info_thumbnail() {
     let thumbnail_request = MediaRequest {
         source: MediaSource::Plain(thumbnail_mxc),
         format: MediaFormat::Thumbnail(MediaThumbnailSettings {
-            size: MediaThumbnailSize {
-                method: ruma::media::Method::Scale,
-                width: uint!(42),
-                height: uint!(1337),
-            },
+            method: ruma::media::Method::Scale,
+            width: uint!(42),
+            height: uint!(1337),
             animated: false,
         }),
     };

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -11,7 +11,7 @@ use assert_matches2::{assert_let, assert_matches};
 use matrix_sdk::{
     attachment::{AttachmentConfig, AttachmentInfo, BaseImageInfo, BaseThumbnailInfo, Thumbnail},
     config::{RequestConfig, StoreConfig},
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
+    media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings},
     send_queue::{
         LocalEcho, LocalEchoContent, RoomSendQueueError, RoomSendQueueStorageError,
         RoomSendQueueUpdate,
@@ -2122,7 +2122,10 @@ async fn test_media_uploads() {
     // The media is immediately available from the cache.
     let file_media = client
         .media()
-        .get_media_content(&MediaRequest { source: local_source, format: MediaFormat::File }, true)
+        .get_media_content(
+            &MediaRequestParameters { source: local_source, format: MediaFormat::File },
+            true,
+        )
         .await
         .expect("media should be found");
     assert_eq!(file_media, b"hello world");
@@ -2145,7 +2148,7 @@ async fn test_media_uploads() {
     let thumbnail_media = client
         .media()
         .get_media_content(
-            &MediaRequest {
+            &MediaRequestParameters {
                 source: local_thumbnail_source,
                 // TODO: extract this reasonable query into a helper function shared across the
                 // codebase
@@ -2203,7 +2206,7 @@ async fn test_media_uploads() {
     let file_media = client
         .media()
         .get_media_content(
-            &MediaRequest { source: new_content.source, format: MediaFormat::File },
+            &MediaRequestParameters { source: new_content.source, format: MediaFormat::File },
             true,
         )
         .await
@@ -2217,7 +2220,7 @@ async fn test_media_uploads() {
     let thumbnail_media = client
         .media()
         .get_media_content(
-            &MediaRequest {
+            &MediaRequestParameters {
                 source: new_thumbnail_source,
                 // TODO: extract this reasonable query into a helper function shared across the
                 // codebase

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -2117,7 +2117,7 @@ async fn test_media_uploads() {
     // Check the data source: it should reference the send queue local storage.
     let local_source = img_content.source;
     assert_let!(MediaSource::Plain(mxc) = &local_source);
-    assert!(mxc.to_string().starts_with("mxc://send-queue.local/"), "{mxc}");
+    assert!(mxc.to_string().starts_with("mxc://send-queue.localhost/"), "{mxc}");
 
     // The media is immediately available from the cache.
     let file_media = client
@@ -2140,7 +2140,7 @@ async fn test_media_uploads() {
     // Check the thumbnail source: it should reference the send queue local storage.
     let local_thumbnail_source = info.thumbnail_source.unwrap();
     assert_let!(MediaSource::Plain(mxc) = &local_thumbnail_source);
-    assert!(mxc.to_string().starts_with("mxc://send-queue.local/"), "{mxc}");
+    assert!(mxc.to_string().starts_with("mxc://send-queue.localhost/"), "{mxc}");
 
     let thumbnail_media = client
         .media()

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -11,7 +11,7 @@ use assert_matches2::{assert_let, assert_matches};
 use matrix_sdk::{
     attachment::{AttachmentConfig, AttachmentInfo, BaseImageInfo, BaseThumbnailInfo, Thumbnail},
     config::{RequestConfig, StoreConfig},
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings, MediaThumbnailSize},
+    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
     send_queue::{
         LocalEcho, LocalEchoContent, RoomSendQueueError, RoomSendQueueStorageError,
         RoomSendQueueUpdate,
@@ -2150,11 +2150,9 @@ async fn test_media_uploads() {
                 // TODO: extract this reasonable query into a helper function shared across the
                 // codebase
                 format: MediaFormat::Thumbnail(MediaThumbnailSettings {
-                    size: MediaThumbnailSize {
-                        height: tinfo.height.unwrap(),
-                        width: tinfo.width.unwrap(),
-                        method: Method::Scale,
-                    },
+                    height: tinfo.height.unwrap(),
+                    width: tinfo.width.unwrap(),
+                    method: Method::Scale,
                     animated: false,
                 }),
             },
@@ -2224,11 +2222,9 @@ async fn test_media_uploads() {
                 // TODO: extract this reasonable query into a helper function shared across the
                 // codebase
                 format: MediaFormat::Thumbnail(MediaThumbnailSettings {
-                    size: MediaThumbnailSize {
-                        height: tinfo.height.unwrap(),
-                        width: tinfo.width.unwrap(),
-                        method: Method::Scale,
-                    },
+                    height: tinfo.height.unwrap(),
+                    width: tinfo.width.unwrap(),
+                    method: Method::Scale,
                     animated: false,
                 }),
             },


### PR DESCRIPTION
Fixes #1732. This adds support for sending medias via the send queue, which gives us local echoes for free.

The process looks like this:

- put the medias (thumbnail and file) into the media cache (with temporary MXC IDs)
- send a local echo for the media event that references the local media cache
- if thumbnail
  - create a request to upload the thumbnail
  - create a dependent request to upload the file, depending on the thumbnail being uploaded
  - create a dependent request to send the media event, depending on the file upload
- otherwise
  - create a request to upload the file
  - create a dependent request to send the media event
- once the medias have been uploaded, send a local echo edit for the media event, that fixes the MXC IDs to the final ones

The send queue dependency system is made such that, a dependent request depends on *at most* one other request. The design chosen in this PR is that dependencies are kept linear, each request depends on the previous one to be finished. As such, it means that when uploading a thumbnail, we need to remember the thumbnail MXC ID when uploading the file, because the file request will pass that information (when it's completed) to the media event.

---

This can *not* be reviewed commit by commit. Instead, I'd recommend looking at the commit which improves the module doc comment first: https://github.com/matrix-org/matrix-rust-sdk/pull/4195/commits/1d0ba021d52e72f4ef80c2220357c00193535abe

And then review the rest of the changes; we can also have a call to do the review together.

Sits on top of https://github.com/matrix-org/matrix-rust-sdk/pull/4199 and https://github.com/matrix-org/matrix-rust-sdk/pull/4200.