### PR TITLE
fix(media): Make sure that local MXC URIs only try to get media from the cache and ignore requested dimensions

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -163,6 +163,11 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             Some(&content),
             "media not found though added"
         );
+        assert_eq!(
+            self.get_media_content_for_uri(uri).await.unwrap().as_ref(),
+            Some(&content),
+            "media not found by URI though added"
+        );
 
         // Let's remove the media.
         self.remove_media_content(&request_file).await.expect("removing media failed");
@@ -171,6 +176,10 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert!(
             self.get_media_content(&request_file).await.unwrap().is_none(),
             "media still there after removing"
+        );
+        assert!(
+            self.get_media_content_for_uri(uri).await.unwrap().is_none(),
+            "media still found by URI after removing"
         );
 
         // Let's add the media again.
@@ -196,6 +205,12 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             "thumbnail not found"
         );
 
+        // We get a file with the URI, we don't know which one.
+        assert!(
+            self.get_media_content_for_uri(uri).await.unwrap().is_some(),
+            "media not found by URI though two where added"
+        );
+
         // Let's add another media with a different URI.
         self.add_media_content(&request_other_file, other_content.clone())
             .await
@@ -206,6 +221,11 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             self.get_media_content(&request_other_file).await.unwrap().as_ref(),
             Some(&other_content),
             "other file not found"
+        );
+        assert_eq!(
+            self.get_media_content_for_uri(other_uri).await.unwrap().as_ref(),
+            Some(&other_content),
+            "other file not found by URI"
         );
 
         // Let's remove media based on URI.
@@ -222,6 +242,14 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert!(
             self.get_media_content(&request_other_file).await.unwrap().is_some(),
             "other media was removed"
+        );
+        assert!(
+            self.get_media_content_for_uri(uri).await.unwrap().is_none(),
+            "media found by URI wasn't removed"
+        );
+        assert!(
+            self.get_media_content_for_uri(other_uri).await.unwrap().is_some(),
+            "other media found by URI was removed"
         );
     }
 

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -176,6 +176,17 @@ impl EventCacheStore for MemoryStore {
         Ok(())
     }
 
