### PR TITLE
ci: Build the Mac framework using the reldbg profile

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -175,7 +175,7 @@ jobs:
         run: swift test
 
       - name: Build Framework
-        run: target/debug/xtask swift build-framework --target=aarch64-apple-ios --profile=release
+        run: target/debug/xtask swift build-framework --target=aarch64-apple-ios --profile=reldbg
 
   complement-crypto:
     name: "Run Complement Crypto tests"


### PR DESCRIPTION
This brings our CI times for the `Build framework` step down to 13 minutes after they have risen to 40+ minutes because of https://github.com/matrix-org/matrix-rust-sdk/pull/4354/commits/191d00871f3b50ef90fde2fbef1c92d7036aec22.