### PR TITLE
refactor(ui): Use an iterator instead of `Vec` to represent events

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -183,7 +183,7 @@ impl TimelineBuilder {
                         if let Ok(events) = inner.reload_pinned_events().await {
                             inner
                                 .replace_with_initial_remote_events(
-                                    events,
+                                    events.into_iter(),
                                     RemoteEventOrigin::Pagination,
                                 )
                                 .await;
@@ -238,7 +238,7 @@ impl TimelineBuilder {
                             // current timeline.
                             match room_event_cache.subscribe().await {
                                 Ok((events, _)) => {
-                                    inner.replace_with_initial_remote_events(events, RemoteEventOrigin::Sync).await;
+                                    inner.replace_with_initial_remote_events(events.into_iter(), RemoteEventOrigin::Sync).await;
                                 }
                                 Err(err) => {
                                     warn!("Error when re-inserting initial events into the timeline: {err}");
@@ -272,7 +272,7 @@ impl TimelineBuilder {
                             trace!("Received new timeline events.");
 
                             inner.add_events_at(
-                                events,
+                                events.into_iter(),
                                 TimelineNewItemPosition::End {                                    origin: match origin {
                                         EventsOrigin::Sync => RemoteEventOrigin::Sync,
                                     }

--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -81,7 +81,7 @@ impl super::Timeline {
                     // `matrix_sdk::event_cache::RoomEventCacheUpdate` from
                     // `matrix_sdk::event_cache::RoomPagination::run_backwards`.
                     self.controller
-                        .add_events_at(events, TimelineNewItemPosition::Start { origin: RemoteEventOrigin::Pagination })
+                        .add_events_at(events.into_iter(), TimelineNewItemPosition::Start { origin: RemoteEventOrigin::Pagination })
                         .await;
 
                     if num_events == 0 && !reached_start {

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -50,7 +50,7 @@ async fn test_initial_events() {
     timeline
         .controller
         .add_events_at(
-            vec![f.text_msg("A").sender(*ALICE), f.text_msg("B").sender(*BOB)],
+            [f.text_msg("A").sender(*ALICE), f.text_msg("B").sender(*BOB)].into_iter(),
             TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
         )
         .await;
@@ -92,7 +92,10 @@ async fn test_replace_with_initial_events_and_read_marker() {
 
     timeline
         .controller
-        .add_events_at(vec![ev], TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync })
+        .add_events_at(
+            [ev].into_iter(),
+            TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
+        )
         .await;
 
     let items = timeline.controller.items().await;
@@ -101,7 +104,10 @@ async fn test_replace_with_initial_events_and_read_marker() {
     assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "hey");
 
     let ev = f.text_msg("yo").sender(*BOB).into_sync();
-    timeline.controller.replace_with_initial_remote_events(vec![ev], RemoteEventOrigin::Sync).await;
+    timeline
+        .controller
+        .replace_with_initial_remote_events([ev].into_iter(), RemoteEventOrigin::Sync)
+        .await;
 
     let items = timeline.controller.items().await;
     assert_eq!(items.len(), 2);
@@ -309,7 +315,7 @@ async fn test_dedup_initial() {
     timeline
         .controller
         .add_events_at(
-            vec![
+            [
                 // two events
                 event_a.clone(),
                 event_b.clone(),
@@ -318,7 +324,8 @@ async fn test_dedup_initial() {
                 event_b,
                 // … and a new event also came in
                 event_c,
-            ],
+            ]
+            .into_iter(),
             TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
         )
         .await;
@@ -356,7 +363,7 @@ async fn test_internal_id_prefix() {
     timeline
         .controller
         .add_events_at(
-            vec![ev_a, ev_b, ev_c],
+            [ev_a, ev_b, ev_c].into_iter(),
             TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
         )
         .await;
@@ -522,7 +529,10 @@ async fn test_replace_with_initial_events_when_batched() {
 
     timeline
         .controller
-        .add_events_at(vec![ev], TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync })
+        .add_events_at(
+            [ev].into_iter(),
+            TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
+        )
         .await;
 
     let (items, mut stream) = timeline.controller.subscribe_batched().await;
@@ -531,7 +541,10 @@ async fn test_replace_with_initial_events_when_batched() {
     assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "hey");
 
     let ev = f.text_msg("yo").sender(*BOB).into_sync();
-    timeline.controller.replace_with_initial_remote_events(vec![ev], RemoteEventOrigin::Sync).await;
+    timeline
+        .controller
+        .replace_with_initial_remote_events([ev].into_iter(), RemoteEventOrigin::Sync)
+        .await;
 
     // Assert there are more than a single Clear diff in the next batch:
     // Clear + PushBack (event) + PushFront (day divider)

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -272,12 +272,12 @@ async fn test_no_read_marker_with_local_echo() {
     timeline
         .controller
         .replace_with_initial_remote_events(
-            vec![f
-                .text_msg("msg1")
+            [f.text_msg("msg1")
                 .sender(user_id!("@a:b.c"))
                 .event_id(event_id)
                 .server_ts(MilliSecondsSinceUnixEpoch::now())
-                .into_sync()],
+                .into_sync()]
+            .into_iter(),
             RemoteEventOrigin::Sync,
         )
         .await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -242,7 +242,7 @@ impl TestTimeline {
         let event = event.into();
         self.controller
             .add_events_at(
-                vec![event],
+                [event].into_iter(),
                 TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
             )
             .await;
@@ -264,7 +264,7 @@ impl TestTimeline {
         let timeline_event = TimelineEvent::new(event.cast());
         self.controller
             .add_events_at(
-                vec![timeline_event],
+                [timeline_event].into_iter(),
                 TimelineNewItemPosition::Start { origin: RemoteEventOrigin::Pagination },
             )
             .await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -196,14 +196,15 @@ async fn test_initial_reaction_timestamp_is_stored() {
     timeline
         .controller
         .add_events_at(
-            vec![
+            [
                 // Reaction comes first.
                 f.reaction(&message_event_id, REACTION_KEY.to_owned())
                     .server_ts(reaction_timestamp)
                     .into_sync(),
                 // Event comes next.
                 f.text_msg("A").event_id(&message_event_id).into_sync(),
-            ],
+            ]
+            .into_iter(),
             TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
         )
         .await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -141,11 +141,12 @@ async fn test_reaction_redaction_timeline_filter() {
     timeline
         .controller
         .add_events_at(
-            vec![SyncTimelineEvent::new(
+            [SyncTimelineEvent::new(
                 timeline
                     .event_builder
                     .make_sync_redacted_message_event(*ALICE, RedactedReactionEventContent::new()),
-            )],
+            )]
+            .into_iter(),
             TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
         )
         .await;


### PR DESCRIPTION
(Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/3512/)

This patch changes `TimelineStateTransaction::add_remote_events_at` to take an `IntoIterator<Item = Into<SyncTimelineEvent>>` for `events`. In the current code, it saves one
`iter().map(Into::into).collect::<Vec<_>>()`, but it will save another one when we will support `VectorDiff`s coming from the `EventCache`.

It also avoids to allocate a vector to pass new events (this mostly happens in the tests, but it can happen in real life).

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280