### PR TITLE
refactor(ui): Create a mapping between remote events to timeline items

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -15,7 +15,7 @@
 use std::{collections::BTreeSet, fmt, sync::Arc};
 
 use as_variant::as_variant;
-use eyeball_im::{ObservableVectorEntry, VectorDiff};
+use eyeball_im::VectorDiff;
 use eyeball_im_util::vector::VectorObserverExt;
 use futures_core::Stream;
 use imbl::Vector;
@@ -54,7 +54,7 @@ use tracing::{
 #[cfg(test)]
 pub(super) use self::observable_items::ObservableItems;
 pub(super) use self::{
-    observable_items::{AllRemoteEvents, ObservableItemsTransaction},
+    observable_items::{AllRemoteEvents, ObservableItemsEntry, ObservableItemsTransaction},
     state::{
         FullEventMeta, PendingEdit, PendingEditKind, TimelineMetadata, TimelineNewItemPosition,
         TimelineState, TimelineStateTransaction,
@@ -1134,7 +1134,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
                 let new_item = entry.with_kind(TimelineItemKind::Event(
                     event_item.with_sender_profile(profile_state.clone()),
                 ));
-                ObservableVectorEntry::set(&mut entry, new_item);
+                ObservableItemsEntry::replace(&mut entry, new_item);
             }
         });
     }
@@ -1160,7 +1160,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
                     let updated_item =
                         event_item.with_sender_profile(TimelineDetails::Ready(profile));
                     let new_item = entry.with_kind(updated_item);
-                    ObservableVectorEntry::set(&mut entry, new_item);
+                    ObservableItemsEntry::replace(&mut entry, new_item);
                 }
                 None => {
                     if !event_item.sender_profile().is_unavailable() {
@@ -1168,7 +1168,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
                         let updated_item =
                             event_item.with_sender_profile(TimelineDetails::Unavailable);
                         let new_item = entry.with_kind(updated_item);
-                        ObservableVectorEntry::set(&mut entry, new_item);
+                        ObservableItemsEntry::replace(&mut entry, new_item);
                     } else {
                         debug!(event_id, transaction_id, "Profile already marked unavailable");
                     }
@@ -1204,7 +1204,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
                         let updated_item =
                             event_item.with_sender_profile(TimelineDetails::Ready(profile));
                         let new_item = entry.with_kind(updated_item);
-                        ObservableVectorEntry::set(&mut entry, new_item);
+                        ObservableItemsEntry::replace(&mut entry, new_item);
                     }
                 }
                 None => {
@@ -1213,7 +1213,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
                         let updated_item =
                             event_item.with_sender_profile(TimelineDetails::Unavailable);
                         let new_item = entry.with_kind(updated_item);
-                        ObservableVectorEntry::set(&mut entry, new_item);
+                        ObservableItemsEntry::replace(&mut entry, new_item);
                     } else {
                         debug!(event_id, transaction_id, "Profile already marked unavailable");
                     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -467,7 +467,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
     ///
     /// Cheap because `im::Vector` is cheap to clone.
     pub(super) async fn items(&self) -> Vector<Arc<TimelineItem>> {
-        self.state.read().await.items.clone()
+        self.state.read().await.items.clone_items()
     }
 
     pub(super) async fn subscribe(
@@ -475,7 +475,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
     ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = VectorDiff<Arc<TimelineItem>>> + Send) {
         trace!("Creating timeline items signal");
         let state = self.state.read().await;
-        (state.items.clone(), state.items.subscribe().into_stream())
+        (state.items.clone_items(), state.items.subscribe().into_stream())
     }
 
     pub(super) async fn subscribe_batched(
@@ -483,7 +483,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
     ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>>) {
         trace!("Creating timeline items signal");
         let state = self.state.read().await;
-        (state.items.clone(), state.items.subscribe().into_batched_stream())
+        (state.items.clone_items(), state.items.subscribe().into_batched_stream())
     }
 
     pub(super) async fn subscribe_filter_map<U, F>(

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -597,7 +597,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
 
                 if reaction_info.is_some() {
                     let new_item = item.with_reactions(reactions);
-                    state.items.set(item_pos, new_item);
+                    state.items.replace(item_pos, new_item);
                 } else {
                     warn!("reaction is missing on the item, not removing it locally, but sending redaction.");
                 }
@@ -621,7 +621,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
                                 .or_default()
                                 .insert(user_id.to_owned(), reaction_info);
                             let new_item = item.with_reactions(reactions);
-                            state.items.set(item_pos, new_item);
+                            state.items.replace(item_pos, new_item);
                         } else {
                             warn!("couldn't find item to re-add reaction anymore; maybe it's been redacted?");
                         }
@@ -817,7 +817,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
                             {
                                 trace!("updated reaction status to sent");
                                 entry.status = ReactionStatus::RemoteToRemote(event_id.to_owned());
-                                txn.items.set(item_pos, event_item.with_reactions(reactions));
+                                txn.items.replace(item_pos, event_item.with_reactions(reactions));
                                 txn.commit();
                                 return;
                             }
@@ -863,7 +863,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
         }
 
         let new_item = item.with_inner_kind(local_item.with_send_state(send_state));
-        txn.items.set(idx, new_item);
+        txn.items.replace(idx, new_item);
 
         txn.commit();
     }
@@ -910,7 +910,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
             let mut reactions = item.reactions().clone();
             if reactions.remove_reaction(&full_key.sender, &full_key.key).is_some() {
                 let updated_item = item.with_reactions(reactions);
-                state.items.set(idx, updated_item);
+                state.items.replace(idx, updated_item);
             } else {
                 warn!(
                     "missing reaction {} for sender {} on timeline item",
@@ -967,7 +967,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
             prev_item.internal_id.to_owned(),
         );
 
-        txn.items.set(idx, new_item);
+        txn.items.replace(idx, new_item);
 
         // This doesn't change the original sending time, so there's no need to adjust
         // day dividers.
@@ -1322,7 +1322,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
 
         trace!("Adding local reaction to local echo");
         let new_item = item.with_reactions(reactions);
-        state.items.set(item_pos, new_item);
+        state.items.replace(item_pos, new_item);
 
         // Add it to the reaction map, so we can discard it later if needs be.
         state.meta.reactions.map.insert(
@@ -1462,7 +1462,7 @@ impl TimelineController {
                 event,
             }),
         ));
-        state.items.set(index, TimelineItem::new(item, internal_id));
+        state.items.replace(index, TimelineItem::new(item, internal_id));
 
         Ok(())
     }
