### PR TITLE
feat(sdk): (re)Enable HTTP/2 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4651,6 +4651,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file.
   related to room access and visibility.
   ([#4401](https://github.com/matrix-org/matrix-rust-sdk/pull/4401))
 
+- Enable HTTP/2 support in the HTTP client.
+  ([#4566](https://github.com/matrix-org/matrix-rust-sdk/pull/4566))
+
 ### Refactor
 
 - [**breaking**] Move the optional `RequestConfig` argument of the

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -124,7 +124,7 @@ zeroize = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { workspace = true, features = ["futures"] }
-reqwest = { workspace = true, features = ["gzip"] }
+reqwest = { workspace = true, features = ["gzip", "http2"] }
 tokio = { workspace = true, features = ["macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -132,7 +132,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 openidconnect = { version = "4.0.0-rc.1", optional = true }
 # only activate reqwest's stream feature on non-wasm, the wasm part seems to not
 # support *sending* streams, which makes it useless for us.
-reqwest = { workspace = true, features = ["stream", "gzip"] }
+reqwest = { workspace = true, features = ["stream", "gzip", "http2"] }
 tokio = { workspace = true, features = ["fs", "rt", "macros"] }
 tokio-util = "0.7.12"
 wiremock = { workspace = true, optional = true }


### PR DESCRIPTION
It became an optional default feature in reqwest 0.12, and we disable the default features, so I don't think it was meant to be disabled when the crate was upgraded in https://github.com/matrix-org/matrix-rust-sdk/pull/3362.

