### PR TITLE
feat(base) Implement `RelationalLinkedChunk`

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -20,7 +20,7 @@ use matrix_sdk_common::{
     ring_buffer::RingBuffer,
     store_locks::memory_store_helper::try_take_leased_lock,
 };
-use ruma::{MxcUri, OwnedMxcUri};
+use ruma::{MxcUri, OwnedMxcUri, RoomId};
 
 use super::{EventCacheStore, EventCacheStoreError, Result};
 use crate::{
@@ -75,9 +75,10 @@ impl EventCacheStore for MemoryStore {
 
     async fn handle_linked_chunk_updates(
         &self,
+        room_id: &RoomId,
         updates: &[Update<Event, Gap>],
     ) -> Result<(), Self::Error> {
-        self.events.write().unwrap().apply_updates(updates);
+        self.events.write().unwrap().apply_updates(room_id, updates);
 
         Ok(())
     }

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -85,11 +85,12 @@ impl EventCacheStore for MemoryStore {
     async fn handle_linked_chunk_updates(
         &self,
         room_id: &RoomId,
-        updates: &[Update<Event, Gap>],
+        updates: Vec<Update<Event, Gap>>,
     ) -> Result<(), Self::Error> {
         let mut inner = self.inner.write().unwrap();
+        inner.events.apply_updates(room_id, updates);
 
-        Ok(inner.events.apply_updates(updates))
+        Ok(())
     }
 
     async fn add_media_content(
@@ -128,7 +129,7 @@ impl EventCacheStore for MemoryStore {
     async fn get_media_content(&self, request: &MediaRequestParameters) -> Result<Option<Vec<u8>>> {
         let expected_key = request.unique_key();
 
-        let inner = self.inner.write().unwrap();
+        let inner = self.inner.read().unwrap();
 
         Ok(inner.media.iter().find_map(|(_media_uri, media_key, media_content)| {
             (media_key == &expected_key).then(|| media_content.to_owned())

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -34,9 +34,14 @@ use crate::{
 #[allow(clippy::type_complexity)]
 #[derive(Debug)]
 pub struct MemoryStore {
-    media: StdRwLock<RingBuffer<(OwnedMxcUri, String /* unique key */, Vec<u8>)>>,
-    leases: StdRwLock<HashMap<String, (String, Instant)>>,
-    events: StdRwLock<RelationalLinkedChunk<Event, Gap>>,
+    inner: StdRwLock<MemoryStoreInner>,
+}
+
+#[derive(Debug)]
+struct MemoryStoreInner {
+    media: RingBuffer<(OwnedMxcUri, String /* unique key */, Vec<u8>)>,
+    leases: HashMap<String, (String, Instant)>,
+    events: RelationalLinkedChunk<Event, Gap>,
 }
 
 // SAFETY: `new_unchecked` is safe because 20 is not zero.
@@ -45,9 +50,11 @@ const NUMBER_OF_MEDIAS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(20) 
 impl Default for MemoryStore {
     fn default() -> Self {
         Self {
-            media: StdRwLock::new(RingBuffer::new(NUMBER_OF_MEDIAS)),
-            leases: Default::default(),
-            events: StdRwLock::new(RelationalLinkedChunk::new()),
+            inner: StdRwLock::new(MemoryStoreInner {
+                media: RingBuffer::new(NUMBER_OF_MEDIAS),
+                leases: Default::default(),
+                events: RelationalLinkedChunk::new(),
+            }),
         }
     }
 }
@@ -70,7 +77,9 @@ impl EventCacheStore for MemoryStore {
         key: &str,
         holder: &str,
     ) -> Result<bool, Self::Error> {
-        Ok(try_take_leased_lock(&self.leases, lease_duration_ms, key, holder))
+        let mut inner = self.inner.write().unwrap();
+
+        Ok(try_take_leased_lock(&mut inner.leases, lease_duration_ms, key, holder))
     }
 
     async fn handle_linked_chunk_updates(
@@ -78,9 +87,9 @@ impl EventCacheStore for MemoryStore {
         room_id: &RoomId,
         updates: &[Update<Event, Gap>],
     ) -> Result<(), Self::Error> {
-        self.events.write().unwrap().apply_updates(room_id, updates);
+        let mut inner = self.inner.write().unwrap();
 
-        Ok(())
+        Ok(inner.events.apply_updates(updates))
     }
 
     async fn add_media_content(
@@ -90,8 +99,10 @@ impl EventCacheStore for MemoryStore {
     ) -> Result<()> {
         // Avoid duplication. Let's try to remove it first.
         self.remove_media_content(request).await?;
+
         // Now, let's add it.
-        self.media.write().unwrap().push((request.uri().to_owned(), request.unique_key(), data));
+        let mut inner = self.inner.write().unwrap();
+        inner.media.push((request.uri().to_owned(), request.unique_key(), data));
 
         Ok(())
     }
@@ -103,8 +114,10 @@ impl EventCacheStore for MemoryStore {
     ) -> Result<(), Self::Error> {
         let expected_key = from.unique_key();
 
-        let mut medias = self.media.write().unwrap();
-        if let Some((mxc, key, _)) = medias.iter_mut().find(|(_, key, _)| *key == expected_key) {
+        let mut inner = self.inner.write().unwrap();
+
+        if let Some((mxc, key, _)) = inner.media.iter_mut().find(|(_, key, _)| *key == expected_key)
+        {
             *mxc = to.uri().to_owned();
             *key = to.unique_key();
         }
@@ -115,8 +128,9 @@ impl EventCacheStore for MemoryStore {
     async fn get_media_content(&self, request: &MediaRequestParameters) -> Result<Option<Vec<u8>>> {
         let expected_key = request.unique_key();
 
-        let media = self.media.read().unwrap();
-        Ok(media.iter().find_map(|(_media_uri, media_key, media_content)| {
+        let inner = self.inner.write().unwrap();
+
+        Ok(inner.media.iter().find_map(|(_media_uri, media_key, media_content)| {
             (media_key == &expected_key).then(|| media_content.to_owned())
         }))
     }
@@ -124,23 +138,27 @@ impl EventCacheStore for MemoryStore {
     async fn remove_media_content(&self, request: &MediaRequestParameters) -> Result<()> {
         let expected_key = request.unique_key();
 
-        let mut media = self.media.write().unwrap();
-        let Some(index) = media
+        let mut inner = self.inner.write().unwrap();
+
+        let Some(index) = inner
+            .media
             .iter()
             .position(|(_media_uri, media_key, _media_content)| media_key == &expected_key)
         else {
             return Ok(());
         };
 
-        media.remove(index);
+        inner.media.remove(index);
 
         Ok(())
     }
 
     async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<()> {
-        let mut media = self.media.write().unwrap();
+        let mut inner = self.inner.write().unwrap();
+
         let expected_key = uri.to_owned();
-        let positions = media
+        let positions = inner
+            .media
             .iter()
             .enumerate()
             .filter_map(|(position, (media_uri, _media_key, _media_content))| {
@@ -150,7 +168,7 @@ impl EventCacheStore for MemoryStore {
 
         // Iterate in reverse-order so that positions stay valid after first removals.
         for position in positions.into_iter().rev() {
-            media.remove(position);
+            inner.media.remove(position);
         }
 
         Ok(())

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -16,7 +16,7 @@ use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
 use matrix_sdk_common::{linked_chunk::Update, AsyncTraitDeps};
-use ruma::MxcUri;
+use ruma::{MxcUri, RoomId};
 
 use super::EventCacheStoreError;
 use crate::{
@@ -45,6 +45,7 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// in-memory. This method aims at forwarding this update inside this store.
     async fn handle_linked_chunk_updates(
         &self,
+        room_id: &RoomId,
         updates: &[Update<Event, Gap>],
     ) -> Result<(), Self::Error>;
 
@@ -144,9 +145,10 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
 
     async fn handle_linked_chunk_updates(
         &self,
+        room_id: &RoomId,
         updates: &[Update<Event, Gap>],
     ) -> Result<(), Self::Error> {
-        self.0.handle_linked_chunk_updates(updates).await.map_err(Into::into)
+        self.0.handle_linked_chunk_updates(room_id, updates).await.map_err(Into::into)
     }
 
     async fn add_media_content(

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -46,7 +46,7 @@ pub trait EventCacheStore: AsyncTraitDeps {
     async fn handle_linked_chunk_updates(
         &self,
         room_id: &RoomId,
-        updates: &[Update<Event, Gap>],
+        updates: Vec<Update<Event, Gap>>,
     ) -> Result<(), Self::Error>;
 
     /// Add a media file's content in the media store.
@@ -146,7 +146,7 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
     async fn handle_linked_chunk_updates(
         &self,
         room_id: &RoomId,
-        updates: &[Update<Event, Gap>],
+        updates: Vec<Update<Event, Gap>>,
     ) -> Result<(), Self::Error> {
         self.0.handle_linked_chunk_updates(room_id, updates).await.map_err(Into::into)
     }

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -93,6 +93,7 @@ macro_rules! assert_items_eq {
 }
 
 mod as_vector;
+pub mod relational;
 mod updates;
 
 use std::{
@@ -933,7 +934,7 @@ impl ChunkIdentifierGenerator {
 /// Learn more with [`ChunkIdentifierGenerator`].
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(transparent)]
-pub struct ChunkIdentifier(u64);
+pub struct ChunkIdentifier(pub(super) u64);
 
 impl PartialEq<u64> for ChunkIdentifier {
     fn eq(&self, other: &u64) -> bool {
@@ -945,7 +946,7 @@ impl PartialEq<u64> for ChunkIdentifier {
 ///
 /// It's a pair of a chunk position and an item index.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Position(ChunkIdentifier, usize);
+pub struct Position(pub(super) ChunkIdentifier, pub(super) usize);
 
 impl Position {
     /// Get the chunk identifier of the item.
@@ -965,6 +966,16 @@ impl Position {
     /// This method will panic if it will underflow, i.e. if the index is 0.
     pub fn decrement_index(&mut self) {
         self.1 = self.1.checked_sub(1).expect("Cannot decrement the index because it's already 0");
+    }
+
+    /// Increment the index part (see [`Self::index`]), i.e. add 1.
+    ///
+    /// # Panic
+    ///
+    /// This method will panic if it will overflow, i.e. if the index is larger
+    /// than `usize::MAX`.
+    pub fn increment_index(&mut self) {
+        self.1 = self.1.checked_add(1).expect("Cannot increment the index because it's too large");
     }
 }
 

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -934,7 +934,19 @@ impl ChunkIdentifierGenerator {
 /// Learn more with [`ChunkIdentifierGenerator`].
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(transparent)]
-pub struct ChunkIdentifier(pub(super) u64);
+pub struct ChunkIdentifier(u64);
+
+impl ChunkIdentifier {
+    /// Create a new [`ChunkIdentifier`].
+    pub(super) fn new(identifier: u64) -> Self {
+        Self(identifier)
+    }
+
+    /// Get the underlying identifier.
+    fn index(&self) -> u64 {
+        self.0
+    }
+}
 
 impl PartialEq<u64> for ChunkIdentifier {
     fn eq(&self, other: &u64) -> bool {
@@ -946,9 +958,14 @@ impl PartialEq<u64> for ChunkIdentifier {
 ///
 /// It's a pair of a chunk position and an item index.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Position(pub(super) ChunkIdentifier, pub(super) usize);
+pub struct Position(ChunkIdentifier, usize);
 
 impl Position {
+    /// Create a new [`Position`].
+    pub(super) fn new(chunk_identifier: ChunkIdentifier, index: usize) -> Self {
+        Self(chunk_identifier, index)
+    }
+
     /// Get the chunk identifier of the item.
     pub fn chunk_identifier(&self) -> ChunkIdentifier {
         self.0

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -872,12 +872,12 @@ impl<const CAP: usize, Item, Gap> Drop for LinkedChunk<CAP, Item, Gap> {
 }
 
 /// A [`LinkedChunk`] can be safely sent over thread boundaries if `Item: Send`
-/// and `Gap: Send`. The only unsafe part if around the `NonNull`, but the API
+/// and `Gap: Send`. The only unsafe part is around the `NonNull`, but the API
 /// and the lifetimes to deref them are designed safely.
 unsafe impl<const CAP: usize, Item: Send, Gap: Send> Send for LinkedChunk<CAP, Item, Gap> {}
 
 /// A [`LinkedChunk`] can be safely share between threads if `Item: Sync` and
-/// `Gap: Sync`. The only unsafe part if around the `NonNull`, but the API and
+/// `Gap: Sync`. The only unsafe part is around the `NonNull`, but the API and
 /// the lifetimes to deref them are designed safely.
 unsafe impl<const CAP: usize, Item: Sync, Gap: Sync> Sync for LinkedChunk<CAP, Item, Gap> {}
 

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -1,0 +1,450 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation for a _relational linked chunk_, see
+//! [`RelationalLinkedChunk`].
+
+use crate::linked_chunk::{ChunkIdentifier, Position, Update};
+
+/// A row of the [`RelationalLinkedChunk::chunks`].
+#[derive(Debug, PartialEq)]
+struct ChunkRow {
+    previous_chunk: Option<ChunkIdentifier>,
+    chunk: ChunkIdentifier,
+    next_chunk: Option<ChunkIdentifier>,
+}
+
+/// A row of the [`RelationalLinkedChunk::items`].
+#[derive(Debug, PartialEq)]
+struct ItemRow<Item, Gap> {
+    position: Position,
+    item: Either<Item, Gap>,
+}
+
+/// Kind of item.
+#[derive(Debug, PartialEq)]
+enum Either<Item, Gap> {
+    /// The content is an item.
+    Item(Item),
+
+    /// The content is a gap.
+    Gap(Gap),
+}
+
+/// A [`LinkedChunk`] but with a relational layout, similar to what we
+/// would have in a database.
+///
+/// This is used by memory stores. The idea is to have a data layout that is
+/// similar for memory stores and for relational database stores, to represent a
+/// [`LinkedChunk`].
+///
+/// This type is also designed to receive [`Update`]. Applying `Update`s
+/// directly on a [`LinkedChunk`] is not ideal and particularly not trivial as
+/// the `Update`s do _not_ match the internal data layout of the `LinkedChunk`,
+/// they are been designed for storages, like a relational database for example.
+///
+/// This type is not as performant as [`LinkedChunk`] (in terms of memory
+/// layout, CPU caches etc.). It is only designed to be used in memory stores,
+/// which are mostly used for test purposes or light usage of the SDK.
+///
+/// [`LinkedChunk`]: super::LinkedChunk
+#[derive(Debug)]
+pub struct RelationalLinkedChunk<Item, Gap> {
+    /// Chunks.
+    chunks: Vec<ChunkRow>,
+
+    /// Items.
+    items: Vec<ItemRow<Item, Gap>>,
+}
+
+impl<Item, Gap> RelationalLinkedChunk<Item, Gap> {
+    /// Create a new relational linked chunk.
+    pub fn new() -> Self {
+        Self { chunks: Vec::new(), items: Vec::new() }
+    }
+
+    /// Apply [`Update`]s. That's the only way to write data inside this
+    /// relational linked chunk.
+    pub fn apply_updates(&mut self, updates: &[Update<Item, Gap>])
+    where
+        Item: Clone,
+        Gap: Clone,
+    {
+        for update in updates {
+            match update {
+                Update::NewItemsChunk { previous, new, next } => {
+                    insert_chunk(&mut self.chunks, previous, new, next);
+                }
+
+                Update::NewGapChunk { previous, new, next, gap } => {
+                    insert_chunk(&mut self.chunks, previous, new, next);
+                    self.items.push(ItemRow {
+                        position: Position(*new, 0),
+                        item: Either::Gap(gap.clone()),
+                    });
+                }
+
+                Update::RemoveChunk(chunk_identifier) => {
+                    remove_chunk(&mut self.chunks, chunk_identifier);
+
+                    let indices_to_remove = self
+                        .items
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(nth, ItemRow { position, .. })| {
+                            (position.chunk_identifier() == *chunk_identifier).then_some(nth)
+                        })
+                        .collect::<Vec<_>>();
+
+                    for index_to_remove in indices_to_remove.into_iter().rev() {
+                        self.items.remove(index_to_remove);
+                    }
+                }
+
+                Update::PushItems { at, items } => {
+                    let mut at = *at;
+
+                    for item in items {
+                        self.items.push(ItemRow { position: at, item: Either::Item(item.clone()) });
+                        at.increment_index();
+                    }
+                }
+
+                Update::RemoveItem { at } => {
+                    let mut entry_to_remove = None;
+
+                    for (nth, ItemRow { position, .. }) in self.items.iter_mut().enumerate() {
+                        // Find the item to remove.
+                        if position == at {
+                            debug_assert!(entry_to_remove.is_none(), "Found the same entry twice");
+
+                            entry_to_remove = Some(nth);
+                        }
+
+                        // Update all items that come _after_ `at` to shift their index.
+                        if position.chunk_identifier() == at.chunk_identifier()
+                            && position.index() > at.index()
+                        {
+                            position.decrement_index();
+                        }
+                    }
+
+                    self.items.remove(entry_to_remove.expect("Remove an unknown item"));
+                }
+
+                Update::DetachLastItems { at } => {
+                    let indices_to_remove = self
+                        .items
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(nth, ItemRow { position, .. })| {
+                            (position.chunk_identifier() == at.chunk_identifier()
+                                && position.index() >= at.index())
+                            .then_some(nth)
+                        })
+                        .collect::<Vec<_>>();
+
+                    for index_to_remove in indices_to_remove.into_iter().rev() {
+                        self.items.remove(index_to_remove);
+                    }
+                }
+
+                Update::StartReattachItems | Update::EndReattachItems => { /* nothing */ }
+            }
+        }
+
+        fn insert_chunk(
+            chunks: &mut Vec<ChunkRow>,
+            previous: &Option<ChunkIdentifier>,
+            new: &ChunkIdentifier,
+            next: &Option<ChunkIdentifier>,
+        ) {
+            // Find the previous chunk, and update its next chunk.
+            if let Some(previous) = previous {
+                let entry_for_previous_chunk = chunks
+                    .iter_mut()
+                    .find(|ChunkRow { chunk, .. }| chunk == previous)
+                    .expect("Previous chunk should be present");
+
+                // Insert the chunk.
+                entry_for_previous_chunk.next_chunk = Some(*new);
+            }
+
+            // Find the next chunk, and update its previous chunk.
+            if let Some(next) = next {
+                let entry_for_next_chunk = chunks
+                    .iter_mut()
+                    .find(|ChunkRow { chunk, .. }| chunk == next)
+                    .expect("Next chunk should be present");
+
+                // Insert the chunk.
+                entry_for_next_chunk.previous_chunk = Some(*new);
+            }
+
+            // Insert the chunk.
+            chunks.push(ChunkRow { previous_chunk: *previous, chunk: *new, next_chunk: *next });
+        }
+
+        fn remove_chunk(chunks: &mut Vec<ChunkRow>, chunk_to_remove: &ChunkIdentifier) {
+            let entry_nth_to_remove = chunks
+                .iter()
+                .enumerate()
+                .find_map(|(nth, ChunkRow { chunk, .. })| (chunk == chunk_to_remove).then_some(nth))
+                .expect("Remove an unknown chunk");
+
+            let ChunkRow { previous_chunk: previous, next_chunk: next, .. } =
+                chunks.remove(entry_nth_to_remove);
+
+            // Find the previous chunk, and update its next chunk.
+            if let Some(previous) = previous {
+                let entry_for_previous_chunk = chunks
+                    .iter_mut()
+                    .find(|ChunkRow { chunk, .. }| *chunk == previous)
+                    .expect("Previous chunk should be present");
+
+                // Insert the chunk.
+                entry_for_previous_chunk.next_chunk = next;
+            }
+
+            // Find the next chunk, and update its previous chunk.
+            if let Some(next) = next {
+                let entry_for_next_chunk = chunks
+                    .iter_mut()
+                    .find(|ChunkRow { chunk, .. }| *chunk == next)
+                    .expect("Next chunk should be present");
+
+                // Insert the chunk.
+                entry_for_next_chunk.previous_chunk = previous;
+            }
+        }
+    }
+}
+
+impl<Item, Gap> Default for RelationalLinkedChunk<Item, Gap> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ChunkIdentifier as CId, *};
+
+    #[test]
+    fn test_new_items_chunk() {
+        let mut relational_linked_chunk = RelationalLinkedChunk::<char, ()>::new();
+
+        relational_linked_chunk.apply_updates(&[
+            // 0
+            Update::NewItemsChunk { previous: None, new: CId(0), next: None },
+            // 1 after 0
+            Update::NewItemsChunk { previous: Some(CId(0)), new: CId(1), next: None },
+            // 2 before 0
+            Update::NewItemsChunk { previous: None, new: CId(2), next: Some(CId(0)) },
+            // 3 between 2 and 0
+            Update::NewItemsChunk { previous: Some(CId(2)), new: CId(3), next: Some(CId(0)) },
+        ]);
+
+        // Chunks are correctly linked.
+        assert_eq!(
+            relational_linked_chunk.chunks,
+            &[
+                ChunkRow { previous_chunk: Some(CId(3)), chunk: CId(0), next_chunk: Some(CId(1)) },
+                ChunkRow { previous_chunk: Some(CId(0)), chunk: CId(1), next_chunk: None },
+                ChunkRow { previous_chunk: None, chunk: CId(2), next_chunk: Some(CId(3)) },
+                ChunkRow { previous_chunk: Some(CId(2)), chunk: CId(3), next_chunk: Some(CId(0)) },
+            ],
+        );
+        // Items have not been modified.
+        assert!(relational_linked_chunk.items.is_empty());
+    }
+
+    #[test]
+    fn test_new_gap_chunk() {
+        let mut relational_linked_chunk = RelationalLinkedChunk::<char, ()>::new();
+
+        relational_linked_chunk.apply_updates(&[
+            // 0
+            Update::NewItemsChunk { previous: None, new: CId(0), next: None },
+            // 1 after 0
+            Update::NewGapChunk { previous: Some(CId(0)), new: CId(1), next: None, gap: () },
+            // 2 after 1
+            Update::NewItemsChunk { previous: Some(CId(1)), new: CId(2), next: None },
+        ]);
+
+        // Chunks are correctly links.
+        assert_eq!(
+            relational_linked_chunk.chunks,
+            &[
+                ChunkRow { previous_chunk: None, chunk: CId(0), next_chunk: Some(CId(1)) },
+                ChunkRow { previous_chunk: Some(CId(0)), chunk: CId(1), next_chunk: Some(CId(2)) },
+                ChunkRow { previous_chunk: Some(CId(1)), chunk: CId(2), next_chunk: None },
+            ],
+        );
+        // Items contains the gap.
+        assert_eq!(
+            relational_linked_chunk.items,
+            &[ItemRow { position: Position(CId(1), 0), item: Either::Gap(()) }],
+        );
+    }
+
+    #[test]
+    fn test_remove_chunk() {
+        let mut relational_linked_chunk = RelationalLinkedChunk::<char, ()>::new();
+
+        relational_linked_chunk.apply_updates(&[
+            // 0
+            Update::NewItemsChunk { previous: None, new: CId(0), next: None },
+            // 1 after 0
+            Update::NewGapChunk { previous: Some(CId(0)), new: CId(1), next: None, gap: () },
+            // 2 after 1
+            Update::NewItemsChunk { previous: Some(CId(1)), new: CId(2), next: None },
+            // remove 1
+            Update::RemoveChunk(CId(1)),
+        ]);
+
+        // Chunks are correctly links.
+        assert_eq!(
+            relational_linked_chunk.chunks,
+            &[
+                ChunkRow { previous_chunk: None, chunk: CId(0), next_chunk: Some(CId(2)) },
+                ChunkRow { previous_chunk: Some(CId(0)), chunk: CId(2), next_chunk: None },
+            ],
+        );
+        // Items no longer contains the gap.
+        assert!(relational_linked_chunk.items.is_empty());
+    }
+
+    #[test]
+    fn test_push_items() {
+        let mut relational_linked_chunk = RelationalLinkedChunk::<char, ()>::new();
+
+        relational_linked_chunk.apply_updates(&[
+            // new chunk (this is not mandatory for this test, but let's try to be realistic)
+            Update::NewItemsChunk { previous: None, new: CId(0), next: None },
+            // new items on 0
+            Update::PushItems { at: Position(CId(0), 0), items: vec!['a', 'b', 'c'] },
+            // new chunk (to test new items are pushed in the correct chunk)
+            Update::NewItemsChunk { previous: Some(CId(0)), new: CId(1), next: None },
+            // new items on 1
+            Update::PushItems { at: Position(CId(1), 0), items: vec!['x', 'y', 'z'] },
+            // new items on 0 again
+            Update::PushItems { at: Position(CId(0), 3), items: vec!['d', 'e'] },
+        ]);
+
+        // Chunks are correctly links.
+        assert_eq!(
+            relational_linked_chunk.chunks,
+            &[
+                ChunkRow { previous_chunk: None, chunk: CId(0), next_chunk: Some(CId(1)) },
+                ChunkRow { previous_chunk: Some(CId(0)), chunk: CId(1), next_chunk: None },
+            ],
+        );
+        // Items contains the pushed items.
+        assert_eq!(
+            relational_linked_chunk.items,
+            &[
+                ItemRow { position: Position(CId(0), 0), item: Either::Item('a') },
+                ItemRow { position: Position(CId(0), 1), item: Either::Item('b') },
+                ItemRow { position: Position(CId(0), 2), item: Either::Item('c') },
+                ItemRow { position: Position(CId(1), 0), item: Either::Item('x') },
+                ItemRow { position: Position(CId(1), 1), item: Either::Item('y') },
+                ItemRow { position: Position(CId(1), 2), item: Either::Item('z') },
+                ItemRow { position: Position(CId(0), 3), item: Either::Item('d') },
+                ItemRow { position: Position(CId(0), 4), item: Either::Item('e') },
+            ],
+        );
+    }
+
+    #[test]
+    fn test_remove_item() {
+        let mut relational_linked_chunk = RelationalLinkedChunk::<char, ()>::new();
+
+        relational_linked_chunk.apply_updates(&[
+            // new chunk (this is not mandatory for this test, but let's try to be realistic)
+            Update::NewItemsChunk { previous: None, new: CId(0), next: None },
+            // new items on 0
+            Update::PushItems { at: Position(CId(0), 0), items: vec!['a', 'b', 'c', 'd', 'e'] },
+            // remove an item: 'a'
+            Update::RemoveItem { at: Position(CId(0), 0) },
+            // remove an item: 'd'
+            Update::RemoveItem { at: Position(CId(0), 2) },
+        ]);
+
+        // Chunks are correctly links.
+        assert_eq!(
+            relational_linked_chunk.chunks,
+            &[ChunkRow { previous_chunk: None, chunk: CId(0), next_chunk: None }],
+        );
+        // Items contains the pushed items.
+        assert_eq!(
+            relational_linked_chunk.items,
+            &[
+                ItemRow { position: Position(CId(0), 0), item: Either::Item('b') },
+                ItemRow { position: Position(CId(0), 1), item: Either::Item('c') },
+                ItemRow { position: Position(CId(0), 2), item: Either::Item('e') },
+            ],
+        );
+    }
+
+    #[test]
+    fn test_detach_last_items() {
+        let mut relational_linked_chunk = RelationalLinkedChunk::<char, ()>::new();
+
+        relational_linked_chunk.apply_updates(&[
+            // new chunk
+            Update::NewItemsChunk { previous: None, new: CId(0), next: None },
+            // new chunk
+            Update::NewItemsChunk { previous: Some(CId(0)), new: CId(1), next: None },
+            // new items on 0
+            Update::PushItems { at: Position(CId(0), 0), items: vec!['a', 'b', 'c', 'd', 'e'] },
+            // new items on 1
+            Update::PushItems { at: Position(CId(1), 0), items: vec!['x', 'y', 'z'] },
+            // detach last items on 0
+            Update::DetachLastItems { at: Position(CId(0), 2) },
+        ]);
+
+        // Chunks are correctly links.
+        assert_eq!(
+            relational_linked_chunk.chunks,
+            &[
+                ChunkRow { previous_chunk: None, chunk: CId(0), next_chunk: Some(CId(1)) },
+                ChunkRow { previous_chunk: Some(CId(0)), chunk: CId(1), next_chunk: None },
+            ],
+        );
+        // Items contains the pushed items.
+        assert_eq!(
+            relational_linked_chunk.items,
+            &[
+                ItemRow { position: Position(CId(0), 0), item: Either::Item('a') },
+                ItemRow { position: Position(CId(0), 1), item: Either::Item('b') },
+                ItemRow { position: Position(CId(1), 0), item: Either::Item('x') },
+                ItemRow { position: Position(CId(1), 1), item: Either::Item('y') },
+                ItemRow { position: Position(CId(1), 2), item: Either::Item('z') },
+            ],
+        );
+    }
+
+    #[test]
+    fn test_start_and_end_reattach_items() {
+        let mut relational_linked_chunk = RelationalLinkedChunk::<char, ()>::new();
+
+        relational_linked_chunk
+            .apply_updates(&[Update::StartReattachItems, Update::EndReattachItems]);
+
+        // Nothing happened.
+        assert!(relational_linked_chunk.chunks.is_empty());
+        assert!(relational_linked_chunk.items.is_empty());
+    }
+}

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -56,7 +56,8 @@ enum Either<Item, Gap> {
 /// This type is also designed to receive [`Update`]. Applying `Update`s
 /// directly on a [`LinkedChunk`] is not ideal and particularly not trivial as
 /// the `Update`s do _not_ match the internal data layout of the `LinkedChunk`,
-/// they are been designed for storages, like a relational database for example.
+/// they have been designed for storages, like a relational database for
+/// example.
 ///
 /// This type is not as performant as [`LinkedChunk`] (in terms of memory
 /// layout, CPU caches etc.). It is only designed to be used in memory stores,
@@ -95,7 +96,7 @@ impl<Item, Gap> RelationalLinkedChunk<Item, Gap> {
                     insert_chunk(&mut self.chunks, room_id, previous, new, next);
                     self.items.push(ItemRow {
                         room_id: room_id.to_owned(),
-                        position: Position(*new, 0),
+                        position: Position::new(*new, 0),
                         item: Either::Gap(gap.clone()),
                     });
                 }
@@ -295,13 +296,17 @@ mod tests {
             room_id,
             &[
                 // 0
-                Update::NewItemsChunk { previous: None, new: CId(0), next: None },
+                Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
                 // 1 after 0
-                Update::NewItemsChunk { previous: Some(CId(0)), new: CId(1), next: None },
+                Update::NewItemsChunk { previous: Some(CId::new(0)), new: CId::new(1), next: None },
                 // 2 before 0
-                Update::NewItemsChunk { previous: None, new: CId(2), next: Some(CId(0)) },
+                Update::NewItemsChunk { previous: None, new: CId::new(2), next: Some(CId::new(0)) },
                 // 3 between 2 and 0
-                Update::NewItemsChunk { previous: Some(CId(2)), new: CId(3), next: Some(CId(0)) },
+                Update::NewItemsChunk {
+                    previous: Some(CId::new(2)),
+                    new: CId::new(3),
+                    next: Some(CId::new(0)),
+                },
             ],
         );
 
@@ -311,27 +316,27 @@ mod tests {
             &[
                 ChunkRow {
                     room_id: room_id.to_owned(),
-                    previous_chunk: Some(CId(3)),
-                    chunk: CId(0),
-                    next_chunk: Some(CId(1))
+                    previous_chunk: Some(CId::new(3)),
+                    chunk: CId::new(0),
+                    next_chunk: Some(CId::new(1))
                 },
                 ChunkRow {
                     room_id: room_id.to_owned(),
-                    previous_chunk: Some(CId(0)),
-                    chunk: CId(1),
+                    previous_chunk: Some(CId::new(0)),
+                    chunk: CId::new(1),
                     next_chunk: None
                 },
                 ChunkRow {
                     room_id: room_id.to_owned(),
                     previous_chunk: None,
-                    chunk: CId(2),
-                    next_chunk: Some(CId(3))
+                    chunk: CId::new(2),
+                    next_chunk: Some(CId::new(3))
                 },
                 ChunkRow {
                     room_id: room_id.to_owned(),
-                    previous_chunk: Some(CId(2)),
-                    chunk: CId(3),
-                    next_chunk: Some(CId(0))
+                    previous_chunk: Some(CId::new(2)),
+                    chunk: CId::new(3),
+                    next_chunk: Some(CId::new(0))
                 },
             ],
         );
@@ -348,11 +353,16 @@ mod tests {
             room_id,
             &[
                 // 0
-                Update::NewItemsChunk { previous: None, new: CId(0), next: None },
+                Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
                 // 1 after 0
-                Update::NewGapChunk { previous: Some(CId(0)), new: CId(1), next: None, gap: () },
+                Update::NewGapChunk {
+                    previous: Some(CId::new(0)),
+                    new: CId::new(1),
+                    next: None,
+                    gap: (),
+                },
                 // 2 after 1
-                Update::NewItemsChunk { previous: Some(CId(1)), new: CId(2), next: None },
+                Update::NewItemsChunk { previous: Some(CId::new(1)), new: CId::new(2), next: None },
             ],
         );
 
@@ -363,19 +373,19 @@ mod tests {
                 ChunkRow {
                     room_id: room_id.to_owned(),
                     previous_chunk: None,
-                    chunk: CId(0),
-                    next_chunk: Some(CId(1))
+                    chunk: CId::new(0),
+                    next_chunk: Some(CId::new(1))
                 },
                 ChunkRow {
                     room_id: room_id.to_owned(),
-                    previous_chunk: Some(CId(0)),
-                    chunk: CId(1),
-                    next_chunk: Some(CId(2))
+                    previous_chunk: Some(CId::new(0)),
+                    chunk: CId::new(1),
+                    next_chunk: Some(CId::new(2))
                 },
                 ChunkRow {
                     room_id: room_id.to_owned(),
-                    previous_chunk: Some(CId(1)),
-                    chunk: CId(2),
+                    previous_chunk: Some(CId::new(1)),
+                    chunk: CId::new(2),
                     next_chunk: None
                 },
             ],
@@ -385,7 +395,7 @@ mod tests {
             relational_linked_chunk.items,
             &[ItemRow {
                 room_id: room_id.to_owned(),
-                position: Position(CId(1), 0),
+                position: Position::new(CId::new(1), 0),
                 item: Either::Gap(())
             }],
         );
@@ -400,13 +410,18 @@ mod tests {
             room_id,
             &[
                 // 0
-                Update::NewItemsChunk { previous: None, new: CId(0), next: None },
+                Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
                 // 1 after 0
-                Update::NewGapChunk { previous: Some(CId(0)), new: CId(1), next: None, gap: () },
+                Update::NewGapChunk {
+                    previous: Some(CId::new(0)),
+                    new: CId::new(1),
+                    next: None,
+                    gap: (),
+                },
                 // 2 after 1
-                Update::NewItemsChunk { previous: Some(CId(1)), new: CId(2), next: None },
+                Update::NewItemsChunk { previous: Some(CId::new(1)), new: CId::new(2), next: None },
                 // remove 1
-                Update::RemoveChunk(CId(1)),
+                Update::RemoveChunk(CId::new(1)),
             ],
         );
 
@@ -417,13 +432,13 @@ mod tests {
                 ChunkRow {
                     room_id: room_id.to_owned(),
                     previous_chunk: None,
-                    chunk: CId(0),
-                    next_chunk: Some(CId(2))
+                    chunk: CId::new(0),
+                    next_chunk: Some(CId::new(2))
                 },
                 ChunkRow {
                     room_id: room_id.to_owned(),
-                    previous_chunk: Some(CId(0)),
-                    chunk: CId(2),
+                    previous_chunk: Some(CId::new(0)),
+                    chunk: CId::new(2),
                     next_chunk: None
                 },
             ],
@@ -441,15 +456,15 @@ mod tests {
             room_id,
             &[
                 // new chunk (this is not mandatory for this test, but let's try to be realistic)
-                Update::NewItemsChunk { previous: None, new: CId(0), next: None },
+                Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
                 // new items on 0
-                Update::PushItems { at: Position(CId(0), 0), items: vec!['a', 'b', 'c'] },
+                Update::PushItems { at: Position::new(CId::new(0), 0), items: vec!['a', 'b', 'c'] },
                 // new chunk (to test new items are pushed in the correct chunk)
-                Update::NewItemsChunk { previous: Some(CId(0)), new: CId(1), next: None },
+                Update::NewItemsChunk { previous: Some(CId::new(0)), new: CId::new(1), next: None },
                 // new items on 1
-                Update::PushItems { at: Position(CId(1), 0), items: vec!['x', 'y', 'z'] },
+                Update::PushItems { at: Position::new(CId::new(1), 0), items: vec!['x', 'y', 'z'] },
                 // new items on 0 again
-                Update::PushItems { at: Position(CId(0), 3), items: vec!['d', 'e'] },
+                Update::PushItems { at: Position::new(CId::new(0), 3), items: vec!['d', 'e'] },
             ],
         );
 
@@ -460,13 +475,13 @@ mod tests {
                 ChunkRow {
                     room_id: room_id.to_owned(),
                     previous_chunk: None,
-                    chunk: CId(0),
-                    next_chunk: Some(CId(1))
+                    chunk: CId::new(0),
+                    next_chunk: Some(CId::new(1))
                 },
                 ChunkRow {
                     room_id: room_id.to_owned(),
-                    previous_chunk: Some(CId(0)),
-                    chunk: CId(1),
+                    previous_chunk: Some(CId::new(0)),
+                    chunk: CId::new(1),
                     next_chunk: None
                 },
             ],
@@ -477,42 +492,42 @@ mod tests {
             &[
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(0), 0),
+                    position: Position::new(CId::new(0), 0),
                     item: Either::Item('a')
                 },
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(0), 1),
+                    position: Position::new(CId::new(0), 1),
                     item: Either::Item('b')
                 },
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(0), 2),
+                    position: Position::new(CId::new(0), 2),
                     item: Either::Item('c')
                 },
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(1), 0),
+                    position: Position::new(CId::new(1), 0),
                     item: Either::Item('x')
                 },
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(1), 1),
+                    position: Position::new(CId::new(1), 1),
                     item: Either::Item('y')
                 },
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(1), 2),
+                    position: Position::new(CId::new(1), 2),
                     item: Either::Item('z')
                 },
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(0), 3),
+                    position: Position::new(CId::new(0), 3),
                     item: Either::Item('d')
                 },
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(0), 4),
+                    position: Position::new(CId::new(0), 4),
                     item: Either::Item('e')
                 },
             ],
@@ -528,13 +543,16 @@ mod tests {
             room_id,
             &[
                 // new chunk (this is not mandatory for this test, but let's try to be realistic)
-                Update::NewItemsChunk { previous: None, new: CId(0), next: None },
+                Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
                 // new items on 0
-                Update::PushItems { at: Position(CId(0), 0), items: vec!['a', 'b', 'c', 'd', 'e'] },
+                Update::PushItems {
+                    at: Position::new(CId::new(0), 0),
+                    items: vec!['a', 'b', 'c', 'd', 'e'],
+                },
                 // remove an item: 'a'
-                Update::RemoveItem { at: Position(CId(0), 0) },
+                Update::RemoveItem { at: Position::new(CId::new(0), 0) },
                 // remove an item: 'd'
-                Update::RemoveItem { at: Position(CId(0), 2) },
+                Update::RemoveItem { at: Position::new(CId::new(0), 2) },
             ],
         );
 
@@ -544,7 +562,7 @@ mod tests {
             &[ChunkRow {
                 room_id: room_id.to_owned(),
                 previous_chunk: None,
-                chunk: CId(0),
+                chunk: CId::new(0),
                 next_chunk: None
             }],
         );
@@ -554,17 +572,17 @@ mod tests {
             &[
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(0), 0),
+                    position: Position::new(CId::new(0), 0),
                     item: Either::Item('b')
                 },
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(0), 1),
+                    position: Position::new(CId::new(0), 1),
                     item: Either::Item('c')
                 },
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(0), 2),
+                    position: Position::new(CId::new(0), 2),
                     item: Either::Item('e')
                 },
             ],
@@ -580,15 +598,18 @@ mod tests {
             room_id,
             &[
                 // new chunk
-                Update::NewItemsChunk { previous: None, new: CId(0), next: None },
+                Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
                 // new chunk
-                Update::NewItemsChunk { previous: Some(CId(0)), new: CId(1), next: None },
+                Update::NewItemsChunk { previous: Some(CId::new(0)), new: CId::new(1), next: None },
                 // new items on 0
-                Update::PushItems { at: Position(CId(0), 0), items: vec!['a', 'b', 'c', 'd', 'e'] },
+                Update::PushItems {
+                    at: Position::new(CId::new(0), 0),
+                    items: vec!['a', 'b', 'c', 'd', 'e'],
+                },
                 // new items on 1
-                Update::PushItems { at: Position(CId(1), 0), items: vec!['x', 'y', 'z'] },
+                Update::PushItems { at: Position::new(CId::new(1), 0), items: vec!['x', 'y', 'z'] },
                 // detach last items on 0
-                Update::DetachLastItems { at: Position(CId(0), 2) },
+                Update::DetachLastItems { at: Position::new(CId::new(0), 2) },
             ],
         );
 
@@ -599,13 +620,13 @@ mod tests {
                 ChunkRow {
                     room_id: room_id.to_owned(),
                     previous_chunk: None,
-                    chunk: CId(0),
-                    next_chunk: Some(CId(1))
+                    chunk: CId::new(0),
+                    next_chunk: Some(CId::new(1))
                 },
                 ChunkRow {
                     room_id: room_id.to_owned(),
-                    previous_chunk: Some(CId(0)),
-                    chunk: CId(1),
+                    previous_chunk: Some(CId::new(0)),
+                    chunk: CId::new(1),
                     next_chunk: None
                 },
             ],
@@ -616,27 +637,27 @@ mod tests {
             &[
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(0), 0),
+                    position: Position::new(CId::new(0), 0),
                     item: Either::Item('a')
                 },
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(0), 1),
+                    position: Position::new(CId::new(0), 1),
                     item: Either::Item('b')
                 },
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(1), 0),
+                    position: Position::new(CId::new(1), 0),
                     item: Either::Item('x')
                 },
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(1), 1),
+                    position: Position::new(CId::new(1), 1),
                     item: Either::Item('y')
                 },
                 ItemRow {
                     room_id: room_id.to_owned(),
-                    position: Position(CId(1), 2),
+                    position: Position::new(CId::new(1), 2),
                     item: Either::Item('z')
                 },
             ],

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -198,7 +198,7 @@ impl<Item, Gap> RelationalLinkedChunk<Item, Gap> {
                     })
                     .expect("Previous chunk should be present");
 
-                // Insert the chunk.
+                // Link the chunk.
                 entry_for_previous_chunk.next_chunk = Some(new);
             }
 
@@ -211,7 +211,7 @@ impl<Item, Gap> RelationalLinkedChunk<Item, Gap> {
                     })
                     .expect("Next chunk should be present");
 
-                // Insert the chunk.
+                // Link the chunk.
                 entry_for_next_chunk.previous_chunk = Some(new);
             }
 
@@ -360,7 +360,7 @@ mod tests {
             ],
         );
 
-        // Chunks are correctly links.
+        // Chunks are correctly linked.
         assert_eq!(
             relational_linked_chunk.chunks,
             &[
@@ -419,7 +419,7 @@ mod tests {
             ],
         );
 
-        // Chunks are correctly links.
+        // Chunks are correctly linked.
         assert_eq!(
             relational_linked_chunk.chunks,
             &[
@@ -462,7 +462,7 @@ mod tests {
             ],
         );
 
-        // Chunks are correctly links.
+        // Chunks are correctly linked.
         assert_eq!(
             relational_linked_chunk.chunks,
             &[
@@ -550,7 +550,7 @@ mod tests {
             ],
         );
 
-        // Chunks are correctly links.
+        // Chunks are correctly linked.
         assert_eq!(
             relational_linked_chunk.chunks,
             &[ChunkRow {
@@ -607,7 +607,7 @@ mod tests {
             ],
         );
 
-        // Chunks are correctly links.
+        // Chunks are correctly linked.
         assert_eq!(
             relational_linked_chunk.chunks,
             &[

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -632,7 +632,7 @@ impl CryptoStore for MemoryStore {
         key: &str,
         holder: &str,
     ) -> Result<bool> {
-        Ok(try_take_leased_lock(&self.leases, lease_duration_ms, key, holder))
+        Ok(try_take_leased_lock(&mut self.leases.write().unwrap(), lease_duration_ms, key, holder))
     }
 }
 

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -186,7 +186,7 @@ impl EventCacheStore for SqliteEventCacheStore {
     async fn handle_linked_chunk_updates(
         &self,
         _room_id: &RoomId,
-        _updates: &[Update<Event, Gap>],
+        _updates: Vec<Update<Event, Gap>>,
     ) -> Result<(), Self::Error> {
         todo!()
     }

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -8,7 +8,7 @@ use matrix_sdk_base::{
     media::{MediaRequestParameters, UniqueKey},
 };
 use matrix_sdk_store_encryption::StoreCipher;
-use ruma::MilliSecondsSinceUnixEpoch;
+use ruma::{MilliSecondsSinceUnixEpoch, RoomId};
 use rusqlite::OptionalExtension;
 use tokio::fs;
 use tracing::debug;
@@ -185,6 +185,7 @@ impl EventCacheStore for SqliteEventCacheStore {
 
     async fn handle_linked_chunk_updates(
         &self,
+        _room_id: &RoomId,
         _updates: &[Update<Event, Gap>],
     ) -> Result<(), Self::Error> {
         todo!()


### PR DESCRIPTION
<figure role="presentation">
<p align="center"><img src="https://github.com/user-attachments/assets/dd188a36-7459-4025-adb9-2567f8e9570b" alt="A flask of poison" width="80%" /></p>
<figcaption><p align="center">A book floating in space in front of a black hole.</p></figcaption>
</figure>

---

A `RelationalLinkedChunk` is like a `LinkedChunk` but with a relational
layout, similar to what we would have in a database.

This is used by memory stores. The idea is to have a data layout that
is similar for memory stores and for relational database stores, to
represent a `LinkedChunk`.

This type is also designed to receive `Update`. Applying `Update`s
directly on a `LinkedChunk` is not ideal and particularly not trivial
as the `Update`s do _not_ match the internal data layout of the
`LinkedChunk`, they have been designed for storages, like a relational
database for example.

This type is not as performant as `LinkedChunk` (in terms of memory
layout, CPU caches etc.). It is only designed to be used in memory
stores, which are mostly used for test purposes or light usages of the
SDK.

---

* ~~Must be merged after https://github.com/matrix-org/matrix-rust-sdk/pull/4299 as it contains its commits~~
* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280