### PR TITLE
Accept any string as a key for `m.direct` account data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3755,7 +3755,7 @@ version = "5.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d385da3c602d29036d2f70beed71c36604df7570be17fed4c5b839616785bf"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom",
  "http",
@@ -4753,8 +4753,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94984418ae8a5e1160e6c87608141330e9ae26330abf22e3d15416efa96d48a"
+source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
 dependencies = [
  "assign",
  "js_int",
@@ -4771,8 +4770,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325e054db8d5545c00767d9868356d61e63f2c6cb8b54768346d66696ea4ad48"
+source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
 dependencies = [
  "as_variant",
  "assign",
@@ -4787,7 +4785,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
- "thiserror 1.0.63",
+ "thiserror 2.0.3",
  "url",
  "web-time",
 ]
@@ -4795,8 +4793,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad71c7f49abaa047ba228339d34f9aaefa4d8b50ebeb8e859d0340cc2138bda8"
+source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -4816,7 +4813,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
- "thiserror 1.0.63",
+ "thiserror 2.0.3",
  "time",
  "tracing",
  "url",
@@ -4828,8 +4825,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be86dccf3504588c1f4dc1bda4ce1f8bbd646fc6dda40c77cc7de6e203e62dad"
+source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
 dependencies = [
  "as_variant",
  "indexmap 2.6.0",
@@ -4844,7 +4840,7 @@ dependencies = [
  "ruma-macros",
  "serde",
  "serde_json",
- "thiserror 1.0.63",
+ "thiserror 2.0.3",
  "tracing",
  "url",
  "web-time",
@@ -4854,8 +4850,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5a09ac22b3352bf7a350514dc9a87e1b56aba04c326ac9ce142740f7218afa"
+source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
 dependencies = [
  "http",
  "js_int",
@@ -4869,8 +4864,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7571886b6df90a4ed72e7481a5a39cc2a5b3a4e956e9366ad798e4e2e9fe8005"
+source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4882,18 +4876,16 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7f9b534a65698d7db3c08d94bf91de0046fe6c7893a7b360502f65e7011ac4"
+source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
 dependencies = [
  "js_int",
- "thiserror 1.0.63",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "ruma-macros"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d57d3cb20e8e758e8f7c5e408ce831d46758003b615100099852e468631934"
+source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4909,8 +4901,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfced466fbed6277f74ac3887eeb96c185a09f4323dc3c39bcea04870430fe9a"
+source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ proptest = { version = "1.5.0", default-features = false, features = ["std"] }
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
 rmp-serde = "1.3.0"
-ruma = { version = "0.11.1", features = [
+ruma = { git = "https://github.com/ruma/ruma.git", rev = "35fda7f2f7811156df2e60b223dbf136fc143bc8", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -70,7 +70,7 @@ ruma = { version = "0.11.1", features = [
     "unstable-msc4075",
     "unstable-msc4140",
 ] }
-ruma-common = "0.14.1"
+ruma-common = { git = "https://github.com/ruma/ruma.git", rev = "35fda7f2f7811156df2e60b223dbf136fc143bc8" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/crates/matrix-sdk-base/src/response_processors.rs
+++ b/crates/matrix-sdk-base/src/response_processors.rs
@@ -18,9 +18,11 @@ use std::{
 };
 
 use ruma::{
-    events::{AnyGlobalAccountDataEvent, GlobalAccountDataEventType},
+    events::{
+        direct::OwnedDirectUserIdentifier, AnyGlobalAccountDataEvent, GlobalAccountDataEventType,
+    },
     serde::Raw,
-    OwnedUserId, RoomId,
+    RoomId,
 };
 use tracing::{debug, instrument, trace, warn};
 
@@ -94,10 +96,10 @@ impl AccountDataProcessor {
         for event in events {
             let AnyGlobalAccountDataEvent::Direct(direct_event) = event else { continue };
 
-            let mut new_dms = HashMap::<&RoomId, HashSet<OwnedUserId>>::new();
-            for (user_id, rooms) in direct_event.content.iter() {
+            let mut new_dms = HashMap::<&RoomId, HashSet<OwnedDirectUserIdentifier>>::new();
+            for (user_identifier, rooms) in direct_event.content.iter() {
                 for room_id in rooms {
-                    new_dms.entry(room_id).or_default().insert(user_id.clone());
+                    new_dms.entry(room_id).or_default().insert(user_identifier.clone());
                 }
             }
 

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -22,6 +22,7 @@ use ruma::{
     events::{
         beacon_info::BeaconInfoEventContent,
         call::member::{CallMemberEventContent, CallMemberStateKey},
+        direct::OwnedDirectUserIdentifier,
         macros::EventContent,
         room::{
             avatar::RoomAvatarEventContent,
@@ -128,7 +129,7 @@ pub struct BaseRoomInfo {
     pub(crate) create: Option<MinimalStateEvent<RoomCreateWithCreatorEventContent>>,
     /// A list of user ids this room is considered as direct message, if this
     /// room is a DM.
-    pub(crate) dm_targets: HashSet<OwnedUserId>,
+    pub(crate) dm_targets: HashSet<OwnedDirectUserIdentifier>,
     /// The `m.room.encryption` event content that enabled E2EE in this room.
     pub(crate) encryption: Option<RoomEncryptionEventContent>,
     /// The guest access policy of this room.

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -33,6 +33,7 @@ use ruma::{
     api::client::sync::sync_events::v3::RoomSummary as RumaSummary,
     events::{
         call::member::{CallMemberStateKey, MembershipData},
+        direct::OwnedDirectUserIdentifier,
         ignored_user_list::IgnoredUserListEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::{
@@ -460,7 +461,7 @@ impl Room {
     /// only be considered as guidance. We leave members in this list to allow
     /// us to re-find a DM with a user even if they have left, since we may
     /// want to re-invite them.
-    pub fn direct_targets(&self) -> HashSet<OwnedUserId> {
+    pub fn direct_targets(&self) -> HashSet<OwnedDirectUserIdentifier> {
         self.inner.read().base_info.dm_targets.clone()
     }
 

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -23,6 +23,7 @@ use std::{
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
 use ruma::{
     events::{
+        direct::OwnedDirectUserIdentifier,
         room::{
             avatar::RoomAvatarEventContent,
             canonical_alias::RoomCanonicalAliasEventContent,
@@ -37,7 +38,7 @@ use ruma::{
         },
         EmptyStateKey, EventContent, RedactContent, StateEventContent, StateEventType,
     },
-    OwnedRoomId, OwnedUserId, RoomId,
+    OwnedRoomId, RoomId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -155,7 +156,7 @@ fn encryption_state_default() -> bool {
 struct BaseRoomInfoV1 {
     avatar: Option<MinimalStateEvent<RoomAvatarEventContent>>,
     canonical_alias: Option<MinimalStateEvent<RoomCanonicalAliasEventContent>>,
-    dm_targets: HashSet<OwnedUserId>,
+    dm_targets: HashSet<OwnedDirectUserIdentifier>,
     encryption: Option<RoomEncryptionEventContent>,
     guest_access: Option<MinimalStateEvent<RoomGuestAccessEventContent>>,
     history_visibility: Option<MinimalStateEvent<RoomHistoryVisibilityEventContent>>,

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -201,9 +201,9 @@ impl BaseRoomInfoV1 {
             MinimalStateEvent::Redacted(ev) => MinimalStateEvent::Redacted(ev),
         });
 
-        let mut dm_targets_converted = HashSet::new();
+        let mut converted_dm_targets = HashSet::new();
         for dm_target in dm_targets {
-            dm_targets_converted.insert(OwnedDirectUserIdentifier::from(dm_target));
+            converted_dm_targets.insert(OwnedDirectUserIdentifier::from(dm_target));
         }
 
         Box::new(BaseRoomInfo {

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -211,7 +211,7 @@ impl BaseRoomInfoV1 {
             beacons: BTreeMap::new(),
             canonical_alias,
             create,
-            dm_targets: dm_targets_converted,
+            dm_targets: converted_dm_targets,
             encryption,
             guest_access,
             history_visibility,

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -38,7 +38,7 @@ use ruma::{
         },
         EmptyStateKey, EventContent, RedactContent, StateEventContent, StateEventType,
     },
-    OwnedRoomId, RoomId,
+    OwnedRoomId, OwnedUserId, RoomId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -156,7 +156,7 @@ fn encryption_state_default() -> bool {
 struct BaseRoomInfoV1 {
     avatar: Option<MinimalStateEvent<RoomAvatarEventContent>>,
     canonical_alias: Option<MinimalStateEvent<RoomCanonicalAliasEventContent>>,
-    dm_targets: HashSet<OwnedDirectUserIdentifier>,
+    dm_targets: HashSet<OwnedUserId>,
     encryption: Option<RoomEncryptionEventContent>,
     guest_access: Option<MinimalStateEvent<RoomGuestAccessEventContent>>,
     history_visibility: Option<MinimalStateEvent<RoomHistoryVisibilityEventContent>>,
@@ -201,12 +201,17 @@ impl BaseRoomInfoV1 {
             MinimalStateEvent::Redacted(ev) => MinimalStateEvent::Redacted(ev),
         });
 
+        let mut dm_targets_converted = HashSet::new();
+        for dm_target in dm_targets {
+            dm_targets_converted.insert(OwnedDirectUserIdentifier::from(dm_target));
+        }
+
         Box::new(BaseRoomInfo {
             avatar,
             beacons: BTreeMap::new(),
             canonical_alias,
             create,
-            dm_targets,
+            dm_targets: dm_targets_converted,
             encryption,
             guest_access,
             history_visibility,

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -861,7 +861,7 @@ impl Account {
         };
 
         for user_id in user_ids {
-            content.entry(user_id.to_owned()).or_default().push(room_id.to_owned());
+            content.entry(user_id.into()).or_default().push(room_id.to_owned());
         }
 
         // TODO: We should probably save the fact that we need to send this out

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -50,7 +50,10 @@ use ruma::{
         uiaa::{AuthData, UiaaInfo},
     },
     assign,
-    events::room::{MediaSource, ThumbnailInfo},
+    events::{
+        direct::DirectUserIdentifier,
+        room::{MediaSource, ThumbnailInfo},
+    },
     DeviceId, OwnedDeviceId, OwnedUserId, TransactionId, UserId,
 };
 use serde::Deserialize;
@@ -605,7 +608,7 @@ impl Client {
         // Find the room we share with the `user_id` and only with `user_id`
         let room = rooms.into_iter().find(|r| {
             let targets = r.direct_targets();
-            targets.len() == 1 && targets.contains(user_id)
+            targets.len() == 1 && targets.contains(<&DirectUserIdentifier>::from(user_id))
         });
 
         trace!(?room, "Found room");

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1224,7 +1224,7 @@ impl Room {
             room_members.retain(|member| member.user_id() != self.own_user_id());
 
             for member in room_members {
-                let entry = content.entry(member.user_id().to_owned()).or_default();
+                let entry = content.entry(member.user_id().into()).or_default();
                 if !entry.iter().any(|room_id| room_id == this_room_id) {
                     entry.push(this_room_id.to_owned());
                 }

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -35,7 +35,10 @@ use ruma::{
     assign, device_id,
     directory::Filter,
     event_id,
-    events::{direct::DirectEventContent, AnyInitialStateEvent},
+    events::{
+        direct::{DirectEventContent, OwnedDirectUserIdentifier},
+        AnyInitialStateEvent,
+    },
     room_id,
     serde::Raw,
     user_id, OwnedUserId,
@@ -496,7 +499,9 @@ async fn test_marking_room_as_dm() {
             "The body of the PUT /account_data request should be a valid DirectEventContent",
         );
 
-        let bob_entry = content.get(bob).expect("We should have bob in the direct event content");
+        let bob_entry = content
+            .get(&OwnedDirectUserIdentifier::from(bob.to_owned()))
+            .expect("We should have bob in the direct event content");
 
         assert_eq!(content.len(), 2, "We should have entries for bob and foo");
         assert_eq!(bob_entry.len(), 3, "Bob should have 3 direct rooms");

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -11,6 +11,7 @@ use matrix_sdk_test::{
 use ruma::{
     event_id,
     events::{
+        direct::DirectUserIdentifier,
         room::{
             avatar::{self, RoomAvatarEventContent},
             member::MembershipState,
@@ -830,7 +831,7 @@ async fn test_is_direct() {
     // The room is direct now.
     let direct_targets = room.direct_targets();
     assert_eq!(direct_targets.len(), 1);
-    assert!(direct_targets.contains(*BOB));
+    assert!(direct_targets.contains(<&DirectUserIdentifier>::from(*BOB)));
     assert!(room.is_direct().await.unwrap());
 
     // Unset the room as direct.

--- a/crates/matrix-sdk/tests/integration/room/left.rs
+++ b/crates/matrix-sdk/tests/integration/room/left.rs
@@ -7,7 +7,10 @@ use matrix_sdk_test::{
     async_test, test_json, GlobalAccountDataTestEvent, LeftRoomBuilder, SyncResponseBuilder,
     DEFAULT_TEST_ROOM_ID,
 };
-use ruma::{events::direct::DirectEventContent, user_id, OwnedRoomOrAliasId};
+use ruma::{
+    events::direct::{DirectEventContent, DirectUserIdentifier},
+    user_id, OwnedRoomOrAliasId,
+};
 use serde_json::json;
 use wiremock::{
     matchers::{header, method, path, path_regex},
@@ -70,7 +73,7 @@ async fn test_forget_direct_room() {
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
     assert_eq!(room.state(), RoomState::Left);
     assert!(room.is_direct().await.unwrap());
-    assert!(room.direct_targets().contains(invited_user_id));
+    assert!(room.direct_targets().contains(<&DirectUserIdentifier>::from(invited_user_id)));
 
     let direct_account_data = client
         .account()
@@ -80,7 +83,10 @@ async fn test_forget_direct_room() {
         .expect("no m.direct account data")
         .deserialize()
         .expect("failed to deserialize m.direct account data");
-    assert_matches!(direct_account_data.get(invited_user_id), Some(invited_user_dms));
+    assert_matches!(
+        direct_account_data.get(<&DirectUserIdentifier>::from(invited_user_id)),
+        Some(invited_user_dms)
+    );
     assert_eq!(invited_user_dms, &[DEFAULT_TEST_ROOM_ID.to_owned()]);
 
     Mock::given(method("POST"))


### PR DESCRIPTION
This is the follow up of this [Ruma PR](https://github.com/ruma/ruma/pull/1946) for the SDK.

Ruma PR needs to be merged first.