### PR TITLE
chore(ui): Remove `Timeline::subscribe`

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -198,7 +198,7 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
                 .await
                 .expect("Could not create timeline");
 
-            let (items, _) = timeline.subscribe().await;
+            let (items, _) = timeline.subscribe_batched().await;
             assert_eq!(items.len(), PINNED_EVENTS_COUNT + 1);
             timeline.clear().await;
         });

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -20,14 +20,14 @@ use eyeball_im_util::vector::VectorObserverExt;
 use futures_core::Stream;
 use imbl::Vector;
 #[cfg(test)]
-use matrix_sdk::crypto::OlmMachine;
+use matrix_sdk::{crypto::OlmMachine, SendOutsideWasm};
 use matrix_sdk::{
     deserialized_responses::{SyncTimelineEvent, TimelineEventKind as SdkTimelineEventKind},
     event_cache::{paginator::Paginator, RoomEventCache},
     send_queue::{
         LocalEcho, LocalEchoContent, RoomSendQueueUpdate, SendHandle, SendReactionHandle,
     },
-    Result, Room, SendOutsideWasm,
+    Result, Room,
 };
 use ruma::{
     api::client::receipt::create_receipt::v3::ReceiptType as SendReceiptType,
@@ -477,6 +477,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
         self.state.read().await.items.clone_items()
     }
 
+    #[cfg(test)]
     pub(super) async fn subscribe(
         &self,
     ) -> (

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -266,23 +266,10 @@ impl Timeline {
         }
     }
 
-    /// Get the current timeline items, and a stream of changes.
-    ///
-    /// You can poll this stream to receive updates. See
-    /// [`futures_util::StreamExt`] for a high-level API on top of [`Stream`].
-    pub async fn subscribe(
-        &self,
-    ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = VectorDiff<Arc<TimelineItem>>>) {
-        let (items, stream) = self.controller.subscribe().await;
-        let stream = TimelineStream::new(stream, self.drop_handle.clone());
-        (items, stream)
-    }
-
     /// Get the current timeline items, and a batched stream of changes.
     ///
-    /// In contrast to [`subscribe`](Self::subscribe), this stream can yield
-    /// multiple diffs at once. The batching is done such that no arbitrary
-    /// delays are added.
+    /// This stream can yield multiple diffs at once. The batching is done such
+    /// that no arbitrary delays are added.
     pub async fn subscribe_batched(
         &self,
     ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>>) {

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2430,7 +2430,7 @@ async fn test_room_timeline() -> Result<(), Error> {
     room.init_timeline_with_builder(room.default_room_timeline_builder().await.unwrap()).await?;
     let timeline = room.timeline().unwrap();
 
-    let (previous_timeline_items, mut timeline_items_stream) = timeline.subscribe().await;
+    let (previous_timeline_items, mut timeline_items_stream) = timeline.subscribe_batched().await;
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
@@ -2493,7 +2493,7 @@ async fn test_room_empty_timeline() {
     // The room wasn't synced, but it will be available
     let room = room_list.room(&room_id).unwrap();
     let timeline = room.default_room_timeline_builder().await.unwrap().build().await.unwrap();
-    let (prev_items, _) = timeline.subscribe().await;
+    let (prev_items, _) = timeline.subscribe_batched().await;
 
     // However, since the room wasn't synced its timeline won't have any initial
     // items

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -19,8 +19,8 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{
-    assert_next_matches_with_timeout, config::SyncSettings, executor::spawn,
-    ruma::MilliSecondsSinceUnixEpoch, test_utils::logged_in_client_with_server,
+    config::SyncSettings, executor::spawn, ruma::MilliSecondsSinceUnixEpoch,
+    test_utils::logged_in_client_with_server,
 };
 use matrix_sdk_test::{
     async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
@@ -33,7 +33,7 @@ use ruma::{
     room_id, uint, user_id,
 };
 use serde_json::json;
-use stream_assert::assert_next_matches;
+use stream_assert::{assert_next_matches, assert_pending};
 use tokio::task::yield_now;
 use wiremock::{
     matchers::{header, method, path_regex},
@@ -65,7 +65,7 @@ async fn test_echo() {
             .await
             .unwrap(),
     );
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
 
     let event_id = event_id!("$ev");
 
@@ -83,7 +83,10 @@ async fn test_echo() {
         timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into()).await
     });
 
-    assert_let!(Some(VectorDiff::PushBack { value: local_echo }) = timeline_stream.next().await);
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 2);
+
+    assert_let!(VectorDiff::PushBack { value: local_echo } = &timeline_updates[0]);
     let item = local_echo.as_event().unwrap();
     assert_matches!(item.send_state(), Some(EventSendState::NotSentYet));
     assert_let!(TimelineItemContent::Message(msg) = item.content());
@@ -92,15 +95,16 @@ async fn test_echo() {
     assert!(item.event_id().is_none());
     let txn_id = item.transaction_id().unwrap();
 
-    assert_let!(Some(VectorDiff::PushFront { value: date_divider }) = timeline_stream.next().await);
+    assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[1]);
     assert!(date_divider.is_date_divider());
 
     // Wait for the sending to finish and assert everything was successful
     send_hdl.await.unwrap().unwrap();
 
-    assert_let!(
-        Some(VectorDiff::Set { index: 1, value: sent_confirmation }) = timeline_stream.next().await
-    );
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 1);
+
+    assert_let!(VectorDiff::Set { index: 1, value: sent_confirmation } = &timeline_updates[0]);
     let item = sent_confirmation.as_event().unwrap();
     assert_matches!(item.send_state(), Some(EventSendState::Sent { .. }));
     assert_eq!(item.event_id(), Some(event_id));
@@ -120,19 +124,24 @@ async fn test_echo() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 4);
+
     // Local echo is replaced with the remote echo.
