### PR TITLE
chore(test): Upgrade ctor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn",

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -16,7 +16,6 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
-#![cfg_attr(test, allow(unexpected_cfgs))] // Triggered by the init_tracing_for_tests!() invocation.
 #![warn(missing_docs, missing_debug_implementations)]
 
 pub use matrix_sdk_common::*;

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -17,7 +17,6 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs, missing_debug_implementations)]
 #![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
-#![cfg_attr(test, allow(unexpected_cfgs))] // Triggered by the init_tracing_for_tests!() invocation.
 
 pub mod backups;
 mod ciphers;

--- a/crates/matrix-sdk-sqlite/src/lib.rs
+++ b/crates/matrix-sdk-sqlite/src/lib.rs
@@ -15,7 +15,6 @@
     not(any(feature = "state-store", feature = "crypto-store", feature = "event-cache")),
     allow(dead_code, unused_imports)
 )]
-#![cfg_attr(test, allow(unexpected_cfgs))] // Triggered by the init_tracing_for_tests!() invocation.
 
 #[cfg(feature = "crypto-store")]
 mod crypto_store;

--- a/crates/matrix-sdk-ui/src/lib.rs
+++ b/crates/matrix-sdk-ui/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(test, allow(unexpected_cfgs))] // Triggered by the init_tracing_for_tests!() invocation.
-
 use ruma::html::HtmlSanitizerMode;
 
 mod events;

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(unexpected_cfgs)] // Triggered by the init_tracing_for_tests!() invocation.
-
 use itertools::Itertools as _;
 use matrix_sdk::deserialized_responses::TimelineEvent;
 use ruma::{events::AnyStateEvent, serde::Raw, EventId, RoomId};

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -17,7 +17,6 @@
 #![warn(missing_debug_implementations, missing_docs)]
 #![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(test, allow(unexpected_cfgs))] // Triggered by the init_tracing_for_tests!() invocation.
 
 pub use async_trait::async_trait;
 pub use bytes;

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -1,6 +1,5 @@
 // The http mocking library is not supported for wasm32
 #![cfg(not(target_arch = "wasm32"))]
-#![allow(unexpected_cfgs)] // Triggered by the init_tracing_for_tests!() invocation.
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server, Client};
 use matrix_sdk_test::test_json;
 use serde::Serialize;

--- a/testing/matrix-sdk-integration-testing/src/lib.rs
+++ b/testing/matrix-sdk-integration-testing/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg(test)]
-#![allow(unexpected_cfgs)] // Triggered by the init_tracing_for_tests!() invocation.
 
 matrix_sdk_test::init_tracing_for_tests!();
 

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -27,7 +27,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ctor = "0.2.0"
+ctor = "0.2.9"
 tokio = { workspace = true, features = ["rt", "macros"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 wiremock = { workspace = true }


### PR DESCRIPTION
Fixes the `unexpected_cfgs` warning so it doesn't need to be disabled anymore.

We are also looking at the one triggered by `EventContent` in https://github.com/ruma/ruma/issues/1956, if anyone has an opinion.