### PR TITLE
chore(ui): Clarifies what `TimelineItemPosition::UpdateDecrypted` holds

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -241,7 +241,7 @@ impl TimelineState {
             let handle_one_res = txn
                 .handle_remote_event(
                     event.into(),
-                    TimelineItemPosition::UpdateDecrypted(idx),
+                    TimelineItemPosition::UpdateDecrypted { timeline_item_index: idx },
                     room_data_provider,
                     settings,
                     &mut day_divider_adjuster,
@@ -447,7 +447,7 @@ impl TimelineStateTransaction<'_> {
                         TimelineItemPosition::End { origin }
                         | TimelineItemPosition::Start { origin } => origin,
 
-                        TimelineItemPosition::UpdateDecrypted(idx) => self
+                        TimelineItemPosition::UpdateDecrypted { timeline_item_index: idx } => self
                             .items
                             .get(idx)
                             .and_then(|item| item.as_event())
@@ -703,7 +703,7 @@ impl TimelineStateTransaction<'_> {
                 self.meta.all_events.push_back(event_meta.base_meta());
             }
 
-            TimelineItemPosition::UpdateDecrypted(_) => {
+            TimelineItemPosition::UpdateDecrypted { .. } => {
                 if let Some(event) =
                     self.meta.all_events.iter_mut().find(|e| e.event_id == event_meta.event_id)
                 {


### PR DESCRIPTION
(Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/3512/)

This patch tries to clear confusion around
`TimelineItemPosition::UpdateDecrypted(usize)`: it does contains a timeline item index. This patch changes to
`TimelineItemPosition::UpdateDecrypted { timeline_item_index: usize }`

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280