### PR TITLE
feat(room): add `JoinRequest` subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,6 +1676,9 @@ checksum = "d93bd0ebf93d61d6332d3c09a96e97975968a44e19a64c947bde06e6baff383f"
 dependencies = [
  "futures-core",
  "readlock",
+ "readlock-tokio",
+ "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -4539,6 +4542,15 @@ name = "readlock"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "072cfe5b1d2dcd38d20e18f85e9c9978b6cc08f0b373e9f1fff1541335622974"
+
+[[package]]
+name = "readlock-tokio"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "867fac64d07214a87e5cf4e88b4ce855844a1cea243534392377d1ac2c911653"
+dependencies = [
+ "tokio",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, pin::pin, sync::Arc};
 
 use anyhow::{Context, Result};
-use futures_util::StreamExt;
+use futures_util::{pin_mut, StreamExt};
 use matrix_sdk::{
     crypto::LocalTrust,
     event_cache::paginator::PaginatorError,
@@ -910,6 +910,108 @@ impl Room {
         let (room_event_cache, _drop_handles) = self.inner.event_cache().await?;
         room_event_cache.clear().await?;
         Ok(())
+    }
+
+    /// Subscribes to requests to join this room, using a `listener` to be
+    /// notified of the changes.
+    ///
+    /// The current requests to join the room will be emitted immediately
+    /// when subscribing, along with a [`TaskHandle`] to cancel the
+    /// subscription.
+    pub async fn subscribe_to_join_requests(
+        self: Arc<Self>,
+        listener: Box<dyn JoinRequestsListener>,
+    ) -> Result<Arc<TaskHandle>, ClientError> {
+        let stream = self.inner.subscribe_to_join_requests().await?;
+
+        let handle = Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
+            pin_mut!(stream);
+            while let Some(requests) = stream.next().await {
+                listener.call(requests.into_iter().map(Into::into).collect());
+            }
+        })));
+
+        Ok(handle)
+    }
+}
+
+impl From<matrix_sdk::room::request_to_join::JoinRequest> for JoinRequest {
+    fn from(request: matrix_sdk::room::request_to_join::JoinRequest) -> Self {
+        Self {
+            event_id: request.event_id.to_string(),
+            user_id: request.member_info.user_id.to_string(),
+            room_id: request.room_id().to_string(),
+            display_name: request.member_info.display_name.clone(),
+            avatar_url: request.member_info.avatar_url.as_ref().map(|url| url.to_string()),
+            reason: request.member_info.reason.clone(),
+            timestamp: request.timestamp.map(|ts| ts.into()),
+            is_seen: request.is_seen,
+            actions: Arc::new(JoinRequestActions { inner: request }),
+        }
+    }
+}
+
+/// A listener for receiving new requests to a join a room.
+#[matrix_sdk_ffi_macros::export(callback_interface)]
+pub trait JoinRequestsListener: Send + Sync {
+    fn call(&self, join_requests: Vec<JoinRequest>);
+}
+
+/// An FFI representation of a request to join a room.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct JoinRequest {
+    /// The event id of the event that contains the `knock` membership change.
+    pub event_id: String,
+    /// The user id of the user who's requesting to join the room.
+    pub user_id: String,
+    /// The room id of the room whose access was requested.
+    pub room_id: String,
+    /// The optional display name of the user who's requesting to join the room.
+    pub display_name: Option<String>,
+    /// The optional avatar url of the user who's requesting to join the room.
+    pub avatar_url: Option<String>,
+    /// An optional reason why the user wants join the room.
+    pub reason: Option<String>,
+    /// The timestamp when this request was created.
+    pub timestamp: Option<u64>,
+    /// Whether the request to join has been marked as `seen` so it can be
+    /// filtered by the client.
+    pub is_seen: bool,
+    /// A set of actions to perform for this request to join.
+    pub actions: Arc<JoinRequestActions>,
+}
+
+/// A set of actions to perform for a request to join.
+#[derive(Debug, Clone, uniffi::Object)]
+pub struct JoinRequestActions {
+    inner: matrix_sdk::room::request_to_join::JoinRequest,
+}
+
+#[matrix_sdk_ffi_macros::export]
+impl JoinRequestActions {
+    /// Accepts the request to join by inviting the user to the room.
+    pub async fn accept(&self) -> Result<(), ClientError> {
+        self.inner.accept().await.map_err(Into::into)
+    }
+
+    /// Declines the request to join by kicking the user from the room with an
+    /// optional reason.
+    pub async fn decline(&self, reason: Option<String>) -> Result<(), ClientError> {
+        self.inner.decline(reason.as_deref()).await.map_err(Into::into)
+    }
+
+    /// Declines the request to join by banning the user from the room with an
+    /// optional reason.
+    pub async fn decline_and_ban(&self, reason: Option<String>) -> Result<(), ClientError> {
+        self.inner.decline_and_ban(reason.as_deref()).await.map_err(Into::into)
+    }
+
+    /// Marks the request as 'seen'.
+    ///
+    /// **IMPORTANT**: this won't update the current reference to this request,
+    /// a new one with the updated value should be emitted instead.
+    pub async fn mark_as_seen(&self) -> Result<(), ClientError> {
+        self.inner.clone().mark_as_seen().await.map_err(Into::into)
     }
 }
 

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -51,7 +51,7 @@ assert_matches2 = { workspace = true, optional = true }
 async-trait = { workspace = true }
 bitflags = { version = "2.6.0", features = ["serde"] }
 decancer = "3.2.8"
