### PR TITLE
crypto: extra logging in `OtherUserIdentity`

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -13,8 +13,12 @@ All notable changes to this project will be documented in this file.
   as parameter instead of a raw byte array. Use `DehydratedDeviceKey::from_bytes` to migrate.
   ([#4383](https://github.com/matrix-org/matrix-rust-sdk/pull/4383))
 
+- Add extra logging in `OtherUserIdentity::pin_current_master_key` and
+  `OtherUserIdentity::withdraw_verification`.
+  ([#4415](https://github.com/matrix-org/matrix-rust-sdk/pull/4415))
+
 - Added new `UtdCause` variants `WithheldForUnverifiedOrInsecureDevice` and `WithheldBySender`.
-  These variants provide clearer categorization for expected Unable-To-Decrypt (UTD) errors 
+  These variants provide clearer categorization for expected Unable-To-Decrypt (UTD) errors
   when the sender either did not wish to share or was unable to share the room_key.
   ([#4305](https://github.com/matrix-org/matrix-rust-sdk/pull/4305))
 

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -31,7 +31,7 @@ use ruma::{
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
-use tracing::error;
+use tracing::{error, info};
 
 use crate::{
     error::SignatureError,
@@ -392,6 +392,7 @@ impl OtherUserIdentity {
 
     /// Pin the current identity (public part of the master signing key).
     pub async fn pin_current_master_key(&self) -> Result<(), CryptoStoreError> {
+        info!(master_key = ?self.master_key.get_first_key(), "Pinning current identity for user '{}'", self.user_id());
         self.inner.pin();
         let to_save = UserIdentityData::Other(self.inner.clone());
         let changes = Changes {
@@ -427,6 +428,7 @@ impl OtherUserIdentity {
 
     /// Remove the requirement for this identity to be verified.
     pub async fn withdraw_verification(&self) -> Result<(), CryptoStoreError> {
+        info!(master_key = ?self.master_key.get_first_key(), "Withdrawing verification status and pinning current identity for user '{}'", self.user_id());
         self.inner.withdraw_verification();
         let to_save = UserIdentityData::Other(self.inner.clone());
         let changes = Changes {


### PR DESCRIPTION
Add some extra logging in these two methods, to try to narrow down a bug report
we received.

<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)