### PR TITLE
fix(media): Make sure that local URIs only try to get media from the cache and ignore requested dimensions and change format used in media cache

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -83,6 +83,11 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             Some(&content),
             "media not found though added"
         );
+        assert_eq!(
+            self.get_media_content_for_uri(uri).await.unwrap().as_ref(),
+            Some(&content),
+            "media not found by URI though added"
+        );
 
         // Let's remove the media.
         self.remove_media_content(&request_file).await.expect("removing media failed");
@@ -91,6 +96,10 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert!(
             self.get_media_content(&request_file).await.unwrap().is_none(),
             "media still there after removing"
+        );
+        assert!(
+            self.get_media_content_for_uri(uri).await.unwrap().is_none(),
+            "media still found by URI after removing"
         );
 
         // Let's add the media again.
@@ -116,6 +125,12 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             "thumbnail not found"
         );
 
+        // We get a file with the URI, we don't know which one.
+        assert!(
+            self.get_media_content_for_uri(uri).await.unwrap().is_some(),
+            "media not found by URI though two where added"
+        );
+
         // Let's add another media with a different URI.
         self.add_media_content(&request_other_file, other_content.clone())
             .await
@@ -126,6 +141,11 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             self.get_media_content(&request_other_file).await.unwrap().as_ref(),
             Some(&other_content),
             "other file not found"
+        );
+        assert_eq!(
+            self.get_media_content_for_uri(other_uri).await.unwrap().as_ref(),
+            Some(&other_content),
+            "other file not found by URI"
         );
 
         // Let's remove media based on URI.
@@ -142,6 +162,14 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert!(
             self.get_media_content(&request_other_file).await.unwrap().is_some(),
             "other media was removed"
+        );
+        assert!(
+            self.get_media_content_for_uri(uri).await.unwrap().is_none(),
+            "media found by URI wasn't removed"
+        );
+        assert!(
+            self.get_media_content_for_uri(other_uri).await.unwrap().is_some(),
+            "other media found by URI was removed"
         );
     }
 

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -154,6 +154,17 @@ impl EventCacheStore for MemoryStore {
         Ok(())
     }
 
+    async fn get_media_content_for_uri(
+        &self,
+        uri: &MxcUri,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        let inner = self.inner.read().unwrap();
+
+        Ok(inner.media.iter().find_map(|(media_uri, _media_key, media_content)| {
+            (media_uri == uri).then(|| media_content.to_owned())
+        }))
+    }
+
     async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<()> {
         let mut inner = self.inner.write().unwrap();
 

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -107,6 +107,23 @@ pub trait EventCacheStore: AsyncTraitDeps {
         request: &MediaRequestParameters,
     ) -> Result<(), Self::Error>;
 
+    /// Get a media file's content associated to an `MxcUri` from the
+    /// media store.
+    ///
+    /// In theory, there could be several files stored using the same URI and a
+    /// different `MediaFormat`. This API is meant to be used with a media file
+    /// that has only been stored with a single format.
+    ///
+    /// If there are several media files for a given URI in different formats,
+    /// this API will only return one of them. Which one is left as an
+    /// implementation detail.
+    ///
+    /// # Arguments
+    ///
+    /// * `uri` - The `MxcUri` of the media file.
+    async fn get_media_content_for_uri(&self, uri: &MxcUri)
+        -> Result<Option<Vec<u8>>, Self::Error>;
+
     /// Remove all the media files' content associated to an `MxcUri` from the
     /// media store.
     ///
@@ -179,6 +196,13 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
         request: &MediaRequestParameters,
     ) -> Result<(), Self::Error> {
         self.0.remove_media_content(request).await.map_err(Into::into)
+    }
+
+    async fn get_media_content_for_uri(
+        &self,
+        uri: &MxcUri,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.0.get_media_content_for_uri(uri).await.map_err(Into::into)
     }
 
     async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -74,9 +74,8 @@ pub use self::integration_tests::StateStoreIntegrationTests;
 pub use self::{
     memory_store::MemoryStore,
     send_queue::{
-        ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind,
-        FinishUploadThumbnailInfo, QueueWedgeError, QueuedRequest, QueuedRequestKind,
-        SentMediaInfo, SentRequestKey, SerializableEventContent,
+        ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind, QueueWedgeError,
+        QueuedRequest, QueuedRequestKind, SentMediaInfo, SentRequestKey, SerializableEventContent,
     },
     traits::{
         ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, ServerCapabilities,

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -23,7 +23,7 @@ use ruma::{
         AnyMessageLikeEventContent, EventContent as _, RawExt as _,
     },
     serde::Raw,
-    OwnedDeviceId, OwnedEventId, OwnedTransactionId, OwnedUserId, TransactionId, UInt,
+    OwnedDeviceId, OwnedEventId, OwnedTransactionId, OwnedUserId, TransactionId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -237,20 +237,9 @@ pub enum DependentQueuedRequestKind {
         /// Transaction id for the file upload.
         file_upload: OwnedTransactionId,
 
-        /// Information about the thumbnail, if present.
-        thumbnail_info: Option<FinishUploadThumbnailInfo>,
+        /// Transaction id for the thumbnail upload, if present.
+        thumbnail_upload: Option<OwnedTransactionId>,
     },
-}
-
-/// Detailed record about a thumbnail used when finishing a media upload.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct FinishUploadThumbnailInfo {
-    /// Transaction id for the thumbnail upload.
-    pub txn: OwnedTransactionId,
-    /// Thumbnail's width.
-    pub width: UInt,
-    /// Thumbnail's height.
-    pub height: UInt,
 }
 
 /// A transaction id identifying a [`DependentQueuedRequest`] rather than its

