### PR TITLE
chore(xtask): tweak the TWiM report to include only merged PRs, not created PRs

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -142,7 +142,7 @@ fn weekly_report() -> Result<()> {
 
     cmd!(
         sh,
-        "gh pr list --search created:>{one_week_ago} --json {JSON_FIELDS} --template {template}"
+        "gh pr list --search merged:>{one_week_ago} --json {JSON_FIELDS} --template {template}"
     )
     .quiet()
     .run()?;


### PR DESCRIPTION
As an outsider, I am mostly interested in features and new developments that have happened, not those that *may* happen. An open-but-not-merged PR may not get merged in the end, or it may not get merged any time soon, creating false expectations. Merged PRs, on the other hand, have definitely happened (even if they get undone, that happens via other PRs that will get merged later). As such, I think it brings more value to outsiders.