### PR TITLE
feat(room): Add fn Room::own_membership_details

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -76,7 +76,7 @@ pub fn matrix_to_user_permalink(user_id: String) -> Result<String, ClientError> 
     Ok(user_id.matrix_to_uri().to_string())
 }
 
-#[derive(uniffi::Record)]
+#[derive(Clone, uniffi::Record)]
 pub struct RoomMember {
     pub user_id: String,
     pub display_name: Option<String>,
@@ -87,6 +87,7 @@ pub struct RoomMember {
     pub normalized_power_level: i64,
     pub is_ignored: bool,
     pub suggested_role_for_power_level: RoomMemberRole,
+    pub membership_change_reason: Option<String>,
 }
 
 impl TryFrom<SdkRoomMember> for RoomMember {
@@ -103,6 +104,7 @@ impl TryFrom<SdkRoomMember> for RoomMember {
             normalized_power_level: m.normalized_power_level(),
             is_ignored: m.is_ignored(),
             suggested_role_for_power_level: m.suggested_role_for_power_level(),
+            membership_change_reason: m.event().reason().map(|s| s.to_owned()),
         })
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room_preview.rs
+++ b/bindings/matrix-sdk-ffi/src/room_preview.rs
@@ -64,6 +64,32 @@ impl RoomPreview {
         let invite_details = room.invite_details().await.ok()?;
         invite_details.inviter.and_then(|m| m.try_into().ok())
     }
+
+    /// Get the membership details for the current user.
+    pub async fn own_membership_details(&self) -> Option<RoomMembershipDetails> {
+        let room = self.client.get_room(&self.inner.room_id)?;
+
+        let (own_member, sender_member) = match room.own_membership_details().await {
+            Ok(memberships) => memberships,
+            Err(error) => {
+                warn!("Couldn't get membership info: {error}");
+                return None;
+            }
+        };
+
+        Some(RoomMembershipDetails {
+            own_room_member: own_member.try_into().ok()?,
+            sender_room_member: sender_member.and_then(|member| member.try_into().ok()),
+        })
+    }
+}
+
+/// Contains the current user's room member info and the optional room member
+/// info of the sender of the `m.room.member` event that this info represents.
+#[derive(uniffi::Record)]
+pub struct RoomMembershipDetails {
+    pub own_room_member: RoomMember,
+    pub sender_room_member: Option<RoomMember>,
 }
 
 impl RoomPreview {


### PR DESCRIPTION
This will retrieve the room member info of both the current user and the info for the sender of the current user's room member event and make it accessible in the FFI layer.

This is needed for `RoomPreview` to display messages such as 'you were banned from this room by Foo'.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
