### PR TITLE
feat(event cache): avoid storing useless prev-batch tokens

### DIFF
--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -62,7 +62,7 @@ mod pagination;
 mod room;
 
 pub mod paginator;
-pub use pagination::{RoomPagination, TimelineHasBeenResetWhilePaginating};
+pub use pagination::{PaginationToken, RoomPagination, TimelineHasBeenResetWhilePaginating};
 pub use room::RoomEventCache;
 
 /// An error observed in the [`EventCache`].

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -280,6 +280,29 @@ impl RoomPagination {
     }
 }
 
+/// Pagination token data, indicating in which state is the current pagination.
+#[derive(Clone, Debug)]
+pub(super) enum PaginationToken {
+    /// We never had a pagination token, so we'll start back-paginating from the
+    /// end, or forward-paginating from the start.
+    None,
+    /// We paginated once before, and we received a prev/next batch token that
+    /// we may reuse for the next query.
+    HasMore(String),
+    /// We've hit one end of the timeline (either the start or the actual end),
+    /// so there's no need to continue paginating.
+    HitEnd,
+}
+
+impl From<Option<String>> for PaginationToken {
+    fn from(token: Option<String>) -> Self {
+        match token {
+            Some(val) => Self::HasMore(val),
+            None => Self::None,
+        }
+    }
+}
+
 /// A type representing whether the timeline has been reset.
 #[derive(Debug)]
 pub enum TimelineHasBeenResetWhilePaginating {

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -209,14 +209,22 @@ impl RoomPagination {
                 };
 
                 // And insert the new gap if needs be.
-                if let Some(new_gap) = new_gap {
-                    if let Some(new_pos) = insert_new_gap_pos {
-                        room_events
-                            .insert_gap_at(new_gap, new_pos)
-                            .expect("events_chunk_pos represents a valid chunk position");
-                    } else {
-                        room_events.push_gap(new_gap);
+                //
+                // We only do this when at least one new, non-duplicated event, has been added
+                // to the chunk. Otherwise it means we've back-paginated all the
+                // known events.
+                if !add_event_report.deduplicated_all_new_events() {
+                    if let Some(new_gap) = new_gap {
+                        if let Some(new_pos) = insert_new_gap_pos {
+                            room_events
+                                .insert_gap_at(new_gap, new_pos)
+                                .expect("events_chunk_pos represents a valid chunk position");
+                        } else {
+                            room_events.push_gap(new_gap);
+                        }
                     }
+                } else {
+                    debug!("not storing previous batch token, because we deduplicated all new back-paginated events");
                 }
 
                 BackPaginationOutcome { events, reached_start }

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -185,7 +185,7 @@ impl RoomPagination {
                 let first_event_pos = room_events.events().next().map(|(item_pos, _)| item_pos);
 
                 // First, insert events.
-                let (add_event_report, insert_new_gap_pos) = if let Some(gap_id) = prev_gap_id {
+                let (added_unique_events, insert_new_gap_pos) = if let Some(gap_id) = prev_gap_id {
                     // There is a prior gap, let's replace it by new events!
                     trace!("replaced gap with new events from backpagination");
                     room_events
@@ -213,7 +213,7 @@ impl RoomPagination {
                 // We only do this when at least one new, non-duplicated event, has been added
                 // to the chunk. Otherwise it means we've back-paginated all the
                 // known events.
-                if !add_event_report.deduplicated_all_new_events() {
+                if added_unique_events {
                     if let Some(new_gap) = new_gap {
                         if let Some(new_pos) = insert_new_gap_pos {
                             room_events

--- a/crates/matrix-sdk/src/event_cache/paginator.rs
+++ b/crates/matrix-sdk/src/event_cache/paginator.rs
@@ -23,6 +23,7 @@ use eyeball::{SharedObservable, Subscriber};
 use matrix_sdk_base::{deserialized_responses::TimelineEvent, SendOutsideWasm, SyncOutsideWasm};
 use ruma::{api::Direction, EventId, OwnedEventId, UInt};
 
+use super::pagination::PaginationToken;
 use crate::{
     room::{EventWithContextResponse, Messages, MessagesOptions, WeakRoom},
     Room,
@@ -65,29 +66,6 @@ pub enum PaginatorError {
     /// There was another SDK error while paginating.
     #[error("an error happened while paginating")]
     SdkError(#[from] Box<crate::Error>),
-}
-
-/// Pagination token data, indicating in which state is the current pagination.
-#[derive(Clone, Debug)]
-enum PaginationToken {
-    /// We never had a pagination token, so we'll start back-paginating from the
-    /// end, or forward-paginating from the start.
-    None,
-    /// We paginated once before, and we received a prev/next batch token that
-    /// we may reuse for the next query.
-    HasMore(String),
-    /// We've hit one end of the timeline (either the start or the actual end),
-    /// so there's no need to continue paginating.
-    HitEnd,
-}
-
-impl From<Option<String>> for PaginationToken {
-    fn from(token: Option<String>) -> Self {
-        match token {
-            Some(val) => Self::HasMore(val),
-            None => Self::None,
-        }
-    }
 }
 
 /// Paginations tokens used for backward and forward pagination.

--- a/crates/matrix-sdk/src/event_cache/paginator.rs
+++ b/crates/matrix-sdk/src/event_cache/paginator.rs
@@ -64,7 +64,7 @@ pub enum PaginatorError {
     },
 
     /// There was another SDK error while paginating.
-    #[error("an error happened while paginating")]
+    #[error("an error happened while paginating: {0}")]
     SdkError(#[from] Box<crate::Error>),
 }
 

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -135,7 +135,7 @@ impl RoomEventCache {
     /// storage.
     pub async fn clear(&self) -> Result<()> {
         // Clear the linked chunk and persisted storage.
-        self.inner.state.write().await.clear().await?;
+        self.inner.state.write().await.reset().await?;
 
         // Clear the (temporary) events mappings.
         self.inner.all_events.write().await.clear();
@@ -721,14 +721,6 @@ mod private {
             };
 
             Ok(Self { room, store, events, waited_for_initial_prev_token: false })
-        }
-
-        /// Clear all cached content for this [`RoomEventCacheState`].
-        pub async fn clear(&mut self) -> Result<(), EventCacheError> {
-            self.events.reset();
-            self.propagate_changes().await?;
-            self.waited_for_initial_prev_token = false;
-            Ok(())
         }
 
         /// Removes the bundled relations from an event, if they were present.

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -1100,3 +1100,105 @@ async fn test_no_gap_stored_after_deduplicated_sync() {
     assert_event_matches_msg(&events[2], "sup");
     assert_eq!(events.len(), 3);
 }
+
+#[async_test]
+async fn test_no_gap_stored_after_deduplicated_backpagination() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let event_cache = client.event_cache();
+
+    // Immediately subscribe the event cache to sync updates.
+    event_cache.subscribe().unwrap();
+    event_cache.enable_storage().unwrap();
+
+    let room_id = room_id!("!omelette:fromage.fr");
+
+    let f = EventFactory::new().room(room_id).sender(user_id!("@a:b.c"));
+
+    // Start with a room with a single event, limited timeline and prev-batch token.
+    let room = server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.text_msg("sup").event_id(event_id!("$3")).into_raw_sync())
+                .set_timeline_limited()
+                .set_timeline_prev_batch("prev-batch".to_owned()),
+        )
+        .await;
+
+    let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
+
+    let (events, mut stream) = room_event_cache.subscribe().await.unwrap();
+    if events.is_empty() {
+        let update = stream.recv().await.expect("read error");
+        assert_matches!(update, RoomEventCacheUpdate::AddTimelineEvents { .. });
+    }
+    drop(events);
+
+    // Now, simulate that we expanded the timeline window with sliding sync, by
+    // returning more items.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_bulk(vec![
+                    f.text_msg("hello").event_id(event_id!("$1")).into_raw_sync(),
+                    f.text_msg("world").event_id(event_id!("$2")).into_raw_sync(),
+                    f.text_msg("sup").event_id(event_id!("$3")).into_raw_sync(),
+                ])
+                .set_timeline_limited()
+                .set_timeline_prev_batch("prev-batch2".to_owned()),
+        )
+        .await;
+
+    // For prev-batch2, the back-pagination returns nothing.
+    server
+        .mock_room_messages()
+        .from("prev-batch2")
+        .ok("start-token-unused".to_owned(), None, Vec::<Raw<AnyTimelineEvent>>::new(), Vec::new())
+        .mock_once()
+        .mount()
+        .await;
+
+    // For prev-batch, the back-pagination returns two events we already know, and a
+    // previous batch token.
+    server
+        .mock_room_messages()
+        .from("prev-batch")
+        .ok(
+            "start-token-unused".to_owned(),
+            Some("prev-batch3".to_owned()),
+            vec![
+                // Items in reverse order, since this is back-pagination.
+                f.text_msg("world").event_id(event_id!("$2")).into_raw_timeline(),
+                f.text_msg("hello").event_id(event_id!("$1")).into_raw_timeline(),
+            ],
+            Vec::new(),
+        )
+        .mock_once()
+        .mount()
+        .await;
+
+    let pagination = room_event_cache.pagination();
+
+    // Run pagination once: it will consume prev-batch2 first, which is the most
+    // recent token.
+    pagination.run_backwards(20, once).await.unwrap();
+
+    // Run pagination a second time: it will consume prev-batch, which is the least
+    // recent token.
+    pagination.run_backwards(20, once).await.unwrap();
+
+    // If this back-pagination fails, that's because we've stored a gap that's
+    // useless. It should be short-circuited because storing the previous gap was
+    // useless.
+    let outcome = pagination.run_backwards(20, once).await.unwrap();
+    assert!(outcome.reached_start);
+
+    let (events, _stream) = room_event_cache.subscribe().await.unwrap();
+    assert_event_matches_msg(&events[0], "hello");
+    assert_event_matches_msg(&events[1], "world");
+    assert_event_matches_msg(&events[2], "sup");
+    assert_eq!(events.len(), 3);
+}


### PR DESCRIPTION
We have a problem right now, with the event cache storage: as soon as you receive a previous-batch token, either from the sync or from a previous back-pagination, we consider that we may have more events to retrieve in the past. Later, after running back-paginations, we may realize those events are duplicated. But since a back-pagination will return another previous-batch token, until we hit the start of the timeline, then we're getting stuck in back-pagination mode, until we've reached the start of the timeline again.

That's bad, because it makes the event cache store basically useless: every time you restore a session, you may receive a previous-batch token from sync (even more so with sliding sync, which will give one previous-batch token when timeline_limit=1, then another one when the timeline limit expands to 20). And so you back-paginate back until the start of the history.

This series of commits fixes that, by introducing two new rules:

- in back-pagination, don't assume the absence of a gap always means we're waiting for a prev-batch token from sync. This is only true if there was no events stored in the linked chunk before; if there's any, then we don't need to restart back-pagination from the end of the timeline to the beginning.
- in back-pagination or sync, don't store a previous-batch token, if all the events (at least one) we've received were already known (and are duplicated).

With these two rules, we're not storing useless previous-batch tokens anymore, and we'll back-paginate at most one, for a given room. Interestingly, this might uncover some bugs related to back-pagination orderings, so we'll desperately want https://github.com/matrix-org/matrix-rust-sdk/pull/4408 <3

Part of #3280.