### PR TITLE
chore: Bump MSRV in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ The rust-sdk consists of multiple crates that can be picked at your convenience:
 - **matrix-sdk-crypto** - No (network) IO encryption state machine that can be
   used to add Matrix E2EE support to your client or client library.
 
-## Minimum Supported Rust Version (MSRV)
-
-These crates are built with the Rust language version 2021 and require a minimum compiler version of `1.70`.
-
 ## Status
 
 The library is in an alpha state, things that are implemented generally work but

--- a/bindings/matrix-sdk-crypto-ffi/README.md
+++ b/bindings/matrix-sdk-crypto-ffi/README.md
@@ -71,10 +71,6 @@ $ cp ../../target/aarch64-linux-android/debug/libmatrix_crypto.so \
      /home/example/matrix-sdk-android/src/main/jniLibs/aarch64/libuniffi_olm.so
 ```
 
-## Minimum Supported Rust Version (MSRV)
-
-These crates are built with the Rust language version 2021 and require a minimum compiler version of `1.62`.
-
 ## License
 
 [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
To match the version in `Cargo.toml`.
