### PR TITLE
feat(sdk,ui): Add `EventsOrigin::Pagination`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -297,8 +297,10 @@ impl TimelineBuilder {
 
                                 inner.add_events_at(
                                     events.into_iter(),
-                                    TimelineNewItemPosition::End {                                    origin: match origin {
+                                    TimelineNewItemPosition::End {
+                                        origin: match origin {
                                             EventsOrigin::Sync => RemoteEventOrigin::Sync,
+                                            EventsOrigin::Pagination => RemoteEventOrigin::Pagination,
                                         }
                                     }
                                 ).await;
@@ -313,6 +315,7 @@ impl TimelineBuilder {
                                     diffs,
                                     match origin {
                                         EventsOrigin::Sync => RemoteEventOrigin::Sync,
+                                        EventsOrigin::Pagination => RemoteEventOrigin::Pagination,
                                     }
                                 ).await;
                             }

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -694,6 +694,9 @@ pub enum RoomEventCacheUpdate {
 pub enum EventsOrigin {
     /// Events are coming from a sync.
     Sync,
+
+    /// Events are coming from pagination.
+    Pagination,
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -234,7 +234,7 @@ impl RoomPagination {
         if !updates_as_vector_diffs.is_empty() {
             let _ = self.inner.sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
                 diffs: updates_as_vector_diffs,
-                origin: EventsOrigin::Sync,
+                origin: EventsOrigin::Pagination,
             });
         }
 


### PR DESCRIPTION
This patch adds the `Pagination` variant to the `EventsOrigin` enum. Not something really mandatory and that is likely to fix a bug, but it's now correct.

---

* Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/4462
* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280