### PR TITLE
refactor!(client): replace the optional `RequestConfig` arg to `Client::send()` with a `with_request_config()` builder method

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -449,15 +449,12 @@ impl Room {
         let int_score = score.map(|value| value.into());
         self.inner
             .client()
-            .send(
-                report_content::v3::Request::new(
-                    self.inner.room_id().into(),
-                    event_id,
-                    int_score,
-                    reason,
-                ),
-                None,
-            )
+            .send(report_content::v3::Request::new(
+                self.inner.room_id().into(),
+                event_id,
+                int_score,
+                reason,
+            ))
             .await?;
         Ok(())
     }

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Refactor
+
+- [**breaking**] Move the optional `RequestConfig` argument of the
+  `Client::send()` method to the `with_request_config()` builder method. You
+  should call `Client::send(request).with_request_config(request_config).awat`
+  now instead.
+
 ## [0.9.0] - 2024-12-18
 
 ### Bug Fixes

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -77,6 +77,13 @@ impl<R> SendRequest<R> {
         self
     }
 
+    /// Use the given [`RequestConfig`] for this send request, instead of the
+    /// one provided by default.
+    pub fn with_request_config(mut self, request_config: impl Into<Option<RequestConfig>>) -> Self {
+        self.config = request_config.into();
+        self
+    }
+
     /// Get a subscriber to observe the progress of sending the request
     /// body.
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -136,7 +136,7 @@ impl Backups {
 
             let algorithm = Raw::new(&backup_info)?.cast();
             let request = create_backup_version::v3::Request::new(algorithm);
-            let response = self.client.send(request, Default::default()).await?;
+            let response = self.client.send(request).await?;
             let version = response.version;
 
             // Reset any state we might have had before the new backup was created.
@@ -454,7 +454,7 @@ impl Backups {
             if let Some(version) = backup_keys.backup_version {
                 let request =
                     get_backup_keys_for_room::v3::Request::new(version.clone(), room_id.to_owned());
-                let response = self.client.send(request, Default::default()).await?;
+                let response = self.client.send(request).await?;
 
                 // Transform response to standard format (map of room ID -> room key).
                 let response = get_backup_keys::v3::Response::new(BTreeMap::from([(
@@ -493,7 +493,7 @@ impl Backups {
                     room_id.to_owned(),
                     session_id.to_owned(),
                 );
-                let response = self.client.send(request, Default::default()).await?;
+                let response = self.client.send(request).await?;
 
                 // Transform response to standard format (map of room ID -> room key).
                 let response = get_backup_keys::v3::Response::new(BTreeMap::from([(
@@ -604,7 +604,7 @@ impl Backups {
         version: String,
     ) -> Result<(), Error> {
         let request = get_backup_keys::v3::Request::new(version.clone());
-        let response = self.client.send(request, Default::default()).await?;
+        let response = self.client.send(request).await?;
 
         let olm_machine = self.client.olm_machine().await;
         let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
@@ -626,7 +626,7 @@ impl Backups {
     ) -> Result<Option<get_latest_backup_info::v3::Response>, Error> {
         let request = get_latest_backup_info::v3::Request::new();
 
-        match self.client.send(request, None).await {
+        match self.client.send(request).await {
             Ok(r) => Ok(Some(r)),
             Err(e) => {
                 if let Some(kind) = e.client_api_error_kind() {
@@ -645,7 +645,7 @@ impl Backups {
     async fn delete_backup_from_server(&self, version: String) -> Result<(), Error> {
         let request = ruma::api::client::backup::delete_backup_version::v3::Request::new(version);
 
-        let ret = match self.client.send(request, Default::default()).await {
+        let ret = match self.client.send(request).await {
             Ok(_) => Ok(()),
             Err(e) => {
                 if let Some(kind) = e.client_api_error_kind() {
@@ -679,7 +679,7 @@ impl Backups {
 
         let add_backup_keys = add_backup_keys::v3::Request::new(request.version, request.rooms);
 
-        match self.client.send(add_backup_keys, Default::default()).await {
+        match self.client.send(add_backup_keys).await {
             Ok(response) => {
                 olm_machine.mark_request_as_sent(request_id, &response).await?;
 

--- a/crates/matrix-sdk/src/encryption/identities/devices.rs
+++ b/crates/matrix-sdk/src/encryption/identities/devices.rs
@@ -290,7 +290,7 @@ impl Device {
     /// ```
     pub async fn verify(&self) -> Result<(), ManualVerifyError> {
         let request = self.inner.verify().await?;
-        self.client.send(request, None).await?;
+        self.client.send(request).await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -366,7 +366,7 @@ impl UserIdentity {
             CryptoUserIdentity::Other(identity) => identity.verify().await?,
         };
 
-        self.client.send(request, None).await?;
+        self.client.send(request).await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -281,7 +281,7 @@ impl CrossSigningResetHandle {
         let mut upload_request = self.upload_request.clone();
         upload_request.auth = auth;
 
-        while let Err(e) = self.client.send(upload_request.clone(), None).await {
+        while let Err(e) = self.client.send(upload_request.clone()).await {
             if *self.is_cancelled.lock().await {
                 return Ok(());
             }
@@ -291,7 +291,7 @@ impl CrossSigningResetHandle {
             }
         }
 
-        self.client.send(self.signatures_request.clone(), None).await?;
+        self.client.send(self.signatures_request.clone()).await?;
 
         Ok(())
     }
@@ -411,7 +411,7 @@ impl Client {
     ) -> Result<get_keys::v3::Response> {
         let request = assign!(get_keys::v3::Request::new(), { device_keys });
 
-        let response = self.send(request, None).await?;
+        let response = self.send(request).await?;
         self.mark_request_as_sent(request_id, &response).await?;
         self.encryption().update_state_after_keys_query(&response).await;
 
@@ -523,7 +523,7 @@ impl Client {
             .get_missing_sessions(users)
             .await?
         {
-            let response = self.send(request, None).await?;
+            let response = self.send(request).await?;
             self.mark_request_as_sent(&request_id, &response).await?;
         }
 
@@ -551,7 +551,7 @@ impl Client {
             "Uploading public encryption keys",
         );
 
-        let response = self.send(request.clone(), None).await?;
+        let response = self.send(request.clone()).await?;
         self.mark_request_as_sent(request_id, &response).await?;
 
         Ok(response)
@@ -582,7 +582,7 @@ impl Client {
             request.messages.clone(),
         );
 
-        self.send(request, None).await
+        self.send(request).await
     }
 
     pub(crate) async fn send_verification_request(
@@ -632,7 +632,7 @@ impl Client {
                 self.mark_request_as_sent(r.request_id(), &response).await?;
             }
             AnyOutgoingRequest::SignatureUpload(request) => {
-                let response = self.send(request.clone(), None).await?;
+                let response = self.send(request.clone()).await?;
                 self.mark_request_as_sent(r.request_id(), &response).await?;
             }
             AnyOutgoingRequest::RoomMessage(request) => {
@@ -640,7 +640,7 @@ impl Client {
                 self.mark_request_as_sent(r.request_id(), &response).await?;
             }
             AnyOutgoingRequest::KeysClaim(request) => {
-                let response = self.send(request.clone(), None).await?;
+                let response = self.send(request.clone()).await?;
                 self.mark_request_as_sent(r.request_id(), &response).await?;
             }
         }
@@ -1146,8 +1146,8 @@ impl Encryption {
         if let Some(req) = upload_keys_req {
             self.client.send_outgoing_request(req).await?;
         }
-        self.client.send(upload_signing_keys_req, None).await?;
-        self.client.send(upload_signatures_req, None).await?;
+        self.client.send(upload_signing_keys_req).await?;
+        self.client.send(upload_signatures_req).await?;
 
         Ok(())
     }
@@ -1209,7 +1209,7 @@ impl Encryption {
             self.client.send_outgoing_request(req).await?;
         }
 
-        if let Err(error) = self.client.send(upload_signing_keys_req.clone(), None).await {
+        if let Err(error) = self.client.send(upload_signing_keys_req.clone()).await {
             if let Some(auth_type) = CrossSigningResetAuthType::new(&self.client, &error).await? {
                 let client = self.client.clone();
 
@@ -1223,7 +1223,7 @@ impl Encryption {
                 Err(error.into())
             }
         } else {
-            self.client.send(upload_signatures_req, None).await?;
+            self.client.send(upload_signatures_req).await?;
 
             Ok(None)
         }

--- a/crates/matrix-sdk/src/encryption/verification/sas.rs
+++ b/crates/matrix-sdk/src/encryption/verification/sas.rs
@@ -86,7 +86,7 @@ impl SasVerification {
         }
 
         if let Some(s) = signature {
-            self.client.send(s, None).await?;
+            self.client.send(s).await?;
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/matrix_auth/login_builder.rs
+++ b/crates/matrix-sdk/src/matrix_auth/login_builder.rs
@@ -182,7 +182,8 @@ impl LoginBuilder {
             refresh_token: self.request_refresh_token,
         });
 
-        let response = client.send(request, Some(RequestConfig::short_retry())).await?;
+        let response =
+            client.send(request).with_request_config(RequestConfig::short_retry()).await?;
         self.auth
             .receive_login_response(
                 &response,

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -98,7 +98,7 @@ impl MatrixAuth {
     /// appropriate method for the next step.
     pub async fn get_login_types(&self) -> HttpResult<get_login_types::v3::Response> {
         let request = get_login_types::v3::Request::new();
-        self.client.send(request, None).await
+        self.client.send(request).await
     }
 
     /// Get the URL to use to log in via Single Sign-On.
@@ -617,7 +617,7 @@ impl MatrixAuth {
             _ => None,
         };
 
-        let response = self.client.send(request, None).await?;
+        let response = self.client.send(request).await?;
         if let Some(session) = MatrixSession::from_register_response(&response) {
             let _ = self
                 .set_session(
@@ -632,7 +632,7 @@ impl MatrixAuth {
     /// Log out the current user.
     pub async fn logout(&self) -> HttpResult<logout::v3::Response> {
         let request = logout::v3::Request::new();
-        self.client.send(request, None).await
+        self.client.send(request).await
     }
 
     /// Get the current access token and optional refresh token for this

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -196,7 +196,7 @@ impl Media {
             content_type: Some(content_type.essence_str().to_owned()),
         });
 
-        self.client.send(request, Some(request_config))
+        self.client.send(request).with_request_config(request_config)
     }
 
     /// Returns a reasonable upload timeout for an upload, based on the size of
@@ -240,7 +240,7 @@ impl Media {
         // Note: this request doesn't have any parameters.
         let request = media::create_mxc_uri::v1::Request::default();
 
-        let response = self.client.send(request, None).await?;
+        let response = self.client.send(request).await?;
 
         Ok(PreallocatedMxcUri {
             uri: response.content_uri,
@@ -278,7 +278,7 @@ impl Media {
 
         let request_config = self.client.request_config().timeout(timeout);
 
-        if let Err(err) = self.client.send(request, Some(request_config)).await {
+        if let Err(err) = self.client.send(request).with_request_config(request_config).await {
             match err.client_api_error_kind() {
                 Some(ErrorKind::CannotOverwriteMedia) => {
                     Err(Error::Media(MediaError::CannotOverwriteMedia))
@@ -446,11 +446,11 @@ impl Media {
                 let content = if use_auth {
                     let request =
                         authenticated_media::get_content::v1::Request::from_uri(&file.url)?;
-                    self.client.send(request, request_config).await?.file
+                    self.client.send(request).with_request_config(request_config).await?.file
                 } else {
                     #[allow(deprecated)]
                     let request = media::get_content::v3::Request::from_url(&file.url)?;
-                    self.client.send(request, None).await?.file
+                    self.client.send(request).await?.file
                 };
 
                 #[cfg(feature = "e2e-encryption")]
@@ -486,7 +486,7 @@ impl Media {
                         request.method = Some(settings.method.clone());
                         request.animated = Some(settings.animated);
 
-                        self.client.send(request, request_config).await?.file
+                        self.client.send(request).with_request_config(request_config).await?.file
                     } else {
                         #[allow(deprecated)]
                         let request = {
@@ -500,15 +500,15 @@ impl Media {
                             request
                         };
 
-                        self.client.send(request, None).await?.file
+                        self.client.send(request).await?.file
                     }
                 } else if use_auth {
                     let request = authenticated_media::get_content::v1::Request::from_uri(uri)?;
-                    self.client.send(request, request_config).await?.file
+                    self.client.send(request).with_request_config(request_config).await?.file
                 } else {
                     #[allow(deprecated)]
                     let request = media::get_content::v3::Request::from_url(uri)?;
-                    self.client.send(request, None).await?.file
+                    self.client.send(request).await?.file
                 }
             }
         };

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -453,32 +453,39 @@ impl NotificationSettings {
             match command {
                 Command::DeletePushRule { kind, rule_id } => {
                     let request = delete_pushrule::v3::Request::new(kind.clone(), rule_id.clone());
-                    self.client.send(request, request_config).await.map_err(|error| {
-                        error!("Unable to delete {kind} push rule `{rule_id}`: {error}");
-                        NotificationSettingsError::UnableToRemovePushRule
-                    })?;
+                    self.client.send(request).with_request_config(request_config).await.map_err(
+                        |error| {
+                            error!("Unable to delete {kind} push rule `{rule_id}`: {error}");
+                            NotificationSettingsError::UnableToRemovePushRule
+                        },
+                    )?;
                 }
                 Command::SetRoomPushRule { room_id, notify: _ } => {
                     let push_rule = command.to_push_rule()?;
                     let request = set_pushrule::v3::Request::new(push_rule);
-                    self.client.send(request, request_config).await.map_err(|error| {
-                        error!("Unable to set room push rule `{room_id}`: {error}");
-                        NotificationSettingsError::UnableToAddPushRule
-                    })?;
+                    self.client.send(request).with_request_config(request_config).await.map_err(
+                        |error| {
+                            error!("Unable to set room push rule `{room_id}`: {error}");
+                            NotificationSettingsError::UnableToAddPushRule
+                        },
+                    )?;
                 }
                 Command::SetOverridePushRule { rule_id, room_id: _, notify: _ } => {
                     let push_rule = command.to_push_rule()?;
                     let request = set_pushrule::v3::Request::new(push_rule);
-                    self.client.send(request, request_config).await.map_err(|error| {
-                        error!("Unable to set override push rule `{rule_id}`: {error}");
-                        NotificationSettingsError::UnableToAddPushRule
-                    })?;
+                    self.client.send(request).with_request_config(request_config).await.map_err(
+                        |error| {
+                            error!("Unable to set override push rule `{rule_id}`: {error}");
+                            NotificationSettingsError::UnableToAddPushRule
+                        },
+                    )?;
                 }
                 Command::SetKeywordPushRule { keyword: _ } => {
                     let push_rule = command.to_push_rule()?;
                     let request = set_pushrule::v3::Request::new(push_rule);
                     self.client
-                        .send(request, request_config)
+                        .send(request)
+                        .with_request_config(request_config)
                         .await
                         .map_err(|_| NotificationSettingsError::UnableToAddPushRule)?;
                 }
@@ -488,10 +495,12 @@ impl NotificationSettings {
                         rule_id.clone(),
                         *enabled,
                     );
-                    self.client.send(request, request_config).await.map_err(|error| {
-                        error!("Unable to set {kind} push rule `{rule_id}` enabled: {error}");
-                        NotificationSettingsError::UnableToUpdatePushRule
-                    })?;
+                    self.client.send(request).with_request_config(request_config).await.map_err(
+                        |error| {
+                            error!("Unable to set {kind} push rule `{rule_id}` enabled: {error}");
+                            NotificationSettingsError::UnableToUpdatePushRule
+                        },
+                    )?;
                 }
                 Command::SetPushRuleActions { kind, rule_id, actions } => {
                     let request = set_pushrule_actions::v3::Request::new(
@@ -499,10 +508,12 @@ impl NotificationSettings {
                         rule_id.clone(),
                         actions.clone(),
                     );
-                    self.client.send(request, request_config).await.map_err(|error| {
-                        error!("Unable to set {kind} push rule `{rule_id}` actions: {error}");
-                        NotificationSettingsError::UnableToUpdatePushRule
-                    })?;
+                    self.client.send(request).with_request_config(request_config).await.map_err(
+                        |error| {
+                            error!("Unable to set {kind} push rule `{rule_id}` actions: {error}");
+                            NotificationSettingsError::UnableToUpdatePushRule
+                        },
+                    )?;
                 }
             }
         }

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -349,8 +349,7 @@ impl Oidc {
     ///
     /// [MSC3861]: https://github.com/matrix-org/matrix-spec-proposals/pull/3861
     pub async fn fetch_authentication_issuer(&self) -> Result<String, HttpError> {
-        let response =
-            self.client.send(get_authentication_issuer::msc2965::Request::new(), None).await?;
+        let response = self.client.send(get_authentication_issuer::msc2965::Request::new()).await?;
 
         Ok(response.issuer)
     }

--- a/crates/matrix-sdk/src/pusher.rs
+++ b/crates/matrix-sdk/src/pusher.rs
@@ -36,14 +36,14 @@ impl Pusher {
     /// Sets a given pusher
     pub async fn set(&self, pusher: ruma::api::client::push::Pusher) -> Result<()> {
         let request = set_pusher::v3::Request::post(pusher);
-        self.client.send(request, None).await?;
+        self.client.send(request).await?;
         Ok(())
     }
 
     /// Deletes a pusher by its ids
     pub async fn delete(&self, pusher_ids: PusherIds) -> Result<()> {
         let request = set_pusher::v3::Request::delete(pusher_ids);
-        self.client.send(request, None).await?;
+        self.client.send(request).await?;
         Ok(())
     }
 }

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -224,7 +224,7 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
                 content,
             );
 
-            let response = room.client.send(request, request_config).await?;
+            let response = room.client.send(request).with_request_config(request_config).await?;
 
             Span::current().record("event_id", tracing::field::debug(&response.event_id));
             info!("Sent event in room");

--- a/crates/matrix-sdk/src/room_preview.rs
+++ b/crates/matrix-sdk/src/room_preview.rs
@@ -241,7 +241,7 @@ impl RoomPreview {
             via,
         );
 
-        let response = client.send(request, None).await?;
+        let response = client.send(request).await?;
 
         // The server returns a `Left` room state for rooms the user has not joined. Be
         // more precise than that, and set it to `None` if we haven't joined
@@ -294,8 +294,8 @@ impl RoomPreview {
         let joined_members_request = joined_members::v3::Request::new(room_id.to_owned());
 
         let (state, joined_members) =
-            try_join!(async { client.send(state_request, None).await }, async {
-                client.send(joined_members_request, None).await
+            try_join!(async { client.send(state_request).await }, async {
+                client.send(joined_members_request).await
             })?;
 
         // Converting from usize to u64 will always work, up to 64-bits devices;

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -578,10 +578,12 @@ impl SlidingSync {
         debug!("Sending request");
 
         // Prepare the request.
-        let request =
-            self.inner.client.send(request, Some(request_config)).with_homeserver_override(
-                self.inner.version.overriding_url().map(ToString::to_string),
-            );
+        let request = self
+            .inner
+            .client
+            .send(request)
+            .with_request_config(request_config)
+            .with_homeserver_override(self.inner.version.overriding_url().map(ToString::to_string));
 
         // Send the request and get a response with end-to-end encryption support.
         //

--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -1156,7 +1156,7 @@ impl<'a> MockEndpoint<'a, RoomSendEndpoint> {
     /// )
     /// .unwrap();
     ///
-    /// let response = room.client().send(r, None).await.unwrap();
+    /// let response = room.client().send(r).await.unwrap();
     /// // The delayed `m.room.message` event type should be mocked by the server.
     /// assert_eq!("$some_id", response.delay_id);
     /// # anyhow::Ok(()) });
@@ -1383,7 +1383,7 @@ impl<'a> MockEndpoint<'a, RoomSendStateEndpoint> {
     ///     &AnyStateEventContent::RoomCreate(RoomCreateEventContent::new_v11()),
     /// )
     /// .unwrap();
-    /// let response = room.client().send(r, None).await.unwrap();
+    /// let response = room.client().send(r).await.unwrap();
     /// // The delayed `m.room.message` event type should be mocked by the server.
     /// assert_eq!("$some_id", response.delay_id);
     ///

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -55,7 +55,7 @@ impl MatrixDriver {
     /// Requests an OpenID token for the current user.
     pub(crate) async fn get_open_id(&self) -> Result<OpenIdResponse> {
         let user_id = self.room.own_user_id().to_owned();
-        self.room.client.send(OpenIdRequest::new(user_id), None).await.map_err(Error::Http)
+        self.room.client.send(OpenIdRequest::new(user_id)).await.map_err(Error::Http)
     }
 
     /// Reads the latest `limit` events of a given `event_type` from the room.
@@ -146,7 +146,7 @@ impl MatrixDriver {
                     delayed_event_parameters,
                     Raw::<AnyMessageLikeEventContent>::from_json(content),
                 );
-                self.room.client.send(r, None).await.map(|r| r.into())?
+                self.room.client.send(r).await.map(|r| r.into())?
             }
 
             (Some(key), Some(delayed_event_parameters)) => {
@@ -157,7 +157,7 @@ impl MatrixDriver {
                     delayed_event_parameters,
                     Raw::<AnyStateEventContent>::from_json(content),
                 );
-                self.room.client.send(r, None).await.map(|r| r.into())?
+                self.room.client.send(r).await.map(|r| r.into())?
             }
         })
     }
@@ -172,7 +172,7 @@ impl MatrixDriver {
         action: UpdateAction,
     ) -> Result<delayed_events::update_delayed_event::unstable::Response> {
         let r = delayed_events::update_delayed_event::unstable::Request::new(delay_id, action);
-        self.room.client.send(r, None).await.map_err(Error::Http)
+        self.room.client.send(r).await.map_err(Error::Http)
     }
 
     /// Starts forwarding new room events. Once the returned `EventReceiver`

--- a/examples/get_profiles/src/main.rs
+++ b/examples/get_profiles/src/main.rs
@@ -22,7 +22,7 @@ async fn get_profile(client: Client, mxid: &UserId) -> MatrixResult<UserProfile>
     let request = profile::get_profile::v3::Request::new(mxid.to_owned());
 
     // Start the request using matrix_sdk::Client::send
-    let resp = client.send(request, None).await?;
+    let resp = client.send(request).await?;
 
     // Use the response and construct a UserProfile struct.
     // See https://docs.rs/ruma-client-api/0.9.0/ruma_client_api/r0/profile/get_profile/struct.Response.html


### PR DESCRIPTION
Instead of `Client::send(request, request_config)`, consumers can now do `Client::send(request).with_request_config(request_config)`. The parameter is still `Option`al to avoid messy patterns, when the `request_config` is an `Option` passed from the caller.

The messy pattern would look like this, if `with_request_config` took a `RequestConfig` and not an `Option<RequestConfig>`:

```
let mut send_req = client.send(req);
if let Some(request_config) = request_config {
  send_req = send_req.with_request_config(request_config);
}
```