### PR TITLE
fix(send queue): when adding a local reaction, look for media events in dependent requests too

### DIFF
--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -367,6 +367,27 @@ pub struct DependentQueuedRequest {
     pub parent_key: Option<SentRequestKey>,
 }
 
+impl DependentQueuedRequest {
+    /// Does the dependent request represent a new event that is *not*
+    /// aggregated, aka it is going to be its own item in a timeline?
+    pub fn is_own_event(&self) -> bool {
+        match self.kind {
+            DependentQueuedRequestKind::EditEvent { .. }
+            | DependentQueuedRequestKind::RedactEvent
+            | DependentQueuedRequestKind::ReactEvent { .. }
+            | DependentQueuedRequestKind::UploadFileWithThumbnail { .. } => {
+                // These are all aggregated events, or non-visible items (file upload producing
+                // a new MXC ID).
+                false
+            }
+            DependentQueuedRequestKind::FinishUpload { .. } => {
+                // This one graduates into a new media event.
+                true
+            }
+        }
+    }
+}
+
 #[cfg(not(tarpaulin_include))]
 impl fmt::Debug for QueuedRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -505,7 +505,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
         let Some(prev_status) = prev_status else {
             match &item.kind {
                 EventTimelineItemKind::Local(local) => {
-                    if let Some(send_handle) = local.send_handle.clone() {
+                    if let Some(send_handle) = &local.send_handle {
                         if send_handle
                             .react(key.to_owned())
                             .await


### PR DESCRIPTION
This allows reacting to a local media upload.

Adding a reaction to a local echo would check that the target of the reaction (identified by its transaction id) is part of the *requests*, but not part of the *dependent requests*. For a media upload, it's more likely the media event will be alive as a dependent request of kind `FinishUpload`, so we need to check there too. With that fix, it's then possible to react to a local media upload.

Part of #4201.