### PR TITLE
refactor!(media): flatten and rename `MediaRequest` and fields

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -8,7 +8,8 @@ use std::{
 use anyhow::{anyhow, Context as _};
 use matrix_sdk::{
     media::{
-        MediaFileHandle as SdkMediaFileHandle, MediaFormat, MediaRequest, MediaThumbnailSettings,
+        MediaFileHandle as SdkMediaFileHandle, MediaFormat, MediaRequestParameters,
+        MediaThumbnailSettings,
     },
     oidc::{
         registrations::{ClientId, OidcRegistrations},
@@ -442,7 +443,7 @@ impl Client {
             .inner
             .media()
             .get_media_file(
-                &MediaRequest { source, format: MediaFormat::File },
+                &MediaRequestParameters { source, format: MediaFormat::File },
                 filename,
                 &mime_type,
                 use_cache,
@@ -721,7 +722,7 @@ impl Client {
         Ok(self
             .inner
             .media()
-            .get_media_content(&MediaRequest { source, format: MediaFormat::File }, true)
+            .get_media_content(&MediaRequestParameters { source, format: MediaFormat::File }, true)
             .await?)
     }
 
@@ -738,7 +739,7 @@ impl Client {
             .inner
             .media()
             .get_media_content(
-                &MediaRequest {
+                &MediaRequestParameters {
                     source,
                     format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
                         Method::Scale,

--- a/crates/matrix-sdk-base/src/event_cache_store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/integration_tests.rs
@@ -20,7 +20,7 @@ use ruma::{
 };
 
 use super::DynEventCacheStore;
-use crate::media::{MediaFormat, MediaRequest, MediaThumbnailSettings};
+use crate::media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings};
 
 /// `EventCacheStore` integration tests.
 ///
@@ -41,9 +41,11 @@ pub trait EventCacheStoreIntegrationTests {
 impl EventCacheStoreIntegrationTests for DynEventCacheStore {
     async fn test_media_content(&self) {
         let uri = mxc_uri!("mxc://localhost/media");
-        let request_file =
-            MediaRequest { source: MediaSource::Plain(uri.to_owned()), format: MediaFormat::File };
-        let request_thumbnail = MediaRequest {
+        let request_file = MediaRequestParameters {
+            source: MediaSource::Plain(uri.to_owned()),
+            format: MediaFormat::File,
+        };
+        let request_thumbnail = MediaRequestParameters {
             source: MediaSource::Plain(uri.to_owned()),
             format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
                 Method::Crop,
@@ -53,7 +55,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         };
 
         let other_uri = mxc_uri!("mxc://localhost/media-other");
-        let request_other_file = MediaRequest {
+        let request_other_file = MediaRequestParameters {
             source: MediaSource::Plain(other_uri.to_owned()),
             format: MediaFormat::File,
         };
@@ -145,8 +147,10 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
     async fn test_replace_media_key(&self) {
         let uri = mxc_uri!("mxc://sendqueue.local/tr4n-s4ct-10n1-d");
-        let req =
-            MediaRequest { source: MediaSource::Plain(uri.to_owned()), format: MediaFormat::File };
+        let req = MediaRequestParameters {
+            source: MediaSource::Plain(uri.to_owned()),
+            format: MediaFormat::File,
+        };
 
         let content = "hello".as_bytes().to_owned();
 
@@ -161,7 +165,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         // Replacing a media request works.
         let new_uri = mxc_uri!("mxc://matrix.org/tr4n-s4ct-10n1-d");
-        let new_req = MediaRequest {
+        let new_req = MediaRequestParameters {
             source: MediaSource::Plain(new_uri.to_owned()),
             format: MediaFormat::File,
         };

--- a/crates/matrix-sdk-base/src/event_cache_store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/memory_store.rs
@@ -19,7 +19,7 @@ use matrix_sdk_common::ring_buffer::RingBuffer;
 use ruma::{MxcUri, OwnedMxcUri};
 
 use super::{EventCacheStore, EventCacheStoreError, Result};
-use crate::media::{MediaRequest, UniqueKey as _};
+use crate::media::{MediaRequestParameters, UniqueKey as _};
 
 /// In-memory, non-persistent implementation of the `EventCacheStore`.
 ///
@@ -51,7 +51,11 @@ impl MemoryStore {
 impl EventCacheStore for MemoryStore {
     type Error = EventCacheStoreError;
 
-    async fn add_media_content(&self, request: &MediaRequest, data: Vec<u8>) -> Result<()> {
+    async fn add_media_content(
+        &self,
+        request: &MediaRequestParameters,
+        data: Vec<u8>,
+    ) -> Result<()> {
         // Avoid duplication. Let's try to remove it first.
         self.remove_media_content(request).await?;
         // Now, let's add it.
@@ -62,8 +66,8 @@ impl EventCacheStore for MemoryStore {
 
     async fn replace_media_key(
         &self,
-        from: &MediaRequest,
-        to: &MediaRequest,
+        from: &MediaRequestParameters,
+        to: &MediaRequestParameters,
     ) -> Result<(), Self::Error> {
         let expected_key = from.unique_key();
 
@@ -76,7 +80,7 @@ impl EventCacheStore for MemoryStore {
         Ok(())
     }
 
-    async fn get_media_content(&self, request: &MediaRequest) -> Result<Option<Vec<u8>>> {
+    async fn get_media_content(&self, request: &MediaRequestParameters) -> Result<Option<Vec<u8>>> {
         let expected_key = request.unique_key();
 
         let media = self.media.read().unwrap();
@@ -85,7 +89,7 @@ impl EventCacheStore for MemoryStore {
         }))
     }
 
-    async fn remove_media_content(&self, request: &MediaRequest) -> Result<()> {
+    async fn remove_media_content(&self, request: &MediaRequestParameters) -> Result<()> {
         let expected_key = request.unique_key();
 
         let mut media = self.media.write().unwrap();

--- a/crates/matrix-sdk-base/src/event_cache_store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache_store/traits.rs
@@ -19,7 +19,7 @@ use matrix_sdk_common::AsyncTraitDeps;
 use ruma::MxcUri;
 
 use super::EventCacheStoreError;
-use crate::media::MediaRequest;
+use crate::media::MediaRequestParameters;
 
 /// An abstract trait that can be used to implement different store backends
 /// for the event cache of the SDK.
@@ -38,7 +38,7 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// * `content` - The content of the file.
     async fn add_media_content(
         &self,
-        request: &MediaRequest,
+        request: &MediaRequestParameters,
         content: Vec<u8>,
     ) -> Result<(), Self::Error>;
 
@@ -63,8 +63,8 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// * `to` - The new `MediaRequest` of the file.
     async fn replace_media_key(
         &self,
-        from: &MediaRequest,
-        to: &MediaRequest,
+        from: &MediaRequestParameters,
+        to: &MediaRequestParameters,
     ) -> Result<(), Self::Error>;
 
     /// Get a media file's content out of the media store.
@@ -74,7 +74,7 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// * `request` - The `MediaRequest` of the file.
     async fn get_media_content(
         &self,
-        request: &MediaRequest,
+        request: &MediaRequestParameters,
     ) -> Result<Option<Vec<u8>>, Self::Error>;
 
     /// Remove a media file's content from the media store.
@@ -82,7 +82,10 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// # Arguments
     ///
     /// * `request` - The `MediaRequest` of the file.
-    async fn remove_media_content(&self, request: &MediaRequest) -> Result<(), Self::Error>;
+    async fn remove_media_content(
+        &self,
+        request: &MediaRequestParameters,
+    ) -> Result<(), Self::Error>;
 
     /// Remove all the media files' content associated to an `MxcUri` from the
     /// media store.
@@ -110,7 +113,7 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
 
     async fn add_media_content(
         &self,
-        request: &MediaRequest,
+        request: &MediaRequestParameters,
         content: Vec<u8>,
     ) -> Result<(), Self::Error> {
         self.0.add_media_content(request, content).await.map_err(Into::into)
@@ -118,20 +121,23 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
 
     async fn replace_media_key(
         &self,
-        from: &MediaRequest,
-        to: &MediaRequest,
+        from: &MediaRequestParameters,
+        to: &MediaRequestParameters,
     ) -> Result<(), Self::Error> {
         self.0.replace_media_key(from, to).await.map_err(Into::into)
     }
 
     async fn get_media_content(
         &self,
-        request: &MediaRequest,
+        request: &MediaRequestParameters,
     ) -> Result<Option<Vec<u8>>, Self::Error> {
         self.0.get_media_content(request).await.map_err(Into::into)
     }
 
-    async fn remove_media_content(&self, request: &MediaRequest) -> Result<(), Self::Error> {
+    async fn remove_media_content(
+        &self,
+        request: &MediaRequestParameters,
+    ) -> Result<(), Self::Error> {
         self.0.remove_media_content(request).await.map_err(Into::into)
     }
 

--- a/crates/matrix-sdk-base/src/media.rs
+++ b/crates/matrix-sdk-base/src/media.rs
@@ -97,9 +97,11 @@ impl UniqueKey for MediaSource {
     }
 }
 
-/// A request for media data.
+/// Parameters for a request for retrieve media data.
+///
+/// This is used as a key in the media cache too.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MediaRequest {
+pub struct MediaRequestParameters {
     /// The source of the media file.
     pub source: MediaSource,
 
@@ -107,7 +109,7 @@ pub struct MediaRequest {
     pub format: MediaFormat,
 }
 
-impl MediaRequest {
+impl MediaRequestParameters {
     /// Get the [`MxcUri`] from `Self`.
     pub fn uri(&self) -> &MxcUri {
         match &self.source {
@@ -117,7 +119,7 @@ impl MediaRequest {
     }
 }
 
-impl UniqueKey for MediaRequest {
+impl UniqueKey for MediaRequestParameters {
     fn unique_key(&self) -> String {
         format!("{}{UNIQUE_SEPARATOR}{}", self.source.unique_key(), self.format.unique_key())
     }
@@ -213,14 +215,14 @@ mod tests {
     fn test_media_request_url() {
         let mxc_uri = mxc_uri!("mxc://homeserver/media");
 
-        let plain = MediaRequest {
+        let plain = MediaRequestParameters {
             source: MediaSource::Plain(mxc_uri.to_owned()),
             format: MediaFormat::File,
         };
 
         assert_eq!(plain.uri(), mxc_uri);
 
-        let file = MediaRequest {
+        let file = MediaRequestParameters {
             source: MediaSource::Encrypted(Box::new(
                 serde_json::from_value(json!({
                     "url": mxc_uri,

--- a/crates/matrix-sdk-base/src/media.rs
+++ b/crates/matrix-sdk-base/src/media.rs
@@ -44,9 +44,9 @@ impl UniqueKey for MediaFormat {
     }
 }
 
-/// The requested size of a media thumbnail.
+/// The desired settings of a media thumbnail.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MediaThumbnailSize {
+pub struct MediaThumbnailSettings {
     /// The desired resizing method.
     pub method: Method,
 
@@ -57,19 +57,6 @@ pub struct MediaThumbnailSize {
     /// The desired height of the thumbnail. The actual thumbnail may not match
     /// the size specified.
     pub height: UInt,
-}
-
-impl UniqueKey for MediaThumbnailSize {
-    fn unique_key(&self) -> String {
-        format!("{}{UNIQUE_SEPARATOR}{}x{}", self.method, self.width, self.height)
-    }
-}
-
-/// The desired settings of a media thumbnail.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MediaThumbnailSettings {
-    /// The desired size of the thumbnail.
-    pub size: MediaThumbnailSize,
 
     /// If we want to request an animated thumbnail from the homeserver.
     ///
@@ -84,13 +71,13 @@ impl MediaThumbnailSettings {
     /// Constructs a new `MediaThumbnailSettings` with the given method, width
     /// and height.
     pub fn new(method: Method, width: UInt, height: UInt) -> Self {
-        Self { size: MediaThumbnailSize { method, width, height }, animated: false }
+        Self { method, width, height, animated: false }
     }
 }
 
 impl UniqueKey for MediaThumbnailSettings {
     fn unique_key(&self) -> String {
-        let mut key = self.size.unique_key();
+        let mut key = format!("{}{UNIQUE_SEPARATOR}{}x{}", self.method, self.width, self.height);
 
         if self.animated {
             key.push_str(UNIQUE_SEPARATOR);

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -27,7 +27,7 @@ use ruma::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::media::MediaRequest;
+use crate::media::MediaRequestParameters;
 
 /// A thin wrapper to serialize a `AnyMessageLikeEventContent`.
 #[derive(Clone, Serialize, Deserialize)]
@@ -95,7 +95,7 @@ pub enum QueuedRequestKind {
 
         /// The cache key used to retrieve the media's bytes in the event cache
         /// store.
-        cache_key: MediaRequest,
+        cache_key: MediaRequestParameters,
 
         /// An optional media source for a thumbnail already uploaded.
         thumbnail_source: Option<MediaSource>,
@@ -216,7 +216,7 @@ pub enum DependentQueuedRequestKind {
 
         /// Media request necessary to retrieve the file itself (not the
         /// thumbnail).
-        cache_key: MediaRequest,
+        cache_key: MediaRequestParameters,
 
         /// To which media transaction id does this upload relate to?
         related_to: OwnedTransactionId,

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 use matrix_sdk_base::{
-    media::{MediaFormat, MediaRequest},
+    media::{MediaFormat, MediaRequestParameters},
     store::StateStoreExt,
     StateStoreDataKey, StateStoreDataValue,
 };
@@ -217,7 +217,7 @@ impl Account {
     /// ```
     pub async fn get_avatar(&self, format: MediaFormat) -> Result<Option<Vec<u8>>> {
         if let Some(url) = self.get_avatar_url().await? {
-            let request = MediaRequest { source: MediaSource::Plain(url), format };
+            let request = MediaRequestParameters { source: MediaSource::Plain(url), format };
             Ok(Some(self.client.media().get_media_content(&request, true).await?))
         } else {
             Ok(None)

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -296,7 +296,7 @@ impl Media {
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn get_media_file(
         &self,
-        request: &MediaRequest,
+        request: &MediaRequestParameters,
         filename: Option<String>,
         content_type: &Mime,
         use_cache: bool,
@@ -371,7 +371,7 @@ impl Media {
     /// * `use_cache` - If we should use the media cache for this request.
     pub async fn get_media_content(
         &self,
-        request: &MediaRequest,
+        request: &MediaRequestParameters,
         use_cache: bool,
     ) -> Result<Vec<u8>> {
         // Read from the cache.
@@ -489,7 +489,7 @@ impl Media {
     /// # Arguments
     ///
     /// * `request` - The `MediaRequest` of the content.
-    pub async fn remove_media_content(&self, request: &MediaRequest) -> Result<()> {
+    pub async fn remove_media_content(&self, request: &MediaRequestParameters) -> Result<()> {
         Ok(self.client.event_cache_store().remove_media_content(request).await?)
     }
 
@@ -525,7 +525,10 @@ impl Media {
     ) -> Result<Option<Vec<u8>>> {
         let Some(source) = event_content.source() else { return Ok(None) };
         let file = self
-            .get_media_content(&MediaRequest { source, format: MediaFormat::File }, use_cache)
+            .get_media_content(
+                &MediaRequestParameters { source, format: MediaFormat::File },
+                use_cache,
+            )
             .await?;
         Ok(Some(file))
     }
@@ -540,7 +543,11 @@ impl Media {
     /// * `event_content` - The media event content.
     pub async fn remove_file(&self, event_content: &impl MediaEventContent) -> Result<()> {
         if let Some(source) = event_content.source() {
-            self.remove_media_content(&MediaRequest { source, format: MediaFormat::File }).await?;
+            self.remove_media_content(&MediaRequestParameters {
+                source,
+                format: MediaFormat::File,
+            })
+            .await?;
         }
 
         Ok(())
@@ -573,7 +580,7 @@ impl Media {
         let Some(source) = event_content.thumbnail_source() else { return Ok(None) };
         let thumbnail = self
             .get_media_content(
-                &MediaRequest { source, format: MediaFormat::Thumbnail(settings) },
+                &MediaRequestParameters { source, format: MediaFormat::Thumbnail(settings) },
                 use_cache,
             )
             .await?;
@@ -597,7 +604,7 @@ impl Media {
         settings: MediaThumbnailSettings,
     ) -> Result<()> {
         if let Some(source) = event_content.source() {
-            self.remove_media_content(&MediaRequest {
+            self.remove_media_content(&MediaRequestParameters {
                 source,
                 format: MediaFormat::Thumbnail(settings),
             })

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -437,16 +437,17 @@ impl Media {
 
                 content
             }
+
             MediaSource::Plain(uri) => {
                 if let MediaFormat::Thumbnail(settings) = &request.format {
                     if use_auth {
                         let mut request =
                             authenticated_media::get_content_thumbnail::v1::Request::from_uri(
                                 uri,
-                                settings.size.width,
-                                settings.size.height,
+                                settings.width,
+                                settings.height,
                             )?;
-                        request.method = Some(settings.size.method.clone());
+                        request.method = Some(settings.method.clone());
                         request.animated = Some(settings.animated);
 
                         self.client.send(request, request_config).await?.file
@@ -455,10 +456,10 @@ impl Media {
                         let request = {
                             let mut request = media::get_content_thumbnail::v3::Request::from_url(
                                 uri,
-                                settings.size.width,
-                                settings.size.height,
+                                settings.width,
+                                settings.height,
                             )?;
-                            request.method = Some(settings.size.method.clone());
+                            request.method = Some(settings.method.clone());
                             request.animated = Some(settings.animated);
                             request
                         };

--- a/crates/matrix-sdk/src/room/member.rs
+++ b/crates/matrix-sdk/src/room/member.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use ruma::events::room::MediaSource;
 
 use crate::{
-    media::{MediaFormat, MediaRequest},
+    media::{MediaFormat, MediaRequestParameters},
     BaseRoomMember, Client, Result,
 };
 
@@ -61,7 +61,7 @@ impl RoomMember {
     /// ```
     pub async fn avatar(&self, format: MediaFormat) -> Result<Option<Vec<u8>>> {
         let Some(url) = self.avatar_url() else { return Ok(None) };
-        let request = MediaRequest { source: MediaSource::Plain(url.to_owned()), format };
+        let request = MediaRequestParameters { source: MediaSource::Plain(url.to_owned()), format };
         Ok(Some(self.client.media().get_media_content(&request, true).await?))
     }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -132,7 +132,7 @@ use crate::{
     error::{BeaconError, WrongRoomState},
     event_cache::{self, EventCacheDropHandles, RoomEventCache},
     event_handler::{EventHandler, EventHandlerDropGuard, EventHandlerHandle, SyncEvent},
-    media::{MediaFormat, MediaRequest},
+    media::{MediaFormat, MediaRequestParameters},
     notification_settings::{IsEncrypted, IsOneToOne, RoomNotificationMode},
     room::power_levels::{RoomPowerLevelChanges, RoomPowerLevelsExt},
     sync::RoomUpdate,
@@ -264,7 +264,7 @@ impl Room {
     /// ```
     pub async fn avatar(&self, format: MediaFormat) -> Result<Option<Vec<u8>>> {
         let Some(url) = self.avatar_url() else { return Ok(None) };
-        let request = MediaRequest { source: MediaSource::Plain(url.to_owned()), format };
+        let request = MediaRequestParameters { source: MediaSource::Plain(url.to_owned()), format };
         Ok(Some(self.client.media().get_media_content(&request, true).await?))
     }
 
@@ -1994,7 +1994,8 @@ impl Room {
             // properly, so only log errors during caching.
 
             debug!("caching the media");
-            let request = MediaRequest { source: media_source.clone(), format: MediaFormat::File };
+            let request =
+                MediaRequestParameters { source: media_source.clone(), format: MediaFormat::File };
             if let Err(err) = cache_store.add_media_content(&request, data).await {
                 warn!("unable to cache the media after uploading it: {err}");
             }
@@ -2006,7 +2007,7 @@ impl Room {
 
                 // Do a best guess at figuring the media request: not animated, cropped
                 // thumbnail of the original size.
-                let request = MediaRequest {
+                let request = MediaRequestParameters {
                     source: source.clone(),
                     format: MediaFormat::Thumbnail(MediaThumbnailSettings {
                         method: ruma::media::Method::Scale,

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -41,7 +41,7 @@ use matrix_sdk_base::{
     deserialized_responses::{
         RawAnySyncOrStrippedState, RawSyncOrStrippedState, SyncOrStrippedState, TimelineEvent,
     },
-    media::{MediaThumbnailSettings, MediaThumbnailSize},
+    media::MediaThumbnailSettings,
     store::StateStoreExt,
     ComposerDraft, RoomInfoNotableUpdateReasons, RoomMemberships, StateChanges, StateStoreDataKey,
     StateStoreDataValue,
@@ -2009,11 +2009,9 @@ impl Room {
                 let request = MediaRequest {
                     source: source.clone(),
                     format: MediaFormat::Thumbnail(MediaThumbnailSettings {
-                        size: MediaThumbnailSize {
-                            method: ruma::media::Method::Scale,
-                            width,
-                            height,
-                        },
+                        method: ruma::media::Method::Scale,
+                        width,
+                        height,
                         animated: false,
                     }),
                 };

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -140,7 +140,7 @@ use std::{
 use as_variant::as_variant;
 use matrix_sdk_base::{
     event_cache_store::EventCacheStoreError,
-    media::MediaRequest,
+    media::MediaRequestParameters,
     store::{
         ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind,
         FinishUploadThumbnailInfo, QueueWedgeError, QueuedRequest, QueuedRequestKind,
@@ -1034,8 +1034,8 @@ impl QueueStorage {
         content_type: Mime,
         send_event_txn: OwnedTransactionId,
         upload_file_txn: OwnedTransactionId,
-        file_media_request: MediaRequest,
-        thumbnail: Option<(FinishUploadThumbnailInfo, MediaRequest, Mime)>,
+        file_media_request: MediaRequestParameters,
+        thumbnail: Option<(FinishUploadThumbnailInfo, MediaRequestParameters, Mime)>,
     ) -> Result<(), RoomSendQueueStorageError> {
         // Keep the lock until we're done touching the storage.
         // TODO refactor to make the relationship between being_sent and the store more

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -15,7 +15,7 @@
 //! Private implementations of the media upload mechanism.
 
 use matrix_sdk_base::{
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings, MediaThumbnailSize},
+    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
     store::{
         ChildTransactionId, FinishUploadThumbnailInfo, QueuedRequestKind, SentMediaInfo,
         SentRequestKey, SerializableEventContent,
@@ -76,7 +76,9 @@ fn make_local_thumbnail_media_request(
     let source =
         MediaSource::Plain(OwnedMxcUri::from(format!("mxc://send-queue.localhost/{}", txn_id)));
     let format = MediaFormat::Thumbnail(MediaThumbnailSettings {
-        size: MediaThumbnailSize { method: Method::Scale, width, height },
+        method: Method::Scale,
+        width,
+        height,
         animated: false,
     });
     MediaRequest { source, format }

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -1,7 +1,7 @@
 use matrix_sdk::{
     config::RequestConfig,
     matrix_auth::{MatrixSession, MatrixSessionTokens},
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
+    media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings},
     test_utils::logged_in_client_with_server,
     Client, SessionMeta,
 };
@@ -35,7 +35,7 @@ async fn test_get_media_content_no_auth() {
 
     let media = client.media();
 
-    let request = MediaRequest {
+    let request = MediaRequestParameters {
         source: MediaSource::Plain(mxc_uri!("mxc://localhost/textfile").to_owned()),
         format: MediaFormat::File,
     };

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -1,7 +1,7 @@
 use matrix_sdk::{
     config::RequestConfig,
     matrix_auth::{MatrixSession, MatrixSessionTokens},
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings, MediaThumbnailSize},
+    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
     test_utils::logged_in_client_with_server,
     Client, SessionMeta,
 };
@@ -183,7 +183,9 @@ async fn test_get_media_file_no_auth() {
         .await;
 
     let settings = MediaThumbnailSettings {
-        size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
+        method: Method::Crop,
+        width: uint!(100),
+        height: uint!(100),
         animated: true,
     };
     client.media().get_thumbnail(&event_content, settings, true).await.unwrap();
@@ -293,7 +295,9 @@ async fn test_get_media_file_with_auth_matrix_1_11() {
         .await;
 
     let settings = MediaThumbnailSettings {
-        size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
+        method: Method::Crop,
+        width: uint!(100),
+        height: uint!(100),
         animated: true,
     };
     client.media().get_thumbnail(&event_content, settings, true).await.unwrap();
@@ -406,7 +410,9 @@ async fn test_get_media_file_with_auth_matrix_stable_feature() {
         .await;
 
     let settings = MediaThumbnailSettings {
-        size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
+        method: Method::Crop,
+        width: uint!(100),
+        height: uint!(100),
         animated: true,
     };
     client.media().get_thumbnail(&event_content, settings, true).await.unwrap();

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -6,7 +6,7 @@ use matrix_sdk::{
         Thumbnail,
     },
     config::SyncSettings,
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
+    media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings},
     test_utils::logged_in_client_with_server,
 };
 use matrix_sdk_test::{async_test, mocks::mock_encryption_state, test_json, DEFAULT_TEST_ROOM_ID};
@@ -245,8 +245,8 @@ async fn test_room_attachment_send_info_thumbnail() {
 
     // Preconditions: nothing is found in the cache.
     let media_request =
-        MediaRequest { source: MediaSource::Plain(media_mxc), format: MediaFormat::File };
-    let thumbnail_request = MediaRequest {
+        MediaRequestParameters { source: MediaSource::Plain(media_mxc), format: MediaFormat::File };
+    let thumbnail_request = MediaRequestParameters {
         source: MediaSource::Plain(thumbnail_mxc.clone()),
         format: MediaFormat::Thumbnail(MediaThumbnailSettings {
             method: ruma::media::Method::Scale,
@@ -297,7 +297,7 @@ async fn test_room_attachment_send_info_thumbnail() {
     let _ = client
         .media()
         .get_media_content(
-            &MediaRequest {
+            &MediaRequestParameters {
                 source: MediaSource::Plain(thumbnail_mxc.clone()),
                 format: MediaFormat::File,
             },
@@ -307,7 +307,7 @@ async fn test_room_attachment_send_info_thumbnail() {
         .unwrap_err();
 
     // But it is not found when requesting it as a thumbnail with a different size.
-    let thumbnail_request = MediaRequest {
+    let thumbnail_request = MediaRequestParameters {
         source: MediaSource::Plain(thumbnail_mxc),
         format: MediaFormat::Thumbnail(MediaThumbnailSettings {
             method: ruma::media::Method::Scale,

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -6,7 +6,7 @@ use matrix_sdk::{
         Thumbnail,
     },
     config::SyncSettings,
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings, MediaThumbnailSize},
+    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
     test_utils::logged_in_client_with_server,
 };
 use matrix_sdk_test::{async_test, mocks::mock_encryption_state, test_json, DEFAULT_TEST_ROOM_ID};
@@ -249,11 +249,9 @@ async fn test_room_attachment_send_info_thumbnail() {
     let thumbnail_request = MediaRequest {
         source: MediaSource::Plain(thumbnail_mxc.clone()),
         format: MediaFormat::Thumbnail(MediaThumbnailSettings {
-            size: MediaThumbnailSize {
-                method: ruma::media::Method::Scale,
-                width: uint!(480),
-                height: uint!(360),
-            },
+            method: ruma::media::Method::Scale,
+            width: uint!(480),
+            height: uint!(360),
             animated: false,
         }),
     };
@@ -312,11 +310,9 @@ async fn test_room_attachment_send_info_thumbnail() {
     let thumbnail_request = MediaRequest {
         source: MediaSource::Plain(thumbnail_mxc),
         format: MediaFormat::Thumbnail(MediaThumbnailSettings {
-            size: MediaThumbnailSize {
-                method: ruma::media::Method::Scale,
-                width: uint!(42),
-                height: uint!(1337),
-            },
+            method: ruma::media::Method::Scale,
+            width: uint!(42),
+            height: uint!(1337),
             animated: false,
         }),
     };

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -11,7 +11,7 @@ use assert_matches2::{assert_let, assert_matches};
 use matrix_sdk::{
     attachment::{AttachmentConfig, AttachmentInfo, BaseImageInfo, BaseThumbnailInfo, Thumbnail},
     config::{RequestConfig, StoreConfig},
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
+    media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings},
     send_queue::{
         LocalEcho, LocalEchoContent, RoomSendQueueError, RoomSendQueueStorageError,
         RoomSendQueueUpdate,
@@ -2122,7 +2122,10 @@ async fn test_media_uploads() {
     // The media is immediately available from the cache.
     let file_media = client
         .media()
-        .get_media_content(&MediaRequest { source: local_source, format: MediaFormat::File }, true)
+        .get_media_content(
+            &MediaRequestParameters { source: local_source, format: MediaFormat::File },
+            true,
+        )
         .await
         .expect("media should be found");
     assert_eq!(file_media, b"hello world");
@@ -2145,7 +2148,7 @@ async fn test_media_uploads() {
     let thumbnail_media = client
         .media()
         .get_media_content(
-            &MediaRequest {
+            &MediaRequestParameters {
                 source: local_thumbnail_source,
                 // TODO: extract this reasonable query into a helper function shared across the
                 // codebase
@@ -2203,7 +2206,7 @@ async fn test_media_uploads() {
     let file_media = client
         .media()
         .get_media_content(
-            &MediaRequest { source: new_content.source, format: MediaFormat::File },
+            &MediaRequestParameters { source: new_content.source, format: MediaFormat::File },
             true,
         )
         .await
@@ -2217,7 +2220,7 @@ async fn test_media_uploads() {
     let thumbnail_media = client
         .media()
         .get_media_content(
-            &MediaRequest {
+            &MediaRequestParameters {
                 source: new_thumbnail_source,
                 // TODO: extract this reasonable query into a helper function shared across the
                 // codebase

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -11,7 +11,7 @@ use assert_matches2::{assert_let, assert_matches};
 use matrix_sdk::{
     attachment::{AttachmentConfig, AttachmentInfo, BaseImageInfo, BaseThumbnailInfo, Thumbnail},
     config::{RequestConfig, StoreConfig},
-    media::{MediaFormat, MediaRequest, MediaThumbnailSettings, MediaThumbnailSize},
+    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
     send_queue::{
         LocalEcho, LocalEchoContent, RoomSendQueueError, RoomSendQueueStorageError,
         RoomSendQueueUpdate,
@@ -2150,11 +2150,9 @@ async fn test_media_uploads() {
                 // TODO: extract this reasonable query into a helper function shared across the
                 // codebase
                 format: MediaFormat::Thumbnail(MediaThumbnailSettings {
-                    size: MediaThumbnailSize {
-                        height: tinfo.height.unwrap(),
-                        width: tinfo.width.unwrap(),
-                        method: Method::Scale,
-                    },
+                    height: tinfo.height.unwrap(),
+                    width: tinfo.width.unwrap(),
+                    method: Method::Scale,
                     animated: false,
                 }),
             },
@@ -2224,11 +2222,9 @@ async fn test_media_uploads() {
                 // TODO: extract this reasonable query into a helper function shared across the
                 // codebase
                 format: MediaFormat::Thumbnail(MediaThumbnailSettings {
-                    size: MediaThumbnailSize {
-                        height: tinfo.height.unwrap(),
-                        width: tinfo.width.unwrap(),
-                        method: Method::Scale,
-                    },
+                    height: tinfo.height.unwrap(),
+                    width: tinfo.width.unwrap(),
+                    method: Method::Scale,
                     animated: false,
                 }),
             },


### PR DESCRIPTION
As a separate PR to help with review.

It's better to change the structure of the fields before landing the other PR, otherwise we'd need a migration (or at least, to clear the send queue tables) when changing this code.

Part of #1732.