### PR TITLE
fix(crypto): Serialize sender data msk in base64 instead of numbers

### DIFF
--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/snapshots/matrix_sdk_crypto__olm__group_sessions__sender_data__tests__snapshot_sender_data-4.snap
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/snapshots/matrix_sdk_crypto__olm__group_sessions__sender_data__tests__snapshot_sender_data-4.snap
@@ -6,39 +6,6 @@ expression: "SenderData::VerificationViolation(KnownSenderData\n{\n    user_id: 
   "VerificationViolation": {
     "user_id": "@foo:bar.baz",
     "device_id": "DEV",
-    "master_key": [
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
+    "master_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   }
 }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/snapshots/matrix_sdk_crypto__olm__group_sessions__sender_data__tests__snapshot_sender_data-5.snap
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/snapshots/matrix_sdk_crypto__olm__group_sessions__sender_data__tests__snapshot_sender_data-5.snap
@@ -6,39 +6,6 @@ expression: "SenderData::SenderUnverified(KnownSenderData\n{\n    user_id: owned
   "SenderUnverified": {
     "user_id": "@foo:bar.baz",
     "device_id": null,
-    "master_key": [
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1
-    ]
+    "master_key": "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE"
   }
 }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/snapshots/matrix_sdk_crypto__olm__group_sessions__sender_data__tests__snapshot_sender_data-6.snap
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/snapshots/matrix_sdk_crypto__olm__group_sessions__sender_data__tests__snapshot_sender_data-6.snap
@@ -6,39 +6,6 @@ expression: "SenderData::SenderVerified(KnownSenderData\n{\n    user_id: owned_u
   "SenderVerified": {
     "user_id": "@foo:bar.baz",
     "device_id": null,
-    "master_key": [
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1
-    ]
+    "master_key": "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE"
   }
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Follow up of https://github.com/matrix-org/matrix-rust-sdk/pull/4449

While adding snapshot test, I detected that sender's data `KnownSenderData` was serializing the cross-signing master key as an array of number. This PR changes that and now serialize the key as a base64 string, adding migration for the old format.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
