### PR TITLE
chore: Downgrade xshell due to broken stdin interactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6814,18 +6814,18 @@ dependencies = [
 
 [[package]]
 name = "xshell"
-version = "0.2.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7290c623014758632efe00737145b6867b66292c42167f2ec381eb566a373d"
+checksum = "6d47097dc5c85234b1e41851b3422dd6d19b3befdd35b4ae5ce386724aeca981"
 dependencies = [
  "xshell-macros",
 ]
 
 [[package]]
 name = "xshell-macros"
-version = "0.2.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
+checksum = "88301b56c26dd9bf5c43d858538f82d6f3f7764767defbc5d34e59459901c41a"
 
 [[package]]
 name = "xtask"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,7 +16,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 fs_extra = "1"
 uniffi_bindgen = { workspace = true }
-xshell = "0.2.7"
+xshell = "0.2.2"
 
 [package.metadata.release]
 release = false


### PR DESCRIPTION
Since xshell 0.2.3 the behavior of the run() function has changed in a incompatible manner. Namely the stdin for the run() function no longer inherits stdin from the shell. This makes it impossible for commands that are executed by the run() function to accept input from the shell.

We don't use this functionality in many places but the `xtask release prepare` command is now broken.

Let's just pin xshell to a working version while we wait for this to be resolved upstream.

Upstream-issue: https://github.com/matklad/xshell/issues/63