### PR TITLE
Make callback interactions with ClientSessionDelegate async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,6 +3297,7 @@ dependencies = [
  "anyhow",
  "as_variant",
  "async-compat",
+ "async-trait",
  "extension-trait",
  "eyeball-im",
  "futures-util",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -24,6 +24,7 @@ vergen = { version = "8.1.3", features = ["build", "git", "gitcl"] }
 anyhow = { workspace = true }
 as_variant = { workspace = true }
 async-compat = "0.2.1"
+async-trait = { workspace = true }
 eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-util = { workspace = true }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -156,9 +156,11 @@ pub trait ClientDelegate: Sync + Send {
 #[matrix_sdk_ffi_macros::export(callback_interface)]
 #[async_trait::async_trait]
 pub trait ClientSessionDelegate: Sync + Send {
-    async fn retrieve_session_from_keychain(&self, user_id: String)
-        -> Result<Session, ClientError>;
-    async fn save_session_in_keychain(&self, session: Session);
+    async fn retrieve_session_from_keychain<'a>(
+        &'a self,
+        user_id: String,
+    ) -> Result<Session, ClientError>;
+    async fn save_session_in_keychain<'a>(&'a self, session: Session);
 }
 
 #[matrix_sdk_ffi_macros::export(callback_interface)]

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2370,8 +2370,8 @@ impl Client {
     /// while [`Self::subscribe_to_session_changes`] provides an async update.
     pub fn set_session_callbacks(
         &self,
-        reload_session_callback: Box<ReloadSessionCallback>,
-        save_session_callback: Box<SaveSessionCallback>,
+        reload_session_callback: Box<dyn ReloadSessionCallback>,
+        save_session_callback: Box<dyn SaveSessionCallback>,
     ) -> Result<()> {
         self.inner
             .auth_ctx

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -548,7 +548,8 @@ impl MatrixAuth {
                 if let Some(save_session_callback) =
                     self.client.inner.auth_ctx.save_session_callback.get()
                 {
-                    if let Err(err) = save_session_callback(self.client.clone()) {
+                    if let Err(err) = save_session_callback.save_session(self.client.clone()).await
+                    {
                         error!("when saving session after refresh: {err}");
                     }
                 }

--- a/crates/matrix-sdk/src/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/oidc/cross_process.rs
@@ -286,7 +286,7 @@ mod tests {
     impl ReloadSessionCallback for TestReloadSessionCallback {
         async fn reload_session(
             &self,
-            client: Client,
+            _client: Client,
         ) -> Result<SessionTokens, SessionCallbackError> {
             Ok(SessionTokens::Oidc(self.tokens.clone()))
         }
@@ -296,7 +296,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl SaveSessionCallback for TestSaveSessionCallback {
-        async fn save_session(&self, client: Client) -> Result<(), SessionCallbackError> {
+        async fn save_session(&self, _client: Client) -> Result<(), SessionCallbackError> {
             panic!("save_session_callback shouldn't be called here")
         }
     }

--- a/crates/matrix-sdk/src/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/oidc/cross_process.rs
@@ -288,7 +288,7 @@ mod tests {
             &self,
             client: Client,
         ) -> Result<SessionTokens, SessionCallbackError> {
-            crate::authentication::SessionTokens::Oidc(self.tokens.clone())
+            Ok(crate::authentication::SessionTokens::Oidc(self.tokens.clone()))
         }
     }
 

--- a/crates/matrix-sdk/src/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/oidc/cross_process.rs
@@ -264,7 +264,9 @@ mod tests {
 
     use super::compute_session_hash;
     use crate::{
-        authentication::{ReloadSessionCallback, SaveSessionCallback, SessionCallbackError},
+        authentication::{
+            ReloadSessionCallback, SaveSessionCallback, SessionCallbackError, SessionTokens,
+        },
         oidc::{
             backend::mock::{MockImpl, ISSUER_URL},
             cross_process::SessionHash,
@@ -273,7 +275,7 @@ mod tests {
             Oidc, OidcSessionTokens,
         },
         test_utils::test_client_builder,
-        Error,
+        Client, Error,
     };
 
     struct TestReloadSessionCallback {
@@ -284,7 +286,7 @@ mod tests {
     impl ReloadSessionCallback for TestReloadSessionCallback {
         async fn reload_session(
             &self,
-            client: matrix_sdk::Client,
+            client: Client,
         ) -> Result<SessionTokens, SessionCallbackError> {
             crate::authentication::SessionTokens::Oidc(self.tokens.clone())
         }
@@ -294,10 +296,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl SaveSessionCallback for TestSaveSessionCallback {
-        async fn save_session(
-            &self,
-            client: matrix_sdk::Client,
-        ) -> Result<(), SessionCallbackError> {
+        async fn save_session(&self, client: Client) -> Result<(), SessionCallbackError> {
             panic!("save_session_callback shouldn't be called here")
         }
     }
@@ -577,7 +576,7 @@ mod tests {
         }
 
         client.set_session_callbacks(
-            Box::new(TestReloadSessionCallback { tokens: next_tokens }),
+            Box::new(TestReloadSessionCallback { tokens: next_tokens.clone() }),
             Box::new(TestSaveSessionCallback {}),
         )?;
 

--- a/crates/matrix-sdk/src/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/oidc/cross_process.rs
@@ -288,7 +288,7 @@ mod tests {
             &self,
             client: Client,
         ) -> Result<SessionTokens, SessionCallbackError> {
-            Ok(crate::authentication::SessionTokens::Oidc(self.tokens.clone()))
+            Ok(SessionTokens::Oidc(self.tokens.clone()))
         }
     }
 
@@ -321,7 +321,7 @@ mod tests {
         client.oidc().enable_cross_process_refresh_lock("test".to_owned()).await?;
 
         client.set_session_callbacks(
-            Box::new(TestReloadSessionCallback { tokens }),
+            Box::new(TestReloadSessionCallback { tokens: tokens.clone() }),
             Box::new(TestSaveSessionCallback {}),
         )?;
 
@@ -543,7 +543,7 @@ mod tests {
             let oidc = unrestored_oidc;
 
             unrestored_client.set_session_callbacks(
-                Box::new(TestReloadSessionCallback { tokens: next_tokens }),
+                Box::new(TestReloadSessionCallback { tokens: next_tokens.clone() }),
                 Box::new(TestSaveSessionCallback {}),
             )?;
 

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -1015,7 +1015,7 @@ impl Oidc {
             .get()
             .ok_or(CrossProcessRefreshLockError::MissingReloadSession)?;
 
-        match callback(self.client.clone()) {
+        match callback.reload_session(self.client.clone()).await {
             Ok(tokens) => {
                 let crate::authentication::SessionTokens::Oidc(tokens) = tokens else {
                     return Err(CrossProcessRefreshLockError::InvalidSessionTokens);
@@ -1337,7 +1337,7 @@ impl Oidc {
         {
             // Satisfies the save_session_callback invariant: set_session_tokens has
             // been called just above.
-            if let Err(err) = save_session_callback(self.client.clone()) {
+            if let Err(err) = save_session_callback.save_session(self.client.clone()).await {
                 error!("when saving session after refresh: {err}");
             }
         }


### PR DESCRIPTION
See issue: https://github.com/matrix-org/matrix-rust-sdk/issues/4516

The client we are using the matrix-rust-sdk (react-native) does not offer synchronous access to the system keychain. In order to make this easier, this change adjusts ClientSessionDelegate to be a CallbackInterface with async methods for storing and retrieving. Retrieving is the only on that strictly speaking needs to be async, but it felt like symmetry was warranted here in case the save operation were to fail at the system level.

 Public API changes documented in changelogs (optional)
Signed-off-by: Daniel Salinas