### PR TITLE
Refactor and clean up our ambiguity handling

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_alias.rs
+++ b/bindings/matrix-sdk-ffi/src/room_alias.rs
@@ -1,4 +1,4 @@
-use matrix_sdk::DisplayName;
+use matrix_sdk::RoomDisplayName;
 use ruma::RoomAliasId;
 
 /// Verifies the passed `String` matches the expected room alias format.
@@ -10,5 +10,5 @@ fn is_room_alias_format_valid(alias: String) -> bool {
 /// Transforms a Room's display name into a valid room alias name.
 #[matrix_sdk_ffi_macros::export]
 fn room_alias_name_from_room_display_name(room_name: String) -> String {
-    DisplayName::Named(room_name).to_room_alias_name()
+    RoomDisplayName::Named(room_name).to_room_alias_name()
 }

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1737,7 +1737,7 @@ mod tests {
 
     use super::BaseClient;
     use crate::{
-        store::StateStoreExt, test_utils::logged_in_base_client, DisplayName, RoomState,
+        store::StateStoreExt, test_utils::logged_in_base_client, RoomDisplayName, RoomState,
         SessionMeta,
     };
 
@@ -1869,7 +1869,7 @@ mod tests {
         assert_eq!(room.state(), RoomState::Invited);
         assert_eq!(
             room.compute_display_name().await.expect("fetching display name failed"),
-            DisplayName::Calculated("Kyra".to_owned())
+            RoomDisplayName::Calculated("Kyra".to_owned())
         );
     }
 

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -56,7 +56,7 @@ pub use http;
 pub use matrix_sdk_crypto as crypto;
 pub use once_cell;
 pub use rooms::{
-    DisplayName, Room, RoomCreateWithCreatorEventContent, RoomHero, RoomInfo,
+    Room, RoomCreateWithCreatorEventContent, RoomDisplayName, RoomHero, RoomInfo,
     RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons, RoomMember, RoomMemberships, RoomState,
     RoomStateFilter,
 };

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -50,7 +50,7 @@ use crate::MinimalStateEvent;
 /// The name of the room, either from the metadata or calculated
 /// according to [matrix specification](https://matrix.org/docs/spec/client_server/latest#calculating-the-display-name-for-a-room)
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum DisplayName {
+pub enum RoomDisplayName {
     /// The room has been named explicitly as
     Named(String),
     /// The room has a canonical alias that should be used
@@ -68,7 +68,7 @@ pub enum DisplayName {
 const WHITESPACE_REGEX: &str = r"\s+";
 const INVALID_SYMBOLS_REGEX: &str = r"[#,:]+";
 
-impl DisplayName {
+impl RoomDisplayName {
     /// Transforms the current display name into the name part of a
     /// `RoomAliasId`.
     pub fn to_room_alias_name(&self) -> String {
@@ -97,14 +97,16 @@ impl DisplayName {
     }
 }
 
-impl fmt::Display for DisplayName {
+impl fmt::Display for RoomDisplayName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            DisplayName::Named(s) | DisplayName::Calculated(s) | DisplayName::Aliased(s) => {
+            RoomDisplayName::Named(s)
+            | RoomDisplayName::Calculated(s)
+            | RoomDisplayName::Aliased(s) => {
                 write!(f, "{s}")
             }
-            DisplayName::EmptyWas(s) => write!(f, "Empty Room (was {s})"),
-            DisplayName::Empty => write!(f, "Empty Room"),
+            RoomDisplayName::EmptyWas(s) => write!(f, "Empty Room (was {s})"),
+            RoomDisplayName::Empty => write!(f, "Empty Room"),
         }
     }
 }
@@ -574,7 +576,7 @@ mod tests {
     use ruma::events::tag::{TagInfo, TagName, Tags};
 
     use super::{BaseRoomInfo, RoomNotableTags};
-    use crate::DisplayName;
+    use crate::RoomDisplayName;
 
     #[test]
     fn test_handle_notable_tags_favourite() {
@@ -608,21 +610,33 @@ mod tests {
 
     #[test]
     fn test_room_alias_from_room_display_name_lowercases() {
-        assert_eq!("roomalias", DisplayName::Named("RoomAlias".to_owned()).to_room_alias_name());
+        assert_eq!(
+            "roomalias",
+            RoomDisplayName::Named("RoomAlias".to_owned()).to_room_alias_name()
+        );
     }
 
     #[test]
     fn test_room_alias_from_room_display_name_removes_whitespace() {
-        assert_eq!("room-alias", DisplayName::Named("Room Alias".to_owned()).to_room_alias_name());
+        assert_eq!(
+            "room-alias",
+            RoomDisplayName::Named("Room Alias".to_owned()).to_room_alias_name()
+        );
     }
 
     #[test]
     fn test_room_alias_from_room_display_name_removes_non_ascii_symbols() {
-        assert_eq!("roomalias", DisplayName::Named("Room±Alias√".to_owned()).to_room_alias_name());
+        assert_eq!(
+            "roomalias",
+            RoomDisplayName::Named("Room±Alias√".to_owned()).to_room_alias_name()
+        );
     }
 
     #[test]
     fn test_room_alias_from_room_display_name_removes_invalid_ascii_symbols() {
-        assert_eq!("roomalias", DisplayName::Named("#Room,Alias:".to_owned()).to_room_alias_name());
+        assert_eq!(
+            "roomalias",
+            RoomDisplayName::Named("#Room,Alias:".to_owned()).to_room_alias_name()
+        );
     }
 }

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -25,9 +25,10 @@ pub use matrix_sdk_base::crypto;
 pub use matrix_sdk_base::{
     deserialized_responses,
     store::{DynStateStore, MemoryStore, StateStoreExt},
-    ComposerDraft, ComposerDraftType, DisplayName, QueueWedgeError, Room as BaseRoom,
-    RoomCreateWithCreatorEventContent, RoomHero, RoomInfo, RoomMember as BaseRoomMember,
-    RoomMemberships, RoomState, SessionMeta, StateChanges, StateStore, StoreError,
+    ComposerDraft, ComposerDraftType, QueueWedgeError, Room as BaseRoom,
+    RoomCreateWithCreatorEventContent, RoomDisplayName, RoomHero, RoomInfo,
+    RoomMember as BaseRoomMember, RoomMemberships, RoomState, SessionMeta, StateChanges,
+    StateStore, StoreError,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -3,7 +3,7 @@ use std::{iter, time::Duration};
 use assert_matches2::{assert_let, assert_matches};
 use js_int::uint;
 use matrix_sdk::{
-    config::SyncSettings, room::RoomMember, test_utils::events::EventFactory, DisplayName,
+    config::SyncSettings, room::RoomMember, test_utils::events::EventFactory, RoomDisplayName,
     RoomMemberships,
 };
 use matrix_sdk_test::{
@@ -66,7 +66,7 @@ async fn test_calculate_room_names_from_summary() {
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
 
     assert_eq!(
-        DisplayName::Calculated("example2".to_owned()),
+        RoomDisplayName::Calculated("example2".to_owned()),
         room.compute_display_name().await.unwrap()
     );
 }
@@ -86,7 +86,7 @@ async fn test_room_names() {
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
 
     assert_eq!(
-        DisplayName::Aliased("tutorial".to_owned()),
+        RoomDisplayName::Aliased("tutorial".to_owned()),
         room.compute_display_name().await.unwrap()
     );
 
@@ -100,7 +100,7 @@ async fn test_room_names() {
     let invited_room = client.get_room(room_id!("!696r7674:example.com")).unwrap();
 
     assert_eq!(
-        DisplayName::Named("My Room Name".to_owned()),
+        RoomDisplayName::Named("My Room Name".to_owned()),
         invited_room.compute_display_name().await.unwrap()
     );
 
@@ -136,7 +136,7 @@ async fn test_room_names() {
     let room = client.get_room(room_id).unwrap();
 
     assert_eq!(
-        DisplayName::Calculated(
+        RoomDisplayName::Calculated(
             "user_0, user_1, user_10, user_11, user_12, and 10 others".to_owned()
         ),
         room.compute_display_name().await.unwrap()
@@ -186,7 +186,7 @@ async fn test_room_names() {
     let room = client.get_room(room_id).unwrap();
 
     assert_eq!(
-        DisplayName::Calculated("Bob, example1".to_owned()),
+        RoomDisplayName::Calculated("Bob, example1".to_owned()),
         room.compute_display_name().await.unwrap()
     );
 
@@ -206,7 +206,7 @@ async fn test_room_names() {
     let room = client.get_room(room_id).unwrap();
 
     assert_eq!(
-        DisplayName::EmptyWas("user_0, user_1, user_2".to_owned()),
+        RoomDisplayName::EmptyWas("user_0, user_1, user_2".to_owned()),
         room.compute_display_name().await.unwrap()
     );
 }


### PR DESCRIPTION
This is in preparation of some higher level user display name handling, thus the rename of our `DisplayName` type as well.

No functional changes here.
