### PR TITLE
fix(send_queue): Use `MediaFormat::File` when caching attachment thumbnail

### DIFF
--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -248,9 +248,15 @@ pub struct FinishUploadThumbnailInfo {
     /// Transaction id for the thumbnail upload.
     pub txn: OwnedTransactionId,
     /// Thumbnail's width.
-    pub width: UInt,
+    ///
+    /// Used previously, kept for backwards compatibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<UInt>,
     /// Thumbnail's height.
-    pub height: UInt,
+    ///
+    /// Used previously, kept for backwards compatibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<UInt>,
 }
 
 /// A transaction id identifying a [`DependentQueuedRequest`] rather than its

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -524,6 +524,12 @@ impl Timeline {
     /// If the encryption feature is enabled, this method will transparently
     /// encrypt the room message if the room is encrypted.
     ///
+    /// The attachment and its optional thumbnail are stored in the media cache
+    /// and can be retrieved at any time, by calling
+    /// [`Media::get_media_content()`] with the `MediaSource` that can be found
+    /// in the corresponding `TimelineEventItem`, and using a
+    /// `MediaFormat::File`.
+    ///
     /// # Arguments
     ///
     /// * `path` - The path of the file to be sent.
@@ -532,6 +538,8 @@ impl Timeline {
     ///
     /// * `config` - An attachment configuration object containing details about
     ///   the attachment like a thumbnail, its size, duration etc.
+    ///
+    /// [`Media::get_media_content()`]: matrix_sdk::Media::get_media_content
     #[instrument(skip_all)]
     pub fn send_attachment(
         &self,

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -97,6 +97,11 @@ impl RoomSendQueue {
     /// client's sending queue will be disabled, and it will need to be
     /// manually re-enabled by the caller (e.g. after network is back, or when
     /// something has been done about the faulty requests).
+    ///
+    /// The attachment and its optional thumbnail are stored in the media cache
+    /// and can be retrieved at any time, by calling
+    /// [`Media::get_media_content()`] with the `MediaSource` that can be found
+    /// in the local or remote echo, and using a `MediaFormat::File`.
     #[instrument(skip_all, fields(event_txn))]
     pub async fn send_attachment(
         &self,

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1893,10 +1893,7 @@ async fn test_media_uploads() {
         .get_media_content(
             &MediaRequestParameters {
                 source: local_thumbnail_source.clone(),
-                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
-                    tinfo.width.unwrap(),
-                    tinfo.height.unwrap(),
-                )),
+                format: MediaFormat::File,
             },
             true,
         )
@@ -1910,7 +1907,10 @@ async fn test_media_uploads() {
         .get_media_content(
             &MediaRequestParameters {
                 source: local_thumbnail_source.clone(),
-                format: MediaFormat::File,
+                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
+                    tinfo.width.unwrap(),
+                    tinfo.height.unwrap(),
+                )),
             },
             true,
         )
@@ -1968,13 +1968,7 @@ async fn test_media_uploads() {
     let thumbnail_media = client
         .media()
         .get_media_content(
-            &MediaRequestParameters {
-                source: new_thumbnail_source,
-                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
-                    tinfo.width.unwrap(),
-                    tinfo.height.unwrap(),
-                )),
-            },
+            &MediaRequestParameters { source: new_thumbnail_source, format: MediaFormat::File },
             true,
         )
         .await
@@ -2150,7 +2144,6 @@ async fn abort_and_verify(
     let file_source = img_content.source;
     let info = img_content.info.unwrap();
     let thumbnail_source = info.thumbnail_source.unwrap();
-    let thumbnail_info = info.thumbnail_info.unwrap();
 
     let aborted = upload_handle.abort().await.unwrap();
     assert!(aborted, "upload must have been aborted");
@@ -2170,13 +2163,7 @@ async fn abort_and_verify(
     client
         .media()
         .get_media_content(
-            &MediaRequestParameters {
-                source: thumbnail_source,
-                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
-                    thumbnail_info.width.unwrap(),
-                    thumbnail_info.height.unwrap(),
-                )),
-            },
+            &MediaRequestParameters { source: thumbnail_source, format: MediaFormat::File },
             true,
         )
         .await


### PR DESCRIPTION
Fix extracted from #4329. 

The `MediaFormat` reflects only the request that would be made to the homeserver. There is no link between the format of the files stored in the media cache and their purpose in an event. `MediaFormat::Thumbnail` means that we request a server-generated thumbnail of a file in the media repository. Since the thumbnail is its own file in the media repository, it makes more sense to use `MediaFormat::File`. See https://github.com/matrix-org/matrix-rust-sdk/pull/4329#discussion_r1873122697 for even more details why this change makes sense.

The fix was simplified a lot here. Instead of requiring a migration, we just minimize the changes in the format of the send queue request in the state store and keep handling the previous case.

This also documents the caching of the media when calling `send_attachment`.