### PR TITLE
feat(media)!: Make all fields of `Thumbnail` required

### DIFF
--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -15,9 +15,7 @@
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
 use extension_trait::extension_trait;
-use matrix_sdk::attachment::{
-    BaseAudioInfo, BaseFileInfo, BaseImageInfo, BaseThumbnailInfo, BaseVideoInfo,
-};
+use matrix_sdk::attachment::{BaseAudioInfo, BaseFileInfo, BaseImageInfo, BaseVideoInfo};
 use ruma::{
     assign,
     events::{
@@ -700,21 +698,6 @@ impl From<ThumbnailInfo> for RumaThumbnailInfo {
             mimetype: value.mimetype,
             size: value.size.map(u64_to_uint),
         })
-    }
-}
-
-impl TryFrom<&ThumbnailInfo> for BaseThumbnailInfo {
-    type Error = MediaInfoError;
-
-    fn try_from(value: &ThumbnailInfo) -> Result<Self, MediaInfoError> {
-        let height = UInt::try_from(value.height.ok_or(MediaInfoError::MissingField)?)
-            .map_err(|_| MediaInfoError::InvalidField)?;
-        let width = UInt::try_from(value.width.ok_or(MediaInfoError::MissingField)?)
-            .map_err(|_| MediaInfoError::InvalidField)?;
-        let size = UInt::try_from(value.size.ok_or(MediaInfoError::MissingField)?)
-            .map_err(|_| MediaInfoError::InvalidField)?;
-
-        Ok(BaseThumbnailInfo { height: Some(height), width: Some(width), size: Some(size) })
     }
 }
 

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -148,27 +148,6 @@ impl From<AttachmentInfo> for FileInfo {
     }
 }
 
