### PR TITLE
refactor: Make experimental-sliding-sync compile on WASM

### DIFF
--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -123,7 +123,10 @@ use std::{
 };
 
 use eyeball_im::Vector;
-use matrix_sdk_common::{deserialized_responses::SyncTimelineEvent, ring_buffer::RingBuffer};
+use matrix_sdk_common::{
+    deserialized_responses::SyncTimelineEvent, ring_buffer::RingBuffer, SendOutsideWasm,
+    SyncOutsideWasm,
+};
 use ruma::{
     events::{
         poll::{start::PollStartEventContent, unstable_start::UnstablePollStartEventContent},
@@ -266,7 +269,7 @@ impl RoomReadReceipts {
 }
 
 /// Provider for timeline events prior to the current sync.
-pub trait PreviousEventsProvider: Send + Sync {
+pub trait PreviousEventsProvider: SendOutsideWasm + SyncOutsideWasm {
     /// Returns the list of known timeline events, in sync order, for the given
     /// room.
     fn for_room(&self, room_id: &RoomId) -> Vector<SyncTimelineEvent>;

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -36,14 +36,14 @@ use async_stream::stream;
 pub use client::{Version, VersionBuilder};
 use futures_core::stream::Stream;
 pub use matrix_sdk_base::sliding_sync::http;
-use matrix_sdk_common::{deserialized_responses::SyncTimelineEvent, timer};
+use matrix_sdk_common::{deserialized_responses::SyncTimelineEvent, executor::spawn, timer};
 use ruma::{
     api::{client::error::ErrorKind, OutgoingRequest},
     assign, OwnedEventId, OwnedRoomId, RoomId,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{
-    select, spawn,
+    select,
     sync::{broadcast::Sender, Mutex as AsyncMutex, OwnedMutexGuard, RwLock as AsyncRwLock},
 };
 use tracing::{debug, error, info, instrument, trace, warn, Instrument, Span};


### PR DESCRIPTION
Unfortunately the matrix_sdk::Client is not Send on WASM, which is probably not going to be easy to fix. Since PreviousEventsProvider is never used as a trait object, there should be no harm in relaxing its supertraits (on WASM).

I intentionally left out `xtask::ci` changes, because I think this should be tested as part of a `matrix-sdk-ui` WASM check down the line.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Jonas Platte <jplatte+matrix@posteo.de>
