### PR TITLE
refactor(send queue): generalize stored send queue data

### DIFF
--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -1212,7 +1212,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         let event0 =
             SerializableEventContent::new(&RoomMessageEventContent::text_plain("msg0").into())
                 .unwrap();
-        self.save_send_queue_request(room_id, txn0.clone(), event0).await.unwrap();
+        self.save_send_queue_request(room_id, txn0.clone(), event0.into()).await.unwrap();
 
         // Reading it will work.
         let pending = self.load_send_queue_requests(room_id).await.unwrap();
@@ -1236,7 +1236,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             )
             .unwrap();
 
-            self.save_send_queue_request(room_id, txn, event).await.unwrap();
+            self.save_send_queue_request(room_id, txn, event.into()).await.unwrap();
         }
 
         // Reading all the events should work.
@@ -1286,7 +1286,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             &RoomMessageEventContent::text_plain("wow that's a cool test").into(),
         )
         .unwrap();
-        self.update_send_queue_request(room_id, txn2, event0).await.unwrap();
+        self.update_send_queue_request(room_id, txn2, event0.into()).await.unwrap();
 
         // And it is reflected.
         let pending = self.load_send_queue_requests(room_id).await.unwrap();
@@ -1334,7 +1334,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             let event =
                 SerializableEventContent::new(&RoomMessageEventContent::text_plain("room2").into())
                     .unwrap();
-            self.save_send_queue_request(room_id2, txn.clone(), event).await.unwrap();
+            self.save_send_queue_request(room_id2, txn.clone(), event.into()).await.unwrap();
         }
 
         // Add and remove one event for room3.
@@ -1344,7 +1344,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             let event =
                 SerializableEventContent::new(&RoomMessageEventContent::text_plain("room3").into())
                     .unwrap();
-            self.save_send_queue_request(room_id3, txn.clone(), event).await.unwrap();
+            self.save_send_queue_request(room_id3, txn.clone(), event.into()).await.unwrap();
 
             self.remove_send_queue_request(room_id3, &txn).await.unwrap();
         }
@@ -1365,7 +1365,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         let event0 =
             SerializableEventContent::new(&RoomMessageEventContent::text_plain("hey").into())
                 .unwrap();
-        self.save_send_queue_request(room_id, txn0.clone(), event0).await.unwrap();
+        self.save_send_queue_request(room_id, txn0.clone(), event0.into()).await.unwrap();
 
         // No dependents, to start with.
         assert!(self.load_dependent_queued_requests(room_id).await.unwrap().is_empty());
@@ -1425,7 +1425,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         let event1 =
             SerializableEventContent::new(&RoomMessageEventContent::text_plain("hey2").into())
                 .unwrap();
-        self.save_send_queue_request(room_id, txn1.clone(), event1).await.unwrap();
+        self.save_send_queue_request(room_id, txn1.clone(), event1.into()).await.unwrap();
 
         self.save_dependent_queued_request(
             room_id,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -76,7 +76,7 @@ pub use self::{
     memory_store::MemoryStore,
     send_queue::{
         ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind, QueueWedgeError,
-        QueuedRequest, QueuedRequestKind, SerializableEventContent,
+        QueuedRequest, QueuedRequestKind, SentRequestKey, SerializableEventContent,
     },
     traits::{
         ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, ServerCapabilities,

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -78,6 +78,12 @@ pub enum QueuedRequestKind {
     },
 }
 
+impl From<SerializableEventContent> for QueuedRequestKind {
+    fn from(content: SerializableEventContent) -> Self {
+        Self::Event { content }
+    }
+}
+
 /// A request to be sent with a send queue.
 #[derive(Clone)]
 pub struct QueuedRequest {

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -42,8 +42,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     send_queue::SentRequestKey, ChildTransactionId, DependentQueuedRequest,
-    DependentQueuedRequestKind, QueueWedgeError, QueuedRequest, SerializableEventContent,
-    StateChanges, StoreError,
+    DependentQueuedRequestKind, QueueWedgeError, QueuedRequest, QueuedRequestKind, StateChanges,
+    StoreError,
 };
 use crate::{
     deserialized_responses::{RawAnySyncOrStrippedState, RawMemberEvent, RawSyncOrStrippedState},
@@ -357,7 +357,7 @@ pub trait StateStore: AsyncTraitDeps {
         &self,
         room_id: &RoomId,
         transaction_id: OwnedTransactionId,
-        content: SerializableEventContent,
+        request: QueuedRequestKind,
     ) -> Result<(), Self::Error>;
 
     /// Updates a send queue request with the given content, and resets its
@@ -375,7 +375,7 @@ pub trait StateStore: AsyncTraitDeps {
         &self,
         room_id: &RoomId,
         transaction_id: &TransactionId,
-        content: SerializableEventContent,
+        content: QueuedRequestKind,
     ) -> Result<bool, Self::Error>;
 
     /// Remove a request previously inserted with
@@ -640,7 +640,7 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         &self,
         room_id: &RoomId,
         transaction_id: OwnedTransactionId,
-        content: SerializableEventContent,
+        content: QueuedRequestKind,
     ) -> Result<(), Self::Error> {
         self.0.save_send_queue_request(room_id, transaction_id, content).await.map_err(Into::into)
     }
@@ -649,7 +649,7 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         &self,
         room_id: &RoomId,
         transaction_id: &TransactionId,
-        content: SerializableEventContent,
+        content: QueuedRequestKind,
     ) -> Result<bool, Self::Error> {
         self.0.update_send_queue_request(room_id, transaction_id, content).await.map_err(Into::into)
     }

--- a/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
@@ -46,7 +46,7 @@ use super::{
 };
 use crate::IndexeddbStateStoreError;
 
-const CURRENT_DB_VERSION: u32 = 11;
+const CURRENT_DB_VERSION: u32 = 12;
 const CURRENT_META_DB_VERSION: u32 = 2;
 
 /// Sometimes Migrations can't proceed without having to drop existing
@@ -234,6 +234,9 @@ pub async fn upgrade_inner_db(
             }
             if old_version < 11 {
                 db = migrate_to_v11(db).await?;
+            }
+            if old_version < 12 {
+                db = migrate_to_v12(db).await?;
             }
         }
 
