### PR TITLE
refactor(crypto): Make memory store behave more like other stores

### DIFF
--- a/crates/matrix-sdk-crypto/src/store/caches.rs
+++ b/crates/matrix-sdk-crypto/src/store/caches.rs
@@ -27,15 +27,12 @@ use std::{
 };
 
 use matrix_sdk_common::locks::RwLock as StdRwLock;
-use ruma::{DeviceId, OwnedDeviceId, OwnedRoomId, OwnedUserId, RoomId, UserId};
+use ruma::{DeviceId, OwnedDeviceId, OwnedUserId, UserId};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, RwLock};
 use tracing::{field::display, instrument, trace, Span};
 
-use crate::{
-    identities::DeviceData,
-    olm::{InboundGroupSession, Session},
-};
+use crate::{identities::DeviceData, olm::Session};
 
 /// In-memory store for Olm Sessions.
 #[derive(Debug, Default, Clone)]
@@ -83,52 +80,6 @@ impl SessionStore {
     /// Add a list of sessions belonging to the sender key.
     pub async fn set_for_sender(&self, sender_key: &str, sessions: Vec<Session>) {
         self.entries.write().await.insert(sender_key.to_owned(), Arc::new(Mutex::new(sessions)));
-    }
-}
-
-#[derive(Debug, Default)]
-/// In-memory store that holds inbound group sessions.
-pub struct GroupSessionStore {
-    entries: StdRwLock<BTreeMap<OwnedRoomId, HashMap<String, InboundGroupSession>>>,
-}
-
-impl GroupSessionStore {
-    /// Create a new empty store.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Add an inbound group session to the store.
-    ///
-    /// Returns true if the session was added, false if the session was
-    /// already in the store.
-    pub fn add(&self, session: InboundGroupSession) -> bool {
-        self.entries
-            .write()
-            .entry(session.room_id().to_owned())
-            .or_default()
-            .insert(session.session_id().to_owned(), session)
-            .is_none()
-    }
-
-    /// Get all the group sessions the store knows about.
-    pub fn get_all(&self) -> Vec<InboundGroupSession> {
-        self.entries.read().values().flat_map(HashMap::values).cloned().collect()
-    }
-
-    /// Get the number of `InboundGroupSession`s we have.
-    pub fn count(&self) -> usize {
-        self.entries.read().values().map(HashMap::len).sum()
-    }
-
-    /// Get a inbound group session from our store.
-    ///
-    /// # Arguments
-    /// * `room_id` - The room id of the room that the session belongs to.
-    ///
-    /// * `session_id` - The unique id of the session.
-    pub fn get(&self, room_id: &RoomId, session_id: &str) -> Option<InboundGroupSession> {
-        self.entries.read().get(room_id)?.get(session_id).cloned()
     }
 }
 
@@ -381,13 +332,10 @@ impl UsersForKeyQuery {
 mod tests {
     use matrix_sdk_test::async_test;
     use proptest::prelude::*;
-    use ruma::room_id;
-    use vodozemac::{Curve25519PublicKey, Ed25519PublicKey};
 
-    use super::{DeviceStore, GroupSessionStore, SequenceNumber, SessionStore};
+    use super::{DeviceStore, SequenceNumber, SessionStore};
     use crate::{
-        identities::device::testing::get_device,
-        olm::{tests::get_account_and_session_test_helper, InboundGroupSession, SenderData},
+        identities::device::testing::get_device, olm::tests::get_account_and_session_test_helper,
     };
 
     #[async_test]
@@ -420,37 +368,6 @@ mod tests {
         let loaded_session = &sessions[0];
 
         assert_eq!(&session, loaded_session);
-    }
-
-    #[async_test]
-    async fn test_group_session_store() {
-        let (account, _) = get_account_and_session_test_helper();
-        let room_id = room_id!("!test:localhost");
-        let curve_key = "Nn0L2hkcCMFKqynTjyGsJbth7QrVmX3lbrksMkrGOAw";
-
-        let (outbound, _) = account.create_group_session_pair_with_defaults(room_id).await;
-
-        assert_eq!(0, outbound.message_index().await);
-        assert!(!outbound.shared());
-        outbound.mark_as_shared();
-        assert!(outbound.shared());
-
-        let inbound = InboundGroupSession::new(
-            Curve25519PublicKey::from_base64(curve_key).unwrap(),
-            Ed25519PublicKey::from_base64("ee3Ek+J2LkkPmjGPGLhMxiKnhiX//xcqaVL4RP6EypE").unwrap(),
-            room_id,
-            &outbound.session_key().await,
-            SenderData::unknown(),
-            outbound.settings().algorithm.to_owned(),
-            None,
-        )
-        .unwrap();
-
-        let store = GroupSessionStore::new();
-        store.add(inbound.clone());
-
-        let loaded_session = store.get(room_id, outbound.session_id()).unwrap();
-        assert_eq!(inbound, loaded_session);
     }
 
     #[async_test]


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Attempt to make the memory store behave more like other stores. 
This is following reports of [Playwright flaky tests](https://github.com/element-hq/crypto-internal/issues/414) that are showing some panics of the memory store (used by the bots not the tested app).

The idea is to make the memory store works more like other stores by removing `unwrap()`s, serializing/deserialising structures instead of keep them around to be mutated by everyone. Add a global save_changes lock

### PRO
Will behave more like other stores (might help and make the tests less flaky)
### CONS
Might be slower

### Breakdown
Best reviewed commit per commit (will squash at the end):
- Replace unwrap with expect https://github.com/matrix-org/matrix-rust-sdk/commit/17fa2c791dbdea0212f37117c4aa477ae8dac2a7
- Serialize account and cache static account data https://github.com/matrix-org/matrix-rust-sdk/commit/b7ac36f4be7d02c2267bc5244d627590e0516b86
- Serialize/Deserialise olm sessions https://github.com/matrix-org/matrix-rust-sdk/commit/7c87d1349a4afc196b0d721c1e5cd9bd1355adda
- Ser/Deser inbound group sessions https://github.com/matrix-org/matrix-rust-sdk/commit/9262c303859969bdd0a10719786a22bbb536a684
- Add a global save change lock similar to other stores https://github.com/matrix-org/matrix-rust-sdk/commit/70c2bafc762140f710b2a6e32362205fe8014371

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