-eyeball = { workspace = true }
+eyeball = { workspace = true, features = ["async-lock"] }
 eyeball-im = { workspace = true }
 futures-util = { workspace = true }
 growable-bloom-filter = { workspace = true }

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -30,7 +30,7 @@ use ruma::{
         StateEventContent, StaticStateEventContent, StrippedStateEvent, SyncStateEvent,
     },
     serde::Raw,
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, UserId,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, UInt, UserId,
 };
 use serde::Serialize;
 use unicode_normalization::UnicodeNormalization;
@@ -475,6 +475,23 @@ impl MemberEvent {
                 .and_then(|c| c.displayname.as_deref())
                 .unwrap_or_else(|| self.user_id().localpart()),
         )
+    }
+
+    /// The optional reason why the membership changed.
+    pub fn reason(&self) -> Option<&str> {
+        match self {
+            MemberEvent::Sync(SyncStateEvent::Original(c)) => c.content.reason.as_deref(),
+            MemberEvent::Stripped(e) => e.content.reason.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// The optional timestamp for this member event.
+    pub fn timestamp(&self) -> Option<UInt> {
+        match self {
+            MemberEvent::Sync(SyncStateEvent::Original(c)) => Some(c.origin_server_ts.0),
+            _ => None,
+        }
     }
 }
 

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1356,6 +1356,11 @@ impl RoomInfo {
         self.members_synced = false;
     }
 
+    /// Returns whether the room members are synced.
+    pub fn are_members_synced(&self) -> bool {
+        self.members_synced
+    }
+
     /// Mark this Room as still missing some state information.
     pub fn mark_state_partially_synced(&mut self) {
         self.sync_info = SyncInfo::PartiallySynced;

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -232,7 +232,7 @@ impl StateStore for MemoryStore {
                 inner.seen_knock_requests.insert(
                     room_id.to_owned(),
                     value
-                        .into_seen_join_requests()
+                        .into_seen_knock_requests()
                         .expect("Session data is not a set of seen join request ids"),
                 );
             }

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -1093,7 +1093,7 @@ impl StateStoreDataValue {
     }
 
     /// Get this value if it is the data for the ignored join requests.
-    pub fn into_seen_join_requests(self) -> Option<BTreeMap<OwnedEventId, OwnedUserId>> {
+    pub fn into_seen_knock_requests(self) -> Option<BTreeMap<OwnedEventId, OwnedUserId>> {
         as_variant!(self, Self::SeenKnockRequests)
     }
 }
@@ -1126,7 +1126,7 @@ pub enum StateStoreDataKey<'a> {
     /// [`ComposerDraft`]: Self::ComposerDraft
     ComposerDraft(&'a RoomId),
 
-    /// A list of requests to join in a room marked as seen.
+    /// A list of knock request ids marked as seen in a room.
     SeenKnockRequests(&'a RoomId),
 }
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -1022,6 +1022,9 @@ pub enum StateStoreDataValue {
     ///
     /// [`ComposerDraft`]: Self::ComposerDraft
     ComposerDraft(ComposerDraft),
+
+    /// A list of knock request ids marked as seen in a room.
+    SeenKnockRequests(BTreeMap<OwnedEventId, OwnedUserId>),
 }
 
 /// Current draft of the composer for the room.
@@ -1088,6 +1091,11 @@ impl StateStoreDataValue {
     pub fn into_server_capabilities(self) -> Option<ServerCapabilities> {
         as_variant!(self, Self::ServerCapabilities)
     }
+
+    /// Get this value if it is the data for the ignored join requests.
+    pub fn into_seen_join_requests(self) -> Option<BTreeMap<OwnedEventId, OwnedUserId>> {
+        as_variant!(self, Self::SeenKnockRequests)
+    }
 }
 
 /// A key for key-value data.
@@ -1117,6 +1125,9 @@ pub enum StateStoreDataKey<'a> {
     ///
     /// [`ComposerDraft`]: Self::ComposerDraft
     ComposerDraft(&'a RoomId),
+
+    /// A list of requests to join in a room marked as seen.
+    SeenKnockRequests(&'a RoomId),
 }
 
 impl StateStoreDataKey<'_> {
@@ -1142,6 +1153,10 @@ impl StateStoreDataKey<'_> {
     /// Key prefix to use for the [`ComposerDraft`][Self::ComposerDraft]
     /// variant.
     pub const COMPOSER_DRAFT: &'static str = "composer_draft";
+
+    /// Key prefix to use for the
+    /// [`SeenKnockRequests`][Self::SeenKnockRequests] variant.
+    pub const SEEN_KNOCK_REQUESTS: &'static str = "seen_knock_requests";
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -583,8 +583,8 @@ impl_state_store!({
             ),
             StateStoreDataKey::SeenKnockRequests(_) => self.serialize_value(
                 &value
-                    .into_seen_join_requests()
-                    .expect("Session data is not a set of seen join request ids"),
+                    .into_seen_knock_requests()
+                    .expect("Session data is not a set of seen knock request ids"),
             ),
         };
 

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -419,6 +419,9 @@ impl IndexeddbStateStore {
             StateStoreDataKey::ComposerDraft(room_id) => {
                 self.encode_key(keys::KV, (StateStoreDataKey::COMPOSER_DRAFT, room_id))
             }
+            StateStoreDataKey::SeenKnockRequests(room_id) => {
+                self.encode_key(keys::KV, (StateStoreDataKey::SEEN_KNOCK_REQUESTS, room_id))
+            }
         }
     }
 }
@@ -537,6 +540,10 @@ impl_state_store!({
                 .map(|f| self.deserialize_value::<ComposerDraft>(&f))
                 .transpose()?
                 .map(StateStoreDataValue::ComposerDraft),
+            StateStoreDataKey::SeenKnockRequests(_) => value
+                .map(|f| self.deserialize_value::<BTreeMap<OwnedEventId, OwnedUserId>>(&f))
+                .transpose()?
+                .map(StateStoreDataValue::SeenKnockRequests),
         };
 
         Ok(value)
@@ -573,6 +580,11 @@ impl_state_store!({
             ),
             StateStoreDataKey::ComposerDraft(_) => self.serialize_value(
                 &value.into_composer_draft().expect("Session data not a composer draft"),
+            ),
+            StateStoreDataKey::SeenKnockRequests(_) => self.serialize_value(
+                &value
+                    .into_seen_join_requests()
+                    .expect("Session data is not a set of seen join request ids"),
             ),
         };
 

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -390,6 +390,9 @@ impl SqliteStateStore {
             StateStoreDataKey::ComposerDraft(room_id) => {
                 Cow::Owned(format!("{}:{room_id}", StateStoreDataKey::COMPOSER_DRAFT))
             }
+            StateStoreDataKey::SeenKnockRequests(room_id) => {
+                Cow::Owned(format!("{}:{room_id}", StateStoreDataKey::SEEN_KNOCK_REQUESTS))
+            }
         };
 
         self.encode_key(keys::KV_BLOB, &*key_s)
@@ -995,6 +998,9 @@ impl StateStore for SqliteStateStore {
                     StateStoreDataKey::ComposerDraft(_) => {
                         StateStoreDataValue::ComposerDraft(self.deserialize_value(&data)?)
                     }
+                    StateStoreDataKey::SeenKnockRequests(_) => {
+                        StateStoreDataValue::SeenKnockRequests(self.deserialize_value(&data)?)
+                    }
                 })
             })
             .transpose()
