### PR TITLE
fix: Implement visit_bytes for the Ed25519PublicKey deserialization

### DIFF
--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -87,6 +87,7 @@ http = { workspace = true }
 indoc = "2.0.5"
 insta = { workspace = true }
 matrix-sdk-test = { workspace = true }
+rmp-serde = { workspace = true }
 proptest = { workspace = true }
 similar-asserts = { workspace = true }
 # required for async_test macro

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -70,12 +70,30 @@ where
         where
             A: de::SeqAccess<'de>,
         {
-            let mut buf = [0u8; 32];
+            let mut buf = [0u8; Ed25519PublicKey::LENGTH];
+
             for (i, item) in buf.iter_mut().enumerate() {
                 *item = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(i, &self))?;
             }
+
             let key = Ed25519PublicKey::from_slice(&buf).map_err(|e| de::Error::custom(&e))?;
+
             Ok(Box::new(key))
+        }
+
+        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if v.len() == Ed25519PublicKey::LENGTH {
+                let mut buf = [0u8; Ed25519PublicKey::LENGTH];
+                buf.copy_from_slice(v);
+
+                let key = Ed25519PublicKey::from_slice(&buf).map_err(|e| de::Error::custom(&e))?;
+                Ok(Box::new(key))
+            } else {
+                Err(de::Error::invalid_length(v.len(), &self))
+            }
         }
     }
 


### PR DESCRIPTION
This fixes the deserialization of the SenderData since it switched to the base64 encoding for serialization of the master key in one of its variants.

The issue was introduced in 5ff556f6c3026ab53b21ba0b0a24749ffa715e17 (#4450).