### PR TITLE
chore(sdk): Remove image-rayon cargo feature check from build.rs

### DIFF
--- a/crates/matrix-sdk/build.rs
+++ b/crates/matrix-sdk/build.rs
@@ -39,9 +39,5 @@ fn main() {
             !env_is_set("CARGO_FEATURE_SSO_LOGIN"),
             "feature 'sso-login' is not available on target arch 'wasm32'",
         );
-        ensure(
-            !env_is_set("CARGO_FEATURE_IMAGE_RAYON"),
-            "feature 'image-rayon' is not available on target arch 'wasm32'",
-        );
     }
 }


### PR DESCRIPTION
The cargo feature was removed in #4132, but the build script was forgotten.
