### PR TITLE
chore(crypto): Add consistency check on device when loading account

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -304,6 +304,13 @@ impl OlmMachine {
                     });
                 }
 
+                // The own device data is always created and saved when the account is created.
+                // So we expect the own device to exist here. Checking for consistency.
+                let own_device = store.get_own_device().await;
+                if own_device.is_err() {
+                    return Err(CryptoStoreError::IncompleteAccountNoOwnDevice);
+                }
+
                 Span::current()
                     .record("ed25519_key", display(account.identity_keys().ed25519))
                     .record("curve25519_key", display(account.identity_keys().curve25519));

--- a/crates/matrix-sdk-crypto/src/store/error.rs
+++ b/crates/matrix-sdk-crypto/src/store/error.rs
@@ -31,6 +31,10 @@ pub enum CryptoStoreError {
     #[error("can't save/load sessions or group sessions in the store before an account is stored")]
     AccountUnset,
 
+    /// An account was saved but no own device was found.
+    #[error("Incomplete account, account data was saved but no own device was found")]
+    IncompleteAccountNoOwnDevice,
+
     /// The store doesn't support multiple accounts and data from another device
     /// was discovered.
     #[error(


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Add a consistency check when loading an account from a store.

When creating an olm machine for an empty store, the own device is explicitely saved before the account (and it is done on purpose before the initial `keys/query` response):
https://github.com/matrix-org/matrix-rust-sdk/blob/210c5749f14ff3e2678efa7e1b32802fc98a79fc/crates/matrix-sdk-crypto/src/machine/mod.rs#L328-L340

However when [loading an existing accoun](https://github.com/matrix-org/matrix-rust-sdk/blob/210c5749f14ff3e2678efa7e1b32802fc98a79fc/crates/matrix-sdk-crypto/src/machine/mod.rs#L310)t we don't check for the existence of this own device.
There are other part in the code when we expect the own device to always exists:
https://github.com/matrix-org/matrix-rust-sdk/blob/210c5749f14ff3e2678efa7e1b32802fc98a79fc/crates/matrix-sdk-sqlite/src/crypto_store.rs#L1205

Let's do the consistency check as soon as possible to avoid future strange states.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
