### PR TITLE
feat(event cache): improve event cache storage a bit (debug, resilience,…)

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -21,9 +21,7 @@ use matrix_sdk_common::{
         AlgorithmInfo, DecryptedRoomEvent, EncryptionInfo, SyncTimelineEvent, TimelineEventKind,
         VerificationState,
     },
-    linked_chunk::{
-        ChunkContent, LinkedChunk, LinkedChunkBuilder, Position, RawLinkedChunk, Update,
-    },
+    linked_chunk::{ChunkContent, LinkedChunk, LinkedChunkBuilder, Position, RawChunk, Update},
 };
 use matrix_sdk_test::{event_factory::EventFactory, ALICE, DEFAULT_TEST_ROOM_ID};
 use ruma::{
@@ -121,9 +119,7 @@ pub trait EventCacheStoreIntegrationTests {
     async fn test_clear_all_rooms_chunks(&self);
 }
 
-fn rebuild_linked_chunk(
-    raws: Vec<RawLinkedChunk<Event, Gap>>,
-) -> Option<LinkedChunk<3, Event, Gap>> {
+fn rebuild_linked_chunk(raws: Vec<RawChunk<Event, Gap>>) -> Option<LinkedChunk<3, Event, Gap>> {
     LinkedChunkBuilder::from_raw_parts(raws).build().unwrap()
 }
 

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -16,13 +16,13 @@ use std::{collections::HashMap, num::NonZeroUsize, sync::RwLock as StdRwLock, ti
 
 use async_trait::async_trait;
 use matrix_sdk_common::{
-    linked_chunk::{relational::RelationalLinkedChunk, LinkedChunk, LinkedChunkBuilder, Update},
+    linked_chunk::{relational::RelationalLinkedChunk, RawLinkedChunk, Update},
     ring_buffer::RingBuffer,
     store_locks::memory_store_helper::try_take_leased_lock,
 };
 use ruma::{MxcUri, OwnedMxcUri, RoomId};
 
-use super::{EventCacheStore, EventCacheStoreError, Result, DEFAULT_CHUNK_CAPACITY};
+use super::{EventCacheStore, EventCacheStoreError, Result};
 use crate::{
     event_cache::{Event, Gap},
     media::{MediaRequestParameters, UniqueKey as _},
@@ -96,23 +96,12 @@ impl EventCacheStore for MemoryStore {
     async fn reload_linked_chunk(
         &self,
         room_id: &RoomId,
-    ) -> Result<Option<LinkedChunk<DEFAULT_CHUNK_CAPACITY, Event, Gap>>, Self::Error> {
+    ) -> Result<Vec<RawLinkedChunk<Event, Gap>>, Self::Error> {
         let inner = self.inner.read().unwrap();
-
-        let mut builder = LinkedChunkBuilder::new();
-
         inner
             .events
-            .reload_chunks(room_id, &mut builder)
-            .map_err(|err| EventCacheStoreError::InvalidData { details: err })?;
-
-        builder.with_update_history();
-
-        let result = builder.build().map_err(|err| EventCacheStoreError::InvalidData {
-            details: format!("when rebuilding a linked chunk: {err}"),
-        })?;
-
-        Ok(result)
+            .reload_chunks(room_id)
+            .map_err(|err| EventCacheStoreError::InvalidData { details: err })
     }
 
     async fn clear_all_rooms_chunks(&self) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -16,7 +16,7 @@ use std::{collections::HashMap, num::NonZeroUsize, sync::RwLock as StdRwLock, ti
 
 use async_trait::async_trait;
 use matrix_sdk_common::{
-    linked_chunk::{relational::RelationalLinkedChunk, RawLinkedChunk, Update},
+    linked_chunk::{relational::RelationalLinkedChunk, RawChunk, Update},
     ring_buffer::RingBuffer,
     store_locks::memory_store_helper::try_take_leased_lock,
 };
@@ -96,7 +96,7 @@ impl EventCacheStore for MemoryStore {
     async fn reload_linked_chunk(
         &self,
         room_id: &RoomId,
-    ) -> Result<Vec<RawLinkedChunk<Event, Gap>>, Self::Error> {
+    ) -> Result<Vec<RawChunk<Event, Gap>>, Self::Error> {
         let inner = self.inner.read().unwrap();
         inner
             .events

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -16,7 +16,7 @@ use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
 use matrix_sdk_common::{
-    linked_chunk::{RawLinkedChunk, Update},
+    linked_chunk::{RawChunk, Update},
     AsyncTraitDeps,
 };
 use ruma::{MxcUri, RoomId};
@@ -62,7 +62,7 @@ pub trait EventCacheStore: AsyncTraitDeps {
     async fn reload_linked_chunk(
         &self,
         room_id: &RoomId,
-    ) -> Result<Vec<RawLinkedChunk<Event, Gap>>, Self::Error>;
+    ) -> Result<Vec<RawChunk<Event, Gap>>, Self::Error>;
 
     /// Clear persisted events for all the rooms.
     ///
@@ -192,7 +192,7 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
     async fn reload_linked_chunk(
         &self,
         room_id: &RoomId,
-    ) -> Result<Vec<RawLinkedChunk<Event, Gap>>, Self::Error> {
+    ) -> Result<Vec<RawChunk<Event, Gap>>, Self::Error> {
         self.0.reload_linked_chunk(room_id).await.map_err(Into::into)
     }
 

--- a/crates/matrix-sdk-common/src/linked_chunk/builder.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/builder.rs
@@ -21,7 +21,7 @@ use tracing::error;
 
 use super::{
     Chunk, ChunkContent, ChunkIdentifier, ChunkIdentifierGenerator, Ends, LinkedChunk,
-    ObservableUpdates,
+    ObservableUpdates, RawLinkedChunk,
 };
 
 /// A temporary chunk representation in the [`LinkedChunkBuilder`].
@@ -259,6 +259,22 @@ impl<const CAP: usize, Item, Gap> LinkedChunkBuilder<CAP, Item, Gap> {
             if self.build_with_update_history { Some(ObservableUpdates::new()) } else { None };
 
         Ok(Some(LinkedChunk { links, chunk_identifier_generator, updates, marker: PhantomData }))
+    }
+
+    /// Fills a linked chunk builder from all the given raw parts.
+    pub fn from_raw_parts(raws: Vec<RawLinkedChunk<Item, Gap>>) -> Self {
+        let mut this = Self::new();
+        for raw in raws {
+            match raw.content {
+                ChunkContent::Gap(gap) => {
+                    this.push_gap(raw.previous, raw.id, raw.next, gap);
+                }
+                ChunkContent::Items(vec) => {
+                    this.push_items(raw.previous, raw.id, raw.next, vec);
+                }
+            }
+        }
+        this
     }
 }
 

--- a/crates/matrix-sdk-common/src/linked_chunk/builder.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/builder.rs
@@ -21,7 +21,7 @@ use tracing::error;
 
 use super::{
     Chunk, ChunkContent, ChunkIdentifier, ChunkIdentifierGenerator, Ends, LinkedChunk,
-    ObservableUpdates, RawLinkedChunk,
+    ObservableUpdates, RawChunk,
 };
 
 /// A temporary chunk representation in the [`LinkedChunkBuilder`].
@@ -262,15 +262,15 @@ impl<const CAP: usize, Item, Gap> LinkedChunkBuilder<CAP, Item, Gap> {
     }
 
     /// Fills a linked chunk builder from all the given raw parts.
-    pub fn from_raw_parts(raws: Vec<RawLinkedChunk<Item, Gap>>) -> Self {
+    pub fn from_raw_parts(raws: Vec<RawChunk<Item, Gap>>) -> Self {
         let mut this = Self::new();
         for raw in raws {
             match raw.content {
                 ChunkContent::Gap(gap) => {
-                    this.push_gap(raw.previous, raw.id, raw.next, gap);
+                    this.push_gap(raw.previous, raw.identifier, raw.next, gap);
                 }
                 ChunkContent::Items(vec) => {
-                    this.push_items(raw.previous, raw.id, raw.next, vec);
+                    this.push_items(raw.previous, raw.identifier, raw.next, vec);
                 }
             }
         }

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -1074,6 +1074,15 @@ pub enum ChunkContent<Item, Gap> {
     Items(Vec<Item>),
 }
 
+impl<Item: Clone, Gap: Clone> Clone for ChunkContent<Item, Gap> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Gap(gap) => Self::Gap(gap.clone()),
+            Self::Items(items) => Self::Items(items.clone()),
+        }
+    }
+}
+
 /// A chunk is a node in the [`LinkedChunk`].
 pub struct Chunk<const CAPACITY: usize, Item, Gap> {
     /// The previous chunk.
@@ -1433,6 +1442,17 @@ pub struct RawLinkedChunk<Item, Gap> {
 
     /// Link to the next chunk, via its identifier.
     pub next: Option<ChunkIdentifier>,
+}
+
+impl<Item: Clone, Gap: Clone> Clone for RawLinkedChunk<Item, Gap> {
+    fn clone(&self) -> Self {
+        Self {
+            content: self.content.clone(),
+            previous: self.previous,
+            id: self.id,
+            next: self.next,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -1064,7 +1064,7 @@ impl<'a, const CAP: usize, Item, Gap> Iterator for Iter<'a, CAP, Item, Gap> {
 }
 
 /// This enum represents the content of a [`Chunk`].
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ChunkContent<Item, Gap> {
     /// The chunk represents a gap in the linked chunk, i.e. a hole. It
     /// means that some items are missing in this location.
@@ -1072,15 +1072,6 @@ pub enum ChunkContent<Item, Gap> {
 
     /// The chunk contains items.
     Items(Vec<Item>),
-}
-
-impl<Item: Clone, Gap: Clone> Clone for ChunkContent<Item, Gap> {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Gap(gap) => Self::Gap(gap.clone()),
-            Self::Items(items) => Self::Items(items.clone()),
-        }
-    }
 }
 
 /// A chunk is a node in the [`LinkedChunk`].
@@ -1429,8 +1420,12 @@ impl EmptyChunk {
 }
 
 /// The raw representation of a linked chunk, as persisted in storage.
-#[derive(Debug)]
-pub struct RawLinkedChunk<Item, Gap> {
+///
+/// It may rebuilt into [`Chunk`] and shares the same internal representation,
+/// except that links are materialized using [`ChunkIdentifier`] instead of raw
+/// pointers to the previous and next chunks.
+#[derive(Clone, Debug)]
+pub struct RawChunk<Item, Gap> {
     /// Content section of the linked chunk.
     pub content: ChunkContent<Item, Gap>,
 
@@ -1438,21 +1433,10 @@ pub struct RawLinkedChunk<Item, Gap> {
     pub previous: Option<ChunkIdentifier>,
 
     /// Current chunk's identifier.
-    pub id: ChunkIdentifier,
+    pub identifier: ChunkIdentifier,
 
     /// Link to the next chunk, via its identifier.
     pub next: Option<ChunkIdentifier>,
-}
-
-impl<Item: Clone, Gap: Clone> Clone for RawLinkedChunk<Item, Gap> {
-    fn clone(&self) -> Self {
-        Self {
-            content: self.content.clone(),
-            previous: self.previous,
-            id: self.id,
-            next: self.next,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -1419,6 +1419,22 @@ impl EmptyChunk {
     }
 }
 
+/// The raw representation of a linked chunk, as persisted in storage.
+#[derive(Debug)]
+pub struct RawLinkedChunk<Item, Gap> {
+    /// Content section of the linked chunk.
+    pub content: ChunkContent<Item, Gap>,
+
+    /// Link to the previous chunk, via its identifier.
+    pub previous: Option<ChunkIdentifier>,
+
+    /// Current chunk's identifier.
+    pub id: ChunkIdentifier,
+
+    /// Link to the next chunk, via its identifier.
+    pub next: Option<ChunkIdentifier>,
+}
+
 #[cfg(test)]
 mod tests {
     use std::{

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -17,7 +17,7 @@
 
 use ruma::{OwnedRoomId, RoomId};
 
-use super::LinkedChunkBuilder;
+use super::{ChunkContent, RawLinkedChunk};
 use crate::linked_chunk::{ChunkIdentifier, Position, Update};
 
 /// A row of the [`RelationalLinkedChunk::chunks`].
@@ -290,11 +290,12 @@ where
     ///
     /// Return an error result if the data was malformed in the struct, with a
     /// string message explaining details about the error.
-    pub fn reload_chunks<const CAP: usize>(
+    pub fn reload_chunks(
         &self,
         room_id: &RoomId,
-        builder: &mut LinkedChunkBuilder<CAP, Item, Gap>,
-    ) -> Result<(), String> {
+    ) -> Result<Vec<RawLinkedChunk<Item, Gap>>, String> {
+        let mut result = Vec::new();
+
         for chunk_row in self.chunks.iter().filter(|chunk| chunk.room_id == room_id) {
             // Find all items that correspond to the chunk.
             let mut items = self
@@ -309,12 +310,12 @@ where
             let Some(first) = items.peek() else {
                 // The only possibility is that we created an empty items chunk; mark it as
                 // such, and continue.
-                builder.push_items(
-                    chunk_row.previous_chunk,
-                    chunk_row.chunk,
-                    chunk_row.next_chunk,
-                    Vec::new(),
-                );
+                result.push(RawLinkedChunk {
+                    content: ChunkContent::Items(Vec::new()),
+                    previous: chunk_row.previous_chunk,
+                    id: chunk_row.chunk,
+                    next: chunk_row.next_chunk,
+                });
                 continue;
             };
 
@@ -339,12 +340,14 @@ where
                     // Sort them by their position.
                     collected_items.sort_unstable_by_key(|(_item, index)| *index);
 
-                    builder.push_items(
-                        chunk_row.previous_chunk,
-                        chunk_row.chunk,
-                        chunk_row.next_chunk,
-                        collected_items.into_iter().map(|(item, _index)| item),
-                    );
+                    result.push(RawLinkedChunk {
+                        content: ChunkContent::Items(
+                            collected_items.into_iter().map(|(item, _index)| item).collect(),
+                        ),
+                        previous: chunk_row.previous_chunk,
+                        id: chunk_row.chunk,
+                        next: chunk_row.next_chunk,
+                    });
                 }
 
                 Either::Gap(gap) => {
@@ -358,17 +361,17 @@ where
                         ));
                     }
 
-                    builder.push_gap(
-                        chunk_row.previous_chunk,
-                        chunk_row.chunk,
-                        chunk_row.next_chunk,
-                        gap.clone(),
-                    );
+                    result.push(RawLinkedChunk {
+                        content: ChunkContent::Gap(gap.clone()),
+                        previous: chunk_row.previous_chunk,
+                        id: chunk_row.chunk,
+                        next: chunk_row.next_chunk,
+                    });
                 }
             }
         }
 
-        Ok(())
+        Ok(result)
     }
 }
 
@@ -383,6 +386,7 @@ mod tests {
     use ruma::room_id;
 
     use super::{ChunkIdentifier as CId, *};
+    use crate::linked_chunk::LinkedChunkBuilder;
 
     #[test]
     fn test_new_items_chunk() {
@@ -828,25 +832,17 @@ mod tests {
     }
 
     #[test]
-    fn test_rebuild_empty_linked_chunk() {
-        let mut builder = LinkedChunkBuilder::<3, _, _>::new();
-
+    fn test_reload_empty_linked_chunk() {
         let room_id = room_id!("!r0:matrix.org");
 
-        // When I rebuild a linked chunk from an empty store,
+        // When I reload the linked chunk components from an empty store,
         let relational_linked_chunk = RelationalLinkedChunk::<char, char>::new();
-        relational_linked_chunk.reload_chunks(room_id, &mut builder).unwrap();
-
-        let lc = builder.build().expect("building succeeds");
-
-        // The builder won't return a linked chunk.
-        assert!(lc.is_none());
+        let result = relational_linked_chunk.reload_chunks(room_id).unwrap();
+        assert!(result.is_empty());
     }
 
     #[test]
     fn test_reload_linked_chunk_with_empty_items() {
-        let mut builder = LinkedChunkBuilder::<3, _, _>::new();
-
         let room_id = room_id!("!r0:matrix.org");
 
         let mut relational_linked_chunk = RelationalLinkedChunk::<char, char>::new();
@@ -858,9 +854,8 @@ mod tests {
         );
 
         // It correctly gets reloaded as such.
-        relational_linked_chunk.reload_chunks(room_id, &mut builder).unwrap();
-
-        let lc = builder
+        let raws = relational_linked_chunk.reload_chunks(room_id).unwrap();
+        let lc = LinkedChunkBuilder::<3, _, _>::from_raw_parts(raws)
             .build()
             .expect("building succeeds")
             .expect("this leads to a non-empty linked chunk");
@@ -870,8 +865,6 @@ mod tests {
 
     #[test]
     fn test_rebuild_linked_chunk() {
-        let mut builder = LinkedChunkBuilder::<3, _, _>::new();
-
         let room_id = room_id!("!r0:matrix.org");
         let mut relational_linked_chunk = RelationalLinkedChunk::<char, char>::new();
 
@@ -896,9 +889,8 @@ mod tests {
             ],
         );
 
-        relational_linked_chunk.reload_chunks(room_id, &mut builder).unwrap();
-
-        let lc = builder
+        let raws = relational_linked_chunk.reload_chunks(room_id).unwrap();
+        let lc = LinkedChunkBuilder::<3, _, _>::from_raw_parts(raws)
             .build()
             .expect("building succeeds")
             .expect("this leads to a non-empty linked chunk");

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -17,7 +17,7 @@
 
 use ruma::{OwnedRoomId, RoomId};
 
-use super::{ChunkContent, RawLinkedChunk};
+use super::{ChunkContent, RawChunk};
 use crate::linked_chunk::{ChunkIdentifier, Position, Update};
 
 /// A row of the [`RelationalLinkedChunk::chunks`].
@@ -290,10 +290,7 @@ where
     ///
     /// Return an error result if the data was malformed in the struct, with a
     /// string message explaining details about the error.
-    pub fn reload_chunks(
-        &self,
-        room_id: &RoomId,
-    ) -> Result<Vec<RawLinkedChunk<Item, Gap>>, String> {
+    pub fn reload_chunks(&self, room_id: &RoomId) -> Result<Vec<RawChunk<Item, Gap>>, String> {
         let mut result = Vec::new();
 
         for chunk_row in self.chunks.iter().filter(|chunk| chunk.room_id == room_id) {
@@ -310,10 +307,10 @@ where
             let Some(first) = items.peek() else {
                 // The only possibility is that we created an empty items chunk; mark it as
                 // such, and continue.
-                result.push(RawLinkedChunk {
+                result.push(RawChunk {
                     content: ChunkContent::Items(Vec::new()),
                     previous: chunk_row.previous_chunk,
-                    id: chunk_row.chunk,
+                    identifier: chunk_row.chunk,
                     next: chunk_row.next_chunk,
                 });
                 continue;
@@ -340,12 +337,12 @@ where
                     // Sort them by their position.
                     collected_items.sort_unstable_by_key(|(_item, index)| *index);
 
-                    result.push(RawLinkedChunk {
+                    result.push(RawChunk {
                         content: ChunkContent::Items(
                             collected_items.into_iter().map(|(item, _index)| item).collect(),
                         ),
                         previous: chunk_row.previous_chunk,
-                        id: chunk_row.chunk,
+                        identifier: chunk_row.chunk,
                         next: chunk_row.next_chunk,
                     });
                 }
@@ -361,10 +358,10 @@ where
                         ));
                     }
 
-                    result.push(RawLinkedChunk {
+                    result.push(RawChunk {
                         content: ChunkContent::Gap(gap.clone()),
                         previous: chunk_row.previous_chunk,
-                        id: chunk_row.chunk,
+                        identifier: chunk_row.chunk,
                         next: chunk_row.next_chunk,
                     });
                 }

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -461,7 +461,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                         Update::PushItems { at, items } => {
                             let chunk_id = at.chunk_identifier().index();
 
-                            trace!(%room_id, "pushing items @ {chunk_id}");
+                            trace!(%room_id, "pushing {} items @ {chunk_id}", items.len());
 
                             for (i, event) in items.into_iter().enumerate() {
                                 let serialized = serde_json::to_vec(&event)?;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -273,7 +273,8 @@ async fn test_wait_for_token() {
                 &ALICE,
                 RoomMessageEventContent::text_plain("live event!"),
             ))
-            .set_timeline_prev_batch(from.to_owned()),
+            .set_timeline_prev_batch(from.to_owned())
+            .set_timeline_limited(),
     );
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
 
@@ -385,7 +386,8 @@ async fn test_timeline_reset_while_paginating() {
                 &ALICE,
                 RoomMessageEventContent::text_plain("live event!"),
             ))
-            .set_timeline_prev_batch("pagination_1".to_owned()),
+            .set_timeline_prev_batch("pagination_1".to_owned())
+            .set_timeline_limited(),
     );
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     client.sync_once(sync_settings.clone()).await.unwrap();
@@ -399,8 +401,8 @@ async fn test_timeline_reset_while_paginating() {
                 &BOB,
                 RoomMessageEventContent::text_plain("new live event."),
             ))
-            .set_timeline_limited()
-            .set_timeline_prev_batch("pagination_2".to_owned()),
+            .set_timeline_prev_batch("pagination_2".to_owned())
+            .set_timeline_limited(),
     );
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
 


### PR DESCRIPTION
- commit 1: refactor in preparation for commit 3; instead of rebuilding the linked chunk in the event cache store impl, do it one layer above. It's similar code all the cache store impls had to copy/paste themselves + it will allow us to inspect the chunks whenever something goes wrong.
- commit 2: display a debug string showing the raw state of a linked chunk, which allows to display invalid states, in particular. Use that display whenever rebuilding the linked chunk fails, in the event cache.
- commit 3: when rebuilding a linked chunk fails, clear the storage, and start afresh.
- commit 4: spawn a task when handling updates to storage, so that it can't be interrupted.
  - question for reviewer: this relies on the fact that getting the store lock requires holding onto a real mutex. I'm afraid that if trying to acquire the cross-process lock doesn't mean holding this mutex anymore, in the future, then we might forget about this place, and run into issues. Should I introduce a new lock for that purpose, here?
- commit 5: tweak a log
- commit 6: something spotted while trying the patch in `multiverse`: we get a prev-batch token on every incremental SSS; we only need to store the gap whenever the timeline is limited (aka, the server tells us we are definitely missing events), and not otherwise.

Because of commit 3, we might not even need to have migrations if the format of events data changes over time, which is kinda sloppy but nice? cc @Hywan @poljar 