### PR TITLE
feat(utd_hook): Report historical expected UTD with new reason

### DIFF
--- a/crates/matrix-sdk-crypto/src/types/events/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/mod.rs
@@ -31,7 +31,7 @@ mod utd_cause;
 
 use ruma::serde::Raw;
 pub use to_device::{ToDeviceCustomEvent, ToDeviceEvent, ToDeviceEvents};
-pub use utd_cause::UtdCause;
+pub use utd_cause::{CryptoContextInfo, UtdCause};
 
 /// A trait for event contents to define their event type.
 pub trait EventType {

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -493,7 +493,7 @@ impl TimelineStateTransaction<'_> {
                     event.sender().to_owned(),
                     event.origin_server_ts(),
                     event.transaction_id().map(ToOwned::to_owned),
-                    TimelineEventKind::from_event(event, &room_version, utd_info),
+                    TimelineEventKind::from_event(event, &raw, room_data_provider, utd_info).await,
                     should_add,
                 )
             }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -47,7 +47,6 @@ use ruma::{
     },
     serde::Raw,
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
-    RoomVersionId,
 };
 use tracing::{debug, error, field::debug, info, instrument, trace, warn};
 
@@ -71,6 +70,7 @@ use crate::{
         controller::PendingEdit,
         event_item::{ReactionInfo, ReactionStatus},
         reactions::PendingReaction,
+        traits::RoomDataProvider,
         RepliedToEvent,
     },
 };
