### PR TITLE
refactor: replace static with const for global constants

### DIFF
--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -110,7 +110,7 @@ pub use verification::{QrVerification, QrVerificationState, ScanError};
 pub use vodozemac;
 
 /// The version of the matrix-sdk-cypto crate being used
-pub static VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(test)]
 matrix_sdk_test::init_tracing_for_tests!();

--- a/crates/matrix-sdk/src/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/oidc/cross_process.rs
@@ -24,7 +24,7 @@ struct SessionHash(Vec<u8>);
 
 impl SessionHash {
     fn to_hex(&self) -> String {
-        static CHARS: &[char; 16] =
+        const CHARS: &[char; 16] =
             &['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'];
         let mut res = String::with_capacity(2 * self.0.len() + 2);
         if !self.0.is_empty() {

--- a/crates/matrix-sdk/src/widget/settings/url_params.rs
+++ b/crates/matrix-sdk/src/widget/settings/url_params.rs
@@ -15,16 +15,16 @@
 use url::Url;
 use urlencoding::encode;
 
-pub static USER_ID: &str = "$matrix_user_id";
-pub static ROOM_ID: &str = "$matrix_room_id";
-pub static WIDGET_ID: &str = "$matrix_widget_id";
-pub static AVATAR_URL: &str = "$matrix_avatar_url";
-pub static DISPLAY_NAME: &str = "$matrix_display_name";
-pub static LANGUAGE: &str = "$org.matrix.msc2873.client_language";
-pub static CLIENT_THEME: &str = "$org.matrix.msc2873.client_theme";
-pub static CLIENT_ID: &str = "$org.matrix.msc2873.client_id";
-pub static DEVICE_ID: &str = "$org.matrix.msc2873.matrix_device_id";
-pub static HOMESERVER_URL: &str = "$org.matrix.msc4039.matrix_base_url";
+pub const USER_ID: &str = "$matrix_user_id";
+pub const ROOM_ID: &str = "$matrix_room_id";
+pub const WIDGET_ID: &str = "$matrix_widget_id";
+pub const AVATAR_URL: &str = "$matrix_avatar_url";
+pub const DISPLAY_NAME: &str = "$matrix_display_name";
+pub const LANGUAGE: &str = "$org.matrix.msc2873.client_language";
+pub const CLIENT_THEME: &str = "$org.matrix.msc2873.client_theme";
+pub const CLIENT_ID: &str = "$org.matrix.msc2873.client_id";
+pub const DEVICE_ID: &str = "$org.matrix.msc2873.matrix_device_id";
+pub const HOMESERVER_URL: &str = "$org.matrix.msc4039.matrix_base_url";
 
 pub struct QueryProperties {
     pub(crate) widget_id: String,


### PR DESCRIPTION
- For global variables which don't need to be mutable, prefer const to static.
<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Integral <integral@member.fsf.org>
