### PR TITLE
fix(event cache): fix back-pagination ordering in one specific case

### DIFF
--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -197,15 +197,16 @@ impl RoomPagination {
                     let first_event_pos = room_events.events().next().map(|(item_pos, _)| item_pos);
 
                     if let Some(pos) = first_event_pos {
+                        room_events
+                            .insert_events_at(sync_events, pos)
+                            .expect("pos is a valid position we just read above");
+
                         if let Some(new_gap) = new_gap {
+                            // Insert the gap, before the events we just inserted at pos.
                             room_events
                                 .insert_gap_at(new_gap, pos)
                                 .expect("pos is a valid position we just read above");
                         }
-
-                        room_events
-                            .insert_events_at(sync_events, pos)
-                            .expect("pos is a valid position we just read above");
                     } else {
                         if let Some(prev_token_gap) = new_gap {
                             room_events.push_gap(prev_token_gap);

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -111,7 +111,7 @@ impl RoomEvents {
 
     /// Push a gap after all events or gaps.
     pub fn push_gap(&mut self, gap: Gap) {
-        self.chunks.push_gap_back(gap)
+        self.chunks.push_gap_back(gap);
     }
 
     /// Insert events at a specified position.


### PR DESCRIPTION
This started as a refactoring of the event cache's logic for back-paginations, for other purposes, but turns out there was a bug if you were in the following conditions:

- a room has some events
- the room doesn't have a prev-batch token / a gap

In this case, if we ran a back-pagination, the next prev-batch token would be in the wrong position, compared to the events that we just back-paginated. Which means that the next back-pagination would insert events in the wrong place. The integration test I added acts as a regression test, which failed on main.