### PR TITLE
fix(base): clear a room's send queue and dependent event queue after removing it from the state store

### DIFF
--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -796,6 +796,8 @@ impl StateStore for MemoryStore {
         self.stripped_members.write().unwrap().remove(room_id);
         self.room_user_receipts.write().unwrap().remove(room_id);
         self.room_event_receipts.write().unwrap().remove(room_id);
+        self.send_queue_events.write().unwrap().remove(room_id);
+        self.dependent_send_queue_events.write().unwrap().remove(room_id);
 
         Ok(())
     }


### PR DESCRIPTION
Since this wasn't properly done for the dependent send queue for rooms, technically we should run a migration to look for the entries in the dependent send queue table, and remove all those that don't correspond to known room ids. I didn't bother here because the value seems quite low (this shouldn't affect many lines), but if the reviewer strongly feels about it, we could clean it up.