### PR TITLE
chore(xtask): Disable `unexpected_cfgs` lint

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)] // Triggered by the xshell::cmd!() invocation.
+
 mod ci;
 mod fixup;
 mod kotlin;


### PR DESCRIPTION
It is triggered by the `xshell::cmd!` macro.

An alternative to this is to upgrade xshell to the latest version (which was not done in https://github.com/matrix-org/matrix-rust-sdk/pull/653 because there is an API break that makes it more complicated to use), or use a different crate.