-    assert_next_matches!(timeline_stream, VectorDiff::Remove { index: 1 });
-    let remote_echo =
-        assert_next_matches!(timeline_stream, VectorDiff::PushFront { value } => value);
+    assert_let!(VectorDiff::Remove { index: 1 } = &timeline_updates[0]);
+
+    assert_let!(VectorDiff::PushFront { value: remote_echo } = &timeline_updates[1]);
     let item = remote_echo.as_event().unwrap();
     assert!(item.is_own());
     assert_eq!(item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(152038280)));
 
     // The date divider is also replaced.
-    let date_divider =
-        assert_next_matches!(timeline_stream, VectorDiff::PushFront { value } => value);
+    assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[2]);
     assert!(date_divider.is_date_divider());
-    assert_next_matches!(timeline_stream, VectorDiff::Remove { index: 2 });
+
+    assert_let!(VectorDiff::Remove { index: 2 } = &timeline_updates[3]);
+
+    assert_pending!(timeline_stream);
 }
 
 #[async_test]
@@ -229,7 +238,7 @@ async fn test_dedup_by_event_id_late() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
 
     let event_id = event_id!("$wWgymRfo7ri1uQx0NXO40vLJ");
 
@@ -251,14 +260,16 @@ async fn test_dedup_by_event_id_late() {
 
     timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into()).await.unwrap();
 
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 2);
+
     // Timeline: [local echo]
-    let local_echo =
-        assert_next_matches_with_timeout!(timeline_stream, VectorDiff::PushBack { value } => value);
+    assert_let!(VectorDiff::PushBack { value: local_echo } = &timeline_updates[0]);
     let item = local_echo.as_event().unwrap();
     assert_matches!(item.send_state(), Some(EventSendState::NotSentYet));
 
     // Timeline: [date-divider, local echo]
-    let date_divider = assert_next_matches_with_timeout!( timeline_stream, VectorDiff::PushFront { value } => value);
+    assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[1]);
     assert!(date_divider.is_date_divider());
 
     let f = EventFactory::new();
@@ -275,21 +286,29 @@ async fn test_dedup_by_event_id_late() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
 
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 2);
+
     // Timeline: [remote-echo, date-divider, local echo]
-    let remote_echo =
-        assert_next_matches!(timeline_stream, VectorDiff::PushFront { value } => value);
+    assert_let!(VectorDiff::PushFront { value: remote_echo } = &timeline_updates[0]);
     let item = remote_echo.as_event().unwrap();
     assert_eq!(item.event_id(), Some(event_id));
 
     // Timeline: [date-divider, remote-echo, date-divider, local echo]
-    let date_divider = assert_next_matches_with_timeout!(timeline_stream, VectorDiff::PushFront { value } => value);
+    assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[1]);
     assert!(date_divider.is_date_divider());
+
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 2);
 
     // Local echo and its date divider are removed.
     // Timeline: [date-divider, remote-echo, date-divider]
-    assert_matches!(timeline_stream.next().await, Some(VectorDiff::Remove { index: 3 }));
+    assert_let!(VectorDiff::Remove { index: 3 } = &timeline_updates[0]);
+
     // Timeline: [date-divider, remote-echo]
-    assert_matches!(timeline_stream.next().await, Some(VectorDiff::Remove { index: 2 }));
+    assert_let!(VectorDiff::Remove { index: 2 } = &timeline_updates[1]);
+
+    assert_pending!(timeline_stream);
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -19,7 +19,6 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{
-    assert_let_timeout,
     config::SyncSettings,
     test_utils::{logged_in_client_with_server, mocks::MatrixMockServer},
 };
