### PR TITLE
feat(room_alias): Add create_room_alias function

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1141,6 +1141,17 @@ impl Client {
         let alias = RoomAliasId::parse(alias)?;
         self.inner.is_room_alias_available(&alias).await.map_err(Into::into)
     }
+
+    /// Creates a new room alias associated with the provided room id.
+    pub async fn create_room_alias(
+        &self,
+        room_alias: String,
+        room_id: String,
+    ) -> Result<(), ClientError> {
+        let room_alias = RoomAliasId::parse(room_alias)?;
+        let room_id = RoomId::parse(room_id)?;
+        self.inner.create_room_alias(&room_alias, &room_id).await.map_err(Into::into)
+    }
 }
 
 #[matrix_sdk_ffi_macros::export(callback_interface)]

--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -208,6 +208,13 @@ impl MatrixMockServer {
             Mock::given(method("GET")).and(path_regex(r"/_matrix/client/r0/directory/room/.*"));
         MockResolveRoomAlias { mock, server: &self.server }
     }
+
+    /// Create a prebuilt mock for creating room aliases.
+    pub fn mock_create_room_alias(&self) -> MockCreateRoomAlias<'_> {
+        let mock =
+            Mock::given(method("PUT")).and(path_regex(r"/_matrix/client/r0/directory/room/.*"));
+        MockCreateRoomAlias { mock, server: &self.server }
+    }
 }
 
 /// Parameter to [`MatrixMockServer::sync_room`].
@@ -547,6 +554,20 @@ impl<'a> MockResolveRoomAlias<'a> {
     /// Returns a data endpoint with a server error.
     pub fn error500(self) -> MatrixMock<'a> {
         let mock = self.mock.respond_with(ResponseTemplate::new(500));
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+/// A prebuilt mock for creating a room alias.
+pub struct MockCreateRoomAlias<'a> {
+    server: &'a MockServer,
+    mock: MockBuilder,
+}
+
+impl<'a> MockCreateRoomAlias<'a> {
+    /// Returns a data endpoint for creating a room alias.
+    pub fn ok(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
         MatrixMock { server: self.server, mock }
     }
 }


### PR DESCRIPTION
This associates a room alias with an existing room through its room id.<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
