### PR TITLE
fix(crypto): migration failure due to optimized handling of &[u8]

### DIFF
--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -87,6 +87,7 @@ http = { workspace = true }
 indoc = "2.0.5"
 insta = { workspace = true }
 matrix-sdk-test = { workspace = true }
+rmp-serde = { workspace = true }
 proptest = { workspace = true }
 similar-asserts = { workspace = true }
 # required for async_test macro


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fix migration bug caused by #4450 when &[u8] serialization is optimized.

=> Migration bug was causing messages to fail to decrypt and the sync to fail with the following errors

```
matrix_sdk_crypto::machine: Failed to decrypt a room event: invalid type: byte array, expected a base64 string or an array of 32 bytes
```
```
ERROR matrix_sdk::sync: Received an invalid response: failed to read or write to the crypto store invalid type: byte array, expected a base64 string or an array of 32 bytes
```
- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
