### PR TITLE
Clean up some imports

### DIFF
--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -5,24 +5,20 @@
 
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
 #[cfg(feature = "e2e-encryption")]
-use ruma::events::{
-    call::{invite::SyncCallInviteEvent, notify::SyncCallNotifyEvent},
-    poll::unstable_start::SyncUnstablePollStartEvent,
-    relation::RelationType,
-    room::message::SyncRoomMessageEvent,
-    AnySyncMessageLikeEvent, AnySyncTimelineEvent,
-};
 use ruma::{
     events::{
-        room::{
-            member::{MembershipState, SyncRoomMemberEvent},
-            power_levels::RoomPowerLevels,
-        },
+        call::{invite::SyncCallInviteEvent, notify::SyncCallNotifyEvent},
+        poll::unstable_start::SyncUnstablePollStartEvent,
+        relation::RelationType,
+        room::member::{MembershipState, SyncRoomMemberEvent},
+        room::message::SyncRoomMessageEvent,
+        room::power_levels::RoomPowerLevels,
         sticker::SyncStickerEvent,
-        AnySyncStateEvent,
+        AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent,
     },
-    MxcUri, OwnedEventId, UserId,
+    UserId,
 };
+use ruma::{MxcUri, OwnedEventId};
 use serde::{Deserialize, Serialize};
 
 use crate::MinimalRoomMemberEvent;

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -22,26 +22,20 @@ use std::{borrow::Cow, collections::BTreeMap};
 
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
-#[cfg(feature = "e2e-encryption")]
-use ruma::api::client::sync::sync_events::v5;
-#[cfg(feature = "e2e-encryption")]
-use ruma::events::AnyToDeviceEvent;
 use ruma::{
     api::client::sync::sync_events::v3::{self, InvitedRoom, KnockedRoom},
     events::{
         room::member::MembershipState, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncStateEvent, StateEventType,
+        AnySyncStateEvent,
     },
     serde::Raw,
     JsOption, OwnedRoomId, RoomId, UInt, UserId,
 };
+#[cfg(feature = "e2e-encryption")]
+use ruma::{api::client::sync::sync_events::v5, events::AnyToDeviceEvent, events::StateEventType};
 use tracing::{debug, error, instrument, trace, warn};
 
 use super::BaseClient;
-#[cfg(feature = "e2e-encryption")]
-use crate::latest_event::{is_suitable_for_latest_event, LatestEvent, PossibleLatestEvent};
-#[cfg(feature = "e2e-encryption")]
-use crate::RoomMemberships;
 use crate::{
     error::Result,
     read_receipts::{compute_unread_counts, PreviousEventsProvider},
@@ -54,6 +48,11 @@ use crate::{
     store::{ambiguity_map::AmbiguityCache, StateChanges, Store},
     sync::{JoinedRoomUpdate, LeftRoomUpdate, Notification, RoomUpdates, SyncResponse},
     Room, RoomInfo,
+};
+#[cfg(feature = "e2e-encryption")]
+use crate::{
+    latest_event::{is_suitable_for_latest_event, LatestEvent, PossibleLatestEvent},
+    RoomMemberships,
 };
 
 impl BaseClient {


### PR DESCRIPTION
With experimental-sliding-sync enabled and e2e-encryption disabled, there were a bunch of warnings about unused imports. This fixes them (but a few warnings about other unused items remain).

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Jonas Platte <jplatte+matrix@posteo.de>
