### PR TITLE
feat(event cache): have a debug representation of a linked chunk and use it in multiverse

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -933,6 +933,13 @@ impl Room {
 
         Ok(handle)
     }
+
+    /// Return a debug representation for the internal room events data
+    /// structure, one line per entry in the resulting vector.
+    pub async fn room_events_debug_string(&self) -> Result<Vec<String>, ClientError> {
+        let (cache, _drop_guards) = self.inner.event_cache().await?;
+        Ok(cache.debug_string().await)
+    }
 }
 
 impl From<matrix_sdk::room::knock_requests::KnockRequest> for KnockRequest {

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -26,7 +26,10 @@ use matrix_sdk_common::linked_chunk::{
 use ruma::OwnedEventId;
 use tracing::{debug, error, warn};
 
-use super::super::deduplicator::{Decoration, Deduplicator};
+use super::{
+    super::deduplicator::{Decoration, Deduplicator},
+    chunk_debug_string,
+};
 
 /// This type represents all events of a single room.
 #[derive(Debug)]
@@ -177,7 +180,6 @@ impl RoomEvents {
     /// Iterate over the chunks, forward.
     ///
     /// The oldest chunk comes first.
-    #[cfg(test)]
     pub fn chunks(
         &self,
     ) -> matrix_sdk_common::linked_chunk::Iter<'_, DEFAULT_CHUNK_CAPACITY, Event, Gap> {
@@ -261,6 +263,18 @@ impl RoomEvents {
             .collect();
 
         (deduplicated_events, duplicated_event_ids)
+    }
+
+    /// Return a nice debug string (a vector of lines) for the linked chunk of
+    /// events for this room.
+    pub fn debug_string(&self) -> Vec<String> {
+        let mut result = Vec::new();
+        for c in self.chunks() {
+            let content = chunk_debug_string(c.content());
+            let line = format!("chunk #{}: {content}", c.identifier().index());
+            result.push(line);
+        }
+        result
     }
 }
 

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -816,9 +816,11 @@ mod private {
                     let items = vec
                         .into_iter()
                         .map(|event| {
-                            event
-                                .event_id()
-                                .map_or_else(|| "<no event id>".to_owned(), |id| id.to_string())
+                            // Limit event ids to 8 chars *after* the $.
+                            event.event_id().map_or_else(
+                                || "<no event id>".to_owned(),
+                                |id| id.as_str().chars().take(1 + 8).collect(),
+                            )
                         })
                         .collect::<Vec<_>>()
                         .join(", ");
@@ -857,7 +859,9 @@ mod private {
 
             raws.push(RawChunk {
                 content: ChunkContent::Items(vec![
-                    f.text_msg("hey").event_id(event_id!("$1")).into_sync(),
+                    f.text_msg("hey")
+                        .event_id(event_id!("$123456789101112131415617181920"))
+                        .into_sync(),
                     f.text_msg("you").event_id(event_id!("$2")).into_sync(),
                 ]),
                 identifier: CId::new(1),
@@ -875,7 +879,7 @@ mod private {
             let output = raw_chunks_debug_string(raws);
             assert_eq!(output.len(), 2);
             assert_eq!(&output[0], "chunk #0 (prev=<none>, next=1): gap['prev-token']");
-            assert_eq!(&output[1], "chunk #1 (prev=0, next=<none>): events[$1, $2]");
+            assert_eq!(&output[1], "chunk #1 (prev=0, next=<none>): events[$12345678, $2]");
         }
     }
 }


### PR DESCRIPTION
I think that this debug representation may show useful to understand issues. Just from using it a few minutes, I've identified a few issues related to storage:

- we shouldn't have empty items chunks; they should be removed, or even better, reused.
- we may have multiple prev-batch token that represent the same events, e.g. if we sync'd a room with timeline_limit=1, then with timeline_limit=20. Not sure if there's anything obvious to do about that.
  - edit: yes there is! do not store a prev-batch token when all the events (at least 1) returned from the backpagination are known. Should be a sufficiently good heuristic 🧠 

![image](https://github.com/user-attachments/assets/b6abb623-d4d5-4ed6-b114-373f3d9e587e)
