### PR TITLE
feat(send queue): maintain ordering of sending

### DIFF
--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -125,6 +125,12 @@ pub struct QueuedRequest {
     ///
     /// `None` if the request is in the queue, waiting to be sent.
     pub error: Option<QueueWedgeError>,
+
+    /// At which priority should this be handled?
+    ///
+    /// The bigger the value, the higher the priority at which this request
+    /// should be handled.
+    pub priority: usize,
 }
 
 impl QueuedRequest {

--- a/crates/matrix-sdk-sqlite/migrations/state_store/009_send_queue_priority.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/009_send_queue_priority.sql
@@ -1,0 +1,3 @@
+-- Add a priority column, defaulting to 0 for all events in the send queue.
+ALTER TABLE "send_queue_events"
+    ADD COLUMN "priority" INTEGER NOT NULL DEFAULT 0;

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -350,7 +350,12 @@ impl QueueStorage {
 
         client
             .store()
-            .save_send_queue_request(&self.room_id, event_txn, new_content.into())
+            .save_send_queue_request(
+                &self.room_id,
+                event_txn,
+                new_content.into(),
+                Self::HIGH_PRIORITY,
+            )
             .await
             .map_err(RoomSendQueueStorageError::StateStoreError)?;
 
@@ -392,7 +397,7 @@ impl QueueStorage {
 
         client
             .store()
-            .save_send_queue_request(&self.room_id, next_upload_txn, request)
+            .save_send_queue_request(&self.room_id, next_upload_txn, request, Self::HIGH_PRIORITY)
             .await
             .map_err(RoomSendQueueStorageError::StateStoreError)?;
 

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -900,12 +900,15 @@ async fn test_edit() {
     // Let the server process the responses.
     drop(lock_guard);
 
-    // Now the server will process the messages in order.
+    // The queue sends the first event, without the edit.
     assert_update!(watch => sent { txn = txn1, });
-    assert_update!(watch => sent { txn = txn2, });
 
-    // Let a bit of time to process the edit event sent to the server for txn1.
+    // The queue sends the edit; we can't check the transaction id because it's
+    // unknown.
     assert_update!(watch => sent {});
+
+    // The queue sends the second event.
+    assert_update!(watch => sent { txn = txn2, });
 
     assert!(watch.is_empty());
 }


### PR DESCRIPTION
Prior to this patch, the send queue would not maintain the ordering of
sending a media *then* a text, because it would push back a dependent
request graduating into a queued request.

The solution implemented here consists in adding a new priority column
to the send queue, defaulting to 0 for existing events, and use higher
priorities for the media uploads, so they're considered before other
requests.

A high priority is also used for aggregation events that are sent late,
so they're sent as soon as possible, before other subsequent events.

Let's say it's part of #4201.