### PR TITLE
chore!(encryption): rename `are_we_the_last_man_standing` to `is_last_device`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -281,7 +281,7 @@ impl Encryption {
     }
 
     pub async fn is_last_device(&self) -> Result<bool> {
-        Ok(self.inner.recovery().are_we_the_last_man_standing().await?)
+        Ok(self.inner.recovery().is_last_device().await?)
     }
 
     pub async fn wait_for_backup_upload_steady_state(

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
   call `AttachmentConfig::new().thumbnail(thumbnail)` now instead.
 - [**breaking**] `Room::send_attachment()` and `RoomSendQueue::send_attachment()`
   now take any type that implements `Into<String>` for the filename.
+- [**breaking**] `Recovery::are_we_the_last_man_standing()` has been renamed to `is_last_device()`.
 
 ## [0.9.0] - 2024-12-18
 

--- a/crates/matrix-sdk/src/encryption/recovery/mod.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/mod.rs
@@ -462,7 +462,7 @@ impl Recovery {
     /// If the user does not enable recovery before logging out of their last
     /// device, they will not be able to decrypt historic messages once they
     /// create a new device.
-    pub async fn are_we_the_last_man_standing(&self) -> Result<bool> {
+    pub async fn is_last_device(&self) -> Result<bool> {
         let olm_machine = self.client.olm_machine().await;
         let olm_machine = olm_machine.as_ref().ok_or(crate::Error::NoOlmMachine)?;
         let user_id = olm_machine.user_id();


### PR DESCRIPTION
While the former name is arguably more fun, the latter is more descriptive of what the function does.