### PR TITLE
feat(Room): Check if the user is allowed to do a room mention before trying to send a call notify event.

### DIFF
--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2975,6 +2975,10 @@ impl Room {
             return Ok(());
         }
 
+        if !self.can_user_trigger_room_notification(self.own_user_id()).await? {
+            return Ok(());
+        }
+
         self.send_call_notification(
             self.room_id().to_string().to_owned(),
             ApplicationType::Call,

--- a/testing/matrix-sdk-test/src/test_json/sync_events.rs
+++ b/testing/matrix-sdk-test/src/test_json/sync_events.rs
@@ -350,6 +350,9 @@ pub static POWER_LEVELS: Lazy<JsonValue> = Lazy::new(|| {
             "kick": 50,
             "redact": 50,
             "state_default": 50,
+            "notifications": {
+                "room": 0
+            },
             "users": {
                 "@example:localhost": 100,
                 "@bob:localhost": 0


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
