### PR TITLE
feat!(timeline): Allow to send attachments from bytes

### DIFF
--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project will be documented in this file.
   non-left room filter did not take the new room stat into account.
   ([#4448](https://github.com/matrix-org/matrix-rust-sdk/pull/4448))
 
+### Features
+
+- [**breaking**] `Timeline::send_attachment()` now takes a type that implements
+  `Into<AttachmentSource>` instead of a type that implements `Into<PathBuf>`.
+  `AttachmentSource` allows to send an attachment either from a file, or with
+  the bytes and the filename of the attachment. Note that all types that
+  implement `Into<PathBuf>` also implement `Into<AttachmentSource>`.
+
 ## [0.9.0] - 2024-12-18
 
 ### Bug Fixes

--- a/crates/matrix-sdk-ui/src/timeline/futures.rs
+++ b/crates/matrix-sdk-ui/src/timeline/futures.rs
@@ -1,4 +1,4 @@
-use std::{fs, future::IntoFuture, path::PathBuf};
+use std::future::IntoFuture;
 
 use eyeball::{SharedObservable, Subscriber};
 use matrix_sdk::{attachment::AttachmentConfig, TransmissionProgress};
@@ -6,11 +6,11 @@ use matrix_sdk_base::boxed_into_future;
 use mime::Mime;
 use tracing::{Instrument as _, Span};
 
-use super::{Error, Timeline};
+use super::{AttachmentSource, Error, Timeline};
 
 pub struct SendAttachment<'a> {
     timeline: &'a Timeline,
-    path: PathBuf,
+    source: AttachmentSource,
     mime_type: Mime,
     config: AttachmentConfig,
     tracing_span: Span,
@@ -21,13 +21,13 @@ pub struct SendAttachment<'a> {
 impl<'a> SendAttachment<'a> {
     pub(crate) fn new(
         timeline: &'a Timeline,
-        path: PathBuf,
+        source: AttachmentSource,
         mime_type: Mime,
         config: AttachmentConfig,
     ) -> Self {
         Self {
             timeline,
-            path,
+            source,
             mime_type,
             config,
             tracing_span: Span::current(),
@@ -61,16 +61,18 @@ impl<'a> IntoFuture for SendAttachment<'a> {
     boxed_into_future!(extra_bounds: 'a);
 
     fn into_future(self) -> Self::IntoFuture {
-        let Self { timeline, path, mime_type, config, tracing_span, use_send_queue, send_progress } =
-            self;
+        let Self {
+            timeline,
+            source,
+            mime_type,
+            config,
+            tracing_span,
+            use_send_queue,
+            send_progress,
+        } = self;
 
         let fut = async move {
-            let filename = path
-                .file_name()
-                .ok_or(Error::InvalidAttachmentFileName)?
-                .to_str()
-                .ok_or(Error::InvalidAttachmentFileName)?;
-            let data = fs::read(&path).map_err(|_| Error::InvalidAttachmentData)?;
+            let (data, filename) = source.try_into_bytes_and_filename()?;
 
             if use_send_queue {
                 let send_queue = timeline.room().send_queue();

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
   `Client::send()` method to the `with_request_config()` builder method. You
   should call `Client::send(request).with_request_config(request_config).await`
   now instead.
+- [**breaking**] `Room::send_attachment()` and `RoomSendQueue::send_attachment()`
+  now take any type that implements `Into<String>` for the filename.
 
 ## [0.9.0] - 2024-12-18
 

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -240,7 +240,7 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
 #[allow(missing_debug_implementations)]
 pub struct SendAttachment<'a> {
     room: &'a Room,
-    filename: &'a str,
+    filename: String,
     content_type: &'a Mime,
     data: Vec<u8>,
     config: AttachmentConfig,
@@ -252,7 +252,7 @@ pub struct SendAttachment<'a> {
 impl<'a> SendAttachment<'a> {
     pub(crate) fn new(
         room: &'a Room,
-        filename: &'a str,
+        filename: String,
         content_type: &'a Mime,
         data: Vec<u8>,
         config: AttachmentConfig,

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1933,12 +1933,12 @@ impl Room {
     #[instrument(skip_all)]
     pub fn send_attachment<'a>(
         &'a self,
-        filename: &'a str,
+        filename: impl Into<String>,
         content_type: &'a Mime,
         data: Vec<u8>,
         config: AttachmentConfig,
     ) -> SendAttachment<'a> {
-        SendAttachment::new(self, filename, content_type, data, config)
+        SendAttachment::new(self, filename.into(), content_type, data, config)
     }
 
     /// Prepare and send an attachment to this room.
@@ -1971,7 +1971,7 @@ impl Room {
     #[instrument(skip_all)]
     pub(super) async fn prepare_and_send_attachment<'a>(
         &'a self,
-        filename: &'a str,
+        filename: String,
         content_type: &'a Mime,
         data: Vec<u8>,
         mut config: AttachmentConfig,
@@ -2076,7 +2076,7 @@ impl Room {
     pub(crate) fn make_attachment_type(
         &self,
         content_type: &Mime,
-        filename: &str,
+        filename: String,
         source: MediaSource,
         caption: Option<String>,
         formatted_caption: Option<FormattedBody>,
@@ -2087,8 +2087,8 @@ impl Room {
         // body is the filename, and the filename is not set.
         // https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/2530-body-as-caption.md
         let (body, filename) = match caption {
-            Some(caption) => (caption, Some(filename.to_owned())),
-            None => (filename.to_owned(), None),
+            Some(caption) => (caption, Some(filename)),
+            None => (filename, None),
         };
 
         let (thumbnail_source, thumbnail_info) = thumbnail.unzip();

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -105,7 +105,7 @@ impl RoomSendQueue {
     #[instrument(skip_all, fields(event_txn))]
     pub async fn send_attachment(
         &self,
-        filename: &str,
+        filename: impl Into<String>,
         content_type: Mime,
         data: Vec<u8>,
         mut config: AttachmentConfig,
@@ -118,6 +118,7 @@ impl RoomSendQueue {
             return Err(RoomSendQueueError::RoomNotJoined);
         }
 
+        let filename = filename.into();
         let upload_file_txn = TransactionId::new();
         let send_event_txn = config.txn_id.map_or_else(ChildTransactionId::new, Into::into);
 


### PR DESCRIPTION
Sometimes we can get the bytes directly, e.g. in Fractal we can get an image from the clipboard. It avoids to have to write the data to a temporary file only to have the data loaded back in memory by the SDK right after.

The first commit to accept any type that implements `Into<String>` for the filename is grouped here because it simplifies slightly the second commit.

Note that we could also use `AttachmentSource` in the other `send_attachment` APIs, on `Room` and `RoomSendQueue`, for consistency.