### PR TITLE
Add support for MSC4717: service members 🫡

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4753,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.11.1"
-source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
+source = "git+https://github.com/ruma/ruma?rev=c91499fc464adc865a7c99d0ce0b35982ad96711#c91499fc464adc865a7c99d0ce0b35982ad96711"
 dependencies = [
  "assign",
  "js_int",
@@ -4770,7 +4770,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.19.0"
-source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
+source = "git+https://github.com/ruma/ruma?rev=c91499fc464adc865a7c99d0ce0b35982ad96711#c91499fc464adc865a7c99d0ce0b35982ad96711"
 dependencies = [
  "as_variant",
  "assign",
@@ -4793,7 +4793,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.14.1"
-source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
+source = "git+https://github.com/ruma/ruma?rev=c91499fc464adc865a7c99d0ce0b35982ad96711#c91499fc464adc865a7c99d0ce0b35982ad96711"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -4825,7 +4825,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.29.1"
-source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
+source = "git+https://github.com/ruma/ruma?rev=c91499fc464adc865a7c99d0ce0b35982ad96711#c91499fc464adc865a7c99d0ce0b35982ad96711"
 dependencies = [
  "as_variant",
  "indexmap 2.6.0",
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.10.0"
-source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
+source = "git+https://github.com/ruma/ruma?rev=c91499fc464adc865a7c99d0ce0b35982ad96711#c91499fc464adc865a7c99d0ce0b35982ad96711"
 dependencies = [
  "http",
  "js_int",
@@ -4864,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.3.0"
-source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
+source = "git+https://github.com/ruma/ruma?rev=c91499fc464adc865a7c99d0ce0b35982ad96711#c91499fc464adc865a7c99d0ce0b35982ad96711"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4876,7 +4876,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.0"
-source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
+source = "git+https://github.com/ruma/ruma?rev=c91499fc464adc865a7c99d0ce0b35982ad96711#c91499fc464adc865a7c99d0ce0b35982ad96711"
 dependencies = [
  "js_int",
  "thiserror 2.0.3",
@@ -4885,7 +4885,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.14.0"
-source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
+source = "git+https://github.com/ruma/ruma?rev=c91499fc464adc865a7c99d0ce0b35982ad96711#c91499fc464adc865a7c99d0ce0b35982ad96711"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4901,7 +4901,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.10.0"
-source = "git+https://github.com/ruma/ruma.git?rev=35fda7f2f7811156df2e60b223dbf136fc143bc8#35fda7f2f7811156df2e60b223dbf136fc143bc8"
+source = "git+https://github.com/ruma/ruma?rev=c91499fc464adc865a7c99d0ce0b35982ad96711#c91499fc464adc865a7c99d0ce0b35982ad96711"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-members = ["benchmarks", "crates/*", "labs/*"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.80"
+rust-version = "1.82"
 
 [workspace.dependencies]
 anyhow = "1.0.93"
@@ -56,7 +56,7 @@ proptest = { version = "1.5.0", default-features = false, features = ["std"] }
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
 rmp-serde = "1.3.0"
-ruma = { git = "https://github.com/ruma/ruma.git", rev = "35fda7f2f7811156df2e60b223dbf136fc143bc8", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "c91499fc464adc865a7c99d0ce0b35982ad96711", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -69,8 +69,9 @@ ruma = { git = "https://github.com/ruma/ruma.git", rev = "35fda7f2f7811156df2e60
     "unstable-msc3489",
     "unstable-msc4075",
     "unstable-msc4140",
+    "unstable-msc4171",
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma.git", rev = "35fda7f2f7811156df2e60b223dbf136fc143bc8" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "c91499fc464adc865a7c99d0ce0b35982ad96711" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+- Introduced support for
+  [MSC4171](https://github.com/matrix-org/matrix-rust-sdk/pull/4335), enabling
+  the designation of certain users as service members. These flagged users are
+  excluded from the room display name calculation.
+  ([#4335](https://github.com/matrix-org/matrix-rust-sdk/pull/4335))
+
 ### Bug Fixes
 
 - Fix an off-by-one error in the `ObservableMap` when the `remove()` method is

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -14,7 +14,10 @@
 
 #![allow(missing_docs)]
 
-use std::sync::atomic::{AtomicU64, Ordering::SeqCst};
+use std::{
+    collections::BTreeSet,
+    sync::atomic::{AtomicU64, Ordering::SeqCst},
+};
 
 use as_variant::as_variant;
 use matrix_sdk_common::deserialized_responses::{
@@ -22,6 +25,7 @@ use matrix_sdk_common::deserialized_responses::{
 };
 use ruma::{
     events::{
+        member_hints::MemberHintsEventContent,
         message::TextContentBlock,
         poll::{
             end::PollEndEventContent,
@@ -397,6 +401,34 @@ impl EventFactory {
         event.state_key = Some(member.to_string());
 
         event
+    }
+
+    /// Create a new `m.member_hints` event with the given service members.
+    ///
+    /// ```
+    /// use std::collections::BTreeSet;
+    ///
+    /// use matrix_sdk_test::event_factory::EventFactory;
+    /// use ruma::{
+    ///     events::{member_hints::MemberHintsEventContent, SyncStateEvent},
+    ///     owned_user_id, room_id,
+    ///     serde::Raw,
+    ///     user_id,
+    /// };
+    ///
+    /// let factory = EventFactory::new().room(room_id!("!test:localhost"));
+    ///
+    /// let event: Raw<SyncStateEvent<MemberHintsEventContent>> = factory
+    ///     .member_hints(BTreeSet::from([owned_user_id!("@alice:localhost")]))
+    ///     .sender(user_id!("@alice:localhost"))
+    ///     .into_raw();
+    /// ```
+    pub fn member_hints(
+        &self,
+        service_members: BTreeSet<OwnedUserId>,
+    ) -> EventBuilder<MemberHintsEventContent> {
+        // The `m.member_hints` event always has an empty state key, so let's set it.
+        self.event(MemberHintsEventContent::new(service_members)).state_key("")
     }
 
     /// Create a new plain/html `m.room.message`.


### PR DESCRIPTION
Depends on https://github.com/matrix-org/matrix-rust-sdk/pull/4228, only the second commit here is relevant.

This adds support for service members to be excluded from the room display name calculation logic as described in [MSC4717](https://github.com/matrix-org/matrix-spec-proposals/blob/tulir/service-members/proposals/4171-service-members.md).