### PR TITLE
test(snapshot): Use snapshot testing in sdk-common

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Insta.rs is run directly via cargo test. We don't want insta.rs to create new snapshots files.
+  # Just want it to run the tests (option `no` instead of `auto`).
+  INSTA_UPDATE: no
 
 jobs:
   xtask:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,33 @@ integration tests that need a running synapse instance. These tests reside in
 synapse for testing purposes.
 
 
+### Snapshot Testing
+
+You can add/review snapshot tests using [insta.rs](https://insta.rs)
+
+Every new struct/enum that derives `Serialize` `Deserialise` should have a snapshot test for it.
+Any code change that breaks serialisation will then break a test, the author will then have to decide
+how to handle migration and test it if needed.
+
+
+And for an improved review experience it's recommended (but not necessary) to install the cargo-insta tool:
+
+Unix:
+```
+curl -LsSf https://insta.rs/install.sh | sh
+```
+
+Windows:
+```
+powershell -c "irm https://insta.rs/install.ps1 | iex"
+```
+
+Usual flow is to first run the test, then review them.
+```
+cargo insta test
+cargo insta review
+```
+
 ## Pull requests
 
 Ideally, a PR should have a *proper title*, with *atomic logical commits*, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,6 +2596,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2788,6 +2801,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3170,6 +3189,7 @@ dependencies = [
  "getrandom",
  "gloo-timers",
  "imbl",
+ "insta",
  "js-sys",
  "matrix-sdk-test-macros",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ hmac = "0.12.1"
 http = "1.1.0"
 imbl = "3.0.0"
 indexmap = "2.6.0"
+insta = { version = "1.41.1", features = ["json"] }
 itertools = "0.13.0"
 js-sys = "0.3.69"
 mime = "0.3.17"
@@ -124,6 +125,9 @@ debug = 0
 # for the extra time of optimizing it for a clean build of matrix-sdk-ffi.
 quote = { opt-level = 2 }
 sha2 = { opt-level = 2 }
+# faster runs for insta.rs snapshot testing
+insta.opt-level = 3
+similar.opt-level = 3
 
 # Custom profile with full debugging info, use `--profile dbg` to select
 [profile.dbg]

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -46,6 +46,7 @@ assert_matches = { workspace = true }
 proptest = { workspace = true }
 matrix-sdk-test-macros = { path = "../../testing/matrix-sdk-test-macros" }
 wasm-bindgen-test = { workspace = true }
+insta = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Enable the test macro.

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_algorithm_info.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_algorithm_info.snap
@@ -1,0 +1,13 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: info
+---
+{
+  "MegolmV1AesSha2": {
+    "curve25519_key": "curvecurvecurve",
+    "sender_claimed_keys": {
+      "ed25519": "claimedclaimeded25519",
+      "curve25519": "claimedclaimedcurve25519"
+    }
+  }
+}

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_encryption_info.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_encryption_info.snap
@@ -1,0 +1,15 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: info
+---
+{
+  "sender": "@alice:localhost",
+  "sender_device": "ABCDEFGH",
+  "algorithm_info": {
+    "MegolmV1AesSha2": {
+      "curve25519_key": "curvecurvecurve",
+      "sender_claimed_keys": {}
+    }
+  },
+  "verification_state": "Verified"
+}

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_codes-2.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_codes-2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&code).unwrap()"
+---
+"UnknownDevice"

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_codes-3.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_codes-3.snap
@@ -1,0 +1,5 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&code).unwrap()"
+---
+"UnsignedDevice"

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_codes-4.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_codes-4.snap
@@ -1,0 +1,5 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&code).unwrap()"
+---
+"UnverifiedIdentity"

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_codes-5.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_codes-5.snap
@@ -1,0 +1,5 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&code).unwrap()"
+---
+"SentInClear"

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_codes-6.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_codes-6.snap
@@ -1,0 +1,5 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&code).unwrap()"
+---
+"VerificationViolation"

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_codes.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_codes.snap
@@ -1,0 +1,5 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&code).unwrap()"
+---
+"AuthenticityNotGuaranteed"

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_states-2.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_states-2.snap
@@ -1,0 +1,10 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&state).unwrap()"
+---
+{
+  "Red": {
+    "code": "UnverifiedIdentity",
+    "message": "a message"
+  }
+}

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_states-3.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_states-3.snap
@@ -1,0 +1,10 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&state).unwrap()"
+---
+{
+  "Grey": {
+    "code": "AuthenticityNotGuaranteed",
+    "message": "authenticity of this message cannot be guaranteed"
+  }
+}

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_states.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_shield_states.snap
@@ -1,0 +1,5 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&state).unwrap()"
+---
+"None"

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_sync_timeline_event.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_sync_timeline_event.snap
@@ -1,0 +1,47 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&room_event).unwrap()"
+---
+{
+  "kind": {
+    "Decrypted": {
+      "encryption_info": {
+        "algorithm_info": {
+          "MegolmV1AesSha2": {
+            "curve25519_key": "xxx",
+            "sender_claimed_keys": {
+              "curve25519": "qzdW3F5IMPFl0HQgz5w/L5Oi/npKUFn8Um84acIHfPY",
+              "ed25519": "I3YsPwqMZQXHkSQbjFNEs7b529uac2xBpI83eN3LUXo"
+            }
+          }
+        },
+        "sender": "@sender:example.com",
+        "sender_device": "ABCDEFGHIJ",
+        "verification_state": "Verified"
+      },
+      "event": {
+        "content": {
+          "body": "secret",
+          "msgtype": "m.text"
+        },
+        "event_id": "$xxxxx:example.org",
+        "origin_server_ts": 2189,
+        "room_id": "!someroom:example.com",
+        "sender": "@carl:example.com",
+        "type": "m.room.message"
+      },
+      "unsigned_encryption_info": {
+        "RelationsThreadLatestEvent": {
+          "UnableToDecrypt": {
+            "reason": {
+              "MissingMegolmSession": {
+                "withheld_code": "m.unverified"
+              }
+            },
+            "session_id": "xyz"
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_level-2.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_level-2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&level).unwrap()"
+---
+"UnsignedDevice"

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_level-3.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_level-3.snap
@@ -1,0 +1,7 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&level).unwrap()"
+---
+{
+  "None": "InsecureSource"
+}

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_level-4.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_level-4.snap
@@ -1,0 +1,7 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&level).unwrap()"
+---
+{
+  "None": "MissingDevice"
+}

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_level-5.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_level-5.snap
@@ -1,0 +1,5 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&level).unwrap()"
+---
+"UnverifiedIdentity"

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_level.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_level.snap
@@ -1,0 +1,5 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&level).unwrap()"
+---
+"VerificationViolation"

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_states-2.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_states-2.snap
@@ -1,0 +1,7 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&state).unwrap()"
+---
+{
+  "Unverified": "VerificationViolation"
+}

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_states-3.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_states-3.snap
@@ -1,0 +1,9 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&state).unwrap()"
+---
+{
+  "Unverified": {
+    "None": "InsecureSource"
+  }
+}

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_states-4.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_states-4.snap
@@ -1,0 +1,9 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&state).unwrap()"
+---
+{
+  "Unverified": {
+    "None": "MissingDevice"
+  }
+}

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_states-5.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_states-5.snap
@@ -1,0 +1,5 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&state).unwrap()"
+---
+"Verified"

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_states.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__snapshot_test_verification_states.snap
@@ -1,0 +1,7 @@
+---
+source: crates/matrix-sdk-common/src/deserialized_responses.rs
+expression: "serde_json::to_value(&state).unwrap()"
+---
+{
+  "Unverified": "UnsignedDevice"
+}


### PR DESCRIPTION
Tentative to introduce snapshot testing using [insta.rs](https://insta.rs/).
Added some initial doc on the Contributing.md file

As a draft now, because I have some open questions on how to do things.

I need also to see what to do for CI

> Insta behaves differently in CI environments. For instance it will not write new snapshot files. This behavior is enabled by the CI environment variable. Please ensure that your CI system sets it.

`export CI=true`


<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
