### PR TITLE
chore(ui): Rename `TimelineEnd` to `TimelineNewItemPosition`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -31,7 +31,7 @@ use super::{
     Error, Timeline, TimelineDropHandle, TimelineFocus,
 };
 use crate::{
-    timeline::{controller::TimelineEnd, event_item::RemoteEventOrigin},
+    timeline::{controller::TimelineNewItemPosition, event_item::RemoteEventOrigin},
     unable_to_decrypt_hook::UtdHookManager,
 };
 
@@ -273,9 +273,9 @@ impl TimelineBuilder {
 
                             inner.add_events_at(
                                 events,
-                                TimelineEnd::Back,
-                                match origin {
-                                    EventsOrigin::Sync => RemoteEventOrigin::Sync,
+                                TimelineNewItemPosition::End {                                    origin: match origin {
+                                        EventsOrigin::Sync => RemoteEventOrigin::Sync,
+                                    }
                                 }
                             ).await;
                         }

--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -26,7 +26,7 @@ use matrix_sdk::event_cache::{
 use tracing::{instrument, trace, warn};
 
 use super::Error;
-use crate::timeline::{controller::TimelineEnd, event_item::RemoteEventOrigin};
+use crate::timeline::{controller::TimelineNewItemPosition, event_item::RemoteEventOrigin};
 
 impl super::Timeline {
     /// Add more events to the start of the timeline.
@@ -81,7 +81,7 @@ impl super::Timeline {
                     // `matrix_sdk::event_cache::RoomEventCacheUpdate` from
                     // `matrix_sdk::event_cache::RoomPagination::run_backwards`.
                     self.controller
-                        .add_events_at(events, TimelineEnd::Front, RemoteEventOrigin::Pagination)
+                        .add_events_at(events, TimelineNewItemPosition::Start { origin: RemoteEventOrigin::Pagination })
                         .await;
 
                     if num_events == 0 && !reached_start {

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -35,7 +35,7 @@ use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
 use crate::timeline::{
-    controller::{TimelineEnd, TimelineSettings},
+    controller::{TimelineNewItemPosition, TimelineSettings},
     event_item::{AnyOtherFullStateEventContent, RemoteEventOrigin},
     tests::{ReadReceiptMap, TestRoomDataProvider},
     MembershipChange, TimelineDetails, TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
@@ -51,8 +51,7 @@ async fn test_initial_events() {
         .controller
         .add_events_at(
             vec![f.text_msg("A").sender(*ALICE), f.text_msg("B").sender(*BOB)],
-            TimelineEnd::Back,
-            RemoteEventOrigin::Sync,
+            TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
         )
         .await;
 
@@ -91,7 +90,10 @@ async fn test_replace_with_initial_events_and_read_marker() {
     let f = &timeline.factory;
     let ev = f.text_msg("hey").sender(*ALICE).into_sync();
 
-    timeline.controller.add_events_at(vec![ev], TimelineEnd::Back, RemoteEventOrigin::Sync).await;
+    timeline
+        .controller
+        .add_events_at(vec![ev], TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync })
+        .await;
 
     let items = timeline.controller.items().await;
     assert_eq!(items.len(), 2);
@@ -317,8 +319,7 @@ async fn test_dedup_initial() {
                 // … and a new event also came in
                 event_c,
             ],
-            TimelineEnd::Back,
-            RemoteEventOrigin::Sync,
+            TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
         )
         .await;
 
@@ -354,7 +355,10 @@ async fn test_internal_id_prefix() {
 
     timeline
         .controller
-        .add_events_at(vec![ev_a, ev_b, ev_c], TimelineEnd::Back, RemoteEventOrigin::Sync)
+        .add_events_at(
+            vec![ev_a, ev_b, ev_c],
+            TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
+        )
         .await;
 
     let timeline_items = timeline.controller.items().await;
@@ -516,7 +520,10 @@ async fn test_replace_with_initial_events_when_batched() {
     let f = &timeline.factory;
     let ev = f.text_msg("hey").sender(*ALICE).into_sync();
 
-    timeline.controller.add_events_at(vec![ev], TimelineEnd::Back, RemoteEventOrigin::Sync).await;
+    timeline
+        .controller
+        .add_events_at(vec![ev], TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync })
+        .await;
 
     let (items, mut stream) = timeline.controller.subscribe_batched().await;
     assert_eq!(items.len(), 2);

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -57,7 +57,7 @@ use ruma::{
 use tokio::sync::RwLock;
 
 use super::{
-    controller::{TimelineEnd, TimelineSettings},
+    controller::{TimelineNewItemPosition, TimelineSettings},
     event_handler::TimelineEventKind,
     event_item::RemoteEventOrigin,
     traits::RoomDataProvider,
@@ -237,7 +237,10 @@ impl TestTimeline {
     async fn handle_live_event(&self, event: impl Into<SyncTimelineEvent>) {
         let event = event.into();
         self.controller
-            .add_events_at(vec![event], TimelineEnd::Back, RemoteEventOrigin::Sync)
+            .add_events_at(
+                vec![event],
+                TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
+            )
             .await;
     }
 
@@ -256,7 +259,10 @@ impl TestTimeline {
     async fn handle_back_paginated_event(&self, event: Raw<AnyTimelineEvent>) {
         let timeline_event = TimelineEvent::new(event.cast());
         self.controller
-            .add_events_at(vec![timeline_event], TimelineEnd::Front, RemoteEventOrigin::Pagination)
+            .add_events_at(
+                vec![timeline_event],
+                TimelineNewItemPosition::Start { origin: RemoteEventOrigin::Pagination },
+            )
             .await;
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -28,8 +28,8 @@ use stream_assert::assert_next_matches;
 use tokio::time::timeout;
 
 use crate::timeline::{
-    controller::TimelineEnd, event_item::RemoteEventOrigin, tests::TestTimeline, ReactionStatus,
-    TimelineEventItemId, TimelineItem,
+    controller::TimelineNewItemPosition, event_item::RemoteEventOrigin, tests::TestTimeline,
+    ReactionStatus, TimelineEventItemId, TimelineItem,
 };
 
 const REACTION_KEY: &str = "👍";
@@ -204,8 +204,7 @@ async fn test_initial_reaction_timestamp_is_stored() {
                 // Event comes next.
                 f.text_msg("A").event_id(&message_event_id).into_sync(),
             ],
-            TimelineEnd::Back,
-            RemoteEventOrigin::Sync,
+            TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
         )
         .await;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -29,8 +29,8 @@ use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
 use crate::timeline::{
-    controller::TimelineEnd, event_item::RemoteEventOrigin, AnyOtherFullStateEventContent,
-    TimelineDetails, TimelineItemContent,
+    controller::TimelineNewItemPosition, event_item::RemoteEventOrigin,
+    AnyOtherFullStateEventContent, TimelineDetails, TimelineItemContent,
 };
 
 #[async_test]
@@ -146,8 +146,7 @@ async fn test_reaction_redaction_timeline_filter() {
                     .event_builder
                     .make_sync_redacted_message_event(*ALICE, RedactedReactionEventContent::new()),
             )],
-            TimelineEnd::Back,
-            RemoteEventOrigin::Sync,
+            TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
         )
         .await;
     // Timeline items are actually empty.


### PR DESCRIPTION
(Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/3512/)

This patch renames `TimelineEnd` into `TimelineNewItemPosition` for 2 reasons:

1. In the following patches, we will introduce a new variant to insert at a specific index, so the suffix `End` would no longer make sense.

2. It's exactly like `TimelineItemPosition` except that it's used only and strictly only to add **new** items, which is why we can't use `TimelineItemPosition` because it contains the `UpdateDecrypted` variant. This renaming reflects it's only about **new** items.

This patch takes the opportunity to move the `RemoteEventOrigin` inside `TimelineNewItemPosition` to simplify method signatures. They always go together.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280