### PR TITLE
refactor(ui): Unify the Timeline pagination API

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -19,8 +19,6 @@ use as_variant::as_variant;
 use content::{InReplyToDetails, RepliedToEventDetails};
 use eyeball_im::VectorDiff;
 use futures_util::{pin_mut, StreamExt as _};
-#[cfg(doc)]
-use matrix_sdk::crypto::CollectStrategy;
 use matrix_sdk::{
     attachment::{
         AttachmentConfig, AttachmentInfo, BaseAudioInfo, BaseFileInfo, BaseImageInfo,
@@ -63,8 +61,6 @@ use tracing::{error, warn};
 use uuid::Uuid;
 
 use self::content::{Reaction, ReactionSenderData, TimelineItemContent};
-#[cfg(doc)]
-use crate::client_builder::ClientBuilder;
 use crate::{
     client::ProgressWatcher,
     error::{ClientError, RoomError},

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -267,16 +267,16 @@ impl Timeline {
 
     /// Paginate backwards, whether we are in focused mode or in live mode.
     ///
-    /// Returns whether we hit the end of the timeline or not.
+    /// Returns whether we hit the start of the timeline or not.
     pub async fn paginate_backwards(&self, num_events: u16) -> Result<bool, ClientError> {
         Ok(self.inner.paginate_backwards(num_events).await?)
     }
 
-    /// Paginate forwards, when in focused mode.
+    /// Paginate forwards, whether we are in focused mode or in live mode.
     ///
     /// Returns whether we hit the end of the timeline or not.
-    pub async fn focused_paginate_forwards(&self, num_events: u16) -> Result<bool, ClientError> {
-        Ok(self.inner.focused_paginate_forwards(num_events).await?)
+    pub async fn paginate_forwards(&self, num_events: u16) -> Result<bool, ClientError> {
+        Ok(self.inner.paginate_forwards(num_events).await?)
     }
 
     pub async fn send_read_receipt(

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -24,6 +24,13 @@ All notable changes to this project will be documented in this file.
   implement `Into<PathBuf>` also implement `Into<AttachmentSource>`.
   ([#4451](https://github.com/matrix-org/matrix-rust-sdk/pull/4451))
 
+### Refactor
+
+- [**breaking**] `Timeline::paginate_forwards` and `Timeline::paginate_backwards`
+  are unified to work on a live or focused timeline.
+  `Timeline::live_paginate_*` and `Timeline::focused_paginate_*` have been
+  removed ([#4584](https://github.com/matrix-org/matrix-rust-sdk/pull/4584)).
+
 ## [0.9.0] - 2024-12-18
 
 ### Bug Fixes
@@ -62,7 +69,6 @@ All notable changes to this project will be documented in this file.
 
 - `EncryptionSyncService` and `Notification` are using
   `Client::cross_process_store_locks_holder_name`.
-
 
 ### Refactor
 

--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -36,26 +36,20 @@ impl super::Timeline {
         if self.controller.is_live().await {
             Ok(self.live_paginate_backwards(num_events).await?)
         } else {
-            Ok(self.focused_paginate_backwards(num_events).await?)
+            Ok(self.controller.focused_paginate_backwards(num_events).await?)
         }
     }
 
-    /// Assuming the timeline is focused on an event, starts a forwards
-    /// pagination.
+    /// Add more events to the end of the timeline.
     ///
     /// Returns whether we hit the end of the timeline.
-    #[instrument(skip_all)]
-    pub async fn focused_paginate_forwards(&self, num_events: u16) -> Result<bool, Error> {
-        Ok(self.controller.focused_paginate_forwards(num_events).await?)
-    }
-
-    /// Assuming the timeline is focused on an event, starts a backwards
-    /// pagination.
-    ///
-    /// Returns whether we hit the start of the timeline.
-    #[instrument(skip(self), fields(room_id = ?self.room().room_id()))]
-    pub async fn focused_paginate_backwards(&self, num_events: u16) -> Result<bool, Error> {
-        Ok(self.controller.focused_paginate_backwards(num_events).await?)
+    #[instrument(skip_all, fields(room_id = ?self.room().room_id()))]
+    pub async fn paginate_forwards(&self, num_events: u16) -> Result<bool, Error> {
+        if self.controller.is_live().await {
+            Ok(true)
+        } else {
+            Ok(self.controller.focused_paginate_forwards(num_events).await?)
+        }
     }
 
     /// Paginate backwards in live mode.
@@ -64,8 +58,7 @@ impl super::Timeline {
     /// on a specific event.
     ///
     /// Returns whether we hit the start of the timeline.
-    #[instrument(skip_all, fields(room_id = ?self.room().room_id()))]
-    pub async fn live_paginate_backwards(&self, batch_size: u16) -> event_cache::Result<bool> {
+    async fn live_paginate_backwards(&self, batch_size: u16) -> event_cache::Result<bool> {
         let pagination = self.event_cache.pagination();
 
         let result = pagination

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -907,7 +907,7 @@ impl PendingEditHelper {
             .mount()
             .await;
 
-        self.timeline.live_paginate_backwards(batch_size).await.unwrap();
+        self.timeline.paginate_backwards(batch_size).await.unwrap();
     }
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -121,7 +121,7 @@ async fn test_new_focused() {
     )
     .await;
 
-    let hit_start = timeline.focused_paginate_backwards(20).await.unwrap();
+    let hit_start = timeline.paginate_backwards(20).await.unwrap();
     assert!(hit_start);
 
     server.reset().await;
@@ -161,7 +161,7 @@ async fn test_new_focused() {
     )
     .await;
 
-    let hit_start = timeline.focused_paginate_forwards(20).await.unwrap();
+    let hit_start = timeline.paginate_forwards(20).await.unwrap();
     assert!(!hit_start); // because we gave it another next2 token.
 
     server.reset().await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -76,7 +76,7 @@ async fn test_back_pagination() {
         .await;
 
     let paginate = async {
-        timeline.live_paginate_backwards(10).await.unwrap();
+        timeline.paginate_backwards(10).await.unwrap();
         server.reset().await;
     };
     let observe_paginating = async {
@@ -145,7 +145,7 @@ async fn test_back_pagination() {
         .mount(&server)
         .await;
 
-    let hit_start = timeline.live_paginate_backwards(10).await.unwrap();
+    let hit_start = timeline.paginate_backwards(10).await.unwrap();
     assert!(hit_start);
     assert_next_eq!(
         back_pagination_status,
@@ -218,7 +218,7 @@ async fn test_back_pagination_highlighted() {
         .mount(&server)
         .await;
 
-    timeline.live_paginate_backwards(10).await.unwrap();
+    timeline.paginate_backwards(10).await.unwrap();
     server.reset().await;
 
     assert_let!(Some(timeline_updates) = timeline_stream.next().await);
@@ -289,7 +289,7 @@ async fn test_wait_for_token() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
 
     let paginate = async {
-        timeline.live_paginate_backwards(10).await.unwrap();
+        timeline.paginate_backwards(10).await.unwrap();
     };
     let observe_paginating = async {
         assert_eq!(back_pagination_status.next().await, Some(LiveBackPaginationStatus::Paginating));
@@ -354,10 +354,10 @@ async fn test_dedup_pagination() {
 
     // If I try to paginate twice at the same time,
     let paginate_1 = async {
-        timeline.live_paginate_backwards(10).await.unwrap();
+        timeline.paginate_backwards(10).await.unwrap();
     };
     let paginate_2 = async {
-        timeline.live_paginate_backwards(10).await.unwrap();
+        timeline.paginate_backwards(10).await.unwrap();
     };
     timeout(Duration::from_secs(5), join(paginate_1, paginate_2)).await.unwrap();
 
@@ -443,7 +443,7 @@ async fn test_timeline_reset_while_paginating() {
 
     let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
-    let paginate = async { timeline.live_paginate_backwards(10).await.unwrap() };
+    let paginate = async { timeline.paginate_backwards(10).await.unwrap() };
 
     let observe_paginating = async {
         let mut seen_paginating = false;
@@ -608,7 +608,7 @@ async fn test_empty_chunk() {
         .await;
 
     let paginate = async {
-        timeline.live_paginate_backwards(10).await.unwrap();
+        timeline.paginate_backwards(10).await.unwrap();
         server.reset().await;
     };
     let observe_paginating = async {
@@ -719,7 +719,7 @@ async fn test_until_num_items_with_empty_chunk() {
         .await;
 
     let paginate = async {
-        timeline.live_paginate_backwards(10).await.unwrap();
+        timeline.paginate_backwards(10).await.unwrap();
     };
     let observe_paginating = async {
         assert_eq!(back_pagination_status.next().await, Some(LiveBackPaginationStatus::Paginating));
@@ -771,7 +771,7 @@ async fn test_until_num_items_with_empty_chunk() {
         assert!(date_divider.is_date_divider());
     }
 
-    timeline.live_paginate_backwards(10).await.unwrap();
+    timeline.paginate_backwards(10).await.unwrap();
 
     assert_let!(Some(timeline_updates) = timeline_stream.next().await);
 
@@ -821,7 +821,7 @@ async fn test_back_pagination_aborted() {
     let paginate = spawn({
         let timeline = timeline.clone();
         async move {
-            timeline.live_paginate_backwards(10).await.unwrap();
+            timeline.paginate_backwards(10).await.unwrap();
         }
     });
 

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -418,7 +418,7 @@ impl App {
         // Start a new one, request batches of 20 events, stop after 10 timeline items
         // have been added.
         *pagination = Some(spawn(async move {
-            if let Err(err) = sdk_timeline.live_paginate_backwards(20).await {
+            if let Err(err) = sdk_timeline.paginate_backwards(20).await {
                 // TODO: would be nice to be able to set the status
                 // message remotely?
                 //self.set_status_message(format!(


### PR DESCRIPTION
This patch simplifies the `Timeline` pagination API as follows:

- a unique `paginate_backwards` method (no more
  `focused_paginate_backwards` and `live_paginate_backwards`),
- a unique `paginate_forwards` method (no more
  `focused_paginate_forwards`, the `live` variant was absent).

The idea is to unify pagination by hiding the `live` and `focused` mode.
It was already partially the case with `paginate_backards`, but the
`live` and `focused` variants were also present. I believe it creates
an unnecessary confusion.