### PR TITLE
Implement test helpers for constructing user device data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3477,6 +3477,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing-subscriber",
+ "vodozemac",
  "wasm-bindgen-test",
  "wiremock",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3468,6 +3468,7 @@ dependencies = [
  "ctor",
  "getrandom",
  "http",
+ "insta",
  "matrix-sdk-common",
  "matrix-sdk-test-macros",
  "once_cell",

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -18,6 +18,7 @@ doctest = false
 [dependencies]
 as_variant = { workspace = true }
 http = { workspace = true }
+insta = { workspace = true }
 matrix-sdk-common = { path = "../../crates/matrix-sdk-common" }
 matrix-sdk-test-macros = { version = "0.7.0", path = "../matrix-sdk-test-macros" }
 once_cell = { workspace = true }

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -24,9 +24,10 @@ matrix-sdk-test-macros = { version = "0.7.0", path = "../matrix-sdk-test-macros"
 once_cell = { workspace = true }
 # Enable the unstable feature for polls support.
 # "client-api-s" enables need the "server" feature of ruma-client-api, which is needed to serialize Response objects to JSON.
-ruma = { workspace = true, features = ["client-api-s", "rand", "unstable-msc3381"] }
+ruma = { workspace = true, features = ["canonical-json", "client-api-s", "rand", "unstable-msc3381"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+vodozemac = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ctor = "0.2.9"

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -22,8 +22,9 @@ insta = { workspace = true }
 matrix-sdk-common = { path = "../../crates/matrix-sdk-common" }
 matrix-sdk-test-macros = { version = "0.7.0", path = "../matrix-sdk-test-macros" }
 once_cell = { workspace = true }
-# Enabling the unstable feature for polls support.
-ruma = { workspace = true, features = ["rand", "unstable-msc3381"] }
+# Enable the unstable feature for polls support.
+# "client-api-s" enables need the "server" feature of ruma-client-api, which is needed to serialize Response objects to JSON.
+ruma = { workspace = true, features = ["client-api-s", "rand", "unstable-msc3381"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/testing/matrix-sdk-test/src/lib.rs
+++ b/testing/matrix-sdk-test/src/lib.rs
@@ -2,7 +2,9 @@ use http::Response;
 pub use matrix_sdk_test_macros::async_test;
 use once_cell::sync::Lazy;
 use ruma::{
-    api::{client::sync::sync_events::v3::Response as SyncResponse, IncomingResponse},
+    api::{
+        client::sync::sync_events::v3::Response as SyncResponse, IncomingResponse, OutgoingResponse,
+    },
     room_id, user_id, RoomId, UserId,
 };
 use serde_json::Value as JsonValue;
@@ -168,4 +170,14 @@ pub fn ruma_response_from_json<ResponseType: IncomingResponse>(
     let http_response =
         Response::builder().status(200).body(json_bytes).expect("Failed to build HTTP response");
     ResponseType::try_from_http_response(http_response).expect("Can't parse the response json")
+}
+
+/// Serialise a typed Ruma [`OutgoingResponse`] object to JSON.
+pub fn ruma_response_to_json<ResponseType: OutgoingResponse>(
+    response: ResponseType,
+) -> serde_json::Value {
+    let http_response: Response<Vec<u8>> =
+        response.try_into_http_response().expect("Failed to build HTTP response");
+    let json_bytes = http_response.into_body();
+    serde_json::from_slice(&json_bytes).expect("Can't parse the response JSON")
 }

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -277,10 +277,45 @@ impl KeyDistributionTestData {
         response
     }
 
-    /// Dan has cross-signing setup, one device is cross signed `JHPUERYQUW`,
-    /// but not the other one `FRGNMZVOKA`.
-    /// `@dan` identity is signed by `@me` identity (alice trust dan)
+    /// Dan has cross-signing set up; one device is cross-signed (`JHPUERYQUW`),
+    /// but not the other one (`FRGNMZVOKA`).
+    ///
+    /// `@dan`'s identity is signed by `@me`'s identity (Alice trusts Dan).
     pub fn dan_keys_query_response() -> KeyQueryResponse {
+        let response = Self::dan_keys_query_response_common();
+        with_settings!({sort_maps => true}, {
+            assert_json_snapshot!(
+                "KeyDistributionTestData::dan_keys_query_response",
+                ruma_response_to_json(response.clone()),
+            );
+        });
+        response
+    }
+
+    /// Same as `dan_keys_query_response` but `FRGNMZVOKA` was removed.
+    pub fn dan_keys_query_response_device_loggedout() -> KeyQueryResponse {
+        let mut response = Self::dan_keys_query_response_common();
+        response
+            .device_keys
+            .get_mut(Self::dan_id())
+            .unwrap()
+            .remove(Self::dan_unsigned_device_id());
+
+        with_settings!({sort_maps => true}, {
+            assert_json_snapshot!(
+                "KeyDistributionTestData::dan_keys_query_response_device_loggedout",
+                ruma_response_to_json(response.clone()),
+            );
+        });
+        response
+    }
+
+    /// Common helper for [`Self::dan_keys_query_response`] and
+    /// [`Self::dan_keys_query_response_device_loggedout`].
+    ///
+    /// Returns the full response, including both devices, without writing the
+    /// snapshot.
+    fn dan_keys_query_response_common() -> KeyQueryResponse {
         let data: Value = json!({
                 "device_keys": {
                     "@dan:localhost": {
@@ -377,102 +412,6 @@ impl KeyDistributionTestData {
         });
 
         let response: KeyQueryResponse = ruma_response_from_json(&data);
-        with_settings!({sort_maps => true}, {
-            assert_json_snapshot!(
-                "KeyDistributionTestData::dan_keys_query_response",
-                ruma_response_to_json(response.clone()),
-            );
-        });
-        response
-    }
-
-    /// Same as `dan_keys_query_response` but `FRGNMZVOKA` was removed.
-    pub fn dan_keys_query_response_device_loggedout() -> KeyQueryResponse {
-        let data = json!({
-                "device_keys": {
-                    "@dan:localhost": {
-                        "JHPUERYQUW": {
-                            "algorithms": [
-                                "m.olm.v1.curve25519-aes-sha2",
-                                "m.megolm.v1.aes-sha2"
-                            ],
-                            "device_id": "JHPUERYQUW",
-                            "keys": {
-                                "curve25519:JHPUERYQUW": "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4",
-                                "ed25519:JHPUERYQUW": "jZ5Ca/J5RXn3qnNWIHFz9EQBZ4637QI/9ExSiEcGC7I"
-                            },
-                            "signatures": {
-                                "@dan:localhost": {
-                                    "ed25519:JHPUERYQUW": "PaVfCE9QODgluq0gYMpjCarfDbraRXU71uRcUN5MoqtiJYlB0bjzY6bD5/qxugrsgcx4DZOgCLgiyoEZ/vW4DQ",
-                                    "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "2sZcF5aSyEuryTfWgsw3rNDevnZisH2Df6fCO5pmGwweiaD+n6+pyrzB75mvA1sOwzm9jfTsjv/2+Uj1CNOTBA"
-                                }
-                            },
-                            "user_id": "@dan:localhost",
-                        },
-                    }
-                },
-                "failures": {},
-                "master_keys": {
-                    "@dan:localhost": {
-                        "keys": {
-                            "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k"
-                        },
-                        "signatures": {
-                            "@dan:localhost": {
-                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "DI/zpWA/wG1tdK9aLof1TGBHtihtQZQ+7e62QRSBbo+RAHlQ+akGcaVskLbtLdEKbcJEt61F+Auol+XVGlCEBA",
-                                "ed25519:SNEBMNPLHN": "5Y8byBteGZo1SvPf8QM88pvThJu+2mJ4020YsTLPhCQ4DfdalHWTPOvE7gw09cCONhX/cKY7YHMyH8R26Yd9DA"
-                            },
-                            "@me:localhost": {
-                                "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "vg2MLJx36Usti4NfsbOfk0ipW7koOoTlBibZkQNrPTMX88V+geTgDjvIMEU/OAyEsgsDHjg3C+2t/yUUDE7hBA"
-                            }
-                        },
-                        "usage": [
-                            "master"
-                        ],
-                        "user_id": "@dan:localhost"
-                    }
-                },
-                "self_signing_keys": {
-                    "@dan:localhost": {
-                        "keys": {
-                            "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak"
-                        },
-                        "signatures": {
-                            "@dan:localhost": {
-                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "vxUCzOO4EGwLp+tzfoFbPOVicynvmWgxVx/bv/3fG/Xfl7piJVmeHP+1qDstOewiREuO4W+ti/tYkOXd7GgoAw"
-                            }
-                        },
-                        "usage": [
-                            "self_signing"
-                        ],
-                        "user_id": "@dan:localhost"
-                    }
-                },
-                "user_signing_keys": {
-                    "@dan:localhost": {
-                        "keys": {
-                            "ed25519:N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU": "N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU"
-                        },
-                        "signatures": {
-                            "@dan:localhost": {
-                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "gbcD579EGVDRePnKV9j6YNwGhssgFeJWhF1NRJhFNAcpbGL8911cW54jyiFKFCev89QemfqyFFljldFLfyN9DA"
-                            }
-                        },
-                        "usage": [
-                            "user_signing"
-                        ],
-                        "user_id": "@dan:localhost"
-                    }
-                }
-        });
-
-        let response: KeyQueryResponse = ruma_response_from_json(&data);
-        with_settings!({sort_maps => true}, {
-            assert_json_snapshot!(
-                "KeyDistributionTestData::dan_keys_query_response_device_loggedout",
-                ruma_response_to_json(response.clone()),
-            );
-        });
         response
     }
 

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -57,7 +57,6 @@ impl KeyDistributionTestData {
                     "signatures": {
                         "@me:localhost": {
                             "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "5G9+Ns28rzNd+2DvP73Y0orr8sxduRQcrJj0YB7ZygH7oeXshvGLeQn6mcNs7q7ZrMR5bYlXxopufKSWWoKpCg",
-                            "ed25519:YVKUSVBKWX": "ih1Kmj4dTB1AjjkwrLA2qIL3e/oPUFisP5Ic8kGp29wrpoHokasKKnkRl1zS7zq6iBcOL6aOZLPPX/ZHYCX5BQ"
                         }
                     },
                     "usage": [
@@ -612,7 +611,6 @@ impl VerificationViolationTestData {
                     "signatures": {
                         "@alice:localhost": {
                             "ed25519:EPVg/QLG9+FmNvKjNXfycZEpQLtfHDaTN+rENAURZSk": "FX+srrw9SRmi12fexYHH1jrlEIWgOfre1aPNzDZWcAlaP9WKRdhcQGh70/3F9hk/PGr51I+ux62YgU4xnRTqAA",
-                            "ed25519:PWVCNMMGCT": "teLq0rCYKX9h8WXu6kH8UE6HPKAtkF/DwCncxJGvVBCyZRtLHD8W1yYEzJXjTNynn+4fibQZBhR3th1RGLn4Ag"
                         }
                     },
                     "usage": [

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -770,58 +770,14 @@ impl VerificationViolationTestData {
     /// `/keys/query` response for Alice, containing the public cross-signing
     /// keys.
     pub fn own_keys_query_response_1() -> KeyQueryResponse {
-        let data = json!({
-            "master_keys": {
-                "@alice:localhost": {
-                    "keys": {
-                        "ed25519:EPVg/QLG9+FmNvKjNXfycZEpQLtfHDaTN+rENAURZSk": "EPVg/QLG9+FmNvKjNXfycZEpQLtfHDaTN+rENAURZSk"
-                    },
-                    "signatures": {
-                        "@alice:localhost": {
-                            "ed25519:EPVg/QLG9+FmNvKjNXfycZEpQLtfHDaTN+rENAURZSk": "FX+srrw9SRmi12fexYHH1jrlEIWgOfre1aPNzDZWcAlaP9WKRdhcQGh70/3F9hk/PGr51I+ux62YgU4xnRTqAA",
-                        }
-                    },
-                    "usage": [
-                        "master"
-                    ],
-                    "user_id": "@alice:localhost"
-                }
-            },
-            "self_signing_keys": {
-                "@alice:localhost": {
-                    "keys": {
-                        "ed25519:WXLer0esHUanp8DCeu2Be0xB5ms9aKFFBrCFl50COjw": "WXLer0esHUanp8DCeu2Be0xB5ms9aKFFBrCFl50COjw"
-                    },
-                    "signatures": {
-                        "@alice:localhost": {
-                            "ed25519:EPVg/QLG9+FmNvKjNXfycZEpQLtfHDaTN+rENAURZSk": "lCV9R1xjD34arzq/CAuej1XBv+Ip4dFfAGHfe7znbW7rnwKDaX5PaX3MHk+EIC7nXvUYEAn502WcUFme5c0cCQ"
-                        }
-                    },
-                    "usage": [
-                        "self_signing"
-                    ],
-                    "user_id": "@alice:localhost"
-                }
-            },
-            "user_signing_keys": {
-                "@alice:localhost": {
-                    "keys": {
-                        "ed25519:MXob/N/bYI7U2655O1/AI9NOX1245RnE03Nl4Hvf+u0": "MXob/N/bYI7U2655O1/AI9NOX1245RnE03Nl4Hvf+u0"
-                    },
-                    "signatures": {
-                        "@alice:localhost": {
-                            "ed25519:EPVg/QLG9+FmNvKjNXfycZEpQLtfHDaTN+rENAURZSk": "A73QfZ5Dzhh7abdal/sEaq1bfgxzPFU8Bvwa9Y5TIe/a5jTmLVubNmsMSsO5tOT+b6aVJg1G4FtId0Q/cb1aAA"
-                        }
-                    },
-                    "usage": [
-                        "user_signing"
-                    ],
-                    "user_id": "@alice:localhost"
-                }
-            }
-        });
+        let builder = KeyQueryResponseTemplate::new(Self::own_id().to_owned())
+            .with_cross_signing_keys(
+                Ed25519SecretKey::from_base64(Self::MASTER_KEY_PRIVATE_EXPORT).unwrap(),
+                Ed25519SecretKey::from_base64(Self::SELF_SIGNING_KEY_PRIVATE_EXPORT).unwrap(),
+                Ed25519SecretKey::from_base64(Self::USER_SIGNING_KEY_PRIVATE_EXPORT).unwrap(),
+            );
 
-        let response: KeyQueryResponse = ruma_response_from_json(&data);
+        let response = builder.build_response();
         with_settings!({sort_maps => true}, {
             assert_json_snapshot!(
                 "VerificationViolationTestData::own_keys_query_response_1",

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -7,7 +7,7 @@ use serde_json::{json, Value};
 
 use super::keys_query::{keys_query, master_keys, KeysQueryUser};
 use crate::{
-    ruma_response_from_json,
+    ruma_response_from_json, ruma_response_to_json,
     test_json::keys_query::{device_keys_payload, self_signing_keys},
 };
 
@@ -100,10 +100,14 @@ impl KeyDistributionTestData {
             }
         });
 
+        let response: KeyQueryResponse = ruma_response_from_json(&data);
         with_settings!({sort_maps => true}, {
-            assert_json_snapshot!("KeyDistributionTestData::me_keys_query_response", data);
+            assert_json_snapshot!(
+                "KeyDistributionTestData::me_keys_query_response",
+                ruma_response_to_json(response.clone()),
+            );
         });
-        ruma_response_from_json(&data)
+        response
     }
 
     /// Dan has cross-signing setup, one device is cross signed `JHPUERYQUW`,
@@ -205,11 +209,14 @@ impl KeyDistributionTestData {
                 }
         });
 
+        let response: KeyQueryResponse = ruma_response_from_json(&data);
         with_settings!({sort_maps => true}, {
-            assert_json_snapshot!("KeyDistributionTestData::dan_keys_query_response", data);
+            assert_json_snapshot!(
+                "KeyDistributionTestData::dan_keys_query_response",
+                ruma_response_to_json(response.clone()),
+            );
         });
-
-        ruma_response_from_json(&data)
+        response
     }
 
     /// Same as `dan_keys_query_response` but `FRGNMZVOKA` was removed.
@@ -292,14 +299,14 @@ impl KeyDistributionTestData {
                 }
         });
 
+        let response: KeyQueryResponse = ruma_response_from_json(&data);
         with_settings!({sort_maps => true}, {
             assert_json_snapshot!(
                 "KeyDistributionTestData::dan_keys_query_response_device_loggedout",
-                data
+                ruma_response_to_json(response.clone()),
             );
         });
-
-        ruma_response_from_json(&data)
+        response
     }
 
     /// Dave is a user that has not enabled cross-signing
@@ -648,10 +655,14 @@ impl VerificationViolationTestData {
             }
         });
 
+        let response: KeyQueryResponse = ruma_response_from_json(&data);
         with_settings!({sort_maps => true}, {
-            assert_json_snapshot!("VerificationViolationTestData::own_keys_query_response_1", data);
+            assert_json_snapshot!(
+                "VerificationViolationTestData::own_keys_query_response_1",
+                ruma_response_to_json(response.clone()),
+            );
         });
-        ruma_response_from_json(&data)
+        response
     }
 
     /// A second `/keys/query` response for Alice, containing a *different* set

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -1,3 +1,4 @@
+use insta::{assert_json_snapshot, with_settings};
 use ruma::{
     api::client::keys::get_keys::v3::Response as KeyQueryResponse, device_id,
     encryption::DeviceKeys, serde::Raw, user_id, DeviceId, OwnedDeviceId, UserId,
@@ -99,6 +100,9 @@ impl KeyDistributionTestData {
             }
         });
 
+        with_settings!({sort_maps => true}, {
+            assert_json_snapshot!("KeyDistributionTestData::me_keys_query_response", data);
+        });
         ruma_response_from_json(&data)
     }
 
@@ -201,6 +205,10 @@ impl KeyDistributionTestData {
                 }
         });
 
+        with_settings!({sort_maps => true}, {
+            assert_json_snapshot!("KeyDistributionTestData::dan_keys_query_response", data);
+        });
+
         ruma_response_from_json(&data)
     }
 
@@ -282,6 +290,13 @@ impl KeyDistributionTestData {
                         "user_id": "@dan:localhost"
                     }
                 }
