### PR TITLE
feat(ffi): Add method to send custom events with JSON content

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -33,3 +33,4 @@ Additions:
 
 - Add `Encryption::get_user_identity` which returns `UserIdentity`
 - Add `ClientBuilder::room_key_recipient_strategy`
+- Add `Room::send_raw`

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -384,19 +384,17 @@ impl Room {
     ///
     /// * `event_type` - The type of the event to send.
     ///
-    /// * `content` - The content of the event to send as JSON string.
-    pub async fn send_custom_event(
+    /// * `content` - The content of the event to send encoded as JSON string.
+    pub async fn send_raw(
         &self,
         event_type: String,
         content: String,
     ) -> Result<(), ClientError> {
-        let content_json: serde_json::Value = match serde_json::from_str(&content) {
-            Ok(json) => json,
-            Err(e) => {
-                return Err(ClientError::Generic { msg: format!("Failed to parse JSON: {}", e) })
-            }
-        };
+        let content_json: serde_json::Value = serde_json::from_str(&content)
+            .map_err(|e| ClientError::Generic { msg: format!("Failed to parse JSON: {e}") })?;
+
         self.inner.send_raw(&event_type, content_json).await?;
+        
         Ok(())
     }
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -385,16 +385,12 @@ impl Room {
     /// * `event_type` - The type of the event to send.
     ///
     /// * `content` - The content of the event to send encoded as JSON string.
-    pub async fn send_raw(
-        &self,
-        event_type: String,
-        content: String,
-    ) -> Result<(), ClientError> {
+    pub async fn send_raw(&self, event_type: String, content: String) -> Result<(), ClientError> {
         let content_json: serde_json::Value = serde_json::from_str(&content)
             .map_err(|e| ClientError::Generic { msg: format!("Failed to parse JSON: {e}") })?;
 
         self.inner.send_raw(&event_type, content_json).await?;
-        
+
         Ok(())
     }
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -378,6 +378,26 @@ impl Room {
         Ok(())
     }
 
+    /// Send a raw event to the room.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` - The type of the event to send.
+    ///
+    /// * `content` - The content of the event to send as JSON string.
+    pub async fn send_custom_event(
+        &self,
+        event_type: String,
+        content: String,
+    ) -> Result<(), ClientError> {
+        let content_json: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(json) => json,
+            Err(e) => return Err(ClientError::Generic { msg: format!("Failed to parse JSON: {}", e) }),
+        };
+        self.inner.send_raw(&event_type, content_json).await?;
+        Ok(())
+    }
+
     /// Redacts an event from the room.
     ///
     /// # Arguments

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -392,7 +392,9 @@ impl Room {
     ) -> Result<(), ClientError> {
         let content_json: serde_json::Value = match serde_json::from_str(&content) {
             Ok(json) => json,
-            Err(e) => return Err(ClientError::Generic { msg: format!("Failed to parse JSON: {}", e) }),
+            Err(e) => {
+                return Err(ClientError::Generic { msg: format!("Failed to parse JSON: {}", e) })
+            }
         };
         self.inner.send_raw(&event_type, content_json).await?;
         Ok(())


### PR DESCRIPTION
This PR adds the send_raw methods to the bindings, making it usable from e.g. Swift.

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Jonas Richard Richter <jonas-richard.richter@telekom.de>
