### PR TITLE
feat(ffi): generate formatted captions for `send_*` media fns

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -48,8 +48,8 @@ use ruma::{
         },
         receipt::ReceiptThread,
         room::message::{
-            ForwardThread, LocationMessageEventContent, MessageType,
-            RoomMessageEventContentWithoutRelation,
+            FormattedBody as RumaFormattedBody, ForwardThread, LocationMessageEventContent,
+            MessageType, RoomMessageEventContentWithoutRelation,
         },
         AnyMessageLikeEventContent,
     },
@@ -289,6 +289,7 @@ impl Timeline {
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
         use_send_queue: bool,
     ) -> Arc<SendAttachmentJoinHandle> {
+        let formatted_caption = formatted_caption_from(&caption, &formatted_caption);
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
             let base_image_info = BaseImageInfo::try_from(&image_info)
                 .map_err(|_| RoomError::InvalidAttachmentData)?;
@@ -297,7 +298,7 @@ impl Timeline {
             let attachment_config = build_thumbnail_info(thumbnail_url, image_info.thumbnail_info)?
                 .info(attachment_info)
                 .caption(caption)
-                .formatted_caption(formatted_caption.map(Into::into));
+                .formatted_caption(formatted_caption);
 
             self.send_attachment(
                 url,
@@ -321,6 +322,7 @@ impl Timeline {
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
         use_send_queue: bool,
     ) -> Arc<SendAttachmentJoinHandle> {
+        let formatted_caption = formatted_caption_from(&caption, &formatted_caption);
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
             let base_video_info: BaseVideoInfo = BaseVideoInfo::try_from(&video_info)
                 .map_err(|_| RoomError::InvalidAttachmentData)?;
@@ -351,6 +353,7 @@ impl Timeline {
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
         use_send_queue: bool,
     ) -> Arc<SendAttachmentJoinHandle> {
+        let formatted_caption = formatted_caption_from(&caption, &formatted_caption);
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
             let base_audio_info: BaseAudioInfo = BaseAudioInfo::try_from(&audio_info)
                 .map_err(|_| RoomError::InvalidAttachmentData)?;
@@ -383,6 +386,7 @@ impl Timeline {
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
         use_send_queue: bool,
     ) -> Arc<SendAttachmentJoinHandle> {
+        let formatted_caption = formatted_caption_from(&caption, &formatted_caption);
         SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
             let base_audio_info: BaseAudioInfo = BaseAudioInfo::try_from(&audio_info)
                 .map_err(|_| RoomError::InvalidAttachmentData)?;
@@ -707,6 +711,24 @@ impl Timeline {
     ) -> Option<Arc<RoomMessageEventContentWithoutRelation>> {
         let msg_type: Option<MessageType> = msg_type.try_into().ok();
         msg_type.map(|m| Arc::new(RoomMessageEventContentWithoutRelation::new(m)))
+    }
+}
+
+/// Given a pair of optional `caption` and `formatted_caption` parameters,
+/// return a formatted caption:
+///
+/// - If a `formatted_caption` exists, return it.
+/// - If it doesn't exist but there is a `caption`, parse it as markdown and
+///   return the result.
+/// - Return `None` if there are no `caption` or `formatted_caption` parameters.
+fn formatted_caption_from(
+    caption: &Option<String>,
+    formatted_caption: &Option<FormattedBody>,
+) -> Option<RumaFormattedBody> {
+    match (&caption, formatted_caption) {
+        (None, None) => None,
+        (Some(body), None) => RumaFormattedBody::markdown(body),
+        (_, Some(formatted_body)) => Some(formatted_body.clone().into()),
     }
 }
 


### PR DESCRIPTION
At the moment we could only pass existing `caption` and `formatted_caption` parameters, assuming they were either plain text for `caption` or already parsed for `formatted_caption`. With these changes, the `caption` parameter is now treated as MD and transformed to HTML which will be used as `formatted_caption` if none is provided.

Bonus screenshot:

<img width="280" alt="image" src="https://github.com/user-attachments/assets/dd3da278-55ee-463b-8520-b45461e5fb56">


- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
