### PR TITLE
task(tests): introduce prebuilt mocks and mocking helpers

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -343,7 +343,7 @@ impl SyncTimelineEvent {
     /// Get the event id of this `SyncTimelineEvent` if the event has any valid
     /// id.
     pub fn event_id(&self) -> Option<OwnedEventId> {
-        self.kind.raw().get_field::<OwnedEventId>("event_id").ok().flatten()
+        self.kind.event_id()
     }
 
     /// Returns a reference to the (potentially decrypted) Matrix event inside
@@ -527,6 +527,12 @@ impl TimelineEventKind {
             TimelineEventKind::UnableToDecrypt { event, .. } => event.cast_ref(),
             TimelineEventKind::PlainText { event } => event,
         }
+    }
+
+    /// Get the event id of this `TimelineEventKind` if the event has any valid
+    /// id.
+    pub fn event_id(&self) -> Option<OwnedEventId> {
+        self.raw().get_field::<OwnedEventId>("event_id").ok().flatten()
     }
 
     /// If the event was a decrypted event that was successfully decrypted, get

--- a/crates/matrix-sdk/src/test_utils.rs
+++ b/crates/matrix-sdk/src/test_utils.rs
@@ -14,6 +14,9 @@ use url::Url;
 
 pub mod events;
 
+#[cfg(not(target_arch = "wasm32"))]
+pub mod mocks;
+
 use crate::{
     config::RequestConfig,
     matrix_auth::{MatrixSession, MatrixSessionTokens},

--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -1,0 +1,471 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Helpers to mock a server and have a client automatically connected to that
+//! server, for the purpose of integration tests.
+
+#![allow(missing_debug_implementations)]
+
+use std::sync::{Arc, Mutex};
+
+use matrix_sdk_base::deserialized_responses::TimelineEvent;
+use matrix_sdk_test::{
+    test_json, InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, LeftRoomBuilder,
+    SyncResponseBuilder,
+};
+use ruma::{OwnedEventId, OwnedRoomId, RoomId};
+use serde_json::json;
+use wiremock::{
+    matchers::{header, method, path, path_regex},
+    Mock, MockBuilder, MockGuard, MockServer, Respond, ResponseTemplate, Times,
+};
+
+use super::logged_in_client;
+use crate::{Client, Room};
+
+/// A `wiremock` server along with a client connected to it, with useful methods
+/// to help mocking Matrix client-server API endpoints easily.
+///
+/// This is a pair of a [`MockServer`] and a [`Client]` (one can retrieve them
+/// respectively with [`Self::server()`] and [`Self::client()`]).
+///
+/// It implements mock endpoints, limiting the shared code as much as possible,
+/// so the mocks are still flexible to use as scoped/unscoped mounts, named, and
+/// so on.
+///
+/// It works like this:
+///
+/// - start by saying which endpoint you'd like to mock, e.g.
+///   [`Self::mock_room_send()`]. This returns a specialized `MockSomething`
+///   data structure, with its own impl. For this example, it's
+///   [`MockRoomSend`].
+/// - configure the response on the endpoint-specific mock data structure. For
+///   instance, if you want the sending to result in a transient failure, call
+///   [`MockRoomSend::error500`]; if you want it to succeed and return the event
+///   `$42`, call [`MockRoomSend::ok`]. It's still possible to call
+///   [`MockRoomSend::respond_with()`], as we do with wiremock MockBuilder, for
+///   maximum flexibility when the helpers aren't sufficient.
+/// - once the endpoint's response is configured, for any mock builder, you get
+///   a [`MatrixMock`]; this is a plain [`wiremock::Mock`] with the server
+///   curried, so one doesn't have to pass it around when calling
+///   [`MatrixMock::mount()`] or [`MatrixMock::mount_as_scoped()`]. As such, it
+///   mostly defers its implementations to [`wiremock::Mock`] under the hood.
+pub struct MatrixMockServer {
+    server: MockServer,
+    client: Client,
+
+    /// Make the sync response builder stateful, to keep in memory the batch
+    /// token and avoid the client ignoring subsequent responses after the first
+    /// one.
+    sync_response_builder: Arc<Mutex<SyncResponseBuilder>>,
+}
+
+impl MatrixMockServer {
+    /// Create a new `wiremock` server specialized for Matrix usage.
+    pub async fn new() -> Self {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri().to_string())).await;
+        Self { client, server, sync_response_builder: Default::default() }
+    }
+
+    /// Creates a new [`MatrixMockServer`] when both parts have been already
+    /// created.
+    pub fn from_parts(server: MockServer, client: Client) -> Self {
+        Self { client, server, sync_response_builder: Default::default() }
+    }
+
+    /// Return the underlying client.
+    pub fn client(&self) -> Client {
+        self.client.clone()
+    }
+
+    /// Return the underlying server.
+    pub fn server(&self) -> &MockServer {
+        &self.server
+    }
+
+    /// Overrides the sync/ endpoint with knowledge that the given
+    /// invited/joined/knocked/left room exists, runs a sync and returns the
+    /// given room.
+    pub async fn sync_room(&self, room_id: &RoomId, room_data: impl Into<AnyRoomBuilder>) -> Room {
+        let any_room = room_data.into();
+
+        self.mock_sync()
+            .ok_and_run(move |builder| match any_room {
+                AnyRoomBuilder::Invited(invited) => {
+                    builder.add_invited_room(invited);
+                }
+                AnyRoomBuilder::Joined(joined) => {
+                    builder.add_joined_room(joined);
+                }
+                AnyRoomBuilder::Left(left) => {
+                    builder.add_left_room(left);
+                }
+                AnyRoomBuilder::Knocked(knocked) => {
+                    builder.add_knocked_room(knocked);
+                }
+            })
+            .await;
+
+        self.client.get_room(room_id).expect("look at me, the room is known now")
+    }
+
+    /// Overrides the sync/ endpoint with knowledge that the given room exists
+    /// in the joined state, runs a sync and returns the given room.
+    pub async fn sync_joined_room(&self, room_id: &RoomId) -> Room {
+        self.sync_room(room_id, JoinedRoomBuilder::new(room_id)).await
+    }
+
+    /// Verify that the previous mocks expected number of requests match
+    /// reality, and then cancels all active mocks.
+    pub async fn verify_and_reset(&self) {
+        self.server.verify().await;
+        self.server.reset().await;
+    }
+}
+
+// Specific mount endpoints.
+impl MatrixMockServer {
+    /// Mocks a sync endpoint.
+    pub fn mock_sync(&self) -> MockSync<'_> {
+        let mock = Mock::given(method("GET"))
+            .and(path("/_matrix/client/r0/sync"))
+            .and(header("authorization", "Bearer 1234"));
+        MockSync {
+            mock,
+            client: self.client.clone(),
+            server: &self.server,
+            sync_response_builder: self.sync_response_builder.clone(),
+        }
+    }
+
+    /// Creates a prebuilt mock for sending an event in a room.
+    ///
+    /// Note: works with *any* room.
+    pub fn mock_room_send(&self) -> MockRoomSend<'_> {
+        let mock = Mock::given(method("PUT"))
+            .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+            .and(header("authorization", "Bearer 1234"));
+        MockRoomSend { mock, server: &self.server }
+    }
+
+    /// Creates a prebuilt mock for asking whether *a* room is encrypted or not.
+    ///
+    /// Note: Applies to all rooms.
+    pub fn mock_room_state_encryption(&self) -> MockEncryptionState<'_> {
+        let mock = Mock::given(method("GET"))
+            .and(header("authorization", "Bearer 1234"))
+            .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/m.*room.*encryption.?"));
+        MockEncryptionState { mock, server: &self.server }
+    }
+
+    /// Creates a prebuilt mock for setting the room encryption state.
+    ///
+    /// Note: Applies to all rooms.
+    pub fn mock_set_room_state_encryption(&self) -> MockSetEncryptionState<'_> {
+        let mock = Mock::given(method("PUT"))
+            .and(header("authorization", "Bearer 1234"))
+            .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/m.*room.*encryption.?"));
+        MockSetEncryptionState { mock, server: &self.server }
+    }
+
+    /// Creates a prebuilt mock for the room redact endpoint.
+    pub fn mock_room_redact(&self) -> MockRoomRedact<'_> {
+        let mock = Mock::given(method("PUT"))
+            .and(path_regex(r"^/_matrix/client/r0/rooms/.*/redact/.*?/.*?"))
+            .and(header("authorization", "Bearer 1234"));
+        MockRoomRedact { mock, server: &self.server }
+    }
+
+    /// Creates a prebuilt mock for retrieving an event with /room/.../event.
+    pub fn mock_room_event(&self) -> MockRoomEvent<'_> {
+        let mock = Mock::given(method("GET")).and(header("authorization", "Bearer 1234"));
+        MockRoomEvent { mock, server: &self.server, room: None, match_event_id: false }
+    }
+}
+
+/// Parameter to [`MatrixMockServer::sync_room`].
+pub enum AnyRoomBuilder {
+    /// A room we've been invited to.
+    Invited(InvitedRoomBuilder),
+    /// A room we've joined.
+    Joined(JoinedRoomBuilder),
+    /// A room we've left.
+    Left(LeftRoomBuilder),
+    /// A room we've knocked to.
+    Knocked(KnockedRoomBuilder),
+}
+
+impl From<InvitedRoomBuilder> for AnyRoomBuilder {
+    fn from(val: InvitedRoomBuilder) -> AnyRoomBuilder {
+        AnyRoomBuilder::Invited(val)
+    }
+}
+
+impl From<JoinedRoomBuilder> for AnyRoomBuilder {
+    fn from(val: JoinedRoomBuilder) -> AnyRoomBuilder {
+        AnyRoomBuilder::Joined(val)
+    }
+}
+
+impl From<LeftRoomBuilder> for AnyRoomBuilder {
+    fn from(val: LeftRoomBuilder) -> AnyRoomBuilder {
+        AnyRoomBuilder::Left(val)
+    }
+}
+
+impl From<KnockedRoomBuilder> for AnyRoomBuilder {
+    fn from(val: KnockedRoomBuilder) -> AnyRoomBuilder {
+        AnyRoomBuilder::Knocked(val)
+    }
+}
+
+/// A wrapper for a [`Mock`] as well as a [`MockServer`], allowing us to call
+/// [`Mock::mount`] or [`Mock::mount_as_scoped`] without having to pass the
+/// [`MockServer`] reference (i.e. call `mount()` instead of `mount(&server)`).
+pub struct MatrixMock<'a> {
+    mock: Mock,
+    server: &'a MockServer,
+}
+
+impl<'a> MatrixMock<'a> {
+    /// Set an expectation on the number of times this [`MatrixMock`] should
+    /// match in the current test case.
+    ///
+    /// Expectations are verified when the server is shutting down: if
+    /// the expectation is not satisfied, the [`MatrixMockServer`] will panic
+    /// and the `error_message` is shown.
+    ///
+    /// By default, no expectation is set for [`MatrixMock`]s.
+    pub fn expect<T: Into<Times>>(self, num_calls: T) -> Self {
+        Self { mock: self.mock.expect(num_calls), ..self }
+    }
+
+    /// Assign a name to your mock.
+    ///
+    /// The mock name will be used in error messages (e.g. if the mock
+    /// expectation is not satisfied) and debug logs to help you identify
+    /// what failed.
+    pub fn named(self, name: impl Into<String>) -> Self {
+        Self { mock: self.mock.named(name), ..self }
+    }
+
+    /// Respond to a response of this endpoint exactly once.
+    ///
+    /// After it's been called, subsequent responses will hit the next handler
+    /// or a 404.
+    ///
+    /// Also verifies that it's been called once.
+    pub fn mock_once(self) -> Self {
+        Self { mock: self.mock.up_to_n_times(1).expect(1), ..self }
+    }
+
+    /// Mount a [`MatrixMock`] on the attached server.
+    ///
+    /// The [`MatrixMock`] will remain active until the [`MatrixMockServer`] is
+    /// shut down. If you want to control or limit how long your
+    /// [`MatrixMock`] stays active, check out [`Self::mount_as_scoped`].
+    pub async fn mount(self) {
+        self.mock.mount(self.server).await;
+    }
+
+    /// Mount a [`MatrixMock`] as **scoped** on the attached server.
+    ///
+    /// When using [`Self::mount`], your [`MatrixMock`]s will be active until
+    /// the [`MatrixMockServer`] is shut down.
+    ///
+    /// When using `mount_as_scoped`, your [`MatrixMock`]s will be active as
+    /// long as the returned [`MockGuard`] is not dropped.
+    ///
+    /// When the returned [`MockGuard`] is dropped, [`MatrixMockServer`] will
+    /// verify that the expectations set on the scoped [`MatrixMock`] were
+    /// verified - if not, it will panic.
+    pub async fn mount_as_scoped(self) -> MockGuard {
+        self.mock.mount_as_scoped(self.server).await
+    }
+}
+
+/// A prebuilt mock for sending events to a room.
+pub struct MockRoomSend<'a> {
+    server: &'a MockServer,
+    mock: MockBuilder,
+}
+
+impl<'a> MockRoomSend<'a> {
+    /// Returns a send endpoint that emulates success, i.e. the event has been
+    /// sent with the given event id.
+    pub fn ok(self, returned_event_id: impl Into<OwnedEventId>) -> MatrixMock<'a> {
+        let returned_event_id = returned_event_id.into();
+        MatrixMock {
+            mock: self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "event_id": returned_event_id
+            }))),
+            server: self.server,
+        }
+    }
+
+    /// Returns a send endpoint that emulates a transient failure, i.e responds
+    /// with error 500.
+    pub fn error500(self) -> MatrixMock<'a> {
+        MatrixMock { mock: self.mock.respond_with(ResponseTemplate::new(500)), server: self.server }
+    }
+
+    /// Returns a send endpoint that emulates a permanent failure (event is too
+    /// large).
+    pub fn error_too_large(self) -> MatrixMock<'a> {
+        MatrixMock {
+            mock: self.mock.respond_with(ResponseTemplate::new(413).set_body_json(json!({
+                // From https://spec.matrix.org/v1.10/client-server-api/#standard-error-response
+                "errcode": "M_TOO_LARGE",
+            }))),
+            server: self.server,
+        }
+    }
+
+    /// Specify how to respond to a query (viz., like
+    /// [`MockBuilder::respond_with`] does), when other predefined responses
+    /// aren't sufficient.
+    pub fn respond_with<R: Respond + 'static>(self, func: R) -> MatrixMock<'a> {
+        MatrixMock { mock: self.mock.respond_with(func), server: self.server }
+    }
+}
+
+/// A prebuilt mock for running sync v2.
+pub struct MockSync<'a> {
+    mock: MockBuilder,
+    server: &'a MockServer,
+    sync_response_builder: Arc<Mutex<SyncResponseBuilder>>,
+    client: Client,
+}
+
+impl<'a> MockSync<'a> {
+    /// Temporarily mocks the sync with the given endpoint and runs a client
+    /// sync with it.
+    ///
+    /// After calling this function, the sync endpoint isn't mocked anymore.
+    pub async fn ok_and_run<F: FnOnce(&mut SyncResponseBuilder)>(self, func: F) {
+        let json_response = {
+            let mut builder = self.sync_response_builder.lock().unwrap();
+            func(&mut builder);
+            builder.build_json_sync_response()
+        };
+
+        let _scope = self
+            .mock
+            .respond_with(ResponseTemplate::new(200).set_body_json(json_response))
+            .mount_as_scoped(self.server)
+            .await;
+
+        let _response = self.client.sync_once(Default::default()).await.unwrap();
+    }
+}
+
+/// A prebuilt mock for reading the encryption state of a room.
+pub struct MockEncryptionState<'a> {
+    server: &'a MockServer,
+    mock: MockBuilder,
+}
+
+impl<'a> MockEncryptionState<'a> {
+    /// Marks the room as encrypted.
+    pub fn encrypted(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(
+            ResponseTemplate::new(200).set_body_json(&*test_json::sync_events::ENCRYPTION_CONTENT),
+        );
+        MatrixMock { mock, server: self.server }
+    }
+
+    /// Marks the room as not encrypted.
+    pub fn plain(self) -> MatrixMock<'a> {
+        let mock = self
+            .mock
+            .respond_with(ResponseTemplate::new(404).set_body_json(&*test_json::NOT_FOUND));
+        MatrixMock { mock, server: self.server }
+    }
+}
+
+/// A prebuilt mock for setting the encryption state of a room.
+pub struct MockSetEncryptionState<'a> {
+    server: &'a MockServer,
+    mock: MockBuilder,
+}
+
+impl<'a> MockSetEncryptionState<'a> {
+    /// Returns a mock for a successful setting of the encryption state event.
+    pub fn ok(self, returned_event_id: impl Into<OwnedEventId>) -> MatrixMock<'a> {
+        let event_id = returned_event_id.into();
+        let mock = self.mock.respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "event_id": event_id })),
+        );
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+/// A prebuilt mock for redacting an event in a room.
+pub struct MockRoomRedact<'a> {
+    server: &'a MockServer,
+    mock: MockBuilder,
+}
+
+impl<'a> MockRoomRedact<'a> {
+    /// Returns a redact endpoint that emulates success, i.e. the redaction
+    /// event has been sent with the given event id.
+    pub fn ok(self, returned_event_id: impl Into<OwnedEventId>) -> MatrixMock<'a> {
+        let event_id = returned_event_id.into();
+        let mock = self.mock.respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "event_id": event_id })),
+        );
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+/// A prebuilt mock for getting a single event in a room.
+pub struct MockRoomEvent<'a> {
+    room: Option<OwnedRoomId>,
+    match_event_id: bool,
+    server: &'a MockServer,
+    mock: MockBuilder,
+}
+
+impl<'a> MockRoomEvent<'a> {
+    /// Limits the scope of this mock to a specific room.
+    pub fn room(self, room: impl Into<OwnedRoomId>) -> Self {
+        Self { room: Some(room.into()), ..self }
+    }
+
+    /// Whether the mock checks for the event id from the event.
+    pub fn match_event_id(self) -> Self {
+        Self { match_event_id: true, ..self }
+    }
+
+    /// Returns a redact endpoint that emulates success, i.e. the redaction
+    /// event has been sent with the given event id.
+    pub fn ok(self, event: TimelineEvent) -> MatrixMock<'a> {
+        let event_path = if self.match_event_id {
+            let event_id = event.kind.event_id().expect("an event id is required");
+            event_id.to_string()
+        } else {
+            // Event is at the end, so no need to add anything.
+            "".to_owned()
+        };
+
+        let room_path = self.room.map_or_else(|| ".*".to_owned(), |room| room.to_string());
+
+        let mock = self
+            .mock
+            .and(path_regex(format!("^/_matrix/client/r0/rooms/{room_path}/event/{event_path}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(event.into_raw().json()));
+        MatrixMock { server: self.server, mock }
+    }
+}

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -1,9 +1,8 @@
 // The http mocking library is not supported for wasm32
 #![cfg(not(target_arch = "wasm32"))]
 
-use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server, Client, Room};
-use matrix_sdk_test::{test_json, SyncResponseBuilder};
-use ruma::RoomId;
+use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server, Client};
+use matrix_sdk_test::test_json;
 use serde::Serialize;
 use wiremock::{
     matchers::{header, method, path, query_param, query_param_is_missing},
@@ -78,29 +77,4 @@ async fn mock_sync_scoped(
         .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
         .mount_as_scoped(server)
         .await
-}
-
-/// Does a sync for a given room, and returns its `Room` object.
-///
-/// Note this sync is token-less.
-async fn mock_sync_with_new_room<F: Fn(&mut SyncResponseBuilder)>(
-    func: F,
-    client: &Client,
-    server: &MockServer,
-    room_id: &RoomId,
-) -> Room {
-    let mut sync_response_builder = SyncResponseBuilder::default();
-    func(&mut sync_response_builder);
-    let json_response = sync_response_builder.build_json_sync_response();
-
-    let _scope = Mock::given(method("GET"))
-        .and(path("/_matrix/client/r0/sync"))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json_response))
-        .mount_as_scoped(server)
-        .await;
-
-    let _response = client.sync_once(Default::default()).await.unwrap();
-
-    client.get_room(room_id).expect("we should find the room we just sync'd from")
 }

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -40,7 +40,8 @@ async fn test_room_attachment_send() {
         .mount()
         .await;
 
-    let room = mock.sync_joined_room(&DEFAULT_TEST_ROOM_ID).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, &DEFAULT_TEST_ROOM_ID).await;
     mock.mock_room_state_encryption().plain().mount().await;
 
     let response = room
