### PR TITLE
feat!(send queue): make unrecoverable errors stop the sending queue

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -260,6 +260,9 @@ async fn test_edit_local_echo() {
     let edit_message = item.content().as_message().unwrap();
     assert_eq!(edit_message.body(), "hello, world");
 
+    // Re-enable the room's queue.
+    timeline.room().send_queue().set_enabled(true);
+
     // Observe the event being sent, and replacing the local echo.
     assert_let!(Some(VectorDiff::Set { index: 1, value: item }) = timeline_stream.next().await);
 

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -622,6 +622,9 @@ impl RoomSendQueue {
                         _ => false,
                     };
 
+                    // Disable the queue for this room after any kind of error happened.
+                    locally_enabled.store(false, Ordering::SeqCst);
+
                     if is_recoverable {
                         warn!(txn_id = %txn_id, error = ?err, "Recoverable error when sending request: {err}, disabling send queue");
 
@@ -629,15 +632,11 @@ impl RoomSendQueue {
                         // as not being sent anymore.
                         queue.mark_as_not_being_sent(&txn_id).await;
 
-                        // Let observers know about a failure *after* we've marked the item as not
-                        // being sent anymore. Otherwise, there's a possible race where a caller
-                        // might try to remove an item, while it's still marked as being sent,
-                        // resulting in a cancellation failure.
-
-                        // Disable the queue for this room after a recoverable error happened. This
-                        // should be the sign that this error is temporary (maybe network
-                        // disconnected, maybe the server had a hiccup).
-                        locally_enabled.store(false, Ordering::SeqCst);
+                        // Let observers know about a failure *after* we've
+                        // marked the item as not being sent anymore. Otherwise,
+                        // there's a possible race where a caller might try to
+                        // remove an item, while it's still marked as being
+                        // sent, resulting in a cancellation failure.
                     } else {
                         warn!(txn_id = %txn_id, error = ?err, "Unrecoverable error when sending request: {err}");
 


### PR DESCRIPTION
Instead of keeping on handling unwedged events from the sending queue, it's now required to re-enable the send queue manually for the room that encountered the sending error, all the time. This is more consistent, and avoids weird behavior when a user would 1. send an event for which sending fails, in an unrecoverable manner, 2. send an event that's actually sendable.

Fixes #4389.