+        });
+
+        with_settings!({sort_maps => true}, {
+            assert_json_snapshot!(
+                "KeyDistributionTestData::dan_keys_query_response_device_loggedout",
+                data
+            );
         });
 
         ruma_response_from_json(&data)
@@ -633,6 +648,9 @@ impl VerificationViolationTestData {
             }
         });
 
+        with_settings!({sort_maps => true}, {
+            assert_json_snapshot!("VerificationViolationTestData::own_keys_query_response_1", data);
+        });
         ruma_response_from_json(&data)
     }
 

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -277,6 +277,18 @@ impl KeyDistributionTestData {
         response
     }
 
+    /// Dan's (base64-encoded) private master cross-signing key.
+    const DAN_PRIVATE_MASTER_CROSS_SIGNING_KEY: &'static str =
+        "QGZo39k199RM0NYvPvFNXBspc5llftHWKKHqEi25q0U";
+
+    /// Dan's (base64-encoded) private self-signing key.
+    const DAN_PRIVATE_SELF_SIGNING_KEY: &'static str =
+        "0ES1HO5VXpy/BsXxadwsk6QcwH/ci99KkV9ZlPakHlU";
+
+    /// Dan's (base64-encoded) private user-signing key.
+    const DAN_PRIVATE_USER_SIGNING_KEY: &'static str =
+        "vSdfrHJO8sZH/54r1uCg8BE0CdcDVGkPQNOu7Ej8BBs";
+
     /// Dan has cross-signing set up; one device is cross-signed (`JHPUERYQUW`),
     /// but not the other one (`FRGNMZVOKA`).
     ///
