### PR TITLE
Use Send-less BoxFuture for HttpClient Service impl on wasm

### DIFF
--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -261,7 +261,7 @@ async fn response_to_http_response(
 impl tower::Service<http::Request<Bytes>> for HttpClient {
     type Response = http::Response<Bytes>;
     type Error = tower::BoxError;
-    type Future = futures_core::future::BoxFuture<'static, Result<Self::Response, Self::Error>>;
+    type Future = matrix_sdk_base::BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(
         &mut self,


### PR DESCRIPTION
The dependencies required for the `experimental-oidc` feature don't currently compile on WASM, but once they do this is another thing inside this repo that's required for the feature to work on WASM.