### PR TITLE
crypto: withhold outgoing messages to unsigned dehydrated devices

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to this project will be documented in this file.
   keys with Olm-encrypted events).
   ([#4420](https://github.com/matrix-org/matrix-rust-sdk/pull/4420))
 
+- Room keys are not shared with unsigned dehydrated devices.
+  ([#4551](https://github.com/matrix-org/matrix-rust-sdk/pull/4551))
+
 ## [0.9.0] - 2024-12-18
 
 ### Features

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -479,9 +479,9 @@ impl Device {
         Ok(raw_encrypted)
     }
 
-    /// Whether or not the device is a dehydrated device.
+    /// True if this device is an [MSC3814](https://github.com/matrix-org/matrix-spec-proposals/pull/3814) dehydrated device.
     pub fn is_dehydrated(&self) -> bool {
-        self.inner.device_keys.dehydrated.unwrap_or(false)
+        self.inner.is_dehydrated()
     }
 }
 
@@ -965,6 +965,11 @@ impl DeviceData {
     /// milliseconds since epoch (client local time).
     pub fn first_time_seen_ts(&self) -> MilliSecondsSinceUnixEpoch {
         self.first_time_seen_ts
+    }
+
+    /// True if this device is an [MSC3814](https://github.com/matrix-org/matrix-spec-proposals/pull/3814) dehydrated device.
+    pub fn is_dehydrated(&self) -> bool {
+        self.device_keys.dehydrated.unwrap_or(false)
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/matrix_sdk_crypto__session_manager__group_sessions__share_strategy__tests__dehydrated_device__prepare_machine_with_dehydrated_device_of_verification_violation_user.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/matrix_sdk_crypto__session_manager__group_sessions__share_strategy__tests__dehydrated_device__prepare_machine_with_dehydrated_device_of_verification_violation_user.snap
@@ -1,0 +1,77 @@
+---
+source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+expression: ruma_response_to_json(keys_query.clone())
+---
+{
+  "device_keys": {
+    "@bob:localhost": {
+      "DEHYDRATED_DEVICE": {
+        "algorithms": [
+          "m.olm.v1.curve25519-aes-sha2",
+          "m.megolm.v1.aes-sha2"
+        ],
+        "dehydrated": true,
+        "device_id": "DEHYDRATED_DEVICE",
+        "keys": {
+          "curve25519:DEHYDRATED_DEVICE": "Y3VydmVwdWJjdXJ2ZXB1YmN1cnZlcHViY3VydmVwdWI",
+          "ed25519:DEHYDRATED_DEVICE": "aXceGe19ufgBArmAjKeIPEEk0eaA4c3yIB6WjkjvYNE"
+        },
+        "signatures": {
+          "@bob:localhost": {
+            "ed25519:DEHYDRATED_DEVICE": "7diDwtxcBHi6gu3fxy3Yau0vtUrvW9r5gBPUQO6qmuOSGfZCJkqhATmruPd7bCu1N5xRCZOd4bEhM/j/yY1vBQ",
+            "ed25519:hpK1owolWNIVv/CIximGep0a1dYwHWyhkdJ/t6flFeU": "lU1441xv6W4WY1d7trmRbdagAcoWwBrwR8D8Lr4VrWn8V0mlL8qSf/zJQ+nh12WcD3NRTEZ6H7rm6ncaBxbKDQ"
+          }
+        },
+        "user_id": "@bob:localhost"
+      }
+    }
+  },
+  "master_keys": {
+    "@bob:localhost": {
+      "keys": {
+        "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0"
+      },
+      "signatures": {
+        "@bob:localhost": {
+          "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "MalGqUfgScuZcEzFyBaJV0nXP6cBGaDz6LZtwrWmvAtfn3uDVatym+CX+YkKZmflog7XJogdeYtHuyn733tWBA"
+        }
+      },
+      "usage": [
+        "master"
+      ],
+      "user_id": "@bob:localhost"
+    }
+  },
+  "self_signing_keys": {
+    "@bob:localhost": {
+      "keys": {
+        "ed25519:hpK1owolWNIVv/CIximGep0a1dYwHWyhkdJ/t6flFeU": "hpK1owolWNIVv/CIximGep0a1dYwHWyhkdJ/t6flFeU"
+      },
+      "signatures": {
+        "@bob:localhost": {
+          "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "h1sADa7kifsHyzGc0ZTGckzjEE15s2YVR9Tz6pdyOWoHJUUcOjBDz6aGNbDarcs/OY49rF3nNXUMsRXEW6ZCBA"
+        }
+      },
+      "usage": [
+        "self_signing"
+      ],
+      "user_id": "@bob:localhost"
+    }
+  },
+  "user_signing_keys": {
+    "@bob:localhost": {
+      "keys": {
+        "ed25519:AXFeCsS+P7TpZOkiYvzjMvO1+K6q3Ljf5CHRY3e19MM": "AXFeCsS+P7TpZOkiYvzjMvO1+K6q3Ljf5CHRY3e19MM"
+      },
+      "signatures": {
+        "@bob:localhost": {
+          "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "gIfvMruwAbB7l7893w6bR/2dqTGTFM4qfSYWZWJ/i981zZYfTQv+8h91URCMhviKXQlelnVnMRrP6osssS8NAA"
+        }
+      },
+      "usage": [
+        "user_signing"
+      ],
+      "user_id": "@bob:localhost"
+    }
+  }
+}

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/matrix_sdk_crypto__session_manager__group_sessions__share_strategy__tests__dehydrated_device__should_not_share_with_unverified_dehydrated_device.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/matrix_sdk_crypto__session_manager__group_sessions__share_strategy__tests__dehydrated_device__should_not_share_with_unverified_dehydrated_device.snap
@@ -1,0 +1,76 @@
+---
+source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+expression: ruma_response_to_json(keys_query.clone())
+---
+{
+  "device_keys": {
+    "@bob:localhost": {
+      "DEHYDRATED_DEVICE": {
+        "algorithms": [
+          "m.olm.v1.curve25519-aes-sha2",
+          "m.megolm.v1.aes-sha2"
+        ],
+        "dehydrated": true,
+        "device_id": "DEHYDRATED_DEVICE",
+        "keys": {
+          "curve25519:DEHYDRATED_DEVICE": "Y3VydmVwdWJjdXJ2ZXB1YmN1cnZlcHViY3VydmVwdWI",
+          "ed25519:DEHYDRATED_DEVICE": "aXceGe19ufgBArmAjKeIPEEk0eaA4c3yIB6WjkjvYNE"
+        },
+        "signatures": {
+          "@bob:localhost": {
+            "ed25519:DEHYDRATED_DEVICE": "7diDwtxcBHi6gu3fxy3Yau0vtUrvW9r5gBPUQO6qmuOSGfZCJkqhATmruPd7bCu1N5xRCZOd4bEhM/j/yY1vBQ"
+          }
+        },
+        "user_id": "@bob:localhost"
+      }
+    }
+  },
+  "master_keys": {
+    "@bob:localhost": {
+      "keys": {
+        "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY"
+      },
+      "signatures": {
+        "@bob:localhost": {
+          "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "vgFiLvyxYeiVxhpMV81Z4HTvjRhgmZgWn1ScnsLC+HojFwXckA6+/Aa9L/+sA1hzapNZJ4Vrbstl9c4Ep4nbAA"
+        }
+      },
+      "usage": [
+        "master"
+      ],
+      "user_id": "@bob:localhost"
+    }
+  },
+  "self_signing_keys": {
+    "@bob:localhost": {
+      "keys": {
+        "ed25519:hpK1owolWNIVv/CIximGep0a1dYwHWyhkdJ/t6flFeU": "hpK1owolWNIVv/CIximGep0a1dYwHWyhkdJ/t6flFeU"
+      },
+      "signatures": {
+        "@bob:localhost": {
+          "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "xQhtPoTJilhxKrruKAhrpQ1MJFKsCPh77R2WUrWHIB5Mi4sPbxpeU1MZvV/jCCfHrZ5ID40PG2EcEAPtPLYgAQ"
+        }
+      },
+      "usage": [
+        "self_signing"
+      ],
+      "user_id": "@bob:localhost"
+    }
+  },
+  "user_signing_keys": {
+    "@bob:localhost": {
+      "keys": {
+        "ed25519:AXFeCsS+P7TpZOkiYvzjMvO1+K6q3Ljf5CHRY3e19MM": "AXFeCsS+P7TpZOkiYvzjMvO1+K6q3Ljf5CHRY3e19MM"
+      },
+      "signatures": {
+        "@bob:localhost": {
+          "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "d9lPdE5nqpl1euENWderCnPJRTClAcH11JMAIlKiPIWObL19U26zxuchBMEgVR4U7UN55ykDiWtPUlDCC7yvAg"
+        }
+      },
+      "usage": [
+        "user_signing"
+      ],
+      "user_id": "@bob:localhost"
+    }
+  }
+}

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/matrix_sdk_crypto__session_manager__group_sessions__share_strategy__tests__dehydrated_device__should_share_with_verified_dehydrated_device.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/matrix_sdk_crypto__session_manager__group_sessions__share_strategy__tests__dehydrated_device__should_share_with_verified_dehydrated_device.snap
@@ -1,0 +1,77 @@
+---
+source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+expression: ruma_response_to_json(keys_query.clone())
+---
+{
+  "device_keys": {
+    "@bob:localhost": {
+      "DEHYDRATED_DEVICE": {
+        "algorithms": [
+          "m.olm.v1.curve25519-aes-sha2",
+          "m.megolm.v1.aes-sha2"
+        ],
+        "dehydrated": true,
+        "device_id": "DEHYDRATED_DEVICE",
+        "keys": {
+          "curve25519:DEHYDRATED_DEVICE": "Y3VydmVwdWJjdXJ2ZXB1YmN1cnZlcHViY3VydmVwdWI",
+          "ed25519:DEHYDRATED_DEVICE": "aXceGe19ufgBArmAjKeIPEEk0eaA4c3yIB6WjkjvYNE"
+        },
+        "signatures": {
+          "@bob:localhost": {
+            "ed25519:DEHYDRATED_DEVICE": "7diDwtxcBHi6gu3fxy3Yau0vtUrvW9r5gBPUQO6qmuOSGfZCJkqhATmruPd7bCu1N5xRCZOd4bEhM/j/yY1vBQ",
+            "ed25519:hpK1owolWNIVv/CIximGep0a1dYwHWyhkdJ/t6flFeU": "lU1441xv6W4WY1d7trmRbdagAcoWwBrwR8D8Lr4VrWn8V0mlL8qSf/zJQ+nh12WcD3NRTEZ6H7rm6ncaBxbKDQ"
+          }
+        },
+        "user_id": "@bob:localhost"
+      }
+    }
+  },
+  "master_keys": {
+    "@bob:localhost": {
+      "keys": {
+        "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY"
+      },
+      "signatures": {
+        "@bob:localhost": {
+          "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "vgFiLvyxYeiVxhpMV81Z4HTvjRhgmZgWn1ScnsLC+HojFwXckA6+/Aa9L/+sA1hzapNZJ4Vrbstl9c4Ep4nbAA"
+        }
+      },
+      "usage": [
+        "master"
+      ],
+      "user_id": "@bob:localhost"
+    }
+  },
+  "self_signing_keys": {
+    "@bob:localhost": {
+      "keys": {
+        "ed25519:hpK1owolWNIVv/CIximGep0a1dYwHWyhkdJ/t6flFeU": "hpK1owolWNIVv/CIximGep0a1dYwHWyhkdJ/t6flFeU"
+      },
+      "signatures": {
+        "@bob:localhost": {
+          "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "xQhtPoTJilhxKrruKAhrpQ1MJFKsCPh77R2WUrWHIB5Mi4sPbxpeU1MZvV/jCCfHrZ5ID40PG2EcEAPtPLYgAQ"
+        }
+      },
+      "usage": [
+        "self_signing"
+      ],
+      "user_id": "@bob:localhost"
+    }
+  },
+  "user_signing_keys": {
+    "@bob:localhost": {
+      "keys": {
+        "ed25519:AXFeCsS+P7TpZOkiYvzjMvO1+K6q3Ljf5CHRY3e19MM": "AXFeCsS+P7TpZOkiYvzjMvO1+K6q3Ljf5CHRY3e19MM"
+      },
+      "signatures": {
+        "@bob:localhost": {
+          "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "d9lPdE5nqpl1euENWderCnPJRTClAcH11JMAIlKiPIWObL19U26zxuchBMEgVR4U7UN55ykDiWtPUlDCC7yvAg"
+        }
+      },
+      "usage": [
+        "user_signing"
+      ],
+      "user_id": "@bob:localhost"
+    }
+  }
+}

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/matrix_sdk_crypto__session_manager__group_sessions__share_strategy__tests__dehydrated_device__should_share_with_verified_device_of_pin_violation_user.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/matrix_sdk_crypto__session_manager__group_sessions__share_strategy__tests__dehydrated_device__should_share_with_verified_device_of_pin_violation_user.snap
@@ -1,0 +1,77 @@
+---
+source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+expression: ruma_response_to_json(keys_query.clone())
+---
+{
+  "device_keys": {
+    "@bob:localhost": {
+      "DEHYDRATED_DEVICE": {
+        "algorithms": [
+          "m.olm.v1.curve25519-aes-sha2",
+          "m.megolm.v1.aes-sha2"
+        ],
+        "dehydrated": true,
+        "device_id": "DEHYDRATED_DEVICE",
+        "keys": {
+          "curve25519:DEHYDRATED_DEVICE": "Y3VydmVwdWJjdXJ2ZXB1YmN1cnZlcHViY3VydmVwdWI",
+          "ed25519:DEHYDRATED_DEVICE": "aXceGe19ufgBArmAjKeIPEEk0eaA4c3yIB6WjkjvYNE"
+        },
+        "signatures": {
+          "@bob:localhost": {
+            "ed25519:DEHYDRATED_DEVICE": "7diDwtxcBHi6gu3fxy3Yau0vtUrvW9r5gBPUQO6qmuOSGfZCJkqhATmruPd7bCu1N5xRCZOd4bEhM/j/yY1vBQ",
+            "ed25519:hpK1owolWNIVv/CIximGep0a1dYwHWyhkdJ/t6flFeU": "lU1441xv6W4WY1d7trmRbdagAcoWwBrwR8D8Lr4VrWn8V0mlL8qSf/zJQ+nh12WcD3NRTEZ6H7rm6ncaBxbKDQ"
+          }
+        },
+        "user_id": "@bob:localhost"
+      }
+    }
+  },
+  "master_keys": {
+    "@bob:localhost": {
+      "keys": {
+        "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0"
+      },
+      "signatures": {
+        "@bob:localhost": {
+          "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "MalGqUfgScuZcEzFyBaJV0nXP6cBGaDz6LZtwrWmvAtfn3uDVatym+CX+YkKZmflog7XJogdeYtHuyn733tWBA"
+        }
+      },
+      "usage": [
+        "master"
+      ],
+      "user_id": "@bob:localhost"
+    }
+  },
+  "self_signing_keys": {
+    "@bob:localhost": {
+      "keys": {
+        "ed25519:hpK1owolWNIVv/CIximGep0a1dYwHWyhkdJ/t6flFeU": "hpK1owolWNIVv/CIximGep0a1dYwHWyhkdJ/t6flFeU"
+      },
+      "signatures": {
+        "@bob:localhost": {
+          "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "h1sADa7kifsHyzGc0ZTGckzjEE15s2YVR9Tz6pdyOWoHJUUcOjBDz6aGNbDarcs/OY49rF3nNXUMsRXEW6ZCBA"
+        }
+      },
+      "usage": [
+        "self_signing"
+      ],
+      "user_id": "@bob:localhost"
+    }
+  },
+  "user_signing_keys": {
+    "@bob:localhost": {
+      "keys": {
+        "ed25519:AXFeCsS+P7TpZOkiYvzjMvO1+K6q3Ljf5CHRY3e19MM": "AXFeCsS+P7TpZOkiYvzjMvO1+K6q3Ljf5CHRY3e19MM"
+      },
+      "signatures": {
+        "@bob:localhost": {
+          "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "gIfvMruwAbB7l7893w6bR/2dqTGTFM4qfSYWZWJ/i981zZYfTQv+8h91URCMhviKXQlelnVnMRrP6osssS8NAA"
+        }
+      },
+      "usage": [
+        "user_signing"
+      ],
+      "user_id": "@bob:localhost"
+    }
+  }
+}


### PR DESCRIPTION
Per https://github.com/matrix-org/matrix-rust-sdk/issues/4313, we should not send outgoing messages to dehydrated devices that are not signed by the user's identity

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/4313