### PR TITLE
refactor(linked chunk): replace `LinkedChunk::len()` with a simpler impl

### DIFF
--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -383,7 +383,7 @@ mod tests {
     fn test_new_room_events_has_zero_events() {
         let room_events = RoomEvents::new();
 
-        assert_eq!(room_events.chunks.len(), 0);
+        assert_eq!(room_events.events().count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
It's unused so it's mostly cosmetic, and it's trivial to reimplement using `linked_chunk.items().count()`, as shown in tests.

Fixes #4332.