### PR TITLE
feat(ui): Add new properties to `UnableToDecryptInfo`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -449,7 +449,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 // timeline.
                 if let Some(hook) = self.meta.unable_to_decrypt_hook.as_ref() {
                     if let Some(event_id) = &self.ctx.flow.event_id() {
-                        hook.on_utd(event_id, utd_cause, self.ctx.timestamp).await;
+                        hook.on_utd(event_id, utd_cause, self.ctx.timestamp, &self.ctx.sender)
+                            .await;
                     }
                 }
             }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -449,7 +449,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 // timeline.
                 if let Some(hook) = self.meta.unable_to_decrypt_hook.as_ref() {
                     if let Some(event_id) = &self.ctx.flow.event_id() {
-                        hook.on_utd(event_id, utd_cause).await;
+                        hook.on_utd(event_id, utd_cause, self.ctx.timestamp).await;
                     }
                 }
             }


### PR DESCRIPTION
Adds a number of new properties to the `UnableToDecryptInfo` that is passed to the application-level `UnableToDecryptHook`.

Part of https://github.com/element-hq/element-meta/issues/2582