### PR TITLE
Use a type alias to allow bindings to take advantage of custom types

### DIFF
--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -17,6 +17,7 @@ use ruma::{
 use crate::{
     room_member::MembershipState,
     ruma::{MessageType, NotifyType},
+    utils::Timestamp,
     ClientError,
 };
 
@@ -33,8 +34,8 @@ impl TimelineEvent {
         self.0.sender().to_string()
     }
 
-    pub fn timestamp(&self) -> u64 {
-        self.0.origin_server_ts().0.into()
+    pub fn timestamp(&self) -> Timestamp {
+        self.0.origin_server_ts().into()
     }
 
     pub fn event_type(&self) -> Result<TimelineEventType, ClientError> {

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -13,7 +13,7 @@ use ruma::UserId;
 use tracing::{error, info};
 
 use super::RUNTIME;
-use crate::error::ClientError;
+use crate::{error::ClientError, utils::Timestamp};
 
 #[derive(uniffi::Object)]
 pub struct SessionVerificationEmoji {
@@ -46,7 +46,7 @@ pub struct SessionVerificationRequestDetails {
     device_id: String,
     display_name: Option<String>,
     /// First time this device was seen in milliseconds since epoch.
-    first_seen_timestamp: u64,
+    first_seen_timestamp: Timestamp,
 }
 
 #[matrix_sdk_ffi_macros::export(callback_interface)]
@@ -242,7 +242,7 @@ impl SessionVerificationController {
                     flow_id: request.flow_id().into(),
                     device_id: other_device_data.device_id().into(),
                     display_name: other_device_data.display_name().map(str::to_string),
-                    first_seen_timestamp: other_device_data.first_time_seen_ts().get().into(),
+                    first_seen_timestamp: other_device_data.first_time_seen_ts().into(),
                 });
             }
         }

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -22,6 +22,7 @@ use super::ProfileDetails;
 use crate::{
     error::ClientError,
     ruma::{ImageInfo, MediaSource, MediaSourceExt, Mentions, MessageType, PollKind},
+    utils::Timestamp,
 };
 
 impl From<matrix_sdk_ui::timeline::TimelineItemContent> for TimelineItemContent {
@@ -187,7 +188,7 @@ pub enum TimelineItemContent {
         max_selections: u64,
         answers: Vec<PollAnswer>,
         votes: HashMap<String, Vec<String>>,
-        end_time: Option<u64>,
+        end_time: Option<Timestamp>,
         has_been_edited: bool,
     },
     CallInvite,
@@ -319,7 +320,7 @@ pub struct Reaction {
 #[derive(Clone, uniffi::Record)]
 pub struct ReactionSenderData {
     pub sender_id: String,
-    pub timestamp: u64,
+    pub timestamp: Timestamp,
 }
 
 #[derive(Clone, uniffi::Enum)]
@@ -481,7 +482,7 @@ impl From<PollResult> for TimelineItemContent {
                 .map(|i| PollAnswer { id: i.id, text: i.text })
                 .collect(),
             votes: value.votes,
-            end_time: value.end_time,
+            end_time: value.end_time.map(|t| t.into()),
             has_been_edited: value.has_been_edited,
         }
     }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -75,6 +75,7 @@ use crate::{
         VideoInfo,
     },
     task_handle::TaskHandle,
+    utils::Timestamp,
     RUNTIME,
 };
 
@@ -986,7 +987,7 @@ impl TimelineItem {
     pub fn as_virtual(self: Arc<Self>) -> Option<VirtualTimelineItem> {
         use matrix_sdk_ui::timeline::VirtualTimelineItem as VItem;
         match self.0.as_virtual()? {
-            VItem::DateDivider(ts) => Some(VirtualTimelineItem::DateDivider { ts: ts.0.into() }),
+            VItem::DateDivider(ts) => Some(VirtualTimelineItem::DateDivider { ts: (*ts).into() }),
             VItem::ReadMarker => Some(VirtualTimelineItem::ReadMarker),
         }
     }
@@ -1081,7 +1082,7 @@ pub struct EventTimelineItem {
     is_own: bool,
     is_editable: bool,
     content: TimelineItemContent,
-    timestamp: u64,
+    timestamp: Timestamp,
     reactions: Vec<Reaction>,
     local_send_state: Option<EventSendState>,
     read_receipts: HashMap<String, Receipt>,
@@ -1101,7 +1102,7 @@ impl From<matrix_sdk_ui::timeline::EventTimelineItem> for EventTimelineItem {
                     .into_iter()
                     .map(|(sender_id, info)| ReactionSenderData {
                         sender_id: sender_id.to_string(),
-                        timestamp: info.timestamp.0.into(),
+                        timestamp: info.timestamp.into(),
                     })
                     .collect(),
             })
@@ -1118,7 +1119,7 @@ impl From<matrix_sdk_ui::timeline::EventTimelineItem> for EventTimelineItem {
             is_own: item.is_own(),
             is_editable: item.is_editable(),
             content: item.content().clone().into(),
-            timestamp: item.timestamp().0.into(),
+            timestamp: item.timestamp().into(),
             reactions,
             local_send_state: item.send_state().map(|s| s.into()),
             read_receipts,
@@ -1131,12 +1132,12 @@ impl From<matrix_sdk_ui::timeline::EventTimelineItem> for EventTimelineItem {
 
 #[derive(Clone, uniffi::Record)]
 pub struct Receipt {
-    pub timestamp: Option<u64>,
+    pub timestamp: Option<Timestamp>,
 }
 
 impl From<ruma::events::receipt::Receipt> for Receipt {
     fn from(value: ruma::events::receipt::Receipt) -> Self {
-        Receipt { timestamp: value.ts.map(|ts| ts.0.into()) }
+        Receipt { timestamp: value.ts.map(|ts| ts.into()) }
     }
 }
 
@@ -1260,7 +1261,7 @@ pub enum VirtualTimelineItem {
     DateDivider {
         /// A timestamp in milliseconds since Unix Epoch on that day in local
         /// time.
-        ts: u64,
+        ts: Timestamp,
     },
 
     /// The user's own read marker.

--- a/bindings/matrix-sdk-ffi/src/utils.rs
+++ b/bindings/matrix-sdk-ffi/src/utils.rs
@@ -15,8 +15,19 @@
 use std::{mem::ManuallyDrop, ops::Deref};
 
 use async_compat::TOKIO1 as RUNTIME;
-use ruma::UInt;
+use ruma::{MilliSecondsSinceUnixEpoch, UInt};
 use tracing::warn;
+
+#[derive(Debug, Clone)]
+pub struct Timestamp(u64);
+
+impl From<MilliSecondsSinceUnixEpoch> for Timestamp {
+    fn from(date: MilliSecondsSinceUnixEpoch) -> Self {
+        Self(date.0.into())
+    }
+}
+
+uniffi::custom_newtype!(Timestamp, u64);
 
 pub(crate) fn u64_to_uint(u: u64) -> UInt {
     UInt::new(u).unwrap_or_else(|| {

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/polls.rs
@@ -146,7 +146,7 @@ impl PollState {
                 .iter()
                 .map(|i| ((*i.0).to_owned(), i.1.iter().map(|i| i.to_string()).collect()))
                 .collect(),
-            end_time: self.end_event_timestamp.map(|millis| millis.0.into()),
+            end_time: self.end_event_timestamp,
             has_been_edited: self.has_been_edited,
         }
     }
@@ -178,7 +178,7 @@ pub struct PollResult {
     pub max_selections: u64,
     pub answers: Vec<PollResultAnswer>,
     pub votes: HashMap<String, Vec<String>>,
-    pub end_time: Option<u64>,
+    pub end_time: Option<MilliSecondsSinceUnixEpoch>,
     pub has_been_edited: bool,
 }
 


### PR DESCRIPTION
This PR adds a new type alias to the matrix-sdk-ffi crate called Date64.  This is aliased to u64 for backwards compatibility (so no change to Swift/Kotlin as is), but as a distinct type it will allow uniffi integrations to customize the unpacking of the type automatically: https://mozilla.github.io/uniffi-rs/latest/udl/custom_types.html

Using this, it is possible to make the uniffi layer automatically convert these from u64 -> an appropriate system Date class in the generated code layer.  

Today a `u64` type can mean either a count or a date, so without an alias implementing a customType would not be possible.  At the very least, the type helps improve the documentation, even if individual bindings choose not to adopt this in their UDL configs.

Signed-off-by: Daniel Salinas
