### PR TITLE
fix(sdk): Ensure a gap has been inserted before removing it

### DIFF
--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -431,7 +431,7 @@ impl RoomEventCacheInner {
 
                     let added_unique_events = room_events.push_events(sync_timeline_events.clone());
 
-                    if !added_unique_events {
+                    if !added_unique_events && prev_batch.is_some() {
                         debug!(
                             "not storing previous batch token, because we deduplicated all new sync events"
                         );


### PR DESCRIPTION
This patch fixes a bug where the code assumes a gap has been inserted, and thus, is always present. But this isn't the case. If `prev_batch` is `None`, a gap is not inserted, and so we cannot remove it. This patch checks that `prev_batch` is `Some(_)`, which means the invariant is correct, and the code can remove the gap.
