### PR TITLE
feat(sdk): Allow to set and check whether an image is animated

### DIFF
--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -570,6 +570,7 @@ pub struct ImageInfo {
     pub thumbnail_info: Option<ThumbnailInfo>,
     pub thumbnail_source: Option<Arc<MediaSource>>,
     pub blurhash: Option<String>,
+    pub is_animated: Option<bool>,
 }
 
 impl From<ImageInfo> for RumaImageInfo {
@@ -582,6 +583,7 @@ impl From<ImageInfo> for RumaImageInfo {
             thumbnail_info: value.thumbnail_info.map(Into::into).map(Box::new),
             thumbnail_source: value.thumbnail_source.map(|source| (*source).clone().into()),
             blurhash: value.blurhash,
+            is_animated: value.is_animated,
         })
     }
 }
@@ -603,6 +605,7 @@ impl TryFrom<&ImageInfo> for BaseImageInfo {
             width: Some(width),
             size: Some(size),
             blurhash: Some(blurhash),
+            is_animated: value.is_animated,
         })
     }
 }
@@ -859,6 +862,7 @@ impl TryFrom<&matrix_sdk::ruma::events::room::ImageInfo> for ImageInfo {
                 .transpose()?
                 .map(Arc::new),
             blurhash: info.blurhash.clone(),
+            is_animated: info.is_animated,
         })
     }
 }

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+- Allow to set and check whether an image is animated via its `ImageInfo`.
+  ([#4503](https://github.com/matrix-org/matrix-rust-sdk/pull/4503))
+
 ### Refactor
 
 - [**breaking**] Move the optional `RequestConfig` argument of the

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 - Allow to set and check whether an image is animated via its `ImageInfo`.
   ([#4503](https://github.com/matrix-org/matrix-rust-sdk/pull/4503))
+- Implement `Default` for `BaseImageInfo`, `BaseVideoInfo`, `BaseAudioInfo` and
+  `BaseFileInfo`. ([#4503](https://github.com/matrix-org/matrix-rust-sdk/pull/4503))
 
 ### Refactor
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -96,7 +96,15 @@ mime2ext = "0.1.53"
 once_cell = { workspace = true }
 pin-project-lite = { workspace = true }
 rand = { workspace = true , optional = true }
-ruma = { workspace = true, features = ["rand", "unstable-msc2448", "unstable-msc2965", "unstable-msc3930", "unstable-msc3245-v1-compat", "unstable-msc2867"] }
+ruma = { workspace = true, features = [
+    "rand",
+    "unstable-msc2448",
+    "unstable-msc2965",
+    "unstable-msc3930",
+    "unstable-msc3245-v1-compat",
+    "unstable-msc2867",
+    "unstable-msc4230",
+] }
 serde = { workspace = true }
 serde_html_form = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -39,6 +39,8 @@ pub struct BaseImageInfo {
     pub size: Option<UInt>,
     /// The [BlurHash](https://blurha.sh/) for this image.
     pub blurhash: Option<String>,
+    /// Whether this image is animated.
+    pub is_animated: Option<bool>,
 }
 
 /// Base metadata about a video.
@@ -100,6 +102,7 @@ impl From<AttachmentInfo> for ImageInfo {
                 width: info.width,
                 size: info.size,
                 blurhash: info.blurhash,
+                is_animated: info.is_animated,
             }),
             _ => ImageInfo::new(),
         }

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -29,7 +29,7 @@ use ruma::{
 };
 
 /// Base metadata about an image.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BaseImageInfo {
     /// The height of the image in pixels.
     pub height: Option<UInt>,
@@ -44,7 +44,7 @@ pub struct BaseImageInfo {
 }
 
 /// Base metadata about a video.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BaseVideoInfo {
     /// The duration of the video.
     pub duration: Option<Duration>,
@@ -59,7 +59,7 @@ pub struct BaseVideoInfo {
 }
 
 /// Base metadata about an audio clip.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BaseAudioInfo {
     /// The duration of the audio clip.
     pub duration: Option<Duration>,
@@ -68,7 +68,7 @@ pub struct BaseAudioInfo {
 }
 
 /// Base metadata about a file.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BaseFileInfo {
     /// The size of the file in bytes.
     pub size: Option<UInt>,

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -87,9 +87,7 @@ async fn test_room_attachment_send_info() {
         .info(AttachmentInfo::Image(BaseImageInfo {
             height: Some(uint!(600)),
             width: Some(uint!(800)),
-            size: None,
-            blurhash: None,
-            is_animated: None,
+            ..Default::default()
         }))
         .caption(Some("image caption".to_owned()));
 
@@ -140,8 +138,7 @@ async fn test_room_attachment_send_wrong_info() {
             height: Some(uint!(600)),
             width: Some(uint!(800)),
             duration: Some(Duration::from_millis(3600)),
-            size: None,
-            blurhash: None,
+            ..Default::default()
         }))
         .caption(Some("image caption".to_owned()));
 
@@ -216,9 +213,7 @@ async fn test_room_attachment_send_info_thumbnail() {
         .info(AttachmentInfo::Image(BaseImageInfo {
             height: Some(uint!(600)),
             width: Some(uint!(800)),
-            size: None,
-            blurhash: None,
-            is_animated: None,
+            ..Default::default()
         }));
 
     let response = room
@@ -336,9 +331,8 @@ async fn test_room_attachment_send_is_animated() {
         .info(AttachmentInfo::Image(BaseImageInfo {
             height: Some(uint!(600)),
             width: Some(uint!(800)),
-            size: None,
-            blurhash: None,
             is_animated: Some(false),
+            ..Default::default()
         }))
         .caption(Some("image caption".to_owned()));
 

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -53,8 +53,7 @@ async fn queue_attachment_no_thumbnail(q: &RoomSendQueue) -> (SendHandle, &'stat
         height: Some(uint!(13)),
         width: Some(uint!(37)),
         size: Some(uint!(42)),
-        blurhash: None,
-        is_animated: None,
+        ..Default::default()
     }));
     let handle = q
         .send_attachment(filename, content_type, data, config)
@@ -85,8 +84,7 @@ async fn queue_attachment_with_thumbnail(q: &RoomSendQueue) -> (SendHandle, &'st
             height: Some(uint!(13)),
             width: Some(uint!(37)),
             size: Some(uint!(42)),
-            blurhash: None,
-            is_animated: None,
+            ..Default::default()
         },
     ));
 
@@ -1812,8 +1810,8 @@ async fn test_media_uploads() {
         height: Some(uint!(14)),
         width: Some(uint!(38)),
         size: Some(uint!(43)),
-        blurhash: None,
         is_animated: Some(false),
+        ..Default::default()
     });
 
     let transaction_id = TransactionId::new();

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -54,6 +54,7 @@ async fn queue_attachment_no_thumbnail(q: &RoomSendQueue) -> (SendHandle, &'stat
         width: Some(uint!(37)),
         size: Some(uint!(42)),
         blurhash: None,
+        is_animated: None,
     }));
     let handle = q
         .send_attachment(filename, content_type, data, config)
@@ -85,6 +86,7 @@ async fn queue_attachment_with_thumbnail(q: &RoomSendQueue) -> (SendHandle, &'st
             width: Some(uint!(37)),
             size: Some(uint!(42)),
             blurhash: None,
+            is_animated: None,
         },
     ));
 
@@ -1811,6 +1813,7 @@ async fn test_media_uploads() {
         width: Some(uint!(38)),
         size: Some(uint!(43)),
         blurhash: None,
+        is_animated: Some(false),
     });
 
     let transaction_id = TransactionId::new();
@@ -1871,6 +1874,7 @@ async fn test_media_uploads() {
     assert_eq!(info.size, Some(uint!(43)));
     assert_eq!(info.mimetype.as_deref(), Some("image/jpeg"));
     assert!(info.blurhash.is_none());
+    assert_eq!(info.is_animated, Some(false));
 
     // Check the data source: it should reference the send queue local storage.
     let local_source = img_content.source;


### PR DESCRIPTION
Using MSC4230.

While I was in the area I added a second commit to implement `Default` for the `Base*Info` types since they only have optional fields and it is easier to construct them that way when we don't want to set all fields.

This can be reviewed commit by commit.

- [x] Public API changes documented in changelogs (optional)

