### PR TITLE
refactor(event cache): make it clearer that vecdiff updates must be handled in `with_events_mut`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -245,7 +245,6 @@ impl RoomEvents {
     /// See [`AsVector`] to learn more.
     ///
     /// [`Update`]: matrix_sdk_base::linked_chunk::Update
-    #[allow(unused)] // gonna be useful very soon! but we need it now for test purposes
     pub fn updates_as_vector_diffs(&mut self) -> Vec<VectorDiff<Event>> {
         self.chunks_updates_as_vectordiffs.take()
     }


### PR DESCRIPTION
Every caller to `with_events_mut` must propagate the vector diff updates, otherwise updates would be missing to the room event cache's observers. This slightly tweaks the signature to make this a bit clearer, and adjusts the code comment as well.