### PR TITLE
feat(ui): Add `m.room.tombstone` to the room list `required_state`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -88,6 +88,7 @@ const DEFAULT_REQUIRED_STATE: &[(StateEventType, &str)] = &[
     (StateEventType::RoomCanonicalAlias, ""),
     (StateEventType::RoomPowerLevels, ""),
     (StateEventType::CallMember, "*"),
+    (StateEventType::RoomTombstone, ""),
 ];
 
 /// The default `required_state` constant value for sliding sync room

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -331,6 +331,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
                         ["m.room.canonical_alias", ""],
                         ["m.room.power_levels", ""],
                         ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.tombstone", ""],
                     ],
                     "include_heroes": true,
                     "filters": {
@@ -2100,6 +2101,7 @@ async fn test_room_subscription() -> Result<(), Error> {
                         ["m.room.canonical_alias", ""],
                         ["m.room.power_levels", ""],
                         ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.tombstone", ""],
                         ["m.room.create", ""],
                         ["m.room.pinned_events", ""],
                     ],
@@ -2138,6 +2140,7 @@ async fn test_room_subscription() -> Result<(), Error> {
                         ["m.room.canonical_alias", ""],
                         ["m.room.power_levels", ""],
                         ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.tombstone", ""],
                         ["m.room.create", ""],
                         ["m.room.pinned_events", ""],
                     ],


### PR DESCRIPTION
This patch adds the `m.room.tombstone` state event to the list of events in `required_state` used by the `RoomListService`. The goal is to offer the possibility for the consumers to know whether a room has been tombstoned or not.