### PR TITLE
chore(xtask): Upgrade xshell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6814,18 +6814,18 @@ dependencies = [
 
 [[package]]
 name = "xshell"
-version = "0.1.17"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaad2035244c56da05573d4d7fda5f903c60a5f35b9110e157a14a1df45a9f14"
+checksum = "9e7290c623014758632efe00737145b6867b66292c42167f2ec381eb566a373d"
 dependencies = [
  "xshell-macros",
 ]
 
 [[package]]
 name = "xshell-macros"
-version = "0.1.17"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4916a4a3cad759e499a3620523bf9545cc162d7a06163727dde97ce9aaa4cf39"
+checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,7 +16,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 fs_extra = "1"
 uniffi_bindgen = { workspace = true }
-xshell = "0.1.17"
+xshell = "0.2.7"
 
 [package.metadata.release]
 release = false

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -73,9 +73,10 @@ impl ReleaseArgs {
         // make sure to not switch back to the workspace dir.
         //
         // More info: https://git-cliff.org/docs/usage/monorepos
+        let sh = sh();
+        let _p;
         if self.cmd != ReleaseCommand::Changelog {
-            let sh = sh();
-            let _p = sh.push_dir(workspace::root_path()?);
+            _p = sh.push_dir(workspace::root_path()?);
         }
 
         match self.cmd {

--- a/xtask/src/workspace.rs
+++ b/xtask/src/workspace.rs
@@ -4,7 +4,7 @@ use camino::Utf8PathBuf;
 use serde::Deserialize;
 use xshell::cmd;
 
-use crate::Result;
+use crate::{sh, Result};
 
 pub fn root_path() -> Result<Utf8PathBuf> {
     #[derive(Deserialize)]
@@ -13,7 +13,8 @@ pub fn root_path() -> Result<Utf8PathBuf> {
     }
 
     let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
-    let metadata_json = cmd!("{cargo} metadata --no-deps --format-version 1").read()?;
+    let sh = sh();
+    let metadata_json = cmd!(sh, "{cargo} metadata --no-deps --format-version 1").read()?;
     Ok(serde_json::from_str::<Metadata>(&metadata_json)?.workspace_root)
 }
 
@@ -24,6 +25,7 @@ pub fn target_path() -> Result<Utf8PathBuf> {
     }
 
     let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
-    let metadata_json = cmd!("{cargo} metadata --no-deps --format-version 1").read()?;
+    let sh = sh();
+    let metadata_json = cmd!(sh, "{cargo} metadata --no-deps --format-version 1").read()?;
     Ok(serde_json::from_str::<Metadata>(&metadata_json)?.target_directory)
 }


### PR DESCRIPTION
Gets rid of an `unexpected_cfgs` warning. Alternative to #4352.

Because most subcommands are functions, this uses a thread-local static shared shell API. If they were methods, we could just use a shared shell API for a given command.