### PR TITLE
Using Cached Libary to store the data in a cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ rust-version = "1.82"
 
 [workspace.dependencies]
 anyhow = "1.0.93"
-cached = "0.36.0"
 aquamarine = "0.6.0"
 assert-json-diff = "2.0.2"
 assert_matches = "1.5.0"
@@ -109,6 +108,7 @@ matrix-sdk-sqlite = { path = "crates/matrix-sdk-sqlite", version = "0.8.0", defa
 matrix-sdk-store-encryption = { path = "crates/matrix-sdk-store-encryption", version = "0.8.0" }
 matrix-sdk-test = { path = "testing/matrix-sdk-test", version = "0.7.0" }
 matrix-sdk-ui = { path = "crates/matrix-sdk-ui", version = "0.8.0", default-features = false }
+cached = { version = "0.36.0", features = ["proc_macro"] }
 
 # Default release profile, select with `--release`
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rust-version = "1.82"
 
 [workspace.dependencies]
 anyhow = "1.0.93"
+cached = "0.36.0"
 aquamarine = "0.6.0"
 assert-json-diff = "2.0.2"
 assert_matches = "1.5.0"

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -46,7 +46,7 @@ use tokio::sync::Mutex;
 use tracing::{debug, warn};
 use wasm_bindgen::JsValue;
 use web_sys::IdbKeyRange;
-
+use cached::proc_macro::cached;
 use self::indexeddb_serializer::MaybeEncrypted;
 use crate::crypto_store::{
     indexeddb_serializer::IndexeddbSerializer, migrations::open_and_upgrade_db,
@@ -1313,7 +1313,7 @@ impl_crypto_store! {
             Ok(None)
         }
     }
-
+    #[cached(size = 100)]
     async fn get_room_settings(&self, room_id: &RoomId) -> Result<Option<RoomSettings>> {
         let key = self.serializer.encode_key(keys::ROOM_SETTINGS, room_id);
         self


### PR DESCRIPTION
## Changes :
- Fixes : #4337 
- Minimizes I/O overhead by fetching frequently accessed data from memory instead of the database.
- Ensures optimal memory usage with built-in size limits and expiration policies.
