### PR TITLE
refactor(ffi): remove duplicated fields in media event contents

### DIFF
--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2052,7 +2052,7 @@ impl Room {
     ) -> MessageType {
         // If caption is set, use it as body, and filename as the file name; otherwise,
         // body is the filename, and the filename is not set.
-        // https://github.com/tulir/matrix-spec-proposals/blob/body-as-caption/proposals/2530-body-as-caption.md
+        // https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/2530-body-as-caption.md
         let (body, filename) = match caption {
             Some(caption) => (caption, Some(filename.to_owned())),
             None => (filename.to_owned(), None),


### PR DESCRIPTION
The caption and filenames were weirdly duplicated in each media content, when the expected behavior is well defined:

- if there's both a caption and a filename, body := caption, filename is its own field.
- if there's only a filename, body := filename.

We can remove all duplicated fields, knowing this, and reconstruct the body based on that information. This should make it clearer to FFI users which is what, and provide a clearer API when creating the caption and so on.