### PR TITLE
feat(event cache): remove events when forgetting a room

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1516,8 +1516,14 @@ impl BaseClient {
     /// # Arguments
     ///
     /// * `room_id` - The id of the room that should be forgotten.
-    pub async fn forget_room(&self, room_id: &RoomId) -> StoreResult<()> {
-        self.store.forget_room(room_id).await
+    pub async fn forget_room(&self, room_id: &RoomId) -> Result<()> {
+        // Forget the room in the state store.
+        self.store.forget_room(room_id).await?;
+
+        // Remove the room in the event cache store too.
+        self.event_cache_store().lock().await?.remove_room(room_id).await?;
+
+        Ok(())
     }
 
     /// Get the olm machine.

--- a/crates/matrix-sdk-base/src/error.rs
+++ b/crates/matrix-sdk-base/src/error.rs
@@ -15,9 +15,12 @@
 
 //! Error conditions.
 
+use matrix_sdk_common::store_locks::LockStoreError;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_crypto::{CryptoStoreError, MegolmError, OlmError};
 use thiserror::Error;
+
+use crate::event_cache::store::EventCacheStoreError;
 
 /// Result type of the rust-sdk.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -41,6 +44,14 @@ pub enum Error {
     /// IO or (de)serialization.
     #[error(transparent)]
     StateStore(#[from] crate::store::StoreError),
+
+    /// An error happened while manipulating the event cache store.
+    #[error(transparent)]
+    EventCacheStore(#[from] EventCacheStoreError),
+
+    /// An error happened while attempting to lock the event cache store.
+    #[error(transparent)]
+    EventCacheLock(#[from] LockStoreError),
 
     /// An error occurred in the crypto store.
     #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -57,6 +57,13 @@ pub trait EventCacheStore: AsyncTraitDeps {
         updates: Vec<Update<Event, Gap>>,
     ) -> Result<(), Self::Error>;
 
+    /// Remove all data tied to a given room from the cache.
+    async fn remove_room(&self, room_id: &RoomId) -> Result<(), Self::Error> {
+        // Right now, this means removing all the linked chunk. If implementations
+        // override this behavior, they should *also* include this code.
+        self.handle_linked_chunk_updates(room_id, vec![Update::Clear]).await
+    }
+
     /// Return all the raw components of a linked chunk, so the caller may
     /// reconstruct the linked chunk later.
     async fn reload_linked_chunk(


### PR DESCRIPTION
Does what it says on the tin, and fixes a bug where clearing a room in the in-memory linked chunk would clear *all* rooms at once.

Part of #3280.