### PR TITLE
refactor(room_preview): make `RoomPreview` use the local known data only for joined rooms

### DIFF
--- a/crates/matrix-sdk/src/room_preview.rs
+++ b/crates/matrix-sdk/src/room_preview.rs
@@ -124,9 +124,8 @@ impl RoomPreview {
         }
     }
 
-    /// Create a room preview from a known room (i.e. one we've been invited to,
-    /// we've joined or we've left).
-    pub(crate) async fn from_known(room: &Room) -> Self {
+    /// Create a room preview from a known room we've joined.
+    pub(crate) async fn from_joined(room: &Room) -> Self {
         let is_direct = room.is_direct().await.ok();
 
         let display_name = room.compute_display_name().await.ok().map(|name| name.to_string());
@@ -142,7 +141,7 @@ impl RoomPreview {
     }
 
     #[instrument(skip(client))]
-    pub(crate) async fn from_unknown(
+    pub(crate) async fn from_not_joined(
         client: &Client,
         room_id: OwnedRoomId,
         room_or_alias_id: &RoomOrAliasId,


### PR DESCRIPTION
When instantiating a room preview, previously the SDK would try to just check if the room exists locally either as joined, invited, knocked, left, etc., and then retrieve the info we cached about it.

While this seems fine for most cases, it turns out for non-joined rooms, the info we have locally will **always** be the one we received when the invite/knock/leave action took place and it'll never be updated, so we may have the case where we knock into a room, never receive a response, someone changes the join rule of the room to something else and we'll think about this room as a 'request to join' room until we clear the local cache. There are other cases such as the room name, topic or other 'public' values changing in the meantime and the user thinking he's trying to join a completely different room too, but these seem like minor issues compared to never being able to join at all.

To prevent all that, I think we can only use the local data for joined rooms, which are constantly updated, and try to use the room summary API and other fallbacks for the rest, even if they're rooms known to us.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
