### PR TITLE
feat: Remove the `experimental-sliding-sync` feature flag

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -56,7 +56,6 @@ features = [
     "anyhow",
     "e2e-encryption",
     "experimental-oidc",
-    "experimental-sliding-sync",
     "experimental-widgets",
     "markdown",
     "rustls-tls", # note: differ from block below
@@ -71,7 +70,6 @@ features = [
     "anyhow",
     "e2e-encryption",
     "experimental-oidc",
-    "experimental-sliding-sync",
     "experimental-widgets",
     "markdown",
     "native-tls", # note: differ from block above

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -21,10 +21,6 @@ e2e-encryption = ["dep:matrix-sdk-crypto"]
 js = ["matrix-sdk-common/js", "matrix-sdk-crypto?/js", "ruma/js", "matrix-sdk-store-encryption/js"]
 qrcode = ["matrix-sdk-crypto?/qrcode"]
 automatic-room-key-forwarding = ["matrix-sdk-crypto?/automatic-room-key-forwarding"]
-experimental-sliding-sync = [
-    "ruma/unstable-msc3575",
-    "ruma/unstable-msc4186",
-]
 uniffi = ["dep:uniffi", "matrix-sdk-crypto?/uniffi", "matrix-sdk-common/uniffi"]
 
 # Private feature, see
@@ -65,7 +61,14 @@ matrix-sdk-store-encryption = { workspace = true }
 matrix-sdk-test = { workspace = true, optional = true }
 once_cell = { workspace = true }
 regex = "1.11.1"
-ruma = { workspace = true, features = ["canonical-json", "unstable-msc3381", "unstable-msc2867", "rand"] }
+ruma = { workspace = true, features = [
+    "canonical-json",
+    "unstable-msc2867",
+    "unstable-msc3381",
+    "unstable-msc3575",
+    "unstable-msc4186",
+    "rand",
+] }
 unicode-normalization = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -1,8 +1,6 @@
 //! Utilities for working with events to decide whether they are suitable for
 //! use as a [crate::Room::latest_event].
 
-#![cfg(any(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
-
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
 #[cfg(feature = "e2e-encryption")]
 use ruma::{
@@ -10,9 +8,11 @@ use ruma::{
         call::{invite::SyncCallInviteEvent, notify::SyncCallNotifyEvent},
         poll::unstable_start::SyncUnstablePollStartEvent,
         relation::RelationType,
-        room::member::{MembershipState, SyncRoomMemberEvent},
-        room::message::SyncRoomMessageEvent,
-        room::power_levels::RoomPowerLevels,
+        room::{
+            member::{MembershipState, SyncRoomMemberEvent},
+            message::SyncRoomMessageEvent,
+            power_levels::RoomPowerLevels,
+        },
         sticker::SyncStickerEvent,
         AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent,
     },
@@ -294,11 +294,16 @@ impl LatestEvent {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "e2e-encryption")]
     use std::collections::BTreeMap;
 
+    #[cfg(feature = "e2e-encryption")]
     use assert_matches::assert_matches;
+    #[cfg(feature = "e2e-encryption")]
     use assert_matches2::assert_let;
     use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
+    use ruma::serde::Raw;
+    #[cfg(feature = "e2e-encryption")]
     use ruma::{
         events::{
             call::{
@@ -336,14 +341,16 @@ mod tests {
             RedactedSyncMessageLikeEvent, RedactedUnsigned, StateUnsigned, SyncMessageLikeEvent,
             UnsignedRoomRedactionEvent,
         },
-        owned_event_id, owned_mxc_uri, owned_user_id,
-        serde::Raw,
-        MilliSecondsSinceUnixEpoch, UInt, VoipVersionId,
+        owned_event_id, owned_mxc_uri, owned_user_id, MilliSecondsSinceUnixEpoch, UInt,
+        VoipVersionId,
     };
     use serde_json::json;
 
-    use crate::latest_event::{is_suitable_for_latest_event, LatestEvent, PossibleLatestEvent};
+    use super::LatestEvent;
+    #[cfg(feature = "e2e-encryption")]
+    use super::{is_suitable_for_latest_event, PossibleLatestEvent};
 
+    #[cfg(feature = "e2e-encryption")]
     #[test]
     fn test_room_messages_are_suitable() {
         let event = AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
@@ -368,6 +375,7 @@ mod tests {
         assert_eq!(m.content.msgtype.msgtype(), "m.image");
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[test]
     fn test_polls_are_suitable() {
         let event = AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::UnstablePollStart(
@@ -391,6 +399,7 @@ mod tests {
         assert_eq!(m.content.poll_start().question.text, "do you like rust?");
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[test]
     fn test_call_invites_are_suitable() {
         let event = AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::CallInvite(
@@ -413,6 +422,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[test]
     fn test_call_notifications_are_suitable() {
         let event = AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::CallNotify(
@@ -435,6 +445,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[test]
     fn test_stickers_are_suitable() {
         let event = AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::Sticker(
@@ -457,6 +468,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[test]
     fn test_different_types_of_messagelike_are_unsuitable() {
         let event =
@@ -479,6 +491,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[test]
     fn test_redacted_messages_are_suitable() {
         // Ruma does not allow constructing UnsignedRoomRedactionEvent instances.
@@ -507,6 +520,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[test]
     fn test_encrypted_messages_are_unsuitable() {
         let event = AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomEncrypted(
@@ -530,6 +544,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[test]
     fn test_state_events_are_unsuitable() {
         let event = AnySyncTimelineEvent::State(AnySyncStateEvent::RoomTopic(
@@ -549,6 +564,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[test]
     fn test_replacement_events_are_unsuitable() {
         let mut event_content = RoomMessageEventContent::text_plain("Bye bye, world!");

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -38,7 +38,6 @@ mod rooms;
 pub mod read_receipts;
 pub use read_receipts::PreviousEventsProvider;
 pub use rooms::RoomMembersUpdate;
-#[cfg(feature = "experimental-sliding-sync")]
 pub mod sliding_sync;
 
 pub mod store;

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
+#[cfg(feature = "e2e-encryption")]
 use std::sync::RwLock as SyncRwLock;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
@@ -24,12 +24,9 @@ use as_variant::as_variant;
 use bitflags::bitflags;
 use eyeball::{AsyncLock, ObservableWriteGuard, SharedObservable, Subscriber};
 use futures_util::{Stream, StreamExt};
-#[cfg(feature = "experimental-sliding-sync")]
 use matrix_sdk_common::deserialized_responses::TimelineEventKind;
-#[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
+#[cfg(feature = "e2e-encryption")]
 use matrix_sdk_common::ring_buffer::RingBuffer;
-#[cfg(feature = "experimental-sliding-sync")]
-use ruma::events::AnySyncTimelineEvent;
 use ruma::{
     api::client::sync::sync_events::v3::RoomSummary as RumaSummary,
     events::{
@@ -51,7 +48,7 @@ use ruma::{
             tombstone::RoomTombstoneEventContent,
         },
         tag::{TagEventContent, Tags},
-        AnyRoomAccountDataEvent, AnyStrippedStateEvent, AnySyncStateEvent,
+        AnyRoomAccountDataEvent, AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,
         RoomAccountDataEventType, StateEventType, SyncStateEvent,
     },
     room::RoomType,
@@ -67,12 +64,11 @@ use super::{
     members::MemberRoomInfo, BaseRoomInfo, RoomCreateWithCreatorEventContent, RoomDisplayName,
     RoomMember, RoomNotableTags,
 };
-#[cfg(feature = "experimental-sliding-sync")]
-use crate::latest_event::LatestEvent;
 use crate::{
     deserialized_responses::{
         DisplayName, MemberEvent, RawMemberEvent, RawSyncOrStrippedState, SyncOrStrippedState,
     },
+    latest_event::LatestEvent,
     notification_settings::RoomNotificationMode,
     read_receipts::RoomReadReceipts,
     store::{DynStateStore, Result as StoreResult, StateStoreExt},
@@ -166,7 +162,7 @@ pub struct Room {
     /// not sure whether holding too many of them might make the cache too
     /// slow to load on startup. Keeping them here means they are not cached
     /// to disk but held in memory.
-    #[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
+    #[cfg(feature = "e2e-encryption")]
     pub latest_encrypted_events: Arc<SyncRwLock<RingBuffer<Raw<AnySyncTimelineEvent>>>>,
 
     /// A map for ids of room membership events in the knocking state linked to
@@ -277,7 +273,7 @@ pub enum RoomMembersUpdate {
 impl Room {
     /// The size of the latest_encrypted_events RingBuffer
     // SAFETY: `new_unchecked` is safe because 10 is not zero.
-    #[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
+    #[cfg(feature = "e2e-encryption")]
     const MAX_ENCRYPTED_EVENTS: std::num::NonZeroUsize =
         unsafe { std::num::NonZeroUsize::new_unchecked(10) };
 
@@ -304,7 +300,7 @@ impl Room {
             room_id: room_info.room_id.clone(),
             store,
             inner: SharedObservable::new(room_info),
-            #[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
+            #[cfg(feature = "e2e-encryption")]
             latest_encrypted_events: Arc::new(SyncRwLock::new(RingBuffer::new(
                 Self::MAX_ENCRYPTED_EVENTS,
             ))),
@@ -925,7 +921,6 @@ impl Room {
 
     /// Return the last event in this room, if one has been cached during
     /// sliding sync.
-    #[cfg(feature = "experimental-sliding-sync")]
     pub fn latest_event(&self) -> Option<LatestEvent> {
         self.inner.read().latest_event.as_deref().cloned()
     }
@@ -934,7 +929,7 @@ impl Room {
     /// to decrypt these, the most recent relevant one will replace
     /// latest_event. (We can't tell which one is relevant until
     /// they are decrypted.)
-    #[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
+    #[cfg(feature = "e2e-encryption")]
     pub(crate) fn latest_encrypted_events(&self) -> Vec<Raw<AnySyncTimelineEvent>> {
         self.latest_encrypted_events.read().unwrap().iter().cloned().collect()
     }
@@ -949,7 +944,7 @@ impl Room {
     ///
     /// It is the responsibility of the caller to apply the changes into the
     /// state store after calling this function.
-    #[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
+    #[cfg(feature = "e2e-encryption")]
     pub(crate) fn on_latest_event_decrypted(
         &self,
         latest_event: Box<LatestEvent>,
@@ -1195,7 +1190,6 @@ impl Room {
     /// Returns the recency stamp of the room.
     ///
     /// Please read `RoomInfo::recency_stamp` to learn more.
-    #[cfg(feature = "experimental-sliding-sync")]
     pub fn recency_stamp(&self) -> Option<u64> {
         self.inner.read().recency_stamp
     }
@@ -1405,7 +1399,6 @@ pub struct RoomInfo {
     pub(crate) encryption_state_synced: bool,
 
     /// The last event send by sliding sync
-    #[cfg(feature = "experimental-sliding-sync")]
     pub(crate) latest_event: Option<Box<LatestEvent>>,
 
     /// Information about read receipts for this room.
@@ -1439,7 +1432,6 @@ pub struct RoomInfo {
     /// Sliding Sync might "ignore” some events when computing the recency
     /// stamp of the room. Thus, using this `recency_stamp` value is
     /// more accurate than relying on the latest event.
-    #[cfg(feature = "experimental-sliding-sync")]
     #[serde(default)]
     pub(crate) recency_stamp: Option<u64>,
 }
@@ -1475,14 +1467,12 @@ impl RoomInfo {
             last_prev_batch: None,
             sync_info: SyncInfo::NoState,
             encryption_state_synced: false,
-            #[cfg(feature = "experimental-sliding-sync")]
             latest_event: None,
             read_receipts: Default::default(),
             base_info: Box::new(BaseRoomInfo::new()),
             warned_about_unknown_room_version: Arc::new(false.into()),
             cached_display_name: None,
             cached_user_defined_notification_mode: None,
-            #[cfg(feature = "experimental-sliding-sync")]
             recency_stamp: None,
         }
     }
@@ -1627,7 +1617,6 @@ impl RoomInfo {
         };
         tracing::Span::current().record("redacts", debug(redacts));
 
-        #[cfg(feature = "experimental-sliding-sync")]
         if let Some(latest_event) = &mut self.latest_event {
             tracing::trace!("Checking if redaction applies to latest event");
             if latest_event.event_id().as_deref() == Some(redacts) {
@@ -1717,19 +1706,16 @@ impl RoomInfo {
     }
 
     /// Updates the joined member count.
-    #[cfg(feature = "experimental-sliding-sync")]
     pub(crate) fn update_joined_member_count(&mut self, count: u64) {
         self.summary.joined_member_count = count;
     }
 
     /// Updates the invited member count.
-    #[cfg(feature = "experimental-sliding-sync")]
     pub(crate) fn update_invited_member_count(&mut self, count: u64) {
         self.summary.invited_member_count = count;
     }
 
     /// Updates the room heroes.
-    #[cfg(feature = "experimental-sliding-sync")]
     pub(crate) fn update_heroes(&mut self, heroes: Vec<RoomHero>) {
         self.summary.room_heroes = heroes;
     }
@@ -1929,7 +1915,6 @@ impl RoomInfo {
     }
 
     /// Returns the latest (decrypted) event recorded for this room.
-    #[cfg(feature = "experimental-sliding-sync")]
     pub fn latest_event(&self) -> Option<&LatestEvent> {
         self.latest_event.as_deref()
     }
@@ -1937,7 +1922,6 @@ impl RoomInfo {
     /// Updates the recency stamp of this room.
     ///
     /// Please read [`Self::recency_stamp`] to learn more.
-    #[cfg(feature = "experimental-sliding-sync")]
     pub(crate) fn update_recency_stamp(&mut self, stamp: u64) {
         self.recency_stamp = Some(stamp);
     }
@@ -2023,7 +2007,6 @@ impl RoomInfo {
     }
 }
 
-#[cfg(feature = "experimental-sliding-sync")]
 fn apply_redaction(
     event: &Raw<AnySyncTimelineEvent>,
     raw_redaction: &Raw<SyncRoomRedactionEvent>,
@@ -2168,7 +2151,6 @@ mod tests {
     };
 
     use assign::assign;
-    #[cfg(feature = "experimental-sliding-sync")]
     use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
     use matrix_sdk_test::{
         async_test,
@@ -2205,9 +2187,8 @@ mod tests {
     use stream_assert::{assert_pending, assert_ready};
 
     use super::{compute_display_name_from_heroes, Room, RoomHero, RoomInfo, RoomState, SyncInfo};
-    #[cfg(any(feature = "experimental-sliding-sync", feature = "e2e-encryption"))]
-    use crate::latest_event::LatestEvent;
     use crate::{
+        latest_event::LatestEvent,
         rooms::RoomNotableTags,
         store::{IntoStateStore, MemoryStore, StateChanges, StateStore, StoreConfig},
         test_utils::logged_in_base_client,
@@ -2216,7 +2197,6 @@ mod tests {
     };
 
     #[test]
-    #[cfg(feature = "experimental-sliding-sync")]
     fn test_room_info_serialization() {
         // This test exists to make sure we don't accidentally change the
         // serialized format for `RoomInfo`.
@@ -2403,7 +2383,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "experimental-sliding-sync")]
     fn test_room_info_deserialization() {
         use ruma::{owned_mxc_uri, owned_user_id};
 
@@ -3153,8 +3132,8 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[async_test]
-    #[cfg(feature = "experimental-sliding-sync")]
     async fn test_setting_the_latest_event_doesnt_cause_a_room_info_notable_update() {
         use std::collections::BTreeMap;
 
@@ -3173,7 +3152,6 @@ mod tests {
                     user_id: user_id!("@alice:example.org").into(),
                     device_id: ruma::device_id!("AYEAYEAYE").into(),
                 },
-                #[cfg(feature = "e2e-encryption")]
                 None,
             )
             .await
@@ -3221,8 +3199,8 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[async_test]
-    #[cfg(feature = "experimental-sliding-sync")]
     async fn test_when_we_provide_a_newly_decrypted_event_it_replaces_latest_event() {
         use std::collections::BTreeMap;
 
@@ -3251,8 +3229,8 @@ mod tests {
         assert_eq!(room.latest_event().unwrap().event_id(), event.event_id());
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[async_test]
-    #[cfg(feature = "experimental-sliding-sync")]
     async fn test_when_a_newly_decrypted_event_appears_we_delete_all_older_encrypted_events() {
         use std::collections::BTreeMap;
 
@@ -3290,8 +3268,8 @@ mod tests {
         assert_eq!(room.latest_event().unwrap().event_id(), new_event.event_id());
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[async_test]
-    #[cfg(feature = "experimental-sliding-sync")]
     async fn test_replacing_the_newest_event_leaves_none_left() {
         use std::collections::BTreeMap;
 
@@ -3323,7 +3301,7 @@ mod tests {
         assert_eq!(enc_evs.len(), 0);
     }
 
-    #[cfg(feature = "experimental-sliding-sync")]
+    #[cfg(feature = "e2e-encryption")]
     fn add_encrypted_event(room: &Room, event_id: &str) {
         room.latest_encrypted_events
             .write()
@@ -3331,7 +3309,7 @@ mod tests {
             .push(Raw::from_json_string(json!({ "event_id": event_id }).to_string()).unwrap());
     }
 
-    #[cfg(feature = "experimental-sliding-sync")]
+    #[cfg(feature = "e2e-encryption")]
     fn make_latest_event(event_id: &str) -> Box<LatestEvent> {
         Box::new(LatestEvent::new(SyncTimelineEvent::new(
             Raw::from_json_string(json!({ "event_id": event_id }).to_string()).unwrap(),

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -893,7 +893,7 @@ fn process_room_properties(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::collections::{BTreeMap, HashSet};
     #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -19,7 +19,6 @@ use std::{
     sync::Arc,
 };
 
-#[cfg(feature = "experimental-sliding-sync")]
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
 use ruma::{
     events::{
@@ -42,10 +41,9 @@ use ruma::{
 };
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "experimental-sliding-sync")]
-use crate::latest_event::LatestEvent;
 use crate::{
     deserialized_responses::SyncOrStrippedState,
+    latest_event::LatestEvent,
     rooms::{
         normal::{RoomSummary, SyncInfo},
         BaseRoomInfo, RoomNotableTags,
@@ -78,7 +76,6 @@ pub struct RoomInfoV1 {
     sync_info: SyncInfo,
     #[serde(default = "encryption_state_default")] // see fn docs for why we use this default
     encryption_state_synced: bool,
-    #[cfg(feature = "experimental-sliding-sync")]
     latest_event: Option<SyncTimelineEvent>,
     base_info: BaseRoomInfoV1,
 }
@@ -106,7 +103,6 @@ impl RoomInfoV1 {
             last_prev_batch,
             sync_info,
             encryption_state_synced,
-            #[cfg(feature = "experimental-sliding-sync")]
             latest_event,
             base_info,
         } = self;
@@ -122,14 +118,12 @@ impl RoomInfoV1 {
             last_prev_batch,
             sync_info,
             encryption_state_synced,
-            #[cfg(feature = "experimental-sliding-sync")]
             latest_event: latest_event.map(|ev| Box::new(LatestEvent::new(ev))),
             read_receipts: Default::default(),
             base_info: base_info.migrate(create),
             warned_about_unknown_room_version: Arc::new(false.into()),
             cached_display_name: None,
             cached_user_defined_notification_mode: None,
-            #[cfg(feature = "experimental-sliding-sync")]
             recency_stamp: None,
         }
     }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -276,7 +276,6 @@ impl Store {
     }
 
     /// Check if a room exists.
-    #[cfg(feature = "experimental-sliding-sync")]
     pub(crate) fn room_exists(&self, room_id: &RoomId) -> bool {
         self.rooms.read().unwrap().get(room_id).is_some()
     }

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -35,7 +35,7 @@ growable-bloom-filter = { workspace = true }
 imbl = { workspace = true, features = ["serde"] }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-matrix-sdk = { workspace = true, features = ["experimental-sliding-sync", "e2e-encryption"] }
+matrix-sdk = { workspace = true, features = ["e2e-encryption"] }
 matrix-sdk-base = { workspace = true }
 mime = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -20,8 +20,8 @@ use assert_matches2::assert_let;
 use eyeball_im::{Vector, VectorDiff};
 use futures_util::{pin_mut, FutureExt, Stream, StreamExt};
 use matrix_sdk::{
-    test_utils::logged_in_client_with_server, SlidingSync, SlidingSyncList, SlidingSyncListBuilder,
-    SlidingSyncMode, UpdateSummary,
+    test_utils::{logged_in_client, logged_in_client_with_server},
+    Client, SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
 };
 use matrix_sdk_test::{async_test, mocks::mock_encryption_state};
 use matrix_sdk_ui::{
@@ -223,7 +223,9 @@ macro_rules! assert_timeline_stream {
 
 pub(crate) use assert_timeline_stream;
 
-async fn new_sliding_sync(lists: Vec<SlidingSyncListBuilder>) -> Result<(MockServer, SlidingSync)> {
+async fn new_sliding_sync(
+    lists: Vec<SlidingSyncListBuilder>,
+) -> Result<(Client, MockServer, SlidingSync)> {
     let (client, server) = logged_in_client_with_server().await;
 
     let mut sliding_sync_builder = client.sliding_sync("integration-test")?;
@@ -234,7 +236,7 @@ async fn new_sliding_sync(lists: Vec<SlidingSyncListBuilder>) -> Result<(MockSer
 
     let sliding_sync = sliding_sync_builder.build().await?;
 
-    Ok((server, sliding_sync))
+    Ok((client, server, sliding_sync))
 }
 
 async fn create_one_room(
@@ -268,13 +270,13 @@ async fn create_one_room(
 }
 
 async fn timeline_test_helper(
+    client: &Client,
     sliding_sync: &SlidingSync,
     room_id: &RoomId,
 ) -> Result<(Vector<Arc<TimelineItem>>, impl Stream<Item = VectorDiff<Arc<TimelineItem>>>)> {
     let sliding_sync_room = sliding_sync.get_room(room_id).await.unwrap();
 
     let room_id = sliding_sync_room.room_id();
-    let client = sliding_sync_room.client();
     let sdk_room = client.get_room(room_id).ok_or_else(|| {
         anyhow::anyhow!("Room {room_id} not found in client. Can't provide a timeline for it")
     })?;
@@ -295,7 +297,7 @@ impl Match for SlidingSyncMatcher {
 
 #[async_test]
 async fn test_timeline_basic() -> Result<()> {
-    let (server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
+    let (client, server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
         .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
     .await?;
 
@@ -309,7 +311,7 @@ async fn test_timeline_basic() -> Result<()> {
     mock_encryption_state(&server, false).await;
 
     let (timeline_items, mut timeline_stream) =
-        timeline_test_helper(&sliding_sync, room_id).await?;
+        timeline_test_helper(&client, &sliding_sync, room_id).await?;
     assert!(timeline_items.is_empty());
 
     // Receiving a bunch of events.
@@ -344,7 +346,7 @@ async fn test_timeline_basic() -> Result<()> {
 
 #[async_test]
 async fn test_timeline_duplicated_events() -> Result<()> {
-    let (server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
+    let (client, server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
         .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
     .await?;
 
@@ -357,7 +359,7 @@ async fn test_timeline_duplicated_events() -> Result<()> {
 
     mock_encryption_state(&server, false).await;
 
-    let (_, mut timeline_stream) = timeline_test_helper(&sliding_sync, room_id).await?;
+    let (_, mut timeline_stream) = timeline_test_helper(&client, &sliding_sync, room_id).await?;
 
     // Receiving events.
     {
@@ -422,7 +424,7 @@ async fn test_timeline_duplicated_events() -> Result<()> {
 
 #[async_test]
 async fn test_timeline_read_receipts_are_updated_live() -> Result<()> {
-    let (server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
+    let (client, server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
         .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
     .await?;
 
@@ -436,7 +438,7 @@ async fn test_timeline_read_receipts_are_updated_live() -> Result<()> {
     mock_encryption_state(&server, false).await;
 
     let (timeline_items, mut timeline_stream) =
-        timeline_test_helper(&sliding_sync, room_id).await?;
+        timeline_test_helper(&client, &sliding_sync, room_id).await?;
     assert!(timeline_items.is_empty());
 
     // Receiving initial events.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -20,8 +20,8 @@ use assert_matches2::assert_let;
 use eyeball_im::{Vector, VectorDiff};
 use futures_util::{pin_mut, FutureExt, Stream, StreamExt};
 use matrix_sdk::{
-    test_utils::{logged_in_client, logged_in_client_with_server},
-    Client, SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
+    test_utils::logged_in_client_with_server, Client, SlidingSync, SlidingSyncList,
+    SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
 };
 use matrix_sdk_test::{async_test, mocks::mock_encryption_state};
 use matrix_sdk_ui::{

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -55,10 +55,6 @@ experimental-oidc = [
     "dep:tower",
     "dep:openidconnect",
 ]
-experimental-sliding-sync = [
-    "matrix-sdk-base/experimental-sliding-sync",
-    "reqwest/gzip",
-]
 experimental-widgets = ["dep:language-tags", "dep:uuid"]
 
 docsrs = ["e2e-encryption", "sqlite", "indexeddb", "sso-login", "qrcode"]
@@ -119,7 +115,7 @@ zeroize = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { workspace = true, features = ["futures"] }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["gzip"] }
 tokio = { workspace = true, features = ["macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -127,7 +123,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 openidconnect = { version = "4.0.0-rc.1", optional = true }
 # only activate reqwest's stream feature on non-wasm, the wasm part seems to not
 # support *sending* streams, which makes it useless for us.
-reqwest = { workspace = true, features = ["stream"] }
+reqwest = { workspace = true, features = ["stream", "gzip"] }
 tokio = { workspace = true, features = ["fs", "rt", "macros"] }
 tokio-util = "0.7.12"
 wiremock = { workspace = true, optional = true }

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -71,7 +71,6 @@ impl<R> SendRequest<R> {
     ///
     /// This is useful at the moment because the current sliding sync
     /// implementation uses a proxy server.
-    #[cfg(feature = "experimental-sliding-sync")]
     pub fn with_homeserver_override(mut self, homeserver_override: Option<String>) -> Self {
         self.homeserver_override = homeserver_override;
         self

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -338,7 +338,6 @@ pub enum Error {
     UserTagName(#[from] InvalidUserTagName),
 
     /// An error occurred within sliding-sync
-    #[cfg(feature = "experimental-sliding-sync")]
     #[error(transparent)]
     SlidingSync(#[from] crate::sliding_sync::Error),
 

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -208,15 +208,6 @@ impl HttpClient {
                 span.record("request_size", ByteSize(request_size).to_string_as(true));
             }
 
-            // Since sliding sync is experimental, and the proxy might not do what we expect
-            // it to do given a specific request body, it's useful to log the
-            // request body here. This doesn't contain any personal information.
-            // TODO: Remove this once sliding sync isn't experimental anymore.
-            #[cfg(feature = "experimental-sliding-sync")]
-            if type_name::<R>() == "ruma_client_api::sync::sync_events::v4::Request" {
-                span.record("request_body", debug(request.body()));
-            }
-
             request
         };
 

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -61,7 +61,6 @@ pub mod futures {
 
     pub use super::client::futures::SendRequest;
 }
-#[cfg(feature = "experimental-sliding-sync")]
 pub mod sliding_sync;
 pub mod sync;
 #[cfg(feature = "experimental-widgets")]
@@ -85,7 +84,6 @@ pub use media::Media;
 pub use pusher::Pusher;
 pub use room::Room;
 pub use ruma::{IdParseError, OwnedServerName, ServerName};
-#[cfg(feature = "experimental-sliding-sync")]
 pub use sliding_sync::{
     SlidingSync, SlidingSyncBuilder, SlidingSyncList, SlidingSyncListBuilder,
     SlidingSyncListLoadingState, SlidingSyncMode, SlidingSyncRoom, UpdateSummary,

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -248,10 +248,7 @@ pub(super) async fn restore_sliding_sync_state(
             restored_fields.rooms = frozen_rooms
                 .into_iter()
                 .map(|frozen_room| {
-                    (
-                        frozen_room.room_id.clone(),
-                        SlidingSyncRoom::from_frozen(frozen_room, client.clone()),
-                    )
+                    (frozen_room.room_id.clone(), SlidingSyncRoom::from_frozen(frozen_room))
                 })
                 .collect();
         }
@@ -355,11 +352,11 @@ mod tests {
 
                 rooms.insert(
                     room_id1.clone(),
-                    SlidingSyncRoom::new(client.clone(), room_id1.clone(), None, Vec::new()),
+                    SlidingSyncRoom::new(room_id1.clone(), None, Vec::new()),
                 );
                 rooms.insert(
                     room_id2.clone(),
-                    SlidingSyncRoom::new(client.clone(), room_id2.clone(), None, Vec::new()),
+                    SlidingSyncRoom::new(room_id2.clone(), None, Vec::new()),
                 );
             }
 

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -75,7 +75,7 @@ async fn clean_storage(
 /// Store the `SlidingSync`'s state in the storage.
 pub(super) async fn store_sliding_sync_state(
     sliding_sync: &SlidingSync,
-    position: &SlidingSyncPositionMarkers,
+    _position: &SlidingSyncPositionMarkers,
 ) -> Result<()> {
     let storage_key = &sliding_sync.inner.storage_key;
     let instance_storage_key = format_storage_key_for_sliding_sync(storage_key);
@@ -94,6 +94,8 @@ pub(super) async fn store_sliding_sync_state(
 
     #[cfg(feature = "e2e-encryption")]
     {
+        let position = _position;
+
         // FIXME (TERRIBLE HACK): we want to save `pos` in a cross-process safe manner,
         // with both processes sharing the same database backend; that needs to
         // go in the crypto process store at the moment, but should be fixed

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -361,7 +361,7 @@ async fn update_in_memory_caches(client: &Client, response: &SyncResponse) -> Re
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::collections::BTreeMap;
 

--- a/crates/matrix-sdk/src/sliding_sync/error.rs
+++ b/crates/matrix-sdk/src/sliding_sync/error.rs
@@ -1,7 +1,7 @@
 //! Sliding Sync errors.
 
+use matrix_sdk_common::executor::JoinError;
 use thiserror::Error;
-use tokio::task::JoinError;
 
 /// Internal representation of errors in Sliding Sync.
 #[derive(Error, Debug)]

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -36,14 +36,14 @@ use async_stream::stream;
 pub use client::{Version, VersionBuilder};
 use futures_core::stream::Stream;
 pub use matrix_sdk_base::sliding_sync::http;
-use matrix_sdk_common::{deserialized_responses::SyncTimelineEvent, timer};
+use matrix_sdk_common::{deserialized_responses::SyncTimelineEvent, executor::spawn, timer};
 use ruma::{
     api::{client::error::ErrorKind, OutgoingRequest},
     assign, OwnedEventId, OwnedRoomId, RoomId,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{
-    select, spawn,
+    select,
     sync::{broadcast::Sender, Mutex as AsyncMutex, OwnedMutexGuard, RwLock as AsyncRwLock},
 };
 use tracing::{debug, error, info, instrument, trace, warn, Instrument, Span};
@@ -1090,7 +1090,7 @@ fn compute_limited(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 #[allow(clippy::dbg_macro)]
 mod tests {
     use std::{
@@ -2857,7 +2857,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(not(target_arch = "wasm32"))] // b/o tokio::time::sleep
     #[async_test]
     async fn test_aborted_request_doesnt_update_future_requests() -> Result<()> {
         let server = MockServer::start().await;

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -359,7 +359,6 @@ impl SlidingSync {
                             rooms_map.insert(
                                 room_id.clone(),
                                 SlidingSyncRoom::new(
-                                    self.inner.client.clone(),
                                     room_id.clone(),
                                     room_data.prev_batch,
                                     timeline,
@@ -2269,9 +2268,6 @@ mod tests {
 
     #[async_test]
     async fn test_limited_flag_computation() {
-        let server = MockServer::start().await;
-        let client = logged_in_client(Some(server.uri())).await;
-
         let make_event = |event_id: &str| -> SyncTimelineEvent {
             SyncTimelineEvent::new(
                 Raw::from_json_string(
@@ -2313,7 +2309,6 @@ mod tests {
                 // it's not marked as initial in the response.
                 not_initial.to_owned(),
                 SlidingSyncRoom::new(
-                    client.clone(),
                     no_overlap.to_owned(),
                     None,
                     vec![event_a.clone(), event_b.clone()],
@@ -2323,7 +2318,6 @@ mod tests {
                 // This has no events overlapping with the response timeline, hence limited.
                 no_overlap.to_owned(),
                 SlidingSyncRoom::new(
-                    client.clone(),
                     no_overlap.to_owned(),
                     None,
                     vec![event_a.clone(), event_b.clone()],
@@ -2333,7 +2327,6 @@ mod tests {
                 // This has event_c in common with the response timeline.
                 partial_overlap.to_owned(),
                 SlidingSyncRoom::new(
-                    client.clone(),
                     partial_overlap.to_owned(),
                     None,
                     vec![event_a.clone(), event_b.clone(), event_c.clone()],
@@ -2343,7 +2336,6 @@ mod tests {
                 // This has all events in common with the response timeline.
                 complete_overlap.to_owned(),
                 SlidingSyncRoom::new(
-                    client.clone(),
                     partial_overlap.to_owned(),
                     None,
                     vec![event_c.clone(), event_d.clone()],
@@ -2354,7 +2346,6 @@ mod tests {
                 // limited.
                 no_remote_events.to_owned(),
                 SlidingSyncRoom::new(
-                    client.clone(),
                     no_remote_events.to_owned(),
                     None,
                     vec![event_c.clone(), event_d.clone()],
@@ -2364,14 +2355,13 @@ mod tests {
                 // We don't have events for this room locally, and even if the remote room contains
                 // some events, it's not a limited sync.
                 no_local_events.to_owned(),
-                SlidingSyncRoom::new(client.clone(), no_local_events.to_owned(), None, vec![]),
+                SlidingSyncRoom::new(no_local_events.to_owned(), None, vec![]),
             ),
             (
                 // Already limited, but would be marked limited if the flag wasn't ignored (same as
                 // partial overlap).
                 already_limited.to_owned(),
                 SlidingSyncRoom::new(
-                    client,
                     already_limited.to_owned(),
                     None,
                     vec![event_a, event_b, event_c.clone()],

--- a/crates/matrix-sdk/src/sliding_sync/utils.rs
+++ b/crates/matrix-sdk/src/sliding_sync/utils.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use tokio::task::{JoinError, JoinHandle};
+use matrix_sdk_common::executor::{JoinError, JoinHandle};
 
 /// Private type to ensure a task is aborted on drop.
 pub(crate) struct AbortOnDrop<T>(JoinHandle<T>);

--- a/crates/matrix-sdk/src/sliding_sync/utils.rs
+++ b/crates/matrix-sdk/src/sliding_sync/utils.rs
@@ -1,5 +1,7 @@
 //! Moaaar features for Sliding Sync.
 
+#![cfg(feature = "e2e-encryption")]
+
 use std::{
     future::Future,
     pin::Pin,
@@ -23,7 +25,7 @@ impl<T> Drop for AbortOnDrop<T> {
     }
 }
 
-impl<T> Future for AbortOnDrop<T> {
+impl<T: 'static> Future for AbortOnDrop<T> {
     type Output = Result<T, JoinError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -714,7 +714,6 @@ async fn test_incremental_upload_of_keys() -> Result<()> {
 }
 
 #[async_test]
-#[cfg(feature = "experimental-sliding-sync")]
 async fn test_incremental_upload_of_keys_sliding_sync() -> Result<()> {
     use tokio::task::spawn_blocking;
 

--- a/crates/matrix-sdk/tests/integration/room_preview.rs
+++ b/crates/matrix-sdk/tests/integration/room_preview.rs
@@ -1,15 +1,14 @@
-#[cfg(feature = "experimental-sliding-sync")]
 use js_int::uint;
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
-#[cfg(feature = "experimental-sliding-sync")]
-use matrix_sdk_base::sliding_sync;
-use matrix_sdk_base::RoomState;
+use matrix_sdk_base::{sliding_sync, RoomState};
 use matrix_sdk_test::{
     async_test, InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, SyncResponseBuilder,
 };
-#[cfg(feature = "experimental-sliding-sync")]
-use ruma::{api::client::sync::sync_events::v5::response::Hero, assign, owned_user_id};
-use ruma::{events::room::member::MembershipState, room_id, space::SpaceRoomJoinRule, RoomId};
+use ruma::{
+    api::client::sync::sync_events::v5::response::Hero, assign,
+    events::room::member::MembershipState, owned_user_id, room_id, space::SpaceRoomJoinRule,
+    RoomId,
+};
 use serde_json::json;
 use wiremock::{
     matchers::{header, method, path_regex},
@@ -115,7 +114,6 @@ async fn test_room_preview_leave_unknown_room_fails() {
     assert!(client.get_room(room_id).is_none());
 }
 
-#[cfg(feature = "experimental-sliding-sync")]
 #[async_test]
 async fn test_room_preview_computes_name_if_room_is_known() {
     let (client, _) = logged_in_client_with_server().await;

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -193,7 +193,7 @@ fn check_clippy() -> Result<()> {
         "rustup run {NIGHTLY} cargo clippy --workspace --all-targets
             --exclude matrix-sdk-crypto --exclude xtask
             --no-default-features
-            --features native-tls,experimental-sliding-sync,sso-login,testing
+            --features native-tls,sso-login,testing
             -- -D warnings"
     )
     .run()?;
@@ -214,10 +214,7 @@ fn check_docs() -> Result<()> {
 
 fn run_feature_tests(cmd: Option<FeatureSet>) -> Result<()> {
     let args = BTreeMap::from([
-        (
-            FeatureSet::NoEncryption,
-            "--no-default-features --features sqlite,native-tls,experimental-sliding-sync,testing",
-        ),
+        (FeatureSet::NoEncryption, "--no-default-features --features sqlite,native-tls,testing"),
         (
             FeatureSet::NoSqlite,
             "--no-default-features --features e2e-encryption,native-tls,testing",


### PR DESCRIPTION
Sliding sync is no longer experimental. It has a solid MSC4186, along with a solid implementation inside Synapse. It's time to consider it mature.

The SDK continues to support the old MSC3575 in addition to MSC4186. This patch only removes the `experimental-sliding-sync` feature flag.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3647