+    async fn get_media_content_for_uri(
+        &self,
+        uri: &MxcUri,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        let inner = self.inner.read().unwrap();
+
+        Ok(inner.media.iter().find_map(|(media_uri, _media_key, media_content)| {
+            (media_uri == uri).then(|| media_content.to_owned())
+        }))
+    }
+
     async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<()> {
         let mut inner = self.inner.write().unwrap();
 

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -120,6 +120,23 @@ pub trait EventCacheStore: AsyncTraitDeps {
         request: &MediaRequestParameters,
     ) -> Result<(), Self::Error>;
 
+    /// Get a media file's content associated to an `MxcUri` from the
+    /// media store.
+    ///
+    /// In theory, there could be several files stored using the same URI and a
+    /// different `MediaFormat`. This API is meant to be used with a media file
+    /// that has only been stored with a single format.
+    ///
+    /// If there are several media files for a given URI in different formats,
+    /// this API will only return one of them. Which one is left as an
+    /// implementation detail.
+    ///
+    /// # Arguments
+    ///
+    /// * `uri` - The `MxcUri` of the media file.
+    async fn get_media_content_for_uri(&self, uri: &MxcUri)
+        -> Result<Option<Vec<u8>>, Self::Error>;
+
     /// Remove all the media files' content associated to an `MxcUri` from the
     /// media store.
     ///
@@ -199,6 +216,13 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
         request: &MediaRequestParameters,
     ) -> Result<(), Self::Error> {
         self.0.remove_media_content(request).await.map_err(Into::into)
+    }
+
+    async fn get_media_content_for_uri(
+        &self,
+        uri: &MxcUri,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.0.get_media_content_for_uri(uri).await.map_err(Into::into)
     }
 
     async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -15,7 +15,7 @@
 //! Private implementations of the media upload mechanism.
 
 use matrix_sdk_base::{
-    media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings},
+    media::{MediaFormat, MediaRequestParameters},
     store::{
         ChildTransactionId, DependentQueuedRequestKind, FinishUploadThumbnailInfo,
         QueuedRequestKind, SentMediaInfo, SentRequestKey, SerializableEventContent,
@@ -25,13 +25,10 @@ use matrix_sdk_base::{
 use mime::Mime;
 use ruma::{
     events::{
-        room::{
-            message::{FormattedBody, MessageType, RoomMessageEventContent},
-            MediaSource,
-        },
+        room::message::{FormattedBody, MessageType, RoomMessageEventContent},
         AnyMessageLikeEventContent,
     },
-    OwnedMxcUri, OwnedTransactionId, TransactionId, UInt,
+    OwnedTransactionId, TransactionId,
 };
 use tracing::{debug, error, instrument, trace, warn, Span};
 
@@ -43,50 +40,8 @@ use crate::{
         LocalEcho, LocalEchoContent, MediaHandles, RoomSendQueueStorageError, RoomSendQueueUpdate,
         SendHandle,
     },
-    Client, Room,
+    Client, Media, Room,
 };
-
-/// Create an [`OwnedMxcUri`] for a file or thumbnail we want to store locally
-/// before sending it.
-///
-/// This uses a MXC ID that is only locally valid.
-fn make_local_uri(txn_id: &TransactionId) -> OwnedMxcUri {
-    // This mustn't represent a potentially valid media server, otherwise it'd be
-    // possible for an attacker to return malicious content under some
-    // preconditions (e.g. the cache store has been cleared before the upload
-    // took place). To mitigate against this, we use the .localhost TLD,
-    // which is guaranteed to be on the local machine. As a result, the only attack
-    // possible would be coming from the user themselves, which we consider a
-    // non-threat.
-    OwnedMxcUri::from(format!("mxc://send-queue.localhost/{txn_id}"))
-}
-
-/// Create a [`MediaRequest`] for a file we want to store locally before
-/// sending it.
-///
-/// This uses a MXC ID that is only locally valid.
-fn make_local_file_media_request(txn_id: &TransactionId) -> MediaRequestParameters {
-    MediaRequestParameters {
-        source: MediaSource::Plain(make_local_uri(txn_id)),
-        format: MediaFormat::File,
-    }
-}
-
-/// Create a [`MediaRequest`] for a file we want to store locally before
-/// sending it.
-///
-/// This uses a MXC ID that is only locally valid.
-fn make_local_thumbnail_media_request(
-    txn_id: &TransactionId,
-    height: UInt,
-    width: UInt,
-) -> MediaRequestParameters {
-    // See comment in [`make_local_file_media_request`].
-    MediaRequestParameters {
-        source: MediaSource::Plain(make_local_uri(txn_id)),
-        format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(width, height)),
-    }
-}
 
 /// Replace the source by the final ones in all the media types handled by
 /// [`Room::make_attachment_type()`].
