### PR TITLE
feat(ffi): add more info to `RoomPreview`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_preview.rs
+++ b/bindings/matrix-sdk-ffi/src/room_preview.rs
@@ -1,10 +1,12 @@
 use anyhow::Context as _;
 use matrix_sdk::{room_preview::RoomPreview as SdkRoomPreview, Client};
-use ruma::space::SpaceRoomJoinRule;
+use ruma::{room::RoomType as RumaRoomType, space::SpaceRoomJoinRule};
 use tracing::warn;
 
-use crate::room_member::RoomMember;
-use crate::{client::JoinRule, error::ClientError, room::Membership, utils::AsyncRuntimeDropped};
+use crate::{
+    client::JoinRule, error::ClientError, room::Membership, room_member::RoomMember,
+    utils::AsyncRuntimeDropped,
+};
 
 /// A room preview for a room. It's intended to be used to represent rooms that
 /// aren't joined yet.
@@ -26,8 +28,8 @@ impl RoomPreview {
             topic: info.topic.clone(),
             avatar_url: info.avatar_url.as_ref().map(|url| url.to_string()),
             num_joined_members: info.num_joined_members,
-            room_type: info.room_type.as_ref().map(|room_type| room_type.to_string()),
             num_active_members: info.num_active_members,
+            room_type: info.room_type.as_ref().into(),
             is_history_world_readable: info.is_world_readable,
             membership: info.state.map(|state| state.into()),
             join_rule: info
@@ -81,7 +83,7 @@ pub struct RoomPreviewInfo {
     /// The number of active members, if known (joined + invited).
     pub num_active_members: Option<u64>,
     /// The room type (space, custom) or nothing, if it's a regular room.
-    pub room_type: Option<String>,
+    pub room_type: RoomType,
     /// Is the history world-readable for this room?
     pub is_history_world_readable: bool,
     /// The membership state for the current user, if known.
@@ -109,5 +111,29 @@ impl TryFrom<SpaceRoomJoinRule> for JoinRule {
                 return Err(());
             }
         })
+    }
+}
+
+/// The type of room for a [`RoomPreviewInfo`].
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum RoomType {
+    /// It's a plain chat room.
+    Room,
+    /// It's a space that can group several rooms.
+    Space,
+    /// It's a custom implementation.
+    Custom { value: String },
+}
+
+impl From<Option<&RumaRoomType>> for RoomType {
+    fn from(value: Option<&RumaRoomType>) -> Self {
+        match value {
+            Some(RumaRoomType::Space) => RoomType::Space,
+            Some(RumaRoomType::_Custom(_)) => RoomType::Custom {
+                // SAFETY: this was checked in the match branch above
+                value: value.unwrap().to_string(),
+            },
+            _ => RoomType::Room,
+        }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room_preview.rs
+++ b/bindings/matrix-sdk-ffi/src/room_preview.rs
@@ -27,6 +27,7 @@ impl RoomPreview {
             avatar_url: info.avatar_url.as_ref().map(|url| url.to_string()),
             num_joined_members: info.num_joined_members,
             room_type: info.room_type.as_ref().map(|room_type| room_type.to_string()),
+            num_active_members: info.num_active_members,
             is_history_world_readable: info.is_world_readable,
             membership: info.state.map(|state| state.into()),
             join_rule: info
@@ -77,6 +78,8 @@ pub struct RoomPreviewInfo {
     pub avatar_url: Option<String>,
     /// The number of joined members.
     pub num_joined_members: u64,
+    /// The number of active members, if known (joined + invited).
+    pub num_active_members: Option<u64>,
     /// The room type (space, custom) or nothing, if it's a regular room.
     pub room_type: Option<String>,
     /// Is the history world-readable for this room?


### PR DESCRIPTION
Changes:

- Add `is_direct` field and `invited` fn.
- Add optional `num_active_members`, available for rooms you're invited to or have requested to join.
- Add `RoomType` enum to map the `Option<ruma::RoomType>`, instead of using a plain String.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
