### PR TITLE
fix(wasm): don't kill task on drop

### DIFF
--- a/crates/matrix-sdk-common/src/executor.rs
+++ b/crates/matrix-sdk-common/src/executor.rs
@@ -47,13 +47,13 @@ where
         let _ = future.await;
     });
 
-    JoinHandle { remote_handle, abort_handle }
+    JoinHandle { remote_handle: Some(remote_handle), abort_handle }
 }
 
 #[cfg(target_arch = "wasm32")]
 #[derive(Debug)]
 pub struct JoinHandle<T> {
-    remote_handle: RemoteHandle<T>,
+    remote_handle: Option<RemoteHandle<T>>,
     abort_handle: AbortHandle,
 }
 
@@ -65,6 +65,16 @@ impl<T> JoinHandle<T> {
 }
 
 #[cfg(target_arch = "wasm32")]
+impl<T> Drop for JoinHandle<T> {
+    fn drop(&mut self) {
+        // don't abort the spawned future
+        if let Some(h) = self.remote_handle.take() {
+            h.forget();
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 impl<T: 'static> Future for JoinHandle<T> {
     type Output = Result<T, JoinError>;
 
@@ -72,8 +82,10 @@ impl<T: 'static> Future for JoinHandle<T> {
         if self.abort_handle.is_aborted() {
             // The future has been aborted. It is not possible to poll it again.
             Poll::Ready(Err(JoinError))
+        } else if let Some(handle) = self.remote_handle.as_mut() {
+            Pin::new(handle).poll(cx).map(Ok)
         } else {
-            Pin::new(&mut self.remote_handle).poll(cx).map(Ok)
+            Poll::Ready(Err(JoinError))
         }
     }
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

makes behavior similar to tokio::spawn otherwise spawned tasks immediately die if join handles are not saved somewhere
