### PR TITLE
feat(ffi): allow `VerificationStateListener` to emit the current state

### DIFF
--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -397,14 +397,8 @@ impl Encryption {
     pub fn verification_state_listener(
         self: Arc<Self>,
         listener: Box<dyn VerificationStateListener>,
-        emit_current_value: bool,
     ) -> Arc<TaskHandle> {
         let mut subscriber = self.inner.verification_state();
-
-        if emit_current_value {
-            // Emit current value first
-            listener.on_update(subscriber.get().into());
-        }
 
         Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
             while let Some(verification_state) = subscriber.next().await {

--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -397,8 +397,15 @@ impl Encryption {
     pub fn verification_state_listener(
         self: Arc<Self>,
         listener: Box<dyn VerificationStateListener>,
+        emit_current_value: bool,
     ) -> Arc<TaskHandle> {
         let mut subscriber = self.inner.verification_state();
+
+        if emit_current_value {
+            // Emit current value first
+            listener.on_update(subscriber.get().into());
+        }
+
         Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
             while let Some(verification_state) = subscriber.next().await {
                 listener.on_update(verification_state.into());

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1604,6 +1604,10 @@ impl Encryption {
 
         let this = self.clone();
         tasks.setup_e2ee = Some(spawn(async move {
+            // Update the current state first, so we don't have to wait for the result of
+            // network requests
+            this.update_verification_state().await;
+
             if this.settings().auto_enable_cross_signing {
                 if let Err(e) = this.bootstrap_cross_signing_if_needed(auth_data).await {
                     error!("Couldn't bootstrap cross signing {e:?}");
@@ -1616,8 +1620,6 @@ impl Encryption {
             if let Err(e) = this.recovery().setup().await {
                 error!("Couldn't setup and resume recovery {e:?}");
             }
-
-            this.update_verification_state().await;
         }));
     }
 

--- a/crates/matrix-sdk/src/test_utils.rs
+++ b/crates/matrix-sdk/src/test_utils.rs
@@ -100,11 +100,13 @@ pub async fn logged_in_client_with_server() -> (Client, wiremock::MockServer) {
     (client, server)
 }
 
-/// Asserts the next item in a [`Stream`] can be loaded in the given timeout in
-/// the given timeout in milliseconds.
+/// Asserts the next item in a `Stream` or `Subscriber` can be loaded in the
+/// given timeout in the given timeout in milliseconds.
 #[macro_export]
 macro_rules! assert_next_with_timeout {
     ($stream:expr, $timeout_ms:expr) => {{
+        // Needed for subscribers, as they won't use the StreamExt features
+        #[allow(unused_imports)]
         use futures_util::StreamExt as _;
         tokio::time::timeout(std::time::Duration::from_millis($timeout_ms), $stream.next())
             .await
@@ -113,8 +115,8 @@ macro_rules! assert_next_with_timeout {
     }};
 }
 
-/// Assert the next item in a [`Stream`] matches the provided pattern in the
-/// given timeout in milliseconds.
+/// Assert the next item in a `Stream` or `Subscriber` matches the provided
+/// pattern in the given timeout in milliseconds.
 ///
 /// If no timeout is provided, a default `100ms` value will be used.
 #[macro_export]


### PR DESCRIPTION
With this, we get notified of the current verification state almost immediately.

Without it, you may either call it too soon and receive an `Unknown` state or you might have to call `Encryption::wait_for_e2ee_initialization_tasks()` and wait until it's finished to request a valid state value.

Also, make sure we get an updated verification value before any network request runs so it can't get deadlocked/time out and we end up not receiving the updated value.
<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
