### PR TITLE
feat(event cache): don't clear a timeline if storage's enabled

### DIFF
--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -1406,6 +1406,11 @@ impl<'a> MockEndpoint<'a, RoomMessagesEndpoint> {
         Self { mock: self.mock.and(query_param("limit", limit.to_string())), ..self }
     }
 
+    /// Expects an optional `from` to be set on the request.
+    pub fn from(self, from: &str) -> Self {
+        Self { mock: self.mock.and(query_param("from", from)), ..self }
+    }
+
     /// Returns a messages endpoint that emulates success, i.e. the messages
     /// provided as `response` could be retrieved.
     ///
@@ -1416,13 +1421,13 @@ impl<'a> MockEndpoint<'a, RoomMessagesEndpoint> {
         start: String,
         end: Option<String>,
         chunk: Vec<impl Into<Raw<AnyTimelineEvent>>>,
-        state: Vec<impl Into<Raw<AnyStateEvent>>>,
+        state: Vec<Raw<AnyStateEvent>>,
     ) -> MatrixMock<'a> {
         let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "start": start,
             "end": end,
             "chunk": chunk.into_iter().map(|ev| ev.into()).collect::<Vec<_>>(),
-            "state": state.into_iter().map(|ev| ev.into()).collect::<Vec<_>>(),
+            "state": state,
         })));
         MatrixMock { server: self.server, mock }
     }

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -38,10 +38,10 @@ use ruma::{
             name::RoomNameEventContent,
             topic::RoomTopicEventContent,
         },
-        AnyStateEvent, StateEventType,
+        StateEventType,
     },
     owned_room_id,
-    serde::{JsonObject, Raw},
+    serde::JsonObject,
     user_id, OwnedRoomId,
 };
 use serde::Serialize;
@@ -307,7 +307,7 @@ async fn test_read_messages_with_msgtype_capabilities() {
     {
         let start = "t392-516_47314_0_7_1_1_1_11444_1".to_owned();
         let end = Some("t47409-4357353_219380_26003_2269".to_owned());
-        let chun2 = vec![
+        let chunk2 = vec![
             f.notice("custom content").event_id(event_id!("$msda7m0df9E9op3")).into_raw_timeline(),
             f.text_msg("hello").event_id(event_id!("$msda7m0df9E9op5")).into_raw_timeline(),
             f.reaction(event_id!("$event_id"), "annotation".to_owned()).into_raw_timeline(),
@@ -315,7 +315,7 @@ async fn test_read_messages_with_msgtype_capabilities() {
         mock_server
             .mock_room_messages()
             .limit(3)
-            .ok(start, end, chun2, Vec::<Raw<AnyStateEvent>>::new())
+            .ok(start, end, chunk2, Vec::new())
             .mock_once()
             .mount()
             .await;

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -64,6 +64,10 @@ async fn main() -> anyhow::Result<()> {
     let config_path = env::args().nth(2).unwrap_or("/tmp/".to_owned());
     let client = configure_client(server_name, config_path).await?;
 
+    let ec = client.event_cache();
+    ec.subscribe().unwrap();
+    ec.enable_storage().unwrap();
+
     init_error_hooks()?;
     let terminal = init_terminal()?;
 
@@ -256,6 +260,7 @@ impl App {
 
                     if let Err(err) = ui_room.init_timeline_with_builder(builder).await {
                         error!("error when creating default timeline: {err}");
+                        continue;
                     }
 
                     // Save the timeline in the cache.


### PR DESCRIPTION
This is one of the last steps for integrating the persistent storage: if a timeline is gappy, then we *don't* need to reset it, either internally or for observers. That's the whole point of persisting the event cache, after all: we should be able to paginate again from any holes we encounter later.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/3280