### PR TITLE
Fix error loading older sender data from storage

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -260,6 +260,7 @@ pub enum ShieldStateCode {
     /// An unencrypted event in an encrypted room.
     SentInClear,
     /// The sender was previously verified but changed their identity.
+    #[serde(alias = "PreviouslyVerified")]
     VerificationViolation,
 }
 
@@ -809,7 +810,7 @@ mod tests {
         TimelineEventKind, UnableToDecryptInfo, UnableToDecryptReason, UnsignedDecryptionResult,
         UnsignedEventLocation, VerificationState,
     };
-    use crate::deserialized_responses::{DeviceLinkProblem, VerificationLevel};
+    use crate::deserialized_responses::{DeviceLinkProblem, ShieldStateCode, VerificationLevel};
 
     fn example_event() -> serde_json::Value {
         json!({
@@ -916,6 +917,40 @@ mod tests {
 
         // Then it is migrated to the new value
         assert_eq!(deserialized.verification_level, VerificationLevel::VerificationViolation);
+    }
+
+    #[test]
+    fn test_shield_state_code_deserializes() {
+        // Given a JSON ShieldStateCode with value VerificationViolation
+        #[derive(Deserialize)]
+        struct Container {
+            shield_state_code: ShieldStateCode,
+        }
+        let container = json!({ "shield_state_code": "VerificationViolation" });
+
+        // When we deserialize it
+        let deserialized: Container = serde_json::from_value(container)
+            .expect("We can deserialize the old PreviouslyVerified value");
+
+        // Then it is populated correctly
+        assert_eq!(deserialized.shield_state_code, ShieldStateCode::VerificationViolation);
+    }
+
+    #[test]
+    fn test_shield_state_code_deserializes_from_old_previously_verified_value() {
+        // Given a JSON ShieldStateCode with the old value PreviouslyVerified
+        #[derive(Deserialize)]
+        struct Container {
+            shield_state_code: ShieldStateCode,
+        }
+        let container = json!({ "shield_state_code": "PreviouslyVerified" });
+
+        // When we deserialize it
+        let deserialized: Container = serde_json::from_value(container)
+            .expect("We can deserialize the old PreviouslyVerified value");
+
+        // Then it is migrated to the new value
+        assert_eq!(deserialized.shield_state_code, ShieldStateCode::VerificationViolation);
     }
 
     #[test]

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -176,6 +176,7 @@ pub enum VerificationLevel {
 
     /// The message was sent by a user identity we have not verified, but the
     /// user was previously verified.
+    #[serde(alias = "PreviouslyVerified")]
     VerificationViolation,
 
     /// The message was sent by a device not linked to (signed by) any user
@@ -881,6 +882,40 @@ mod tests {
             deserialized.state,
             VerificationState::Unverified(VerificationLevel::UnsignedDevice)
         );
+    }
+
+    #[test]
+    fn test_verification_level_deserializes() {
+        // Given a JSON VerificationLevel
+        #[derive(Deserialize)]
+        struct Container {
+            verification_level: VerificationLevel,
+        }
+        let container = json!({ "verification_level": "VerificationViolation" });
+
+        // When we deserialize it
+        let deserialized: Container = serde_json::from_value(container)
+            .expect("We can deserialize the old PreviouslyVerified value");
+
+        // Then it is populated correctly
+        assert_eq!(deserialized.verification_level, VerificationLevel::VerificationViolation);
+    }
+
+    #[test]
+    fn test_verification_level_deserializes_from_old_previously_verified_value() {
+        // Given a JSON VerificationLevel with the old value PreviouslyVerified
+        #[derive(Deserialize)]
+        struct Container {
+            verification_level: VerificationLevel,
+        }
+        let container = json!({ "verification_level": "PreviouslyVerified" });
+
+        // When we deserialize it
+        let deserialized: Container = serde_json::from_value(container)
+            .expect("We can deserialize the old PreviouslyVerified value");
+
+        // Then it is migrated to the new value
+        assert_eq!(deserialized.verification_level, VerificationLevel::VerificationViolation);
     }
 
     #[test]

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -911,6 +911,7 @@ enum OwnUserIdentityVerifiedState {
     NeverVerified,
 
     /// We previously verified this identity, but it has changed.
+    #[serde(alias = "PreviouslyVerifiedButNoLonger")]
     VerificationViolation,
 
     /// We have verified the current identity.
@@ -1530,26 +1531,10 @@ pub(crate) mod tests {
     /// that we can deserialize boolean values.
     #[test]
     fn test_deserialize_own_user_identity_bool_verified() {
-        let mut json = json!({
-            "user_id": "@example:localhost",
-            "master_key": {
-                "user_id":"@example:localhost",
-                "usage":["master"],
-                "keys":{"ed25519:rJ2TAGkEOP6dX41Ksll6cl8K3J48l8s/59zaXyvl2p0":"rJ2TAGkEOP6dX41Ksll6cl8K3J48l8s/59zaXyvl2p0"},
-            },
-            "self_signing_key": {
-                "user_id":"@example:localhost",
-                "usage":["self_signing"],
-                "keys":{"ed25519:0C8lCBxrvrv/O7BQfsKnkYogHZX3zAgw3RfJuyiq210":"0C8lCBxrvrv/O7BQfsKnkYogHZX3zAgw3RfJuyiq210"}
-            },
-            "user_signing_key": {
-                "user_id":"@example:localhost",
-                "usage":["user_signing"],
-                "keys":{"ed25519:DU9z4gBFKFKCk7a13sW9wjT0Iyg7Hqv5f0BPM7DEhPo":"DU9z4gBFKFKCk7a13sW9wjT0Iyg7Hqv5f0BPM7DEhPo"}
-            },
-            "verified": false
-        });
+        let mut json = own_user_identity_data();
 
+        // Set `"verified": false`
+        *json.get_mut("verified").unwrap() = false.into();
         let id: OwnUserIdentityData = serde_json::from_value(json.clone()).unwrap();
         assert_eq!(*id.verified.read().unwrap(), OwnUserIdentityVerifiedState::NeverVerified);
 
@@ -1557,6 +1542,38 @@ pub(crate) mod tests {
         *json.get_mut("verified").unwrap() = true.into();
         let id: OwnUserIdentityData = serde_json::from_value(json.clone()).unwrap();
         assert_eq!(*id.verified.read().unwrap(), OwnUserIdentityVerifiedState::Verified);
+    }
+
+    #[test]
+    fn test_own_user_identity_verified_state_verification_violation_deserializes() {
+        // Given data containing verified: VerificationViolation
+        let mut json = own_user_identity_data();
+        *json.get_mut("verified").unwrap() = "VerificationViolation".into();
+
+        // When we deserialize
+        let id: OwnUserIdentityData = serde_json::from_value(json.clone()).unwrap();
+
+        // Then the value is correctly populated
+        assert_eq!(
+            *id.verified.read().unwrap(),
+            OwnUserIdentityVerifiedState::VerificationViolation
+        );
+    }
+
+    #[test]
+    fn test_own_user_identity_verified_state_previously_verified_deserializes() {
+        // Given data containing verified: PreviouslyVerifiedButNoLonger
+        let mut json = own_user_identity_data();
+        *json.get_mut("verified").unwrap() = "PreviouslyVerifiedButNoLonger".into();
+
+        // When we deserialize
+        let id: OwnUserIdentityData = serde_json::from_value(json.clone()).unwrap();
+
+        // Then the old value is re-interpreted as VerificationViolation
+        assert_eq!(
+            *id.verified.read().unwrap(),
+            OwnUserIdentityVerifiedState::VerificationViolation
+        );
     }
 
     #[test]
@@ -1894,5 +1911,27 @@ pub(crate) mod tests {
         assert!(!own_identity.is_verified());
         assert!(!own_identity.was_previously_verified());
         assert!(!own_identity.has_verification_violation());
+    }
+
+    fn own_user_identity_data() -> Value {
+        json!({
+            "user_id": "@example:localhost",
+            "master_key": {
+                "user_id":"@example:localhost",
+                "usage":["master"],
+                "keys":{"ed25519:rJ2TAGkEOP6dX41Ksll6cl8K3J48l8s/59zaXyvl2p0":"rJ2TAGkEOP6dX41Ksll6cl8K3J48l8s/59zaXyvl2p0"},
+            },
+            "self_signing_key": {
+                "user_id":"@example:localhost",
+                "usage":["self_signing"],
+                "keys":{"ed25519:0C8lCBxrvrv/O7BQfsKnkYogHZX3zAgw3RfJuyiq210":"0C8lCBxrvrv/O7BQfsKnkYogHZX3zAgw3RfJuyiq210"}
+            },
+            "user_signing_key": {
+                "user_id":"@example:localhost",
+                "usage":["user_signing"],
+                "keys":{"ed25519:DU9z4gBFKFKCk7a13sW9wjT0Iyg7Hqv5f0BPM7DEhPo":"DU9z4gBFKFKCk7a13sW9wjT0Iyg7Hqv5f0BPM7DEhPo"}
+            },
+            "verified": false
+        })
     }
 }


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/4424 in the release-for-crypto-wasm-11 branch

Rebased version of https://github.com/matrix-org/matrix-rust-sdk/pull/4425 on top of the newly-created `release-for-crypto-wasm-11` branch.