### PR TITLE
feat: Implement `EventCacheStoreLock::lock()` with poison error, and `::lock_unchecked`

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -260,57 +260,57 @@ macro_rules! event_cache_store_integration_tests_time {
                 let store = get_event_cache_store().await.unwrap().into_event_cache_store();
 
                 let acquired0 = store.try_take_leased_lock(0, "key", "alice").await.unwrap();
-                assert!(acquired0);
+                assert_eq!(acquired0, Some(0)); // first lock generation
 
                 // Should extend the lease automatically (same holder).
                 let acquired2 = store.try_take_leased_lock(300, "key", "alice").await.unwrap();
-                assert!(acquired2);
+                assert_eq!(acquired2, Some(0)); // same lock generation
 
                 // Should extend the lease automatically (same holder + time is ok).
                 let acquired3 = store.try_take_leased_lock(300, "key", "alice").await.unwrap();
-                assert!(acquired3);
+                assert_eq!(acquired3, Some(0)); // same lock generation
 
                 // Another attempt at taking the lock should fail, because it's taken.
                 let acquired4 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();
-                assert!(!acquired4);
+                assert!(acquired4.is_none()); // not acquired
 
                 // Even if we insist.
                 let acquired5 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();
-                assert!(!acquired5);
+                assert!(acquired5.is_none()); // not acquired
 
                 // That's a nice test we got here, go take a little nap.
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 // Still too early.
                 let acquired55 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();
-                assert!(!acquired55);
+                assert!(acquired55.is_none()); // not acquired
 
                 // Ok you can take another nap then.
                 tokio::time::sleep(Duration::from_millis(250)).await;
 
                 // At some point, we do get the lock.
                 let acquired6 = store.try_take_leased_lock(0, "key", "bob").await.unwrap();
-                assert!(acquired6);
+                assert_eq!(acquired6, Some(1)); // new lock generation!
 
                 tokio::time::sleep(Duration::from_millis(1)).await;
 
                 // The other gets it almost immediately too.
                 let acquired7 = store.try_take_leased_lock(0, "key", "alice").await.unwrap();
-                assert!(acquired7);
+                assert_eq!(acquired7, Some(2)); // new lock generation!
 
                 tokio::time::sleep(Duration::from_millis(1)).await;
 
-                // But when we take a longer lease...
+                // But when we take a longer lease…
                 let acquired8 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();
-                assert!(acquired8);
+                assert_eq!(acquired8, Some(3)); // new lock generation!
 
                 // It blocks the other user.
                 let acquired9 = store.try_take_leased_lock(300, "key", "alice").await.unwrap();
-                assert!(!acquired9);
+                assert!(acquired9.is_none()); // not acquired
 
                 // We can hold onto our lease.
                 let acquired10 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();
-                assert!(acquired10);
+                assert_eq!(acquired10, Some(3)); // same lock generation
             }
         }
     };

--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -19,7 +19,7 @@
 //! into the event cache for the actual storage. By default this brings an
 //! in-memory store.
 
-use std::{fmt, ops::Deref, str::Utf8Error, sync::Arc};
+use std::{fmt, ops::Deref, result::Result as StdResult, str::Utf8Error, sync::Arc};
 
 #[cfg(any(test, feature = "testing"))]
 #[macro_use]
@@ -160,7 +160,7 @@ impl EventCacheStoreError {
 }
 
 /// An `EventCacheStore` specific result type.
-pub type Result<T, E = EventCacheStoreError> = std::result::Result<T, E>;
+pub type Result<T, E = EventCacheStoreError> = StdResult<T, E>;
 
 /// A type that wraps the [`EventCacheStore`] but implements [`BackingStore`] to
 /// make it usable inside the cross process lock.
@@ -177,7 +177,7 @@ impl BackingStore for LockableEventCacheStore {
         lease_duration_ms: u32,
         key: &str,
         holder: &str,
-    ) -> std::result::Result<bool, Self::LockError> {
-        self.0.try_take_leased_lock(lease_duration_ms, key, holder).await
+    ) -> StdResult<bool, Self::LockError> {
+        Ok(self.0.try_take_leased_lock(lease_duration_ms, key, holder).await?.is_some())
     }
 }

--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -80,7 +80,10 @@ impl EventCacheStoreLock {
     }
 
     /// Acquire a spin lock (see [`CrossProcessStoreLock::spin_lock`]).
