### PR TITLE
feat(room): add methods to customise a Room's privacy settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,6 +3110,7 @@ dependencies = [
  "mime2ext",
  "once_cell",
  "openidconnect",
+ "percent-encoding",
  "pin-project-lite",
  "proptest",
  "rand",

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1152,17 +1152,6 @@ impl Client {
         let alias = RoomAliasId::parse(alias)?;
         self.inner.is_room_alias_available(&alias).await.map_err(Into::into)
     }
-
-    /// Creates a new room alias associated with the provided room id.
-    pub async fn create_room_alias(
-        &self,
-        room_alias: String,
-        room_id: String,
-    ) -> Result<(), ClientError> {
-        let room_alias = RoomAliasId::parse(room_alias)?;
-        let room_id = RoomId::parse(room_id)?;
-        self.inner.create_room_alias(&room_alias, &room_id).await.map_err(Into::into)
-    }
 }
 
 #[matrix_sdk_ffi_macros::export(callback_interface)]
@@ -1462,6 +1451,9 @@ pub enum RoomVisibility {
 
     /// Indicates that the room will not be shown in the published room list.
     Private,
+
+    /// A custom value that's not present in the spec.
+    Custom { value: String },
 }
 
 impl From<RoomVisibility> for Visibility {
@@ -1469,6 +1461,17 @@ impl From<RoomVisibility> for Visibility {
         match value {
             RoomVisibility::Public => Self::Public,
             RoomVisibility::Private => Self::Private,
+            RoomVisibility::Custom { value } => value.as_str().into(),
+        }
+    }
+}
+
+impl From<Visibility> for RoomVisibility {
+    fn from(value: Visibility) -> Self {
+        match value {
+            Visibility::Public => Self::Public,
+            Visibility::Private => Self::Private,
+            _ => Self::Custom { value: value.as_str().to_owned() },
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -155,6 +155,12 @@ impl From<RoomSendQueueError> for ClientError {
     }
 }
 
+impl From<NotYetImplemented> for ClientError {
+    fn from(_: NotYetImplemented) -> Self {
+        Self::new("This functionality is not implemented yet.")
+    }
+}
+
 /// Bindings version of the sdk type replacing OwnedUserId/DeviceIds with simple
 /// String.
 ///

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -5,8 +5,9 @@ use tracing::warn;
 
 use crate::{
     client::JoinRule,
+    error::ClientError,
     notification_settings::RoomNotificationMode,
-    room::{Membership, RoomHero},
+    room::{Membership, RoomHero, RoomHistoryVisibility},
     room_member::RoomMember,
 };
 
@@ -60,10 +61,12 @@ pub struct RoomInfo {
     pinned_event_ids: Vec<String>,
     /// The join rule for this room, if known.
     join_rule: Option<JoinRule>,
+    /// The history visibility for this room, if known.
+    history_visibility: RoomHistoryVisibility,
 }
 
 impl RoomInfo {
-    pub(crate) async fn new(room: &matrix_sdk::Room) -> matrix_sdk::Result<Self> {
+    pub(crate) async fn new(room: &matrix_sdk::Room) -> Result<Self, ClientError> {
         let unread_notification_counts = room.unread_notification_counts();
 
         let power_levels_map = room.users_with_power_levels().await;
@@ -128,6 +131,7 @@ impl RoomInfo {
             num_unread_mentions: room.num_unread_mentions(),
             pinned_event_ids,
             join_rule: join_rule.ok(),
+            history_visibility: room.history_visibility_or_default().try_into()?,
         })
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -566,7 +566,7 @@ impl RoomListItem {
     }
 
     async fn room_info(&self) -> Result<RoomInfo, ClientError> {
-        Ok(RoomInfo::new(self.inner.inner_room()).await?)
+        RoomInfo::new(self.inner.inner_room()).await
     }
 
     /// The room's current membership state.

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Expose `Client::server_versions()` publicly to allow users of the library to
   get the versions of Matrix supported by the homeserver.
   ([#4519](https://github.com/matrix-org/matrix-rust-sdk/pull/4519))
+- Create `RoomPrivacySettings` helper to group room settings functionality related to room access and visibility ([#4401](https://github.com/matrix-org/matrix-rust-sdk/pull/4401)). 
 
 ### Refactor
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -94,6 +94,7 @@ matrix-sdk-test = { workspace = true, optional = true }
 mime = { workspace = true }
 mime2ext = "0.1.53"
 once_cell = { workspace = true }
+percent-encoding = "2.3.1"
 pin-project-lite = { workspace = true }
 rand = { workspace = true , optional = true }
 ruma = { workspace = true, features = [

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -41,7 +41,7 @@ use ruma::{
     api::{
         client::{
             account::whoami,
-            alias::{create_alias, get_alias},
+            alias::{create_alias, delete_alias, get_alias},
             device::{delete_devices, get_devices, update_device},
             directory::{get_public_rooms, get_public_rooms_filtered},
             discovery::{
@@ -1204,6 +1204,13 @@ impl Client {
     /// Adds a new room alias associated with a room to the room directory.
     pub async fn create_room_alias(&self, alias: &RoomAliasId, room_id: &RoomId) -> HttpResult<()> {
         let request = create_alias::v3::Request::new(alias.to_owned(), room_id.to_owned());
+        self.send(request).await?;
+        Ok(())
+    }
+
+    /// Removes a room alias from the room directory.
+    pub async fn remove_room_alias(&self, alias: &RoomAliasId) -> HttpResult<()> {
+        let request = delete_alias::v3::Request::new(alias.to_owned());
         self.send(request).await?;
         Ok(())
     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1201,7 +1201,7 @@ impl Client {
         }
     }
 
-    /// Creates a new room alias associated with a room.
+    /// Adds a new room alias associated with a room to the room directory.
     pub async fn create_room_alias(&self, alias: &RoomAliasId, room_id: &RoomId) -> HttpResult<()> {
         let request = create_alias::v3::Request::new(alias.to_owned(), room_id.to_owned());
         self.send(request).await?;
@@ -3163,7 +3163,7 @@ pub(crate) mod tests {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
 
-        server.mock_create_room_alias().ok().expect(1).mount().await;
+        server.mock_room_directory_create_room_alias().ok().expect(1).mount().await;
 
         let ret = client
             .create_room_alias(

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -145,6 +145,7 @@ use crate::{
     room::{
         knock_requests::{KnockRequest, KnockRequestMemberInfo},
         power_levels::{RoomPowerLevelChanges, RoomPowerLevelsExt},
+        privacy_settings::RoomPrivacySettings,
     },
     sync::RoomUpdate,
     utils::{IntoRawMessageLikeEventContent, IntoRawStateEventContent},
@@ -161,6 +162,9 @@ pub mod knock_requests;
 mod member;
 mod messages;
 pub mod power_levels;
+
+/// Contains all the functionality for modifying the privacy settings in a room.
+pub mod privacy_settings;
 
 /// A struct containing methods that are common for Joined, Invited and Left
 /// Rooms
@@ -3356,6 +3360,11 @@ impl Room {
                 ))
             })
             .collect())
+    }
+
+    /// Access the room settings related to privacy and visibility.
+    pub fn privacy_settings(&self) -> RoomPrivacySettings<'_> {
+        RoomPrivacySettings::new(&self.inner, &self.client)
     }
 }
 

--- a/crates/matrix-sdk/src/room/privacy_settings.rs
+++ b/crates/matrix-sdk/src/room/privacy_settings.rs
@@ -1,0 +1,122 @@
+use matrix_sdk_base::Room as BaseRoom;
+use ruma::{
+    api::client::{
+        state::send_state_event,
+    },
+    assign,
+    events::{
+        room::{
+            canonical_alias::RoomCanonicalAliasEventContent,
+        },
+        EmptyStateKey,
+    },
+    OwnedRoomAliasId,
+};
+
+use crate::{Client, Result};
+
+/// A helper to group the methods in [Room](crate::Room) related to the room's
+/// visibility and access.
+#[derive(Debug)]
+pub struct RoomPrivacySettings<'a> {
+    room: &'a BaseRoom,
+    client: &'a Client,
+}
+
+impl<'a> RoomPrivacySettings<'a> {
+    pub(crate) fn new(room: &'a BaseRoom, client: &'a Client) -> Self {
+        Self { room, client }
+    }
+
+    /// Update the canonical alias of the room.
+    ///
+    /// # Arguments:
+    /// * `alias` - The new main alias to use for the room. A `None` value
+    ///   removes the existing main canonical alias.
+    /// * `alt_aliases` - The list of alternative aliases for this room.
+    ///
+    /// See <https://spec.matrix.org/v1.12/client-server-api/#mroomcanonical_alias> for more info about the canonical alias.
+    ///
+    /// Note that publishing the alias in the room directory is done separately,
+    /// and a room alias must have already been published before it can be set
+    /// as the canonical alias.
+    pub async fn update_canonical_alias(
+        &'a self,
+        alias: Option<OwnedRoomAliasId>,
+        alt_aliases: Vec<OwnedRoomAliasId>,
+    ) -> Result<()> {
+        // Create a new alias event combining both the new and previous values
+        let content = assign!(
+            RoomCanonicalAliasEventContent::new(),
+            { alias, alt_aliases }
+        );
+
+        // Send the state event
+        let request = send_state_event::v3::Request::new(
+            self.room.room_id().to_owned(),
+            &EmptyStateKey,
+            &content,
+        )?;
+        self.client.send(request).await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use matrix_sdk_test::{async_test};
+    use ruma::{
+        event_id,
+        events::{
+            StateEventType,
+        },
+        owned_room_alias_id, room_id,
+    };
+
+    use crate::test_utils::mocks::MatrixMockServer;
+
+    #[async_test]
+    async fn test_update_canonical_alias_with_some_value() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        let room_id = room_id!("!a:b.c");
+        let room = server.sync_joined_room(&client, room_id).await;
+
+        server
+            .mock_room_send_state()
+            .for_type(StateEventType::RoomCanonicalAlias)
+            .ok(event_id!("$a:b.c"))
+            .mock_once()
+            .mount()
+            .await;
+
+        let room_alias = owned_room_alias_id!("#a:b.c");
+        let ret = room
+            .privacy_settings()
+            .update_canonical_alias(Some(room_alias.clone()), Vec::new())
+            .await;
+        assert!(ret.is_ok());
+    }
+
+    #[async_test]
+    async fn test_update_canonical_alias_with_no_value() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        let room_id = room_id!("!a:b.c");
+        let room = server.sync_joined_room(&client, room_id).await;
+
+        server
+            .mock_room_send_state()
+            .for_type(StateEventType::RoomCanonicalAlias)
+            .ok(event_id!("$a:b.c"))
+            .mock_once()
+            .mount()
+            .await;
+
+        let ret = room.privacy_settings().update_canonical_alias(None, Vec::new()).await;
+        assert!(ret.is_ok());
+    }
+}

--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -579,6 +579,41 @@ impl MatrixMockServer {
         MockEndpoint { mock, server: &self.server, endpoint: CreateRoomAliasEndpoint }
     }
 
+    /// Create a prebuilt mock for removing room aliases from the room
+    /// directory.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// use matrix_sdk::{
+    ///     ruma::room_alias_id, test_utils::mocks::MatrixMockServer,
+    /// };
+    ///
+    /// let mock_server = MatrixMockServer::new().await;
+    /// let client = mock_server.client_builder().build().await;
+    ///
+    /// mock_server
+    ///     .mock_room_directory_remove_room_alias()
+    ///     .ok()
+    ///     .mock_once()
+    ///     .mount()
+    ///     .await;
+    ///
+    /// client
+    ///     .remove_room_alias(room_alias_id!("#a:b.c"))
+    ///     .await
+    ///     .expect("We should be able to remove the room alias");
+    /// # anyhow::Ok(()) });
+    /// ```
+    pub fn mock_room_directory_remove_room_alias(
+        &self,
+    ) -> MockEndpoint<'_, RemoveRoomAliasEndpoint> {
+        let mock =
+            Mock::given(method("DELETE")).and(path_regex(r"/_matrix/client/v3/directory/room/.*"));
+        MockEndpoint { mock, server: &self.server, endpoint: RemoveRoomAliasEndpoint }
+    }
+
     /// Create a prebuilt mock for listing public rooms.
     ///
     /// # Examples
@@ -1937,6 +1972,17 @@ pub struct CreateRoomAliasEndpoint;
 
 impl<'a> MockEndpoint<'a, CreateRoomAliasEndpoint> {
     /// Returns a data endpoint for creating a room alias.
+    pub fn ok(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+/// A prebuilt mock for removing a room alias.
+pub struct RemoveRoomAliasEndpoint;
+
+impl<'a> MockEndpoint<'a, RemoveRoomAliasEndpoint> {
+    /// Returns a data endpoint for removing a room alias.
     pub fn ok(self) -> MatrixMock<'a> {
         let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
         MatrixMock { server: self.server, mock }

--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -28,6 +28,7 @@ use matrix_sdk_test::{
     SyncResponseBuilder,
 };
 use ruma::{
+    api::client::room::Visibility,
     directory::PublicRoomsChunk,
     events::{
         room::member::RoomMemberEvent, AnyStateEvent, AnyTimelineEvent, MessageLikeEventType,
@@ -563,6 +564,46 @@ impl MatrixMockServer {
     pub fn mock_public_rooms(&self) -> MockEndpoint<'_, PublicRoomsEndpoint> {
         let mock = Mock::given(method("POST")).and(path_regex(r"/_matrix/client/v3/publicRooms"));
         MockEndpoint { mock, server: &self.server, endpoint: PublicRoomsEndpoint }
+    }
+
+    /// Create a prebuilt mock for getting a room's visibility in the room
+    /// directory.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// use matrix_sdk::{ruma::room_id, test_utils::mocks::MatrixMockServer};
+    /// use ruma::api::client::room::Visibility;
+    ///
+    /// let mock_server = MatrixMockServer::new().await;
+    /// let client = mock_server.client_builder().build().await;
+    ///
+    /// mock_server
+    ///     .mock_room_directory_get_room_visibility()
+    ///     .ok(Visibility::Public)
+    ///     .mock_once()
+    ///     .mount()
+    ///     .await;
+    ///
+    /// let room = mock_server
+    ///     .sync_joined_room(&client, room_id!("!room_id:localhost"))
+    ///     .await;
+    ///
+    /// let visibility = room
+    ///     .privacy_settings()
+    ///     .get_room_visibility()
+    ///     .await
+    ///     .expect("We should be able to get the room's visibility");
+    /// assert_eq!(visibility, Visibility::Public);
+    /// # anyhow::Ok(()) });
+    /// ```
+    pub fn mock_room_directory_get_room_visibility(
+        &self,
+    ) -> MockEndpoint<'_, GetRoomVisibilityEndpoint> {
+        let mock = Mock::given(method("GET"))
+            .and(path_regex(r"^/_matrix/client/v3/directory/list/room/.*$"));
+        MockEndpoint { mock, server: &self.server, endpoint: GetRoomVisibilityEndpoint }
     }
 
     /// Create a prebuilt mock for fetching information about key storage
@@ -1816,6 +1857,19 @@ impl<'a> MockEndpoint<'a, PublicRoomsEndpoint> {
                 "total_room_count_estimate": chunk.len(),
             }))
         });
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+/// A prebuilt mock for getting the room's visibility in the room directory.
+pub struct GetRoomVisibilityEndpoint;
+
+impl<'a> MockEndpoint<'a, GetRoomVisibilityEndpoint> {
+    /// Returns an endpoint that get the room's public visibility.
+    pub fn ok(self, visibility: Visibility) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "visibility": visibility,
+        })));
         MatrixMock { server: self.server, mock }
     }
 }

--- a/testing/matrix-sdk-integration-testing/src/tests.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests.rs
@@ -6,5 +6,6 @@ mod redaction;
 mod repeated_join;
 mod room;
 mod room_directory_search;
+mod room_privacy;
 mod sliding_sync;
 mod timeline;

--- a/testing/matrix-sdk-integration-testing/src/tests/room_privacy.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room_privacy.rs
@@ -1,0 +1,242 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use assert_matches2::assert_matches;
+use assign::assign;
+use matrix_sdk::{
+    config::SyncSettings,
+    ruma::{
+        api::client::{
+            directory::get_public_rooms_filtered,
+            room::{create_room::v3::Request as CreateRoomRequest, Visibility},
+        },
+        directory::Filter,
+        events::room::{
+            canonical_alias::{InitialRoomCanonicalAliasEvent, RoomCanonicalAliasEventContent},
+            history_visibility::{
+                HistoryVisibility, InitialRoomHistoryVisibilityEvent,
+                RoomHistoryVisibilityEventContent,
+            },
+        },
+        serde::Raw,
+        RoomAliasId,
+    },
+};
+use matrix_sdk_base::ruma::events::room::canonical_alias::SyncRoomCanonicalAliasEvent;
+use rand::random;
+use tokio::sync::mpsc::unbounded_channel;
+
+use crate::helpers::TestClientBuilder;
+
+#[tokio::test]
+async fn test_publishing_room_alias() -> anyhow::Result<()> {
+    let client = TestClientBuilder::new("alice").build().await?;
+    let server_name = client.user_id().expect("A user id should exist").server_name();
+
+    let sync_handle = tokio::task::spawn({
+        let client = client.clone();
+        async move {
+            client.sync(SyncSettings::default()).await.expect("Sync should not fail");
+        }
+    });
+
+    // The room can only be visible in the public room directory later if its join
+    // rule is one of  [public, knock, knock_restricted] or its history
+    // visibility is `world_readable`. Let's use this last option.
+    let room_history_visibility = InitialRoomHistoryVisibilityEvent::new(
+        RoomHistoryVisibilityEventContent::new(HistoryVisibility::WorldReadable),
+    )
+    .to_raw_any();
+    let room_id = client
+        .create_room(assign!(CreateRoomRequest::new(), {
+            initial_state: vec![
+                room_history_visibility,
+            ]
+        }))
+        .await?
+        .room_id()
+        .to_owned();
+
+    // Wait for the room to be synced
+    let room = client.await_room_remote_echo(&room_id).await;
+
+    // Initial checks for the room's state
+    let room_visibility = room.privacy_settings().get_room_visibility().await?;
+    assert_matches!(room_visibility, Visibility::Private);
+
+    let canonical_alias = room.canonical_alias();
+    assert!(canonical_alias.is_none());
+
+    let alternative_aliases = room.alt_aliases();
+    assert!(alternative_aliases.is_empty());
+
+    // We'll add a room alias to it
+    let random_id: u128 = random();
+    let raw_room_alias = format!("#a-room-alias-{random_id}:{server_name}");
+    let room_alias = RoomAliasId::parse(raw_room_alias).expect("The room alias should be valid");
+
+    // We publish the room alias
+    let published =
+        room.privacy_settings().publish_room_alias_in_room_directory(&room_alias).await?;
+    assert!(published);
+
+    // We can't publish it again
+    let published =
+        room.privacy_settings().publish_room_alias_in_room_directory(&room_alias).await?;
+    assert!(!published);
+
+    // We can publish an alternative alias too
+    let alt_alias = RoomAliasId::parse(format!("#alt-alias-{random_id}:{server_name}"))
+        .expect("The alt room alias should be valid");
+    let published =
+        room.privacy_settings().publish_room_alias_in_room_directory(&alt_alias).await?;
+    assert!(published);
+
+    // Since we only published the room alias, the canonical alias is not set yet
+    let canonical_alias = room.canonical_alias();
+    assert!(canonical_alias.is_none());
+
+    // We update the canonical alias now
+    room.privacy_settings()
+        .update_canonical_alias(Some(room_alias.clone()), vec![alt_alias.clone()])
+        .await?;
+
+    // Wait until we receive the canonical alias event through sync
+    let (tx, mut rx) = unbounded_channel();
+    let handle = room.add_event_handler(move |_: Raw<SyncRoomCanonicalAliasEvent>| {
+        let _ = tx.send(());
+        async {}
+    });
+    let _ = tokio::time::timeout(Duration::from_secs(2), rx.recv()).await?;
+    client.remove_event_handler(handle);
+
+    // And we can check it actually changed the aliases
+    let canonical_alias = room.canonical_alias();
+    assert!(canonical_alias.is_some());
+    assert_eq!(canonical_alias.unwrap(), room_alias);
+
+    let alternative_aliases = room.alt_aliases();
+    assert_eq!(alternative_aliases, vec![alt_alias]);
+
+    // Since the room is still not public, the room directory can't find it
+    let public_rooms_filter = assign!(Filter::new(), {
+        generic_search_term: Some(room_alias.to_string()),
+    });
+    let public_rooms_request = assign!(get_public_rooms_filtered::v3::Request::new(), {
+        filter: public_rooms_filter,
+    });
+    let results = client.public_rooms_filtered(public_rooms_request.clone()).await?.chunk;
+    assert!(results.is_empty());
+
+    // We can set the room as visible now in the public room directory
+    room.privacy_settings().update_room_visibility(Visibility::Public).await?;
+
+    // And confirm it's public
+    let room_visibility = room.privacy_settings().get_room_visibility().await?;
+    assert_matches!(room_visibility, Visibility::Public);
+
+    // We can check again the public room directory and we should have some results
+    let results = client.public_rooms_filtered(public_rooms_request).await?.chunk;
+    assert_eq!(results.len(), 1);
+
+    sync_handle.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_removing_published_room_alias() -> anyhow::Result<()> {
+    let client = TestClientBuilder::new("alice").build().await?;
+    let server_name = client.user_id().expect("A user id should exist").server_name();
+
+    let sync_handle = tokio::task::spawn({
+        let client = client.clone();
+        async move {
+            client.sync(SyncSettings::default()).await.expect("Sync should not fail");
+        }
+    });
+
+    // We'll add a room alias to it
+    let random_id: u128 = random();
+    let local_part_room_alias = format!("a-room-alias-{}", random_id);
+    let raw_room_alias = format!("#{local_part_room_alias}:{server_name}");
+    let room_alias = RoomAliasId::parse(raw_room_alias).expect("The room alias should be valid");
+
+    // The room can only be visible in the public room directory later if its join
+    // rule is one of  [public, knock, knock_restricted] or its history
+    // visibility is `world_readable`. Let's use this last option.
+    // This room will be created with a room alias and being visible in the public
+    // room directory.
+    let room_history_visibility = InitialRoomHistoryVisibilityEvent::new(
+        RoomHistoryVisibilityEventContent::new(HistoryVisibility::WorldReadable),
+    )
+    .to_raw_any();
+    let canonical_alias = InitialRoomCanonicalAliasEvent::new(
+        assign!(RoomCanonicalAliasEventContent::new(), { alias: Some(room_alias.clone()) }),
+    )
+    .to_raw_any();
+    let room_id = client
+        .create_room(assign!(CreateRoomRequest::new(), {
+            room_alias_name: Some(local_part_room_alias),
+            initial_state: vec![
+                room_history_visibility,
+                canonical_alias,
+            ],
+            visibility: Visibility::Public,
+        }))
+        .await?
+        .room_id()
+        .to_owned();
+
+    // Wait for the room to be synced
+    let room = client.await_room_remote_echo(&room_id).await;
+
+    // Initial checks for the room's state
+    let room_visibility = room.privacy_settings().get_room_visibility().await?;
+    assert_matches!(room_visibility, Visibility::Public);
+
+    let alternative_aliases = room.alt_aliases();
+    assert!(alternative_aliases.is_empty());
+
+    // We can check the room is published
+    let public_rooms_filter = assign!(Filter::new(), {
+        generic_search_term: Some(room_alias.to_string()),
+    });
+    let public_rooms_request = assign!(get_public_rooms_filtered::v3::Request::new(), {
+        filter: public_rooms_filter,
+    });
+    let results = client.public_rooms_filtered(public_rooms_request.clone()).await?.chunk;
+    assert_eq!(results.len(), 1);
+
+    // We remove the room alias
+    let removed =
+        room.privacy_settings().remove_room_alias_from_room_directory(&room_alias).await?;
+    assert!(removed);
+
+    // We can't remove it again
+    let removed =
+        room.privacy_settings().remove_room_alias_from_room_directory(&room_alias).await?;
+    assert!(!removed);
+
+    // If we check the public room list again using the room alias as the search
+    // term, we don't have any results now
+    let results = client.public_rooms_filtered(public_rooms_request.clone()).await?.chunk;
+    assert!(results.is_empty());
+
+    sync_handle.abort();
+
+    Ok(())
+}


### PR DESCRIPTION
These include:

- Updating the canonical alias.
- Creating and removing a room alias from the room directory.
- Enabling encryption in a room.
- Updating the join rule of a room.
- Updating the room history visiblity.
- Updating the room visibility in the room directory.

Also, expose the room history visibility through the FFI RoomInfo.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
