### PR TITLE
feat(ffi): wrap Ruma MediaSources and run validations before passing them over FFI

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -13,10 +13,3 @@ interface RoomMessageEventContentWithoutRelation {
 interface ClientError {
     Generic(string msg);
 };
-
-interface MediaSource {
-    [Name=from_json, Throws=ClientError]
-    constructor(string json);
-    string to_json();
-    string url();
-};

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -32,9 +32,7 @@ use matrix_sdk::{
             user_directory::search_users,
         },
         events::{
-            room::{
-                avatar::RoomAvatarEventContent, encryption::RoomEncryptionEventContent, MediaSource,
-            },
+            room::{avatar::RoomAvatarEventContent, encryption::RoomEncryptionEventContent},
             AnyInitialStateEvent, AnyToDeviceEvent, InitialStateEvent,
         },
         serde::Raw,
@@ -81,7 +79,7 @@ use crate::{
     notification_settings::NotificationSettings,
     room_directory_search::RoomDirectorySearch,
     room_preview::RoomPreview,
-    ruma::AuthData,
+    ruma::{AuthData, MediaSource},
     sync_service::{SyncService, SyncServiceBuilder},
     task_handle::TaskHandle,
     utils::AsyncRuntimeDropped,
@@ -455,7 +453,7 @@ impl Client {
             .inner
             .media()
             .get_media_file(
-                &MediaRequestParameters { source, format: MediaFormat::File },
+                &MediaRequestParameters { source: source.media_source, format: MediaFormat::File },
                 filename,
                 &mime_type,
                 use_cache,
@@ -728,7 +726,7 @@ impl Client {
         &self,
         media_source: Arc<MediaSource>,
     ) -> Result<Vec<u8>, ClientError> {
-        let source = (*media_source).clone();
+        let source = (*media_source).clone().media_source;
 
         debug!(?source, "requesting media file");
         Ok(self
@@ -744,9 +742,9 @@ impl Client {
         width: u64,
         height: u64,
     ) -> Result<Vec<u8>, ClientError> {
-        let source = (*media_source).clone();
+        let source = (*media_source).clone().media_source;
 
-        debug!(source = ?media_source, width, height, "requesting media thumbnail");
+        debug!(?source, width, height, "requesting media thumbnail");
         Ok(self
             .inner
             .media()

--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -202,7 +202,7 @@ impl TryFrom<AnySyncMessageLikeEvent> for MessageLikeEventContent {
                         _ => None,
                     });
                 MessageLikeEventContent::RoomMessage {
-                    message_type: original_content.msgtype.into(),
+                    message_type: original_content.msgtype.try_into()?,
                     in_reply_to_event_id,
                 }
             }

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -33,13 +33,11 @@ mod utils;
 mod widget;
 
 use async_compat::TOKIO1 as RUNTIME;
-use matrix_sdk::ruma::events::room::{
-    message::RoomMessageEventContentWithoutRelation, MediaSource,
-};
+use matrix_sdk::ruma::events::room::message::RoomMessageEventContentWithoutRelation;
 
 use self::{
     error::ClientError,
-    ruma::{MediaSourceExt, Mentions, RoomMessageEventContentWithoutRelationExt},
+    ruma::{Mentions, RoomMessageEventContentWithoutRelationExt},
     task_handle::TaskHandle,
 };
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -973,7 +973,7 @@ impl TryFrom<ImageInfo> for RumaAvatarImageInfo {
 
     fn try_from(value: ImageInfo) -> Result<Self, MediaInfoError> {
         let thumbnail_url = if let Some(media_source) = value.thumbnail_source {
-            match media_source.as_ref() {
+            match &media_source.as_ref().media_source {
                 MediaSource::Plain(mxc_uri) => Some(mxc_uri.clone()),
                 MediaSource::Encrypted(_) => return Err(MediaInfoError::InvalidField),
             }

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -16,26 +16,55 @@ use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::{crypto::types::events::UtdCause, room::power_levels::power_level_user_changes};
 use matrix_sdk_ui::timeline::{PollResult, RoomPinnedEventsChange, TimelineDetails};
-use ruma::events::{room::MediaSource, FullStateEventContent};
+use ruma::events::{room::MediaSource as RumaMediaSource, EventContent, FullStateEventContent};
 
 use super::ProfileDetails;
-use crate::ruma::{ImageInfo, Mentions, MessageType, PollKind};
+use crate::{
+    error::ClientError,
+    ruma::{ImageInfo, MediaSource, MediaSourceExt, Mentions, MessageType, PollKind},
+};
 
 impl From<matrix_sdk_ui::timeline::TimelineItemContent> for TimelineItemContent {
     fn from(value: matrix_sdk_ui::timeline::TimelineItemContent) -> Self {
         use matrix_sdk_ui::timeline::TimelineItemContent as Content;
 
         match value {
-            Content::Message(message) => TimelineItemContent::Message { content: message.into() },
+            Content::Message(message) => {
+                let msgtype = message.msgtype().msgtype().to_owned();
+
+                match TryInto::<MessageContent>::try_into(message) {
+                    Ok(message) => TimelineItemContent::Message { content: message },
+                    Err(error) => TimelineItemContent::FailedToParseMessageLike {
+                        event_type: msgtype,
+                        error: error.to_string(),
+                    },
+                }
+            }
 
             Content::RedactedMessage => TimelineItemContent::RedactedMessage,
 
             Content::Sticker(sticker) => {
                 let content = sticker.content();
-                TimelineItemContent::Sticker {
-                    body: content.body.clone(),
-                    info: (&content.info).into(),
-                    source: Arc::new(MediaSource::from(content.source.clone())),
+
+                let media_source = RumaMediaSource::from(content.source.clone());
+
+                if let Err(error) = media_source.verify() {
+                    return TimelineItemContent::FailedToParseMessageLike {
+                        event_type: sticker.content().event_type().to_string(),
+                        error: error.to_string(),
+                    };
+                }
+
+                match TryInto::<ImageInfo>::try_into(&content.info) {
+                    Ok(info) => TimelineItemContent::Sticker {
+                        body: content.body.clone(),
+                        info,
+                        source: Arc::new(MediaSource { media_source }),
+                    },
+                    Err(error) => TimelineItemContent::FailedToParseMessageLike {
+                        event_type: sticker.content().event_type().to_string(),
+                        error: error.to_string(),
+                    },
                 }
             }
 
@@ -117,16 +146,18 @@ pub struct MessageContent {
     pub mentions: Option<Mentions>,
 }
 
-impl From<matrix_sdk_ui::timeline::Message> for MessageContent {
-    fn from(value: matrix_sdk_ui::timeline::Message) -> Self {
-        Self {
-            msg_type: value.msgtype().clone().into(),
+impl TryFrom<matrix_sdk_ui::timeline::Message> for MessageContent {
+    type Error = ClientError;
+
+    fn try_from(value: matrix_sdk_ui::timeline::Message) -> Result<Self, Self::Error> {
+        Ok(Self {
+            msg_type: value.msgtype().clone().try_into()?,
             body: value.body().to_owned(),
             in_reply_to: value.in_reply_to().map(|r| Arc::new(r.clone().into())),
             is_edited: value.is_edited(),
             thread_root: value.thread_root().map(|id| id.to_string()),
             mentions: value.mentions().cloned().map(|m| m.into()),
-        }
+        })
     }
 }
 


### PR DESCRIPTION
Ruma doesn't currently validate mxuri's and as such `MediaSource`s passed over FFI can contain invalid/empty URLs. 

This change introduces a wrapper type around Ruma's and failable transformations so that appropiate actions can be taken beforehand e.g. returning a `TimelineItemContent::FailedToParseMessageLike` or nil-ing out the thumbnail info.