@@ -327,16 +339,18 @@ impl KeyDistributionTestData {
                             "device_id": "JHPUERYQUW",
                             "keys": {
                                 "curve25519:JHPUERYQUW": "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4",
-                                "ed25519:JHPUERYQUW": "jZ5Ca/J5RXn3qnNWIHFz9EQBZ4637QI/9ExSiEcGC7I"
+                                // Private key: "yzj53Kccfqx2yx9lcTwaRfPZX+7jU19harsDWWu5YnM"
+                                "ed25519:JHPUERYQUW": "+qMutlCB/eWCbI3bIskWhjYVGrRX8hF+F48sNsmg1YE"
                             },
                             "signatures": {
                                 "@dan:localhost": {
-                                    "ed25519:JHPUERYQUW": "PaVfCE9QODgluq0gYMpjCarfDbraRXU71uRcUN5MoqtiJYlB0bjzY6bD5/qxugrsgcx4DZOgCLgiyoEZ/vW4DQ",
-                                    "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "2sZcF5aSyEuryTfWgsw3rNDevnZisH2Df6fCO5pmGwweiaD+n6+pyrzB75mvA1sOwzm9jfTsjv/2+Uj1CNOTBA"
+                                    "ed25519:JHPUERYQUW": "I9mcfT2BIwbWfga1P85rdbhEDh5qc/3pLgY8jsqlzXbjl4AfHKBZUvcgQ54kKFOf/jK9pTK2Ed35cDQ1QZ44Cw",
+                                    "ed25519:FZSpCr3lGMCfjgRtlLxxHkGJ8dMw5YSYvSYaf7bJ2QA": "msmrAwToOpBmSLeWyThuV7vS7fXGB291C3KUrM+2a0L6CS6pqpK12nBZG/dLeDzVSAamyWjB3OuwhTl0kE7UCA"
                                 }
                             },
                             "user_id": "@dan:localhost",
                         },