@@ -769,6 +772,23 @@ async fn migrate_to_v11(db: IdbDatabase) -> Result<IdbDatabase> {
         data: Default::default(),
     };
     apply_migration(db, 11, migration).await
+}
+
+/// Drop entries from the [`keys::DEPENDENT_SEND_QUEUE`] table.
+async fn migrate_to_v12(db: IdbDatabase) -> Result<IdbDatabase> {
+    let tx =
+        db.transaction_on_one_with_mode(keys::DEPENDENT_SEND_QUEUE, IdbTransactionMode::Readwrite)?;
+
+    let store = tx.object_store(keys::DEPENDENT_SEND_QUEUE)?;
+    store.clear()?;
+
+    tx.await.into_result()?;
+
+    let name = db.name();
+    db.close();
+
+    // Update the version of the database.
+    Ok(IdbDatabase::open_u32(&name, 12)?.await?)
 }
 
 #[cfg(all(test, target_arch = "wasm32"))]

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -26,8 +26,8 @@ use matrix_sdk_base::{
     deserialized_responses::RawAnySyncOrStrippedState,
     store::{
         ChildTransactionId, ComposerDraft, DependentQueuedRequest, DependentQueuedRequestKind,
-        QueuedRequest, QueuedRequestKind, SerializableEventContent, ServerCapabilities,
-        StateChanges, StateStore, StoreError,
+        QueuedRequest, QueuedRequestKind, SentRequestKey, SerializableEventContent,
+        ServerCapabilities, StateChanges, StateStore, StoreError,
     },
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, StateStoreDataKey, StateStoreDataValue,
 };
@@ -1548,7 +1548,7 @@ impl_state_store!({
             kind: content,
             parent_transaction_id: parent_txn_id.to_owned(),
             own_transaction_id: own_txn_id,
-            event_id: None,
+            parent_key: None,
         });
 
         // Save the new vector into db.