@@ -40,7 +39,7 @@ use ruma::{
     owned_event_id, room_id, user_id, MilliSecondsSinceUnixEpoch,
 };
 use serde_json::json;
-use stream_assert::{assert_next_matches, assert_pending};
+use stream_assert::assert_pending;
 use wiremock::{
     matchers::{header, method, path_regex},
     Mock, ResponseTemplate,
@@ -80,7 +79,7 @@ async fn test_reaction() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
 
     sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
@@ -113,17 +112,18 @@ async fn test_reaction() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 4);
+
     // The new message starts with their author's read receipt.
-    assert_let_timeout!(Some(VectorDiff::PushBack { value: message }) = timeline_stream.next());
+    assert_let!(VectorDiff::PushBack { value: message } = &timeline_updates[0]);
     let event_item = message.as_event().unwrap();
     assert_matches!(event_item.content(), TimelineItemContent::Message(_));
     assert_eq!(event_item.read_receipts().len(), 1);
 
     // The new message is getting the reaction, which implies an implicit read
     // receipt that's obtained first.
-    assert_let_timeout!(
-        Some(VectorDiff::Set { index: 0, value: updated_message }) = timeline_stream.next()
-    );
+    assert_let!(VectorDiff::Set { index: 0, value: updated_message } = &timeline_updates[1]);
     let event_item = updated_message.as_event().unwrap();
     assert_let!(TimelineItemContent::Message(msg) = event_item.content());
     assert!(!msg.is_edited());
@@ -131,9 +131,7 @@ async fn test_reaction() {
     assert_eq!(event_item.reactions().len(), 0);
 
     // Then the reaction is taken into account.
-    assert_let_timeout!(
-        Some(VectorDiff::Set { index: 0, value: updated_message }) = timeline_stream.next()
-    );
+    assert_let!(VectorDiff::Set { index: 0, value: updated_message } = &timeline_updates[2]);
     let event_item = updated_message.as_event().unwrap();
     assert_let!(TimelineItemContent::Message(msg) = event_item.content());
     assert!(!msg.is_edited());
@@ -145,9 +143,7 @@ async fn test_reaction() {
     assert_eq!(senders.as_slice(), [user_id!("@bob:example.org")]);
 
     // The date divider.
-    assert_let_timeout!(
-        Some(VectorDiff::PushFront { value: date_divider }) = timeline_stream.next()
-    );
+    assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[3]);
     assert!(date_divider.is_date_divider());
 
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
@@ -165,13 +161,16 @@ async fn test_reaction() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let_timeout!(
-        Some(VectorDiff::Set { index: 1, value: updated_message }) = timeline_stream.next()
-    );
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 1);
+
+    assert_let!(VectorDiff::Set { index: 1, value: updated_message } = &timeline_updates[0]);
     let event_item = updated_message.as_event().unwrap();
     assert_let!(TimelineItemContent::Message(msg) = event_item.content());
     assert!(!msg.is_edited());
     assert_eq!(event_item.reactions().len(), 0);
+
+    assert_pending!(timeline_stream);
 }
 
 #[async_test]
@@ -191,7 +190,7 @@ async fn test_redacted_message() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
 
     sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
@@ -226,11 +225,16 @@ async fn test_redacted_message() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(VectorDiff::PushBack { value: first }) = timeline_stream.next().await);
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 2);
+
+    assert_let!(VectorDiff::PushBack { value: first } = &timeline_updates[0]);
     assert_matches!(first.as_event().unwrap().content(), TimelineItemContent::RedactedMessage);
 
-    assert_let!(Some(VectorDiff::PushFront { value: date_divider }) = timeline_stream.next().await);
+    assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[1]);
     assert!(date_divider.is_date_divider());
+
+    assert_pending!(timeline_stream);
 }
 
 #[async_test]
@@ -244,7 +248,7 @@ async fn test_redact_message() {
     server.mock_room_state_encryption().plain().mount().await;
 
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
 
     let factory = EventFactory::new();
     factory.set_next_ts(MilliSecondsSinceUnixEpoch::now().get().into());
@@ -258,13 +262,16 @@ async fn test_redact_message() {
         )
         .await;
 
-    assert_let!(Some(VectorDiff::PushBack { value: first }) = timeline_stream.next().await);
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 2);
+
+    assert_let!(VectorDiff::PushBack { value: first } = &timeline_updates[0]);
     assert_eq!(
         first.as_event().unwrap().content().as_message().unwrap().body(),
         "buy my bitcoins bro"
     );
 
-    assert_let!(Some(VectorDiff::PushFront { value: date_divider }) = timeline_stream.next().await);
+    assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[1]);
     assert!(date_divider.is_date_divider());
 
     // Redacting a remote event works.