@@ -1594,7 +1594,7 @@ async fn fetch_replied_to_event(
     let event_item = item.with_content(TimelineItemContent::Message(reply), None);
 
     let new_timeline_item = TimelineItem::new(event_item, internal_id);
-    state.items.set(index, new_timeline_item);
+    state.items.replace(index, new_timeline_item);
 
     // Don't hold the state lock while the network request is made
     drop(state);

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -54,7 +54,10 @@ use tracing::{
 #[cfg(test)]
 pub(super) use self::observable_items::ObservableItems;
 pub(super) use self::{
-    observable_items::{AllRemoteEvents, ObservableItemsEntry, ObservableItemsTransaction},
+    observable_items::{
+        AllRemoteEvents, ObservableItemsEntry, ObservableItemsTransaction,
+        ObservableItemsTransactionEntry,
+    },
     state::{
         FullEventMeta, PendingEdit, PendingEditKind, TimelineMetadata, TimelineNewItemPosition,
         TimelineState, TimelineStateTransaction,

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -51,9 +51,14 @@ use tracing::{
     debug, error, field, field::debug, info, info_span, instrument, trace, warn, Instrument as _,
 };
 
-pub(super) use self::state::{
-    AllRemoteEvents, FullEventMeta, PendingEdit, PendingEditKind, TimelineMetadata,
-    TimelineNewItemPosition, TimelineState, TimelineStateTransaction,
+#[cfg(test)]
+pub(super) use self::observable_items::ObservableItems;
+pub(super) use self::{
+    observable_items::ObservableItemsTransaction,
+    state::{
+        AllRemoteEvents, FullEventMeta, PendingEdit, PendingEditKind, TimelineMetadata,
+        TimelineNewItemPosition, TimelineState, TimelineStateTransaction,
+    },
 };
 use super::{
     event_handler::TimelineEventKind,
@@ -77,6 +82,7 @@ use crate::{
     unable_to_decrypt_hook::UtdHookManager,
 };
 
+mod observable_items;
 mod state;
 
 /// Data associated to the current timeline focus.

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -95,7 +95,7 @@ impl ObservableItems {
     /// # Panics
     ///
     /// Panics if `timeline_item_index > total_number_of_timeline_items`.
-    pub fn set(
+    pub fn replace(
         &mut self,
         timeline_item_index: usize,
         timeline_item: Arc<TimelineItem>,
@@ -161,7 +161,7 @@ impl<'observable_items> ObservableItemsTransaction<'observable_items> {
         self.all_remote_events.get_by_event_id_mut(event_id)
     }
 
-    pub fn set(
+    pub fn replace(
         &mut self,
         timeline_item_index: usize,
         timeline_item: Arc<TimelineItem>,

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -35,7 +35,11 @@ use super::{state::EventMeta, TimelineItem};
 pub struct ObservableItems {
     /// All timeline items.
     ///
-    /// Yeah, there are here!
+    /// Yeah, there are here! This [`ObservableVector`] contains all the
+    /// timeline items that are rendered in your magnificent Matrix client.
+    ///
+    /// These items are the _core_ of the timeline, see [`TimelineItem`] to
+    /// learn more.
     items: ObservableVector<Arc<TimelineItem>>,
 
     /// List of all the remote events as received in the timeline, even the ones

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -1,0 +1,142 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{ops::Deref, sync::Arc};
+
+use eyeball_im::{
+    ObservableVector, ObservableVectorEntries, ObservableVectorEntry, ObservableVectorTransaction,
+    ObservableVectorTransactionEntry, VectorSubscriber,
+};
+use imbl::Vector;
+
+use super::TimelineItem;
+
+#[derive(Debug)]
+pub struct ObservableItems {
+    items: ObservableVector<Arc<TimelineItem>>,
+}
+
+impl ObservableItems {
+    pub fn new() -> Self {
+        Self {
+            // Upstream default capacity is currently 16, which is making
+            // sliding-sync tests with 20 events lag. This should still be
+            // small enough.
+            items: ObservableVector::with_capacity(32),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    pub fn subscribe(&self) -> VectorSubscriber<Arc<TimelineItem>> {
+        self.items.subscribe()
+    }
+
+    pub fn clone(&self) -> Vector<Arc<TimelineItem>> {
+        self.items.clone()
+    }
+
+    pub fn transaction(&mut self) -> ObservableItemsTransaction<'_> {
+        ObservableItemsTransaction { items: self.items.transaction() }
+    }
+
+    pub fn set(
+        &mut self,
+        timeline_item_index: usize,
+        timeline_item: Arc<TimelineItem>,
+    ) -> Arc<TimelineItem> {
+        self.items.set(timeline_item_index, timeline_item)
+    }
+
+    pub fn entries(&mut self) -> ObservableVectorEntries<'_, Arc<TimelineItem>> {
+        self.items.entries()
+    }
+
+    pub fn for_each<F>(&mut self, f: F)
+    where
+        F: FnMut(ObservableVectorEntry<'_, Arc<TimelineItem>>),
+    {
+        self.items.for_each(f)
+    }
+}
+
+// It's fine to deref to an immutable reference to `Vector`.
+impl Deref for ObservableItems {
+    type Target = Vector<Arc<TimelineItem>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.items
+    }
+}
+
+#[derive(Debug)]
+pub struct ObservableItemsTransaction<'observable_items> {
+    items: ObservableVectorTransaction<'observable_items, Arc<TimelineItem>>,
+}
+
+impl<'observable_items> ObservableItemsTransaction<'observable_items> {
+    pub fn get(&self, timeline_item_index: usize) -> Option<&Arc<TimelineItem>> {
+        self.items.get(timeline_item_index)
+    }
+
+    pub fn set(
+        &mut self,
+        timeline_item_index: usize,
+        timeline_item: Arc<TimelineItem>,
+    ) -> Arc<TimelineItem> {
+        self.items.set(timeline_item_index, timeline_item)
+    }
+
+    pub fn remove(&mut self, timeline_item_index: usize) -> Arc<TimelineItem> {
+        self.items.remove(timeline_item_index)
+    }
+
+    pub fn insert(&mut self, timeline_item_index: usize, timeline_item: Arc<TimelineItem>) {
+        self.items.insert(timeline_item_index, timeline_item);
+    }
+
+    pub fn push_front(&mut self, timeline_item: Arc<TimelineItem>) {
+        self.items.push_front(timeline_item);
+    }
+
+    pub fn push_back(&mut self, timeline_item: Arc<TimelineItem>) {
+        self.items.push_back(timeline_item);
+    }
+
+    pub fn clear(&mut self) {
+        self.items.clear();
+    }
+
+    pub fn for_each<F>(&mut self, f: F)
+    where
+        F: FnMut(ObservableVectorTransactionEntry<'_, 'observable_items, Arc<TimelineItem>>),
+    {
+        self.items.for_each(f)
+    }
+
+    pub fn commit(self) {
+        self.items.commit()
+    }
+}
+
+// It's fine to deref to an immutable reference to `Vector`.
+impl Deref for ObservableItemsTransaction<'_> {
+    type Target = Vector<Arc<TimelineItem>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.items
+    }
+}

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -199,7 +199,7 @@ impl<'observable_items> ObservableItemsTransaction<'observable_items> {
         self.all_remote_events
     }
 
-    /// Remove a remote event at position `event_index`.
+    /// Remove a remote event at the `event_index` position.
     ///
     /// Not to be confused with removing a timeline item!
     pub fn remove_remote_event(&mut self, event_index: usize) -> Option<EventMeta> {
@@ -208,14 +208,14 @@ impl<'observable_items> ObservableItemsTransaction<'observable_items> {
 
     /// Push a new remote event at the front of all remote events.
     ///
-    /// Not to be confused with pushing front a timeline item!
+    /// Not to be confused with pushing a timeline item to the front!
     pub fn push_front_remote_event(&mut self, event_meta: EventMeta) {
         self.all_remote_events.push_front(event_meta);
     }
 
     /// Push a new remote event at the back of all remote events.
     ///
-    /// Not to be confused with pushing back a timeline item!
+    /// Not to be confused with pushing a timeline item to the back!
     pub fn push_back_remote_event(&mut self, event_meta: EventMeta) {
         self.all_remote_events.push_back(event_meta);
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -124,6 +124,10 @@ impl ObservableItems {
 }
 
 // It's fine to deref to an immutable reference to `Vector`.
+//
+// We don't want, however, to deref to a mutable reference: it should be done
+// via proper methods to control precisely the mapping between remote events and
+// timeline items.
 impl Deref for ObservableItems {
     type Target = Vector<Arc<TimelineItem>>;
 
@@ -154,6 +158,11 @@ impl ObservableItemsEntry<'_> {
     }
 }
 
+// It's fine to deref to an immutable reference to `Arc<TimelineItem>`.
+//
+// We don't want, however, to deref to a mutable reference: it should be done
+// via proper methods to control precisely the mapping between remote events and
+// timeline items.
 impl Deref for ObservableItemsEntry<'_> {
     type Target = Arc<TimelineItem>;
 
@@ -302,6 +311,10 @@ impl<'observable_items> ObservableItemsTransaction<'observable_items> {
 }
 
 // It's fine to deref to an immutable reference to `Vector`.
+//
+// We don't want, however, to deref to a mutable reference: it should be done
+// via proper methods to control precisely the mapping between remote events and
+// timeline items.
 impl Deref for ObservableItemsTransaction<'_> {
     type Target = Vector<Arc<TimelineItem>>;
 
@@ -335,6 +348,11 @@ impl ObservableItemsTransactionEntry<'_, '_> {
     }
 }
 
+// It's fine to deref to an immutable reference to `Arc<TimelineItem>`.
+//
+// We don't want, however, to deref to a mutable reference: it should be done
+// via proper methods to control precisely the mapping between remote events and
+// timeline items.
 impl Deref for ObservableItemsTransactionEntry<'_, '_> {
     type Target = Arc<TimelineItem>;
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -82,7 +82,7 @@ impl ObservableItems {
     /// Get a clone of all timeline items.
     ///
     /// Note that it doesn't clone `Self`, only the inner timeline items.
-    pub fn clone(&self) -> Vector<Arc<TimelineItem>> {
+    pub fn clone_items(&self) -> Vector<Arc<TimelineItem>> {
         self.items.clone()
     }
 
@@ -498,7 +498,7 @@ mod observable_items_tests {
     }
 
     #[test]
-    fn test_clone() {
+    fn test_clone_items() {
         let mut items = ObservableItems::new();
 
         let mut transaction = items.transaction();
@@ -506,10 +506,10 @@ mod observable_items_tests {
         transaction.push_back(item("$ev1"), Some(1));
         transaction.commit();
 
-        let events = items.clone();
-        assert_eq!(events.len(), 2);
-        assert_event_id!(events[0], "$ev0");
-        assert_event_id!(events[1], "$ev1");
+        let items = items.clone_items();
+        assert_eq!(items.len(), 2);
+        assert_event_id!(items[0], "$ev0");
+        assert_event_id!(items[1], "$ev1");
     }
 
     #[test]
@@ -524,9 +524,9 @@ mod observable_items_tests {
         // That's time to replace it!
         items.replace(0, item("$ev1"));
 
-        let events = items.clone();
-        assert_eq!(events.len(), 1);
-        assert_event_id!(events[0], "$ev1");
+        let items = items.clone_items();
+        assert_eq!(items.len(), 1);
+        assert_event_id!(items[0], "$ev1");
     }
 
     #[test]

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -136,7 +136,12 @@ impl Deref for ObservableItems {
     }
 }
 
-/// An “iterator“ that yields entries into an `ObservableItems`.
+/// An iterator that yields entries into an `ObservableItems`.
+///
+/// It doesn't implement [`Iterator`] though because of a lifetime conflict: the
+/// returned `Iterator::Item` could live longer than the `Iterator` itself.
+/// Ideally, `Iterator::next` should take a `&'a mut self`, but this is not
+/// possible.
 pub struct ObservableItemsEntries<'a>(ObservableVectorEntries<'a, Arc<TimelineItem>>);
 
 impl ObservableItemsEntries<'_> {

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -189,7 +189,7 @@ pub struct ObservableItemsTransaction<'observable_items> {
 }
 
 impl<'observable_items> ObservableItemsTransaction<'observable_items> {
-    /// Get a reference to the timeline index at position `timeline_item_index`.
+    /// Get a reference to the timeline item at position `timeline_item_index`.
     pub fn get(&self, timeline_item_index: usize) -> Option<&Arc<TimelineItem>> {
         self.items.get(timeline_item_index)
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -12,19 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{ops::Deref, sync::Arc};
+use std::{
+    cmp::Ordering,
+    collections::{vec_deque::Iter, VecDeque},
+    ops::Deref,
+    sync::Arc,
+};
 
 use eyeball_im::{
     ObservableVector, ObservableVectorEntries, ObservableVectorEntry, ObservableVectorTransaction,
     ObservableVectorTransactionEntry, VectorSubscriber,
 };
 use imbl::Vector;
+use ruma::EventId;
 
-use super::TimelineItem;
+use super::{state::EventMeta, TimelineItem};
 
 #[derive(Debug)]
 pub struct ObservableItems {
+    /// All timeline items.
+    ///
+    /// Yeah, there are here!
     items: ObservableVector<Arc<TimelineItem>>,
+
+    /// List of all the remote events as received in the timeline, even the ones
+    /// that are discarded in the timeline items.
+    ///
+    /// This is useful to get this for the moment as it helps the `Timeline` to
+    /// compute read receipts and read markers. It also helps to map event to
+    /// timeline item, see [`EventMeta::timeline_item_index`] to learn more.
+    all_remote_events: AllRemoteEvents,
 }
 
 impl ObservableItems {
@@ -34,7 +51,12 @@ impl ObservableItems {
             // sliding-sync tests with 20 events lag. This should still be
             // small enough.
             items: ObservableVector::with_capacity(32),
+            all_remote_events: AllRemoteEvents::default(),
         }
+    }
+
+    pub fn all_remote_events(&self) -> &AllRemoteEvents {
+        &self.all_remote_events
     }
 
     pub fn is_empty(&self) -> bool {
@@ -50,7 +72,10 @@ impl ObservableItems {
     }
 
     pub fn transaction(&mut self) -> ObservableItemsTransaction<'_> {
-        ObservableItemsTransaction { items: self.items.transaction() }
+        ObservableItemsTransaction {
+            items: self.items.transaction(),
+            all_remote_events: &mut self.all_remote_events,
+        }
     }
 
     pub fn set(
@@ -85,11 +110,35 @@ impl Deref for ObservableItems {
 #[derive(Debug)]
 pub struct ObservableItemsTransaction<'observable_items> {
     items: ObservableVectorTransaction<'observable_items, Arc<TimelineItem>>,
+    all_remote_events: &'observable_items mut AllRemoteEvents,
 }
 
 impl<'observable_items> ObservableItemsTransaction<'observable_items> {
     pub fn get(&self, timeline_item_index: usize) -> Option<&Arc<TimelineItem>> {
         self.items.get(timeline_item_index)
+    }
+
+    pub fn all_remote_events(&self) -> &AllRemoteEvents {
+        &self.all_remote_events
+    }
+
+    pub fn remove_remote_event(&mut self, event_index: usize) -> Option<EventMeta> {
+        self.all_remote_events.remove(event_index)
+    }
+
+    pub fn push_front_remote_event(&mut self, event_meta: EventMeta) {
+        self.all_remote_events.push_front(event_meta);
+    }
+
+    pub fn push_back_remote_event(&mut self, event_meta: EventMeta) {
+        self.all_remote_events.push_back(event_meta);
+    }
+
+    pub fn get_remote_event_by_event_id_mut(
+        &mut self,
+        event_id: &EventId,
+    ) -> Option<&mut EventMeta> {
+        self.all_remote_events.get_by_event_id_mut(event_id)
     }
 
     pub fn set(
@@ -101,23 +150,36 @@ impl<'observable_items> ObservableItemsTransaction<'observable_items> {
     }
 
     pub fn remove(&mut self, timeline_item_index: usize) -> Arc<TimelineItem> {
-        self.items.remove(timeline_item_index)
+        let removed_timeline_item = self.items.remove(timeline_item_index);
+        self.all_remote_events.timeline_item_has_been_removed_at(timeline_item_index);
+
+        removed_timeline_item
     }
 
-    pub fn insert(&mut self, timeline_item_index: usize, timeline_item: Arc<TimelineItem>) {
+    pub fn insert(
+        &mut self,
+        timeline_item_index: usize,
+        timeline_item: Arc<TimelineItem>,
+        event_index: Option<usize>,
+    ) {
         self.items.insert(timeline_item_index, timeline_item);
+        self.all_remote_events.timeline_item_has_been_inserted_at(timeline_item_index, event_index);
     }
 
-    pub fn push_front(&mut self, timeline_item: Arc<TimelineItem>) {
+    pub fn push_front(&mut self, timeline_item: Arc<TimelineItem>, event_index: Option<usize>) {
         self.items.push_front(timeline_item);
+        self.all_remote_events.timeline_item_has_been_inserted_at(0, event_index);
     }
 
-    pub fn push_back(&mut self, timeline_item: Arc<TimelineItem>) {
+    pub fn push_back(&mut self, timeline_item: Arc<TimelineItem>, event_index: Option<usize>) {
         self.items.push_back(timeline_item);
+        self.all_remote_events
+            .timeline_item_has_been_inserted_at(self.items.len().saturating_sub(1), event_index);
     }
 
     pub fn clear(&mut self) {
         self.items.clear();
+        self.all_remote_events.clear();
     }
 
     pub fn for_each<F>(&mut self, f: F)
@@ -138,5 +200,144 @@ impl Deref for ObservableItemsTransaction<'_> {
 
     fn deref(&self) -> &Self::Target {
         &self.items
+    }
+}
+
+/// A type for all remote events.
+///
+/// Having this type helps to know exactly which parts of the code and how they
+/// use all remote events. It also helps to give a bit of semantics on top of
+/// them.
+#[derive(Clone, Debug, Default)]
+pub struct AllRemoteEvents(VecDeque<EventMeta>);
+
+impl AllRemoteEvents {
+    /// Return a front-to-back iterator over all remote events.
+    pub fn iter(&self) -> Iter<'_, EventMeta> {
+        self.0.iter()
+    }
+
+    /// Remove all remote events.
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Insert a new remote event at the front of all the others.
+    fn push_front(&mut self, event_meta: EventMeta) {
+        // If there is an associated `timeline_item_index`, shift all the
+        // `timeline_item_index` that come after this one.
+        if let Some(new_timeline_item_index) = event_meta.timeline_item_index {
+            self.increment_all_timeline_item_index_after(new_timeline_item_index);
+        }
+
+        // Push the event.
+        self.0.push_front(event_meta)
+    }
+
+    /// Insert a new remote event at the back of all the others.
+    fn push_back(&mut self, event_meta: EventMeta) {
+        // If there is an associated `timeline_item_index`, shift all the
+        // `timeline_item_index` that come after this one.
+        if let Some(new_timeline_item_index) = event_meta.timeline_item_index {
+            self.increment_all_timeline_item_index_after(new_timeline_item_index);
+        }
+
+        // Push the event.
+        self.0.push_back(event_meta)
+    }
+
+    /// Remove one remote event at a specific index, and return it if it exists.
+    fn remove(&mut self, event_index: usize) -> Option<EventMeta> {
+        // Remove the event.
+        let event_meta = self.0.remove(event_index)?;
+
+        // If there is an associated `timeline_item_index`, shift all the
+        // `timeline_item_index` that come after this one.
+        if let Some(removed_timeline_item_index) = event_meta.timeline_item_index {
+            self.decrement_all_timeline_item_index_after(removed_timeline_item_index);
+        };
+
+        Some(event_meta)
+    }
+
+    /// Return a reference to the last remote event if it exists.
+    pub fn last(&self) -> Option<&EventMeta> {
+        self.0.back()
+    }
+
+    /// Return the index of the last remote event if it exists.
+    pub fn last_index(&self) -> Option<usize> {
+        self.0.len().checked_sub(1)
+    }
+
+    /// Get a mutable reference to a specific remote event by its ID.
+    pub fn get_by_event_id_mut(&mut self, event_id: &EventId) -> Option<&mut EventMeta> {
+        self.0.iter_mut().rev().find(|event_meta| event_meta.event_id == event_id)
+    }
+
+    /// Shift to the right all timeline item indexes that are equal to or
+    /// greater than `new_timeline_item_index`.
+    fn increment_all_timeline_item_index_after(&mut self, new_timeline_item_index: usize) {
+        for event_meta in self.0.iter_mut() {
+            if let Some(timeline_item_index) = event_meta.timeline_item_index.as_mut() {
+                if *timeline_item_index >= new_timeline_item_index {
+                    *timeline_item_index += 1;
+                }
+            }
+        }
+    }
+
+    /// Shift to the left all timeline item indexes that are greater than
+    /// `removed_wtimeline_item_index`.
+    fn decrement_all_timeline_item_index_after(&mut self, removed_timeline_item_index: usize) {
+        for event_meta in self.0.iter_mut() {
+            if let Some(timeline_item_index) = event_meta.timeline_item_index.as_mut() {
+                if *timeline_item_index > removed_timeline_item_index {
+                    *timeline_item_index -= 1;
+                }
+            }
+        }
+    }
+
+    fn timeline_item_has_been_inserted_at(
+        &mut self,
+        new_timeline_item_index: usize,
+        event_index: Option<usize>,
+    ) {
+        self.increment_all_timeline_item_index_after(new_timeline_item_index);
+
+        if let Some(event_index) = event_index {
+            if let Some(event_meta) = self.0.get_mut(event_index) {
+                event_meta.timeline_item_index = Some(new_timeline_item_index);
+            }
+        }
+    }
+
+    fn timeline_item_has_been_removed_at(&mut self, timeline_item_index_to_remove: usize) {
+        for event_meta in self.0.iter_mut() {
+            let mut remove_timeline_item_index = false;
+
+            // A `timeline_item_index` is removed. Let's shift all indexes that come
+            // after the removed one.
+            if let Some(timeline_item_index) = event_meta.timeline_item_index.as_mut() {
+                match (*timeline_item_index).cmp(&timeline_item_index_to_remove) {
+                    Ordering::Equal => {
+                        remove_timeline_item_index = true;
+                    }
+
+                    Ordering::Greater => {
+                        *timeline_item_index -= 1;
+                    }
+
+                    Ordering::Less => {}
+                }
+            }
+
+            // This is the `event_meta` that holds the `timeline_item_index` that is being
+            // removed. So let's clean it.
+            if remove_timeline_item_index {
+                event_meta.timeline_item_index = None;
+            }
+        }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -180,8 +180,8 @@ impl Deref for ObservableItemsEntry<'_> {
 /// an atomic unit.
 ///
 /// For updates from the transaction to have affect, it has to be finalized with
-/// [`Self::commit`]. If the transaction is dropped without that method being
-/// called, the updates will be discarded.
+/// [`ObservableItemsTransaction::commit`]. If the transaction is dropped
+/// without that method being called, the updates will be discarded.
 #[derive(Debug)]
 pub struct ObservableItemsTransaction<'observable_items> {
     items: ObservableVectorTransaction<'observable_items, Arc<TimelineItem>>,

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -169,7 +169,7 @@ pub struct ObservableItemsTransaction<'observable_items> {
 }
 
 impl<'observable_items> ObservableItemsTransaction<'observable_items> {
-    /// Get a referene to the timeline index at position `timeline_item_index`.
+    /// Get a reference to the timeline index at position `timeline_item_index`.
     pub fn get(&self, timeline_item_index: usize) -> Option<&Arc<TimelineItem>> {
         self.items.get(timeline_item_index)
     }
@@ -429,6 +429,10 @@ impl AllRemoteEvents {
         }
     }
 
+    /// Notify that a timeline item has been inserted at
+    /// `new_timeline_item_index`. If `event_index` is `Some(_)`, it means the
+    /// remote event at `event_index` must be mapped to
+    /// `new_timeline_item_index`.
     fn timeline_item_has_been_inserted_at(
         &mut self,
         new_timeline_item_index: usize,
@@ -443,6 +447,9 @@ impl AllRemoteEvents {
         }
     }
 
+    /// Notify that a timeline item has been removed at
+    /// `new_timeline_item_index`. If `event_index` is `Some(_)`, it means the
+    /// remote event at `event_index` must be unmapped.
     fn timeline_item_has_been_removed_at(&mut self, timeline_item_index_to_remove: usize) {
         for event_meta in self.0.iter_mut() {
             let mut remove_timeline_item_index = false;

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -45,9 +45,10 @@ pub struct ObservableItems {
     /// List of all the remote events as received in the timeline, even the ones
     /// that are discarded in the timeline items.
     ///
-    /// This is useful to get this for the moment as it helps the `Timeline` to
-    /// compute read receipts and read markers. It also helps to map event to
-    /// timeline item, see [`EventMeta::timeline_item_index`] to learn more.
+    /// The list of all remote events is used to compute the read receipts and
+    /// read markers; additionally it's used to map events to timeline items,
+    /// for more info about that, take a look at the documentation for
+    /// [`EventMeta::timeline_item_index`].
     all_remote_events: AllRemoteEvents,
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -130,7 +130,7 @@ impl Deref for ObservableItems {
 /// An “iterator“ that yields entries into an `ObservableItems`.
 pub struct ObservableItemsEntries<'a>(ObservableVectorEntries<'a, Arc<TimelineItem>>);
 
-impl<'a> ObservableItemsEntries<'a> {
+impl ObservableItemsEntries<'_> {
     /// Advance this iterator, yielding an `ObservableItemsEntry` for the next
     /// item in the timeline, or `None` if all items have been visited.
     pub fn next(&mut self) -> Option<ObservableItemsEntry<'_>> {
@@ -141,7 +141,7 @@ impl<'a> ObservableItemsEntries<'a> {
 /// A handle to a single timeline item in an `ObservableItems`.
 pub struct ObservableItemsEntry<'a>(ObservableVectorEntry<'a, Arc<TimelineItem>>);
 
-impl<'a> ObservableItemsEntry<'a> {
+impl ObservableItemsEntry<'_> {
     /// Replace the timeline item by `timeline_item`.
     pub fn replace(this: &mut Self, timeline_item: Arc<TimelineItem>) -> Arc<TimelineItem> {
         ObservableVectorEntry::set(&mut this.0, timeline_item)
@@ -176,7 +176,7 @@ impl<'observable_items> ObservableItemsTransaction<'observable_items> {
 
     /// Get a reference to all remote events.
     pub fn all_remote_events(&self) -> &AllRemoteEvents {
-        &self.all_remote_events
+        self.all_remote_events
     }
 
     /// Remove a remote event at position `event_index`.
@@ -307,7 +307,7 @@ pub struct ObservableItemsTransactionEntry<'a, 'observable_items>(
     ObservableVectorTransactionEntry<'a, 'observable_items, Arc<TimelineItem>>,
 );
 
-impl<'a, 'o> ObservableItemsTransactionEntry<'a, 'o> {
+impl ObservableItemsTransactionEntry<'_, '_> {
     /// Replace the timeline item by `timeline_item`.
     pub fn replace(this: &mut Self, timeline_item: Arc<TimelineItem>) -> Arc<TimelineItem> {
         ObservableVectorTransactionEntry::set(&mut this.0, timeline_item)

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -788,7 +788,7 @@ impl TimelineStateTransaction<'_> {
 
                 // Replace the existing item with a new version with the right encryption flag
                 let item = item.with_kind(cloned_event);
-                self.items.set(idx, item);
+                self.items.replace(idx, item);
             }
         }
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -731,7 +731,7 @@ impl TimelineStateTransaction<'_> {
         match position {
             TimelineItemPosition::Start { .. } => {
                 if let Some(pos) =
-                    event_already_exists(event_meta.event_id, &self.items.all_remote_events())
+                    event_already_exists(event_meta.event_id, self.items.all_remote_events())
                 {
                     self.items.remove_remote_event(pos);
                 }
@@ -741,7 +741,7 @@ impl TimelineStateTransaction<'_> {
 
             TimelineItemPosition::End { .. } => {
                 if let Some(pos) =
-                    event_already_exists(event_meta.event_id, &self.items.all_remote_events())
+                    event_already_exists(event_meta.event_id, self.items.all_remote_events())
                 {
                     self.items.remove_remote_event(pos);
                 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -657,12 +657,7 @@ impl TimelineStateTransaction<'_> {
             // Remove all remote events and the read marker
             self.items.for_each(|entry| {
                 if entry.is_remote_event() || entry.is_read_marker() {
-                    // SAFETY: this method removes all events except local events. Local events
-                    // don't have a mapping from remote events to timeline items because… well… they
-                    // are local events, not remove events.
-                    unsafe {
-                        ObservableItemsTransactionEntry::remove(entry);
-                    }
+                    ObservableItemsTransactionEntry::remove(entry);
                 }
             });
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -1199,7 +1199,7 @@ pub(crate) struct EventMeta {
     ///
     /// Once rendered in a timeline, it for example produces:
     ///
-    /// | index | item              | aside items          |
+    /// | index | item              | related items        |
     /// +-------+-------------------+----------------------+
     /// | 0     | content of `$ev0` |                      |
     /// | 1     | content of `$ev2` | reaction with `$ev4` |
@@ -1211,10 +1211,10 @@ pub(crate) struct EventMeta {
     /// a reaction to `$ev2`. Finally note that `$ev1` is not rendered in
     /// the timeline.
     ///
-    /// The mapping between remove event index to timeline item index will look
+    /// The mapping between remote event index to timeline item index will look
     /// like this:
     ///
-    /// | remove event index | timeline item index | comment                                    |
+    /// | remote event index | timeline item index | comment                                    |
     /// +--------------------+---------------------+--------------------------------------------+
     /// | 0                  | `Some(0)`           | `$ev0` is rendered as the #0 timeline item |
     /// | 1                  | `None`              | `$ev1` isn't rendered in the timeline      |

--- a/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
@@ -330,7 +330,7 @@ impl DayDividerAdjuster {
                         unique_id.to_owned(),
                     );
 
-                    items.set(at, item);
+                    items.replace(at, item);
                     max_i = i;
                 }
 

--- a/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
@@ -301,11 +301,11 @@ impl DayDividerAdjuster {
 
                     // Keep push semantics, if we're inserting at the front or the back.
                     if at == items.len() {
-                        items.push_back(item);
+                        items.push_back(item, None);
                     } else if at == 0 {
-                        items.push_front(item);
+                        items.push_front(item, None);
                     } else {
-                        items.insert(at, item);
+                        items.insert(at, item, None);
                     }
 
                     offset += 1;
@@ -654,9 +654,12 @@ mod tests {
         let timestamp_next_day =
             MilliSecondsSinceUnixEpoch((42 + 3600 * 24 * 1000).try_into().unwrap());
 
-        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp)));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp_next_day)));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::ReadMarker));
+        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp)), None);
+        txn.push_back(
+            meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp_next_day)),
+            None,
+        );
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::ReadMarker), None);
 
         let mut adjuster = DayDividerAdjuster::default();
         adjuster.run(&mut txn, &mut meta);
@@ -690,10 +693,13 @@ mod tests {
         assert_ne!(timestamp_to_date(timestamp), timestamp_to_date(timestamp_next_day));
 
         let event = event_with_ts(timestamp);
-        txn.push_back(meta.new_timeline_item(event.clone()));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp_next_day)));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::ReadMarker));
-        txn.push_back(meta.new_timeline_item(event));
+        txn.push_back(meta.new_timeline_item(event.clone()), None);
+        txn.push_back(
+            meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp_next_day)),
+            None,
+        );
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::ReadMarker), None);
+        txn.push_back(meta.new_timeline_item(event), None);
 
         let mut adjuster = DayDividerAdjuster::default();
         adjuster.run(&mut txn, &mut meta);
@@ -721,12 +727,12 @@ mod tests {
             MilliSecondsSinceUnixEpoch((42 + 3600 * 24 * 1000).try_into().unwrap());
         assert_ne!(timestamp_to_date(timestamp), timestamp_to_date(timestamp_next_day));
 
-        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp)));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::ReadMarker));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)));
-        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp_next_day)));
+        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp)), None);
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)), None);
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)), None);
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::ReadMarker), None);
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)), None);
+        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp_next_day)), None);
 
         let mut adjuster = DayDividerAdjuster::default();
         adjuster.run(&mut txn, &mut meta);