--- a/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
@@ -23,7 +23,7 @@ use js_sys::Date as JsDate;
 use matrix_sdk_base::{
     deserialized_responses::SyncOrStrippedState,
     store::{
-        migration_helpers::{DependentQueuedRequestKindV1, DependentQueuedRequestV1, RoomInfoV1},
+        migration_helpers::{DependentQueuedRequestV1, RoomInfoV1},
         DependentQueuedRequest,
     },
     StateStoreDataKey,

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -270,6 +270,35 @@ impl EventCacheStore for SqliteEventCacheStore {
         Ok(())
     }
 
+    async fn get_media_content_for_uri(
+        &self,
+        uri: &ruma::MxcUri,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        let uri = self.encode_key(keys::MEDIA, uri);
+        let conn = self.acquire().await?;
+        let data = conn
+            .with_transaction::<_, rusqlite::Error, _>(move |txn| {
+                // Update the last access.
+                // We need to do this first so the transaction is in write mode right away.
+                // See: https://sqlite.org/lang_transaction.html#read_transactions_versus_write_transactions
+                txn.execute(
+                    "UPDATE media SET last_access = CAST(strftime('%s') as INT) \
+                     WHERE uri = ?",
+                    (&uri,),
+                )?;
+
+                txn.query_row::<Vec<u8>, _, _>(
+                    "SELECT data FROM media WHERE uri = ?",
+                    (&uri,),
+                    |row| row.get(0),
+                )
+                .optional()
+            })
+            .await?;
+
+        data.map(|v| self.decode_value(&v).map(Into::into)).transpose()
+    }
+
     async fn remove_media_content_for_uri(&self, uri: &ruma::MxcUri) -> Result<()> {
         let uri = self.encode_key(keys::MEDIA, uri);
 

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -32,7 +32,7 @@ use ruma::{
     },
     assign,
     events::room::{MediaSource, ThumbnailInfo},
-    MilliSecondsSinceUnixEpoch, MxcUri, OwnedMxcUri,
+    MilliSecondsSinceUnixEpoch, MxcUri, OwnedMxcUri, TransactionId,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use tempfile::{Builder as TempFileBuilder, NamedTempFile, TempDir};
@@ -678,5 +678,31 @@ impl Media {
         let url = response.content_uri;
 
         Ok(Some((MediaSource::Plain(url), thumbnail_info)))
+    }
+
+    /// Create an [`OwnedMxcUri`] for a file or thumbnail we want to store
+    /// locally before sending it.
+    ///
+    /// This uses a MXC ID that is only locally valid.
+    pub(crate) fn make_local_uri(txn_id: &TransactionId) -> OwnedMxcUri {
+        // This mustn't represent a potentially valid media server, otherwise it'd be
+        // possible for an attacker to return malicious content under some
+        // preconditions (e.g. the cache store has been cleared before the upload
+        // took place). To mitigate against this, we use the .localhost TLD,
+        // which is guaranteed to be on the local machine. As a result, the only attack
+        // possible would be coming from the user themselves, which we consider a
+        // non-threat.
+        OwnedMxcUri::from(format!("mxc://send-queue.localhost/{txn_id}"))
+    }
+
+    /// Create a [`MediaRequest`] for a file we want to store locally before
+    /// sending it.
+    ///
+    /// This uses a MXC ID that is only locally valid.
+    pub(crate) fn make_local_file_media_request(txn_id: &TransactionId) -> MediaRequestParameters {
+        MediaRequestParameters {
+            source: MediaSource::Plain(Self::make_local_uri(txn_id)),
+            format: MediaFormat::File,
+        }
     }
 }

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1891,13 +1891,7 @@ async fn test_media_uploads() {
     let thumbnail_media = client
         .media()
         .get_media_content(
-            &MediaRequestParameters {
-                source: local_thumbnail_source,
-                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
-                    tinfo.width.unwrap(),
-                    tinfo.height.unwrap(),
-                )),
-            },
+            &MediaRequestParameters { source: local_thumbnail_source, format: MediaFormat::File },
             true,
         )
         .await
@@ -1954,13 +1948,7 @@ async fn test_media_uploads() {
     let thumbnail_media = client
         .media()
         .get_media_content(
-            &MediaRequestParameters {
-                source: new_thumbnail_source,
-                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
-                    tinfo.width.unwrap(),
-                    tinfo.height.unwrap(),
-                )),
-            },
+            &MediaRequestParameters { source: new_thumbnail_source, format: MediaFormat::File },
             true,
         )
         .await


### PR DESCRIPTION
Avoids a tricky API where the users need to make exactly the right media request to get the local file in cache, and avoids to make a request over the network when we know that the file should only be found locally. 

cc @bnjbvr, I don't think this is exactly what you had in mind but it does the job.