@@ -278,14 +285,20 @@ async fn test_redact_message() {
         .await
         .unwrap();
 
-    assert_let!(Some(VectorDiff::PushBack { value: second }) = timeline_stream.next().await);
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 1);
+
+    assert_let!(VectorDiff::PushBack { value: second } = &timeline_updates[0]);
 
     let second = second.as_event().unwrap();
     assert_matches!(second.send_state(), Some(EventSendState::NotSentYet));
 
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 1);
+
     // We haven't set a route for sending events, so this will fail.
-    assert_let!(Some(VectorDiff::Set { index, value: second }) = timeline_stream.next().await);
-    assert_eq!(index, 2);
+    assert_let!(VectorDiff::Set { index, value: second } = &timeline_updates[0]);
+    assert_eq!(*index, 2);
 
     let second = second.as_event().unwrap();
     assert!(second.is_local_echo());
@@ -294,8 +307,13 @@ async fn test_redact_message() {
     // Let's redact the local echo.
     timeline.redact(&second.identifier(), None).await.unwrap();
 
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 1);
+
     // Observe local echo being removed.
-    assert_matches!(timeline_stream.next().await, Some(VectorDiff::Remove { index: 2 }));
+    assert_let!(VectorDiff::Remove { index: 2 } = &timeline_updates[0]);
+
+    assert_pending!(timeline_stream);
 }
 
 #[async_test]
@@ -309,7 +327,7 @@ async fn test_redact_local_sent_message() {
     server.mock_room_state_encryption().plain().mount().await;
 
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
 
     // Mock event sending.
     server.mock_room_send().ok(event_id!("$wWgymRfo7ri1uQx0NXO40vLJ")).mock_once().mount().await;
@@ -320,21 +338,27 @@ async fn test_redact_local_sent_message() {
         .await
         .unwrap();
 
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 2);
+
     // Assert the local event is in the timeline now and is not sent yet.
-    assert_let_timeout!(Some(VectorDiff::PushBack { value: item }) = timeline_stream.next());
+    assert_let!(VectorDiff::PushBack { value: item } = &timeline_updates[0]);
     let event = item.as_event().unwrap();
     assert!(event.is_local_echo());
     assert_matches!(event.send_state(), Some(EventSendState::NotSentYet));
 
     // As well as a date divider.
-    assert_let_timeout!(
-        Some(VectorDiff::PushFront { value: date_divider }) = timeline_stream.next()
-    );
+    assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[1]);
     assert!(date_divider.is_date_divider());
 
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 1);
+
     // We receive an update in the timeline from the send queue.
-    assert_let_timeout!(Some(VectorDiff::Set { index, value: item }) = timeline_stream.next());
-    assert_eq!(index, 1);
+    assert_let!(VectorDiff::Set { index, value: item } = &timeline_updates[0]);
+    assert_eq!(*index, 1);
+
+    assert_pending!(timeline_stream);
 
     // Check the event is sent but still considered local.
     let event = item.as_event().unwrap();
@@ -396,7 +420,7 @@ async fn test_read_marker() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
 
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         sync_timeline_event!({
@@ -415,10 +439,13 @@ async fn test_read_marker() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(VectorDiff::PushBack { value: message }) = timeline_stream.next().await);
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 2);
+
+    assert_let!(VectorDiff::PushBack { value: message } = &timeline_updates[0]);
     assert_matches!(message.as_event().unwrap().content(), TimelineItemContent::Message(_));
 
-    assert_let!(Some(VectorDiff::PushFront { value: date_divider }) = timeline_stream.next().await);
+    assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[1]);
     assert!(date_divider.is_date_divider());
 
     sync_builder.add_joined_room(
@@ -448,13 +475,16 @@ async fn test_read_marker() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(VectorDiff::PushBack { value: message }) = timeline_stream.next().await);
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 2);
+
+    assert_let!(VectorDiff::PushBack { value: message } = &timeline_updates[0]);
     assert_matches!(message.as_event().unwrap().content(), TimelineItemContent::Message(_));
 
-    assert_let!(
-        Some(VectorDiff::Insert { index: 2, value: marker }) = timeline_stream.next().await
-    );
+    assert_let!(VectorDiff::Insert { index: 2, value: marker } = &timeline_updates[1]);
     assert_matches!(marker.as_virtual().unwrap(), VirtualTimelineItem::ReadMarker);
+
+    assert_pending!(timeline_stream);
 }
 
 #[async_test]
