### PR TITLE
build (apple): add dynamic type to debug package

### DIFF
--- a/bindings/apple/Debug-Package.swift
+++ b/bindings/apple/Debug-Package.swift
@@ -13,6 +13,7 @@ let package = Package(
     ],
     products: [
         .library(name: "MatrixRustSDK",
+                 type: .dynamic,
                  targets: ["MatrixRustSDK"]),
     ],
     targets: [


### PR DESCRIPTION
On the latest Xcode versions this is required to make the app run when building the SDK locally