### PR TITLE
tests: Refactor the widget tests to use `MockMatrixServer`

### DIFF
--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -354,15 +354,13 @@ impl MatrixMockServer {
     ///     .mount()
     ///     .await;
     ///
-    /// let responseNotMocked = room.send_raw("m.room.reaction", json!({ "body": "Hello world" })).await?;
+    /// let responseNotMocked = room.send_raw("m.room.reaction", json!({ "body": "Hello world" })).await;
+    /// // The `m.room.reaction` event type should not be mocked by the server.
+    /// assert!(responseNotMocked.is_err());
     ///
-    /// assert!(
-    ///     responseNotMocked,
-    ///     "The event ID we mocked should match the one we received when we sent the event"
-    /// );
     ///
     /// let response = room.send_raw("m.room.message", json!({ "body": "Hello world" })).await?;
-    ///
+    /// // The `m.room.message` event type should be mocked by the server.
     /// assert_eq!(
     ///     event_id,
     ///     response.event_id,

--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -874,8 +874,6 @@ impl<'a> MockEndpoint<'a, RoomSendEndpoint> {
 
     /// Ensures that the send endpoint request uses a specific event type.
     ///
-    /// Note: works with *any* room.
-    ///
     /// # Examples
     ///
     /// see also [`MatrixMockServer::mock_room_send`] for more context.
@@ -906,7 +904,6 @@ impl<'a> MockEndpoint<'a, RoomSendEndpoint> {
     /// let responseNotMocked = room.send_raw("m.room.reaction", json!({ "body": "Hello world" })).await;
     /// // The `m.room.reaction` event type should not be mocked by the server.
     /// assert!(responseNotMocked.is_err());
-    ///
     ///
     /// let response = room.send_raw("m.room.message", json!({ "body": "Hello world" })).await?;
     /// // The `m.room.message` event type should be mocked by the server.
@@ -977,10 +974,11 @@ impl<'a> MockEndpoint<'a, RoomSendStateEndpoint> {
     fn generate_path_regex(endpoint: &RoomSendStateEndpoint) -> String {
         format!(
             r"^/_matrix/client/v3/rooms/.*/state/{}/{}",
-            endpoint.event_type.as_ref().map(|t| t.to_string()).unwrap_or(".*".to_owned()),
-            endpoint.state_key.as_ref().map(|k| k.to_string()).unwrap_or(".*".to_owned())
+            endpoint.event_type.as_ref().map(|t| t.to_string()).unwrap_or_else(|| ".*".to_owned()),
+            endpoint.state_key.as_ref().map(|k| k.to_string()).unwrap_or_else(|| ".*".to_owned())
         )
     }
+
     /// Ensures that the body of the request is a superset of the provided
     /// `body` parameter.
     ///

--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -954,7 +954,7 @@ impl<'a> MockEndpoint<'a, RoomSendEndpoint> {
             .endpoint
             .event_type
             .as_ref()
-            .map_or_else(|| "*".to_owned(), |event_type| event_type.to_string());
+            .map_or_else(|| ".*".to_owned(), |event_type| event_type.to_string());
 
         self.mock = self
             .mock
@@ -1369,7 +1369,7 @@ pub struct RoomMessagesEndpoint;
 
 /// A prebuilt mock for getting a room messages in a room.
 impl<'a> MockEndpoint<'a, RoomMessagesEndpoint> {
-    /// Expects an optional limit to be set on the mock.
+    /// Expects an optional limit to be set on the request.
     pub fn limit(self, limit: u32) -> Self {
         Self { mock: self.mock.and(query_param("limit", limit.to_string())), ..self }
     }

--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -318,7 +318,7 @@ impl MatrixMockServer {
     pub fn mock_room_send(&self) -> MockEndpoint<'_, RoomSendEndpoint> {
         let mock = Mock::given(method("PUT"))
             .and(header("authorization", "Bearer 1234"))
-            .and(path_regex(format!(r"^/_matrix/client/v3/rooms/.*/send/.*",)));
+            .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*".to_owned()));
         MockEndpoint { mock, server: &self.server, endpoint: RoomSendEndpoint }
     }
 

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -257,6 +257,7 @@ async fn test_ignored_unignored() {
 /// Puts a mounting point for /messages for a pagination request, matching
 /// against a precise `from` token given as `expected_from`, and returning the
 /// chunk of events and the next token as `end` (if available).
+// TODO: replace this with the `mock_room_messages` form mocks.rs
 async fn mock_messages(
     server: &MockServer,
     expected_from: &str,

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -257,7 +257,7 @@ async fn test_ignored_unignored() {
 /// Puts a mounting point for /messages for a pagination request, matching
 /// against a precise `from` token given as `expected_from`, and returning the
 /// chunk of events and the next token as `end` (if available).
-// TODO: replace this with the `mock_room_messages` form mocks.rs
+// TODO: replace this with the `mock_room_messages` from mocks.rs
 async fn mock_messages(
     server: &MockServer,
     expected_from: &str,

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -313,7 +313,8 @@ async fn test_read_messages_with_msgtype_capabilities() {
             f.reaction(event_id!("$event_id"), "annotation".to_owned()).into_raw_timeline(),
         ];
         mock_server
-            .mock_room_messages(Some(3))
+            .mock_room_messages()
+            .limit(3)
             .ok(start, end, chun2, Vec::<Raw<AnyStateEvent>>::new())
             .mock_once()
             .mount()


### PR DESCRIPTION
This is a follow up PR on: https://github.com/matrix-org/matrix-rust-sdk/pull/3987
And tries to use the `MockMatrixServer` wherever reasonable in the widget integration tests.
<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