@@ -480,7 +510,7 @@ async fn test_sync_highlighted() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
 
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         sync_timeline_event!({
@@ -499,12 +529,15 @@ async fn test_sync_highlighted() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(VectorDiff::PushBack { value: first }) = timeline_stream.next().await);
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 2);
+
+    assert_let!(VectorDiff::PushBack { value: first } = &timeline_updates[0]);
     let remote_event = first.as_event().unwrap();
     // Own events don't trigger push rules.
     assert!(!remote_event.is_highlighted());
 
-    assert_let!(Some(VectorDiff::PushFront { value: date_divider }) = timeline_stream.next().await);
+    assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[1]);
     assert!(date_divider.is_date_divider());
 
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
@@ -525,10 +558,15 @@ async fn test_sync_highlighted() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(VectorDiff::PushBack { value: second }) = timeline_stream.next().await);
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 1);
+
+    assert_let!(VectorDiff::PushBack { value: second } = &timeline_updates[0]);
     let remote_event = second.as_event().unwrap();
     // `m.room.tombstone` should be highlighted by default.
     assert!(remote_event.is_highlighted());
+
+    assert_pending!(timeline_stream);
 }
 
 #[async_test]
@@ -724,7 +762,7 @@ async fn test_timeline_without_encryption_info() {
     // Previously this would have panicked.
     let timeline = room.timeline().await.unwrap();
 
-    let (items, _) = timeline.subscribe().await;
+    let (items, _) = timeline.subscribe_batched().await;
     assert_eq!(items.len(), 2);
     assert!(items[0].as_virtual().is_some());
     // No encryption, no shields
@@ -756,7 +794,7 @@ async fn test_timeline_without_encryption_can_update() {
     // encryption changes
     let timeline = Timeline::builder(&room).build().await.unwrap();
 
-    let (items, mut stream) = timeline.subscribe().await;
+    let (items, mut stream) = timeline.subscribe_batched().await;
     assert_eq!(items.len(), 2);
     assert!(items[0].as_virtual().is_some());
     // No encryption, no shields
@@ -772,21 +810,24 @@ async fn test_timeline_without_encryption_can_update() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    assert_let!(Some(timeline_updates) = stream.next().await);
+    assert_eq!(timeline_updates.len(), 3);
+
     // Previous timeline event now has a shield
-    assert_next_matches!(stream, VectorDiff::Set { index, value } => {
-        assert_eq!(index, 1);
-        assert!(value.as_event().unwrap().get_shield(false).is_some());
-    });
+    assert_let!(VectorDiff::Set { index, value } = &timeline_updates[0]);
+    assert_eq!(*index, 1);
+    assert!(value.as_event().unwrap().get_shield(false).is_some());
+
     // Room encryption event is received
-    assert_next_matches!(stream, VectorDiff::PushBack { value } => {
-        assert_let!(TimelineItemContent::OtherState(other_state) = value.as_event().unwrap().content());
-        assert_let!(AnyOtherFullStateEventContent::RoomEncryption(_) = other_state.content());
-        assert!(value.as_event().unwrap().get_shield(false).is_some());
-    });
+    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[1]);
+    assert_let!(TimelineItemContent::OtherState(other_state) = value.as_event().unwrap().content());
+    assert_let!(AnyOtherFullStateEventContent::RoomEncryption(_) = other_state.content());
+    assert!(value.as_event().unwrap().get_shield(false).is_some());
+
     // New message event is received and has a shield
-    assert_next_matches!(stream, VectorDiff::PushBack { value } => {
-        assert!(value.as_event().unwrap().get_shield(false).is_some());
-    });
+    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[2]);
+    assert!(value.as_event().unwrap().get_shield(false).is_some());
+
     assert_pending!(stream);
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -329,15 +329,20 @@ async fn test_clear_with_echoes() {
 
     // Send a message without mocking the server response.
     {
-        let (_, mut timeline_stream) = timeline.subscribe().await;
+        let (_, mut timeline_stream) = timeline.subscribe_batched().await;
 
         timeline.send(RoomMessageEventContent::text_plain("Send failure").into()).await.unwrap();
 
         // Wait for the first message to fail. Don't use time, but listen for the first
         // timeline item diff to get back signalling the error.
-        let _date_divider = timeline_stream.next().await;
-        let _local_echo = timeline_stream.next().await;
-        let _local_echo_replaced_with_failure = timeline_stream.next().await;
+
+        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        // 2 updates: date divider and local echo.
+        assert_eq!(timeline_updates.len(), 2);
+
+        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        // 1 updates: local echo replaced with failure.
+        assert_eq!(timeline_updates.len(), 1);
     }
 
     // Next message will take "forever" to send.
@@ -403,7 +408,7 @@ async fn test_no_duplicate_date_divider() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
 
     // Response for first message takes 200ms to respond.
     Mock::given(method("PUT"))
@@ -440,35 +445,36 @@ async fn test_no_duplicate_date_divider() {
     // Let the send queue handle the event.
     yield_now().await;
 
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 3);
+
     // Local echoes are available as soon as `timeline.send` returns.
-    assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
-        assert_eq!(value.as_event().unwrap().content().as_message().unwrap().body(), "First!");
-    });
+    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);
+    assert_eq!(value.as_event().unwrap().content().as_message().unwrap().body(), "First!");
 
