### PR TITLE
feat(event cache): connect the room event cache and persistent storage

### DIFF
--- a/crates/matrix-sdk-common/src/linked_chunk/updates.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/updates.rs
@@ -129,7 +129,7 @@ impl<Item, Gap> ObservableUpdates<Item, Gap> {
     /// Take new updates.
     ///
     /// Updates that have been taken will not be read again.
-    pub(super) fn take(&mut self) -> Vec<Update<Item, Gap>>
+    pub fn take(&mut self) -> Vec<Update<Item, Gap>>
     where
         Item: Clone,
         Gap: Clone,

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -97,6 +97,7 @@ matrix-sdk-sqlite = { workspace = true, optional = true }
 matrix-sdk-test = { workspace = true, optional = true }
 mime = { workspace = true }
 mime2ext = "0.1.53"
+once_cell = { workspace = true }
 pin-project-lite = { workspace = true }
 rand = { workspace = true , optional = true }
 ruma = { workspace = true, features = ["rand", "unstable-msc2448", "unstable-msc2965", "unstable-msc3930", "unstable-msc3245-v1-compat", "unstable-msc2867"] }
@@ -140,7 +141,6 @@ dirs = "5.0.1"
 futures-executor = { workspace = true }
 matrix-sdk-base = { workspace = true, features = ["testing"] }
 matrix-sdk-test = { workspace = true }
-once_cell = { workspace = true }
 serde_urlencoded = "0.7.1"
 similar-asserts = { workspace = true }
 stream_assert = { workspace = true }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -265,7 +265,7 @@ pub(crate) struct ClientInner {
     pub(crate) http_client: HttpClient,
 
     /// User session data.
-    base_client: BaseClient,
+    pub(super) base_client: BaseClient,
 
     /// Server capabilities, either prefilled during building or fetched from
     /// the server.

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -42,6 +42,7 @@ use matrix_sdk_base::{
 };
 use matrix_sdk_common::executor::{spawn, JoinHandle};
 use once_cell::sync::OnceCell;
+use room::RoomEventCacheState;
 use ruma::{
     events::{relation::RelationType, AnySyncEphemeralRoomEvent},
     serde::Raw,
@@ -458,9 +459,12 @@ impl EventCacheInner {
                     return Ok(room.clone());
                 }
 
+                let room_state =
+                    RoomEventCacheState::new(room_id.to_owned(), self.store.clone()).await?;
+
                 let room_event_cache = RoomEventCache::new(
                     self.client.clone(),
-                    self.store.clone(),
+                    room_state,
                     room_id.to_owned(),
                     self.all_events.clone(),
                 );

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -16,7 +16,10 @@ use std::cmp::Ordering;
 
 use eyeball_im::VectorDiff;
 pub use matrix_sdk_base::event_cache::{Event, Gap};
-use matrix_sdk_base::{event_cache::store::DEFAULT_CHUNK_CAPACITY, linked_chunk::AsVector};
+use matrix_sdk_base::{
+    event_cache::store::DEFAULT_CHUNK_CAPACITY,
+    linked_chunk::{AsVector, ObservableUpdates},
+};
 use matrix_sdk_common::linked_chunk::{
     Chunk, ChunkIdentifier, EmptyChunk, Error, Iter, LinkedChunk, Position,
 };
@@ -183,6 +186,12 @@ impl RoomEvents {
     #[allow(unused)] // gonna be useful very soon! but we need it now for test purposes
     pub fn updates_as_vector_diffs(&mut self) -> Vec<VectorDiff<Event>> {
         self.chunks_updates_as_vectordiffs.take()
+    }
+
+    /// Get a mutable reference to the [`LinkedChunk`] updates, aka
+    /// [`ObservableUpdates`].
+    pub(super) fn updates(&mut self) -> &mut ObservableUpdates<Event, Gap> {
+        self.chunks.updates().expect("this is always built with an update history in the ctor")
     }
 
     /// Deduplicate `events` considering all events in `Self::chunks`.


### PR DESCRIPTION
This implements both directions for interacting between the event cache and the storage backend. I think this is fine design… as long as we don't have any other process writing into the cache, in which case we'll need to reset at different places.

## writing

The main idea in this PR is to use `RoomEventCacheState::with_events_mut(func: impl FnMut(&mut RoomEvents))` to perform any write to the underlying `RoomEvent` data structure. The function takes care of maintaining the storage, after updates have been performed.

Additionally: this behavior isn't enabled by default; callers have to call `EventCache::enable_storage()` when they start using the event cache.

I've put the `RoomEventCacheState` data structure in a private module, so that even the same module can't access its private fields, and we don't make mistakes by accidentally misusing `events`.

## reading

Reading happens by reloading the chunks initially, and prefilling the deduplicator with the reloaded events information. It's mostly boring changes at this point.

---

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/3280. On top of #4362. Split and reworked from https://github.com/matrix-org/matrix-rust-sdk/pull/4308.