### PR TITLE
fix(common): `LinkedChunk` emits an `Update::NewItemsChunk` when constructed

### DIFF
--- a/crates/matrix-sdk-common/src/linked_chunk/updates.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/updates.rs
@@ -384,7 +384,21 @@ mod tests {
             other_token
         };
 
-        // There is no new update yet.
+        // There is an initial update.
+        {
+            let updates = linked_chunk.updates().unwrap();
+
+            assert_eq!(
+                updates.take(),
+                &[NewItemsChunk { previous: None, new: ChunkIdentifier(0), next: None }],
+            );
+            assert_eq!(
+                updates.inner.write().unwrap().take_with_token(other_token),
+                &[NewItemsChunk { previous: None, new: ChunkIdentifier(0), next: None }],
+            );
+        }
+
+        // No new update.
         {
             let updates = linked_chunk.updates().unwrap();
 
@@ -617,7 +631,16 @@ mod tests {
         let updates_subscriber = linked_chunk.updates().unwrap().subscribe();
         pin_mut!(updates_subscriber);
 
-        // No update, stream is pending.
+        // Initial update, stream is ready.
+        assert_matches!(
+            updates_subscriber.as_mut().poll_next(&mut context),
+            Poll::Ready(Some(items)) => {
+                assert_eq!(
+                    items,
+                    &[NewItemsChunk { previous: None, new: ChunkIdentifier(0), next: None }]
+                );
+            }
+        );
         assert_matches!(updates_subscriber.as_mut().poll_next(&mut context), Poll::Pending);
         assert_eq!(*counter_waker.number_of_wakeup.lock().unwrap(), 0);
 
@@ -651,6 +674,7 @@ mod tests {
         assert_eq!(
             linked_chunk.updates().unwrap().take(),
             &[
+                NewItemsChunk { previous: None, new: ChunkIdentifier(0), next: None },
                 PushItems { at: Position(ChunkIdentifier(0), 0), items: vec!['a'] },
                 PushItems { at: Position(ChunkIdentifier(0), 1), items: vec!['b'] },
                 PushItems { at: Position(ChunkIdentifier(0), 2), items: vec!['c'] },
@@ -701,9 +725,28 @@ mod tests {
             let updates_subscriber2 = linked_chunk.updates().unwrap().subscribe();
             pin_mut!(updates_subscriber2);
 
-            // No update, streams are pending.
+            // Initial updates, streams are ready.
+            assert_matches!(
+                updates_subscriber1.as_mut().poll_next(&mut context1),
+                Poll::Ready(Some(items)) => {
+                    assert_eq!(
+                        items,
+                        &[NewItemsChunk { previous: None, new: ChunkIdentifier(0), next: None }]
+                    );
+                }
+            );
             assert_matches!(updates_subscriber1.as_mut().poll_next(&mut context1), Poll::Pending);
             assert_eq!(*counter_waker1.number_of_wakeup.lock().unwrap(), 0);
+
+            assert_matches!(
+                updates_subscriber2.as_mut().poll_next(&mut context2),
+                Poll::Ready(Some(items)) => {
+                    assert_eq!(
+                        items,
+                        &[NewItemsChunk { previous: None, new: ChunkIdentifier(0), next: None }]
+                    );
+                }
+            );
             assert_matches!(updates_subscriber2.as_mut().poll_next(&mut context2), Poll::Pending);
             assert_eq!(*counter_waker2.number_of_wakeup.lock().unwrap(), 0);
 


### PR DESCRIPTION
This patch updates `LinkedChunk::new_with_update_history` to emit an `Update::NewItemsChunk` because the first chunk is created and it must emit an update accordingly.

The fix is 9 lines changes, the rest is only test updates.

---

* Fix https://github.com/matrix-org/matrix-rust-sdk/issues/4314