### PR TITLE
feat(event cache): don't replace a gap chunk by an empty items chunks

### DIFF
--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -178,12 +178,9 @@ impl RoomPagination {
                 let insert_new_gap_pos = if let Some(gap_id) = prev_gap_id {
                     // There is a prior gap, let's replace it by new events!
                     trace!("replaced gap with new events from backpagination");
-                    Some(
-                        room_events
-                            .replace_gap_at(sync_events, gap_id)
-                            .expect("gap_identifier is a valid chunk id we read previously")
-                            .first_position(),
-                    )
+                    room_events
+                        .replace_gap_at(sync_events, gap_id)
+                        .expect("gap_identifier is a valid chunk id we read previously")
                 } else if let Some(pos) = first_event_pos {
                     // No prior gap, but we had some events: assume we need to prepend events
                     // before those.


### PR DESCRIPTION
It was simpler to add a new function rather than trying to fiddle with `replace_gap_at`, especially in terms of the return type of this function. After a few back-and-forth, they're close enough that we could probably merge them together, if you have strong opinions about it.

This was the only place where we'd create an empty chunk, so with this, the storage doesn't keep empty chunks anymore \o/

Part of #3280.