### PR TITLE
task(crypto): Support receiving stable identifier for MSC4147

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+- Accept stable identifier `sender_device_keys` for MSC4147 (Including device
+  keys with Olm-encrypted events).
+  ([#4420](https://github.com/matrix-org/matrix-rust-sdk/pull/4420))
+
 ## [0.9.0] - 2024-12-18
 
 - Expose new API `DehydratedDevices::get_dehydrated_device_pickle_key`, `DehydratedDevices::save_dehydrated_device_pickle_key`

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
@@ -171,7 +171,7 @@ impl<'a> SenderDataFinder<'a> {
         room_key_event: &'a DecryptedRoomKeyEvent,
     ) -> Result<SenderData, SessionDeviceKeysCheckError> {
         // Does the to-device message contain the device_keys property from MSC4147?
-        if let Some(sender_device_keys) = &room_key_event.device_keys {
+        if let Some(sender_device_keys) = &room_key_event.sender_device_keys {
             // Yes: use the device keys to continue.
 
             // Validate the signature of the DeviceKeys supplied.

--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -380,6 +380,6 @@ mod tests {
         // DecryptedOlmV1Event
         let event: DecryptedOlmV1Event<DummyEventContent> =
             serde_json::from_str(&bob_session_result.plaintext).unwrap();
-        assert_eq!(event.device_keys.unwrap(), alice.device_keys());
+        assert_eq!(event.sender_device_keys.unwrap(), alice.device_keys());
     }
 }

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -1027,7 +1027,7 @@ macro_rules! cryptostore_integration_tests {
                     recipient_keys: OlmV1Keys {
                         ed25519: account.identity_keys().ed25519,
                     },
-                    device_keys: None,
+                    sender_device_keys: None,
                     content: SecretSendContent::new(id.to_owned(), secret.to_owned()),
                 };
 


### PR DESCRIPTION
Part of https://github.com/element-hq/element-meta/issues/2665

On the receiving side, allow `sender_device_keys` as well as `org.matrix.msc4147.device_keys` for the sender's device keys in to-device event. Once this has time to bed in, we will change the sending side to use this stable identifier since the MSC has been merged.

- [x] Public API changes documented in changelogs (optional)