### PR TITLE
feat(timeline): mark media events as editable

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -368,7 +368,15 @@ impl EventTimelineItem {
 
         match self.content() {
             TimelineItemContent::Message(message) => {
-                matches!(message.msgtype(), MessageType::Text(_) | MessageType::Emote(_))
+                matches!(
+                    message.msgtype(),
+                    MessageType::Text(_)
+                        | MessageType::Emote(_)
+                        | MessageType::Audio(_)
+                        | MessageType::File(_)
+                        | MessageType::Image(_)
+                        | MessageType::Video(_)
+                )
             }
             TimelineItemContent::Poll(poll) => {
                 poll.response_data.is_empty() && poll.end_event_timestamp.is_none()


### PR DESCRIPTION
This PR makes audio, file, image and video messages be editable so that the timeline signals when it is possible to use #4277/#4300 for editing captions.