### PR TITLE
fix(Room): Use `subscribe_reset` for `subscribe_info` (instead of just `subscribe`)

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -856,8 +856,11 @@ impl Room {
     }
 
     /// Subscribe to the inner `RoomInfo`.
+    ///
+    /// Behaves like a `subscribe_reset`:
+    /// The first call to `next().await` will immediately return the current info.
     pub fn subscribe_info(&self) -> Subscriber<RoomInfo> {
-        self.inner.subscribe()
+        self.inner.subscribe_reset()
     }
 
     /// Clone the inner `RoomInfo`.


### PR DESCRIPTION
When calling `subscribe_info` users will most likely expect to get the info and not to wait for the next info change.

Has been discussed with @bnjbvr.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
