### PR TITLE
refactor!(send queue): move `RoomSendQueue::unwedge` to the `SendHandle` type

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -25,8 +25,7 @@ use ruma::{
         },
         TimelineEventType,
     },
-    EventId, Int, OwnedDeviceId, OwnedTransactionId, OwnedUserId, RoomAliasId, TransactionId,
-    UserId,
+    EventId, Int, OwnedDeviceId, OwnedUserId, RoomAliasId, UserId,
 };
 use tokio::sync::RwLock;
 use tracing::error;
@@ -40,7 +39,7 @@ use crate::{
     room_info::RoomInfo,
     room_member::RoomMember,
     ruma::{ImageInfo, Mentions, NotifyType},
-    timeline::{FocusEventError, ReceiptType, Timeline},
+    timeline::{FocusEventError, ReceiptType, SendHandle, Timeline},
     utils::u64_to_uint,
     TaskHandle,
 };
@@ -790,10 +789,8 @@ impl Room {
     pub async fn withdraw_verification_and_resend(
         &self,
         user_ids: Vec<String>,
-        transaction_id: String,
+        send_handle: Arc<SendHandle>,
     ) -> Result<(), ClientError> {
-        let transaction_id: OwnedTransactionId = transaction_id.into();
-
         let user_ids: Vec<OwnedUserId> =
             user_ids.iter().map(UserId::parse).collect::<Result<_, _>>()?;
 
@@ -805,7 +802,7 @@ impl Room {
             }
         }
 
-        self.inner.send_queue().unwedge(&transaction_id).await?;
+        send_handle.try_resend().await?;
 
         Ok(())
     }
@@ -823,10 +820,8 @@ impl Room {
     pub async fn ignore_device_trust_and_resend(
         &self,
         devices: HashMap<String, Vec<String>>,
-        transaction_id: String,
+        send_handle: Arc<SendHandle>,
     ) -> Result<(), ClientError> {
-        let transaction_id: OwnedTransactionId = transaction_id.into();
-
         let encryption = self.inner.client().encryption();
 
         for (user_id, device_ids) in devices.iter() {
@@ -841,26 +836,8 @@ impl Room {
             }
         }
 
-        self.inner.send_queue().unwedge(&transaction_id).await?;
+        send_handle.try_resend().await?;
 
-        Ok(())
-    }
-
-    /// Attempt to manually resend messages that failed to send due to issues
-    /// that should now have been fixed.
-    ///
-    /// This is useful for example, when there's a
-    /// `SessionRecipientCollectionError::VerifiedUserChangedIdentity` error;
-    /// the user may have re-verified on a different device and would now
-    /// like to send the failed message that's waiting on this device.
-    ///
-    /// # Arguments
-    ///
-    /// * `transaction_id` - The send queue transaction identifier of the local
-    ///   echo that should be unwedged.
-    pub async fn try_resend(&self, transaction_id: String) -> Result<(), ClientError> {
-        let transaction_id: &TransactionId = transaction_id.as_str().into();
-        self.inner.send_queue().unwedge(transaction_id).await?;
         Ok(())
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -270,7 +270,7 @@ impl Timeline {
         msg: Arc<RoomMessageEventContentWithoutRelation>,
     ) -> Result<Arc<SendHandle>, ClientError> {
         match self.inner.send((*msg).to_owned().with_relation(None).into()).await {
-            Ok(handle) => Ok(Arc::new(SendHandle { inner: Mutex::new(Some(handle)) })),
+            Ok(handle) => Ok(Arc::new(SendHandle::new(handle))),
             Err(err) => {
                 error!("error when sending a message: {err}");
                 Err(anyhow::anyhow!(err).into())
@@ -710,9 +710,16 @@ impl Timeline {
     }
 }
 
+/// A handle to perform actions onto a local echo.
 #[derive(uniffi::Object)]
 pub struct SendHandle {
     inner: Mutex<Option<matrix_sdk::send_queue::SendHandle>>,
+}
+
+impl SendHandle {
+    fn new(handle: matrix_sdk::send_queue::SendHandle) -> Self {
+        Self { inner: Mutex::new(Some(handle)) }
+    }
 }
 
 #[matrix_sdk_ffi_macros::export]
@@ -732,9 +739,31 @@ impl SendHandle {
                 .await
                 .map_err(|err| anyhow::anyhow!("error when saving in store: {err}"))?)
         } else {
-            warn!("trying to abort an send handle that's already been actioned");
+            warn!("trying to abort a send handle that's already been actioned");
             Ok(false)
         }
+    }
+
+    /// Attempt to manually resend messages that failed to send due to issues
+    /// that should now have been fixed.
+    ///
+    /// This is useful for example, when there's a
+    /// `SessionRecipientCollectionError::VerifiedUserChangedIdentity` error;
+    /// the user may have re-verified on a different device and would now
+    /// like to send the failed message that's waiting on this device.
+    ///
+    /// # Arguments
+    ///
+    /// * `transaction_id` - The send queue transaction identifier of the local
+    ///   echo that should be unwedged.
+    pub async fn try_resend(self: Arc<Self>) -> Result<(), ClientError> {
+        let locked = self.inner.lock().await;
+        if let Some(handle) = locked.as_ref() {
+            handle.unwedge().await?;
+        } else {
+            warn!("trying to unwedge a send handle that's been aborted");
+        }
+        Ok(())
     }
 }
 
@@ -1272,5 +1301,11 @@ impl LazyTimelineItemProvider {
             original_json: self.0.original_json().map(|raw| raw.json().get().to_owned()),
             latest_edit_json: self.0.latest_edit_json().map(|raw| raw.json().get().to_owned()),
         }
+    }
+
+    /// For local echoes, return the associated send handle; returns `None` for
+    /// remote echoes.
+    fn get_send_handle(&self) -> Option<Arc<SendHandle>> {
+        self.0.local_echo_send_handle().map(|handle| Arc::new(SendHandle::new(handle)))
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -570,6 +570,11 @@ impl EventTimelineItem {
             EventTimelineItemKind::Remote(remote) => TimelineItemHandle::Remote(&remote.event_id),
         }
     }
+
+    /// For local echoes, return the associated send handle.
+    pub fn local_echo_send_handle(&self) -> Option<SendHandle> {
+        as_variant!(self.handle(), TimelineItemHandle::Local(handle) => handle.clone())
+    }
 }
 
 impl From<LocalEventTimelineItem> for EventTimelineItemKind {

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1674,7 +1674,8 @@ async fn test_unwedge_unrecoverable_errors() {
         .await;
 
     // Queue the unrecoverable message.
-    q.send(RoomMessageEventContent::text_plain("i'm too big for ya").into()).await.unwrap();
+    let send_handle =
+        q.send(RoomMessageEventContent::text_plain("i'm too big for ya").into()).await.unwrap();
 
     // Message is seen as a local echo.
     let (txn1, _) = assert_update!(watch => local echo { body = "i'm too big for ya" });
@@ -1694,7 +1695,7 @@ async fn test_unwedge_unrecoverable_errors() {
     assert!(client.send_queue().is_enabled());
 
     // Unwedge the previously failed message and try sending it again
-    q.unwedge(&txn1).await.unwrap();
+    send_handle.unwedge().await.unwrap();
 
     // The message should be retried
     assert_update!(watch => retry { txn=txn1 });


### PR DESCRIPTION
This better encapsulates the transaction id of the send handle. Also introduced a FFI method to retrieve the `SendHandle` of a timeline local echo.

Let's see how hard it becomes in practice for EX apps, cc @jmartinesp @stefanceriu.