### PR TITLE
feat(event cache): redact previously-seen events in the linked chunk too

### DIFF
--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -37,7 +37,6 @@ mod rooms;
 
 pub mod read_receipts;
 pub use read_receipts::PreviousEventsProvider;
-pub use rooms::RoomMembersUpdate;
 pub mod sliding_sync;
 
 pub mod store;
@@ -56,9 +55,9 @@ pub use http;
 pub use matrix_sdk_crypto as crypto;
 pub use once_cell;
 pub use rooms::{
-    Room, RoomCreateWithCreatorEventContent, RoomDisplayName, RoomHero, RoomInfo,
-    RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons, RoomMember, RoomMemberships, RoomState,
-    RoomStateFilter,
+    apply_redaction, Room, RoomCreateWithCreatorEventContent, RoomDisplayName, RoomHero, RoomInfo,
+    RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons, RoomMember, RoomMembersUpdate,
+    RoomMemberships, RoomState, RoomStateFilter,
 };
 pub use store::{
     ComposerDraft, ComposerDraftType, QueueWedgeError, StateChanges, StateStore, StateStoreDataKey,

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -12,7 +12,7 @@ use std::{
 use bitflags::bitflags;
 pub use members::RoomMember;
 pub use normal::{
-    Room, RoomHero, RoomInfo, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons,
+    apply_redaction, Room, RoomHero, RoomInfo, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons,
     RoomMembersUpdate, RoomState, RoomStateFilter,
 };
 use regex::Regex;

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -2007,7 +2007,9 @@ impl RoomInfo {
     }
 }
 
-fn apply_redaction(
+/// Apply a redaction to the given target `event`, given the raw redaction event
+/// and the room version.
+pub fn apply_redaction(
     event: &Raw<AnySyncTimelineEvent>,
     raw_redaction: &Raw<SyncRoomRedactionEvent>,
     room_version: &RoomVersionId,
@@ -2033,7 +2035,7 @@ fn apply_redaction(
     let redact_result = redact_in_place(&mut event_json, room_version, Some(redacted_because));
 
     if let Err(e) = redact_result {
-        warn!("Failed to redact latest event: {e}");
+        warn!("Failed to redact event: {e}");
         return None;
     }
 

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -390,6 +390,19 @@ impl SyncTimelineEvent {
         self.kind.raw()
     }
 
+    /// Replace the raw event included in this item by another one.
+    pub fn replace_raw(&mut self, replacement: Raw<AnyMessageLikeEvent>) {
+        match &mut self.kind {
+            TimelineEventKind::Decrypted(decrypted) => decrypted.event = replacement,
+            TimelineEventKind::UnableToDecrypt { event, .. }
+            | TimelineEventKind::PlainText { event } => {
+                // It's safe to cast `AnyMessageLikeEvent` into `AnySyncMessageLikeEvent`,
+                // because the former contains a superset of the fields included in the latter.
+                *event = replacement.cast();
+            }
+        }
+    }
+
     /// If the event was a decrypted event that was successfully decrypted, get
     /// its encryption info. Otherwise, `None`.
     pub fn encryption_info(&self) -> Option<&EncryptionInfo> {

--- a/crates/matrix-sdk-common/src/linked_chunk/updates.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/updates.rs
@@ -79,6 +79,18 @@ pub enum Update<Item, Gap> {
         items: Vec<Item>,
     },
 
+    /// An item has been replaced in the linked chunk.
+    ///
+    /// The `at` position MUST resolve to the actual position an existing *item*
+    /// (not a gap).
+    ReplaceItem {
+        /// The position of the item that's being replaced.
+        at: Position,
+
+        /// The new value for the item.
+        item: Item,
+    },
+
     /// An item has been removed inside a chunk of kind Items.
     RemoveItem {
         /// The [`Position`] of the item.

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -459,6 +459,28 @@ impl EventCacheStore for SqliteEventCacheStore {
                             }
                         }
 
+                        Update::ReplaceItem { at, item: event } => {
+                            let chunk_id = at.chunk_identifier().index();
+                            let index = at.index();
+
+                            trace!(%room_id, "replacing item @ {chunk_id}:{index}");
+
+                            let serialized = serde_json::to_vec(&event)?;
+                            let content = this.encode_value(serialized)?;
+
+                            // The event id should be the same, but just in case it changed…
+                            let event_id = event.event_id().map(|event_id| event_id.to_string());
+
+                            txn.execute(
+                                r#"
+                                UPDATE events
+                                SET content = ?, event_id = ?
+                                WHERE room_id = ? AND chunk_id = ? AND position = ?
+                            "#,
+                                (content, event_id, &hashed_room_id, chunk_id, index,)
+                            )?;
+                        }
+
                         Update::RemoveItem { at } => {
                             let chunk_id = at.chunk_identifier().index();
                             let index = at.index();
@@ -975,6 +997,52 @@ mod tests {
         assert_eq!(c.next, None);
         assert_matches!(c.content, ChunkContent::Gap(gap) => {
             assert_eq!(gap.prev_token, "raclette");
+        });
+    }
+
+    #[async_test]
+    async fn test_linked_chunk_replace_item() {
+        let store = get_event_cache_store().await.expect("creating cache store failed");
+
+        let room_id = &DEFAULT_TEST_ROOM_ID;
+
+        store
+            .handle_linked_chunk_updates(
+                room_id,
+                vec![
+                    Update::NewItemsChunk {
+                        previous: None,
+                        new: ChunkIdentifier::new(42),
+                        next: None,
+                    },
+                    Update::PushItems {
+                        at: Position::new(ChunkIdentifier::new(42), 0),
+                        items: vec![
+                            make_test_event(room_id, "hello"),
+                            make_test_event(room_id, "world"),
+                        ],
+                    },
+                    Update::ReplaceItem {
+                        at: Position::new(ChunkIdentifier::new(42), 1),
+                        item: make_test_event(room_id, "yolo"),
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+
+        let mut chunks = store.reload_linked_chunk(room_id).await.unwrap();
+
+        assert_eq!(chunks.len(), 1);
+
+        let c = chunks.remove(0);
+        assert_eq!(c.identifier, ChunkIdentifier::new(42));
+        assert_eq!(c.previous, None);
+        assert_eq!(c.next, None);
+        assert_matches!(c.content, ChunkContent::Items(events) => {
+            assert_eq!(events.len(), 2);
+            check_test_event(&events[0], "hello");
+            check_test_event(&events[1], "yolo");
         });
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -497,6 +497,26 @@ impl TimelineStateTransaction<'_> {
                     .await;
                 }
 
+                VectorDiff::Set { index: event_index, value: event } => {
+                    if let Some(timeline_item_index) = self
+                        .items
+                        .all_remote_events()
+                        .get(event_index)
+                        .and_then(|meta| meta.timeline_item_index)
+                    {
+                        self.handle_remote_event(
+                            event,
+                            TimelineItemPosition::UpdateDecrypted { timeline_item_index },
+                            room_data_provider,
+                            settings,
+                            &mut date_divider_adjuster,
+                        )
+                        .await;
+                    } else {
+                        warn!(event_index, "Set update dropped because there wasn't any attached timeline item index.");
+                    }
+                }
+
                 VectorDiff::Remove { index: event_index } => {
                     self.remove_timeline_item(event_index, &mut date_divider_adjuster);
                 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -281,7 +281,7 @@ impl TimelineState {
             let handle_one_res = txn
                 .handle_remote_event(
                     event.into(),
-                    TimelineItemPosition::UpdateDecrypted { timeline_item_index: idx },
+                    TimelineItemPosition::UpdateAt { timeline_item_index: idx },
                     room_data_provider,
                     settings,
                     &mut date_divider_adjuster,
@@ -506,7 +506,7 @@ impl TimelineStateTransaction<'_> {
                     {
                         self.handle_remote_event(
                             event,
-                            TimelineItemPosition::UpdateDecrypted { timeline_item_index },
+                            TimelineItemPosition::UpdateAt { timeline_item_index },
                             room_data_provider,
                             settings,
                             &mut date_divider_adjuster,
@@ -592,7 +592,7 @@ impl TimelineStateTransaction<'_> {
                         | TimelineItemPosition::Start { origin }
                         | TimelineItemPosition::At { origin, .. } => origin,
 
-                        TimelineItemPosition::UpdateDecrypted { timeline_item_index: idx } => self
+                        TimelineItemPosition::UpdateAt { timeline_item_index: idx } => self
                             .items
                             .get(idx)
                             .and_then(|item| item.as_event())
@@ -876,7 +876,7 @@ impl TimelineStateTransaction<'_> {
                 self.items.insert_remote_event(event_index, event_meta.base_meta());
             }
 
-            TimelineItemPosition::UpdateDecrypted { .. } => {
+            TimelineItemPosition::UpdateAt { .. } => {
                 if let Some(event) =
                     self.items.get_remote_event_by_event_id_mut(event_meta.event_id)
                 {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -115,15 +115,15 @@ async fn test_reaction() {
     server.reset().await;
 
     // The new message starts with their author's read receipt.
-    assert_let!(Some(VectorDiff::PushBack { value: message }) = timeline_stream.next().await);
+    assert_let_timeout!(Some(VectorDiff::PushBack { value: message }) = timeline_stream.next());
     let event_item = message.as_event().unwrap();
     assert_matches!(event_item.content(), TimelineItemContent::Message(_));
     assert_eq!(event_item.read_receipts().len(), 1);
 
     // The new message is getting the reaction, which implies an implicit read
     // receipt that's obtained first.
-    assert_let!(
-        Some(VectorDiff::Set { index: 0, value: updated_message }) = timeline_stream.next().await
+    assert_let_timeout!(
+        Some(VectorDiff::Set { index: 0, value: updated_message }) = timeline_stream.next()
     );
     let event_item = updated_message.as_event().unwrap();
     assert_let!(TimelineItemContent::Message(msg) = event_item.content());
@@ -132,8 +132,8 @@ async fn test_reaction() {
     assert_eq!(event_item.reactions().len(), 0);
 
     // Then the reaction is taken into account.
-    assert_let!(
-        Some(VectorDiff::Set { index: 0, value: updated_message }) = timeline_stream.next().await
+    assert_let_timeout!(
+        Some(VectorDiff::Set { index: 0, value: updated_message }) = timeline_stream.next()
     );
     let event_item = updated_message.as_event().unwrap();
     assert_let!(TimelineItemContent::Message(msg) = event_item.content());
@@ -146,7 +146,9 @@ async fn test_reaction() {
     assert_eq!(senders.as_slice(), [user_id!("@bob:example.org")]);
 
     // The date divider.
-    assert_let!(Some(VectorDiff::PushFront { value: date_divider }) = timeline_stream.next().await);
+    assert_let_timeout!(
+        Some(VectorDiff::PushFront { value: date_divider }) = timeline_stream.next()
+    );
     assert!(date_divider.is_date_divider());
 
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
@@ -164,8 +166,8 @@ async fn test_reaction() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(
-        Some(VectorDiff::Set { index: 1, value: updated_message }) = timeline_stream.next().await
+    assert_let_timeout!(
+        Some(VectorDiff::Set { index: 1, value: updated_message }) = timeline_stream.next()
     );
     let event_item = updated_message.as_event().unwrap();
     assert_let!(TimelineItemContent::Message(msg) = event_item.content());


### PR DESCRIPTION
This makes it possible to:

- replace one item in a linked chunk, and have all the consumers handle the update. This will be useful for the second part of the PR (applying redactions to the linked chunk), and in the future to replace decrypted events ([when decryption happens in the event cache](https://github.com/matrix-org/matrix-rust-sdk/issues/3872)).
- redact, in memory and in storage, an event by its redacted form, so that it's not possible to read it on disk.

We _could_ add a migration to apply redactions for existing users of the nightly cache. I'd rather do this as a followup, since this PR is growing a bit large already (and another possibility is also to clear all events stored in the event cache, as a dirty yet safe migration — we might need this because I spotted an opportunity to not persist unneeded data from storage).