### PR TITLE
fix(oidc): remove unnecessary e2e-encryption imports

### DIFF
--- a/crates/matrix-sdk/src/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/oidc/cross_process.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+#[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::{
     store::{LockableCryptoStore, Store},
     CryptoStoreError,

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -188,9 +188,9 @@ use mas_oidc_client::{
         IdToken,
     },
 };
-use matrix_sdk_base::{
-    crypto::types::qr_login::QrCodeData, once_cell::sync::OnceCell, SessionMeta,
-};
+#[cfg(feature = "e2e-encryption")]
+use matrix_sdk_base::crypto::types::qr_login::QrCodeData;
+use matrix_sdk_base::{once_cell::sync::OnceCell, SessionMeta};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use ruma::api::client::discovery::get_authentication_issuer;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
<!-- description of the changes in this PR -->

I noticed that the crate won't build without the  `e2e-encryption` feature enabled. This does not make it build rather it is a step towards it. 
There is still https://github.com/neodyme-labs/matrix-rust-sdk/blob/oidc_e2e/crates/matrix-sdk/src/oidc/mod.rs#L319 missing.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Kilimnik daniel@neoydme.io
