### PR TITLE
Ensure that we request the correct state event for the service members to work correctly

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -92,6 +92,8 @@ const DEFAULT_REQUIRED_STATE: &[(StateEventType, &str)] = &[
     // Those two events are required to properly compute room previews.
     (StateEventType::RoomCreate, ""),
     (StateEventType::RoomHistoryVisibility, ""),
+    // Required to correctly calculate the room display name.
+    (StateEventType::MemberHints, ""),
 ];
 
 /// The default `required_state` constant value for sliding sync room

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -365,6 +365,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
                         ["m.room.join_rules", ""],
                         ["m.room.create", ""],
                         ["m.room.history_visibility", ""],
+                        ["io.element.functional_members", ""],
                     ],
                     "include_heroes": true,
                     "filters": {
@@ -2232,6 +2233,7 @@ async fn test_room_subscription() -> Result<(), Error> {
                         ["m.room.join_rules", ""],
                         ["m.room.create", ""],
                         ["m.room.history_visibility", ""],
+                        ["io.element.functional_members", ""],
                         ["m.room.pinned_events", ""],
                     ],
                     "timeline_limit": 20,
@@ -2272,6 +2274,7 @@ async fn test_room_subscription() -> Result<(), Error> {
                         ["m.room.join_rules", ""],
                         ["m.room.create", ""],
                         ["m.room.history_visibility", ""],
+                        ["io.element.functional_members", ""],
                         ["m.room.pinned_events", ""],
                     ],
                     "timeline_limit": 20,


### PR DESCRIPTION
We forgot that under sliding sync we won't have access to all state events, which meant that #4335 never got working.

The first commit adds the relevant event to the required state for the UI crate.

The second commit fixes another edge case in the case where we homeserver does provide a room summary containing service members in the heroes and thus in the joined members count.