### PR TITLE
chore(sdk): Disable `unused_async` clippy lint for unimplemented method

### DIFF
--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -650,6 +650,7 @@ async fn build_indexeddb_store_config(
 }
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "indexeddb"))]
+#[allow(clippy::unused_async)]
 async fn build_indexeddb_store_config(
     _name: &str,
     _passphrase: Option<&str>,


### PR DESCRIPTION
Clippy only shows the warning when the `indexeddb` is active but we are not under WASM.