### PR TITLE
feat(event cache): add a way to clear all chunks, clear a room's chunks + FFI feature flag

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -898,6 +898,16 @@ impl Room {
 
         Ok(())
     }
+
+    /// Clear the event cache storage for the current room.
+    ///
+    /// This will remove all the information related to the event cache, in
+    /// memory and in the persisted storage, if enabled.
+    pub async fn clear_event_cache_storage(&self) -> Result<(), ClientError> {
+        let (room_event_cache, _drop_handles) = self.inner.event_cache().await?;
+        room_event_cache.clear().await?;
+        Ok(())
+    }
 }
 
 /// Generates a `matrix.to` permalink to the given room alias.

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -115,6 +115,11 @@ impl EventCacheStore for MemoryStore {
         Ok(result)
     }
 
+    async fn clear_all_rooms_chunks(&self) -> Result<(), Self::Error> {
+        self.inner.write().unwrap().events.clear();
+        Ok(())
+    }
+
     async fn add_media_content(
         &self,
         request: &MediaRequestParameters,

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -62,6 +62,12 @@ pub trait EventCacheStore: AsyncTraitDeps {
         room_id: &RoomId,
     ) -> Result<Option<LinkedChunk<DEFAULT_CHUNK_CAPACITY, Event, Gap>>, Self::Error>;
 
+    /// Clear persisted events for all the rooms.
+    ///
+    /// This will empty and remove all the linked chunks stored previously,
+    /// using the above [`Self::handle_linked_chunk_updates`] methods.
+    async fn clear_all_rooms_chunks(&self) -> Result<(), Self::Error>;
+
     /// Add a media file's content in the media store.
     ///
     /// # Arguments
@@ -186,6 +192,10 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
         room_id: &RoomId,
     ) -> Result<Option<LinkedChunk<DEFAULT_CHUNK_CAPACITY, Event, Gap>>, Self::Error> {
         self.0.reload_linked_chunk(room_id).await.map_err(Into::into)
+    }
+
+    async fn clear_all_rooms_chunks(&self) -> Result<(), Self::Error> {
+        self.0.clear_all_rooms_chunks().await.map_err(Into::into)
     }
 
     async fn add_media_content(

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -80,6 +80,12 @@ impl<Item, Gap> RelationalLinkedChunk<Item, Gap> {
         Self { chunks: Vec::new(), items: Vec::new() }
     }
 
+    /// Removes all the chunks and items from this relational linked chunk.
+    pub fn clear(&mut self) {
+        self.chunks.clear();
+        self.items.clear();
+    }
+
     /// Apply [`Update`]s. That's the only way to write data inside this
     /// relational linked chunk.
     pub fn apply_updates(&mut self, room_id: &RoomId, updates: Vec<Update<Item, Gap>>) {

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -609,6 +609,17 @@ impl EventCacheStore for SqliteEventCacheStore {
         })
     }
 
+    async fn clear_all_rooms_chunks(&self) -> Result<(), Self::Error> {
+        self.acquire()
+            .await?
+            .with_transaction(move |txn| {
+                // Remove all the chunks, and let cascading do its job.
+                txn.execute("DELETE FROM linked_chunks", ())
+            })
+            .await?;
+        Ok(())
+    }
+
     async fn add_media_content(
         &self,
         request: &MediaRequestParameters,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -615,7 +615,7 @@ impl Client {
     }
 
     /// Get a reference to the event cache store.
-    pub(crate) fn event_cache_store(&self) -> &EventCacheStoreLock {
+    pub fn event_cache_store(&self) -> &EventCacheStoreLock {
         self.base_client().event_cache_store()
     }
 

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -352,6 +352,13 @@ struct AllEventsCache {
     relations: RelationsMap,
 }
 
+impl AllEventsCache {
+    fn clear(&mut self) {
+        self.events.clear();
+        self.relations.clear();
+    }
+}
+
 struct EventCacheInner {
     /// A weak reference to the inner client, useful when trying to get a handle
     /// on the owning client.


### PR DESCRIPTION
This adds a way to:

- clear all the rooms' linked chunk, all at once: this will be useful when disabling the feature flag
- clear a single room's event cache persistent storage: this should be useful for testing purposes, and in case storage is completely borked
- enable a feature flag on an FFI `ClientBuilder` to enable or disable persistent storage. Note: after persistent storage has been enabled, if the embedder decides to disable it, they must explicitly set it to `false` the next time; otherwise the on-disk storage isn't cleared.

The last item isn't very satisfying, but I don't see how to do it otherwise without more involved refactorings. The way persistent storage works right now, is by checking the presence of an event cache store reference in the `RoomEventCacheState` data structure. This is filled at most once, and only once, and never cleared (it's not even clearable). As such, a restart is required for disabling the persistent storage; after restarting is the right time to clear a previous on-disk persisted storage. If we do it sooner than that, then the live `RoomEventCacheState` may keep on trying to store new updates…

Part of #3280.