### PR TITLE
fix(ui): Consider banned rooms as rooms we left in the non-left rooms matcher

### DIFF
--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Bug Fixes
+
+- Don't consider rooms in the banned state to be non-left rooms. This bug was
+  introduced due to the introduction of the banned state for rooms, and the
+  non-left room filter did not take the new room stat into account.
+  ([#4448](https://github.com/matrix-org/matrix-rust-sdk/pull/4448))
+
 ## [0.9.0] - 2024-12-18
 
 ### Bug Fixes

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/non_left.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/non_left.rs
@@ -28,7 +28,10 @@ where
     F: Fn(&Room) -> RoomState,
 {
     fn matches(&self, room: &Room) -> bool {
-        (self.state)(room) != RoomState::Left
+        match (self.state)(room) {
+            RoomState::Joined | RoomState::Invited | RoomState::Knocked => true,
+            RoomState::Left | RoomState::Banned => false,
+        }
     }
 }
 
@@ -57,6 +60,10 @@ mod tests {
 
         // When a room has been left, it doesn't match.
         let matcher = NonLeftRoomMatcher { state: |_| RoomState::Left };
+        assert!(!matcher.matches(&room));
+
+        // When a room is in the banned state, it doesn't match either.
+        let matcher = NonLeftRoomMatcher { state: |_| RoomState::Banned };
         assert!(!matcher.matches(&room));
 
         // When a room has been joined, it does match (unless it's empty).


### PR DESCRIPTION
Recently we started to differentiate between rooms we've been banned from from rooms we have left on our own.

Sadly the non-left rooms matcher only checked if the room state is not equal to the Left state. This then accidentally moved all the banned rooms to be considered as non-left.

We replace the single if expression with a match and list all the states, this way we're going to be notified by the compiler that we need to consider any new states we add in the future.

This closes: #4447.