### PR TITLE
fix(sdk): Do not always remove empty chunks from `LinkedChunk`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/linked_chunk/as_vector.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/as_vector.rs
@@ -452,7 +452,10 @@ mod tests {
 
     use imbl::{vector, Vector};
 
-    use super::{super::LinkedChunk, VectorDiff};
+    use super::{
+        super::{EmptyChunk, LinkedChunk},
+        VectorDiff,
+    };
 
     fn apply_and_assert_eq<Item>(
         accumulator: &mut Vector<Item>,
@@ -614,7 +617,10 @@ mod tests {
         );
 
         let removed_item = linked_chunk
-            .remove_item_at(linked_chunk.item_position(|item| *item == 'c').unwrap())
+            .remove_item_at(
+                linked_chunk.item_position(|item| *item == 'c').unwrap(),
+                EmptyChunk::Remove,
+            )
             .unwrap();
         assert_eq!(removed_item, 'c');
         assert_items_eq!(
@@ -634,7 +640,10 @@ mod tests {
         apply_and_assert_eq(&mut accumulator, as_vector.take(), &[VectorDiff::Remove { index: 7 }]);
 
         let removed_item = linked_chunk
-            .remove_item_at(linked_chunk.item_position(|item| *item == 'z').unwrap())
+            .remove_item_at(
+                linked_chunk.item_position(|item| *item == 'z').unwrap(),
+                EmptyChunk::Remove,
+            )
             .unwrap();
         assert_eq!(removed_item, 'z');
         assert_items_eq!(
@@ -773,7 +782,7 @@ mod tests {
                                 continue;
                             };
 
-                            linked_chunk.remove_item_at(position).expect("Failed to remove an item");
+                            linked_chunk.remove_item_at(position, EmptyChunk::Remove).expect("Failed to remove an item");
                         }
                     }
                 }


### PR DESCRIPTION
This patch introduces `EmptyChunk`, a new enum used to represent whether empty chunks must be removed/unlink or kept from the `LinkedChunk`. It is used by `LinkedChunk::remove_item_at`.

Why is it important? For example, imagine the following situation:

- one inserts a single event in a new chunk (possible if a (sliding) sync is done with `timeline_limit=1`),
- one inserts many events at the position of the previous event, with one of the new events being a duplicate of the first event (possible if a (sliding) sync is done with `timeline_limit=10` this time),
- prior to this patch, the older event was removed, resulting in an empty chunk, which was removed from the `LinkedChunk`, invalidating the insertion position!

So, with this patch:

- `RoomEvents::remove_events` does remove empty chunks, but
- `RoomEvents::remove_events_and_update_insert_position` does NOT remove empty chunks, they are kept in case the position wants to insert in this same chunk.