### PR TITLE
feat(sdk): Expose Client::server_versions publicly

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
   ([#4503](https://github.com/matrix-org/matrix-rust-sdk/pull/4503))
 - Implement `Default` for `BaseImageInfo`, `BaseVideoInfo`, `BaseAudioInfo` and
   `BaseFileInfo`. ([#4503](https://github.com/matrix-org/matrix-rust-sdk/pull/4503))
+- Expose `Client::server_versions()` publicly to allow users of the library to
+  get the versions of Matrix supported by the homeserver. 
 
 ### Refactor
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to this project will be documented in this file.
 - Implement `Default` for `BaseImageInfo`, `BaseVideoInfo`, `BaseAudioInfo` and
   `BaseFileInfo`. ([#4503](https://github.com/matrix-org/matrix-rust-sdk/pull/4503))
 - Expose `Client::server_versions()` publicly to allow users of the library to
-  get the versions of Matrix supported by the homeserver. 
+  get the versions of Matrix supported by the homeserver.
+  ([#4519](https://github.com/matrix-org/matrix-rust-sdk/pull/4519))
 
 ### Refactor
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1736,11 +1736,30 @@ impl Client {
         Ok(f(&guard).unwrap())
     }
 
-    pub(crate) async fn server_versions(&self) -> HttpResult<Box<[MatrixVersion]>> {
+    /// Get the Matrix versions supported by the homeserver by fetching them
+    /// from the server or the cache.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ruma::api::MatrixVersion;
+    /// # use matrix_sdk::{Client, config::SyncSettings};
+    /// # use url::Url;
+    /// # async {
+    /// # let homeserver = Url::parse("http://localhost:8080")?;
+    /// # let mut client = Client::new(homeserver).await?;
+    ///
+    /// let server_versions = client.server_versions().await?;
+    /// let supports_1_1 = server_versions.contains(&MatrixVersion::V1_1);
+    /// println!("The homeserver supports Matrix 1.1: {supports_1_1:?}");
+    /// # anyhow::Ok(()) };
+    /// ```
+    pub async fn server_versions(&self) -> HttpResult<Box<[MatrixVersion]>> {
         self.get_or_load_and_cache_server_capabilities(|caps| caps.server_versions.clone()).await
     }
 
-    /// Get unstable features from by fetching from the server or the cache.
+    /// Get the unstable features supported by the homeserver by fetching them
+    /// from the server or the cache.
     ///
     /// # Examples
     ///
@@ -1751,7 +1770,9 @@ impl Client {
     /// # let homeserver = Url::parse("http://localhost:8080")?;
     /// # let mut client = Client::new(homeserver).await?;
     /// let unstable_features = client.unstable_features().await?;
-    /// let msc_x = unstable_features.get("msc_x").unwrap_or(&false);
+    /// let supports_msc_x =
+    ///     unstable_features.get("msc_x").copied().unwrap_or(false);
+    /// println!("The homeserver supports msc X: {supports_msc_x:?}");
     /// # anyhow::Ok(()) };
     /// ```
     pub async fn unstable_features(&self) -> HttpResult<BTreeMap<String, bool>> {


### PR DESCRIPTION
We have one specific use case at the moment for this in Fractal, to build the [UIAA fallback URL](https://spec.matrix.org/v1.13/client-server-api/#fallback) depending on the Matrix version.  Currently we always use the r0 version that is hardcoded in our code.

But I also don't see why it should not be public.

- [x] Public API changes documented in changelogs (optional)

