### PR TITLE
fix(pinned_events): get pinned event ids from the HS as fallback

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -171,8 +171,9 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
     );
 
     let room = client.get_room(&room_id).expect("Room not found");
-    assert!(!room.pinned_event_ids().is_empty());
-    assert_eq!(room.pinned_event_ids().len(), PINNED_EVENTS_COUNT);
+    let pinned_event_ids = room.pinned_event_ids().unwrap_or_default();
+    assert!(!pinned_event_ids.is_empty());
+    assert_eq!(pinned_event_ids.len(), PINNED_EVENTS_COUNT);
 
     let count = PINNED_EVENTS_COUNT;
     let name = format!("{count} pinned events");
@@ -191,8 +192,9 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
 
     group.bench_function(BenchmarkId::new("load_pinned_events", name), |b| {
         b.to_async(&runtime).iter(|| async {
-            assert!(!room.pinned_event_ids().is_empty());
-            assert_eq!(room.pinned_event_ids().len(), PINNED_EVENTS_COUNT);
+            let pinned_event_ids = room.pinned_event_ids().unwrap_or_default();
+            assert!(!pinned_event_ids.is_empty());
+            assert_eq!(pinned_event_ids.len(), PINNED_EVENTS_COUNT);
 
             // Reset cache so it always loads the events from the mocked endpoint
             client.event_cache().empty_immutable_cache().await;

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -67,7 +67,8 @@ impl RoomInfo {
         for (id, level) in power_levels_map.iter() {
             user_power_levels.insert(id.to_string(), *level);
         }
-        let pinned_event_ids = room.pinned_event_ids().iter().map(|id| id.to_string()).collect();
+        let pinned_event_ids =
+            room.pinned_event_ids().unwrap_or_default().iter().map(|id| id.to_string()).collect();
 
         Ok(Self {
             id: room.room_id().to_string(),

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1019,7 +1019,7 @@ impl Room {
     }
 
     /// Returns the current pinned event ids for this room.
-    pub fn pinned_event_ids(&self) -> Vec<OwnedEventId> {
+    pub fn pinned_event_ids(&self) -> Option<Vec<OwnedEventId>> {
         self.inner.read().pinned_event_ids()
     }
 }
@@ -1596,8 +1596,8 @@ impl RoomInfo {
     }
 
     /// Returns the current pinned event ids for this room.
-    pub fn pinned_event_ids(&self) -> Vec<OwnedEventId> {
-        self.base_info.pinned_events.clone().map(|c| c.pinned).unwrap_or_default()
+    pub fn pinned_event_ids(&self) -> Option<Vec<OwnedEventId>> {
+        self.base_info.pinned_events.clone().map(|c| c.pinned)
     }
 
     /// Checks if an `EventId` is currently pinned.

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -2509,7 +2509,7 @@ mod tests {
         // The newly created room has no pinned event ids
         let room = client.get_room(room_id).unwrap();
         let pinned_event_ids = room.pinned_event_ids();
-        assert!(pinned_event_ids.is_empty());
+        assert_matches!(pinned_event_ids, None);
 
         // Load new pinned event id
         let mut room_response = http::response::Room::new();
@@ -2522,7 +2522,7 @@ mod tests {
         let response = response_with_room(room_id, room_response);
         client.process_sliding_sync(&response, &(), true).await.expect("Failed to process sync");
 
-        let pinned_event_ids = room.pinned_event_ids();
+        let pinned_event_ids = room.pinned_event_ids().unwrap_or_default();
         assert_eq!(pinned_event_ids.len(), 1);
         assert_eq!(pinned_event_ids[0], pinned_event_id);
 
@@ -2536,7 +2536,7 @@ mod tests {
         ));
         let response = response_with_room(room_id, room_response);
         client.process_sliding_sync(&response, &(), true).await.expect("Failed to process sync");
-        let pinned_event_ids = room.pinned_event_ids();
+        let pinned_event_ids = room.pinned_event_ids().unwrap();
         assert!(pinned_event_ids.is_empty());
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -61,6 +61,7 @@ impl PinnedEventsLoader {
         let pinned_event_ids: Vec<OwnedEventId> = self
             .room
             .pinned_event_ids()
+            .unwrap_or_default()
             .into_iter()
             .rev()
             .take(self.max_events_to_load)
@@ -134,7 +135,7 @@ pub trait PinnedEventsRoom: SendOutsideWasm + SyncOutsideWasm {
     ) -> BoxFuture<'a, Result<(SyncTimelineEvent, Vec<SyncTimelineEvent>), PaginatorError>>;
 
     /// Get the pinned event ids for a room.
-    fn pinned_event_ids(&self) -> Vec<OwnedEventId>;
+    fn pinned_event_ids(&self) -> Option<Vec<OwnedEventId>>;
 
     /// Checks whether an event id is pinned in this room.
     ///
@@ -168,7 +169,7 @@ impl PinnedEventsRoom for Room {
         .boxed()
     }
 
-    fn pinned_event_ids(&self) -> Vec<OwnedEventId> {
+    fn pinned_event_ids(&self) -> Option<Vec<OwnedEventId>> {
         self.clone_info().pinned_event_ids()
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -351,7 +351,7 @@ impl PinnedEventsRoom for TestRoomDataProvider {
         unimplemented!();
     }
 
-    fn pinned_event_ids(&self) -> Vec<OwnedEventId> {
+    fn pinned_event_ids(&self) -> Option<Vec<OwnedEventId>> {
         unimplemented!();
     }
 

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -1388,5 +1388,5 @@ async fn test_restore_room() {
 
     let room = client.get_room(room_id).unwrap();
     assert!(room.is_favourite());
-    assert!(!room.pinned_event_ids().is_empty());
+    assert!(!room.pinned_event_ids().unwrap().is_empty());
 }


### PR DESCRIPTION
When the required state of a room doesn't contain pinned events info for some reason, try using the `/state` endpoint from the HS to get this data instead.

This should take care of a bug that caused pinned events to be incorrectly removed when the new pinned event ids list was based on an empty one if the required state of the room didn't contain any pinned events info

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
