### PR TITLE
chore(xtask): Fix clippy lints

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 mod ci;
 mod fixup;
 mod kotlin;

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -127,7 +127,7 @@ fn publish(execute: bool) -> Result<()> {
 }
 
 fn weekly_report() -> Result<()> {
-    const JSON_FIELDS: &'static str = "title,number,url,author";
+    const JSON_FIELDS: &str = "title,number,url,author";
 
     let sh = sh();
 


### PR DESCRIPTION
See the commit messages for details.

Since it was not noticed before, it seems that CI does not lint xtask with clippy. Maybe it should?