### PR TITLE
fix(ui): Disable `share_pos()` inside `RoomListService`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -136,9 +136,10 @@ impl RoomListService {
             }))
             .with_typing_extension(assign!(http::request::Typing::default(), {
                 enabled: Some(true),
-            }))
-            // We don't deal with encryption device messages here so this is safe
-            .share_pos();
+            }));
+        // TODO: Re-enable once we know it creates slowness.
+        // // We don't deal with encryption device messages here so this is safe
+        // .share_pos();
 
         let sliding_sync = builder
             .add_cached_list(

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -591,6 +591,7 @@ async fn test_sync_resumes_from_previous_state() -> Result<(), Error> {
 }
 
 #[async_test]
+#[ignore] // `share_pos()` has been disabled in the room list, see there to learn more.
 async fn test_sync_resumes_from_previous_state_after_restart() -> Result<(), Error> {
     let tmp_dir = TempDir::new().unwrap();
     let store_path = tmp_dir.path();


### PR DESCRIPTION
This patch disables the call to `share_pos()` inside the `RoomListService` because it creates slowness we need to investigate.

---

- Fix https://github.com/matrix-org/matrix-rust-sdk/issues/4244
- Address https://github.com/matrix-org/matrix-rust-sdk/pull/4035
- Reopen https://github.com/matrix-org/matrix-rust-sdk/issues/3936