### PR TITLE
refactor: `TimelineStateTransaction::add_or_update_remote_event` always return `true`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -544,6 +544,7 @@ impl TimelineStateTransaction<'_> {
                     };
 
                     // Remember the event before returning prematurely.
+                    // See [`TimelineMetadata::all_remote_events`].
                     self.add_or_update_remote_event(
                         event_meta,
                         position,
@@ -582,6 +583,7 @@ impl TimelineStateTransaction<'_> {
                         };
 
                         // Remember the event before returning prematurely.
+                        // See [`TimelineMetadata::all_remote_events`].
                         self.add_or_update_remote_event(
                             event_meta,
                             position,
@@ -607,6 +609,7 @@ impl TimelineStateTransaction<'_> {
         };
 
         // Remember the event.
+        // See [`TimelineMetadata::all_remote_events`].
         self.add_or_update_remote_event(event_meta, position, room_data_provider, settings).await;
 
         let sender_profile = room_data_provider.profile_from_user_id(&sender).await;
@@ -918,6 +921,9 @@ pub(in crate::timeline) struct TimelineMetadata {
 
     /// List of all the remote events as received in the timeline, even the ones
     /// that are discarded in the timeline items.
+    ///
+    /// This is useful to get this for the moment as it helps the `Timeline` to
+    /// compute read receipts and read markers.
     pub all_remote_events: VecDeque<EventMeta>,
 
     /// State helping matching reactions to their associated events, and


### PR DESCRIPTION
The `add_or_update_remote_event` method always returns `true`. This
patch updates the method to return nothing, and cleans up the call sites
accordingly. This patch also adds comments to clarify the code flow.

The bool value returned by `add_or_update_remote_event` was supposed
to be `false` if the event was duplicated. First off, as soon as the
`Timeline` receives its events from the `EventCache` via `VectorDiff`,
the `event_cache::Deduplicator` will take care of deduplication,
so the `Timeline` won't have to handle that itself. Second,
`add_or_update_remote_event` was sometimes removing an event, but it
was re-inserting a new one immediately without returning `false`: it was
never returning `false` because a new event was always added.