-    pub async fn lock(&self) -> Result<EventCacheStoreLockGuard<'_>, LockStoreError> {
+    ///
+    /// It doesn't check whether the lock has been poisoned or not.
+    /// A lock has been poisoned if it's been acquired from another holder.
+    pub async fn lock_unchecked(&self) -> Result<EventCacheStoreLockGuard<'_>, LockStoreError> {
         let cross_process_lock_guard = self.cross_process_lock.spin_lock(None).await?;
 
         Ok(EventCacheStoreLockGuard { cross_process_lock_guard, store: self.store.deref() })

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -15,7 +15,7 @@
 use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
-use matrix_sdk_common::AsyncTraitDeps;
+use matrix_sdk_common::{store_locks::LockGeneration, AsyncTraitDeps};
 use ruma::MxcUri;
 
 use super::EventCacheStoreError;
@@ -35,7 +35,7 @@ pub trait EventCacheStore: AsyncTraitDeps {
         lease_duration_ms: u32,
         key: &str,
         holder: &str,
-    ) -> Result<bool, Self::Error>;
+    ) -> Result<Option<LockGeneration>, Self::Error>;
 
     /// Add a media file's content in the media store.
     ///
@@ -127,7 +127,7 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
         lease_duration_ms: u32,
         key: &str,
         holder: &str,
-    ) -> Result<bool, Self::Error> {
+    ) -> Result<Option<LockGeneration>, Self::Error> {
         self.0.try_take_leased_lock(lease_duration_ms, key, holder).await.map_err(Into::into)
     }
 