@@ -755,10 +761,10 @@ mod tests {
             MilliSecondsSinceUnixEpoch((42 + 3600 * 24 * 1000).try_into().unwrap());
         assert_ne!(timestamp_to_date(timestamp), timestamp_to_date(timestamp_next_day));
 
-        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp_next_day)));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)));
-        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp_next_day)));
+        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp_next_day)), None);
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)), None);
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)), None);
+        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp_next_day)), None);
 
         let mut adjuster = DayDividerAdjuster::default();
         adjuster.run(&mut txn, &mut meta);
@@ -782,9 +788,9 @@ mod tests {
 
         let timestamp = MilliSecondsSinceUnixEpoch(uint!(42));
 
-        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp)));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::ReadMarker));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)));
+        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp)), None);
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::ReadMarker), None);
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)), None);
 
         let mut adjuster = DayDividerAdjuster::default();
         adjuster.run(&mut txn, &mut meta);
@@ -808,9 +814,9 @@ mod tests {
 
         let timestamp = MilliSecondsSinceUnixEpoch(uint!(42));
 
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::ReadMarker));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)));
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)));
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::ReadMarker), None);
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)), None);
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::DayDivider(timestamp)), None);
 
         let mut adjuster = DayDividerAdjuster::default();
         adjuster.run(&mut txn, &mut meta);