-    assert_next_matches!(timeline_stream, VectorDiff::PushFront { value } => {
-        assert!(value.is_date_divider());
-    });
+    assert_let!(VectorDiff::PushFront { value } = &timeline_updates[1]);
+    assert!(value.is_date_divider());
 
-    assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
-        assert_eq!(value.as_event().unwrap().content().as_message().unwrap().body(), "Second.");
-    });
+    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[2]);
+    assert_eq!(value.as_event().unwrap().content().as_message().unwrap().body(), "Second.");
 
     // Wait 200ms for the first msg, 100ms for the second, 200ms for overhead.
     sleep(Duration::from_millis(500)).await;
 
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 2);
+
     // The first item should be updated first.
-    assert_next_matches!(timeline_stream, VectorDiff::Set { index: 1, value } => {
-        let value = value.as_event().unwrap();
-        assert_eq!(value.content().as_message().unwrap().body(), "First!");
-        assert_eq!(value.event_id().unwrap(), "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP");
-    });
+    assert_let!(VectorDiff::Set { index: 1, value } = &timeline_updates[0]);
+    let value = value.as_event().unwrap();
+    assert_eq!(value.content().as_message().unwrap().body(), "First!");
+    assert_eq!(value.event_id().unwrap(), "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP");
 
     // Then the second one.
-    assert_next_matches!(timeline_stream, VectorDiff::Set { index: 2, value } => {
-        let value = value.as_event().unwrap();
-        assert_eq!(value.content().as_message().unwrap().body(), "Second.");
-        assert_eq!(value.event_id().unwrap(), "$5E2kLK/Sg342bgBU9ceEIEPYpbFaqJpZ");
-    });
+    assert_let!(VectorDiff::Set { index: 2, value } = &timeline_updates[1]);
+    let value = value.as_event().unwrap();
+    assert_eq!(value.content().as_message().unwrap().body(), "Second.");
+    assert_eq!(value.event_id().unwrap(), "$5E2kLK/Sg342bgBU9ceEIEPYpbFaqJpZ");
 
     assert_pending!(timeline_stream);
 
@@ -496,31 +502,32 @@ async fn test_no_duplicate_date_divider() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_eq!(timeline_updates.len(), 6);
+
     // The first message is removed -> [DD Second]
-    assert_next_matches!(timeline_stream, VectorDiff::Remove { index: 1 });
+    assert_let!(VectorDiff::Remove { index: 1 } = &timeline_updates[0]);
 
     // The first message is reinserted -> [First DD Second]
-    assert_next_matches!(timeline_stream, VectorDiff::PushFront { value } => {
-        let value = value.as_event().unwrap();
-        assert_eq!(value.content().as_message().unwrap().body(), "First!");
-        assert_eq!(value.event_id().unwrap(), "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP");
-    });
+    assert_let!(VectorDiff::PushFront { value } = &timeline_updates[1]);
+    let value = value.as_event().unwrap();
+    assert_eq!(value.content().as_message().unwrap().body(), "First!");
+    assert_eq!(value.event_id().unwrap(), "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP");
 
     // The second message is replaced -> [First Second DD]
-    assert_next_matches!(timeline_stream, VectorDiff::Remove { index: 2 });
-    assert_next_matches!(timeline_stream, VectorDiff::Insert { index: 1, value } => {
-        let value = value.as_event().unwrap();
-        assert_eq!(value.content().as_message().unwrap().body(), "Second.");
-        assert_eq!(value.event_id().unwrap(), "$5E2kLK/Sg342bgBU9ceEIEPYpbFaqJpZ");
-    });
+    assert_let!(VectorDiff::Remove { index: 2 } = &timeline_updates[2]);
+
+    assert_let!(VectorDiff::Insert { index: 1, value } = &timeline_updates[3]);
+    let value = value.as_event().unwrap();
+    assert_eq!(value.content().as_message().unwrap().body(), "Second.");
+    assert_eq!(value.event_id().unwrap(), "$5E2kLK/Sg342bgBU9ceEIEPYpbFaqJpZ");
 
     // A new date divider is inserted -> [DD First Second DD]