@@ -164,7 +119,7 @@ impl RoomSendQueue {
         Span::current().record("event_txn", tracing::field::display(&*send_event_txn));
         debug!(filename, %content_type, %upload_file_txn, "sending an attachment");
 
-        let file_media_request = make_local_file_media_request(&upload_file_txn);
+        let file_media_request = Media::make_local_file_media_request(&upload_file_txn);
 
         let (upload_thumbnail_txn, event_thumbnail_info, queue_thumbnail_info) = {
             let client = room.client();
@@ -195,7 +150,7 @@ impl RoomSendQueue {
 
                 // Cache thumbnail in the cache store.
                 let thumbnail_media_request =
-                    make_local_thumbnail_media_request(&txn, height, width);
+                    Media::make_local_thumbnail_media_request(&txn, height, width);
                 cache_store
                     .add_media_content(&thumbnail_media_request, data)
                     .await
@@ -287,7 +242,7 @@ impl QueueStorage {
         // Update cache keys in the cache store.
         {
             // Do it for the file itself.
-            let from_req = make_local_file_media_request(&file_upload_txn);
+            let from_req = Media::make_local_file_media_request(&file_upload_txn);
 
             trace!(from = ?from_req.source, to = ?sent_media.file, "renaming media file key in cache store");
             let cache_store = client
@@ -312,7 +267,7 @@ impl QueueStorage {
                 thumbnail_info.as_ref().zip(sent_media.thumbnail.clone())
             {
                 let from_req =
-                    make_local_thumbnail_media_request(&info.txn, info.height, info.width);
+                    Media::make_local_thumbnail_media_request(&info.txn, info.height, info.width);
 
                 trace!(from = ?from_req.source, to = ?new_source, "renaming thumbnail file key in cache store");
 
@@ -514,10 +469,10 @@ impl QueueStorage {
         {
             let event_cache = client.event_cache_store().lock().await?;
             event_cache
-                .remove_media_content_for_uri(&make_local_uri(&handles.upload_file_txn))
+                .remove_media_content_for_uri(&Media::make_local_uri(&handles.upload_file_txn))
                 .await?;
             if let Some(txn) = &handles.upload_thumbnail_txn {
-                event_cache.remove_media_content_for_uri(&make_local_uri(txn)).await?;
+                event_cache.remove_media_content_for_uri(&Media::make_local_uri(txn)).await?;
             }
         }
 

--- a/crates/matrix-sdk/src/utils.rs
+++ b/crates/matrix-sdk/src/utils.rs
@@ -246,16 +246,6 @@ pub fn formatted_body_from(
     }
 }
 
-/// Construct a `404 NOT_FOUND` error response from the server, with the given
-/// message.
-pub(crate) fn not_found_error(message: String) -> HttpError {
-    FromHttpResponseError::Server(RumaApiError::ClientApi(ClientApiError::new(
-        StatusCode::NOT_FOUND,
-        ClientApiErrorBody::Standard { kind: ClientApiErrorKind::NotFound, message },
-    )))
-    .into()
-}
-
 #[cfg(test)]
 mod test {
     #[cfg(feature = "markdown")]

--- a/crates/matrix-sdk/src/utils.rs
+++ b/crates/matrix-sdk/src/utils.rs
@@ -21,17 +21,9 @@ use std::sync::{Arc, RwLock};
 use futures_core::Stream;
 #[cfg(feature = "e2e-encryption")]
 use futures_util::StreamExt;
-use http::StatusCode;
 #[cfg(feature = "markdown")]
 use ruma::events::room::message::FormattedBody;
 use ruma::{
-    api::{
-        client::error::{
-            Error as ClientApiError, ErrorBody as ClientApiErrorBody,
-            ErrorKind as ClientApiErrorKind,
-        },
-        error::FromHttpResponseError,
-    },
     events::{AnyMessageLikeEventContent, AnyStateEventContent},
     serde::Raw,
     RoomAliasId,
@@ -44,7 +36,6 @@ use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
 
 #[cfg(doc)]
 use crate::Room;
-use crate::{HttpError, RumaApiError};
 
 /// An observable with channel semantics.
 ///

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1892,11 +1892,25 @@ async fn test_media_uploads() {
         .media()
         .get_media_content(
             &MediaRequestParameters {
-                source: local_thumbnail_source,
+                source: local_thumbnail_source.clone(),
                 format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
                     tinfo.width.unwrap(),
                     tinfo.height.unwrap(),
                 )),
+            },
+            true,
+        )
+        .await
+        .expect("media should be found");
+    assert_eq!(thumbnail_media, b"thumbnail");
+
+    // The format should be ignored when requesting a local media.
+    let thumbnail_media = client
+        .media()
+        .get_media_content(
+            &MediaRequestParameters {
+                source: local_thumbnail_source.clone(),
+                format: MediaFormat::File,
             },
             true,
         )
@@ -1966,6 +1980,16 @@ async fn test_media_uploads() {
         .await
         .expect("media should be found");
     assert_eq!(thumbnail_media, b"thumbnail");
+
+    // The local URI does not work anymore.
+    client
+        .media()
+        .get_media_content(
+            &MediaRequestParameters { source: local_thumbnail_source, format: MediaFormat::File },
+            true,
+        )
+        .await
+        .expect_err("media with local URI should not be found");
 
     // The event is sent, at some point.
     assert_update!(watch => sent {


### PR DESCRIPTION
Extracted from #4329. This does not change the `MediaFormat` of the request used in the media cache by the send queue.
