### PR TITLE
feat(room): Separate `RoomState::Ban` from `RoomState::Left`.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -50,6 +50,7 @@ pub enum Membership {
     Joined,
     Left,
     Knocked,
+    Banned,
 }
 
 impl From<RoomState> for Membership {
@@ -59,6 +60,7 @@ impl From<RoomState> for Membership {
             RoomState::Joined => Membership::Joined,
             RoomState::Left => Membership::Left,
             RoomState::Knocked => Membership::Knocked,
+            RoomState::Banned => Membership::Banned,
         }
     }
 }


### PR DESCRIPTION
This is needed to tell apart rooms in left and banned state in places like `RoomInfo` or `RoomPreview`.

The banned rooms will still count as left rooms in the sync processes.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
