### PR TITLE
fix(timeline): Add UTDs to the timeline conditionally

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -447,7 +447,9 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
             TimelineEventKind::UnableToDecrypt { content, utd_cause } => {
                 // TODO: Handle replacements if the replaced event is also UTD
-                self.add_item(TimelineItemContent::unable_to_decrypt(content, utd_cause), None);
+                if should_add {
+                    self.add_item(TimelineItemContent::unable_to_decrypt(content, utd_cause), None);
+                }
 
                 // Let the hook know that we ran into an unable-to-decrypt that is added to the
                 // timeline.


### PR DESCRIPTION
Should fix https://github.com/element-hq/element-x-ios/issues/3669.

Take into account the `should_add` parameter for including UTDs in the timeline, as is done for other types of events.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
