### PR TITLE
Invalidate members on kick to prevent stale results

### DIFF
--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1333,6 +1333,10 @@ impl Room {
             { reason: reason.map(ToOwned::to_owned) }
         );
         self.client.send(request, None).await?;
+
+        // Force future room members reload
+        self.mark_members_missing();
+
         Ok(())
     }
 


### PR DESCRIPTION
Mark the members list as 'invalid' when a user is kicked from a room, to allow a reload to happen the next time `members()` is invoked.

- [ ] Public API changes documented in changelogs (optional)

Signed-off-by: Daniel Salinas
