### PR TITLE
chore(timeline): rename `TimelineItemPosition::Update` to `UpdateDecrypted`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -241,7 +241,7 @@ impl TimelineState {
             let handle_one_res = txn
                 .handle_remote_event(
                     event.into(),
-                    TimelineItemPosition::Update(idx),
+                    TimelineItemPosition::UpdateDecrypted(idx),
                     room_data_provider,
                     settings,
                     &mut day_divider_adjuster,
@@ -447,7 +447,7 @@ impl TimelineStateTransaction<'_> {
                         TimelineItemPosition::End { origin }
                         | TimelineItemPosition::Start { origin } => origin,
 
-                        TimelineItemPosition::Update(idx) => self
+                        TimelineItemPosition::UpdateDecrypted(idx) => self
                             .items
                             .get(idx)
                             .and_then(|item| item.as_event())
@@ -703,7 +703,7 @@ impl TimelineStateTransaction<'_> {
                 self.meta.all_events.push_back(event_meta.base_meta());
             }
 
-            TimelineItemPosition::Update(_) => {
+            TimelineItemPosition::UpdateDecrypted(_) => {
                 if let Some(event) =
                     self.meta.all_events.iter_mut().find(|e| e.event_id == event_meta.event_id)
                 {


### PR DESCRIPTION
What it says on the tin. There were ideas to also rename `TimelineItemPosition`, but we're fine with the status quo, until we get more progress on the event cache.