-#[derive(Debug, Default, Clone)]
-/// Base metadata about a thumbnail.
-pub struct BaseThumbnailInfo {
-    /// The height of the thumbnail in pixels.
-    pub height: Option<UInt>,
-    /// The width of the thumbnail in pixels.
-    pub width: Option<UInt>,
-    /// The file size of the thumbnail in bytes.
-    pub size: Option<UInt>,
-}
-
-impl From<BaseThumbnailInfo> for ThumbnailInfo {
-    fn from(info: BaseThumbnailInfo) -> Self {
-        assign!(ThumbnailInfo::new(), {
-            height: info.height,
-            width: info.width,
-            size: info.size,
-        })
-    }
-}
-
 /// A thumbnail to upload and send for an attachment.
 #[derive(Debug)]
 pub struct Thumbnail {
@@ -176,20 +155,23 @@ pub struct Thumbnail {
     pub data: Vec<u8>,
     /// The type of the thumbnail, this will be used as the content-type header.
     pub content_type: mime::Mime,
-    /// The metadata of the thumbnail.
-    pub info: Option<BaseThumbnailInfo>,
+    /// The height of the thumbnail in pixels.
+    pub height: UInt,
+    /// The width of the thumbnail in pixels.
+    pub width: UInt,
+    /// The file size of the thumbnail in bytes.
+    pub size: UInt,
 }
 
 impl Thumbnail {
     /// Convert this `Thumbnail` into a `(data, content_type, info)` tuple.
     pub fn into_parts(self) -> (Vec<u8>, mime::Mime, Box<ThumbnailInfo>) {
-        let thumbnail_info = assign!(
-            self.info
-                .as_ref()
-                .map(|info| ThumbnailInfo::from(info.clone()))
-                .unwrap_or_default(),
-            { mimetype: Some(self.content_type.to_string()) }
-        );
+        let thumbnail_info = assign!(ThumbnailInfo::new(), {
+            height: Some(self.height),
+            width: Some(self.width),
+            size: Some(self.size),
+            mimetype: Some(self.content_type.to_string())
+        });
         (self.data, self.content_type, Box::new(thumbnail_info))
     }
 }

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -180,6 +180,20 @@ pub struct Thumbnail {
     pub info: Option<BaseThumbnailInfo>,
 }
 
+impl Thumbnail {
+    /// Convert this `Thumbnail` into a `(data, content_type, info)` tuple.
+    pub fn into_parts(self) -> (Vec<u8>, mime::Mime, Box<ThumbnailInfo>) {
+        let thumbnail_info = assign!(
+            self.info
+                .as_ref()
+                .map(|info| ThumbnailInfo::from(info.clone()))
+                .unwrap_or_default(),
+            { mimetype: Some(self.content_type.to_string()) }
+        );
+        (self.data, self.content_type, Box::new(thumbnail_info))
+    }
+}
+
 /// Configuration for sending an attachment.
 #[derive(Debug, Default)]
 pub struct AttachmentConfig {

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -460,8 +460,7 @@ impl Client {
         thumbnail: Option<Thumbnail>,
         send_progress: SharedObservable<TransmissionProgress>,
     ) -> Result<(MediaSource, Option<(MediaSource, Box<ThumbnailInfo>)>)> {
-        let upload_thumbnail =
-            self.upload_encrypted_thumbnail(thumbnail, content_type, send_progress.clone());
+        let upload_thumbnail = self.upload_encrypted_thumbnail(thumbnail, send_progress.clone());
 
         let upload_attachment = async {
             let mut cursor = Cursor::new(data);
@@ -480,7 +479,6 @@ impl Client {
     async fn upload_encrypted_thumbnail(
         &self,
         thumbnail: Option<Thumbnail>,
-        content_type: &mime::Mime,
         send_progress: SharedObservable<TransmissionProgress>,
     ) -> Result<Option<(MediaSource, Box<ThumbnailInfo>)>> {
         let Some(thumbnail) = thumbnail else {
@@ -490,7 +488,7 @@ impl Client {
         let mut cursor = Cursor::new(thumbnail.data);
 
         let file = self
-            .upload_encrypted_file(content_type, &mut cursor)
+            .upload_encrypted_file(&thumbnail.content_type, &mut cursor)
             .with_send_progress_observable(send_progress)
             .await?;
 

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -485,20 +485,15 @@ impl Client {
             return Ok(None);
         };
 
-        let mut cursor = Cursor::new(thumbnail.data);
+        let (data, content_type, thumbnail_info) = thumbnail.into_parts();
+        let mut cursor = Cursor::new(data);
 
         let file = self
-            .upload_encrypted_file(&thumbnail.content_type, &mut cursor)
+            .upload_encrypted_file(&content_type, &mut cursor)
             .with_send_progress_observable(send_progress)
             .await?;
 
-        #[rustfmt::skip]
-            let thumbnail_info =
-                assign!(thumbnail.info.map(ThumbnailInfo::from).unwrap_or_default(), {
-                    mimetype: Some(thumbnail.content_type.as_ref().to_owned())
-                });
-
-        Ok(Some((MediaSource::Encrypted(Box::new(file)), Box::new(thumbnail_info))))
+        Ok(Some((MediaSource::Encrypted(Box::new(file)), thumbnail_info)))
     }
 
     /// Claim one-time keys creating new Olm sessions.

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -669,20 +669,14 @@ impl Media {
             return Ok(None);
         };
 
+        let (data, content_type, thumbnail_info) = thumbnail.into_parts();
+
         let response = self
-            .upload(&thumbnail.content_type, thumbnail.data, None)
+            .upload(&content_type, data, None)
             .with_send_progress_observable(send_progress)
             .await?;
         let url = response.content_uri;
 
-        let thumbnail_info = assign!(
-            thumbnail.info
-                .as_ref()
-                .map(|info| ThumbnailInfo::from(info.clone()))
-                .unwrap_or_default(),
-            { mimetype: Some(thumbnail.content_type.as_ref().to_owned()) }
-        );
-
-        Ok(Some((MediaSource::Plain(url), Box::new(thumbnail_info))))
+        Ok(Some((MediaSource::Plain(url), thumbnail_info)))
     }
 }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1949,14 +1949,9 @@ impl Room {
 
         // If necessary, store caching data for the thumbnail ahead of time.
         let thumbnail_cache_info = if store_in_cache {
-            // Use a small closure returning Option to avoid an unnecessary complicated
-            // chain of map/and_then.
-            let get_info = || {
-                let thumbnail = thumbnail.as_ref()?;
-                let info = thumbnail.info.as_ref()?;
-                Some((thumbnail.data.clone(), info.height?, info.width?))
-            };
-            get_info()
+            thumbnail
+                .as_ref()
+                .map(|thumbnail| (thumbnail.data.clone(), thumbnail.height, thumbnail.width))
         } else {
             None
         };

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -1,10 +1,7 @@
 use std::time::Duration;
 
 use matrix_sdk::{
-    attachment::{
-        AttachmentConfig, AttachmentInfo, BaseImageInfo, BaseThumbnailInfo, BaseVideoInfo,
-        Thumbnail,
-    },
+    attachment::{AttachmentConfig, AttachmentInfo, BaseImageInfo, BaseVideoInfo, Thumbnail},
     media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings},
     test_utils::mocks::MatrixMockServer,
 };
@@ -210,11 +207,9 @@ async fn test_room_attachment_send_info_thumbnail() {
     let config = AttachmentConfig::with_thumbnail(Thumbnail {
         data: b"Thumbnail".to_vec(),
         content_type: mime::IMAGE_JPEG,
-        info: Some(BaseThumbnailInfo {
-            height: Some(uint!(360)),
-            width: Some(uint!(480)),
-            size: Some(uint!(3600)),
-        }),
+        height: uint!(360),
+        width: uint!(480),
+        size: uint!(3600),
     })
     .info(AttachmentInfo::Image(BaseImageInfo {
         height: Some(uint!(600)),


### PR DESCRIPTION
`Thumbnail` is used to provide the data and information when uploading a thumbnail along an attachment. It seems sensible to assume that if a client is able to generate a thumbnail, it should be able to get all this information for it too.
A thumbnail with no information is not really useful, as we don't know when it could be used instead of the original image.

It allows to simplify the send queue to not have to handle the case where the dimensions of the thumbnail are missing.

Removes `BaseThumbnailInfo` in the process by merging its fields in `Thumbnail` directly.

There are also 2 pre-commits to refactor part of the code to simplify the changes.

cc @bnjbvr.