@@ -118,6 +118,7 @@ impl Flow {
 pub(super) struct TimelineEventContext {
     pub(super) sender: OwnedUserId,
     pub(super) sender_profile: Option<Profile>,
+    /// The event's `origin_server_ts` field (or creation time for local echo).
     pub(super) timestamp: MilliSecondsSinceUnixEpoch,
     pub(super) is_own_event: bool,
     pub(super) read_receipts: IndexMap<OwnedUserId, Receipt>,
@@ -141,10 +142,7 @@ pub(super) enum TimelineEventKind {
     },
 
     /// An encrypted event that could not be decrypted
-    UnableToDecrypt {
-        content: RoomEncryptedEventContent,
-        unable_to_decrypt_info: UnableToDecryptInfo,
-    },
+    UnableToDecrypt { content: RoomEncryptedEventContent, utd_cause: UtdCause },
 
     /// Some remote event that was redacted a priori, i.e. we never had the
     /// original content, so we'll just display a dummy redacted timeline
@@ -180,15 +178,27 @@ pub(super) enum TimelineEventKind {
 }
 
 impl TimelineEventKind {
-    /// Creates a new `TimelineEventKind` with the given event and room version.
-    pub fn from_event(
+    /// Creates a new `TimelineEventKind`.
+    ///
+    /// # Arguments
+    ///
+    /// * `event` - The event for which we should create a `TimelineEventKind`.
+    /// * `raw_event` - The [`Raw`] JSON for `event`. (Required so that we can
+    ///   access `unsigned` data.)
+    /// * `room_data_provider` - An object which will provide information about
+    ///   the room containing the event.
+    /// * `unable_to_decrypt_info` - If `event` represents a failure to decrypt,
+    ///   information about that failure. Otherwise, `None`.
+    pub async fn from_event<P: RoomDataProvider>(
         event: AnySyncTimelineEvent,
-        room_version: &RoomVersionId,
+        raw_event: &Raw<AnySyncTimelineEvent>,
+        room_data_provider: &P,
         unable_to_decrypt_info: Option<UnableToDecryptInfo>,
     ) -> Self {
+        let room_version = room_data_provider.room_version();
         match event {
             AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomRedaction(ev)) => {
-                if let Some(redacts) = ev.redacts(room_version).map(ToOwned::to_owned) {
+                if let Some(redacts) = ev.redacts(&room_version).map(ToOwned::to_owned) {
                     Self::Redaction { redacts }
                 } else {
                     Self::RedactedMessage { event_type: ev.event_type() }
@@ -198,7 +208,12 @@ impl TimelineEventKind {
                 Some(AnyMessageLikeEventContent::RoomEncrypted(content)) => {
                     // An event which is still encrypted.
                     if let Some(unable_to_decrypt_info) = unable_to_decrypt_info {
-                        Self::UnableToDecrypt { content, unable_to_decrypt_info }
+                        let utd_cause = UtdCause::determine(
+                            raw_event,
+                            room_data_provider.crypto_context_info().await,
+                            &unable_to_decrypt_info,
+                        );
+                        Self::UnableToDecrypt { content, utd_cause }
                     } else {
                         // If we get here, it means that some part of the code has created a
                         // `SyncTimelineEvent` containing an `m.room.encrypted` event
@@ -426,17 +441,15 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 }
             },
 
-            TimelineEventKind::UnableToDecrypt { content, unable_to_decrypt_info } => {
+            TimelineEventKind::UnableToDecrypt { content, utd_cause } => {
                 // TODO: Handle replacements if the replaced event is also UTD
-                let raw_event = self.ctx.flow.raw_event();
-                let cause = UtdCause::determine(raw_event, &unable_to_decrypt_info);
-                self.add_item(TimelineItemContent::unable_to_decrypt(content, cause), None);
+                self.add_item(TimelineItemContent::unable_to_decrypt(content, utd_cause), None);
 
                 // Let the hook know that we ran into an unable-to-decrypt that is added to the
                 // timeline.
                 if let Some(hook) = self.meta.unable_to_decrypt_hook.as_ref() {
                     if let Some(event_id) = &self.ctx.flow.event_id() {
-                        hook.on_utd(event_id, cause).await;
+                        hook.on_utd(event_id, utd_cause).await;
                     }
                 }
             }

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -20,8 +20,8 @@ use indexmap::IndexMap;
 #[cfg(test)]
 use matrix_sdk::crypto::{DecryptionSettings, RoomEventDecryptionResult, TrustRequirement};
 use matrix_sdk::{
-    deserialized_responses::TimelineEvent, event_cache::paginator::PaginableRoom, BoxFuture,
-    Result, Room,
+    crypto::types::events::CryptoContextInfo, deserialized_responses::TimelineEvent,
+    event_cache::paginator::PaginableRoom, BoxFuture, Result, Room,
 };
 use matrix_sdk_base::{latest_event::LatestEvent, RoomInfo};
 use ruma::{
@@ -76,6 +76,8 @@ pub(super) trait RoomDataProvider:
     fn own_user_id(&self) -> &UserId;
     fn room_version(&self) -> RoomVersionId;
 
+    fn crypto_context_info(&self) -> BoxFuture<'_, CryptoContextInfo>;
+
     fn profile_from_user_id<'a>(&'a self, user_id: &'a UserId) -> BoxFuture<'a, Option<Profile>>;
     fn profile_from_latest_event(&self, latest_event: &LatestEvent) -> Option<Profile>;
 
@@ -119,6 +121,10 @@ impl RoomDataProvider for Room {
 
     fn room_version(&self) -> RoomVersionId {
         (**self).clone_info().room_version_or_default()
+    }
+
+    fn crypto_context_info(&self) -> BoxFuture<'_, CryptoContextInfo> {
+        async move { self.crypto_context_info().await }.boxed()
     }
 
     fn profile_from_user_id<'a>(&'a self, user_id: &'a UserId) -> BoxFuture<'a, Option<Profile>> {

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -48,11 +48,6 @@ use matrix_sdk_base::{
 };
 use matrix_sdk_common::{deserialized_responses::SyncTimelineEvent, timeout::timeout};
 use mime::Mime;
-#[cfg(feature = "e2e-encryption")]
-use ruma::events::{
-    room::encrypted::OriginalSyncRoomEncryptedEvent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
-    SyncMessageLikeEvent,
-};
 use ruma::{
     api::client::{
         config::{set_global_account_data, set_room_account_data},
@@ -113,6 +108,14 @@ use ruma::{
     EventId, Int, MatrixToUri, MatrixUri, MxcUri, OwnedEventId, OwnedRoomId, OwnedServerName,
     OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UInt, UserId,
 };
+#[cfg(feature = "e2e-encryption")]
+use ruma::{
+    events::{
+        room::encrypted::OriginalSyncRoomEncryptedEvent, AnySyncMessageLikeEvent,
+        AnySyncTimelineEvent, SyncMessageLikeEvent,
+    },
+    MilliSecondsSinceUnixEpoch,
+};
 use serde::de::DeserializeOwned;
 use thiserror::Error;
 use tokio::sync::broadcast;
@@ -139,6 +142,8 @@ use crate::{
     utils::{IntoRawMessageLikeEventContent, IntoRawStateEventContent},
     BaseRoom, Client, Error, HttpResult, Result, RoomState, TransmissionProgress,
 };
+#[cfg(feature = "e2e-encryption")]
+use crate::{crypto::types::events::CryptoContextInfo, encryption::backups::BackupState};
 
 pub mod edit;
 pub mod futures;
@@ -608,6 +613,20 @@ impl Room {
         }
 
         Ok(self.inner.is_encrypted())
+    }
+
+    /// Gets additional context info about the client crypto.
+    #[cfg(feature = "e2e-encryption")]
+    pub async fn crypto_context_info(&self) -> CryptoContextInfo {
+        let encryption = self.client.encryption();
+        CryptoContextInfo {
+            device_creation_ts: match encryption.get_own_device().await {
+                Ok(Some(device)) => device.first_time_seen_ts(),
+                // Should not happen, there will always be an own device
+                _ => MilliSecondsSinceUnixEpoch::now(),
+            },
+            is_backup_configured: encryption.backups().state() == BackupState::Enabled,
+        }
     }
 
     fn are_events_visible(&self) -> bool {


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fixes https://github.com/element-hq/element-meta/issues/2581 

Detect and report expected historical UTDs as such. Must be integrated by clients and reported with [this code](https://github.com/matrix-org/matrix-analytics-events/blob/564a8b1386f2f46eee65f429b2a07940916d8257/schemas/Error.json#L23) in Analytics.

To determine if an event is device historical (i.e sent before the current login existed) we use an heuristic based on the event `origin_server_ts` and the device creation local timestamp.


- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
