### PR TITLE
Fix indexing issue in `ObservableMap`

### DIFF
--- a/crates/matrix-sdk-base/src/store/observable_map.rs
+++ b/crates/matrix-sdk-base/src/store/observable_map.rs
@@ -138,10 +138,13 @@ where
         L: Hash + Eq + ?Sized,
     {
         let position = self.mapping.remove(key)?;
-        // reindex every mapped entry that is after the position we're looking to remove
-        for mposition in self.mapping.values_mut().filter(|mposition| **mposition > position) {
-            *mposition = mposition.saturating_sub(1);
+
+        // Reindex every mapped entry that is after the position we're looking to
+        // remove.
+        for mapped_pos in self.mapping.values_mut().filter(|pos| **pos > position) {
+            *mapped_pos = mapped_pos.saturating_sub(1);
         }
+
         Some(self.values.remove(position))
     }
 }

--- a/crates/matrix-sdk-base/src/store/observable_map.rs
+++ b/crates/matrix-sdk-base/src/store/observable_map.rs
@@ -195,6 +195,12 @@ mod tests {
         assert_eq!(map.get(&'a'), Some(&'E'));
         assert_eq!(map.get(&'b'), Some(&'f'));
         assert_eq!(map.get(&'c'), Some(&'G'));
+
+        // remove non-last item
+        assert_eq!(map.remove(&'b'), Some('f'));
+
+        // get_or_create item after the removed one
+        assert_eq!(map.get_or_create(&'c', || 'G'), &'G');
     }
 
     #[test]
@@ -208,20 +214,26 @@ mod tests {
         // new items
         map.insert('a', 'e');
         map.insert('b', 'f');
+        map.insert('c', 'g');
 
         assert_eq!(map.get(&'a'), Some(&'e'));
         assert_eq!(map.get(&'b'), Some(&'f'));
-        assert!(map.get(&'c').is_none());
+        assert_eq!(map.get(&'c'), Some(&'g'));
+        assert!(map.get(&'d').is_none());
 
-        // remove one item
-        assert_eq!(map.remove(&'b'), Some('f'));
+        // remove last item
+        assert_eq!(map.remove(&'c'), Some('g'));
 
         assert_eq!(map.get(&'a'), Some(&'e'));
-        assert_eq!(map.get(&'b'), None);
+        assert_eq!(map.get(&'b'), Some(&'f'));
         assert_eq!(map.get(&'c'), None);
 
         // remove a non-existent item
         assert_eq!(map.remove(&'c'), None);
+
+        // remove a non-last item
+        assert_eq!(map.remove(&'a'), Some('e'));
+        assert_eq!(map.get(&'b'), Some(&'f'));
     }
 
     #[test]

--- a/crates/matrix-sdk-base/src/store/observable_map.rs
+++ b/crates/matrix-sdk-base/src/store/observable_map.rs
@@ -138,6 +138,10 @@ where
         L: Hash + Eq + ?Sized,
     {
         let position = self.mapping.remove(key)?;
+        // reindex every mapped entry that is after the position we're looking to remove
+        for mposition in self.mapping.values_mut().filter(|mposition| **mposition > position) {
+            *mposition = mposition.saturating_sub(1);
+        }
         Some(self.values.remove(position))
     }
 }


### PR DESCRIPTION
The client we're building is panicking on startups in some random cases with the following error message `Value should be present or has just been inserted, but it's missing`. There seems to be a pretty serious bug in `observable_map.rs` which I initially demonstrated with an extension of the existing unit tests in 6d6f8e4dada2ec43f89d1aa07118efb608a0a60a.

Any `.remove` operation called on a `ObservableMap` will not re-index `values` _after_ the removed position, which means any later operation on elements inserted after the previously removed key will either be fetched wrongly, or panic when using `.get_or_create`.

This PR fixes these two related bugs and adds extra test cases.