### PR TITLE
chore: Allow backoff to be used in the cargo-deny config

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -10,6 +10,7 @@ exclude = [
 version = 2
 ignore = [
     { id = "RUSTSEC-2023-0071", reason = "We are not using RSA directly, nor do we depend on the RSA crate directly" },
+    { id = "RUSTSEC-2024-0384", reason = "Unmaintained backoff crate, not critical. We'll migrate soon." },
 ]
 
 [licenses]


### PR DESCRIPTION
Backoff seems to be unmaintained, there's no drop-in replacement so let's silence the warning for now.