### PR TITLE
refactor!(room list): remove unneeded argument from `RoomList::entries_with_dynamic_adapters`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -183,7 +183,6 @@ impl RoomList {
         listener: Box<dyn RoomListEntriesListener>,
     ) -> Arc<RoomListEntriesWithDynamicAdaptersResult> {
         let this = self.clone();
-        let client = self.room_list_service.inner.client();
         let utd_hook = self.room_list_service.utd_hook.clone();
 
         // The following code deserves a bit of explanation.
@@ -231,10 +230,7 @@ impl RoomList {
         // borrowing `this`, which is going to live long enough since it will live as
         // long as `entries_stream` and `dynamic_entries_controller`.
         let (entries_stream, dynamic_entries_controller) =
-            this.inner.entries_with_dynamic_adapters(
-                page_size.try_into().unwrap(),
-                client.room_info_notable_update_receiver(),
-            );
+            this.inner.entries_with_dynamic_adapters(page_size.try_into().unwrap());
 
         // FFI dance to make those values consumable by foreign language, nothing fancy
         // here, that's the real code for this method.

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -144,8 +144,8 @@ impl RoomList {
     pub fn entries_with_dynamic_adapters(
         &self,
         page_size: usize,
-        room_info_notable_update_receiver: broadcast::Receiver<RoomInfoNotableUpdate>,
     ) -> (impl Stream<Item = Vec<VectorDiff<Room>>> + '_, RoomListDynamicEntriesController) {
+        let room_info_notable_update_receiver = self.client.room_info_notable_update_receiver();
         let list = self.sliding_sync_list.clone();
 
         let filter_fn_cell = AsyncCell::shared();

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -1196,15 +1196,14 @@ async fn test_loading_states() -> Result<(), Error> {
 
 #[async_test]
 async fn test_dynamic_entries_stream() -> Result<(), Error> {
-    let (client, server, room_list) = new_room_list_service().await?;
+    let (_client, server, room_list) = new_room_list_service().await?;
 
     let sync = room_list.sync();
     pin_mut!(sync);
 
     let all_rooms = room_list.all_rooms().await?;
 
-    let (dynamic_entries_stream, dynamic_entries) =
-        all_rooms.entries_with_dynamic_adapters(5, client.room_info_notable_update_receiver());
+    let (dynamic_entries_stream, dynamic_entries) = all_rooms.entries_with_dynamic_adapters(5);
     pin_mut!(dynamic_entries_stream);
 
     sync_then_assert_request_and_fake_response! {
@@ -1599,15 +1598,14 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
 
 #[async_test]
 async fn test_room_sorting() -> Result<(), Error> {
-    let (client, server, room_list) = new_room_list_service().await?;
+    let (_client, server, room_list) = new_room_list_service().await?;
 
     let sync = room_list.sync();
     pin_mut!(sync);
 
     let all_rooms = room_list.all_rooms().await?;
 
-    let (stream, dynamic_entries) =
-        all_rooms.entries_with_dynamic_adapters(10, client.room_info_notable_update_receiver());
+    let (stream, dynamic_entries) = all_rooms.entries_with_dynamic_adapters(10);
     pin_mut!(stream);
 
     sync_then_assert_request_and_fake_response! {

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -182,7 +182,6 @@ impl App {
             Default::default();
         let timelines = Arc::new(Mutex::new(HashMap::new()));
 
-        let c = client.clone();
         let r = rooms.clone();
         let ri = room_infos.clone();
         let ur = ui_rooms.clone();
@@ -192,14 +191,12 @@ impl App {
         let all_rooms = room_list_service.all_rooms().await?;
 
         let listen_task = spawn(async move {
-            let client = c;
             let rooms = r;
             let room_infos = ri;
             let ui_rooms = ur;
             let timelines = t;
 
-            let (stream, entries_controller) = all_rooms
-                .entries_with_dynamic_adapters(50_000, client.room_info_notable_update_receiver());
+            let (stream, entries_controller) = all_rooms.entries_with_dynamic_adapters(50_000);
             entries_controller.set_filter(Box::new(new_filter_non_left()));
 
             pin_mut!(stream);

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -771,8 +771,7 @@ async fn test_delayed_decryption_latest_event() -> Result<()> {
 
     // Get the room list of Alice.
     let alice_all_rooms = alice_sync_service.room_list_service().all_rooms().await.unwrap();
-    let (alice_room_list_stream, entries) = alice_all_rooms
-        .entries_with_dynamic_adapters(10, alice.room_info_notable_update_receiver());
+    let (alice_room_list_stream, entries) = alice_all_rooms.entries_with_dynamic_adapters(10);
     entries.set_filter(Box::new(new_filter_all(vec![])));
     pin_mut!(alice_room_list_stream);
 
@@ -935,8 +934,7 @@ async fn test_room_info_notable_update_deduplication() -> Result<()> {
     alice_room.enable_encryption().await.unwrap();
 
     let alice_room_list = alice_sync_service.room_list_service().all_rooms().await.unwrap();
-    let (alice_rooms, alice_room_controller) = alice_room_list
-        .entries_with_dynamic_adapters(10, alice.room_info_notable_update_receiver());
+    let (alice_rooms, alice_room_controller) = alice_room_list.entries_with_dynamic_adapters(10);
 
     alice_room_controller.set_filter(Box::new(new_filter_all(vec![])));
 


### PR DESCRIPTION
The parameter `room_info_notable_update_receiver` was removed
 from `RoomList::entries_with_dynamic_adapters`, since it could be
 inferred internally instead.

Alternative to #4212, which I think avoids the problem altogether by providing a better API.