### PR TITLE
feat(ffi): add room alias format validation & room name to alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
  "serde",
 ]
 
@@ -2965,6 +2965,7 @@ dependencies = [
  "matrix-sdk-store-encryption",
  "matrix-sdk-test",
  "once_cell",
+ "regex",
  "ruma",
  "serde",
  "serde_json",
@@ -4143,7 +4144,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -4385,14 +4386,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4406,13 +4407,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4423,9 +4424,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -16,6 +16,7 @@ mod notification;
 mod notification_settings;
 mod platform;
 mod room;
+mod room_alias;
 mod room_directory_search;
 mod room_info;
 mod room_list;
@@ -30,7 +31,6 @@ mod timeline_event_filter;
 mod tracing;
 mod utils;
 mod widget;
-mod room_alias;
 
 use async_compat::TOKIO1 as RUNTIME;
 use matrix_sdk::ruma::events::room::{

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -30,6 +30,7 @@ mod timeline_event_filter;
 mod tracing;
 mod utils;
 mod widget;
+mod room_alias;
 
 use async_compat::TOKIO1 as RUNTIME;
 use matrix_sdk::ruma::events::room::{

--- a/bindings/matrix-sdk-ffi/src/room_alias.rs
+++ b/bindings/matrix-sdk-ffi/src/room_alias.rs
@@ -1,0 +1,7 @@
+use ruma::RoomAliasId;
+
+/// Verifies the passed `String` matches the expected room alias format.
+#[matrix_sdk_ffi_macros::export]
+fn is_room_alias_format_valid(alias: String) -> bool {
+    RoomAliasId::parse(alias).is_ok()
+}

--- a/bindings/matrix-sdk-ffi/src/room_alias.rs
+++ b/bindings/matrix-sdk-ffi/src/room_alias.rs
@@ -1,7 +1,14 @@
+use matrix_sdk::DisplayName;
 use ruma::RoomAliasId;
 
 /// Verifies the passed `String` matches the expected room alias format.
 #[matrix_sdk_ffi_macros::export]
 fn is_room_alias_format_valid(alias: String) -> bool {
     RoomAliasId::parse(alias).is_ok()
+}
+
+/// Transforms a Room's display name into a valid room alias name.
+#[matrix_sdk_ffi_macros::export]
+fn room_alias_name_from_room_display_name(room_name: String) -> String {
+    DisplayName::Named(room_name).to_room_alias_name()
 }

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -67,6 +67,7 @@ tokio = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uniffi = { workspace = true, optional = true }
+regex = "1.11.1"
 
 [dev-dependencies]
 assert_matches = { workspace = true }


### PR DESCRIPTION
Add two FFI functions:

`is_room_alias_format_valid`: to check if a passed string has a valid room alias format in Ruma.
`room_alias_from_room_display_name`: to get a suggestion of a room alias to use given a room name.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
