### PR TITLE
chore(ffi): silence useless logs coming out of the ffi crate

### DIFF
--- a/bindings/matrix-sdk-ffi/src/platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform.rs
@@ -288,8 +288,9 @@ const DEFAULT_TARGET_LOG_LEVELS: &[(LogTarget, LogLevel)] = &[
 ];
 
 const IMMUTABLE_TARGET_LOG_LEVELS: &[LogTarget] = &[
-    LogTarget::Hyper,     // Too verbose
-    LogTarget::MatrixSdk, // Too generic
+    LogTarget::Hyper,        // Too verbose
+    LogTarget::MatrixSdk,    // Too generic
+    LogTarget::MatrixSdkFfi, // Too verbose
 ];
 
 #[derive(uniffi::Record)]
@@ -398,7 +399,7 @@ mod tests {
             filter,
             "panic=error,\
             hyper=warn,\
-            matrix_sdk_ffi=trace,\
+            matrix_sdk_ffi=info,\
             matrix_sdk=info,\
             matrix_sdk::client=trace,\
             matrix_sdk_crypto=trace,\


### PR DESCRIPTION
Setting the default log level to `debug` results in logs like:

```
log: log_event
log: latest_event
log: log_event
log: log_event
log: room_info
log: latest_event
log: log_event
log: room_info
```

Presumably they're coming out of the custom tracing configuration and we definitely don't need them