+
                         "FRGNMZVOKA": {
                             "algorithms": [
                                 "m.olm.v1.curve25519-aes-sha2",
@@ -345,11 +359,12 @@ impl KeyDistributionTestData {
                             "device_id": "FRGNMZVOKA",
                             "keys": {
                                 "curve25519:FRGNMZVOKA": "Hc/BC/xyQIEnScyZkEk+ilDMfOARxHMFoEcggPqqRw4",
-                                "ed25519:FRGNMZVOKA": "jVroR0JoRemjF0vJslY3HirJgwfX5gm5DCM64hZgkI0"
+                                // Private key: "/SlFtNKxTPN+i4pHzSPWZ1Oc6ymMB33sS32GXZkaLos"
+                                "ed25519:FRGNMZVOKA": "xp/IW9Sh8Jw/buUYlARWD20EV2TdUG/SZ+Pa4iEtcew"
                             },
                             "signatures": {
                                 "@dan:localhost": {
-                                    "ed25519:FRGNMZVOKA": "+row23EcWR2D8EKgwzZmy3dWz/l5DHvEHR6jHKnBohphEIsBl0o3Cp9rIztFpStFGRPSAa3xEqfMVW2dIaKkCg"
+                                    "ed25519:FRGNMZVOKA": "G6f8s4a3rXOnODPdSQTUOjJ0YtxlxwDSTPNkzbAMHEwdmnmUuFhTdEYNP/dzDDGd8kViWpMteaPqvlAKIlvlBg"
                                 }
                             },
                             "user_id": "@dan:localhost",
@@ -360,15 +375,14 @@ impl KeyDistributionTestData {
                 "master_keys": {
                     "@dan:localhost": {
                         "keys": {
-                            "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k"
+                            "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo"
                         },
                         "signatures": {
                             "@dan:localhost": {
-                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "DI/zpWA/wG1tdK9aLof1TGBHtihtQZQ+7e62QRSBbo+RAHlQ+akGcaVskLbtLdEKbcJEt61F+Auol+XVGlCEBA",
-                                "ed25519:SNEBMNPLHN": "5Y8byBteGZo1SvPf8QM88pvThJu+2mJ4020YsTLPhCQ4DfdalHWTPOvE7gw09cCONhX/cKY7YHMyH8R26Yd9DA"
+                                "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "WiSxmg/RpT8BTHcLvNS7vgKyonsRpX/K6E9EzEfLpNOxXfisPClbpuVtxEb3te/Cx/1UKaio1MJcDxqKFMVmDw"
                             },
                             "@me:localhost": {
-                                "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "vg2MLJx36Usti4NfsbOfk0ipW7koOoTlBibZkQNrPTMX88V+geTgDjvIMEU/OAyEsgsDHjg3C+2t/yUUDE7hBA"
+                                "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "lSa34sDcviLPgk8yECGxwdSt2074sf2R8uSmxpTuK5NBqv9dpu0NwTJkO4PLohQTvleIYZSH+uXc3mPZpFy8DQ"
                             }
                         },
                         "usage": [
@@ -380,11 +394,11 @@ impl KeyDistributionTestData {
                 "self_signing_keys": {
                     "@dan:localhost": {
                         "keys": {
-                            "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak"
+                            "ed25519:FZSpCr3lGMCfjgRtlLxxHkGJ8dMw5YSYvSYaf7bJ2QA": "FZSpCr3lGMCfjgRtlLxxHkGJ8dMw5YSYvSYaf7bJ2QA"
                         },
                         "signatures": {
                             "@dan:localhost": {
-                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "vxUCzOO4EGwLp+tzfoFbPOVicynvmWgxVx/bv/3fG/Xfl7piJVmeHP+1qDstOewiREuO4W+ti/tYkOXd7GgoAw"
+                                "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "ZKjShHHjXbnkhAUk6P2c03FsUr4wB+3xH7llKV/7QD5wuOapgM7OucABCixivA6xiUVWPGjzZ76y6DFG6YloAA"
                             }
                         },
                         "usage": [
@@ -396,11 +410,11 @@ impl KeyDistributionTestData {
                 "user_signing_keys": {
                     "@dan:localhost": {
                         "keys": {
-                            "ed25519:N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU": "N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU"
+                            "ed25519:2MZakmHIYdjIvYEmUsoNJoAx8Rx2hviO2hq8q5jQ4Rk": "2MZakmHIYdjIvYEmUsoNJoAx8Rx2hviO2hq8q5jQ4Rk"
                         },
                         "signatures": {
                             "@dan:localhost": {
-                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "gbcD579EGVDRePnKV9j6YNwGhssgFeJWhF1NRJhFNAcpbGL8911cW54jyiFKFCev89QemfqyFFljldFLfyN9DA"
+                                "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "bsjJnBMMYcRwcNysPhW9r8jOXuui7otHJH1/clnf7jhEHzj2v8ei4IjZaKLvodFdNLyl/DQE5eOKlhCgt5ekDQ"
                             }
                         },
                         "usage": [

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -219,8 +219,6 @@ impl KeyQueryResponseTemplate {
 }
 
 /// This set of keys/query response was generated using a local synapse.
-/// Each users was created, device added according to needs and the payload
-/// of the keys query have been copy/pasted here.
 ///
 /// The current user is `@me:localhost`, the private part of the
 /// cross-signing keys have been exported using the console with the
@@ -328,105 +326,33 @@ impl KeyDistributionTestData {
     /// Returns the full response, including both devices, without writing the
     /// snapshot.
     fn dan_keys_query_response_common() -> KeyQueryResponse {
-        let data: Value = json!({
-                "device_keys": {
-                    "@dan:localhost": {
-                        "JHPUERYQUW": {
-                            "algorithms": [
-                                "m.olm.v1.curve25519-aes-sha2",
-                                "m.megolm.v1.aes-sha2"
-                            ],
-                            "device_id": "JHPUERYQUW",
-                            "keys": {
-                                "curve25519:JHPUERYQUW": "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4",
-                                // Private key: "yzj53Kccfqx2yx9lcTwaRfPZX+7jU19harsDWWu5YnM"
-                                "ed25519:JHPUERYQUW": "+qMutlCB/eWCbI3bIskWhjYVGrRX8hF+F48sNsmg1YE"
-                            },
-                            "signatures": {
-                                "@dan:localhost": {
-                                    "ed25519:JHPUERYQUW": "I9mcfT2BIwbWfga1P85rdbhEDh5qc/3pLgY8jsqlzXbjl4AfHKBZUvcgQ54kKFOf/jK9pTK2Ed35cDQ1QZ44Cw",
-                                    "ed25519:FZSpCr3lGMCfjgRtlLxxHkGJ8dMw5YSYvSYaf7bJ2QA": "msmrAwToOpBmSLeWyThuV7vS7fXGB291C3KUrM+2a0L6CS6pqpK12nBZG/dLeDzVSAamyWjB3OuwhTl0kE7UCA"
-                                }
-                            },
-                            "user_id": "@dan:localhost",
-                        },
+        let builder = KeyQueryResponseTemplate::new(Self::dan_id().to_owned())
+            .with_cross_signing_keys(
+                Ed25519SecretKey::from_base64(Self::DAN_PRIVATE_MASTER_CROSS_SIGNING_KEY).unwrap(),
+                Ed25519SecretKey::from_base64(Self::DAN_PRIVATE_SELF_SIGNING_KEY).unwrap(),
+                Ed25519SecretKey::from_base64(Self::DAN_PRIVATE_USER_SIGNING_KEY).unwrap(),
+            )
+            .with_user_verification_signature(Self::me_id(), &Self::me_private_user_signing_key());
 
-                        "FRGNMZVOKA": {
-                            "algorithms": [
-                                "m.olm.v1.curve25519-aes-sha2",
-                                "m.megolm.v1.aes-sha2"
-                            ],
-                            "device_id": "FRGNMZVOKA",
-                            "keys": {
-                                "curve25519:FRGNMZVOKA": "Hc/BC/xyQIEnScyZkEk+ilDMfOARxHMFoEcggPqqRw4",
-                                // Private key: "/SlFtNKxTPN+i4pHzSPWZ1Oc6ymMB33sS32GXZkaLos"
-                                "ed25519:FRGNMZVOKA": "xp/IW9Sh8Jw/buUYlARWD20EV2TdUG/SZ+Pa4iEtcew"
-                            },
-                            "signatures": {
-                                "@dan:localhost": {
-                                    "ed25519:FRGNMZVOKA": "G6f8s4a3rXOnODPdSQTUOjJ0YtxlxwDSTPNkzbAMHEwdmnmUuFhTdEYNP/dzDDGd8kViWpMteaPqvlAKIlvlBg"
-                                }
-                            },
-                            "user_id": "@dan:localhost",
-                        },
-                    }
-                },
-                "failures": {},
-                "master_keys": {
-                    "@dan:localhost": {
-                        "keys": {
-                            "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo"
-                        },
-                        "signatures": {
-                            "@dan:localhost": {
-                                "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "WiSxmg/RpT8BTHcLvNS7vgKyonsRpX/K6E9EzEfLpNOxXfisPClbpuVtxEb3te/Cx/1UKaio1MJcDxqKFMVmDw"
-                            },
-                            "@me:localhost": {
-                                "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "lSa34sDcviLPgk8yECGxwdSt2074sf2R8uSmxpTuK5NBqv9dpu0NwTJkO4PLohQTvleIYZSH+uXc3mPZpFy8DQ"
-                            }
-                        },
-                        "usage": [
-                            "master"
-                        ],
-                        "user_id": "@dan:localhost"
-                    }
-                },
-                "self_signing_keys": {
-                    "@dan:localhost": {
-                        "keys": {
-                            "ed25519:FZSpCr3lGMCfjgRtlLxxHkGJ8dMw5YSYvSYaf7bJ2QA": "FZSpCr3lGMCfjgRtlLxxHkGJ8dMw5YSYvSYaf7bJ2QA"
-                        },
-                        "signatures": {
-                            "@dan:localhost": {
-                                "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "ZKjShHHjXbnkhAUk6P2c03FsUr4wB+3xH7llKV/7QD5wuOapgM7OucABCixivA6xiUVWPGjzZ76y6DFG6YloAA"
-                            }
-                        },
-                        "usage": [
-                            "self_signing"
-                        ],
-                        "user_id": "@dan:localhost"
-                    }
-                },
-                "user_signing_keys": {
-                    "@dan:localhost": {
-                        "keys": {
-                            "ed25519:2MZakmHIYdjIvYEmUsoNJoAx8Rx2hviO2hq8q5jQ4Rk": "2MZakmHIYdjIvYEmUsoNJoAx8Rx2hviO2hq8q5jQ4Rk"
-                        },
-                        "signatures": {
-                            "@dan:localhost": {
-                                "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "bsjJnBMMYcRwcNysPhW9r8jOXuui7otHJH1/clnf7jhEHzj2v8ei4IjZaKLvodFdNLyl/DQE5eOKlhCgt5ekDQ"
-                            }
-                        },
-                        "usage": [
-                            "user_signing"
-                        ],
-                        "user_id": "@dan:localhost"
-                    }
-                }
-        });
+        // Add signed device JHPUERYQUW
+        let builder = builder.with_device(
+            Self::dan_signed_device_id(),
+            &Curve25519PublicKey::from_base64("PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4")
+                .unwrap(),
+            &Ed25519SecretKey::from_base64("yzj53Kccfqx2yx9lcTwaRfPZX+7jU19harsDWWu5YnM").unwrap(),
+            true,
+        );
 
-        let response: KeyQueryResponse = ruma_response_from_json(&data);
-        response
+        // Add unsigned device FRGNMZVOKA
+        let builder = builder.with_device(
+            Self::dan_unsigned_device_id(),
+            &Curve25519PublicKey::from_base64("Hc/BC/xyQIEnScyZkEk+ilDMfOARxHMFoEcggPqqRw4")
+                .unwrap(),
+            &Ed25519SecretKey::from_base64("/SlFtNKxTPN+i4pHzSPWZ1Oc6ymMB33sS32GXZkaLos").unwrap(),
+            false,
+        );
+
+        builder.build_response()
     }
 
     /// Dave is a user that has not enabled cross-signing

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -21,6 +21,71 @@ use crate::{
 
 /// A test helper for building test data sets for `/keys/query` response objects
 /// ([`KeyQueryResponse`]).
+///
+/// # Examples
+///
+/// A simple case with no cross-signing identity and a single device:
+///
+/// ```
+/// # use ruma::{device_id, owned_user_id};
+/// # use vodozemac::{Curve25519PublicKey, Ed25519SecretKey};
+/// # use matrix_sdk_test::test_json::keys_query_sets::KeyQueryResponseTemplate;
+///
+/// let pub_curve_key = "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4";
+/// let ed25519_key = "yzj53Kccfqx2yx9lcTwaRfPZX+7jU19harsDWWu5YnM";
+///
+/// let builder = KeyQueryResponseTemplate::new(owned_user_id!("@alice:localhost"))
+///     .with_device(
+///         device_id!("TESTDEVICE"),
+///         &Curve25519PublicKey::from_base64(pub_curve_key).unwrap(),
+///         &Ed25519SecretKey::from_base64(ed25519_key).unwrap(),
+///         false,
+///     );
+///
+/// let response = builder.build_response();
+/// ```
+///
+///
+/// A more complex case, with cross-signing keys and a signed device:
+///
+/// ```
+/// # use ruma::{device_id, owned_user_id, user_id};
+/// # use vodozemac::{Curve25519PublicKey, Ed25519SecretKey};
+/// # use matrix_sdk_test::test_json::keys_query_sets::KeyQueryResponseTemplate;
+///
+/// // Private cross-signing keys
+/// let master_key = "QGZo39k199RM0NYvPvFNXBspc5llftHWKKHqEi25q0U";
+/// let ssk = "0ES1HO5VXpy/BsXxadwsk6QcwH/ci99KkV9ZlPakHlU";
+/// let usk = "vSdfrHJO8sZH/54r1uCg8BE0CdcDVGkPQNOu7Ej8BBs";
+///
+/// // Device keys
+/// let pub_curve_key = "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4";
+/// let ed25519_key = "yzj53Kccfqx2yx9lcTwaRfPZX+7jU19harsDWWu5YnM";
+///
+/// let other_user_usk = "zQSosK46giUFs2ACsaf32bA7drcIXbmViyEt+TLfloI";
+///
+/// let builder = KeyQueryResponseTemplate::new(owned_user_id!("@me:localhost"))
+///     // add cross-signing keys
+///     .with_cross_signing_keys(
+///         Ed25519SecretKey::from_base64(master_key).unwrap(),
+///         Ed25519SecretKey::from_base64(ssk).unwrap(),
+///         Ed25519SecretKey::from_base64(usk).unwrap(),
+///     )
+///     // add verification from another user
+///     .with_user_verification_signature(
+///         user_id!("@them:localhost"),
+///         &Ed25519SecretKey::from_base64(other_user_usk).unwrap(),
+///     )
+///     // add signed device
+///     .with_device(
+///         device_id!("SECUREDEVICE"),
+///         &Curve25519PublicKey::from_base64(pub_curve_key).unwrap(),
+///         &Ed25519SecretKey::from_base64(ed25519_key).unwrap(),
+///         true,
+///     );
+///
+/// let response = builder.build_response();
+/// ```
 pub struct KeyQueryResponseTemplate {
     /// The User ID of the user that this test data is about.
     user_id: OwnedUserId,

--- a/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::dan_keys_query_response.snap
+++ b/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::dan_keys_query_response.snap
@@ -13,11 +13,11 @@ expression: ruma_response_to_json(response.clone())
         "device_id": "FRGNMZVOKA",
         "keys": {
           "curve25519:FRGNMZVOKA": "Hc/BC/xyQIEnScyZkEk+ilDMfOARxHMFoEcggPqqRw4",
-          "ed25519:FRGNMZVOKA": "jVroR0JoRemjF0vJslY3HirJgwfX5gm5DCM64hZgkI0"
+          "ed25519:FRGNMZVOKA": "xp/IW9Sh8Jw/buUYlARWD20EV2TdUG/SZ+Pa4iEtcew"
         },
         "signatures": {
           "@dan:localhost": {
-            "ed25519:FRGNMZVOKA": "+row23EcWR2D8EKgwzZmy3dWz/l5DHvEHR6jHKnBohphEIsBl0o3Cp9rIztFpStFGRPSAa3xEqfMVW2dIaKkCg"
+            "ed25519:FRGNMZVOKA": "G6f8s4a3rXOnODPdSQTUOjJ0YtxlxwDSTPNkzbAMHEwdmnmUuFhTdEYNP/dzDDGd8kViWpMteaPqvlAKIlvlBg"
           }
         },
         "user_id": "@dan:localhost"
@@ -30,12 +30,12 @@ expression: ruma_response_to_json(response.clone())
         "device_id": "JHPUERYQUW",
         "keys": {
           "curve25519:JHPUERYQUW": "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4",
-          "ed25519:JHPUERYQUW": "jZ5Ca/J5RXn3qnNWIHFz9EQBZ4637QI/9ExSiEcGC7I"
+          "ed25519:JHPUERYQUW": "+qMutlCB/eWCbI3bIskWhjYVGrRX8hF+F48sNsmg1YE"
         },
         "signatures": {
           "@dan:localhost": {
-            "ed25519:JHPUERYQUW": "PaVfCE9QODgluq0gYMpjCarfDbraRXU71uRcUN5MoqtiJYlB0bjzY6bD5/qxugrsgcx4DZOgCLgiyoEZ/vW4DQ",
-            "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "2sZcF5aSyEuryTfWgsw3rNDevnZisH2Df6fCO5pmGwweiaD+n6+pyrzB75mvA1sOwzm9jfTsjv/2+Uj1CNOTBA"
+            "ed25519:FZSpCr3lGMCfjgRtlLxxHkGJ8dMw5YSYvSYaf7bJ2QA": "msmrAwToOpBmSLeWyThuV7vS7fXGB291C3KUrM+2a0L6CS6pqpK12nBZG/dLeDzVSAamyWjB3OuwhTl0kE7UCA",
+            "ed25519:JHPUERYQUW": "I9mcfT2BIwbWfga1P85rdbhEDh5qc/3pLgY8jsqlzXbjl4AfHKBZUvcgQ54kKFOf/jK9pTK2Ed35cDQ1QZ44Cw"
           }
         },
         "user_id": "@dan:localhost"
@@ -45,15 +45,14 @@ expression: ruma_response_to_json(response.clone())
   "master_keys": {
     "@dan:localhost": {
       "keys": {
-        "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k"
+        "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo"
       },
       "signatures": {
         "@dan:localhost": {
-          "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "DI/zpWA/wG1tdK9aLof1TGBHtihtQZQ+7e62QRSBbo+RAHlQ+akGcaVskLbtLdEKbcJEt61F+Auol+XVGlCEBA",
-          "ed25519:SNEBMNPLHN": "5Y8byBteGZo1SvPf8QM88pvThJu+2mJ4020YsTLPhCQ4DfdalHWTPOvE7gw09cCONhX/cKY7YHMyH8R26Yd9DA"
+          "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "WiSxmg/RpT8BTHcLvNS7vgKyonsRpX/K6E9EzEfLpNOxXfisPClbpuVtxEb3te/Cx/1UKaio1MJcDxqKFMVmDw"
         },
         "@me:localhost": {
-          "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "vg2MLJx36Usti4NfsbOfk0ipW7koOoTlBibZkQNrPTMX88V+geTgDjvIMEU/OAyEsgsDHjg3C+2t/yUUDE7hBA"
+          "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "lSa34sDcviLPgk8yECGxwdSt2074sf2R8uSmxpTuK5NBqv9dpu0NwTJkO4PLohQTvleIYZSH+uXc3mPZpFy8DQ"
         }
       },
       "usage": [
@@ -65,11 +64,11 @@ expression: ruma_response_to_json(response.clone())
   "self_signing_keys": {
     "@dan:localhost": {
       "keys": {
-        "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak"
+        "ed25519:FZSpCr3lGMCfjgRtlLxxHkGJ8dMw5YSYvSYaf7bJ2QA": "FZSpCr3lGMCfjgRtlLxxHkGJ8dMw5YSYvSYaf7bJ2QA"
       },
       "signatures": {
         "@dan:localhost": {
-          "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "vxUCzOO4EGwLp+tzfoFbPOVicynvmWgxVx/bv/3fG/Xfl7piJVmeHP+1qDstOewiREuO4W+ti/tYkOXd7GgoAw"
+          "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "ZKjShHHjXbnkhAUk6P2c03FsUr4wB+3xH7llKV/7QD5wuOapgM7OucABCixivA6xiUVWPGjzZ76y6DFG6YloAA"
         }
       },
       "usage": [
@@ -81,11 +80,11 @@ expression: ruma_response_to_json(response.clone())
   "user_signing_keys": {
     "@dan:localhost": {
       "keys": {
-        "ed25519:N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU": "N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU"
+        "ed25519:2MZakmHIYdjIvYEmUsoNJoAx8Rx2hviO2hq8q5jQ4Rk": "2MZakmHIYdjIvYEmUsoNJoAx8Rx2hviO2hq8q5jQ4Rk"
       },
       "signatures": {
         "@dan:localhost": {
-          "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "gbcD579EGVDRePnKV9j6YNwGhssgFeJWhF1NRJhFNAcpbGL8911cW54jyiFKFCev89QemfqyFFljldFLfyN9DA"
+          "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "bsjJnBMMYcRwcNysPhW9r8jOXuui7otHJH1/clnf7jhEHzj2v8ei4IjZaKLvodFdNLyl/DQE5eOKlhCgt5ekDQ"
         }
       },
       "usage": [

--- a/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::dan_keys_query_response.snap
+++ b/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::dan_keys_query_response.snap
@@ -1,6 +1,6 @@
 ---
 source: testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
-expression: data
+expression: ruma_response_to_json(response.clone())
 ---
 {
   "device_keys": {
@@ -42,7 +42,6 @@ expression: data
       }
     }
   },
-  "failures": {},
   "master_keys": {
     "@dan:localhost": {
       "keys": {

--- a/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::dan_keys_query_response.snap
+++ b/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::dan_keys_query_response.snap
@@ -1,0 +1,98 @@
+---
+source: testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+expression: data
+---
+{
+  "device_keys": {
+    "@dan:localhost": {
+      "FRGNMZVOKA": {
+        "algorithms": [
+          "m.olm.v1.curve25519-aes-sha2",
+          "m.megolm.v1.aes-sha2"
+        ],
+        "device_id": "FRGNMZVOKA",
+        "keys": {
+          "curve25519:FRGNMZVOKA": "Hc/BC/xyQIEnScyZkEk+ilDMfOARxHMFoEcggPqqRw4",
+          "ed25519:FRGNMZVOKA": "jVroR0JoRemjF0vJslY3HirJgwfX5gm5DCM64hZgkI0"
+        },
+        "signatures": {
+          "@dan:localhost": {
+            "ed25519:FRGNMZVOKA": "+row23EcWR2D8EKgwzZmy3dWz/l5DHvEHR6jHKnBohphEIsBl0o3Cp9rIztFpStFGRPSAa3xEqfMVW2dIaKkCg"
+          }
+        },
+        "user_id": "@dan:localhost"
+      },
+      "JHPUERYQUW": {
+        "algorithms": [
+          "m.olm.v1.curve25519-aes-sha2",
+          "m.megolm.v1.aes-sha2"
+        ],
+        "device_id": "JHPUERYQUW",
+        "keys": {
+          "curve25519:JHPUERYQUW": "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4",
+          "ed25519:JHPUERYQUW": "jZ5Ca/J5RXn3qnNWIHFz9EQBZ4637QI/9ExSiEcGC7I"
+        },
+        "signatures": {
+          "@dan:localhost": {
+            "ed25519:JHPUERYQUW": "PaVfCE9QODgluq0gYMpjCarfDbraRXU71uRcUN5MoqtiJYlB0bjzY6bD5/qxugrsgcx4DZOgCLgiyoEZ/vW4DQ",
+            "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "2sZcF5aSyEuryTfWgsw3rNDevnZisH2Df6fCO5pmGwweiaD+n6+pyrzB75mvA1sOwzm9jfTsjv/2+Uj1CNOTBA"
+          }
+        },
+        "user_id": "@dan:localhost"
+      }
+    }
+  },
+  "failures": {},
+  "master_keys": {
+    "@dan:localhost": {
+      "keys": {
+        "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k"
+      },
+      "signatures": {
+        "@dan:localhost": {
+          "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "DI/zpWA/wG1tdK9aLof1TGBHtihtQZQ+7e62QRSBbo+RAHlQ+akGcaVskLbtLdEKbcJEt61F+Auol+XVGlCEBA",
+          "ed25519:SNEBMNPLHN": "5Y8byBteGZo1SvPf8QM88pvThJu+2mJ4020YsTLPhCQ4DfdalHWTPOvE7gw09cCONhX/cKY7YHMyH8R26Yd9DA"
+        },
+        "@me:localhost": {
+          "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "vg2MLJx36Usti4NfsbOfk0ipW7koOoTlBibZkQNrPTMX88V+geTgDjvIMEU/OAyEsgsDHjg3C+2t/yUUDE7hBA"
+        }
+      },
+      "usage": [
+        "master"
+      ],
+      "user_id": "@dan:localhost"
+    }
+  },
+  "self_signing_keys": {
+    "@dan:localhost": {
+      "keys": {
+        "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak"
+      },
+      "signatures": {
+        "@dan:localhost": {
+          "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "vxUCzOO4EGwLp+tzfoFbPOVicynvmWgxVx/bv/3fG/Xfl7piJVmeHP+1qDstOewiREuO4W+ti/tYkOXd7GgoAw"
+        }
+      },
+      "usage": [
+        "self_signing"
+      ],
+      "user_id": "@dan:localhost"
+    }
+  },
+  "user_signing_keys": {
+    "@dan:localhost": {
+      "keys": {
+        "ed25519:N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU": "N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU"
+      },
+      "signatures": {
+        "@dan:localhost": {
+          "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "gbcD579EGVDRePnKV9j6YNwGhssgFeJWhF1NRJhFNAcpbGL8911cW54jyiFKFCev89QemfqyFFljldFLfyN9DA"
+        }
+      },
+      "usage": [
+        "user_signing"
+      ],
+      "user_id": "@dan:localhost"
+    }
+  }
+}

--- a/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::dan_keys_query_response_device_loggedout.snap
+++ b/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::dan_keys_query_response_device_loggedout.snap
@@ -1,6 +1,6 @@
 ---
 source: testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
-expression: data
+expression: ruma_response_to_json(response.clone())
 ---
 {
   "device_keys": {
@@ -25,7 +25,6 @@ expression: data
       }
     }
   },
-  "failures": {},
   "master_keys": {
     "@dan:localhost": {
       "keys": {

--- a/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::dan_keys_query_response_device_loggedout.snap
+++ b/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::dan_keys_query_response_device_loggedout.snap
@@ -13,12 +13,12 @@ expression: ruma_response_to_json(response.clone())
         "device_id": "JHPUERYQUW",
         "keys": {
           "curve25519:JHPUERYQUW": "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4",
-          "ed25519:JHPUERYQUW": "jZ5Ca/J5RXn3qnNWIHFz9EQBZ4637QI/9ExSiEcGC7I"
+          "ed25519:JHPUERYQUW": "+qMutlCB/eWCbI3bIskWhjYVGrRX8hF+F48sNsmg1YE"
         },
         "signatures": {
           "@dan:localhost": {
-            "ed25519:JHPUERYQUW": "PaVfCE9QODgluq0gYMpjCarfDbraRXU71uRcUN5MoqtiJYlB0bjzY6bD5/qxugrsgcx4DZOgCLgiyoEZ/vW4DQ",
-            "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "2sZcF5aSyEuryTfWgsw3rNDevnZisH2Df6fCO5pmGwweiaD+n6+pyrzB75mvA1sOwzm9jfTsjv/2+Uj1CNOTBA"
+            "ed25519:FZSpCr3lGMCfjgRtlLxxHkGJ8dMw5YSYvSYaf7bJ2QA": "msmrAwToOpBmSLeWyThuV7vS7fXGB291C3KUrM+2a0L6CS6pqpK12nBZG/dLeDzVSAamyWjB3OuwhTl0kE7UCA",
+            "ed25519:JHPUERYQUW": "I9mcfT2BIwbWfga1P85rdbhEDh5qc/3pLgY8jsqlzXbjl4AfHKBZUvcgQ54kKFOf/jK9pTK2Ed35cDQ1QZ44Cw"
           }
         },
         "user_id": "@dan:localhost"
@@ -28,15 +28,14 @@ expression: ruma_response_to_json(response.clone())
   "master_keys": {
     "@dan:localhost": {
       "keys": {
-        "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k"
+        "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo"
       },
       "signatures": {
         "@dan:localhost": {
-          "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "DI/zpWA/wG1tdK9aLof1TGBHtihtQZQ+7e62QRSBbo+RAHlQ+akGcaVskLbtLdEKbcJEt61F+Auol+XVGlCEBA",
-          "ed25519:SNEBMNPLHN": "5Y8byBteGZo1SvPf8QM88pvThJu+2mJ4020YsTLPhCQ4DfdalHWTPOvE7gw09cCONhX/cKY7YHMyH8R26Yd9DA"
+          "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "WiSxmg/RpT8BTHcLvNS7vgKyonsRpX/K6E9EzEfLpNOxXfisPClbpuVtxEb3te/Cx/1UKaio1MJcDxqKFMVmDw"
         },
         "@me:localhost": {
-          "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "vg2MLJx36Usti4NfsbOfk0ipW7koOoTlBibZkQNrPTMX88V+geTgDjvIMEU/OAyEsgsDHjg3C+2t/yUUDE7hBA"
+          "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "lSa34sDcviLPgk8yECGxwdSt2074sf2R8uSmxpTuK5NBqv9dpu0NwTJkO4PLohQTvleIYZSH+uXc3mPZpFy8DQ"
         }
       },
       "usage": [
@@ -48,11 +47,11 @@ expression: ruma_response_to_json(response.clone())
   "self_signing_keys": {
     "@dan:localhost": {
       "keys": {
-        "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak"
+        "ed25519:FZSpCr3lGMCfjgRtlLxxHkGJ8dMw5YSYvSYaf7bJ2QA": "FZSpCr3lGMCfjgRtlLxxHkGJ8dMw5YSYvSYaf7bJ2QA"
       },
       "signatures": {
         "@dan:localhost": {
-          "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "vxUCzOO4EGwLp+tzfoFbPOVicynvmWgxVx/bv/3fG/Xfl7piJVmeHP+1qDstOewiREuO4W+ti/tYkOXd7GgoAw"
+          "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "ZKjShHHjXbnkhAUk6P2c03FsUr4wB+3xH7llKV/7QD5wuOapgM7OucABCixivA6xiUVWPGjzZ76y6DFG6YloAA"
         }
       },
       "usage": [
@@ -64,11 +63,11 @@ expression: ruma_response_to_json(response.clone())
   "user_signing_keys": {
     "@dan:localhost": {
       "keys": {
-        "ed25519:N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU": "N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU"
+        "ed25519:2MZakmHIYdjIvYEmUsoNJoAx8Rx2hviO2hq8q5jQ4Rk": "2MZakmHIYdjIvYEmUsoNJoAx8Rx2hviO2hq8q5jQ4Rk"
       },
       "signatures": {
         "@dan:localhost": {
-          "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "gbcD579EGVDRePnKV9j6YNwGhssgFeJWhF1NRJhFNAcpbGL8911cW54jyiFKFCev89QemfqyFFljldFLfyN9DA"
+          "ed25519:ZzirLovLjBbJ9KkCl/w1+WevTSQdn0ngS4xl36bAuZo": "bsjJnBMMYcRwcNysPhW9r8jOXuui7otHJH1/clnf7jhEHzj2v8ei4IjZaKLvodFdNLyl/DQE5eOKlhCgt5ekDQ"
         }
       },
       "usage": [

--- a/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::dan_keys_query_response_device_loggedout.snap
+++ b/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::dan_keys_query_response_device_loggedout.snap
@@ -1,0 +1,81 @@
+---
+source: testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+expression: data
+---
+{
+  "device_keys": {
+    "@dan:localhost": {
+      "JHPUERYQUW": {
+        "algorithms": [
+          "m.olm.v1.curve25519-aes-sha2",
+          "m.megolm.v1.aes-sha2"
+        ],
+        "device_id": "JHPUERYQUW",
+        "keys": {
+          "curve25519:JHPUERYQUW": "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4",
+          "ed25519:JHPUERYQUW": "jZ5Ca/J5RXn3qnNWIHFz9EQBZ4637QI/9ExSiEcGC7I"
+        },
+        "signatures": {
+          "@dan:localhost": {
+            "ed25519:JHPUERYQUW": "PaVfCE9QODgluq0gYMpjCarfDbraRXU71uRcUN5MoqtiJYlB0bjzY6bD5/qxugrsgcx4DZOgCLgiyoEZ/vW4DQ",
+            "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "2sZcF5aSyEuryTfWgsw3rNDevnZisH2Df6fCO5pmGwweiaD+n6+pyrzB75mvA1sOwzm9jfTsjv/2+Uj1CNOTBA"
+          }
+        },
+        "user_id": "@dan:localhost"
+      }
+    }
+  },
+  "failures": {},
+  "master_keys": {
+    "@dan:localhost": {
+      "keys": {
+        "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k"
+      },
+      "signatures": {
+        "@dan:localhost": {
+          "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "DI/zpWA/wG1tdK9aLof1TGBHtihtQZQ+7e62QRSBbo+RAHlQ+akGcaVskLbtLdEKbcJEt61F+Auol+XVGlCEBA",
+          "ed25519:SNEBMNPLHN": "5Y8byBteGZo1SvPf8QM88pvThJu+2mJ4020YsTLPhCQ4DfdalHWTPOvE7gw09cCONhX/cKY7YHMyH8R26Yd9DA"
+        },
+        "@me:localhost": {
+          "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "vg2MLJx36Usti4NfsbOfk0ipW7koOoTlBibZkQNrPTMX88V+geTgDjvIMEU/OAyEsgsDHjg3C+2t/yUUDE7hBA"
+        }
+      },
+      "usage": [
+        "master"
+      ],
+      "user_id": "@dan:localhost"
+    }
+  },
+  "self_signing_keys": {
+    "@dan:localhost": {
+      "keys": {
+        "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak"
+      },
+      "signatures": {
+        "@dan:localhost": {
+          "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "vxUCzOO4EGwLp+tzfoFbPOVicynvmWgxVx/bv/3fG/Xfl7piJVmeHP+1qDstOewiREuO4W+ti/tYkOXd7GgoAw"
+        }
+      },
+      "usage": [
+        "self_signing"
+      ],
+      "user_id": "@dan:localhost"
+    }
+  },
+  "user_signing_keys": {
+    "@dan:localhost": {
+      "keys": {
+        "ed25519:N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU": "N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU"
+      },
+      "signatures": {
+        "@dan:localhost": {
+          "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "gbcD579EGVDRePnKV9j6YNwGhssgFeJWhF1NRJhFNAcpbGL8911cW54jyiFKFCev89QemfqyFFljldFLfyN9DA"
+        }
+      },
+      "usage": [
+        "user_signing"
+      ],
+      "user_id": "@dan:localhost"
+    }
+  }
+}

--- a/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::me_keys_query_response.snap
+++ b/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::me_keys_query_response.snap
@@ -10,8 +10,7 @@ expression: data
       },
       "signatures": {
         "@me:localhost": {
-          "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "5G9+Ns28rzNd+2DvP73Y0orr8sxduRQcrJj0YB7ZygH7oeXshvGLeQn6mcNs7q7ZrMR5bYlXxopufKSWWoKpCg",
-          "ed25519:YVKUSVBKWX": "ih1Kmj4dTB1AjjkwrLA2qIL3e/oPUFisP5Ic8kGp29wrpoHokasKKnkRl1zS7zq6iBcOL6aOZLPPX/ZHYCX5BQ"
+          "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "5G9+Ns28rzNd+2DvP73Y0orr8sxduRQcrJj0YB7ZygH7oeXshvGLeQn6mcNs7q7ZrMR5bYlXxopufKSWWoKpCg"
         }
       },
       "usage": [

--- a/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::me_keys_query_response.snap
+++ b/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__KeyDistributionTestData::me_keys_query_response.snap
@@ -1,0 +1,55 @@
+---
+source: testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+expression: data
+---
+{
+  "master_keys": {
+    "@me:localhost": {
+      "keys": {
+        "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4"
+      },
+      "signatures": {
+        "@me:localhost": {
+          "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "5G9+Ns28rzNd+2DvP73Y0orr8sxduRQcrJj0YB7ZygH7oeXshvGLeQn6mcNs7q7ZrMR5bYlXxopufKSWWoKpCg",
+          "ed25519:YVKUSVBKWX": "ih1Kmj4dTB1AjjkwrLA2qIL3e/oPUFisP5Ic8kGp29wrpoHokasKKnkRl1zS7zq6iBcOL6aOZLPPX/ZHYCX5BQ"
+        }
+      },
+      "usage": [
+        "master"
+      ],
+      "user_id": "@me:localhost"
+    }
+  },
+  "self_signing_keys": {
+    "@me:localhost": {
+      "keys": {
+        "ed25519:9gXJQzvqZ+KQunfBTd0g9AkrulwEeFfspyWTSQFqqrw": "9gXJQzvqZ+KQunfBTd0g9AkrulwEeFfspyWTSQFqqrw"
+      },
+      "signatures": {
+        "@me:localhost": {
+          "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "amiKDLpWIwUQPzq+eov6KJsoskkWA1YzrGNb7HF3OcGV0nm4t7df0tUdZB/OpREtT5D78BKtzOPUipde2DxUAw"
+        }
+      },
+      "usage": [
+        "self_signing"
+      ],
+      "user_id": "@me:localhost"
+    }
+  },
+  "user_signing_keys": {
+    "@me:localhost": {
+      "keys": {
+        "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY"
+      },
+      "signatures": {
+        "@me:localhost": {
+          "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "Cv56vTHAzRkvdcELleOlhECZQP0pXcikCdEZrnXbkjXQ/k0ZvVOJ1beG/SiH8xc6zh1bCIMYv96C9p8o+7VZCQ"
+        }
+      },
+      "usage": [
+        "user_signing"
+      ],
+      "user_id": "@me:localhost"
+    }
+  }
+}

--- a/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__VerificationViolationTestData::own_keys_query_response_1.snap
+++ b/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__VerificationViolationTestData::own_keys_query_response_1.snap
@@ -10,8 +10,7 @@ expression: data
       },
       "signatures": {
         "@alice:localhost": {
-          "ed25519:EPVg/QLG9+FmNvKjNXfycZEpQLtfHDaTN+rENAURZSk": "FX+srrw9SRmi12fexYHH1jrlEIWgOfre1aPNzDZWcAlaP9WKRdhcQGh70/3F9hk/PGr51I+ux62YgU4xnRTqAA",
-          "ed25519:PWVCNMMGCT": "teLq0rCYKX9h8WXu6kH8UE6HPKAtkF/DwCncxJGvVBCyZRtLHD8W1yYEzJXjTNynn+4fibQZBhR3th1RGLn4Ag"
+          "ed25519:EPVg/QLG9+FmNvKjNXfycZEpQLtfHDaTN+rENAURZSk": "FX+srrw9SRmi12fexYHH1jrlEIWgOfre1aPNzDZWcAlaP9WKRdhcQGh70/3F9hk/PGr51I+ux62YgU4xnRTqAA"
         }
       },
       "usage": [

--- a/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__VerificationViolationTestData::own_keys_query_response_1.snap
+++ b/testing/matrix-sdk-test/src/test_json/snapshots/matrix_sdk_test__test_json__keys_query_sets__VerificationViolationTestData::own_keys_query_response_1.snap
@@ -1,0 +1,55 @@
+---
+source: testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+expression: data
+---
+{
+  "master_keys": {
+    "@alice:localhost": {
+      "keys": {
+        "ed25519:EPVg/QLG9+FmNvKjNXfycZEpQLtfHDaTN+rENAURZSk": "EPVg/QLG9+FmNvKjNXfycZEpQLtfHDaTN+rENAURZSk"
+      },
+      "signatures": {
+        "@alice:localhost": {
+          "ed25519:EPVg/QLG9+FmNvKjNXfycZEpQLtfHDaTN+rENAURZSk": "FX+srrw9SRmi12fexYHH1jrlEIWgOfre1aPNzDZWcAlaP9WKRdhcQGh70/3F9hk/PGr51I+ux62YgU4xnRTqAA",
+          "ed25519:PWVCNMMGCT": "teLq0rCYKX9h8WXu6kH8UE6HPKAtkF/DwCncxJGvVBCyZRtLHD8W1yYEzJXjTNynn+4fibQZBhR3th1RGLn4Ag"
+        }
+      },
+      "usage": [
+        "master"
+      ],
+      "user_id": "@alice:localhost"
+    }
+  },
+  "self_signing_keys": {
+    "@alice:localhost": {
+      "keys": {
+        "ed25519:WXLer0esHUanp8DCeu2Be0xB5ms9aKFFBrCFl50COjw": "WXLer0esHUanp8DCeu2Be0xB5ms9aKFFBrCFl50COjw"
+      },
+      "signatures": {
+        "@alice:localhost": {
+          "ed25519:EPVg/QLG9+FmNvKjNXfycZEpQLtfHDaTN+rENAURZSk": "lCV9R1xjD34arzq/CAuej1XBv+Ip4dFfAGHfe7znbW7rnwKDaX5PaX3MHk+EIC7nXvUYEAn502WcUFme5c0cCQ"
+        }
+      },
+      "usage": [
+        "self_signing"
+      ],
+      "user_id": "@alice:localhost"
+    }
+  },
+  "user_signing_keys": {
+    "@alice:localhost": {
+      "keys": {
+        "ed25519:MXob/N/bYI7U2655O1/AI9NOX1245RnE03Nl4Hvf+u0": "MXob/N/bYI7U2655O1/AI9NOX1245RnE03Nl4Hvf+u0"
+      },
+      "signatures": {
+        "@alice:localhost": {
+          "ed25519:EPVg/QLG9+FmNvKjNXfycZEpQLtfHDaTN+rENAURZSk": "A73QfZ5Dzhh7abdal/sEaq1bfgxzPFU8Bvwa9Y5TIe/a5jTmLVubNmsMSsO5tOT+b6aVJg1G4FtId0Q/cb1aAA"
+        }
+      },
+      "usage": [
+        "user_signing"
+      ],
+      "user_id": "@alice:localhost"
+    }
+  }
+}


### PR DESCRIPTION
Currently it's very hard to extend our test data because it has been generated manually with real users and devices. I'd like to change that so that the data is created more dynamically, so that it is easier to extend.

This PR introduces a builder type which can be used to help construct such test data, and rebuilds some of the existing test data using it. Unfortunately we're lacking some private keys, so I've had to replace a couple of keys.

The PR also introduces some snapshots, so we can keep an eye on how the data is changing.

Recommend reviewing commit-by-commit.