### PR TITLE
chore(ui): Display the real error of `Error::EventCache`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -449,7 +449,7 @@ pub enum Error {
     #[error("An error occurred while initializing the timeline")]
     InitializingTimeline(#[source] timeline::Error),
 
-    #[error("The attached event cache ran into an error")]
+    #[error("The attached event cache ran into an error: {0}")]
     EventCache(#[from] EventCacheError),
 }
 

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -432,7 +432,7 @@ impl RoomListService {
 #[derive(Debug, Error)]
 pub enum Error {
     /// Error from [`matrix_sdk::SlidingSync`].
-    #[error("SlidingSync failed: {0}")]
+    #[error(transparent)]
     SlidingSync(SlidingSyncError),
 
     /// An operation has been requested on an unknown list.
@@ -446,10 +446,10 @@ pub enum Error {
     #[error("A timeline instance already exists for room {0}")]
     TimelineAlreadyExists(OwnedRoomId),
 
-    #[error("An error occurred while initializing the timeline")]
-    InitializingTimeline(#[source] timeline::Error),
+    #[error(transparent)]
+    InitializingTimeline(#[from] timeline::Error),
 
-    #[error("The attached event cache ran into an error: {0}")]
+    #[error(transparent)]
     EventCache(#[from] EventCacheError),
 }
 


### PR DESCRIPTION
This patch displays the wrapped error.