### PR TITLE
feat(ui): expose a method for checking whether a message contains only emojis and should be boosted (use a bigger font size)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "emojis"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99e1f1df1f181f2539bac8bf027d31ca5ffbf9e559e3f2d09413b9107b5c02f4"
+dependencies = [
+ "phf",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3505,6 +3514,7 @@ dependencies = [
  "async-stream",
  "async_cell",
  "chrono",
+ "emojis",
  "eyeball",
  "eyeball-im",
  "eyeball-im-util",
@@ -3531,6 +3541,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "unicode-normalization",
+ "unicode-segmentation",
  "uniffi",
  "wiremock",
 ]
@@ -4376,7 +4387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -6149,9 +6160,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -1322,4 +1322,8 @@ impl LazyTimelineItemProvider {
     fn get_send_handle(&self) -> Option<Arc<SendHandle>> {
         self.0.local_echo_send_handle().map(|handle| Arc::new(SendHandle::new(handle)))
     }
+
+    fn should_boost(&self) -> bool {
+        self.0.should_boost()
+    }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -1323,7 +1323,7 @@ impl LazyTimelineItemProvider {
         self.0.local_echo_send_handle().map(|handle| Arc::new(SendHandle::new(handle)))
     }
 
-    fn should_boost(&self) -> bool {
-        self.0.should_boost()
+    fn contains_only_emojis(&self) -> bool {
+        self.0.contains_only_emojis()
     }
 }

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -51,6 +51,9 @@ tracing = { workspace = true, features = ["attributes"] }
 unicode-normalization = { workspace = true }
 uniffi = { workspace = true, optional = true }
 
+emojis = "0.6.4"
+unicode-segmentation = "1.12.0"
+
 [dev-dependencies]
 anyhow = { workspace = true }
 assert-json-diff = { workspace = true }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -620,7 +620,14 @@ impl EventTimelineItem {
     ///   [`MessageType::Video`] if present
     /// - all other message types will not match
     ///
-    /// See `test_emoji_detection` for examples.
+    /// # Examples
+    /// # fn render_timeline_item(timeline_item: TimelineItem) {
+    /// if timeline_item.contains_only_emojis() {
+    ///     // e.g. increase the font size
+    /// }
+    /// # }
+    ///
+    /// See `test_emoji_detection` for more examples.
     pub fn contains_only_emojis(&self) -> bool {
         let body = match self.content() {
             TimelineItemContent::Message(msg) => match msg.msgtype() {

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -656,7 +656,9 @@ impl EventTimelineItem {
             let graphemes = body.trim().graphemes(true).collect::<Vec<&str>>();
 
             // Limit the check to 5 graphemes for performance and security
-            // reasons
+            // reasons. This will probably be used for every new message so we
+            // want it to be fast and we don't want to allow a DoS attack by
+            // sending a huge message.
             if graphemes.len() > 5 {
                 return false;
             }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -443,19 +443,6 @@ impl EventTimelineItem {
         }
     }
 
-    pub fn should_boost(&self) -> bool {
-        match self.content() {
-            TimelineItemContent::Message(msg) => match msg.msgtype() {
-                MessageType::Text(text) => {
-                    let graphmes = text.body.graphemes(true).collect::<Vec<&str>>();
-                    graphmes.iter().all(|g| emojis::get(g).is_some())
-                }
-                _ => false,
-            },
-            _ => false,
-        }
-    }
-
     /// Check whether this item can be replied to.
     pub fn can_be_replied_to(&self) -> bool {
         // This must be in sync with the early returns of `Timeline::send_reply`
@@ -617,6 +604,60 @@ impl EventTimelineItem {
     /// For local echoes, return the associated send handle.
     pub fn local_echo_send_handle(&self) -> Option<SendHandle> {
         as_variant!(self.handle(), TimelineItemHandle::Local(handle) => handle.clone())
+    }
+
+    /// Some clients may want to know if a particular text message or media
+    /// caption contains only emojis so that they can render them bigger for
+    /// added effect.
+    ///
+    /// This function provides that feature with the following
+    /// behavior/limitations:
+    /// - ignores leading and trailing white spaces
+    /// - fails texts bigger than 5 graphemes for performance reasons
+    /// - checks the body only for [`MessageType::Text`]
+    /// - only checks the caption for [`MessageType::Audio`],
+    ///   [`MessageType::File`], [`MessageType::Image`], and
+    ///   [`MessageType::Video`] if present
+    /// - all other message types will not match
+    ///
+    /// See `test_emoji_detection` for examples.
+    pub fn contains_only_emojis(&self) -> bool {
+        let body = match self.content() {
+            TimelineItemContent::Message(msg) => match msg.msgtype() {
+                MessageType::Text(text) => Some(text.body.as_str()),
+                MessageType::Audio(audio) => audio.caption(),
+                MessageType::File(file) => file.caption(),
+                MessageType::Image(image) => image.caption(),
+                MessageType::Video(video) => video.caption(),
+                _ => None,
+            },
+            TimelineItemContent::RedactedMessage
+            | TimelineItemContent::Sticker(_)
+            | TimelineItemContent::UnableToDecrypt(_)
+            | TimelineItemContent::MembershipChange(_)
+            | TimelineItemContent::ProfileChange(_)
+            | TimelineItemContent::OtherState(_)
+            | TimelineItemContent::FailedToParseMessageLike { .. }
+            | TimelineItemContent::FailedToParseState { .. }
+            | TimelineItemContent::Poll(_)
+            | TimelineItemContent::CallInvite
+            | TimelineItemContent::CallNotify => None,
+        };
+
+        if let Some(body) = body {
+            // Collect the graphemes after trimming white spaces.
+            let graphemes = body.trim().graphemes(true).collect::<Vec<&str>>();
+
+            // Limit the check to 5 graphemes for performance and security
+            // reasons
+            if graphemes.len() > 5 {
+                return false;
+            }
+
+            graphemes.iter().all(|g| emojis::get(g).is_some())
+        } else {
+            false
+        }
     }
 }
 
@@ -1086,31 +1127,34 @@ mod tests {
                 .await
                 .unwrap();
 
-        assert!(!timeline_item.should_boost());
+        assert!(!timeline_item.contains_only_emojis());
 
+        // Ignores leading and trailing white spaces
+        event = message_event(room_id, user_id, " 🚀 ", "", 0);
+        timeline_item =
+            EventTimelineItem::from_latest_event(client.clone(), room_id, LatestEvent::new(event))
+                .await
+                .unwrap();
+
+        assert!(timeline_item.contains_only_emojis());
+
+        // Too many
         event = message_event(room_id, user_id, "👨‍👩‍👦1️⃣🚀👳🏾‍♂️🪩👍👍🏻🫱🏼‍🫲🏾🙂👋", "", 0);
         timeline_item =
             EventTimelineItem::from_latest_event(client.clone(), room_id, LatestEvent::new(event))
                 .await
                 .unwrap();
 
-        assert!(timeline_item.should_boost());
+        assert!(!timeline_item.contains_only_emojis());
 
-        event = message_event(room_id, user_id, "0", "", 0);
+        // Works with combined emojis
+        event = message_event(room_id, user_id, "👨‍👩‍👦1️⃣👳🏾‍♂️👍🏻🫱🏼‍🫲🏾", "", 0);
         timeline_item =
             EventTimelineItem::from_latest_event(client.clone(), room_id, LatestEvent::new(event))
                 .await
                 .unwrap();
 
-        assert!(!timeline_item.should_boost());
-
-        event = message_event(room_id, user_id, "0*", "", 0);
-        timeline_item =
-            EventTimelineItem::from_latest_event(client, room_id, LatestEvent::new(event))
-                .await
-                .unwrap();
-
-        assert!(!timeline_item.should_boost());
+        assert!(timeline_item.contains_only_emojis());
     }
 
     fn member_event(


### PR DESCRIPTION
- supports only text room message types
- enumerates through their body's grapheme clusters and check that every single one of them is an emoji
- part of the `LazyTimelineItemProvider` so that it can be opt in