### PR TITLE
feat(crypto): Support storing the dehydrated device pickle key

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+- Expose new API `DehydratedDevices::get_dehydrated_device_pickle_key`, `DehydratedDevices::save_dehydrated_device_pickle_key`
+  and `DehydratedDevices::delete_dehydrated_device_pickle_key` to store/load the dehydrated device pickle key.
+  This allows client to automatically rotate the dehydrated device to avoid one-time-keys exhaustion and to_device accumulation.
+  [**breaking**] `DehydratedDevices::keys_for_upload` and `DehydratedDevices::rehydrate` now use the `DehydratedDeviceKey`
+  as parameter instead of a raw byte array. Use `DehydratedDeviceKey::from_bytes` to migrate.
+  ([#4383](https://github.com/matrix-org/matrix-rust-sdk/pull/4383))
+
 - Added new `UtdCause` variants `WithheldForUnverifiedOrInsecureDevice` and `WithheldBySender`.
   These variants provide clearer categorization for expected Unable-To-Decrypt (UTD) errors 
   when the sender either did not wish to share or was unable to share the room_key.

--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -57,7 +57,7 @@ use tracing::{instrument, trace};
 use vodozemac::LibolmPickleError;
 
 use crate::{
-    store::{CryptoStoreWrapper, MemoryStore, RoomKeyInfo, Store},
+    store::{Changes, CryptoStoreWrapper, DehydratedDeviceKey, MemoryStore, RoomKeyInfo, Store},
     verification::VerificationMachine,
     Account, CryptoStoreError, EncryptionSyncChanges, OlmError, OlmMachine, SignatureError,
 };
@@ -132,14 +132,48 @@ impl DehydratedDevices {
     ///   private keys of the device.
     pub async fn rehydrate(
         &self,
-        pickle_key: &[u8; 32],
+        pickle_key: &DehydratedDeviceKey,
         device_id: &DeviceId,
         device_data: Raw<DehydratedDeviceData>,
     ) -> Result<RehydratedDevice, DehydrationError> {
-        let pickle_key = expand_pickle_key(pickle_key, device_id);
+        let pickle_key = expand_pickle_key(pickle_key.inner.as_ref(), device_id);
         let rehydrated = self.inner.rehydrate(&pickle_key, device_id, device_data).await?;
 
         Ok(RehydratedDevice { rehydrated, original: self.inner.to_owned() })
+    }
+
+    /// Get the cached dehydrated device pickle key if any.
+    ///
+    /// None if the key was not previously cached (via
+    /// [`DehydratedDevices::save_dehydrated_device_pickle_key`]).
+    ///
+    /// Should be used to periodically rotate the dehydrated device to avoid
+    /// one-time keys exhaustion and accumulation of to_device messages.
+    pub async fn get_dehydrated_device_pickle_key(
+        &self,
+    ) -> Result<Option<DehydratedDeviceKey>, DehydrationError> {
+        Ok(self.inner.store().load_dehydrated_device_pickle_key().await?)
+    }
+
+    /// Store the dehydrated device pickle key in the crypto store.
+    ///
+    /// This is useful if the client wants to periodically rotate dehydrated
+    /// devices to avoid one-time keys exhaustion and accumulated to_device
+    /// problems.
+    pub async fn save_dehydrated_device_pickle_key(
+        &self,
+        dehydrated_device_pickle_key: &DehydratedDeviceKey,
+    ) -> Result<(), DehydrationError> {
+        let changes = Changes {
+            dehydrated_device_pickle_key: Some(dehydrated_device_pickle_key.clone()),
+            ..Default::default()
+        };
+        Ok(self.inner.store().save_changes(changes).await?)
+    }
+
+    /// Deletes the previously stored dehydrated device pickle key.
+    pub async fn delete_dehydrated_device_pickle_key(&self) -> Result<(), DehydrationError> {
+        Ok(self.inner.store().delete_dehydrated_device_pickle_key().await?)
     }
 }
 
@@ -170,7 +204,7 @@ impl RehydratedDevice {
     ///
     /// ```no_run
     /// # use anyhow::Result;
-    /// # use matrix_sdk_crypto::OlmMachine;
+    /// # use matrix_sdk_crypto::{ OlmMachine, store::DehydratedDeviceKey };
     /// # use ruma::{api::client::dehydrated_device, DeviceId};
     /// # async fn example() -> Result<()> {
     /// # let machine: OlmMachine = unimplemented!();
@@ -184,9 +218,9 @@ impl RehydratedDevice {
     /// ) -> Result<dehydrated_device::get_events::unstable::Response> {
     ///     todo!("Download the to-device events of the dehydrated device");
     /// }
-    ///
-    /// // Don't use a zero key for real.
-    /// let pickle_key = [0u8; 32];
+    /// // Get the cached dehydrated key (got it after verification/recovery)
+    /// let pickle_key = machine
+    ///     .dehydrated_devices().get_dehydrated_device_pickle_key().await?.unwrap();
     ///
     /// // Fetch the dehydrated device from the server.
     /// let response = get_dehydrated_device().await?;
@@ -285,11 +319,13 @@ impl DehydratedDevice {
     /// # Examples
     ///
     /// ```no_run
-    /// # use matrix_sdk_crypto::OlmMachine;
-    /// # async fn example() -> anyhow::Result<()> {
+    /// # use matrix_sdk_crypto::OlmMachine;    /// #
+    /// use matrix_sdk_crypto::store::DehydratedDeviceKey;
+    ///
+    /// async fn example() -> anyhow::Result<()> {
     /// # let machine: OlmMachine = unimplemented!();
-    /// // Don't use a zero key for real.
-    /// let pickle_key = [0u8; 32];
+    /// // Create a new random key
+    /// let pickle_key = DehydratedDeviceKey::new()?;
     ///
     /// // Create the dehydrated device.
     /// let device = machine.dehydrated_devices().create().await?;
@@ -298,6 +334,9 @@ impl DehydratedDevice {
     /// let request = device
     ///     .keys_for_upload("Dehydrated device".to_owned(), &pickle_key)
     ///     .await?;
+    ///
+    /// // Save the key if you want to later one rotate the dehydrated device
+    /// machine.dehydrated_devices().save_dehydrated_device_pickle_key(&pickle_key).await.unwrap();
     ///
     /// // Send the request out using your HTTP client.
     /// // client.send(request).await?;
@@ -314,7 +353,7 @@ impl DehydratedDevice {
     pub async fn keys_for_upload(
         &self,
         initial_device_display_name: String,
-        pickle_key: &[u8; 32],
+        pickle_key: &DehydratedDeviceKey,
     ) -> Result<put_dehydrated_device::unstable::Request, DehydrationError> {
         let mut transaction = self.store.transaction().await;
 
@@ -330,7 +369,8 @@ impl DehydratedDevice {
 
         trace!("Creating an upload request for a dehydrated device");
 
-        let pickle_key = expand_pickle_key(pickle_key, &self.store.static_account().device_id);
+        let pickle_key =
+            expand_pickle_key(pickle_key.inner.as_ref(), &self.store.static_account().device_id);
         let device_id = self.store.static_account().device_id.clone();
         let device_data = account.dehydrate(&pickle_key);
         let initial_device_display_name = Some(initial_device_display_name);
@@ -393,12 +433,15 @@ mod tests {
             tests::to_device_requests_to_content,
         },
         olm::OutboundGroupSession,
+        store::DehydratedDeviceKey,
         types::{events::ToDeviceEvent, DeviceKeys as DeviceKeysType},
         utilities::json_convert,
         EncryptionSettings, OlmMachine,
     };
 
-    const PICKLE_KEY: &[u8; 32] = &[0u8; 32];
+    fn pickle_key() -> DehydratedDeviceKey {
+        DehydratedDeviceKey::from_bytes(&[0u8; 32])
+    }
 
     fn user_id() -> &'static UserId {
         user_id!("@alice:localhost")
@@ -467,7 +510,7 @@ mod tests {
         let dehydrated_device = olm_machine.dehydrated_devices().create().await.unwrap();
 
         let request = dehydrated_device
-            .keys_for_upload("Foo".to_owned(), PICKLE_KEY)
+            .keys_for_upload("Foo".to_owned(), &pickle_key())
             .await
             .expect("We should be able to create a request to upload a dehydrated device");
 
@@ -497,7 +540,7 @@ mod tests {
         let dehydrated_device = alice.dehydrated_devices().create().await.unwrap();
 
         let mut request = dehydrated_device
-            .keys_for_upload("Foo".to_owned(), PICKLE_KEY)
+            .keys_for_upload("Foo".to_owned(), &pickle_key())
             .await
             .expect("We should be able to create a request to upload a dehydrated device");
 
@@ -531,7 +574,7 @@ mod tests {
         // Rehydrate the device.
         let rehydrated = bob
             .dehydrated_devices()
-            .rehydrate(PICKLE_KEY, &request.device_id, request.device_data)
+            .rehydrate(&pickle_key(), &request.device_id, request.device_data)
             .await
             .expect("We should be able to rehydrate the device");
 
@@ -560,5 +603,44 @@ mod tests {
             group_session.session_id(),
             "The session ids of the imported room key and the outbound group session should match"
         );
+    }
+
+    #[async_test]
+    async fn test_dehydrated_device_pickle_key_cache() {
+        let alice = get_olm_machine().await;
+
+        let dehydrated_manager = alice.dehydrated_devices();
+
+        let stored_key = dehydrated_manager.get_dehydrated_device_pickle_key().await.unwrap();
+        assert!(stored_key.is_none());
+
+        let pickle_key = DehydratedDeviceKey::new().unwrap();
+
+        dehydrated_manager.save_dehydrated_device_pickle_key(&pickle_key).await.unwrap();
+
+        let stored_key =
+            dehydrated_manager.get_dehydrated_device_pickle_key().await.unwrap().unwrap();
+        assert_eq!(stored_key.to_base64(), pickle_key.to_base64());
+
+        let dehydrated_device = dehydrated_manager.create().await.unwrap();
+
+        let request = dehydrated_device
+            .keys_for_upload("Foo".to_owned(), &stored_key)
+            .await
+            .expect("We should be able to create a request to upload a dehydrated device");
+
+        // Rehydrate the device.
+        dehydrated_manager
+            .rehydrate(&stored_key, &request.device_id, request.device_data)
+            .await
+            .expect("We should be able to rehydrate the device");
+
+        dehydrated_manager
+            .delete_dehydrated_device_pickle_key()
+            .await
+            .expect("Should be able to delete the dehydrated device key");
+
+        let stored_key = dehydrated_manager.get_dehydrated_device_pickle_key().await.unwrap();
+        assert!(stored_key.is_none());
     }
 }

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -22,7 +22,8 @@ use ruma::{
 use vodozemac::Curve25519PublicKey;
 
 use super::{
-    BackupKeys, Changes, CryptoStoreError, PendingChanges, Result, RoomKeyCounts, RoomSettings,
+    BackupKeys, Changes, CryptoStoreError, DehydratedDeviceKey, PendingChanges, Result,
+    RoomKeyCounts, RoomSettings,
 };
 #[cfg(doc)]
 use crate::olm::SenderData;
@@ -194,6 +195,14 @@ pub trait CryptoStore: AsyncTraitDeps {
 
     /// Get the backup keys we have stored.
     async fn load_backup_keys(&self) -> Result<BackupKeys, Self::Error>;
+
+    /// Get the dehydrated device pickle key we have stored.
+    async fn load_dehydrated_device_pickle_key(
+        &self,
+    ) -> Result<Option<DehydratedDeviceKey>, Self::Error>;
+
+    /// Deletes the previously stored dehydrated device pickle key.
+    async fn delete_dehydrated_device_pickle_key(&self) -> Result<(), Self::Error>;
 
     /// Get the outbound group session we have stored that is used for the
     /// given room.
@@ -463,6 +472,14 @@ impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
 
     async fn load_backup_keys(&self) -> Result<BackupKeys> {
         self.0.load_backup_keys().await.map_err(Into::into)
+    }
+
+    async fn load_dehydrated_device_pickle_key(&self) -> Result<Option<DehydratedDeviceKey>> {
+        self.0.load_dehydrated_device_pickle_key().await.map_err(Into::into)
+    }
+
+    async fn delete_dehydrated_device_pickle_key(&self) -> Result<(), Self::Error> {
+        self.0.delete_dehydrated_device_pickle_key().await.map_err(Into::into)
     }
 
     async fn get_outbound_group_session(


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/4186

No need for migration, the pickle key is stored in the generic Key/Value store.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
