### PR TITLE
feat(room): add `Room::remove_outdated_seen_knock_requests_ids` method

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -924,13 +924,15 @@ impl Room {
         self: Arc<Self>,
         listener: Box<dyn KnockRequestsListener>,
     ) -> Result<Arc<TaskHandle>, ClientError> {
-        let stream = self.inner.subscribe_to_knock_requests().await?;
+        let (stream, seen_ids_cleanup_handle) = self.inner.subscribe_to_knock_requests().await?;
 
         let handle = Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
             pin_mut!(stream);
             while let Some(requests) = stream.next().await {
                 listener.call(requests.into_iter().map(Into::into).collect());
             }
+            // Cancel the seen ids cleanup task
+            seen_ids_cleanup_handle.abort();
         })));
 
         Ok(handle)

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -37,6 +37,7 @@ mod rooms;
 
 pub mod read_receipts;
 pub use read_receipts::PreviousEventsProvider;
+pub use rooms::RoomMembersUpdate;
 #[cfg(feature = "experimental-sliding-sync")]
 pub mod sliding_sync;
 

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -12,8 +12,8 @@ use std::{
 use bitflags::bitflags;
 pub use members::RoomMember;
 pub use normal::{
-    Room, RoomHero, RoomInfo, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons, RoomState,
-    RoomStateFilter,
+    Room, RoomHero, RoomInfo, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons,
+    RoomMembersUpdate, RoomState, RoomStateFilter,
 };
 use regex::Regex;
 use ruma::{

--- a/crates/matrix-sdk/src/test_utils/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mod.rs
@@ -117,6 +117,18 @@ macro_rules! assert_next_with_timeout {
     }};
 }
 
+/// Asserts the next item in a `Receiver` can be loaded in the given timeout in
+/// milliseconds.
+#[macro_export]
+macro_rules! assert_recv_with_timeout {
+    ($receiver:expr, $timeout_ms:expr) => {{
+        tokio::time::timeout(std::time::Duration::from_millis($timeout_ms), $receiver.recv())
+            .await
+            .expect("Next event timed out")
+            .expect("No next event received")
+    }};
+}
+
 /// Assert the next item in a `Stream` or `Subscriber` matches the provided
 /// pattern in the given timeout in milliseconds.
 ///


### PR DESCRIPTION
In a previous PR (https://github.com/matrix-org/matrix-rust-sdk/pull/4338) we introduced the concept of a 'seen' knock request id, that is, a member event with knock membership that the current user has seen and decided to explicitly ignore so it can be filtered out in the future in the clients and won't clutter the UI. However, if left alone this list will only grow indefinitely, so we need a way to observe the changes in knock room members in the room and remove outdated seen request ids.

Take this PR as a follow-up of the one mentioned above.

A new `matrix_sdk_base::room_member_updates_sender` field was added too, which will broadcast when a room members update is received, both when loading the room members from the HS and when new member state events are received in a sync.

On `fn Room::subscribe_to_knock_requests` a new cleanup task is also spawned to listen to these broadcast and call the `fn Room::remove_outdated_seen_knock_requests_ids`, which will compare the existing seen knock request ids with the room members having a knock membership state in the room and discard the seen knock request ids that are no longer valid.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
