### PR TITLE
test(event cache): rely less on `EventCache::add_initial_events()`

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -675,20 +675,14 @@ async fn test_send_edit_poll() {
 
 #[async_test]
 async fn test_send_edit_when_timeline_is_clear() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let room = server.sync_joined_room(&client, room_id).await;
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    server.mock_room_state_encryption().plain().mount().await;
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
@@ -699,13 +693,13 @@ async fn test_send_edit_when_timeline_is_clear() {
         .sender(client.user_id().unwrap())
         .event_id(event_id!("$original_event"))
         .into_raw_sync();
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id).add_timeline_event(raw_original_event.clone()),
-    );
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(raw_original_event.clone()),
+        )
+        .await;
 
     let hello_world_item =
         assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);
@@ -713,9 +707,13 @@ async fn test_send_edit_when_timeline_is_clear() {
     assert!(!hello_world_message.is_edited());
     assert!(hello_world_item.is_editable());
 
-    // Clear the event cache (hence the timeline) to make sure the old item does not
-    // need to be available in it for the edit to work.
-    client.event_cache().add_initial_events(room_id, vec![], None).await.unwrap();
+    // Receive a limited (gappy) sync for this room, which will clear the timeline…
+    //
+    // TODO: …until the event cache storage is enabled by default, a time where
+    // we'll be able to get rid of this test entirely (or update its
+    // expectations).
+
+    server.sync_room(&client, JoinedRoomBuilder::new(room_id).set_timeline_limited()).await;
     client.event_cache().empty_immutable_cache().await;
 
     yield_now().await;
@@ -741,8 +739,7 @@ async fn test_send_edit_when_timeline_is_clear() {
     // updates, so just wait for a bit before verifying that the endpoint was
     // called.
     sleep(Duration::from_millis(200)).await;
-
-    server.verify().await;
+    assert!(timeline_stream.next().now_or_never().is_none());
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -279,16 +279,6 @@ async fn timeline_test_helper(
         anyhow::anyhow!("Room {room_id} not found in client. Can't provide a timeline for it")
     })?;
 
-    // TODO: when the event cache handles its own cache, we can remove this.
-    client
-        .event_cache()
-        .add_initial_events(
-            room_id,
-            sliding_sync_room.timeline_queue().iter().cloned().collect(),
-            sliding_sync_room.prev_batch(),
-        )
-        .await?;
-
     let timeline = Timeline::builder(&sdk_room).track_read_marker_and_receipts().build().await?;
 
     Ok(timeline.subscribe().await)

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -312,6 +312,11 @@ impl EventCache {
         events: Vec<SyncTimelineEvent>,
         prev_batch: Option<String>,
     ) -> Result<()> {
+        // If the event cache's storage has been enabled, do nothing.
+        if self.inner.store.get().is_some() {
+            return Ok(());
+        }
+
         let room_cache = self.inner.for_room(room_id).await?;
 
         // We could have received events during a previous sync; remove them all, since

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -60,7 +60,7 @@ async fn test_must_explicitly_subscribe() {
 }
 
 #[async_test]
-async fn test_add_initial_events() {
+async fn test_event_cache_receives_events() {
     let (client, server) = logged_in_client_with_server().await;
 
     // Immediately subscribe the event cache to sync updates.
@@ -115,32 +115,6 @@ async fn test_add_initial_events() {
     assert_let!(RoomEventCacheUpdate::AddTimelineEvents { events, .. } = update);
     assert_eq!(events.len(), 1);
     assert_event_matches_msg(&events[0], "bonjour monde");
-
-    // And when I later add initial events to this room,
-
-    // XXX: when we get rid of `add_initial_events`, we can keep this test as a
-    // smoke test for the event cache.
-    client
-        .event_cache()
-        .add_initial_events(room_id, vec![ev_factory.text_msg("new choice!").into_sync()], None)
-        .await
-        .unwrap();
-
-    // Then I receive an update that the room has been cleared,
-    let update = timeout(Duration::from_secs(2), subscriber.recv())
-        .await
-        .expect("timeout after receiving a sync update")
-        .expect("should've received a room event cache update");
-    assert_let!(RoomEventCacheUpdate::Clear = update);
-
-    // Before receiving the "initial" event.
-    let update = timeout(Duration::from_secs(2), subscriber.recv())
-        .await
-        .expect("timeout after receiving a sync update")
-        .expect("should've received a room event cache update");
-    assert_let!(RoomEventCacheUpdate::AddTimelineEvents { events, .. } = update);
-    assert_eq!(events.len(), 1);
-    assert_event_matches_msg(&events[0], "new choice!");
 
     // That's all, folks!
     assert!(subscriber.is_empty());


### PR DESCRIPTION
`EventCache::add_initial_events()` was supposed to be temporary, until the event cache has its own storage. It's been used in multiple tests, as a way to prefill the event cache. It's used in other place, when constructing a timeline, to prefill the room event cache with the (soon-to-be-deprecated) cached timeline we stored in the sliding sync storage (aka `timeline_queue()`).

This patch gets rids of all uses in tests, so that there remains only a single use (when creating the timeline). We can later remove this function, once the storage has been enabled unconditionally.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/3280
Split from #4308.