@@ -831,8 +837,8 @@ mod tests {
         let mut meta = test_metadata();
         let timestamp = MilliSecondsSinceUnixEpoch(uint!(42));
 
-        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::ReadMarker));
-        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp)));
+        txn.push_back(meta.new_timeline_item(VirtualTimelineItem::ReadMarker), None);
+        txn.push_back(meta.new_timeline_item(event_with_ts(timestamp)), None);
 
         let mut adjuster = DayDividerAdjuster::default();
         adjuster.run(&mut txn, &mut meta);

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -578,7 +578,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 Self::maybe_update_responses(self.items, &replacement.event_id, &new_item);
 
                 // Update the event itself.
-                self.items.set(item_pos, TimelineItem::new(new_item, internal_id));
+                self.items.replace(item_pos, TimelineItem::new(new_item, internal_id));
                 self.result.items_updated += 1;
             }
         } else if let Flow::Remote { position, raw_event, .. } = &self.ctx.flow {
@@ -732,7 +732,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 },
             );
 
-            self.items.set(idx, event_item.with_reactions(reactions));
+            self.items.replace(idx, event_item.with_reactions(reactions));
 
             self.result.items_updated += 1;
         } else {
@@ -796,7 +796,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         };
 
         trace!("Applying poll start edit.");
