### PR TITLE
feat(timeline): allow sending mentions along with media

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -298,6 +298,7 @@ impl Timeline {
         image_info: ImageInfo,
         caption: Option<String>,
         formatted_caption: Option<FormattedBody>,
+        mentions: Option<Mentions>,
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
         use_send_queue: bool,
     ) -> Arc<SendAttachmentJoinHandle> {
@@ -313,7 +314,8 @@ impl Timeline {
                 .thumbnail(thumbnail)
                 .info(attachment_info)
                 .caption(caption)
-                .formatted_caption(formatted_caption);
+                .formatted_caption(formatted_caption)
+                .mentions(mentions.map(Into::into));
 
             self.send_attachment(
                 url,
@@ -334,6 +336,7 @@ impl Timeline {
         video_info: VideoInfo,
         caption: Option<String>,
         formatted_caption: Option<FormattedBody>,
+        mentions: Option<Mentions>,
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
         use_send_queue: bool,
     ) -> Arc<SendAttachmentJoinHandle> {
@@ -349,7 +352,8 @@ impl Timeline {
                 .thumbnail(thumbnail)
                 .info(attachment_info)
                 .caption(caption)
-                .formatted_caption(formatted_caption.map(Into::into));
+                .formatted_caption(formatted_caption.map(Into::into))
+                .mentions(mentions.map(Into::into));
 
             self.send_attachment(
                 url,
@@ -362,12 +366,14 @@ impl Timeline {
         }))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn send_audio(
         self: Arc<Self>,
         url: String,
         audio_info: AudioInfo,
         caption: Option<String>,
         formatted_caption: Option<FormattedBody>,
+        mentions: Option<Mentions>,
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
         use_send_queue: bool,
     ) -> Arc<SendAttachmentJoinHandle> {
@@ -381,7 +387,8 @@ impl Timeline {
             let attachment_config = AttachmentConfig::new()
                 .info(attachment_info)
                 .caption(caption)
-                .formatted_caption(formatted_caption.map(Into::into));
+                .formatted_caption(formatted_caption.map(Into::into))
+                .mentions(mentions.map(Into::into));
 
             self.send_attachment(
                 url,
@@ -401,6 +408,7 @@ impl Timeline {
         audio_info: AudioInfo,
         waveform: Vec<u16>,
         caption: Option<String>,
+        mentions: Option<Mentions>,
         formatted_caption: Option<FormattedBody>,
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
         use_send_queue: bool,
@@ -416,7 +424,8 @@ impl Timeline {
             let attachment_config = AttachmentConfig::new()
                 .info(attachment_info)
                 .caption(caption)
-                .formatted_caption(formatted_caption.map(Into::into));
+                .formatted_caption(formatted_caption.map(Into::into))
+                .mentions(mentions.map(Into::into));
 
             self.send_attachment(
                 url,
@@ -429,12 +438,14 @@ impl Timeline {
         }))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn send_file(
         self: Arc<Self>,
         url: String,
         file_info: FileInfo,
         caption: Option<String>,
         formatted_caption: Option<FormattedBody>,
+        mentions: Option<Mentions>,
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
         use_send_queue: bool,
     ) -> Arc<SendAttachmentJoinHandle> {
@@ -448,7 +459,8 @@ impl Timeline {
             let attachment_config = AttachmentConfig::new()
                 .info(attachment_info)
                 .caption(caption)
-                .formatted_caption(formatted_caption.map(Into::into));
+                .formatted_caption(formatted_caption.map(Into::into))
+                .mentions(mentions.map(Into::into));
 
             self.send_attachment(
                 url,


### PR DESCRIPTION
Since 8205da898e11c34b77b13fe4794d0b2e1bcdd2a8 it has been possible to attach (intentional) mentions to _edited_ media captions, but the `send_${mediatype}()` timeline APIs provided no way to send them with the initial event. This fixes that.

- [ ] Public API changes documented in changelogs (optional)

![image](https://github.com/user-attachments/assets/c2c6dba3-1ae0-4097-b2dd-bb68dbd53fdd)

If I missed something, or completely got the wrong end of the stick, feel free to decline this or point me in the right direction. I'm not familiar with Rust, but this at least compiles and doesn't crash EXA on my phone.