-    assert_next_matches!(timeline_stream, VectorDiff::PushFront { value } => {
-        assert!(value.is_date_divider());
-    });
+    assert_let!(VectorDiff::PushFront { value } = &timeline_updates[4]);
+    assert!(value.is_date_divider());
 
     // The useless date divider is removed. -> [DD First Second]
-    assert_next_matches!(timeline_stream, VectorDiff::Remove { index: 3 });
+    assert_let!(VectorDiff::Remove { index: 3 } = &timeline_updates[5]);
 
     assert_pending!(timeline_stream);
 }

--- a/examples/timeline/src/main.rs
+++ b/examples/timeline/src/main.rs
@@ -71,12 +71,12 @@ async fn main() -> Result<()> {
     // Get the timeline stream and listen to it.
     let room = client.get_room(&room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (timeline_items, mut timeline_stream) = timeline.subscribe().await;
+    let (timeline_items, mut timeline_stream) = timeline.subscribe_batched().await;
 
     println!("Initial timeline items: {timeline_items:#?}");
     tokio::spawn(async move {
-        while let Some(diff) = timeline_stream.next().await {
-            println!("Received a timeline diff: {diff:#?}");
+        while let Some(diffs) = timeline_stream.next().await {
+            println!("Received timeline diffs: {diffs:#?}");
         }
     });
 

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -266,7 +266,7 @@ impl App {
 
                     // Save the timeline in the cache.
                     let sdk_timeline = ui_room.timeline().unwrap();
-                    let (items, stream) = sdk_timeline.subscribe().await;
+                    let (items, stream) = sdk_timeline.subscribe_batched().await;
                     let items = Arc::new(Mutex::new(items));
 
                     // Spawn a timeline task that will listen to all the timeline item changes.
@@ -274,9 +274,12 @@ impl App {
                     let timeline_task = spawn(async move {
                         pin_mut!(stream);
                         let items = i;
-                        while let Some(diff) = stream.next().await {
+                        while let Some(diffs) = stream.next().await {
                             let mut items = items.lock().unwrap();
-                            diff.apply(&mut items);
+
+                            for diff in diffs {
+                                diff.apply(&mut items);
+                            }
                         }
                     });
 

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -893,7 +893,7 @@ async fn test_delayed_invite_response_and_sent_message_decryption() {
 
     // Join the room from Bob's client.
     let bob_timeline = bob_room.timeline().await.unwrap();
-    let (_, timeline_stream) = bob_timeline.subscribe().await;
+    let (_, timeline_stream) = bob_timeline.subscribe_batched().await;
     pin_mut!(timeline_stream);
 
     info!("Bob joins the room.");
@@ -908,31 +908,33 @@ async fn test_delayed_invite_response_and_sent_message_decryption() {
     bob_timeline.paginate_backwards(3).await.unwrap();
 
     // Look for the sent message, which should not be an UTD event.
-    while let Ok(Some(diff)) = timeout(Duration::from_secs(3), timeline_stream.next()).await {
-        trace!(?diff, "Received diff from Bob's room");
+    while let Ok(Some(diffs)) = timeout(Duration::from_secs(3), timeline_stream.next()).await {
+        trace!(?diffs, "Received diffs from Bob's room");
 
-        match diff {
-            VectorDiff::PushFront { value: event }
-            | VectorDiff::PushBack { value: event }
-            | VectorDiff::Insert { value: event, .. }
-            | VectorDiff::Set { value: event, .. } => {
-                let Some(event) = event.as_event() else {
-                    continue;
-                };
+        for diff in diffs {
+            match diff {
+                VectorDiff::PushFront { value: event }
+                | VectorDiff::PushBack { value: event }
+                | VectorDiff::Insert { value: event, .. }
+                | VectorDiff::Set { value: event, .. } => {
+                    let Some(event) = event.as_event() else {
+                        continue;
+                    };
 
-                let content = event.content();
+                    let content = event.content();
 
-                if content.as_unable_to_decrypt().is_some() {
-                    info!("Observed UTD for {}", event.event_id().unwrap());
+                    if content.as_unable_to_decrypt().is_some() {
+                        info!("Observed UTD for {}", event.event_id().unwrap());
+                    }
+
+                    if let Some(message) = content.as_message() {
+                        assert_eq!(message.body(), "hello world");
+                        return;
+                    }
                 }
 
-                if let Some(message) = content.as_message() {
-                    assert_eq!(message.body(), "hello world");
-                    return;
-                }
+                _ => {}
             }
-
-            _ => {}
         }
     }
 

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -55,12 +55,9 @@ use crate::helpers::TestClientBuilder;
 ///
 /// A macro to help lowering compile times and getting better error locations.
 macro_rules! assert_event_is_updated {
-    ($stream:expr, $event_id:expr, $index:expr) => {{
-        assert_let!(
-            Ok(Some(VectorDiff::Set { index: i, value: event })) =
-                timeout(Duration::from_secs(1), $stream.next()).await
-        );
-        assert_eq!(i, $index, "unexpected position for event update, value = {event:?}");
+    ($diff:expr, $event_id:expr, $index:expr) => {{
+        assert_let!(VectorDiff::Set { index: i, value: event } = &$diff);
+        assert_eq!(*i, $index, "unexpected position for event update, value = {event:?}");
 
         let event = event.as_event().unwrap();
         assert_eq!(event.event_id().unwrap(), $event_id);
@@ -94,7 +91,7 @@ async fn test_toggling_reaction() -> Result<()> {
     // waiting for it.
 
     let timeline = room.timeline().await.unwrap();
-    let (mut items, mut stream) = timeline.subscribe().await;
+    let (mut items, mut stream) = timeline.subscribe_batched().await;
 
     let event_id_task: JoinHandle<Result<_>> = spawn(async move {
         let find_event_id = |items: &Vector<Arc<TimelineItem>>| {
@@ -114,9 +111,13 @@ async fn test_toggling_reaction() -> Result<()> {
 
         warn!(?items, "Waiting for updates…");
 
-        while let Some(diff) = stream.next().await {
-            warn!(?diff, "received a diff");
-            diff.apply(&mut items);
+        while let Some(diffs) = stream.next().await {
+            warn!(?diffs, "received diffs");
+
+            for diff in diffs {
+                diff.apply(&mut items);
+            }
+
             if let Some(event_id) = find_event_id(&items) {
                 return Ok(event_id);
             }
@@ -145,12 +146,14 @@ async fn test_toggling_reaction() -> Result<()> {
     // Give a bit of time for the timeline to process all sync updates.
     sleep(Duration::from_secs(1)).await;
 
-    let (mut items, mut stream) = timeline.subscribe().await;
+    let (mut items, mut stream) = timeline.subscribe_batched().await;
 
     // Skip all stream updates that have happened so far.
     debug!("Skipping all other stream updates…");
-    while let Some(Some(diff)) = stream.next().now_or_never() {
-        diff.apply(&mut items);
+    while let Some(Some(diffs)) = stream.next().now_or_never() {
+        for diff in diffs {
+            diff.apply(&mut items);
+        }
     }
 
     let (message_position, item_id) = items
@@ -171,9 +174,14 @@ async fn test_toggling_reaction() -> Result<()> {
         // Add the reaction.
         timeline.toggle_reaction(&item_id, &reaction_key).await.expect("toggling reaction");
 
+        sleep(Duration::from_secs(1)).await;
+
+        assert_let!(Some(timeline_updates) = stream.next().await);
+        assert_eq!(timeline_updates.len(), 2);
+
         // Local echo is added.
         {
-            let event = assert_event_is_updated!(stream, event_id, message_position);
+            let event = assert_event_is_updated!(timeline_updates[0], event_id, message_position);
             let reactions = event.reactions().get(&reaction_key).unwrap();
             let reaction = reactions.get(&user_id).unwrap();
             assert_matches!(reaction.status, ReactionStatus::LocalToRemote(..));
@@ -181,7 +189,7 @@ async fn test_toggling_reaction() -> Result<()> {
 
         // Remote echo is added.
         {
-            let event = assert_event_is_updated!(stream, event_id, message_position);
+            let event = assert_event_is_updated!(timeline_updates[1], event_id, message_position);
 
             let reactions = event.reactions().get(&reaction_key).unwrap();
             assert_eq!(reactions.keys().count(), 1);
@@ -202,11 +210,16 @@ async fn test_toggling_reaction() -> Result<()> {
             .await
             .expect("toggling reaction the second time");
 
+        sleep(Duration::from_secs(1)).await;
+
+        assert_let!(Some(timeline_updates) = stream.next().await);
+        assert_eq!(timeline_updates.len(), 1);
+
         // The reaction is removed.
-        let event = assert_event_is_updated!(stream, event_id, message_position);
+        let event = assert_event_is_updated!(timeline_updates[0], event_id, message_position);
         assert!(event.reactions().is_empty());
 
-        assert!(stream.next().now_or_never().is_none());
+        assert_pending!(stream);
     }
 
     Ok(())


### PR DESCRIPTION
This patch removes `Timeline::subscribe` and keeps `::subscribe_batched`, which is the only method that is really used.

Edit: I agree that's a non-negligible amount of work, but we want to clean up this API. The more API, the more maintenance and documentation. Also, `subscribe_batched` is more performant from the caller's perspective. Finally, we want the test to use the same API as more users are using, which is the case now with this PR.