--- a/crates/matrix-sdk-base/src/test_utils.rs
+++ b/crates/matrix-sdk-base/src/test_utils.rs
@@ -23,11 +23,24 @@ use crate::{store::StoreConfig, BaseClient, SessionMeta};
 /// Create a [`BaseClient`] with the given user id, if provided, or an hardcoded
 /// one otherwise.
 pub(crate) async fn logged_in_base_client(user_id: Option<&UserId>) -> BaseClient {
-    let client = BaseClient::with_store_config(StoreConfig::new(
-        "cross-process-store-locks-holder-name".to_owned(),
-    ));
+    logged_in_base_client_with_store_config(
+        user_id,
+        StoreConfig::new("cross-process-store-locks-holder-name".to_owned()),
+    )
+    .await
+}
+
+/// Create a [`BaseClient`] with the given user id, if provided, or an hardcoded
+/// one otherwise, and with a store config.
+pub(crate) async fn logged_in_base_client_with_store_config(
+    user_id: Option<&UserId>,
+    store_config: StoreConfig,
+) -> BaseClient {
+    let client = BaseClient::with_store_config(store_config);
+
     let user_id =
         user_id.map(|user_id| user_id.to_owned()).unwrap_or_else(|| owned_user_id!("@u:e.uk"));
+
     client
         .set_session_meta(
             SessionMeta { user_id: user_id.to_owned(), device_id: "FOOBAR".into() },
@@ -36,5 +49,6 @@ pub(crate) async fn logged_in_base_client(user_id: Option<&UserId>) -> BaseClien
         )
         .await
         .expect("set_session_meta failed!");
+
     client
 }

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/003_lease_locks_with_generation.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/003_lease_locks_with_generation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "lease_locks" ADD COLUMN "generation" INTEGER NOT NULL DEFAULT 0;

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -225,6 +225,7 @@ impl EventCache {
         mut room_updates_feed: Receiver<RoomUpdates>,
     ) {
         trace!("Spawning the listen task");
+
         loop {
             match room_updates_feed.recv().await {
                 Ok(updates) => {

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -393,8 +393,13 @@ impl Media {
     ) -> Result<Vec<u8>> {
         // Read from the cache.
         if use_cache {
-            if let Some(content) =
-                self.client.event_cache_store().lock().await?.get_media_content(request).await?
+            if let Some(content) = self
+                .client
+                .event_cache_store()
+                .lock_unchecked()
+                .await?
+                .get_media_content(request)
+                .await?
             {
                 return Ok(content);
             }
@@ -497,7 +502,7 @@ impl Media {
         if use_cache {
             self.client
                 .event_cache_store()
-                .lock()
+                .lock_unchecked()
                 .await?
                 .add_media_content(request, content.clone())
                 .await?;
@@ -512,7 +517,13 @@ impl Media {
     ///
     /// * `request` - The `MediaRequest` of the content.
     pub async fn remove_media_content(&self, request: &MediaRequestParameters) -> Result<()> {
-        Ok(self.client.event_cache_store().lock().await?.remove_media_content(request).await?)
+        Ok(self
+            .client
+            .event_cache_store()
+            .lock_unchecked()
+            .await?
+            .remove_media_content(request)
+            .await?)
     }
 
     /// Delete all the media content corresponding to the given
@@ -522,7 +533,13 @@ impl Media {
     ///
     /// * `uri` - The `MxcUri` of the files.
     pub async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<()> {
-        Ok(self.client.event_cache_store().lock().await?.remove_media_content_for_uri(uri).await?)
+        Ok(self
+            .client
+            .event_cache_store()
+            .lock_unchecked()
+            .await?
+            .remove_media_content_for_uri(uri)
+            .await?)
     }
 
     /// Get the file of the given media event content.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1988,7 +1988,7 @@ impl Room {
             .await?;
 
         if store_in_cache {
-            let cache_store_lock_guard = self.client.event_cache_store().lock().await?;
+            let cache_store_lock_guard = self.client.event_cache_store().lock_unchecked().await?;
 
             // A failure to cache shouldn't prevent the whole upload from finishing
             // properly, so only log errors during caching.

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -706,7 +706,7 @@ impl RoomSendQueue {
                     let data = room
                         .client()
                         .event_cache_store()
-                        .lock()
+                        .lock_unchecked()
                         .await?
                         .get_media_content(&cache_key)
                         .await?

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -167,7 +167,7 @@ impl RoomSendQueue {
             let client = room.client();
             let cache_store = client
                 .event_cache_store()
-                .lock()
+                .lock_unchecked()
                 .await
                 .map_err(RoomSendQueueStorageError::LockError)?;
 
@@ -301,7 +301,7 @@ impl QueueStorage {
 
             let cache_store = client
                 .event_cache_store()
-                .lock()
+                .lock_unchecked()
                 .await
                 .map_err(RoomSendQueueStorageError::LockError)?;
 
@@ -530,7 +530,7 @@ impl QueueStorage {
         // At this point, all the requests and dependent requests have been cleaned up.
         // Perform the final step: empty the cache from the local items.
         {
-            let event_cache = client.event_cache_store().lock().await?;
+            let event_cache = client.event_cache_store().lock_unchecked().await?;
             event_cache
                 .remove_media_content_for_uri(&make_local_uri(&handles.upload_file_txn))
                 .await?;


### PR DESCRIPTION
<figure role="presentation">
<p align="center"><img src="https://github.com/user-attachments/assets/40bf80ed-bb8f-4ea0-a98f-0b5873928247" alt="A flask of poison" width="50%" align /></p>
<figcaption><p align="center">A flask of poison.</p></figcaption>
</figure>

---

Since https://github.com/matrix-org/matrix-rust-sdk/pull/4192, the event cache has a cross-process lock via `EventCacheLock`. It brings a `lock` method. Great! However, the caller is not aware if the lock has been acquired from the same holder or from another holder. The _holder_ refers to the process name usually. If the _holder_ of the lock changes, it means the in-memory data might now be invalid! That's absolutely terrifying. Imagine the following scenario:

- the main app process adds events inside the event cache store
- the main app process is paused
- the push notification process is fired, and adds events inside the event cache store
- the main app process is resumed
- now what? how this process is able to know its data are invalid and should be reloaded?

Poor main app process 😢. We must help this poor main app process, don't we?

Hence this PR.

It introduces a _generation_ counter. The principle is really simple: every time the lock is acquired from _another holder_, the _generation_ is incremented by one. The generation does **not** change if the holder stays the same between lock acquisitions.

So.

* The first patch do that: a `generation` value is added inside the stores (e.g. `matrix-sdk-sqlite`).
* Next, `EventCacheStoreLock::lock` is renamed `lock_unchecked`. Why do we want an _unchecked_ version of the lock? What does it even mean? A lock can be poisoned, but sometimes we just don't care! If we want to add a media in the cache, there is no in-memory invalidation involved. Using `lock_unchecked` is perfect in this case.
* After that, we do a bit of Rust magic with `BackingStore` being automatically implemented for all `Arc<T>` where `T: BackingStore`.
* And now we are ready to implement `LockableEventCacheStore::is_poisoned`. This “poisoning” API is restricted to the event cache; I didn't want to touch the `CrossProcessStoreLock` API. Maybe that would be useful for all cross-process store locks later, but for now, only event cache, nah!
* All pieces are ready. We can implement `EventCacheStoreLock::lock()`.
* Finally, the test parts.

It's better to review this PR commit-by-commit for your own sanity.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280