-        self.items.set(item_pos, TimelineItem::new(new_item, item.internal_id.to_owned()));
+        self.items.replace(item_pos, TimelineItem::new(new_item, item.internal_id.to_owned()));
         self.result.items_updated += 1;
     }
 
@@ -900,7 +900,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         );
 
         trace!("Adding poll response.");
-        self.items.set(item_pos, TimelineItem::new(new_item, item.internal_id.to_owned()));
+        self.items.replace(item_pos, TimelineItem::new(new_item, item.internal_id.to_owned()));
         self.result.items_updated += 1;
     }
 
@@ -919,7 +919,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 let new_item = item.with_content(TimelineItemContent::Poll(poll_state), None);
 
                 trace!("Ending poll.");
-                self.items.set(item_pos, TimelineItem::new(new_item, item.internal_id.to_owned()));
+                self.items
+                    .replace(item_pos, TimelineItem::new(new_item, item.internal_id.to_owned()));
                 self.result.items_updated += 1;
             }
             Err(_) => {
@@ -961,7 +962,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     // the replied-to event there as well.
                     Self::maybe_update_responses(self.items, &redacted, &new_item);
 
-                    self.items.set(idx, TimelineItem::new(new_item, internal_id));
+                    self.items.replace(idx, TimelineItem::new(new_item, internal_id));
                     self.result.items_updated += 1;
                 }
             } else {
@@ -1002,7 +1003,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             let mut reactions = item.reactions.clone();
             if reactions.remove_reaction(&sender, &key).is_some() {
                 trace!("Removing reaction");
-                self.items.set(item_pos, item.with_reactions(reactions));
+                self.items.replace(item_pos, item.with_reactions(reactions));
                 self.result.items_updated += 1;
                 return true;
             }
@@ -1153,7 +1154,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         // If the old item is the last one and no day divider
                         // changes need to happen, replace and return early.
                         trace!(idx, "Replacing existing event");
-                        self.items.set(idx, TimelineItem::new(item, old_item_id.to_owned()));
+                        self.items.replace(idx, TimelineItem::new(item, old_item_id.to_owned()));
                         return;
                     }
 
