### PR TITLE
refactor!(sdk): Set thumbnail in `AttachmentConfig` with builder method instead of constructor

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
   `Client::send()` method to the `with_request_config()` builder method. You
   should call `Client::send(request).with_request_config(request_config).await`
   now instead.
+- [**breaking**] Remove the `AttachmentConfig::with_thumbnail()` constructor and
+  replace it with the `AttachmentConfig::thumbnail()` builder method. You should
+  call `AttachmentConfig::new().thumbnail(thumbnail)` now instead.
 
 ## [0.9.0] - 2024-12-18
 

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -188,21 +188,21 @@ pub struct AttachmentConfig {
 }
 
 impl AttachmentConfig {
-    /// Create a new default `AttachmentConfig` without providing a thumbnail.
-    ///
-    /// To provide a thumbnail use [`AttachmentConfig::with_thumbnail()`].
+    /// Create a new empty `AttachmentConfig`.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Create a new default `AttachmentConfig` with a `thumbnail`.
+    /// Set the thumbnail to send.
     ///
     /// # Arguments
     ///
     /// * `thumbnail` - The thumbnail of the media. If the `content_type` does
-    ///   not support it (eg audio clips), it is ignored.
-    pub fn with_thumbnail(thumbnail: Thumbnail) -> Self {
-        Self { thumbnail: Some(thumbnail), ..Default::default() }
+    ///   not support it (e.g. audio clips), it is ignored.
+    #[must_use]
+    pub fn thumbnail(mut self, thumbnail: Option<Thumbnail>) -> Self {
+        self.thumbnail = thumbnail;
+        self
     }
 
     /// Set the transaction ID to send.

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -204,19 +204,20 @@ async fn test_room_attachment_send_info_thumbnail() {
     let _ = client.media().get_media_content(&thumbnail_request, true).await.unwrap_err();
 
     // Send the attachment with a thumbnail.
-    let config = AttachmentConfig::with_thumbnail(Thumbnail {
-        data: b"Thumbnail".to_vec(),
-        content_type: mime::IMAGE_JPEG,
-        height: uint!(360),
-        width: uint!(480),
-        size: uint!(3600),
-    })
-    .info(AttachmentInfo::Image(BaseImageInfo {
-        height: Some(uint!(600)),
-        width: Some(uint!(800)),
-        size: None,
-        blurhash: None,
-    }));
+    let config = AttachmentConfig::new()
+        .thumbnail(Some(Thumbnail {
+            data: b"Thumbnail".to_vec(),
+            content_type: mime::IMAGE_JPEG,
+            height: uint!(360),
+            width: uint!(480),
+            size: uint!(3600),
+        }))
+        .info(AttachmentInfo::Image(BaseImageInfo {
+            height: Some(uint!(600)),
+            width: Some(uint!(800)),
+            size: None,
+            blurhash: None,
+        }));
 
     let response = room
         .send_attachment("image", &mime::IMAGE_JPEG, b"Hello world".to_vec(), config)

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -79,13 +79,14 @@ async fn queue_attachment_with_thumbnail(q: &RoomSendQueue) -> (SendHandle, &'st
         size: uint!(42),
     };
 
-    let config =
-        AttachmentConfig::with_thumbnail(thumbnail).info(AttachmentInfo::Image(BaseImageInfo {
+    let config = AttachmentConfig::new().thumbnail(Some(thumbnail)).info(AttachmentInfo::Image(
+        BaseImageInfo {
             height: Some(uint!(13)),
             width: Some(uint!(37)),
             size: Some(uint!(42)),
             blurhash: None,
-        }));
+        },
+    ));
 
     let handle = q
         .send_attachment(filename, content_type, data, config)
@@ -1801,7 +1802,8 @@ async fn test_media_uploads() {
 
     let transaction_id = TransactionId::new();
     let mentions = Mentions::with_user_ids([owned_user_id!("@ivan:sdk.rs")]);
-    let config = AttachmentConfig::with_thumbnail(thumbnail)
+    let config = AttachmentConfig::new()
+        .thumbnail(Some(thumbnail))
         .txn_id(&transaction_id)
         .caption(Some("caption".to_owned()))
         .mentions(Some(mentions.clone()))


### PR DESCRIPTION
`AttachmentConfig::with_thumbnail()` is replaced by `AttachmentConfig::new().thumbnail()`.

Simplifies the use of `AttachmentConfig`, by avoiding code like:

```rust
let config = if let Some(thumbnail) = thumbnail {
  AttachmentConfig::with_thumbnail(thumbnail)
} else {
  AttachmentConfig::new()
};
```