@@ -81,7 +82,8 @@ async fn test_room_attachment_send_info() {
         .mount()
         .await;
 
-    let room = mock.sync_joined_room(&DEFAULT_TEST_ROOM_ID).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, &DEFAULT_TEST_ROOM_ID).await;
     mock.mock_room_state_encryption().plain().mount().await;
 
     let config = AttachmentConfig::new()
@@ -130,7 +132,8 @@ async fn test_room_attachment_send_wrong_info() {
         .mount()
         .await;
 
-    let room = mock.sync_joined_room(&DEFAULT_TEST_ROOM_ID).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, &DEFAULT_TEST_ROOM_ID).await;
     mock.mock_room_state_encryption().plain().mount().await;
 
     // Here, using `AttachmentInfo::Video`…
@@ -188,7 +191,8 @@ async fn test_room_attachment_send_info_thumbnail() {
     // Second request: return the media MXC.
     mock.mock_upload().expect_mime_type("image/jpeg").ok(&media_mxc).mock_once().mount().await;
 
-    let room = mock.sync_joined_room(&DEFAULT_TEST_ROOM_ID).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, &DEFAULT_TEST_ROOM_ID).await;
     mock.mock_room_state_encryption().plain().mount().await;
 
     // Preconditions: nothing is found in the cache.
