### PR TITLE
fix(tests): Fix a flaky test by marking a room's members as synced.

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -391,6 +391,17 @@ impl Room {
         self.inner.read().members_synced
     }
 
+    /// Mark this Room as holding all member information.
+    ///
+    /// Useful in tests if we want to persuade the Room not to sync when asked
+    /// about its members.
+    #[cfg(feature = "testing")]
+    pub fn mark_members_synced(&self) {
+        self.inner.update(|info| {
+            info.members_synced = true;
+        });
+    }
+
     /// Mark this Room as still missing member information.
     pub fn mark_members_missing(&self) {
         self.inner.update_if(|info| {

--- a/crates/matrix-sdk/src/room/identity_status_changes.rs
+++ b/crates/matrix-sdk/src/room/identity_status_changes.rs
@@ -917,6 +917,8 @@ mod tests {
                 .build_sync_response();
             client.process_sync(create_room_sync_response).await.unwrap();
             let room = client.get_room(&DEFAULT_TEST_ROOM_ID).expect("Room should exist");
+            room.inner.mark_members_synced();
+
             assert_eq!(room.state(), RoomState::Joined);
             assert_eq!(
                 *room


### PR DESCRIPTION
This is intended to prevent the test
`test_when_user_in_verification_violation_becomes_verified_we_report_it` flaking. I found that sometimes when it called `Room::members` the result was empty due to it trying to fetch the answer from the server. This change prevents that behaviour. I don't know why the behaviour was inconsistent before.