### PR TITLE
feat(send queue): allow editing media captions

### DIFF
--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -1452,7 +1452,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         // Update the event id.
         let event_id = owned_event_id!("$1");
         let num_updated = self
-            .update_dependent_queued_request(
+            .mark_dependent_queued_requests_as_ready(
                 room_id,
                 &txn0,
                 SentRequestKey::Event(event_id.clone()),

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -917,7 +917,7 @@ impl StateStore for MemoryStore {
         Ok(())
     }
 
-    async fn update_dependent_queued_request(
+    async fn mark_dependent_queued_requests_as_ready(
         &self,
         room: &RoomId,
         parent_txn_id: &TransactionId,

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -437,6 +437,16 @@ pub trait StateStore: AsyncTraitDeps {
         sent_parent_key: SentRequestKey,
     ) -> Result<usize, Self::Error>;
 
+    /// Update a dependent send queue request with the new content.
+    ///
+    /// Returns true if the request was found and could be updated.
+    async fn update_dependent_queued_request(
+        &self,
+        room_id: &RoomId,
+        own_transaction_id: &ChildTransactionId,
+        new_content: DependentQueuedRequestKind,
+    ) -> Result<bool, Self::Error>;
+
     /// Remove a specific dependent send queue request by id.
     ///
     /// Returns true if the dependent send queue request has been indeed
@@ -732,6 +742,18 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         room_id: &RoomId,
     ) -> Result<Vec<DependentQueuedRequest>, Self::Error> {
         self.0.load_dependent_queued_requests(room_id).await.map_err(Into::into)
+    }
+
+    async fn update_dependent_queued_request(
+        &self,
+        room_id: &RoomId,
+        own_transaction_id: &ChildTransactionId,
+        new_content: DependentQueuedRequestKind,
+    ) -> Result<bool, Self::Error> {
+        self.0
+            .update_dependent_queued_request(room_id, own_transaction_id, new_content)
+            .await
+            .map_err(Into::into)
     }
 }
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -422,15 +422,15 @@ pub trait StateStore: AsyncTraitDeps {
         content: DependentQueuedRequestKind,
     ) -> Result<(), Self::Error>;
 
-    /// Update a set of dependent send queue requests with a key identifying the
-    /// homeserver's response, effectively marking them as ready.
+    /// Mark a set of dependent send queue requests as ready, using a key
+    /// identifying the homeserver's response.
     ///
     /// ⚠ Beware! There's no verification applied that the parent key type is
     /// compatible with the dependent event type. The invalid state may be
     /// lazily filtered out in `load_dependent_queued_requests`.
     ///
     /// Returns the number of updated requests.
-    async fn update_dependent_queued_request(
+    async fn mark_dependent_queued_requests_as_ready(
         &self,
         room_id: &RoomId,
         parent_txn_id: &TransactionId,
@@ -707,14 +707,14 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
             .map_err(Into::into)
     }
 
-    async fn update_dependent_queued_request(
+    async fn mark_dependent_queued_requests_as_ready(
         &self,
         room_id: &RoomId,
         parent_txn_id: &TransactionId,
         sent_parent_key: SentRequestKey,
     ) -> Result<usize, Self::Error> {
         self.0
-            .update_dependent_queued_request(room_id, parent_txn_id, sent_parent_key)
+            .mark_dependent_queued_requests_as_ready(room_id, parent_txn_id, sent_parent_key)
             .await
             .map_err(Into::into)
     }

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -1569,7 +1569,7 @@ impl_state_store!({
         Ok(())
     }
 
-    async fn update_dependent_queued_request(
+    async fn mark_dependent_queued_requests_as_ready(
         &self,
         room_id: &RoomId,
         parent_txn_id: &TransactionId,

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -1569,6 +1569,48 @@ impl_state_store!({
         Ok(())
     }
 
+    async fn update_dependent_queued_request(
+        &self,
+        room_id: &RoomId,
+        own_transaction_id: &ChildTransactionId,
+        new_content: DependentQueuedRequestKind,
+    ) -> Result<bool> {
+        let encoded_key = self.encode_key(keys::DEPENDENT_SEND_QUEUE, room_id);
+
+        let tx = self.inner.transaction_on_one_with_mode(
+            keys::DEPENDENT_SEND_QUEUE,
+            IdbTransactionMode::Readwrite,
+        )?;
+
+        let obj = tx.object_store(keys::DEPENDENT_SEND_QUEUE)?;
+
+        // We store an encoded vector of the dependent requests.
+        // Reload the previous vector for this room, or create an empty one.
+        let prev = obj.get(&encoded_key)?.await?;
+
+        let mut prev = prev.map_or_else(
+            || Ok(Vec::new()),
+            |val| self.deserialize_value::<Vec<DependentQueuedRequest>>(&val),
+        )?;
+
+        // Modify the dependent request, if found.
+        let mut found = false;
+        for entry in prev.iter_mut() {
+            if entry.own_transaction_id == *own_transaction_id {
+                found = true;
+                entry.kind = new_content;
+                break;
+            }
+        }
+
+        if found {
+            obj.put_key_val(&encoded_key, &self.serialize_value(&prev)?)?;
+            tx.await.into_result()?;
+        }
+
+        Ok(found)
+    }
+
     async fn mark_dependent_queued_requests_as_ready(
         &self,
         room_id: &RoomId,

--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -101,6 +101,9 @@ pub enum Error {
 
     #[error("Redaction failed: {0}")]
     Redaction(#[source] ruma::canonical_json::RedactionError),
+
+    #[error("An update keyed by unique ID touched more than one entry")]
+    InconsistentUpdate,
 }
 
 macro_rules! impl_from {

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1873,7 +1873,7 @@ impl StateStore for SqliteStateStore {
             .await
     }
 
-    async fn update_dependent_queued_request(
+    async fn mark_dependent_queued_requests_as_ready(
         &self,
         room_id: &RoomId,
         parent_txn_id: &TransactionId,

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1873,6 +1873,39 @@ impl StateStore for SqliteStateStore {
             .await
     }
 
+    async fn update_dependent_queued_request(
+        &self,
+        room_id: &RoomId,
+        own_transaction_id: &ChildTransactionId,
+        new_content: DependentQueuedRequestKind,
+    ) -> Result<bool> {
+        let room_id = self.encode_key(keys::DEPENDENTS_SEND_QUEUE, room_id);
+        let content = self.serialize_json(&new_content)?;
+
+        // See comment in `save_send_queue_event`.
+        let own_txn_id = own_transaction_id.to_string();
+
+        let num_updated = self
+            .acquire()
+            .await?
+            .with_transaction(move |txn| {
+                txn.prepare_cached(
+                    r#"UPDATE dependent_send_queue_events
+                       SET content = ?
+                       WHERE own_transaction_id = ?
+                       AND room_id = ?"#,
+                )?
+                .execute((content, own_txn_id, room_id))
+            })
+            .await?;
+
+        if num_updated > 1 {
+            return Err(Error::InconsistentUpdate);
+        }
+
+        Ok(num_updated == 1)
+    }
+
     async fn mark_dependent_queued_requests_as_ready(
         &self,
         room_id: &RoomId,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -478,8 +478,15 @@ impl Timeline {
                         }
                     }
 
-                    EditedContent::MediaCaption { caption: _, formatted_caption: _ } => {
-                        todo!("bnjbvr you had one job");
+                    EditedContent::MediaCaption { caption, formatted_caption } => {
+                        if handle
+                            .edit_media_caption(caption, formatted_caption)
+                            .await
+                            .map_err(RoomSendQueueError::StorageError)?
+                        {
+                            return Ok(());
+                        }
+                        return Err(EditError::InvalidLocalEchoState.into());
                     }
                 };
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -461,6 +461,7 @@ impl Timeline {
                             .into());
                         }
                     }
+
                     EditedContent::PollStart { new_content, .. } => {
                         if matches!(item.content, TimelineItemContent::Poll(_)) {
                             AnyMessageLikeEventContent::UnstablePollStart(
@@ -475,6 +476,10 @@ impl Timeline {
                             }
                             .into());
                         }
+                    }
+
+                    EditedContent::MediaCaption { caption: _, formatted_caption: _ } => {
+                        todo!("bnjbvr you had one job");
                     }
                 };
 

--- a/crates/matrix-sdk/src/room/edit.rs
+++ b/crates/matrix-sdk/src/room/edit.rs
@@ -23,9 +23,13 @@ use ruma::{
             ReplacementUnstablePollStartEventContent, UnstablePollStartContentBlock,
             UnstablePollStartEventContent,
         },
-        room::message::{Relation, ReplacementMetadata, RoomMessageEventContentWithoutRelation},
+        room::message::{
+            FormattedBody, MessageType, Relation, ReplacementMetadata, RoomMessageEventContent,
+            RoomMessageEventContentWithoutRelation,
+        },
         AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent,
-        AnySyncTimelineEvent, AnyTimelineEvent, MessageLikeEvent, SyncMessageLikeEvent,
+        AnySyncTimelineEvent, AnyTimelineEvent, MessageLikeEvent, OriginalMessageLikeEvent,
+        SyncMessageLikeEvent,
     },
     EventId, RoomId, UserId,
 };
@@ -38,6 +42,19 @@ use crate::Room;
 pub enum EditedContent {
     /// The content is a `m.room.message`.
     RoomMessage(RoomMessageEventContentWithoutRelation),
+
+    /// Tweak a caption for a `m.room.message` that's a media.
+    MediaCaption {
+        /// New caption for the media.
+        ///
+        /// Set to `None` to remove an existing caption.
+        caption: Option<String>,
+
+        /// New formatted caption for the media.
+        ///
+        /// Set to `None` to remove an existing formatted caption.
+        formatted_caption: Option<FormattedBody>,
+    },
 
     /// The content is a new poll start.
     PollStart {
@@ -53,6 +70,7 @@ impl std::fmt::Debug for EditedContent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::RoomMessage(_) => f.debug_tuple("RoomMessage").finish(),
+            Self::MediaCaption { .. } => f.debug_tuple("MediaCaption").finish(),
             Self::PollStart { .. } => f.debug_tuple("PollStart").finish(),
         }
     }
@@ -133,6 +151,28 @@ impl<'a> EventSource for &'a Room {
     }
 }
 
+/// Sets the caption of a media event content.
+///
+/// Why a macro over a plain function: the event content types all differ from
+/// each other, and it would require adding a trait and implementing it for all
+/// event types instead of having this simple macro.
+macro_rules! set_caption {
+    ($event:expr, $caption:expr) => {
+        let filename = $event.filename().to_owned();
+        // As a reminder:
+        // - body and no filename set means the body is the filename
+        // - body and filename set means the body is the caption, and filename is the
+        //   filename.
+        if let Some(caption) = $caption {
+            $event.filename = Some(filename);
+            $event.body = caption;
+        } else {
+            $event.filename = None;
+            $event.body = filename;
+        }
+    };
+}
+
 async fn make_edit_event<S: EventSource>(
     source: S,
     room_id: &RoomId,
@@ -167,47 +207,66 @@ async fn make_edit_event<S: EventSource>(
             };
 
             let mentions = original.content.mentions.clone();
+            let replied_to_original_room_msg =
+                extract_replied_to(source, room_id, original.content.relates_to).await;
 
-            // Do a best effort at finding the replied-to original event.
-            let replied_to_sync_timeline_event =
-                if let Some(Relation::Reply { in_reply_to }) = original.content.relates_to {
-                    source
-                        .get_event(&in_reply_to.event_id)
-                        .await
-                        .map_err(|err| {
-                            warn!("couldn't fetch the replied-to event, when editing: {err}");
-                            err
-                        })
-                        .ok()
-                } else {
-                    None
-                };
+            let replacement = new_content.make_replacement(
+                ReplacementMetadata::new(event_id.to_owned(), mentions),
+                replied_to_original_room_msg.as_ref(),
+            );
 
-            let replied_to_original_room_msg = replied_to_sync_timeline_event
-                .and_then(|sync_timeline_event| {
-                    sync_timeline_event
-                        .raw()
-                        .deserialize()
-                        .map_err(|err| warn!("unable to deserialize replied-to event: {err}"))
-                        .ok()
-                })
-                .and_then(|event| {
-                    if let AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
-                        MessageLikeEvent::Original(original),
-                    )) = event.into_full_event(room_id.to_owned())
-                    {
-                        Some(original)
-                    } else {
-                        None
-                    }
+            Ok(replacement.into())
+        }
+
+        EditedContent::MediaCaption { caption, formatted_caption } => {
+            // Handle edits of m.room.message.
+            let AnySyncMessageLikeEvent::RoomMessage(SyncMessageLikeEvent::Original(original)) =
+                message_like_event
+            else {
+                return Err(EditError::IncompatibleEditType {
+                    target: message_like_event.event_type().to_string(),
+                    new_content: "caption for a media room message",
                 });
+            };
 
-            Ok(new_content
-                .make_replacement(
-                    ReplacementMetadata::new(event_id.to_owned(), mentions),
-                    replied_to_original_room_msg.as_ref(),
-                )
-                .into())
+            let mentions = original.content.mentions.clone();
+            let replied_to_original_room_msg =
+                extract_replied_to(source, room_id, original.content.relates_to.clone()).await;
+
+            let mut prev_content = original.content;
+
+            match &mut prev_content.msgtype {
+                MessageType::Audio(event) => {
+                    set_caption!(event, caption);
+                    event.formatted = formatted_caption;
+                }
+                MessageType::File(event) => {
+                    set_caption!(event, caption);
+                    event.formatted = formatted_caption;
+                }
+                MessageType::Image(event) => {
+                    set_caption!(event, caption);
+                    event.formatted = formatted_caption;
+                }
+                MessageType::Video(event) => {
+                    set_caption!(event, caption);
+                    event.formatted = formatted_caption;
+                }
+
+                _ => {
+                    return Err(EditError::IncompatibleEditType {
+                        target: prev_content.msgtype.msgtype().to_owned(),
+                        new_content: "caption for a media room message",
+                    })
+                }
+            }
+
+            let replacement = prev_content.make_replacement(
+                ReplacementMetadata::new(event_id.to_owned(), mentions),
+                replied_to_original_room_msg.as_ref(),
+            );
+
+            Ok(replacement.into())
         }
 
         EditedContent::PollStart { fallback_text, new_content } => {
@@ -234,6 +293,45 @@ async fn make_edit_event<S: EventSource>(
     }
 }
 
+/// Try to find the original replied-to event content, in a best-effort manner.
+async fn extract_replied_to<S: EventSource>(
+    source: S,
+    room_id: &RoomId,
+    relates_to: Option<Relation<RoomMessageEventContentWithoutRelation>>,
+) -> Option<OriginalMessageLikeEvent<RoomMessageEventContent>> {
+    let replied_to_sync_timeline_event = if let Some(Relation::Reply { in_reply_to }) = relates_to {
+        source
+            .get_event(&in_reply_to.event_id)
+            .await
+            .map_err(|err| {
+                warn!("couldn't fetch the replied-to event, when editing: {err}");
+                err
+            })
+            .ok()
+    } else {
+        None
+    };
+
+    replied_to_sync_timeline_event
+        .and_then(|sync_timeline_event| {
+            sync_timeline_event
+                .raw()
+                .deserialize()
+                .map_err(|err| warn!("unable to deserialize replied-to event: {err}"))
+                .ok()
+        })
+        .and_then(|event| {
+            if let AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
+                MessageLikeEvent::Original(original),
+            )) = event.into_full_event(room_id.to_owned())
+            {
+                Some(original)
+            } else {
+                None
+            }
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -244,10 +342,10 @@ mod tests {
     use ruma::{
         event_id,
         events::{
-            room::message::{Relation, RoomMessageEventContentWithoutRelation},
+            room::message::{MessageType, Relation, RoomMessageEventContentWithoutRelation},
             AnyMessageLikeEventContent, AnySyncTimelineEvent,
         },
-        room_id,
+        owned_mxc_uri, room_id,
         serde::Raw,
         user_id, EventId, OwnedEventId,
     };
@@ -372,6 +470,140 @@ mod tests {
 
         assert_eq!(repl.event_id, event_id);
         assert_eq!(repl.new_content.msgtype.body(), "the edit");
+    }
+
+    #[async_test]
+    async fn test_make_edit_caption_for_non_media_room_message() {
+        let event_id = event_id!("$1");
+        let own_user_id = user_id!("@me:saucisse.bzh");
+
+        let mut cache = TestEventCache::default();
+        let f = EventFactory::new();
+        cache.events.insert(
+            event_id.to_owned(),
+            f.text_msg("hello world").event_id(event_id).sender(own_user_id).into(),
+        );
+
+        let room_id = room_id!("!galette:saucisse.bzh");
+
+        let err = make_edit_event(
+            cache,
+            room_id,
+            own_user_id,
+            event_id,
+            EditedContent::MediaCaption { caption: Some("yo".to_owned()), formatted_caption: None },
+        )
+        .await
+        .unwrap_err();
+
+        assert_let!(EditError::IncompatibleEditType { target, new_content } = err);
+        assert_eq!(target, "m.text");
+        assert_eq!(new_content, "caption for a media room message");
+    }
+
+    #[async_test]
+    async fn test_add_caption_for_media() {
+        let event_id = event_id!("$1");
+        let own_user_id = user_id!("@me:saucisse.bzh");
+
+        let filename = "rickroll.gif";
+
+        let mut cache = TestEventCache::default();
+        let f = EventFactory::new();
+        cache.events.insert(
+            event_id.to_owned(),
+            f.image(filename.to_owned(), owned_mxc_uri!("mxc://sdk.rs/rickroll"))
+                .event_id(event_id)
+                .sender(own_user_id)
+                .into(),
+        );
+
+        let room_id = room_id!("!galette:saucisse.bzh");
+
+        let edit_event = make_edit_event(
+            cache,
+            room_id,
+            own_user_id,
+            event_id,
+            EditedContent::MediaCaption {
+                caption: Some("Best joke ever".to_owned()),
+                formatted_caption: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_let!(AnyMessageLikeEventContent::RoomMessage(msg) = edit_event);
+        assert_let!(MessageType::Image(image) = msg.msgtype);
+
+        assert_eq!(image.filename(), filename);
+        assert_eq!(image.caption(), Some("* Best joke ever")); // Fallback for a replacement 🤷
+        assert!(image.formatted_caption().is_none());
+
+        assert_let!(Some(Relation::Replacement(repl)) = msg.relates_to);
+        assert_let!(MessageType::Image(new_image) = repl.new_content.msgtype);
+        assert_eq!(new_image.filename(), filename);
+        assert_eq!(new_image.caption(), Some("Best joke ever"));
+        assert!(new_image.formatted_caption().is_none());
+    }
+
+    #[async_test]
+    async fn test_remove_caption_for_media() {
+        let event_id = event_id!("$1");
+        let own_user_id = user_id!("@me:saucisse.bzh");
+
+        let filename = "rickroll.gif";
+
+        let mut cache = TestEventCache::default();
+        let f = EventFactory::new();
+
+        let event: SyncTimelineEvent = f
+            .image(filename.to_owned(), owned_mxc_uri!("mxc://sdk.rs/rickroll"))
+            .caption(Some("caption".to_owned()), None)
+            .event_id(event_id)
+            .sender(own_user_id)
+            .into();
+
+        {
+            // Sanity checks.
+            let event = event.raw().deserialize().unwrap();
+            assert_let!(AnySyncTimelineEvent::MessageLike(event) = event);
+            assert_let!(
+                AnyMessageLikeEventContent::RoomMessage(msg) = event.original_content().unwrap()
+            );
+            assert_let!(MessageType::Image(image) = msg.msgtype);
+            assert_eq!(image.filename(), filename);
+            assert_eq!(image.caption(), Some("caption"));
+            assert!(image.formatted_caption().is_none());
+        }
+
+        cache.events.insert(event_id.to_owned(), event);
+
+        let room_id = room_id!("!galette:saucisse.bzh");
+
+        let edit_event = make_edit_event(
+            cache,
+            room_id,
+            own_user_id,
+            event_id,
+            // Remove the caption by setting it to None.
+            EditedContent::MediaCaption { caption: None, formatted_caption: None },
+        )
+        .await
+        .unwrap();
+
+        assert_let!(AnyMessageLikeEventContent::RoomMessage(msg) = edit_event);
+        assert_let!(MessageType::Image(image) = msg.msgtype);
+
+        assert_eq!(image.filename(), "* rickroll.gif"); // Fallback for a replacement 🤷
+        assert!(image.caption().is_none());
+        assert!(image.formatted_caption().is_none());
+
+        assert_let!(Some(Relation::Replacement(repl)) = msg.relates_to);
+        assert_let!(MessageType::Image(new_image) = repl.new_content.msgtype);
+        assert_eq!(new_image.filename(), "rickroll.gif");
+        assert!(new_image.caption().is_none());
+        assert!(new_image.formatted_caption().is_none());
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -1077,7 +1077,9 @@ impl QueueStorage {
         let store = client.store();
 
         // Update all dependent requests.
-        store.update_dependent_queued_request(&self.room_id, transaction_id, parent_key).await?;
+        store
+            .mark_dependent_queued_requests_as_ready(&self.room_id, transaction_id, parent_key)
+            .await?;
 
         let removed = store.remove_send_queue_request(&self.room_id, transaction_id).await?;
 

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -155,7 +155,10 @@ use ruma::{
     events::{
         reaction::ReactionEventContent,
         relation::Annotation,
-        room::{message::RoomMessageEventContent, MediaSource},
+        room::{
+            message::{FormattedBody, RoomMessageEventContent},
+            MediaSource,
+        },
         AnyMessageLikeEventContent, EventContent as _,
     },
     serde::Raw,
@@ -1840,10 +1843,13 @@ pub enum RoomSendQueueStorageError {
     #[error("The client is shutting down.")]
     ClientShuttingDown,
 
-    /// An operation not implemented yet on a send handle.
-    // TODO: remove this
-    #[error("This operation is not implemented yet for media uploads")]
+    /// An operation not implemented on a send handle.
+    #[error("This operation is not implemented for media uploads")]
     OperationNotImplementedYet,
+
+    /// Trying to edit a media caption for something that's not a media.
+    #[error("Can't edit a media caption when the underlying event isn't a media")]
+    InvalidMediaCaptionEdit,
 }
 
 /// Extra transaction IDs useful during an upload.
@@ -1970,6 +1976,43 @@ impl SendHandle {
             new_content.event_type().to_string(),
         )
         .await
+    }
+
+    /// Edits the content of a local echo with a media caption.
+    ///
+    /// Will fail if the event to be sent, represented by this send handle,
+    /// wasn't a media.
+    pub async fn edit_media_caption(
+        &self,
+        caption: Option<String>,
+        formatted_caption: Option<FormattedBody>,
+    ) -> Result<bool, RoomSendQueueStorageError> {
+        if let Some(new_content) = self
+            .room
+            .inner
+            .queue
+            .edit_media_caption(&self.transaction_id, caption, formatted_caption)
+            .await?
+        {
+            trace!("successful edit of media caption");
+
+            // Wake up the queue, in case the room was asleep before the edit.
+            self.room.inner.notifier.notify_one();
+
+            let new_content = SerializableEventContent::new(&new_content)
+                .map_err(RoomSendQueueStorageError::JsonSerialization)?;
+
+            // Propagate a replaced update too.
+            let _ = self.room.inner.updates.send(RoomSendQueueUpdate::ReplacedLocalEvent {
+                transaction_id: self.transaction_id.clone(),
+                new_content,
+            });
+
+            Ok(true)
+        } else {
+            debug!("local echo doesn't exist anymore, can't edit media caption");
+            Ok(false)
+        }
     }
 
     /// Unwedge a local echo identified by its transaction identifier and try to

--- a/crates/matrix-sdk/src/test_utils/events.rs
+++ b/crates/matrix-sdk/src/test_utils/events.rs
@@ -34,13 +34,16 @@ use ruma::{
         relation::{Annotation, InReplyTo, Replacement, Thread},
         room::{
             encrypted::{EncryptedEventScheme, RoomEncryptedEventContent},
-            message::{Relation, RoomMessageEventContent, RoomMessageEventContentWithoutRelation},
+            message::{
+                FormattedBody, ImageMessageEventContent, MessageType, Relation,
+                RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
+            },
             redaction::RoomRedactionEventContent,
         },
         AnySyncTimelineEvent, AnyTimelineEvent, BundledMessageLikeRelations, EventContent,
     },
     serde::Raw,
-    server_name, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
+    server_name, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomId,
     OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UInt, UserId,
 };
 use serde::Serialize;
@@ -232,6 +235,37 @@ impl EventBuilder<RoomMessageEventContent> {
             Some(Relation::Replacement(Replacement::new(edited_event_id.to_owned(), new_content)));
         self
     }
+
+    /// Adds a caption to a media event.
+    ///
+    /// Will crash if the event isn't a media room message.
+    pub fn caption(
+        mut self,
+        caption: Option<String>,
+        formatted_caption: Option<FormattedBody>,
+    ) -> Self {
+        match &mut self.content.msgtype {
+            MessageType::Image(image) => {
+                let filename = image.filename().to_owned();
+                if let Some(caption) = caption {
+                    image.body = caption;
+                    image.filename = Some(filename);
+                } else {
+                    image.body = filename;
+                    image.filename = None;
+                }
+                image.formatted = formatted_caption;
+            }
+
+            MessageType::Audio(_) | MessageType::Video(_) | MessageType::File(_) => {
+                unimplemented!();
+            }
+
+            _ => panic!("unexpected event type for a caption"),
+        }
+
+        self
+    }
 }
 
 impl<E: EventContent> From<EventBuilder<E>> for Raw<AnySyncTimelineEvent>
@@ -411,6 +445,17 @@ impl EventFactory {
             poll_start_id.to_owned(),
         );
         self.event(poll_end_content)
+    }
+
+    /// Creates a plain (unencrypted) image event content referencing the given
+    /// MXC ID.
+    pub fn image(
+        &self,
+        filename: String,
+        url: OwnedMxcUri,
+    ) -> EventBuilder<RoomMessageEventContent> {
+        let image_event_content = ImageMessageEventContent::plain(filename, url);
+        self.event(RoomMessageEventContent::new(MessageType::Image(image_event_content)))
     }
 
     /// Set the next server timestamp.


### PR DESCRIPTION
This allows editing media captions:

- for remote echo'd events, adding support in `make_edit_event` is sufficient,
- for local events (that are in the send queue), a bit more work is necessary:
  - either the media event is a dependent request, and we need to update it
  - or the media event is a request, and we need to update it
  - or the media event is being sent, and we'll record a dependent request for an edit

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/4201