### PR TITLE
feat(send queue): retry uploads

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -703,7 +703,7 @@ impl Client {
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Result<String, ClientError> {
         let mime_type: mime::Mime = mime_type.parse().context("Parsing mime type")?;
-        let request = self.inner.media().upload(&mime_type, data);
+        let request = self.inner.media().upload(&mime_type, data, None);
 
         if let Some(progress_watcher) = progress_watcher {
             let mut subscriber = request.subscribe_to_send_progress();

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -252,7 +252,7 @@ impl Account {
     ///
     /// [`Media::upload()`]: crate::Media::upload
     pub async fn upload_avatar(&self, content_type: &Mime, data: Vec<u8>) -> Result<OwnedMxcUri> {
-        let upload_response = self.client.media().upload(content_type, data).await?;
+        let upload_response = self.client.media().upload(content_type, data, None).await?;
         self.set_avatar_url(Some(&upload_response.content_uri)).await?;
         Ok(upload_response.content_uri)
     }

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -40,7 +40,8 @@ use tempfile::{Builder as TempFileBuilder, NamedTempFile, TempDir};
 use tokio::{fs::File as TokioFile, io::AsyncWriteExt};
 
 use crate::{
-    attachment::Thumbnail, futures::SendRequest, Client, Error, Result, TransmissionProgress,
+    attachment::Thumbnail, config::RequestConfig, futures::SendRequest, Client, Error, Result,
+    TransmissionProgress,
 };
 
 /// A conservative upload speed of 1Mbps
@@ -144,8 +145,11 @@ impl Media {
     /// * `content_type` - The type of the media, this will be used as the
     ///   content-type header.
     ///
-    /// * `reader` - A `Reader` that will be used to fetch the raw bytes of the
-    ///   media.
+    /// * `data` - Vector of bytes to be uploaded to the server.
+    ///
+    /// * `request_config` - Optional request configuration for the HTTP client,
+    ///   overriding the default. If not provided, a reasonable timeout value is
+    ///   inferred.
     ///
     /// # Examples
     ///
@@ -159,23 +163,36 @@ impl Media {
     /// # let mut client = Client::new(homeserver).await?;
     /// let image = fs::read("/home/example/my-cat.jpg")?;
     ///
-    /// let response = client.media().upload(&mime::IMAGE_JPEG, image).await?;
+    /// let response =
+    ///     client.media().upload(&mime::IMAGE_JPEG, image, None).await?;
     ///
     /// println!("Cat URI: {}", response.content_uri);
     /// # anyhow::Ok(()) };
     /// ```
-    pub fn upload(&self, content_type: &Mime, data: Vec<u8>) -> SendUploadRequest {
-        let timeout = std::cmp::max(
-            Duration::from_secs(data.len() as u64 / DEFAULT_UPLOAD_SPEED),
-            MIN_UPLOAD_REQUEST_TIMEOUT,
-        );
+    pub fn upload(
+        &self,
+        content_type: &Mime,
+        data: Vec<u8>,
+        request_config: Option<RequestConfig>,
+    ) -> SendUploadRequest {
+        let request_config = request_config.unwrap_or_else(|| {
+            self.client.request_config().timeout(Self::reasonable_upload_timeout(&data))
+        });
 
         let request = assign!(media::create_content::v3::Request::new(data), {
             content_type: Some(content_type.essence_str().to_owned()),
         });
 
-        let request_config = self.client.request_config().timeout(timeout);
         self.client.send(request, Some(request_config))
+    }
+
+    /// Returns a reasonable upload timeout for an upload, based on the size of
+    /// the data to be uploaded.
+    pub(crate) fn reasonable_upload_timeout(data: &[u8]) -> Duration {
+        std::cmp::max(
+            Duration::from_secs(data.len() as u64 / DEFAULT_UPLOAD_SPEED),
+            MIN_UPLOAD_REQUEST_TIMEOUT,
+        )
     }
 
     /// Preallocates an MXC URI for a media that will be uploaded soon.
@@ -630,7 +647,7 @@ impl Media {
         let upload_thumbnail = self.upload_thumbnail(thumbnail, send_progress.clone());
 
         let upload_attachment = async move {
-            self.upload(content_type, data)
+            self.upload(content_type, data, None)
                 .with_send_progress_observable(send_progress)
                 .await
                 .map_err(Error::from)
@@ -653,7 +670,7 @@ impl Media {
         };
 
         let response = self
-            .upload(&thumbnail.content_type, thumbnail.data)
+            .upload(&thumbnail.content_type, thumbnail.data, None)
             .with_send_progress_observable(send_progress)
             .await?;
         let url = response.content_uri;

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2263,7 +2263,7 @@ impl Room {
     ) -> Result<send_state_event::v3::Response> {
         self.ensure_room_joined()?;
 
-        let upload_response = self.client.media().upload(mime, data).await?;
+        let upload_response = self.client.media().upload(mime, data, None).await?;
         let mut info = info.unwrap_or_default();
         info.blurhash = upload_response.blurhash;
         info.mimetype = Some(mime.to_string());

--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -293,6 +293,13 @@ impl<'a> MatrixMock<'a> {
         Self { mock: self.mock.up_to_n_times(1).expect(1), ..self }
     }
 
+    /// Specify an upper limit to the number of times you would like this
+    /// [`MatrixMock`] to respond to incoming requests that satisfy the
+    /// conditions imposed by your matchers.
+    pub fn up_to_n_times(self, num: u64) -> Self {
+        Self { mock: self.mock.up_to_n_times(num), ..self }
+    }
+
     /// Mount a [`MatrixMock`] on the attached server.
     ///
     /// The [`MatrixMock`] will remain active until the [`MatrixMockServer`] is
@@ -515,6 +522,13 @@ impl<'a> MockUpload<'a> {
         let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "content_uri": mxc_id
         })));
+        MatrixMock { server: self.server, mock }
+    }
+
+    /// Returns a send endpoint that emulates a transient failure, i.e responds
+    /// with error 500.
+    pub fn error500(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(500));
         MatrixMock { server: self.server, mock }
     }
 

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1932,3 +1932,91 @@ async fn test_media_uploads() {
     // That's all, folks!
     assert!(watch.is_empty());
 }
+
+#[async_test]
+async fn test_media_upload_retry() {
+    let mock = MatrixMockServer::new().await;
+
+    // Mark the room as joined.
+    let room_id = room_id!("!a:b.c");
+    let client = mock.make_client().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
+
+    let q = room.send_queue();
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
+    assert!(local_echoes.is_empty());
+
+    // Create the media to send (no thumbnails).
+    let filename = "surprise.jpeg.exe";
+    let content_type = mime::IMAGE_JPEG;
+    let data = b"hello world".to_vec();
+
+    let config = AttachmentConfig::new().info(AttachmentInfo::Image(BaseImageInfo {
+        height: Some(uint!(13)),
+        width: Some(uint!(37)),
+        size: Some(uint!(42)),
+        blurhash: None,
+    }));
+
+    // Prepare endpoints.
+    mock.mock_room_state_encryption().plain().mount().await;
+
+    // Fail for the first three attempts.
+    mock.mock_upload()
+        .expect_mime_type("image/jpeg")
+        .error500()
+        .up_to_n_times(3)
+        .expect(3)
+        .mount()
+        .await;
+
+    // Send the media.
+    assert!(watch.is_empty());
+    q.send_attachment(filename, content_type, data, config)
+        .await
+        .expect("queuing the attachment works");
+
+    // Observe the local echo.
+    let (event_txn, _send_handle, content) = assert_update!(watch => local echo event);
+    assert_let!(MessageType::Image(img_content) = content.msgtype);
+    assert_eq!(img_content.body, filename);
+
+    // Let the upload stumble and the queue disable itself.
+    let error = assert_update!(watch => error { recoverable=true, txn=event_txn });
+    let error = error.as_client_api_error().unwrap();
+    assert_eq!(error.status_code, 500);
+    assert!(q.is_enabled().not());
+
+    // Mount the mock for the upload and sending the event.
+    mock.mock_upload()
+        .expect_mime_type("image/jpeg")
+        .ok(mxc_uri!("mxc://sdk.rs/media"))
+        .mock_once()
+        .mount()
+        .await;
+    mock.mock_room_send().ok(event_id!("$1")).mock_once().mount().await;
+
+    // Restart the send queue.
+    q.set_enabled(true);
+
+    assert_update!(watch => uploaded {
+        related_to = event_txn,
+        mxc = mxc_uri!("mxc://sdk.rs/media")
+    });
+
+    let edit_msg = assert_update!(watch => edit local echo {
+        txn = event_txn
+    });
+    assert_let!(MessageType::Image(new_content) = edit_msg.msgtype);
+    assert_let!(MediaSource::Plain(new_uri) = &new_content.source);
+    assert_eq!(new_uri, mxc_uri!("mxc://sdk.rs/media"));
+
+    // The event is sent, at some point.
+    assert_update!(watch => sent {
+        txn = event_txn,
+        event_id = event_id!("$1")
+    });
+
+    // That's all, folks!
+    assert!(watch.is_empty());
+}


### PR DESCRIPTION
A small foresight from the initial PR: 

- make it possible to define a `RequestConfig` for upload, plain or encrypted
- use that to request a short retry of uploads, in the send queue

Part of #1732.