### PR TITLE
refactor(live_location_share): exclude live location events of own user

### DIFF
--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3244,6 +3244,9 @@ impl Room {
     ///
     /// The returned observable will receive the newest event for each sync
     /// response that contains an `m.beacon` event.
+    ///
+    /// Returns a stream of `ObservableLiveLocation` events from other users
+    /// in the room, excluding the live location events of the room's own user.
     pub fn observe_live_location_shares(&self) -> ObservableLiveLocation {
         ObservableLiveLocation::new(&self.client, self.room_id())
     }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3245,7 +3245,7 @@ impl Room {
     /// The returned observable will receive the newest event for each sync
     /// response that contains an `m.beacon` event.
     ///
-    /// Returns a stream of `ObservableLiveLocation` events from other users
+    /// Returns a stream of [`ObservableLiveLocation`] events from other users
     /// in the room, excluding the live location events of the room's own user.
     pub fn observe_live_location_shares(&self) -> ObservableLiveLocation {
         ObservableLiveLocation::new(&self.client, self.room_id())

--- a/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
@@ -396,8 +396,6 @@ async fn test_observing_live_location_does_not_return_own_beacon_updates() {
 
     let f = EventFactory::new().room(room_id);
 
-    let ts = Some(MilliSecondsSinceUnixEpoch(1_636_829_458_u64.try_into().unwrap()));
-
     let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f
         .event(BeaconInfoEventContent::new(None, Duration::from_secs(60), false, None))
         .event_id(event_id)


### PR DESCRIPTION
This change ensures that the user's own live location events are excluded from the location sharing stream. Since the user's location is already represented on the map by the blue dot, processing their own events is redundant and unnecessary.