### PR TITLE
feat(WidgetDriver): Send state from state sync and not from timeline to widget

### DIFF
--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -184,7 +184,7 @@ impl MatrixDriver {
         let drop_guard_state = self.room.client().event_handler_drop_guard(handle_state);
 
         // The receiver will get a combination of state and messgage like events.
-        // The state events will come from the state section of the sync.
+        // The state events will come from the state section of the sync. (to always represent current resolved state)
         // All state events in the timeline section of the sync will not be forwarded to
         // the widget.
         // TODO annotate the events and send both timeline and state section state events.

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -184,10 +184,11 @@ impl MatrixDriver {
         let drop_guard_state = self.room.client().event_handler_drop_guard(handle_state);
 
         // The receiver will get a combination of state and messgage like events.
-        // The state events will come from the state section of the sync. (to always represent current resolved state)
-        // All state events in the timeline section of the sync will not be forwarded to
-        // the widget.
-        // TODO annotate the events and send both timeline and state section state events.
+        // The state events will come from the state section of the sync. (to always
+        // represent current resolved state) All state events in the timeline
+        // section of the sync will not be forwarded to the widget.
+        // TODO annotate the events and send both timeline and state section state
+        // events.
         EventReceiver { rx, _drop_guards: [drop_guard_msg_like, drop_guard_state] }
     }
 }

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -183,7 +183,7 @@ impl MatrixDriver {
         });
         let drop_guard_state = self.room.client().event_handler_drop_guard(handle_state);
 
-        // The receiver will get a combination of state and messgage like events.
+        // The receiver will get a combination of state and message like events.
         // The state events will come from the state section of the sync. (to always
         // represent current resolved state) All state events in the timeline
         // section of the sync will not be forwarded to the widget.

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -184,8 +184,8 @@ impl MatrixDriver {
         let drop_guard_state = self.room.client().event_handler_drop_guard(handle_state);
 
         // The receiver will get a combination of state and message like events.
-        // The state events will come from the state section of the sync. (to always
-        // represent current resolved state) All state events in the timeline
+        // The state events will come from the state section of the sync (to always
+        // represent current resolved state). All state events in the timeline
         // section of the sync will not be forwarded to the widget.
         // TODO annotate the events and send both timeline and state section state
         // events.


### PR DESCRIPTION
This PR changes the source of messages send to the widget. Instead of using: 
`let handle = self.room.add_event_handler(move |raw: Raw<AnySyncTimelineEvent>| {})`
which listens to all events form the timeline section of the sync, we use two listeners for state and message like:
`let handle = self.room.add_event_handler(move |raw: Raw<AnySyncStateEvent>| {})`
And
`let handle = self.room.add_event_handler(move |raw: Raw<AnySyncMessageLikeEvent>| {})`

`AnySyncStateEvent` should only get events from the state block of the SSS response.
and `AnySyncMessageLikeEvent` all the message like events from the timeline block.

This makes the behaviour equivalent to: https://github.com/element-hq/element-web/pull/28422
<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
