### PR TITLE
Add 'conn_id' field to `sync_once` span

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -703,7 +703,7 @@ impl SlidingSync {
             || !self.inner.lists.read().await.is_empty()
     }
 
-    #[instrument(skip_all, fields(pos))]
+    #[instrument(skip_all, fields(pos, conn_id = self.inner.id))]
     async fn sync_once(&self) -> Result<UpdateSummary> {
         let (request, request_config, position_guard) =
             self.generate_sync_request(&mut LazyTransactionId::new()).await?;


### PR DESCRIPTION
This is to make it easier to see which sync requests are for which connection when debugging.