### PR TITLE
crypto: refactor the room key sharing strategies

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -680,15 +680,20 @@ pub struct EncryptionSettings {
 
 impl From<EncryptionSettings> for RustEncryptionSettings {
     fn from(v: EncryptionSettings) -> Self {
+        let sharing_strategy = if v.only_allow_trusted_devices {
+            CollectStrategy::OnlyTrustedDevices
+        } else if v.error_on_verified_user_problem {
+            CollectStrategy::ErrorOnVerifiedUserProblem
+        } else {
+            CollectStrategy::AllDevices
+        };
+
         RustEncryptionSettings {
             algorithm: v.algorithm.into(),
             rotation_period: Duration::from_secs(v.rotation_period),
             rotation_period_msgs: v.rotation_period_msgs,
             history_visibility: v.history_visibility.into(),
-            sharing_strategy: CollectStrategy::DeviceBasedStrategy {
-                only_allow_trusted_devices: v.only_allow_trusted_devices,
-                error_on_verified_user_problem: v.error_on_verified_user_problem,
-            },
+            sharing_strategy,
         }
     }
 }

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] `CollectStrategy::DeviceBasedStrategy` is now split into three
+  separate strategies (`AllDevices`, `ErrorOnVerifiedUserProblem`,
+  `OnlyTrustedDevices`), to make the behaviour clearer.
+  ([#4581](https://github.com/matrix-org/matrix-rust-sdk/pull/4581))
+
 - Accept stable identifier `sender_device_keys` for MSC4147 (Including device
   keys with Olm-encrypted events).
   ([#4420](https://github.com/matrix-org/matrix-rust-sdk/pull/4420))

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -374,9 +374,7 @@ pub enum SetRoomSettingsError {
 pub enum SessionRecipientCollectionError {
     /// One or more verified users has one or more unsigned devices.
     ///
-    /// Happens only with [`CollectStrategy::DeviceBasedStrategy`] when
-    /// [`error_on_verified_user_problem`](`CollectStrategy::DeviceBasedStrategy::error_on_verified_user_problem`)
-    /// is true.
+    /// Happens only with [`CollectStrategy::ErrorOnVerifiedUserProblem`].
     ///
     /// In order to resolve this, the caller can set the trust level of the
     /// affected devices to [`LocalTrust::Ignored`] or
@@ -388,9 +386,8 @@ pub enum SessionRecipientCollectionError {
     /// One or more users was previously verified, but they have changed their
     /// identity.
     ///
-    /// Happens only with [`CollectStrategy::DeviceBasedStrategy`] when
-    /// [`error_on_verified_user_problem`](`CollectStrategy::DeviceBasedStrategy::error_on_verified_user_problem`)
-    /// is true, or with [`CollectStrategy::IdentityBasedStrategy`].
+    /// Happens only with [`CollectStrategy::ErrorOnVerifiedUserProblem`] or
+    /// [`CollectStrategy::IdentityBasedStrategy`].
     ///
     /// In order to resolve this, the user can:
     ///

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -594,10 +594,7 @@ async fn test_withheld_unverified() {
 
     let encryption_settings = EncryptionSettings::default();
     let encryption_settings = EncryptionSettings {
-        sharing_strategy: CollectStrategy::DeviceBasedStrategy {
-            only_allow_trusted_devices: true,
-            error_on_verified_user_problem: false,
-        },
+        sharing_strategy: CollectStrategy::OnlyTrustedDevices,
         ..encryption_settings
     };
 

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -788,10 +788,7 @@ mod tests {
         let settings = EncryptionSettings::new(
             content.clone(),
             HistoryVisibility::Joined,
-            CollectStrategy::DeviceBasedStrategy {
-                only_allow_trusted_devices: false,
-                error_on_verified_user_problem: false,
-            },
+            CollectStrategy::AllDevices,
         );
 
         assert_eq!(settings.rotation_period, ROTATION_PERIOD);
@@ -803,10 +800,7 @@ mod tests {
         let settings = EncryptionSettings::new(
             content,
             HistoryVisibility::Shared,
-            CollectStrategy::DeviceBasedStrategy {
-                only_allow_trusted_devices: false,
-                error_on_verified_user_problem: false,
-            },
+            CollectStrategy::AllDevices,
         );
 
         assert_eq!(settings.rotation_period, Duration::from_millis(3600));

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
@@ -1163,10 +1163,7 @@ mod tests {
             .any(|d| d.user_id() == user_id && d.device_id() == device_id));
 
         let settings = EncryptionSettings {
-            sharing_strategy: CollectStrategy::DeviceBasedStrategy {
-                only_allow_trusted_devices: true,
-                error_on_verified_user_problem: false,
-            },
+            sharing_strategy: CollectStrategy::OnlyTrustedDevices,
             ..Default::default()
         };
         let users = [user_id].into_iter();
@@ -1226,10 +1223,7 @@ mod tests {
 
         let users = keys_claim.one_time_keys.keys().map(Deref::deref);
         let settings = EncryptionSettings {
-            sharing_strategy: CollectStrategy::DeviceBasedStrategy {
-                only_allow_trusted_devices: true,
-                error_on_verified_user_problem: false,
-            },
+            sharing_strategy: CollectStrategy::OnlyTrustedDevices,
             ..Default::default()
         };
 

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -517,6 +517,7 @@ mod tests {
 
     use assert_matches::assert_matches;
     use assert_matches2::assert_let;
+    use insta::assert_snapshot;
     use matrix_sdk_common::deserialized_responses::WithheldCode;
     use matrix_sdk_test::{
         async_test, test_json,
@@ -577,6 +578,15 @@ mod tests {
         machine.mark_request_as_sent(&txn_id_good, &keys_query_good).await.unwrap();
 
         machine
+    }
+
+    /// Assert that [`CollectStrategy::DeviceBasedStrategy`] retains the same
+    /// serialization format.
+    #[test]
+    fn test_serialize_device_based_strategy() {
+        let encryption_settings = device_based_strategy_settings();
+        let serialized = serde_json::to_string(&encryption_settings).unwrap();
+        assert_snapshot!(serialized);
     }
 
     #[async_test]

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -583,13 +583,7 @@ mod tests {
     async fn test_share_with_per_device_strategy_to_all() {
         let machine = set_up_test_machine().await;
 
-        let encryption_settings = EncryptionSettings {
-            sharing_strategy: CollectStrategy::DeviceBasedStrategy {
-                only_allow_trusted_devices: false,
-                error_on_verified_user_problem: false,
-            },
-            ..Default::default()
-        };
+        let encryption_settings = device_based_strategy_settings();
 
         let group_session = create_test_outbound_group_session(&machine, &encryption_settings);
 
@@ -1090,10 +1084,7 @@ mod tests {
     async fn test_share_with_identity_strategy() {
         let machine = set_up_test_machine().await;
 
-        let strategy = CollectStrategy::new_identity_based();
-
-        let encryption_settings =
-            EncryptionSettings { sharing_strategy: strategy.clone(), ..Default::default() };
+        let encryption_settings = identity_based_strategy_settings();
 
         let group_session = create_test_outbound_group_session(&machine, &encryption_settings);
 
@@ -1169,10 +1160,7 @@ mod tests {
 
         let fake_room_id = room_id!("!roomid:localhost");
 
-        let encryption_settings = EncryptionSettings {
-            sharing_strategy: CollectStrategy::new_identity_based(),
-            ..Default::default()
-        };
+        let encryption_settings = identity_based_strategy_settings();
 
         let request_result = machine
             .share_room_key(
@@ -1295,10 +1283,7 @@ mod tests {
         let fake_room_id = room_id!("!roomid:localhost");
 
         // We share the key using the identity-based strategy.
-        let encryption_settings = EncryptionSettings {
-            sharing_strategy: CollectStrategy::new_identity_based(),
-            ..Default::default()
-        };
+        let encryption_settings = identity_based_strategy_settings();
 
         let request_result = machine
             .share_room_key(
@@ -1439,14 +1424,7 @@ mod tests {
         let machine = set_up_test_machine().await;
 
         let fake_room_id = room_id!("!roomid:localhost");
-
-        let strategy = CollectStrategy::DeviceBasedStrategy {
-            only_allow_trusted_devices: false,
-            error_on_verified_user_problem: false,
-        };
-
-        let encryption_settings =
-            EncryptionSettings { sharing_strategy: strategy.clone(), ..Default::default() };
+        let encryption_settings = device_based_strategy_settings();
 
         let requests = machine
             .share_room_key(
@@ -1538,6 +1516,18 @@ mod tests {
         machine
     }
 
+    /// [`EncryptionSettings`] with [`CollectStrategy::DeviceBasedStrategy`]
+    /// (with default settings)
+    fn device_based_strategy_settings() -> EncryptionSettings {
+        EncryptionSettings {
+            sharing_strategy: CollectStrategy::DeviceBasedStrategy {
+                only_allow_trusted_devices: false,
+                error_on_verified_user_problem: false,
+            },
+            ..Default::default()
+        }
+    }
+
     /// [`EncryptionSettings`] with `error_on_verified_user_problem` set
     fn error_on_verification_problem_encryption_settings() -> EncryptionSettings {
         EncryptionSettings {
@@ -1545,6 +1535,14 @@ mod tests {
                 only_allow_trusted_devices: false,
                 error_on_verified_user_problem: true,
             },
+            ..Default::default()
+        }
+    }
+
+    /// [`EncryptionSettings`] with [`CollectStrategy::IdentityBasedStrategy`]
+    fn identity_based_strategy_settings() -> EncryptionSettings {
+        EncryptionSettings {
+            sharing_strategy: CollectStrategy::IdentityBasedStrategy,
             ..Default::default()
         }
     }

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/matrix_sdk_crypto__session_manager__group_sessions__share_strategy__tests__serialize_device_based_strategy.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/matrix_sdk_crypto__session_manager__group_sessions__share_strategy__tests__serialize_device_based_strategy.snap
@@ -1,0 +1,5 @@
+---
+source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+expression: serialized
+---
+{"algorithm":"m.megolm.v1.aes-sha2","rotation_period":{"secs":604800,"nanos":0},"rotation_period_msgs":100,"history_visibility":"shared","sharing_strategy":{"DeviceBasedStrategy":{"only_allow_trusted_devices":false,"error_on_verified_user_problem":false}}}

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/matrix_sdk_crypto__session_manager__group_sessions__share_strategy__tests__serialize_device_based_strategy.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/matrix_sdk_crypto__session_manager__group_sessions__share_strategy__tests__serialize_device_based_strategy.snap
@@ -2,4 +2,4 @@
 source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
 expression: serialized
 ---
-{"algorithm":"m.megolm.v1.aes-sha2","rotation_period":{"secs":604800,"nanos":0},"rotation_period_msgs":100,"history_visibility":"shared","sharing_strategy":{"DeviceBasedStrategy":{"only_allow_trusted_devices":false,"error_on_verified_user_problem":false}}}
+{"algorithm":"m.megolm.v1.aes-sha2","rotation_period":{"secs":604800,"nanos":0},"rotation_period_msgs":100,"history_visibility":"shared","sharing_strategy":"AllDevices"}


### PR DESCRIPTION
Currently, we have two `CollectStrategy` settings, of which one (`DeviceBasedStrategy`) is a bit of a confusing mess of options. Let's split things up so that each option has its own strategy; I find this makes the behaviour much clearer.

It takes quite a bit of refactoring to get there in a way which doesn't end up duplicating a lot of code. Suggest review commit-by-commit.