### PR TITLE
chore: Upgrade Ruma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4786,8 +4786,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5100fcaf13d18b9c5c2dfdee5632c428e3201b04ddefd82c930953b461d000a"
+source = "git+https://github.com/ruma/ruma?rev=71be4a316198d6db91f512b2ceb8eb91238581f1#71be4a316198d6db91f512b2ceb8eb91238581f1"
 dependencies = [
  "assign",
  "js_int",
@@ -4803,8 +4802,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f5929f675a96adb22dcfbab1c527862d7f92a6346a280f2ddcfc6380b19391"
+source = "git+https://github.com/ruma/ruma?rev=71be4a316198d6db91f512b2ceb8eb91238581f1#71be4a316198d6db91f512b2ceb8eb91238581f1"
 dependencies = [
  "as_variant",
  "assign",
@@ -4827,8 +4825,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c537899b20312655aa9bf4cd825aaf00dd13203f215df2007bc4fbbeac8d8ba"
+source = "git+https://github.com/ruma/ruma?rev=71be4a316198d6db91f512b2ceb8eb91238581f1#71be4a316198d6db91f512b2ceb8eb91238581f1"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -4860,8 +4857,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e4f72eb598c62f51a199bd9218f3fc36a5d50361ecc7a30d864df7bfcef220"
+source = "git+https://github.com/ruma/ruma?rev=71be4a316198d6db91f512b2ceb8eb91238581f1#71be4a316198d6db91f512b2ceb8eb91238581f1"
 dependencies = [
  "as_variant",
  "indexmap 2.6.0",
@@ -4886,8 +4882,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d70c3d37a8e42992aeaa5786cb406ad302bcd05c0e7e3073d5316b4574340dd"
+source = "git+https://github.com/ruma/ruma?rev=71be4a316198d6db91f512b2ceb8eb91238581f1#71be4a316198d6db91f512b2ceb8eb91238581f1"
 dependencies = [
  "http",
  "js_int",
@@ -4901,8 +4896,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3257ce3398e171ff15245767b1a3d201cfc5cce75f5af7ec7f6b8b5e1d2bdb"
+source = "git+https://github.com/ruma/ruma?rev=71be4a316198d6db91f512b2ceb8eb91238581f1#71be4a316198d6db91f512b2ceb8eb91238581f1"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4913,19 +4907,17 @@ dependencies = [
 
 [[package]]
 name = "ruma-identifiers-validation"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7f9b534a65698d7db3c08d94bf91de0046fe6c7893a7b360502f65e7011ac4"
+version = "0.10.1"
+source = "git+https://github.com/ruma/ruma?rev=71be4a316198d6db91f512b2ceb8eb91238581f1#71be4a316198d6db91f512b2ceb8eb91238581f1"
 dependencies = [
  "js_int",
- "thiserror 1.0.63",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "ruma-macros"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7bc55ea278668253c9898dd905325bf1f72df4bf2abddd04ff1c99b7b3c4fb"
+source = "git+https://github.com/ruma/ruma?rev=71be4a316198d6db91f512b2ceb8eb91238581f1#71be4a316198d6db91f512b2ceb8eb91238581f1"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ proptest = { version = "1.5.0", default-features = false, features = ["std"] }
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
 rmp-serde = "1.3.0"
-ruma = { version = "0.12.0", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "71be4a316198d6db91f512b2ceb8eb91238581f1", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -72,7 +72,7 @@ ruma = { version = "0.12.0", features = [
     "unstable-msc4140",
     "unstable-msc4171",
 ] }
-ruma-common = "0.15.0"
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "71be4a316198d6db91f512b2ceb8eb91238581f1" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/crates/matrix-sdk/src/room/edit.rs
+++ b/crates/matrix-sdk/src/room/edit.rs
@@ -689,22 +689,13 @@ mod tests {
         assert!(image.caption().is_none());
         assert!(image.formatted_caption().is_none());
 
-        // The raw event doesn't contain the mention :(
-        // TODO: this is a bug in Ruma! When Ruma gets upgraded in the SDK, this test
-        // may start failing. In this case, remove the following code, and replace it
-        // with the commented code below.
-
-        assert_matches!(msg.mentions, None);
-
-        /*
-            // The raw event contains the mention.
-            assert_let!(Some(mentions) = msg.mentions);
-            assert!(!mentions.room);
-            assert_eq!(
-                mentions.user_ids.into_iter().collect::<Vec<_>>(),
-                vec![mentioned_user_id.clone()]
-            );
-        */
+        // The raw event contains the mention.
+        assert_let!(Some(mentions) = msg.mentions);
+        assert!(!mentions.room);
+        assert_eq!(
+            mentions.user_ids.into_iter().collect::<Vec<_>>(),
+            vec![mentioned_user_id.clone()]
+        );
 
         assert_let!(Some(Relation::Replacement(repl)) = msg.relates_to);
         assert_let!(MessageType::Image(new_image) = repl.new_content.msgtype);


### PR DESCRIPTION
This is using the `ruma-0.12` branch where non-breaking changes are backported.

Includes the commit necessary for https://github.com/matrix-org/matrix-rust-sdk/pull/4421.