### PR TITLE
refactor(ui): Introduce the `AllRemoteEvents` type

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -52,7 +52,7 @@ use tracing::{
 };
 
 pub(super) use self::state::{
-    EventMeta, FullEventMeta, PendingEdit, PendingEditKind, TimelineMetadata,
+    AllRemoteEvents, FullEventMeta, PendingEdit, PendingEditKind, TimelineMetadata,
     TimelineNewItemPosition, TimelineState, TimelineStateTransaction,
 };
 use super::{

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1529,7 +1529,7 @@ impl TimelineController {
     /// it's folded into another timeline item.
     pub(crate) async fn latest_event_id(&self) -> Option<OwnedEventId> {
         let state = self.state.read().await;
-        state.meta.all_remote_events.back().map(|event_meta| &event_meta.event_id).cloned()
+        state.meta.all_remote_events.last().map(|event_meta| &event_meta.event_id).cloned()
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -1183,7 +1183,7 @@ impl AllRemoteEvents {
     }
 
     /// Return a reference to the last remote event if it exists.
-    pub fn back(&self) -> Option<&EventMeta> {
+    pub fn last(&self) -> Option<&EventMeta> {
         self.0.back()
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -13,10 +13,7 @@
 // limitations under the License.
 
 use std::{
-    collections::{
-        vec_deque::{Iter, IterMut},
-        HashMap, VecDeque,
-    },
+    collections::{vec_deque::Iter, HashMap, VecDeque},
     future::Future,
     num::NonZeroUsize,
     sync::{Arc, RwLock},
@@ -745,11 +742,8 @@ impl TimelineStateTransaction<'_> {
             }
 
             TimelineItemPosition::UpdateDecrypted { .. } => {
-                if let Some(event) = self
-                    .meta
-                    .all_remote_events
-                    .iter_mut()
-                    .find(|e| e.event_id == event_meta.event_id)
+                if let Some(event) =
+                    self.meta.all_remote_events.get_by_event_id_mut(event_meta.event_id)
                 {
                     if event.visible != event_meta.visible {
                         event.visible = event_meta.visible;
@@ -1156,12 +1150,6 @@ impl AllRemoteEvents {
         self.0.iter()
     }
 
-    /// Return a front-to-back iterator over all remote events as mutable
-    /// references.
-    pub fn iter_mut(&mut self) -> IterMut<'_, EventMeta> {
-        self.0.iter_mut()
-    }
-
     /// Remove all remote events.
     pub fn clear(&mut self) {
         self.0.clear();
@@ -1185,6 +1173,11 @@ impl AllRemoteEvents {
     /// Return a reference to the last remote event if it exists.
     pub fn last(&self) -> Option<&EventMeta> {
         self.0.back()
+    }
+
+    /// Get a mutable reference to a specific remote event by its ID.
+    pub fn get_by_event_id_mut(&mut self, event_id: &EventId) -> Option<&mut EventMeta> {
+        self.0.iter_mut().rev().find(|event_meta| event_meta.event_id == event_id)
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    cmp::Ordering,
-    collections::{HashMap, VecDeque},
-    sync::Arc,
-};
+use std::{cmp::Ordering, collections::HashMap, sync::Arc};
 
 use eyeball_im::ObservableVectorTransaction;
 use futures_core::Stream;
@@ -31,7 +27,7 @@ use tracing::{debug, error, warn};
 
 use super::{
     controller::{
-        EventMeta, FullEventMeta, TimelineMetadata, TimelineState, TimelineStateTransaction,
+        AllRemoteEvents, FullEventMeta, TimelineMetadata, TimelineState, TimelineStateTransaction,
     },
     traits::RoomDataProvider,
     util::{rfind_event_by_id, RelativePosition},
@@ -103,7 +99,7 @@ impl ReadReceipts {
         &mut self,
         new_receipt: FullReceipt<'_>,
         is_own_user_id: bool,
-        all_events: &VecDeque<EventMeta>,
+        all_events: &AllRemoteEvents,
         timeline_items: &mut ObservableVectorTransaction<'_, Arc<TimelineItem>>,
     ) {
         // Get old receipt.
@@ -243,7 +239,7 @@ impl ReadReceipts {
     pub(super) fn compute_event_receipts(
         &self,
         event_id: &EventId,
-        all_events: &VecDeque<EventMeta>,
+        all_events: &AllRemoteEvents,
         at_end: bool,
     ) -> IndexMap<OwnedUserId, Receipt> {
         let mut all_receipts = self.get_event_receipts(event_id).cloned().unwrap_or_default();


### PR DESCRIPTION
<figure role="presentation">
<p align="center"><img src="https://github.com/user-attachments/assets/fdbe72c4-c82a-441e-8307-c218cd7eac76" width="80%" /></p>
<figcaption><p align="center">A shepherdess gathering a herd of sheep.</p></figcaption>
</figure>

---

Build on top of https://github.com/matrix-org/matrix-rust-sdk/pull/4369.

The first patch replaces `VecDeque<EventMeta>` by `AllRemoteEvents` which
is a wrapper type around `VecDeque<EventMeta>`, but this new type aims
at adding semantics API rather than a generic API. It also helps to
isolate the use of these values and to know precisely when and how they
are used.

As a first step, `AllRemoteEvents` implements a generic API to not break
the existing code. Next patches are revisiting that a little bit step
by step:

* `AllRemoteEvents::back` becomes `last` to add semantics.
* `AllRemoteEvents::iter_mut` are removed and `get_by_event_id_mut`
  is created.

This PR should be reviewed patch-by-patch.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280