### PR TITLE
Use Instant from web-time in more places (via ruma re-export)

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, num::NonZeroUsize, sync::RwLock as StdRwLock, time::Instant};
+use std::{collections::HashMap, num::NonZeroUsize, sync::RwLock as StdRwLock};
 
 use async_trait::async_trait;
 use matrix_sdk_common::{
@@ -20,7 +20,7 @@ use matrix_sdk_common::{
     ring_buffer::RingBuffer,
     store_locks::memory_store_helper::try_take_leased_lock,
 };
-use ruma::{MxcUri, OwnedMxcUri, RoomId};
+use ruma::{time::Instant, MxcUri, OwnedMxcUri, RoomId};
 
 use super::{EventCacheStore, EventCacheStoreError, Result};
 use crate::{

--- a/crates/matrix-sdk-common/src/store_locks.rs
+++ b/crates/matrix-sdk-common/src/store_locks.rs
@@ -500,10 +500,9 @@ mod tests {
 /// Some code that is shared by almost all `MemoryStore` implementations out
 /// there.
 pub mod memory_store_helper {
-    use std::{
-        collections::{hash_map::Entry, HashMap},
-        time::{Duration, Instant},
-    };
+    use std::collections::{hash_map::Entry, HashMap};
+
+    use ruma::time::{Duration, Instant};
 
     pub fn try_take_leased_lock(
         leases: &mut HashMap<String, (String, Instant)>,

--- a/crates/matrix-sdk-common/src/tracing_timer.rs
+++ b/crates/matrix-sdk-common/src/tracing_timer.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Instant;
-
+use ruma::time::Instant;
 use tracing::{callsite::DefaultCallsite, Callsite as _};
 
 /// A named RAII that will show on Drop how long its covered section took to

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -16,14 +16,13 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     convert::Infallible,
     sync::RwLock as StdRwLock,
-    time::Instant,
 };
 
 use async_trait::async_trait;
 use matrix_sdk_common::store_locks::memory_store_helper::try_take_leased_lock;
 use ruma::{
-    events::secret::request::SecretName, DeviceId, OwnedDeviceId, OwnedRoomId, OwnedTransactionId,
-    OwnedUserId, RoomId, TransactionId, UserId,
+    events::secret::request::SecretName, time::Instant, DeviceId, OwnedDeviceId, OwnedRoomId,
+    OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
 };
 use tokio::sync::RwLock;
 use tracing::warn;

--- a/crates/matrix-sdk-ui/src/room_list_service/state.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/state.rs
@@ -14,14 +14,11 @@
 
 //! States and actions for the `RoomList` state machine.
 
-use std::{
-    future::ready,
-    sync::Mutex,
-    time::{Duration, Instant},
-};
+use std::{future::ready, sync::Mutex};
 
 use eyeball::{SharedObservable, Subscriber};
 use matrix_sdk::{sliding_sync::Range, SlidingSync, SlidingSyncMode};
+use ruma::time::{Duration, Instant};
 
 use super::Error;
 

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -21,13 +21,15 @@
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
-    time::{Duration, Instant},
 };
 
 use growable_bloom_filter::{GrowableBloom, GrowableBloomBuilder};
 use matrix_sdk::{crypto::types::events::UtdCause, Client};
 use matrix_sdk_base::{StateStoreDataKey, StateStoreDataValue, StoreError};
-use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName, UserId};
+use ruma::{
+    time::{Duration, Instant},
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName, UserId,
+};
 use tokio::{
     spawn,
     sync::{Mutex as AsyncMutex, MutexGuard},

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -1,7 +1,4 @@
-use std::{
-    ops::Not,
-    time::{Duration, Instant},
-};
+use std::ops::Not;
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
@@ -27,8 +24,11 @@ use matrix_sdk_ui::{
     RoomListService,
 };
 use ruma::{
-    api::client::room::create_room::v3::Request as CreateRoomRequest, event_id,
-    events::room::message::RoomMessageEventContent, mxc_uri, room_id,
+    api::client::room::create_room::v3::Request as CreateRoomRequest,
+    event_id,
+    events::room::message::RoomMessageEventContent,
+    mxc_uri, room_id,
+    time::{Duration, Instant},
 };
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};

--- a/crates/matrix-sdk/src/widget/machine/pending.rs
+++ b/crates/matrix-sdk/src/widget/machine/pending.rs
@@ -15,9 +15,8 @@
 //! A wrapper around a hash map that tracks pending requests and makes sure
 //! that expired requests are removed.
 
-use std::time::{Duration, Instant};
-
 use indexmap::{map::Entry, IndexMap};
+use ruma::time::{Duration, Instant};
 use tracing::warn;
 use uuid::Uuid;
 


### PR DESCRIPTION
web-time's Instant type is already used elsewhere in the project. It is an alias for std's Instant type on most targets, but tries to call into JavaScript on wasm32-unknown-unknown (assuming that the wasm blob is used in from a browser context). Its Duration type is a plain re-export of std's Duration, even on wasm32-unknown-unknown. (it is only used to avoid splitting the `time::` import in two)

Signed-off-by: Jonas Platte <jplatte+matrix@posteo.de>
