### PR TITLE
Provide the reason why an event was an expected UTD

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.
   when the sender either did not wish to share or was unable to share the room_key.
   ([#4305](https://github.com/matrix-org/matrix-rust-sdk/pull/4305))
 
+- `UtdCause` has two new variants that replace the existing `HistoricalMessage`:
+  `HistoricalMessageAndBackupIsDisabled` and `HistoricalMessageAndDeviceIsUnverified`.
+  These give more detail about what went wrong and allow us to suggest to users
+  what actions they can take to fix the problem. See the doc comments on these
+  variants for suggested wording.
+  ([#4384](https://github.com/matrix-org/matrix-rust-sdk/pull/4384))
+
 ## [0.8.0] - 2024-11-19
 
 ### Features

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -387,6 +387,8 @@ impl RoomDataProvider for TestRoomDataProvider {
             )
             .unwrap_or(MilliSecondsSinceUnixEpoch::now()),
             is_backup_configured: false,
+            this_device_is_verified: true,
+            backup_exists_on_server: true,
         })
         .boxed()
     }


### PR DESCRIPTION
Part of https://github.com/element-hq/element-meta/issues/2638

Distinguish between 3 cases where we can't find keys for an old message:

- There is no backup -> `HistoricalMessageAndBackupIsDisabled`
- Backup is not working and we have not verified our device -> `HistoricalMessageAndDeviceIsUnverified`
- Something else -> `Unknown`