### PR TITLE
refactor(ffi): Make `is_room_alias_format_valid` stricter

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_alias.rs
+++ b/bindings/matrix-sdk-ffi/src/room_alias.rs
@@ -1,10 +1,13 @@
 use matrix_sdk::RoomDisplayName;
-use ruma::RoomAliasId;
 
-/// Verifies the passed `String` matches the expected room alias format.
+/// Verifies the passed `String` matches the expected room alias format:
+///
+/// This means it's lowercase, with no whitespace chars, has a single leading
+/// `#` char and a single `:` separator between the local and domain parts, and
+/// the local part only contains characters that can't be percent encoded.
 #[matrix_sdk_ffi_macros::export]
 fn is_room_alias_format_valid(alias: String) -> bool {
-    RoomAliasId::parse(alias).is_ok()
+    matrix_sdk::utils::is_room_alias_format_valid(alias)
 }
 
 /// Transforms a Room's display name into a valid room alias name.

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -66,7 +66,7 @@ pub enum RoomDisplayName {
 }
 
 const WHITESPACE_REGEX: &str = r"\s+";
-const INVALID_SYMBOLS_REGEX: &str = r"[#,:]+";
+const INVALID_SYMBOLS_REGEX: &str = r"[#,:\{\}\\]+";
 
 impl RoomDisplayName {
     /// Transforms the current display name into the name part of a
@@ -636,7 +636,7 @@ mod tests {
     fn test_room_alias_from_room_display_name_removes_invalid_ascii_symbols() {
         assert_eq!(
             "roomalias",
-            RoomDisplayName::Named("#Room,Alias:".to_owned()).to_room_alias_name()
+            RoomDisplayName::Named("#Room,{Alias}:".to_owned()).to_room_alias_name()
         );
     }
 }

--- a/crates/matrix-sdk/src/utils.rs
+++ b/crates/matrix-sdk/src/utils.rs
@@ -191,7 +191,7 @@ impl IntoRawStateEventContent for &Box<RawJsonValue> {
     }
 }
 
-const INVALID_ROOM_ALIAS_NAME_CHARS: &str = "#,:";
+const INVALID_ROOM_ALIAS_NAME_CHARS: &str = "#,:{}\\";
 
 /// Verifies the passed `String` matches the expected room alias format:
 ///
@@ -265,7 +265,7 @@ mod test {
 
     #[test]
     fn test_is_room_alias_format_valid_when_name_part_has_invalid_char_is_not_valid() {
-        assert!(!is_room_alias_format_valid("#alias,test:domain.org".to_owned()))
+        assert!(!is_room_alias_format_valid("#a#lias,{t\\est}:domain.org".to_owned()))
     }
 
     #[test]


### PR DESCRIPTION
Previously this only used the Ruma checks, which only handled the initial `#` char and the domain part. With these changes, the name part is also validated, checking it's lowercase, with no whitespaces and containing only allowed chars, similar to what `DisplayName::to_room_alias_name` does.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
