### PR TITLE
fix(utd_hook): Fix regression causing retry to report false late decrypt

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1064,16 +1064,22 @@ impl<P: RoomDataProvider> TimelineController<P> {
 
                     match decryptor.decrypt_event_impl(original_json).await {
                         Ok(event) => {
-                            trace!(
-                                "Successfully decrypted event that previously failed to decrypt"
-                            );
+                            if let matrix_sdk::deserialized_responses::TimelineEventKind::UnableToDecrypt { utd_info, ..} = event.kind {
+                                info!("Failed to decrypt event after receiving room key: {:?}", utd_info.reason);
+                                None
+                            } else {
+                                trace!(
+                                    kind = ?event.kind,
+                                    "Successfully decrypted event that previously failed to decrypt"
+                                );
 
-                            // Notify observers that we managed to eventually decrypt an event.
-                            if let Some(hook) = unable_to_decrypt_hook {
-                                hook.on_late_decrypt(&remote_event.event_id, *utd_cause).await;
+                                // Notify observers that we managed to eventually decrypt an event.
+                                if let Some(hook) = unable_to_decrypt_hook {
+                                    hook.on_late_decrypt(&remote_event.event_id, *utd_cause).await;
+                                }
+
+                                Some(event)
                             }
-
-                            Some(event)
                         }
                         Err(e) => {
                             info!("Failed to decrypt event after receiving room key: {e}");


### PR DESCRIPTION
<!-- description of the changes in this PR -->

There has been a recent change on `Decryptor#decrypt_event_impl` causing the function to return an TimelineEvent of kind unable to decrypt instead of failing with an error.

The `late_decrypt` detection code was not change, causing any retry to mark UTDs as late decrypt.


- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