@@ -1563,7 +1563,7 @@ impl_state_store!({
         &self,
         room_id: &RoomId,
         parent_txn_id: &TransactionId,
-        event_id: OwnedEventId,
+        parent_key: SentRequestKey,
     ) -> Result<usize> {
         let encoded_key = self.encode_key(keys::DEPENDENT_SEND_QUEUE, room_id);
 
@@ -1586,7 +1586,7 @@ impl_state_store!({
         // Modify all requests that match.
         let mut num_updated = 0;
         for entry in prev.iter_mut().filter(|entry| entry.parent_transaction_id == parent_txn_id) {
-            entry.event_id = Some(event_id.clone());
+            entry.parent_key = Some(parent_key.clone());
             num_updated += 1;
         }
 

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -1328,7 +1328,7 @@ impl_state_store!({
         &self,
         room_id: &RoomId,
         transaction_id: OwnedTransactionId,
-        content: SerializableEventContent,
+        kind: QueuedRequestKind,
     ) -> Result<()> {
         let encoded_key = self.encode_key(keys::ROOM_SEND_QUEUE, room_id);
 
@@ -1352,7 +1352,7 @@ impl_state_store!({
         // Push the new request.
         prev.push(PersistedQueuedRequest {
             room_id: room_id.to_owned(),
-            kind: Some(QueuedRequestKind::Event { content }),
+            kind: Some(kind),
             transaction_id,
             error: None,
             is_wedged: None,
@@ -1371,7 +1371,7 @@ impl_state_store!({
         &self,
         room_id: &RoomId,
         transaction_id: &TransactionId,
-        content: SerializableEventContent,
+        kind: QueuedRequestKind,
     ) -> Result<bool> {
         let encoded_key = self.encode_key(keys::ROOM_SEND_QUEUE, room_id);
 
@@ -1394,7 +1394,7 @@ impl_state_store!({
 
         // Modify the one request.
         if let Some(entry) = prev.iter_mut().find(|entry| entry.transaction_id == transaction_id) {
-            entry.kind = Some(QueuedRequestKind::Event { content });
+            entry.kind = Some(kind);
             // Reset the error state.
             entry.error = None;
             // Remove migrated fields.

--- a/crates/matrix-sdk-sqlite/migrations/state_store/008_send_queue.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/008_send_queue.sql
@@ -1,0 +1,7 @@
+-- Delete all previous entries in the dependent send queue table, because the format changed.
+DELETE FROM "dependent_send_queue_events";
+
+-- Rename its "event_id" column to "parent_key", while we're at it.
+ALTER TABLE "dependent_send_queue_events"
+    RENAME COLUMN "event_id"
+    TO "parent_key";

--- a/crates/matrix-sdk-sqlite/migrations/state_store/008_send_queue.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/008_send_queue.sql
@@ -5,3 +5,6 @@ DELETE FROM "dependent_send_queue_events";
 ALTER TABLE "dependent_send_queue_events"
     RENAME COLUMN "event_id"
     TO "parent_key";
+
+--- Delete all previous entries in the send queue, since the content's format has changed.
+DELETE FROM "send_queue_events";

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -13,7 +13,7 @@ use matrix_sdk_base::{
     store::{
         migration_helpers::RoomInfoV1, ChildTransactionId, DependentQueuedRequest,
         DependentQueuedRequestKind, QueueWedgeError, QueuedRequest, QueuedRequestKind,
-        SentRequestKey, SerializableEventContent,
+        SentRequestKey,
     },
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, RoomState, StateChanges, StateStore,
     StateStoreDataKey, StateStoreDataValue,
@@ -1684,7 +1684,7 @@ impl StateStore for SqliteStateStore {
         &self,
         room_id: &RoomId,
         transaction_id: OwnedTransactionId,
-        content: SerializableEventContent,
+        content: QueuedRequestKind,
     ) -> Result<(), Self::Error> {
         let room_id_key = self.encode_key(keys::SEND_QUEUE, room_id);
         let room_id_value = self.serialize_value(&room_id.to_owned())?;
@@ -1709,7 +1709,7 @@ impl StateStore for SqliteStateStore {
         &self,
         room_id: &RoomId,
         transaction_id: &TransactionId,
-        content: SerializableEventContent,
+        content: QueuedRequestKind,
     ) -> Result<bool, Self::Error> {
         let room_id = self.encode_key(keys::SEND_QUEUE, room_id);
 
@@ -1778,7 +1778,7 @@ impl StateStore for SqliteStateStore {
         for entry in res {
             requests.push(QueuedRequest {
                 transaction_id: entry.0.into(),
-                kind: QueuedRequestKind::Event { content: self.deserialize_json(&entry.1)? },
+                kind: self.deserialize_json(&entry.1)?,
                 error: entry.2.map(|v| self.deserialize_value(&v)).transpose()?,
             });
         }


### PR DESCRIPTION
See the first commit message, which explains the whole point.

Because of this PR, the send queue events and dependent events tables are both cleared, because there's a change in the format of serde-serialized data, and I didn't bother to write a migration for those. Events stuck in there would only be wedged events, or events that were still in the queue before closing the app; worst case scenario is some users lose some messages they tried to send before an update of an app. Is that OK? otherwise, can look into a sane migration, if needs be.

Part of #1732, blocks #4195.