@@ -1028,6 +1034,11 @@ impl StateStore for SqliteStateStore {
             )?,
             StateStoreDataKey::ComposerDraft(_) => self.serialize_value(
                 &value.into_composer_draft().expect("Session data not a composer draft"),
+            )?,
+            StateStoreDataKey::SeenKnockRequests(_) => self.serialize_value(
+                &value
+                    .into_seen_join_requests()
+                    .expect("Session data is not a set of seen join request ids"),
             )?,
         };
 

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1037,8 +1037,8 @@ impl StateStore for SqliteStateStore {
             )?,
             StateStoreDataKey::SeenKnockRequests(_) => self.serialize_value(
                 &value
-                    .into_seen_join_requests()
-                    .expect("Session data is not a set of seen join request ids"),
+                    .into_seen_knock_requests()
+                    .expect("Session data is not a set of seen knock request ids"),
             )?,
         };
 

--- a/crates/matrix-sdk/src/room/knock_requests.rs
+++ b/crates/matrix-sdk/src/room/knock_requests.rs
@@ -19,24 +19,24 @@ use crate::{room::RoomMember, Error, Room};
 
 /// A request to join a room with `knock` join rule.
 #[derive(Debug, Clone)]
-pub struct JoinRequest {
+pub struct KnockRequest {
     room: Room,
     /// The event id of the event containing knock membership change.
     pub event_id: OwnedEventId,
     /// The timestamp when this request was created.
     pub timestamp: Option<UInt>,
     /// Some general room member info to display.
-    pub member_info: RequestToJoinMemberInfo,
+    pub member_info: KnockRequestMemberInfo,
     /// Whether it's been marked as 'seen' by the client.
     pub is_seen: bool,
 }
 
-impl JoinRequest {
+impl KnockRequest {
     pub(crate) fn new(
         room: &Room,
         event_id: &EventId,
         timestamp: Option<UInt>,
-        member: RequestToJoinMemberInfo,
+        member: KnockRequestMemberInfo,
         is_seen: bool,
     ) -> Self {
         Self {
@@ -48,30 +48,30 @@ impl JoinRequest {
         }
     }
 
-    /// The room id for the `Room` form whose access is requested.
+    /// The room id for the `Room` from whose access is requested.
     pub fn room_id(&self) -> &RoomId {
         self.room.room_id()
     }
 
-    /// Marks the request to join as 'seen' so the client can ignore it in the
+    /// Marks the knock request as 'seen' so the client can ignore it in the
     /// future.
     pub async fn mark_as_seen(&self) -> Result<(), Error> {
-        self.room.mark_join_requests_as_seen(&[self.event_id.to_owned()]).await?;
+        self.room.mark_knock_requests_as_seen(&[self.member_info.user_id.to_owned()]).await?;
         Ok(())
     }
 
-    /// Accepts the request to join by inviting the user to the room.
+    /// Accepts the knock request by inviting the user to the room.
     pub async fn accept(&self) -> Result<(), Error> {
         self.room.invite_user_by_id(&self.member_info.user_id).await
     }
 
-    /// Declines the request to join by kicking the user from the room, with an
+    /// Declines the knock request by kicking the user from the room, with an
     /// optional reason.
     pub async fn decline(&self, reason: Option<&str>) -> Result<(), Error> {
         self.room.kick_user(&self.member_info.user_id, reason).await
     }
 
-    /// Declines the request to join by banning the user from the room, with an
+    /// Declines the knock request by banning the user from the room, with an
     /// optional reason.
     pub async fn decline_and_ban(&self, reason: Option<&str>) -> Result<(), Error> {
         self.room.ban_user(&self.member_info.user_id, reason).await
@@ -80,7 +80,7 @@ impl JoinRequest {
 
 /// General room member info to display along with the join request.
 #[derive(Debug, Clone)]
-pub struct RequestToJoinMemberInfo {
+pub struct KnockRequestMemberInfo {
     /// The user id for the room member requesting access.
     pub user_id: OwnedUserId,
     /// The optional display name of the room member requesting access.
@@ -91,8 +91,8 @@ pub struct RequestToJoinMemberInfo {
     pub reason: Option<String>,
 }
 
-impl From<RoomMember> for RequestToJoinMemberInfo {
-    fn from(member: RoomMember) -> Self {
+impl KnockRequestMemberInfo {
+    pub(crate) fn from_member(member: &RoomMember) -> Self {
         Self {
             user_id: member.user_id().to_owned(),
             display_name: member.display_name().map(ToOwned::to_owned),
@@ -102,13 +102,18 @@ impl From<RoomMember> for RequestToJoinMemberInfo {
     }
 }
 
+// The http mocking library is not supported for wasm32
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use matrix_sdk_test::async_test;
-    use ruma::{event_id, owned_user_id, room_id, EventId};
+    use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder};
+    use ruma::{
+        event_id,
+        events::room::member::{MembershipState, RoomMemberEventContent},
+        owned_user_id, room_id, user_id, EventId,
+    };
 
     use crate::{
-        room::request_to_join::{JoinRequest, RequestToJoinMemberInfo},
+        room::knock_requests::{KnockRequest, KnockRequestMemberInfo},
         test_utils::mocks::MatrixMockServer,
         Room,
     };
@@ -119,19 +124,31 @@ mod tests {
         let client = server.client_builder().build().await;
         let room_id = room_id!("!a:b.c");
         let event_id = event_id!("$a:b.c");
+        let user_id = user_id!("@alice:b.c");
 
-        let room = server.sync_joined_room(&client, room_id).await;
+        let f = EventFactory::new().room(room_id);
+        let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f
+            .event(RoomMemberEventContent::new(MembershipState::Knock))
+            .event_id(event_id)
+            .sender(user_id)
+            .state_key(user_id)
+            .into_raw_timeline()
+            .cast()]);
+        let room = server.sync_room(&client, joined_room_builder).await;
 
-        let join_request = mock_join_request(&room, Some(event_id));
+        let knock_request = make_knock_request(&room, Some(event_id));
 
-        // When we mark the join request as seen
-        join_request.mark_as_seen().await.expect("Failed to mark as seen");
+        // When we mark the knock request as seen
+        knock_request.mark_as_seen().await.expect("Failed to mark as seen");
 
         // Then we can check it was successfully marked as seen from the room
         let seen_ids =
-            room.get_seen_join_request_ids().await.expect("Failed to get seen join request ids");
+            room.get_seen_knock_request_ids().await.expect("Failed to get seen join request ids");
         assert_eq!(seen_ids.len(), 1);
-        assert_eq!(seen_ids.into_iter().next().expect("Couldn't load next item"), event_id);
+        assert_eq!(
+            seen_ids.into_iter().next().expect("Couldn't load next item"),
+            (event_id.to_owned(), user_id.to_owned())
+        );
     }
 
     #[async_test]
@@ -142,13 +159,13 @@ mod tests {
 
         let room = server.sync_joined_room(&client, room_id).await;
 
-        let join_request = mock_join_request(&room, None);
+        let knock_request = make_knock_request(&room, None);
 
         // The /invite endpoint must be called once
         server.mock_invite_user_by_id().ok().mock_once().mount().await;
 
-        // When we accept the join request
-        join_request.accept().await.expect("Failed to accept the request");
+        // When we accept the knock request
+        knock_request.accept().await.expect("Failed to accept the request");
     }
 
     #[async_test]
@@ -159,13 +176,13 @@ mod tests {
 
         let room = server.sync_joined_room(&client, room_id).await;
 
-        let join_request = mock_join_request(&room, None);
+        let knock_request = make_knock_request(&room, None);
 
         // The /kick endpoint must be called once
         server.mock_kick_user().ok().mock_once().mount().await;
 
-        // When we decline the join request
-        join_request.decline(None).await.expect("Failed to decline the request");
+        // When we decline the knock request
+        knock_request.decline(None).await.expect("Failed to decline the request");
     }
 
     #[async_test]
@@ -176,24 +193,24 @@ mod tests {
 
         let room = server.sync_joined_room(&client, room_id).await;
 
-        let join_request = mock_join_request(&room, None);
+        let knock_request = make_knock_request(&room, None);
 
         // The /ban endpoint must be called once
         server.mock_ban_user().ok().mock_once().mount().await;
 
-        // When we decline the join request and ban the user from the room
-        join_request
+        // When we decline the knock request and ban the user from the room
+        knock_request
             .decline_and_ban(None)
             .await
             .expect("Failed to decline the request and ban the user");
     }
 
-    fn mock_join_request(room: &Room, event_id: Option<&EventId>) -> JoinRequest {
-        JoinRequest::new(
+    fn make_knock_request(room: &Room, event_id: Option<&EventId>) -> KnockRequest {
+        KnockRequest::new(
             room,
             event_id.unwrap_or(event_id!("$a:b.c")),
             None,
-            RequestToJoinMemberInfo {
+            KnockRequestMemberInfo {
                 user_id: owned_user_id!("@alice:b.c"),
                 display_name: None,
                 avatar_url: None,

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -149,6 +149,8 @@ pub mod identity_status_changes;
 mod member;
 mod messages;
 pub mod power_levels;
+/// Contains code related to requests to join a room.
+pub mod request_to_join;
 
 /// A struct containing methods that are common for Joined, Invited and Left
 /// Rooms

--- a/crates/matrix-sdk/src/room/request_to_join.rs
+++ b/crates/matrix-sdk/src/room/request_to_join.rs
@@ -1,0 +1,205 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use js_int::UInt;
+use ruma::{EventId, OwnedEventId, OwnedMxcUri, OwnedUserId, RoomId};
+
+use crate::{room::RoomMember, Error, Room};
+
+/// A request to join a room with `knock` join rule.
+#[derive(Debug, Clone)]
+pub struct JoinRequest {
+    room: Room,
+    /// The event id of the event containing knock membership change.
+    pub event_id: OwnedEventId,
+    /// The timestamp when this request was created.
+    pub timestamp: Option<UInt>,
+    /// Some general room member info to display.
+    pub member_info: RequestToJoinMemberInfo,
+    /// Whether it's been marked as 'seen' by the client.
+    pub is_seen: bool,
+}
+
+impl JoinRequest {
+    pub(crate) fn new(
+        room: &Room,
+        event_id: &EventId,
+        timestamp: Option<UInt>,
+        member: RequestToJoinMemberInfo,
+        is_seen: bool,
+    ) -> Self {
+        Self {
+            room: room.clone(),
+            event_id: event_id.to_owned(),
+            timestamp,
+            member_info: member,
+            is_seen,
+        }
+    }
+
+    /// The room id for the `Room` form whose access is requested.
+    pub fn room_id(&self) -> &RoomId {
+        self.room.room_id()
+    }
+
+    /// Marks the request to join as 'seen' so the client can ignore it in the
+    /// future.
+    pub async fn mark_as_seen(&self) -> Result<(), Error> {
+        self.room.mark_join_requests_as_seen(&[self.event_id.to_owned()]).await?;
+        Ok(())
+    }
+
+    /// Accepts the request to join by inviting the user to the room.
+    pub async fn accept(&self) -> Result<(), Error> {
+        self.room.invite_user_by_id(&self.member_info.user_id).await
+    }
+
+    /// Declines the request to join by kicking the user from the room, with an
+    /// optional reason.
+    pub async fn decline(&self, reason: Option<&str>) -> Result<(), Error> {
+        self.room.kick_user(&self.member_info.user_id, reason).await
+    }
+
+    /// Declines the request to join by banning the user from the room, with an
+    /// optional reason.
+    pub async fn decline_and_ban(&self, reason: Option<&str>) -> Result<(), Error> {
+        self.room.ban_user(&self.member_info.user_id, reason).await
+    }
+}
+
+/// General room member info to display along with the join request.
+#[derive(Debug, Clone)]
+pub struct RequestToJoinMemberInfo {
+    /// The user id for the room member requesting access.
+    pub user_id: OwnedUserId,
+    /// The optional display name of the room member requesting access.
+    pub display_name: Option<String>,
+    /// The optional avatar url of the room member requesting access.
+    pub avatar_url: Option<OwnedMxcUri>,
+    /// An optional reason why the user wants access to the room.
+    pub reason: Option<String>,
+}
+
+impl From<RoomMember> for RequestToJoinMemberInfo {
+    fn from(member: RoomMember) -> Self {
+        Self {
+            user_id: member.user_id().to_owned(),
+            display_name: member.display_name().map(ToOwned::to_owned),
+            avatar_url: member.avatar_url().map(ToOwned::to_owned),
+            reason: member.event().reason().map(ToOwned::to_owned),
+        }
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use matrix_sdk_test::async_test;
+    use ruma::{event_id, owned_user_id, room_id, EventId};
+
+    use crate::{
+        room::request_to_join::{JoinRequest, RequestToJoinMemberInfo},
+        test_utils::mocks::MatrixMockServer,
+        Room,
+    };
+
+    #[async_test]
+    async fn test_mark_as_seen() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let room_id = room_id!("!a:b.c");
+        let event_id = event_id!("$a:b.c");
+
+        let room = server.sync_joined_room(&client, room_id).await;
+
+        let join_request = mock_join_request(&room, Some(event_id));
+
+        // When we mark the join request as seen
+        join_request.mark_as_seen().await.expect("Failed to mark as seen");
+
+        // Then we can check it was successfully marked as seen from the room
+        let seen_ids =
+            room.get_seen_join_request_ids().await.expect("Failed to get seen join request ids");
+        assert_eq!(seen_ids.len(), 1);
+        assert_eq!(seen_ids.into_iter().next().expect("Couldn't load next item"), event_id);
+    }
+
+    #[async_test]
+    async fn test_accept() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let room_id = room_id!("!a:b.c");
+
+        let room = server.sync_joined_room(&client, room_id).await;
+
+        let join_request = mock_join_request(&room, None);
+
+        // The /invite endpoint must be called once
+        server.mock_invite_user_by_id().ok().mock_once().mount().await;
+
+        // When we accept the join request
+        join_request.accept().await.expect("Failed to accept the request");
+    }
+
+    #[async_test]
+    async fn test_decline() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let room_id = room_id!("!a:b.c");
+
+        let room = server.sync_joined_room(&client, room_id).await;
+
+        let join_request = mock_join_request(&room, None);
+
+        // The /kick endpoint must be called once
+        server.mock_kick_user().ok().mock_once().mount().await;
+
+        // When we decline the join request
+        join_request.decline(None).await.expect("Failed to decline the request");
+    }
+
+    #[async_test]
+    async fn test_decline_and_ban() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let room_id = room_id!("!a:b.c");
+
+        let room = server.sync_joined_room(&client, room_id).await;
+
+        let join_request = mock_join_request(&room, None);
+
+        // The /ban endpoint must be called once
+        server.mock_ban_user().ok().mock_once().mount().await;
+
+        // When we decline the join request and ban the user from the room
+        join_request
+            .decline_and_ban(None)
+            .await
+            .expect("Failed to decline the request and ban the user");
+    }
+
+    fn mock_join_request(room: &Room, event_id: Option<&EventId>) -> JoinRequest {
+        JoinRequest::new(
+            room,
+            event_id.unwrap_or(event_id!("$a:b.c")),
+            None,
+            RequestToJoinMemberInfo {
+                user_id: owned_user_id!("@alice:b.c"),
+                display_name: None,
+                avatar_url: None,
+                reason: None,
+            },
+            false,
+        )
+    }
+}

--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -607,6 +607,95 @@ impl MatrixMockServer {
             .and(header("authorization", "Bearer 1234"));
         MockEndpoint { mock, server: &self.server, endpoint: DeleteRoomKeysVersionEndpoint }
     }
+
+    /// Creates a prebuilt mock for inviting a user to a room by its id.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ruma::user_id;
+    /// tokio_test::block_on(async {
+    /// use matrix_sdk::{
+    ///     ruma::room_id,
+    ///     test_utils::mocks::MatrixMockServer,
+    /// };
+    ///
+    /// let mock_server = MatrixMockServer::new().await;
+    /// let client = mock_server.client_builder().build().await;
+    ///
+    /// mock_server.mock_invite_user_by_id().ok().mock_once().mount().await;
+    ///
+    /// let room = mock_server
+    ///     .sync_joined_room(&client, room_id!("!room_id:localhost"))
+    ///     .await;
+    ///
+    /// room.invite_user_by_id(user_id!("@alice:localhost")).await.unwrap();
+    /// # anyhow::Ok(()) });
+    /// ```
+    pub fn mock_invite_user_by_id(&self) -> MockEndpoint<'_, InviteUserByIdEndpoint> {
+        let mock =
+            Mock::given(method("POST")).and(path_regex(r"^/_matrix/client/v3/rooms/.*/invite$"));
+        MockEndpoint { mock, server: &self.server, endpoint: InviteUserByIdEndpoint }
+    }
+
+    /// Creates a prebuilt mock for kicking a user from a room.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ruma::user_id;
+    /// tokio_test::block_on(async {
+    /// use matrix_sdk::{
+    ///     ruma::room_id,
+    ///     test_utils::mocks::MatrixMockServer,
+    /// };
+    ///
+    /// let mock_server = MatrixMockServer::new().await;
+    /// let client = mock_server.client_builder().build().await;
+    ///
+    /// mock_server.mock_kick_user().ok().mock_once().mount().await;
+    ///
+    /// let room = mock_server
+    ///     .sync_joined_room(&client, room_id!("!room_id:localhost"))
+    ///     .await;
+    ///
+    /// room.kick_user(user_id!("@alice:localhost"), None).await.unwrap();
+    /// # anyhow::Ok(()) });
+    /// ```
+    pub fn mock_kick_user(&self) -> MockEndpoint<'_, KickUserEndpoint> {
+        let mock =
+            Mock::given(method("POST")).and(path_regex(r"^/_matrix/client/v3/rooms/.*/kick"));
+        MockEndpoint { mock, server: &self.server, endpoint: KickUserEndpoint }
+    }
+
+    /// Creates a prebuilt mock for banning a user from a room.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ruma::user_id;
+    /// tokio_test::block_on(async {
+    /// use matrix_sdk::{
+    ///     ruma::room_id,
+    ///     test_utils::mocks::MatrixMockServer,
+    /// };
+    ///
+    /// let mock_server = MatrixMockServer::new().await;
+    /// let client = mock_server.client_builder().build().await;
+    ///
+    /// mock_server.mock_ban_user().ok().mock_once().mount().await;
+    ///
+    /// let room = mock_server
+    ///     .sync_joined_room(&client, room_id!("!room_id:localhost"))
+    ///     .await;
+    ///
+    /// room.ban_user(user_id!("@alice:localhost"), None).await.unwrap();
+    /// # anyhow::Ok(()) });
+    /// ```
+    pub fn mock_ban_user(&self) -> MockEndpoint<'_, BanUserEndpoint> {
+        let mock = Mock::given(method("POST")).and(path_regex(r"^/_matrix/client/v3/rooms/.*/ban"));
+        MockEndpoint { mock, server: &self.server, endpoint: BanUserEndpoint }
+    }
 }
 
 /// Parameter to [`MatrixMockServer::sync_room`].
@@ -1758,6 +1847,40 @@ impl<'a> MockEndpoint<'a, DeleteRoomKeysVersionEndpoint> {
             .mock
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
             .named("DELETE for the backup deletion");
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+
+/// A prebuilt mock for `POST /invite` request.
+pub struct InviteUserByIdEndpoint;
+
+impl<'a> MockEndpoint<'a, InviteUserByIdEndpoint> {
+    /// Returns a successful invite user by id request.
+    pub fn ok(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+/// A prebuilt mock for `POST /kick` request.
+pub struct KickUserEndpoint;
+
+impl<'a> MockEndpoint<'a, KickUserEndpoint> {
+    /// Returns a successful kick user request.
+    pub fn ok(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+/// A prebuilt mock for `POST /ban` request.
+pub struct BanUserEndpoint;
+
+impl<'a> MockEndpoint<'a, BanUserEndpoint> {
+    /// Returns a successful ban user request.
+    pub fn ok(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
         MatrixMock { server: self.server, mock }
     }
 }

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -3,8 +3,9 @@ use std::{
     time::Duration,
 };
 
-use futures_util::future::join_all;
+use futures_util::{future::join_all, pin_mut};
 use matrix_sdk::{
+    assert_next_with_timeout,
     config::SyncSettings,
     room::{edit::EditedContent, Receipts, ReportedContentScore, RoomMemberRole},
     test_utils::mocks::MatrixMockServer,
@@ -24,7 +25,10 @@ use ruma::{
     events::{
         direct::DirectUserIdentifier,
         receipt::ReceiptThread,
-        room::message::{RoomMessageEventContent, RoomMessageEventContentWithoutRelation},
+        room::{
+            member::{MembershipState, RoomMemberEventContent},
+            message::{RoomMessageEventContent, RoomMessageEventContentWithoutRelation},
+        },
         TimelineEventType,
     },
     int, mxc_uri, owned_event_id, room_id, thirdparty, user_id, OwnedUserId, TransactionId,
@@ -832,4 +836,112 @@ async fn test_enable_encryption_doesnt_stay_unencrypted() {
     mock.mock_room_state_encryption().encrypted().mount().await;
 
     assert!(room.is_encrypted().await.unwrap());
+}
+
+#[async_test]
+async fn test_subscribe_to_requests_to_join() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let room_id = room_id!("!a:b.c");
+    let f = EventFactory::new().room(room_id);
+
+    let alice_user_id = user_id!("@alice:b.c");
+    let alice_knock_event_id = event_id!("$alice-knock:b.c");
+    let alice_knock_event = f
+        .event(RoomMemberEventContent::new(MembershipState::Knock))
+        .event_id(alice_knock_event_id)
+        .sender(alice_user_id)
+        .state_key(alice_user_id)
+        .into_raw_timeline()
+        .cast();
+
+    server.mock_get_members().ok(vec![alice_knock_event]).mock_once().mount().await;
+
+    let room = server.sync_joined_room(&client, room_id).await;
+    let stream = room.subscribe_to_join_requests().await.unwrap();
+
+    pin_mut!(stream);
+
+    // We receive an initial request to join from Alice
+    let initial = assert_next_with_timeout!(stream, 100);
+    assert!(!initial.is_empty());
+
+    let alices_request_to_join = &initial[0];
+    assert_eq!(alices_request_to_join.event_id, alice_knock_event_id);
+    assert!(!alices_request_to_join.is_seen);
+
+    // We then mark the request to join as seen
+    room.mark_join_requests_as_seen(&[alice_knock_event_id.to_owned()]).await.unwrap();
+
+    // Now it's received again as seen
+    let seen = assert_next_with_timeout!(stream, 100);
+    assert!(!seen.is_empty());
+    let alices_seen_request_to_join = &seen[0];
+    assert_eq!(alices_seen_request_to_join.event_id, alice_knock_event_id);
+    assert!(alices_seen_request_to_join.is_seen);
+
+    // If we then receive a new member event for Alice that's not 'knock'
+    let alice_join_event_id = event_id!("$alice-join:b.c");
+    let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f
+        .event(RoomMemberEventContent::new(MembershipState::Invite))
+        .event_id(alice_join_event_id)
+        .sender(alice_user_id)
+        .state_key(alice_user_id)
+        .into_raw_timeline()
+        .cast()]);
+    server.sync_room(&client, joined_room_builder).await;
+
+    // The requests to join are now empty
+    let updated_requests = assert_next_with_timeout!(stream, 100);
+    assert!(updated_requests.is_empty());
+}
+
+#[async_test]
+async fn test_subscribe_to_requests_to_join_reloads_members_on_limited_sync() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let room_id = room_id!("!a:b.c");
+    let f = EventFactory::new().room(room_id);
+
+    let alice_user_id = user_id!("@alice:b.c");
+    let alice_knock_event_id = event_id!("$alice-knock:b.c");
+    let alice_knock_event = f
+        .event(RoomMemberEventContent::new(MembershipState::Knock))
+        .event_id(alice_knock_event_id)
+        .sender(alice_user_id)
+        .state_key(alice_user_id)
+        .into_raw_timeline()
+        .cast();
+
+    server
+        .mock_get_members()
+        .ok(vec![alice_knock_event])
+        // The endpoint will be called twice:
+        // 1. For the initial loading of room members.
+        // 2. When a gappy (limited) sync is received.
+        .expect(2)
+        .mount()
+        .await;
+
+    let room = server.sync_joined_room(&client, room_id).await;
+    let stream = room.subscribe_to_join_requests().await.unwrap();
+
+    pin_mut!(stream);
+
+    // We receive an initial request to join from Alice
+    let initial = assert_next_with_timeout!(stream, 500);
+    assert!(!initial.is_empty());
+
+    // This limited sync should trigger a new emission of join requests, with a
+    // reloading of the room members
+    server.sync_room(&client, JoinedRoomBuilder::new(room_id).set_timeline_limited()).await;
+
+    // We should receive a new list of join requests
+    assert_next_with_timeout!(stream, 500);
 }


### PR DESCRIPTION
## What

This PR adds support for listening to changes in requests to join a room (aka: knock memberships): to do this, we listen to new room member events to trigger the emission of a new list of join requests, as well as to the `RoomInfo::members_synced` flag to understand if we need to reload the room members because a gappy sync happened

Since having too many/old requests to join to display can be an UX problem, I added the concept of a 'seen' join request, and an internal set of join request ids (these referencing the knock membership event), so we can mark some of these join requests as seen and filter them out in the clients at will. Also, when a join request is marked as seen, a new list of join requests is emitted with the updated value.

## Why

When a user of a knockable room has the power level to invite to or kick members from the room, there should be a way to display the incoming join requests in a live manner so this user can know about them and act on them ASAP, instead of having to manually reload the room member list when performing some UI interaction: that's why we need a way to subscribe to these kinds of changes in a live manner.

However, having some component that persistently displays the latest requests to join and having no way to dismiss them can make the room UI difficult to use in the clients, so there should be some way to ignore the displayed requests, or mark them as 'seen' so they can still be reviewed but they can be hidden from the user in that case.

This PR should be reviewed commit-by-commit, since it's fairly large.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
