### PR TITLE
feat(event cache): reload a linked chunk from a store

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -16,13 +16,13 @@ use std::{collections::HashMap, num::NonZeroUsize, sync::RwLock as StdRwLock, ti
 
 use async_trait::async_trait;
 use matrix_sdk_common::{
-    linked_chunk::{relational::RelationalLinkedChunk, Update},
+    linked_chunk::{relational::RelationalLinkedChunk, LinkedChunk, Update},
     ring_buffer::RingBuffer,
     store_locks::memory_store_helper::try_take_leased_lock,
 };
 use ruma::{MxcUri, OwnedMxcUri, RoomId};
 
-use super::{EventCacheStore, EventCacheStoreError, Result};
+use super::{EventCacheStore, EventCacheStoreError, Result, DEFAULT_CHUNK_CAPACITY};
 use crate::{
     event_cache::{Event, Gap},
     media::{MediaRequestParameters, UniqueKey as _},
@@ -91,6 +91,14 @@ impl EventCacheStore for MemoryStore {
         inner.events.apply_updates(room_id, updates);
 
         Ok(())
+    }
+
+    async fn reload_linked_chunk(
+        &self,
+        _room_id: &RoomId,
+    ) -> Result<Option<LinkedChunk<DEFAULT_CHUNK_CAPACITY, Event, Gap>>, Self::Error> {
+        // TODO(hywan)
+        Ok(Default::default())
     }
 
     async fn add_media_content(

--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -36,7 +36,7 @@ pub use matrix_sdk_store_encryption::Error as StoreEncryptionError;
 pub use self::integration_tests::EventCacheStoreIntegrationTests;
 pub use self::{
     memory_store::MemoryStore,
-    traits::{DynEventCacheStore, EventCacheStore, IntoEventCacheStore},
+    traits::{DynEventCacheStore, EventCacheStore, IntoEventCacheStore, DEFAULT_CHUNK_CAPACITY},
 };
 
 /// The high-level public type to represent an `EventCacheStore` lock.

--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -148,6 +148,13 @@ pub enum EventCacheStoreError {
          current version: {0}, latest version: {1}"
     )]
     UnsupportedDatabaseVersion(usize, usize),
+
+    /// The store contains invalid data.
+    #[error("The store contains invalid data: {details}")]
+    InvalidData {
+        /// Details why the data contained in the store was invalid.
+        details: String,
+    },
 }
 
 impl EventCacheStoreError {

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -17,6 +17,7 @@
 
 use ruma::{OwnedRoomId, RoomId};
 
+use super::LinkedChunkBuilder;
 use crate::linked_chunk::{ChunkIdentifier, Position, Update};
 
 /// A row of the [`RelationalLinkedChunk::chunks`].
@@ -271,6 +272,90 @@ impl<Item, Gap> RelationalLinkedChunk<Item, Gap> {
                 entry_for_next_chunk.previous_chunk = previous;
             }
         }
+    }
+}
+
+impl<Item, Gap> RelationalLinkedChunk<Item, Gap>
+where
+    Gap: Clone,
+    Item: Clone,
+{
+    /// Reloads the chunks.
+    ///
+    /// Return an error result if the data was malformed in the struct, with a
+    /// string message explaining details about the error.
+    pub fn reload_chunks<const CAP: usize>(
+        &self,
+        room_id: &RoomId,
+        builder: &mut LinkedChunkBuilder<CAP, Item, Gap>,
+    ) -> Result<(), String> {
+        for chunk_row in self.chunks.iter().filter(|chunk| chunk.room_id == room_id) {
+            // Find all items that correspond to the chunk.
+            let mut items = self
+                .items
+                .iter()
+                .filter(|row| {
+                    row.room_id == room_id && row.position.chunk_identifier() == chunk_row.chunk
+                })
+                .peekable();
+
+            // Look at the first chunk item type, to reconstruct the chunk at hand.
+            let Some(first) = items.peek() else {
+                // No items found for this chunk; don't include it in the builder.
+                return Err(format!("chunk {} had no corresponding row", chunk_row.chunk.index()));
+            };
+
+            match &first.item {
+                Either::Item(_) => {
+                    // Collect all the related items.
+                    let mut collected_items = Vec::new();
+                    for row in items {
+                        match &row.item {
+                            Either::Item(item) => {
+                                collected_items.push((item.clone(), row.position.index()))
+                            }
+                            Either::Gap(_) => {
+                                return Err(format!(
+                                    "unexpected gap in items chunk {}",
+                                    chunk_row.chunk.index()
+                                ));
+                            }
+                        }
+                    }
+
+                    // Sort them by their position.
+                    collected_items.sort_unstable_by_key(|(_item, index)| *index);
+
+                    builder.push_items(
+                        chunk_row.previous_chunk,
+                        chunk_row.chunk,
+                        chunk_row.next_chunk,
+                        collected_items.into_iter().map(|(item, _index)| item),
+                    );
+                }
+
+                Either::Gap(gap) => {
+                    assert!(items.next().is_some(), "we just peeked the gap");
+
+                    // We shouldn't have more than one item row for this chunk.
+                    if items.next().is_some() {
+                        return Err(format!(
+                            "there shouldn't be more than one item row attached in gap chunk {}",
+                            chunk_row.chunk.index()
+                        ));
+                    }
+
+                    builder.push_gap(
+                        chunk_row.previous_chunk,
+                        chunk_row.chunk,
+                        chunk_row.next_chunk,
+                        gap.clone(),
+                    );
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -727,5 +812,60 @@ mod tests {
         relational_linked_chunk.apply_updates(room_id, vec![Update::Clear]);
         assert!(relational_linked_chunk.chunks.is_empty());
         assert!(relational_linked_chunk.items.is_empty());
+    }
+
+    #[test]
+    fn test_rebuild_empty_linked_chunk() {
+        let mut builder = LinkedChunkBuilder::<3, _, _>::new();
+
+        let room_id = room_id!("!r0:matrix.org");
+
+        // When I rebuild a linked chunk from an empty store,
+        let relational_linked_chunk = RelationalLinkedChunk::<char, char>::new();
+        relational_linked_chunk.reload_chunks(room_id, &mut builder).unwrap();
+
+        let lc = builder.build().expect("building succeeds");
+
+        // The builder won't return a linked chunk.
+        assert!(lc.is_none());
+    }
+
+    #[test]
+    fn test_rebuild_linked_chunk() {
+        let mut builder = LinkedChunkBuilder::<3, _, _>::new();
+
+        let room_id = room_id!("!r0:matrix.org");
+        let mut relational_linked_chunk = RelationalLinkedChunk::<char, char>::new();
+
+        relational_linked_chunk.apply_updates(
+            room_id,
+            vec![
+                // new chunk
+                Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
+                // new items on 0
+                Update::PushItems { at: Position::new(CId::new(0), 0), items: vec!['a', 'b', 'c'] },
+                // a gap chunk
+                Update::NewGapChunk {
+                    previous: Some(CId::new(0)),
+                    new: CId::new(1),
+                    next: None,
+                    gap: 'g',
+                },
+                // another items chunk
+                Update::NewItemsChunk { previous: Some(CId::new(1)), new: CId::new(2), next: None },
+                // new items on 0
+                Update::PushItems { at: Position::new(CId::new(2), 0), items: vec!['d', 'e', 'f'] },
+            ],
+        );
+
+        relational_linked_chunk.reload_chunks(room_id, &mut builder).unwrap();
+
+        let lc = builder
+            .build()
+            .expect("building succeeds")
+            .expect("this leads to a non-empty linked chunk");
+
+        // The linked chunk is correctly reloaded.
+        assert_items_eq!(lc, ['a', 'b', 'c'] [-] ['d', 'e', 'f']);
     }
 }

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -16,7 +16,7 @@ use std::cmp::Ordering;
 
 use eyeball_im::VectorDiff;
 pub use matrix_sdk_base::event_cache::{Event, Gap};
-use matrix_sdk_base::linked_chunk::AsVector;
+use matrix_sdk_base::{event_cache::store::DEFAULT_CHUNK_CAPACITY, linked_chunk::AsVector};
 use matrix_sdk_common::linked_chunk::{
     Chunk, ChunkIdentifier, EmptyChunk, Error, Iter, LinkedChunk, Position,
 };
@@ -24,8 +24,6 @@ use ruma::OwnedEventId;
 use tracing::{debug, error, warn};
 
 use super::super::deduplicator::{Decoration, Deduplicator};
-
-const DEFAULT_CHUNK_CAPACITY: usize = 128;
 
 /// This type represents all events of a single room.
 #[derive(Debug)]


### PR DESCRIPTION
This implements the following:

- add a new trait method to reload a linked chunk from the store. In particular, we want to distinguish reloading when there's nothing in the store (could happen if we never saved a chunk before) from reloading a non-empty chunk. The reason is, that there's an invariant in the linked chunk code that when it's empty, a linked chunk has a single empty Events chunk; we let the caller maintain that invariant by creating the linked chunk in this case.
- implement that trait for the sqlite store; it's trivial, since the sqlite store had to implement similar functionality just so as to be tested.
- implement that trait for the in-memory store; while not complicated, it's a bit unwieldy because the in-memory store keeps one line per item in a chunk, instead of storing the entire items vector. But still, relatively easy to manage :-)
- adds integration tests at the trait level for the event cache store, for handling *and* reloading a chunk at the same time. Moves a bit of code from the sqlite testing framework, to help with creating and checking synthetic events.