### PR TITLE
refactor: Rename `TimelineMetadata::all_events` to `all_remote_events`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1529,7 +1529,7 @@ impl TimelineController {
     /// it's folded into another timeline item.
     pub(crate) async fn latest_event_id(&self) -> Option<OwnedEventId> {
         let state = self.state.read().await;
-        state.meta.all_events.back().map(|event_meta| &event_meta.event_id).cloned()
+        state.meta.all_remote_events.back().map(|event_meta| &event_meta.event_id).cloned()
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -537,7 +537,12 @@ impl TimelineStateTransaction<'_> {
                         visible: false,
                     };
                     let _event_added_or_updated = self
-                        .add_or_update_event(event_meta, position, room_data_provider, settings)
+                        .add_or_update_remote_event(
+                            event_meta,
+                            position,
+                            room_data_provider,
+                            settings,
+                        )
                         .await;
 
                     return HandleEventResult::default();
@@ -564,7 +569,12 @@ impl TimelineStateTransaction<'_> {
                             visible: false,
                         };
                         let _event_added_or_updated = self
-                            .add_or_update_event(event_meta, position, room_data_provider, settings)
+                            .add_or_update_remote_event(
+                                event_meta,
+                                position,
+                                room_data_provider,
+                                settings,
+                            )
                             .await;
                     }
 
@@ -583,8 +593,9 @@ impl TimelineStateTransaction<'_> {
             visible: should_add,
         };
 
-        let event_added_or_updated =
-            self.add_or_update_event(event_meta, position, room_data_provider, settings).await;
+        let event_added_or_updated = self
+            .add_or_update_remote_event(event_meta, position, room_data_provider, settings)
+            .await;
 
         // If the event has not been added or updated, it's because it's a duplicated
         // event. Let's return early.
@@ -686,7 +697,7 @@ impl TimelineStateTransaction<'_> {
     /// It returns `true` if the event has been added or updated, `false`
     /// otherwise. The latter happens if the event already exists, i.e. if
     /// an existing event is requested to be added.
-    async fn add_or_update_event<P: RoomDataProvider>(
+    async fn add_or_update_remote_event<P: RoomDataProvider>(
         &mut self,
         event_meta: FullEventMeta<'_>,
         position: TimelineItemPosition,

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -390,7 +390,7 @@ impl TimelineStateTransaction<'_> {
                     self.meta.read_receipts.maybe_update_read_receipt(
                         full_receipt,
                         is_own_user_id,
-                        &self.meta.all_events,
+                        &self.meta.all_remote_events,
                         &mut self.items,
                     );
                 }
@@ -425,7 +425,7 @@ impl TimelineStateTransaction<'_> {
             self.meta.read_receipts.maybe_update_read_receipt(
                 full_receipt,
                 user_id == own_user_id,
-                &self.meta.all_events,
+                &self.meta.all_remote_events,
                 &mut self.items,
             );
         }
@@ -454,7 +454,7 @@ impl TimelineStateTransaction<'_> {
         self.meta.read_receipts.maybe_update_read_receipt(
             full_receipt,
             is_own_event,
-            &self.meta.all_events,
+            &self.meta.all_remote_events,
             &mut self.items,
         );
     }
@@ -465,7 +465,7 @@ impl TimelineStateTransaction<'_> {
         // Find the previous visible event, if there is one.
         let Some(prev_event_meta) = self
             .meta
-            .all_events
+            .all_remote_events
             .iter()
             .rev()
             // Find the event item.
@@ -495,7 +495,7 @@ impl TimelineStateTransaction<'_> {
 
         let read_receipts = self.meta.read_receipts.compute_event_receipts(
             &remote_prev_event_item.event_id,
-            &self.meta.all_events,
+            &self.meta.all_remote_events,
             false,
         );
 
@@ -585,7 +585,7 @@ impl TimelineState {
 
         // Find the corresponding visible event.
         self.meta
-            .all_events
+            .all_remote_events
             .iter()
             .rev()
             .skip_while(|ev| ev.event_id != *latest_receipt_id)


### PR DESCRIPTION
This patch renames the `all_events` field to `all_remote_events` in `TimelineMetada` for the sake of clarity.