### PR TITLE
feat(event cache): handle linked chunk updates and reload in the sqlite backend

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -138,6 +138,10 @@ pub enum EventCacheStoreError {
     #[error("Error encoding or decoding data from the event cache store: {0}")]
     Codec(#[from] Utf8Error),
 
+    /// The store failed to serialize or deserialize some data.
+    #[error("Error serializing or deserializing data from the event cache store: {0}")]
+    Serialization(#[from] serde_json::Error),
+
     /// The database format has changed in a backwards incompatible way.
     #[error(
         "The database format of the event cache store changed in an incompatible way, \

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -587,6 +587,11 @@ impl fmt::Debug for TimelineEventKind {
 /// A successfully-decrypted encrypted event.
 pub struct DecryptedRoomEvent {
     /// The decrypted event.
+    ///
+    /// Note: it's not an error that this contains an `AnyMessageLikeEvent`: an
+    /// encrypted payload *always contains* a room id, by the [spec].
+    ///
+    /// [spec]: https://spec.matrix.org/v1.12/client-server-api/#mmegolmv1aes-sha2
     pub event: Raw<AnyMessageLikeEvent>,
 
     /// The encryption info about the event.

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -975,12 +975,12 @@ pub struct ChunkIdentifier(u64);
 
 impl ChunkIdentifier {
     /// Create a new [`ChunkIdentifier`].
-    pub(super) fn new(identifier: u64) -> Self {
+    pub fn new(identifier: u64) -> Self {
         Self(identifier)
     }
 
     /// Get the underlying identifier.
-    fn index(&self) -> u64 {
+    pub fn index(&self) -> u64 {
         self.0
     }
 }
@@ -999,7 +999,7 @@ pub struct Position(ChunkIdentifier, usize);
 
 impl Position {
     /// Create a new [`Position`].
-    pub(super) fn new(chunk_identifier: ChunkIdentifier, index: usize) -> Self {
+    pub fn new(chunk_identifier: ChunkIdentifier, index: usize) -> Self {
         Self(chunk_identifier, index)
     }
 

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/003_events.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/003_events.sql
@@ -1,0 +1,46 @@
+CREATE TABLE "linked_chunks" (
+    -- Identifier of the chunk, unique per room.
+    "id" INTEGER,
+    -- Which room does this chunk belong to? (hashed key shared with the two other tables)
+    "room_id" BLOB NOT NULL,
+
+    -- Previous chunk in the linked list.
+    "previous" INTEGER,
+    -- Next chunk in the linked list.
+    "next" INTEGER,
+    -- Type of underlying entries: E for event, G for gaps
+    "type" TEXT CHECK("type" IN ('E', 'G')) NOT NULL
+);
+
+CREATE UNIQUE INDEX "linked_chunks_id_and_room_id" ON linked_chunks (id, room_id);
+
+CREATE TABLE "gaps" (
+    -- Which chunk does this gap refer to?
+    "chunk_id" INTEGER NOT NULL,
+    -- Which room does this event belong to? (hashed key shared with linked_chunks)
+    "room_id" BLOB NOT NULL,
+
+    -- The previous batch token of a gap (encrypted value).
+    "prev_token" BLOB NOT NULL,
+
+    -- If the owning chunk gets deleted, delete the entry too.
+    FOREIGN KEY(chunk_id, room_id) REFERENCES linked_chunks(id, room_id) ON DELETE CASCADE
+);
+
+-- Items for an event chunk.
+CREATE TABLE "events" (
+    -- Which chunk does this event refer to?
+    "chunk_id" INTEGER NOT NULL,
+    -- Which room does this event belong to? (hashed key shared with linked_chunks)
+    "room_id" BLOB NOT NULL,
+
+    -- `OwnedEventId` for events, can be null if malformed.
+    "event_id" TEXT,
+    -- JSON serialized `SyncTimelineEvent` (encrypted value).
+    "content" BLOB NOT NULL,
+    -- Position (index) in the chunk.
+    "position" INTEGER NOT NULL,
+
+    -- If the owning chunk gets deleted, delete the entry too.
+    FOREIGN KEY(chunk_id, room_id) REFERENCES linked_chunks(id, room_id) ON DELETE CASCADE
+);

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/003_events.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/003_events.sql
@@ -1,21 +1,21 @@
 CREATE TABLE "linked_chunks" (
-    -- Identifier of the chunk, unique per room.
+    -- Identifier of the chunk, unique per room. Corresponds to a `ChunkIdentifier`.
     "id" INTEGER,
     -- Which room does this chunk belong to? (hashed key shared with the two other tables)
     "room_id" BLOB NOT NULL,
 
-    -- Previous chunk in the linked list.
+    -- Previous chunk in the linked list. Corresponds to a `ChunkIdentifier`.
     "previous" INTEGER,
-    -- Next chunk in the linked list.
+    -- Next chunk in the linked list. Corresponds to a `ChunkIdentifier`.
     "next" INTEGER,
-    -- Type of underlying entries: E for event, G for gaps
+    -- Type of underlying entries: E for events, G for gaps
     "type" TEXT CHECK("type" IN ('E', 'G')) NOT NULL
 );
 
 CREATE UNIQUE INDEX "linked_chunks_id_and_room_id" ON linked_chunks (id, room_id);
 
 CREATE TABLE "gaps" (
-    -- Which chunk does this gap refer to?
+    -- Which chunk does this gap refer to? Corresponds to a `ChunkIdentifier`.
     "chunk_id" INTEGER NOT NULL,
     -- Which room does this event belong to? (hashed key shared with linked_chunks)
     "room_id" BLOB NOT NULL,
@@ -29,7 +29,7 @@ CREATE TABLE "gaps" (
 
 -- Items for an event chunk.
 CREATE TABLE "events" (
-    -- Which chunk does this event refer to?
+    -- Which chunk does this event refer to? Corresponds to a `ChunkIdentifier`.
     "chunk_id" INTEGER NOT NULL,
     -- Which room does this event belong to? (hashed key shared with linked_chunks)
     "room_id" BLOB NOT NULL,

--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -104,6 +104,9 @@ pub enum Error {
 
     #[error("An update keyed by unique ID touched more than one entry")]
     InconsistentUpdate,
+
+    #[error("The store contains invalid data: {details}")]
+    InvalidData { details: String },
 }
 
 macro_rules! impl_from {

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -1,3 +1,19 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A sqlite-based backend for the [`EventCacheStore`].
+
 #![allow(dead_code)] // Most of the unused code may be used soonish.
 
 use std::{borrow::Cow, fmt, path::Path, sync::Arc};

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -358,6 +358,9 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 3 {
+        // Enable foreign keys for this database.
+        conn.execute_batch("PRAGMA foreign_keys = ON;").await?;
+
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/event_cache_store/003_events.sql"))?;
             txn.set_db_version(3)


### PR DESCRIPTION
So, it's a bit of a chatty PR:

- because of the tests,
- because the tests required reading out from the store, I've implemented the full linked chunk reloading; it's using the intermediary raw format at this point, and later we can use the `LinkedChunkBuilder` to recreate the full thing.

Apart from that, the changes here are somewhat boring, and just running SQL requests.

I've taken the liberty to add a (clear) event id as a column for the events table, so we can add fetch_by_id easily in the future; this avoids a trivial migration.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/3280
Split from #4308.