@@ -199,7 +203,6 @@ async fn test_room_attachment_send_info_thumbnail() {
         format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(uint!(480), uint!(360))),
     };
 
-    let client = mock.client();
     let _ = client.media().get_media_content(&media_request, true).await.unwrap_err();
     let _ = client.media().get_media_content(&thumbnail_request, true).await.unwrap_err();
 
@@ -283,7 +286,8 @@ async fn test_room_attachment_send_mentions() {
         .mount()
         .await;
 
-    let room = mock.sync_joined_room(&DEFAULT_TEST_ROOM_ID).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, &DEFAULT_TEST_ROOM_ID).await;
     mock.mock_room_state_encryption().plain().mount().await;
 
     let response = room

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -721,10 +721,11 @@ async fn test_make_reply_event_doesnt_require_event_cache() {
     // /event query to get details on an event.
 
     let mock = MatrixMockServer::new().await;
-    let user_id = mock.client().user_id().unwrap().to_owned();
+    let client = mock.make_client().await;
+    let user_id = client.user_id().unwrap().to_owned();
 
     let room_id = room_id!("!galette:saucisse.bzh");
-    let room = mock.sync_joined_room(room_id).await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     let event_id = event_id!("$1");
     let f = EventFactory::new();
@@ -744,12 +745,13 @@ async fn test_make_reply_event_doesnt_require_event_cache() {
 #[async_test]
 async fn test_enable_encryption_doesnt_stay_unencrypted() {
     let mock = MatrixMockServer::new().await;
+    let client = mock.make_client().await;
 
     mock.mock_room_state_encryption().plain().mount().await;
     mock.mock_set_room_state_encryption().ok(event_id!("$1")).mount().await;
 
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     assert!(!room.is_encrypted().await.unwrap());
 

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -210,7 +210,8 @@ async fn test_cant_send_invited_room() {
 
     // When I'm invited to a room,
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_room(room_id, InvitedRoomBuilder::new(room_id)).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_room(&client, room_id, InvitedRoomBuilder::new(room_id)).await;
 
     // I can't send message to it with the send queue.
     assert_matches!(
@@ -225,7 +226,8 @@ async fn test_cant_send_left_room() {
 
     // When I've left a room,
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_room(room_id, LeftRoomBuilder::new(room_id)).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_room(&client, room_id, LeftRoomBuilder::new(room_id)).await;
 
     // I can't send message to it with the send queue.
     assert_matches!(
@@ -242,7 +244,8 @@ async fn test_cant_send_knocked_room() {
 
     // When I've knocked into a room,
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_room(room_id, KnockedRoomBuilder::new(room_id)).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_room(&client, room_id, KnockedRoomBuilder::new(room_id)).await;
 
     // I can't send message to it with the send queue.
     assert_matches!(
@@ -259,13 +262,14 @@ async fn test_nothing_sent_when_disabled() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     // When I disable the send queue,
     let event_id = event_id!("$1");
     mock.mock_room_send().ok(event_id).expect(0).mount().await;
 
-    mock.client().send_queue().set_enabled(false).await;
+    client.send_queue().set_enabled(false).await;
 
     // A message is queued, but never sent.
     room.send_queue()
@@ -289,7 +293,9 @@ async fn test_smoke() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     let q = room.send_queue();
 
@@ -353,7 +359,8 @@ async fn test_smoke_raw() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     let q = room.send_queue();
 
@@ -395,7 +402,7 @@ async fn test_smoke_raw() {
 async fn test_error_then_locally_reenabling() {
     let mock = MatrixMockServer::new().await;
 
-    let client = mock.client();
+    let client = mock.make_client().await;
     let mut errors = client.send_queue().subscribe_errors();
 
     // Starting with a globally enabled queue.
@@ -404,7 +411,7 @@ async fn test_error_then_locally_reenabling() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     let q = room.send_queue();
 
@@ -497,7 +504,7 @@ async fn test_error_then_locally_reenabling() {
 async fn test_error_then_globally_reenabling() {
     let mock = MatrixMockServer::new().await;
 
-    let client = mock.client();
+    let client = mock.make_client().await;
     let mut errors = client.send_queue().subscribe_errors();
 
     // Starting with a globally enabled queue.
@@ -506,7 +513,7 @@ async fn test_error_then_globally_reenabling() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     let q = room.send_queue();
 
@@ -564,9 +571,9 @@ async fn test_reenabling_queue() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
-    let client = mock.client();
     let errors = client.send_queue().subscribe_errors();
 
     assert!(errors.is_empty());
@@ -637,10 +644,9 @@ async fn test_disjoint_enabled_status() {
     let room_id1 = room_id!("!a:b.c");
     let room_id2 = room_id!("!b:b.c");
 
-    let room1 = mock.sync_joined_room(room_id1).await;
-    let room2 = mock.sync_joined_room(room_id2).await;
-
-    let client = mock.client();
+    let client = mock.make_client().await;
+    let room1 = mock.sync_joined_room(&client, room_id1).await;
+    let room2 = mock.sync_joined_room(&client, room_id2).await;
 
     // When I start with a disabled send queue,
     client.send_queue().set_enabled(false).await;
@@ -673,7 +679,8 @@ async fn test_cancellation() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     let q = room.send_queue();
 
@@ -789,7 +796,8 @@ async fn test_edit() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     let q = room.send_queue();
 
@@ -833,7 +841,6 @@ async fn test_edit() {
 
     // The /event endpoint is used to retrieve the original event, during creation
     // of the edit event.
-    let client = mock.client();
     mock.mock_room_event()
         .room(room_id)
         .ok(EventFactory::new()
@@ -893,7 +900,8 @@ async fn test_edit_with_poll_start() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     let q = room.send_queue();
 
@@ -938,7 +946,6 @@ async fn test_edit_with_poll_start() {
 
     // The /event endpoint is used to retrieve the original event, during creation
     // of the edit event.
-    let client = mock.client();
     mock.mock_room_event()
         .ok(EventFactory::new()
             .poll_start("poll_start", "question", vec!["Answer A"])
@@ -1021,7 +1028,8 @@ async fn test_edit_while_being_sent_and_fails() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     let q = room.send_queue();
 
@@ -1101,7 +1109,8 @@ async fn test_edit_wakes_the_sending_task() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     let q = room.send_queue();
 
@@ -1150,9 +1159,9 @@ async fn test_abort_after_disable() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
-    let client = mock.client();
     let mut errors = client.send_queue().subscribe_errors();
 
     assert!(errors.is_empty());
@@ -1208,10 +1217,10 @@ async fn test_abort_or_edit_after_send() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     // Start with an enabled sending queue.
-    let client = mock.client();
     client.send_queue().set_enabled(true).await;
 
     let q = room.send_queue();
@@ -1251,7 +1260,8 @@ async fn test_abort_while_being_sent_and_fails() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     let q = room.send_queue();
 
@@ -1319,9 +1329,9 @@ async fn test_unrecoverable_errors() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
-    let client = mock.client();
     let mut errors = client.send_queue().subscribe_errors();
 
     assert!(errors.is_empty());
@@ -1381,9 +1391,9 @@ async fn test_unwedge_unrecoverable_errors() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
-    let client = mock.client();
     let mut errors = client.send_queue().subscribe_errors();
 
     assert!(errors.is_empty());
@@ -1447,11 +1457,11 @@ async fn test_no_network_access_error_is_recoverable() {
     // which is effectively dropped upon `drop()`.
     let server = wiremock::MockServer::builder().start().await;
     let client = logged_in_client(Some(server.uri().to_string())).await;
-    let mock = MatrixMockServer::from_parts(server, client.clone());
+    let mock = MatrixMockServer::from_server(server);
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     // Dropping the server: any subsequent attempt to connect mimics an unreachable
     // server, which might be caused by missing network.
@@ -1511,11 +1521,11 @@ async fn test_reloading_rooms_with_unsent_events() {
         .unwrap();
     set_client_session(&client).await;
 
-    let mock = MatrixMockServer::from_parts(server, client.clone());
+    let mock = MatrixMockServer::from_server(server);
 
     // Mark two rooms as joined.
-    let room = mock.sync_joined_room(room_id).await;
-    let room2 = mock.sync_joined_room(room_id2).await;
+    let room = mock.sync_joined_room(&client, room_id).await;
+    let room2 = mock.sync_joined_room(&client, room_id2).await;
 
     // Globally disable the send queue.
     let q = client.send_queue();
@@ -1581,7 +1591,8 @@ async fn test_reactions() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     let q = room.send_queue();
 
@@ -1703,8 +1714,8 @@ async fn test_media_uploads() {
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
-
-    let room = mock.sync_joined_room(room_id).await;
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
 
     let q = room.send_queue();
 
@@ -1798,7 +1809,6 @@ async fn test_media_uploads() {
     assert!(mxc.to_string().starts_with("mxc://send-queue.localhost/"), "{mxc}");
 
     // The media is immediately available from the cache.
-    let client = mock.client();
     let file_media = client
         .media()
         .get_media_content(


### PR DESCRIPTION
This introduces new test utilities, starting with `MatrixMockServer`. This is a pair of a `MockServer` and a `Client` (one can retrieve them respectively with `.server()` and `.client()`).

It implements a few mock endpoints, expanding and limited the shared code as much as possible, so the mocks are still flexible to use as scoped/unscoped mounts, named, and so on.

It works like this:

- start with telling which endpoint you'd like to mock, e.g. `mock_room_send()`. This returns a specialized `MockSomething` data structure, with its own impl. For this example, it's `MockRoomSend`.
- configure the response on the endpoint-specific mock data structure. For instance, if you want the sending to result in a transient failure, call `MockRoomSend::error500()`; if you want it to succeed and return the event $42, call `MockRoomSend::ok(event_id!("$42"))`. It's still possible to call `respond_with()`, as we do with wiremock MockBuilder, for maximum flexibility when the helpers aren't sufficient.
- once the endpoint's response is configured, for *any* mock builder, you get a `MatrixMock`; this is a plain `wiremock::Mock` with the server curried, so one doesn't have to pass it around when calling `.mount()` or `.mount_as_scoped()`. As such, it mostly defers its implementations to `wiremock::Mock` under the hood.

## Example

With this, we can go from that code:

```rust
#[async_test]
async fn test_make_reply_event_doesnt_require_event_cache() {
    let (client, server) = logged_in_client_with_server().await;

    let event_id = event_id!("$1");
    let resp_event_id = event_id!("$resp");
    let room_id = room_id!("!galette:saucisse.bzh");

    let f = EventFactory::new();

    let raw_original_event = f
        .text_msg("hi")
        .event_id(event_id)
        .sender(client.user_id().unwrap())
        .room(room_id)
        .into_raw_timeline();

    mock_sync_with_new_room(
        |builder| {
            builder.add_joined_room(JoinedRoomBuilder::new(room_id));
        },
        &client,
        &server,
        room_id,
    )
    .await;

    Mock::given(method("GET"))
        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/event/"))
        .and(header("authorization", "Bearer 1234"))
        .respond_with(ResponseTemplate::new(200).set_body_json(raw_original_event.json()))
        .expect(1)
        .named("/event")
        .mount(&server)
        .await;

    let new_content = RoomMessageEventContentWithoutRelation::text_plain("uh i mean bonjour");

    let room = client.get_room(room_id).unwrap();

    // make_edit_event works, even if the event cache hasn't been enabled.
    room.make_edit_event(resp_event_id, EditedContent::RoomMessage(new_content)).await.unwrap();
}
```

To that code:

```rust
#[async_test]
async fn test_make_reply_event_doesnt_require_event_cache() {
    let mock = MatrixMockServer::new().await;
    let user_id = mock.client().user_id().unwrap().to_owned();

    let room_id = room_id!("!galette:saucisse.bzh");
    let room = mock.sync_joined_room(room_id).await;

    let event_id = event_id!("$1");
    let f = EventFactory::new();
    mock.mock_room_event()
        .ok(f.text_msg("hi").event_id(event_id).sender(&user_id).room(room_id).into_timeline())
        .expect(1)
        .named("/event")
        .mount()
        .await;

    let new_content = RoomMessageEventContentWithoutRelation::text_plain("uh i mean bonjour");

    // make_edit_event works, even if the event cache hasn't been enabled.
    room.make_edit_event(event_id, EditedContent::RoomMessage(new_content)).await.unwrap();
}
```