### PR TITLE
doc(ui): Clarify how to obtain `room_info_notable_update_receiver` for `RoomList::entries_with_dynamic_adapters()`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -136,6 +136,9 @@ impl RoomList {
     /// entries, and that it's also possible to “paginate” over the entries by
     /// `page_size`. The rooms are also sorted.
     ///
+    /// The `room_info_notable_update_receiver` argument can be obtained from
+    /// [`Client::room_info_notable_update_receiver()`].
+    ///
     /// The returned stream will only start yielding diffs once a filter is set
     /// through the returned [`RoomListDynamicEntriesController`]. For every
     /// call to [`RoomListDynamicEntriesController::set_filter`], the stream


### PR DESCRIPTION
When migrating to the new `RoomList::entries_with_dynamic_adapters()`, I spent an embarrassingly long time trying to figure out what I should pass in for the `room_info_notable_update_receiver` argument and where to obtain it. This PR clarifies that with a direct link to the `Client` function that provides the receiver.


Signed-off-by: Kevin Boos <kevinaboos@gmail.com>
