### PR TITLE
test: minimize usage of `EventFactory::state_key`

### DIFF
--- a/crates/matrix-sdk/src/room/knock_requests.rs
+++ b/crates/matrix-sdk/src/room/knock_requests.rs
@@ -107,9 +107,7 @@ impl KnockRequestMemberInfo {
 mod tests {
     use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder};
     use ruma::{
-        event_id,
-        events::room::member::{MembershipState, RoomMemberEventContent},
-        owned_user_id, room_id, user_id, EventId,
+        event_id, events::room::member::MembershipState, owned_user_id, room_id, user_id, EventId,
     };
 
     use crate::{
@@ -128,10 +126,9 @@ mod tests {
 
         let f = EventFactory::new().room(room_id);
         let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f
-            .event(RoomMemberEventContent::new(MembershipState::Knock))
+            .member(user_id)
+            .membership(MembershipState::Knock)
             .event_id(event_id)
-            .sender(user_id)
-            .state_key(user_id)
             .into_raw_timeline()
             .cast()]);
         let room = server.sync_room(&client, joined_room_builder).await;

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3694,11 +3694,7 @@ mod tests {
         async_test, event_factory::EventFactory, test_json, JoinedRoomBuilder, StateTestEvent,
         SyncResponseBuilder,
     };
-    use ruma::{
-        device_id, event_id,
-        events::room::member::{MembershipState, RoomMemberEventContent},
-        int, room_id, user_id,
-    };
+    use ruma::{device_id, event_id, events::room::member::MembershipState, int, room_id, user_id};
     use wiremock::{
         matchers::{header, method, path_regex},
         Mock, MockServer, ResponseTemplate,
@@ -3894,10 +3890,9 @@ mod tests {
 
         let f = EventFactory::new().room(room_id);
         let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f
-            .event(RoomMemberEventContent::new(MembershipState::Knock))
+            .member(user_id)
+            .membership(MembershipState::Knock)
             .event_id(event_id)
-            .sender(user_id)
-            .state_key(user_id)
             .into_raw_timeline()
             .cast()]);
         let room = server.sync_room(&client, joined_room_builder).await;

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -12,11 +12,7 @@ use ruma::{
     event_id,
     events::{
         direct::DirectUserIdentifier,
-        room::{
-            avatar::{self, RoomAvatarEventContent},
-            member::MembershipState,
-            message::RoomMessageEventContent,
-        },
+        room::{avatar, member::MembershipState, message::RoomMessageEventContent},
         AnySyncStateEvent, AnySyncTimelineEvent, StateEventType,
     },
     mxc_uri, room_id,
@@ -881,9 +877,7 @@ async fn test_room_avatar() {
     // Set the avatar, but not the info.
     let avatar_url_1 = mxc_uri!("mxc://server.local/abcdef");
 
-    let mut content = RoomAvatarEventContent::new();
-    content.url = Some(avatar_url_1.to_owned());
-    let event = factory.event(content).state_key("").into_raw_sync();
+    let event = factory.room_avatar().url(avatar_url_1).into_raw_sync();
 
     let mut sync_builder = SyncResponseBuilder::new();
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(event));
@@ -903,10 +897,7 @@ async fn test_room_avatar() {
     avatar_info_2.mimetype = Some("image/png".to_owned());
     avatar_info_2.size = Some(uint!(5243));
 
-    let mut content = RoomAvatarEventContent::new();
-    content.url = Some(avatar_url_2.to_owned());
-    content.info = Some(avatar_info_2.into());
-    let event = factory.event(content).state_key("").into_raw_sync();
+    let event = factory.room_avatar().url(avatar_url_2).info(avatar_info_2).into_raw_sync();
 
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(event));
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -28,7 +28,7 @@ use ruma::{
         direct::DirectUserIdentifier,
         receipt::ReceiptThread,
         room::{
-            member::{MembershipState, RoomMemberEventContent},
+            member::MembershipState,
             message::{RoomMessageEventContent, RoomMessageEventContentWithoutRelation},
         },
         TimelineEventType,
@@ -843,10 +843,9 @@ async fn test_subscribe_to_knock_requests() {
     let user_id = user_id!("@alice:b.c");
     let knock_event_id = event_id!("$alice-knock:b.c");
     let knock_event = f
-        .event(RoomMemberEventContent::new(MembershipState::Knock))
+        .member(user_id)
+        .membership(MembershipState::Knock)
         .event_id(knock_event_id)
-        .sender(user_id)
-        .state_key(user_id)
         .into_raw_timeline()
         .cast();
 
@@ -877,9 +876,8 @@ async fn test_subscribe_to_knock_requests() {
 
     // If we then receive a new member event for Alice that's not 'knock'
     let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f
-        .event(RoomMemberEventContent::new(MembershipState::Invite))
-        .sender(user_id)
-        .state_key(user_id)
+        .member(user_id)
+        .membership(MembershipState::Invite)
         .into_raw_timeline()
         .cast()]);
     server.sync_room(&client, joined_room_builder).await;
@@ -917,12 +915,8 @@ async fn test_subscribe_to_knock_requests_reloads_members_on_limited_sync() {
     let f = EventFactory::new().room(room_id);
 
     let user_id = user_id!("@alice:b.c");
-    let knock_event = f
-        .event(RoomMemberEventContent::new(MembershipState::Knock))
-        .sender(user_id)
-        .state_key(user_id)
-        .into_raw_timeline()
-        .cast();
+    let knock_event =
+        f.member(user_id).membership(MembershipState::Knock).into_raw_timeline().cast();
 
     server
         .mock_get_members()
@@ -969,10 +963,9 @@ async fn test_remove_outdated_seen_knock_requests_ids_when_membership_changed() 
     let user_id = user_id!("@alice:b.c");
     let knock_event_id = event_id!("$alice-knock:b.c");
     let knock_event = f
-        .event(RoomMemberEventContent::new(MembershipState::Knock))
+        .member(user_id)
+        .membership(MembershipState::Knock)
         .event_id(knock_event_id)
-        .sender(user_id)
-        .state_key(user_id)
         .into_raw_timeline()
         .cast();
 
@@ -990,12 +983,8 @@ async fn test_remove_outdated_seen_knock_requests_ids_when_membership_changed() 
 
     // If we then load the members again and the previously knocking member is in
     // another state now
-    let joined_event = f
-        .event(RoomMemberEventContent::new(MembershipState::Join))
-        .sender(user_id)
-        .state_key(user_id)
-        .into_raw_timeline()
-        .cast();
+    let joined_event =
+        f.member(user_id).membership(MembershipState::Join).into_raw_timeline().cast();
 
     server.mock_get_members().ok(vec![joined_event]).mock_once().mount().await;
 
@@ -1024,10 +1013,9 @@ async fn test_remove_outdated_seen_knock_requests_ids_when_we_have_an_outdated_k
     let user_id = user_id!("@alice:b.c");
     let knock_event_id = event_id!("$alice-knock:b.c");
     let knock_event = f
-        .event(RoomMemberEventContent::new(MembershipState::Knock))
+        .member(user_id)
+        .membership(MembershipState::Knock)
         .event_id(knock_event_id)
-        .sender(user_id)
-        .state_key(user_id)
         .into_raw_timeline()
         .cast();
 
@@ -1046,10 +1034,9 @@ async fn test_remove_outdated_seen_knock_requests_ids_when_we_have_an_outdated_k
     // If we then load the members again and the previously knocking member has a
     // different event id
     let knock_event = f
-        .event(RoomMemberEventContent::new(MembershipState::Knock))
+        .member(user_id)
+        .membership(MembershipState::Knock)
         .event_id(event_id!("$knock-2:b.c"))
-        .sender(user_id)
-        .state_key(user_id)
         .into_raw_timeline()
         .cast();
 
@@ -1080,10 +1067,9 @@ async fn test_subscribe_to_knock_requests_clears_seen_ids_on_member_reload() {
     let user_id = user_id!("@alice:b.c");
     let knock_event_id = event_id!("$alice-knock:b.c");
     let knock_event = f
-        .event(RoomMemberEventContent::new(MembershipState::Knock))
+        .member(user_id)
+        .membership(MembershipState::Knock)
         .event_id(knock_event_id)
-        .sender(user_id)
-        .state_key(user_id)
         .into_raw_timeline()
         .cast();
 
@@ -1114,12 +1100,8 @@ async fn test_subscribe_to_knock_requests_clears_seen_ids_on_member_reload() {
 
     // If we then load the members again and the previously knocking member is in
     // another state now
-    let joined_event = f
-        .event(RoomMemberEventContent::new(MembershipState::Join))
-        .sender(user_id)
-        .state_key(user_id)
-        .into_raw_timeline()
-        .cast();
+    let joined_event =
+        f.member(user_id).membership(MembershipState::Join).into_raw_timeline().cast();
 
     server.mock_get_members().ok(vec![joined_event]).mock_once().mount().await;
 
@@ -1163,9 +1145,8 @@ async fn test_room_member_updates_sender_on_full_member_reload() {
     let user_id = user_id!("@alice:b.c");
     let joined_event = EventFactory::new()
         .room(room_id)
-        .event(RoomMemberEventContent::new(MembershipState::Join))
-        .sender(user_id)
-        .state_key(user_id)
+        .member(user_id)
+        .membership(MembershipState::Join)
         .into_raw_timeline()
         .cast();
     server.mock_get_members().ok(vec![joined_event]).mock_once().mount().await;
@@ -1191,9 +1172,8 @@ async fn test_room_member_updates_sender_on_partial_members_update() {
     let user_id = user_id!("@alice:b.c");
     let joined_event = EventFactory::new()
         .room(room_id)
-        .event(RoomMemberEventContent::new(MembershipState::Join))
-        .sender(user_id)
-        .state_key(user_id)
+        .member(user_id)
+        .membership(MembershipState::Join)
         .into_raw_sync()
         .cast();
     server

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -38,6 +38,7 @@ use ruma::{
         receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
         relation::{Annotation, InReplyTo, Replacement, Thread},
         room::{
+            avatar::{self, RoomAvatarEventContent},
             encrypted::{EncryptedEventScheme, RoomEncryptedEventContent},
             member::{MembershipState, RoomMemberEventContent},
             message::{
@@ -170,6 +171,10 @@ where
         self
     }
 
+    /// For state events manually created, define the state key.
+    ///
+    /// For other state events created in the [`EventFactory`], this is
+    /// automatically filled upon creation or update of the events.
     pub fn state_key(mut self, state_key: impl Into<String>) -> Self {
         self.state_key = Some(state_key.into());
         self
@@ -465,6 +470,14 @@ impl EventFactory {
         event
     }
 
+    /// Create an empty state event for the room avatar.
+    pub fn room_avatar(&self) -> EventBuilder<RoomAvatarEventContent> {
+        let mut event = self.event(RoomAvatarEventContent::new());
+        // The state key is empty for a room avatar state event.
+        event.state_key = Some("".to_owned());
+        event
+    }
+
     /// Create a new `m.member_hints` event with the given service members.
     ///
     /// ```
@@ -745,6 +758,20 @@ impl EventBuilder<RoomMemberEventContent> {
         }
 
         self.unsigned.get_or_insert_with(Default::default).prev_content = Some(prev_content);
+        self
+    }
+}
+
+impl EventBuilder<RoomAvatarEventContent> {
+    /// Defines the URL for the room avatar.
+    pub fn url(mut self, url: &MxcUri) -> Self {
+        self.content.url = Some(url.to_owned());
+        self
+    }
+
+    /// Defines the image info for the avatar.
+    pub fn info(mut self, image: avatar::ImageInfo) -> Self {
+        self.content.info = Some(Box::new(image));
         self
     }
 }


### PR DESCRIPTION
It was used in places where we could make use of other helpers, in some cases. Also introduces the `room_avatar` helper to create the room avatar state event.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/3716