@@ -1228,7 +1229,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 Self::maybe_update_responses(self.items, decrypted_event_id, &item);
 
                 let internal_id = self.items[*idx].internal_id.clone();
-                self.items.set(*idx, TimelineItem::new(item, internal_id));
+                self.items.replace(*idx, TimelineItem::new(item, internal_id));
             }
         }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -1180,12 +1180,18 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     })
                     .unwrap_or(0);
 
-                let event_index =
-                    Some(self.items.all_remote_events().last_index()
-                        // The last remote event is necessarily associated to this
-                        // timeline item, see the contract of this method.
-                        .expect("A timeline item is being added but its associated remote event is missing")
-                    );
+                let event_index = self
+                    .items
+                    .all_remote_events()
+                    .last_index()
+                    // The last remote event is necessarily associated to this
+                    // timeline item, see the contract of this method. Let's fallback to a similar
+                    // value as `timeline_item_index` instead of panicking.
+                    .or_else(|| {
+                        error!(?event_id, "Failed to read the last event index from `AllRemoteEvents`: at least one event must be present");
+
+                        Some(0)
+                    });
 
                 // Try to keep precise insertion semantics here, in this exact order:
                 //

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use as_variant::as_variant;
-use eyeball_im::{ObservableVectorTransaction, ObservableVectorTransactionEntry};
+use eyeball_im::ObservableVectorTransactionEntry;
 use indexmap::IndexMap;
 use matrix_sdk::{
     crypto::types::events::UtdCause,
@@ -51,7 +51,9 @@ use ruma::{
 use tracing::{debug, error, field::debug, info, instrument, trace, warn};
 
 use super::{
-    controller::{PendingEditKind, TimelineMetadata, TimelineStateTransaction},
+    controller::{
+        ObservableItemsTransaction, PendingEditKind, TimelineMetadata, TimelineStateTransaction,
+    },
     day_dividers::DayDividerAdjuster,
     event_item::{
         extract_bundled_edit_event_json, extract_poll_edit_content, extract_room_msg_edit_content,
@@ -330,7 +332,7 @@ pub(super) struct HandleEventResult {
 /// existing timeline item, transforming that item or creating a new one,
 /// updating the reactive Vec).
 pub(super) struct TimelineEventHandler<'a, 'o> {
-    items: &'a mut ObservableVectorTransaction<'o, Arc<TimelineItem>>,
+    items: &'a mut ObservableItemsTransaction<'o>,
     meta: &'a mut TimelineMetadata,
     ctx: TimelineEventContext,
     result: HandleEventResult,
@@ -1243,7 +1245,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
     /// After updating the timeline item `new_item` which id is
     /// `target_event_id`, update other items that are responses to this item.
     fn maybe_update_responses(
-        items: &mut ObservableVectorTransaction<'_, Arc<TimelineItem>>,
+        items: &mut ObservableItemsTransaction<'_>,
         target_event_id: &EventId,
         new_item: &EventTimelineItem,
     ) {

--- a/crates/matrix-sdk-ui/src/timeline/item.rs
+++ b/crates/matrix-sdk-ui/src/timeline/item.rs
@@ -26,13 +26,14 @@ use super::{EventTimelineItem, VirtualTimelineItem};
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TimelineUniqueId(pub String);
 
+/// The type of timeline item.
 #[derive(Clone, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum TimelineItemKind {
     /// An event or aggregation of multiple events.
     Event(EventTimelineItem),
     /// An item that doesn't correspond to an event, for example the user's
-    /// own read marker.
+    /// own read marker, or a day divider.
     Virtual(VirtualTimelineItem),
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -485,7 +485,7 @@ impl TimelineStateTransaction<'_> {
 
         let read_receipts = self.meta.read_receipts.compute_event_receipts(
             &remote_prev_event_item.event_id,
-            &self.items.all_remote_events(),
+            self.items.all_remote_events(),
             false,
         );
 

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{cmp::Ordering, collections::HashMap, sync::Arc};
+use std::{cmp::Ordering, collections::HashMap};
 
-use eyeball_im::ObservableVectorTransaction;
 use futures_core::Stream;
 use indexmap::IndexMap;
 use ruma::{
@@ -27,7 +26,8 @@ use tracing::{debug, error, warn};
 
 use super::{
     controller::{
-        AllRemoteEvents, FullEventMeta, TimelineMetadata, TimelineState, TimelineStateTransaction,
+        AllRemoteEvents, FullEventMeta, ObservableItemsTransaction, TimelineMetadata,
+        TimelineState, TimelineStateTransaction,
     },
     traits::RoomDataProvider,
     util::{rfind_event_by_id, RelativePosition},
@@ -100,7 +100,7 @@ impl ReadReceipts {
         new_receipt: FullReceipt<'_>,
         is_own_user_id: bool,
         all_events: &AllRemoteEvents,
-        timeline_items: &mut ObservableVectorTransaction<'_, Arc<TimelineItem>>,
+        timeline_items: &mut ObservableItemsTransaction<'_>,
     ) {
         // Get old receipt.
         let old_receipt = self.get_latest(new_receipt.user_id, &new_receipt.receipt_type);
@@ -284,11 +284,7 @@ struct ReadReceiptTimelineUpdate {
 
 impl ReadReceiptTimelineUpdate {
     /// Remove the old receipt from the corresponding timeline item.
-    fn remove_old_receipt(
-        &self,
-        items: &mut ObservableVectorTransaction<'_, Arc<TimelineItem>>,
-        user_id: &UserId,
-    ) {
+    fn remove_old_receipt(&self, items: &mut ObservableItemsTransaction<'_>, user_id: &UserId) {
         let Some(event_id) = &self.old_event_id else {
             // Nothing to do.
             return;
@@ -319,7 +315,7 @@ impl ReadReceiptTimelineUpdate {
     /// Add the new receipt to the corresponding timeline item.
     fn add_new_receipt(
         self,
-        items: &mut ObservableVectorTransaction<'_, Arc<TimelineItem>>,
+        items: &mut ObservableItemsTransaction<'_>,
         user_id: OwnedUserId,
         receipt: Receipt,
     ) {
@@ -348,7 +344,7 @@ impl ReadReceiptTimelineUpdate {
     /// Apply this update to the timeline.
     fn apply(
         self,
-        items: &mut ObservableVectorTransaction<'_, Arc<TimelineItem>>,
+        items: &mut ObservableItemsTransaction<'_>,
         user_id: OwnedUserId,
         receipt: Receipt,
     ) {

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -307,7 +307,7 @@ impl ReadReceiptTimelineUpdate {
                      receipt doesn't have a receipt for the user"
                 );
             }
-            items.set(receipt_pos, TimelineItem::new(event_item, event_item_id));
+            items.replace(receipt_pos, TimelineItem::new(event_item, event_item_id));
         } else {
             warn!("received a read receipt for a local item, this should not be possible");
         }
@@ -336,7 +336,7 @@ impl ReadReceiptTimelineUpdate {
 
         if let Some(remote_event_item) = event_item.as_remote_mut() {
             remote_event_item.read_receipts.insert(user_id, receipt);
-            items.set(receipt_pos, TimelineItem::new(event_item, event_item_id));
+            items.replace(receipt_pos, TimelineItem::new(event_item, event_item_id));
         } else {
             warn!("received a read receipt for a local item, this should not be possible");
         }
@@ -495,7 +495,7 @@ impl TimelineStateTransaction<'_> {
         }
 
         remote_prev_event_item.read_receipts = read_receipts;
-        self.items.set(prev_item_pos, TimelineItem::new(prev_event_item, prev_event_item_id));
+        self.items.replace(prev_item_pos, TimelineItem::new(prev_event_item, prev_event_item_id));
     }
 }
 


### PR DESCRIPTION
<figure role="presentation">
<p align="center"><img src="https://github.com/user-attachments/assets/ea94db30-494e-44d3-8479-24451ff2cb67" width="80%" /></p>
<figcaption><p align="center">A messenger trying to find its path in an unknown land</p></figcaption>
</figure>

---

Don't be fooled by the number of new lines in this PR, patches are small and relatively easy to read. Most of the new lines are documentation or tests (around 1300).

The idea of this PR is to create a mapping between events to timeline items. More precisely, a mapping between event indexes and timeline item indexes. Why is this needed? We want `Timeline` to receive its updates via `VectorDiff`. Those `VectorDiff` are generated by the `EventCache` (via `linked_chunk::AsVector`). The indexes from these `VectorDiff` —like `VectorDiff::Insert { index, .. }` or `VectorDiff::Remove { index }`— are _event index_. The `Timeline` manipulates a collection of timeline items, where each item has an event ID, but no event index.

Fortunately for us, a recent patch has clarified an internal data type, now known as `AllRemoteEvents` (see https://github.com/matrix-org/matrix-rust-sdk/pull/4370). We can re-use this type to maintain an index between the events and the timeline items.

This PR must be reviewed patch-by-patch:

- The first 3 patches are adding the `EventMeta::timeline_item_index` field, and maintains it. That's it, everything works at this step!
- The other patches are a refactoring to make this mechanism more robust:
  - It introduces `ObservableItems` which is a new type that replaces/wraps `ObservableVector<Arc<TimelineItem>>`: the idea is to provide a small API we control!
  - Then, `AllRemoteEvents` is moved inside `ObservableItems`, so that operations on the items and the events happen “atomically”, which removes many possible errors of misuses.
- Finally, the last patches add documentations and tests.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280
* Follow up https://github.com/matrix-org/matrix-rust-sdk/pull/3512 but these patches have taken a very different approach with new types like `AllRemoteEvents` and `ObservableItems` types.