### PR TITLE
chore(ui): Rename `Timeline::subscribe_batched` to `Timeline::subscribe`

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -198,7 +198,7 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
                 .await
                 .expect("Could not create timeline");
 
-            let (items, _) = timeline.subscribe_batched().await;
+            let (items, _) = timeline.subscribe().await;
             assert_eq!(items.len(), PINNED_EVENTS_COUNT + 1);
             timeline.clear().await;
         });

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -212,7 +212,7 @@ pub struct UploadParameters {
 #[matrix_sdk_ffi_macros::export]
 impl Timeline {
     pub async fn add_listener(&self, listener: Box<dyn TimelineListener>) -> Arc<TaskHandle> {
-        let (timeline_items, timeline_stream) = self.inner.subscribe_batched().await;
+        let (timeline_items, timeline_stream) = self.inner.subscribe().await;
 
         Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
             pin_mut!(timeline_stream);

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -30,6 +30,11 @@ All notable changes to this project will be documented in this file.
   are unified to work on a live or focused timeline.
   `Timeline::live_paginate_*` and `Timeline::focused_paginate_*` have been
   removed ([#4584](https://github.com/matrix-org/matrix-rust-sdk/pull/4584)).
+- [**breaking**] `Timeline::subscribe_batched` replaces
+  `Timeline::subscribe`. `subscribe` has been removed in
+  [#4567](https://github.com/matrix-org/matrix-rust-sdk/pull/4567),
+  and `subscribe_batched` has been renamed to `subscribe` in
+  [#4585](https://github.com/matrix-org/matrix-rust-sdk/pull/4585).
 
 ## [0.9.0] - 2024-12-18
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -484,7 +484,6 @@ impl<P: RoomDataProvider> TimelineController<P> {
         Vector<Arc<TimelineItem>>,
         impl Stream<Item = VectorDiff<Arc<TimelineItem>>> + SendOutsideWasm,
     ) {
-        trace!("Creating timeline items signal");
         let state = self.state.read().await;
         (state.items.clone_items(), state.items.subscribe().into_stream())
     }
@@ -492,7 +491,6 @@ impl<P: RoomDataProvider> TimelineController<P> {
     pub(super) async fn subscribe_batched(
         &self,
     ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>>) {
-        trace!("Creating timeline items signal");
         let state = self.state.read().await;
         (state.items.clone_items(), state.items.subscribe().into_batched_stream())
     }
@@ -505,7 +503,6 @@ impl<P: RoomDataProvider> TimelineController<P> {
         U: Clone,
         F: Fn(Arc<TimelineItem>) -> Option<U>,
     {
-        trace!("Creating timeline items signal");
         self.state.read().await.items.subscribe().filter_map(f)
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -266,11 +266,13 @@ impl Timeline {
         }
     }
 
-    /// Get the current timeline items, and a batched stream of changes.
+    /// Get the current timeline items, along with a stream of updates of
+    /// timeline items.
     ///
-    /// This stream can yield multiple diffs at once. The batching is done such
-    /// that no arbitrary delays are added.
-    pub async fn subscribe_batched(
+    /// The stream produces `Vec<VectorDiff<_>>`, which means multiple updates
+    /// at once. There are no delays, it consumes as many updates as possible
+    /// and batches them.
+    pub async fn subscribe(
         &self,
     ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>>) {
         let (items, stream) = self.controller.subscribe_batched().await;

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2430,7 +2430,7 @@ async fn test_room_timeline() -> Result<(), Error> {
     room.init_timeline_with_builder(room.default_room_timeline_builder().await.unwrap()).await?;
     let timeline = room.timeline().unwrap();
 
-    let (previous_timeline_items, mut timeline_items_stream) = timeline.subscribe_batched().await;
+    let (previous_timeline_items, mut timeline_items_stream) = timeline.subscribe().await;
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
@@ -2493,7 +2493,7 @@ async fn test_room_empty_timeline() {
     // The room wasn't synced, but it will be available
     let room = room_list.room(&room_id).unwrap();
     let timeline = room.default_room_timeline_builder().await.unwrap().build().await.unwrap();
-    let (prev_items, _) = timeline.subscribe_batched().await;
+    let (prev_items, _) = timeline.subscribe().await;
 
     // However, since the room wasn't synced its timeline won't have any initial
     // items

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -65,7 +65,7 @@ async fn test_echo() {
             .await
             .unwrap(),
     );
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let event_id = event_id!("$ev");
 
@@ -238,7 +238,7 @@ async fn test_dedup_by_event_id_late() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let event_id = event_id!("$wWgymRfo7ri1uQx0NXO40vLJ");
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -86,7 +86,7 @@ async fn test_edit() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let event_id = event_id!("$msda7m:localhost");
     sync_builder.add_joined_room(
@@ -187,7 +187,7 @@ async fn test_edit_local_echo() {
     server.mock_room_state_encryption().plain().mount().await;
 
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let mounted_send =
         server.mock_room_send().error_too_large().mock_once().mount_as_scoped().await;
@@ -758,7 +758,7 @@ async fn test_edit_local_echo_with_unsupported_content() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
@@ -916,7 +916,7 @@ async fn test_pending_edit() {
     let mut h = PendingEditHelper::new().await;
     let f = EventFactory::new();
 
-    let (_, mut timeline_stream) = h.timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = h.timeline.subscribe().await;
 
     // When I receive an edit event for an event I don't know about…
     let original_event_id = event_id!("$original");
@@ -969,7 +969,7 @@ async fn test_pending_edit_overrides() {
     let mut h = PendingEditHelper::new().await;
     let f = EventFactory::new();
 
-    let (_, mut timeline_stream) = h.timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = h.timeline.subscribe().await;
 
     // When I receive multiple edit events for an event I don't know about…
     let original_event_id = event_id!("$original");
@@ -1024,7 +1024,7 @@ async fn test_pending_edit_from_backpagination() {
     let mut h = PendingEditHelper::new().await;
     let f = EventFactory::new();
 
-    let (_, mut timeline_stream) = h.timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = h.timeline.subscribe().await;
 
     // When I receive an edit from a back-pagination for an event I don't know
     // about…
@@ -1090,7 +1090,7 @@ async fn test_pending_edit_from_backpagination_doesnt_override_pending_edit_from
     )
     .await;
 
-    let (_, mut timeline_stream) = h.timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = h.timeline.subscribe().await;
 
     // And then I receive an edit from a back-pagination for the same event…
     let edit_event_id2 = event_id!("$edit2");
@@ -1139,7 +1139,7 @@ async fn test_pending_poll_edit() {
     let mut h = PendingEditHelper::new().await;
     let f = EventFactory::new();
 
-    let (_, mut timeline_stream) = h.timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = h.timeline.subscribe().await;
 
     // When I receive an edit event for an event I don't know about…
     let original_event_id = event_id!("$original");

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -86,7 +86,7 @@ async fn test_new_focused() {
 
     server.reset().await;
 
-    let (items, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
 
     assert_eq!(items.len(), 5 + 1); // event items + a date divider
     assert!(items[0].is_date_divider());
@@ -229,7 +229,7 @@ async fn test_focused_timeline_reacts() {
 
     server.reset().await;
 
-    let (items, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
 
     assert_eq!(items.len(), 1 + 1); // event items + a date divider
     assert!(items[0].is_date_divider());
@@ -314,7 +314,7 @@ async fn test_focused_timeline_local_echoes() {
 
     server.reset().await;
 
-    let (items, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
 
     assert_eq!(items.len(), 1 + 1); // event items + a date divider
     assert!(items[0].is_date_divider());
@@ -393,7 +393,7 @@ async fn test_focused_timeline_doesnt_show_local_echoes() {
 
     server.reset().await;
 
-    let (items, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
 
     assert_eq!(items.len(), 1 + 1); // event items + a date divider
     assert!(items[0].is_date_divider());

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -79,7 +79,7 @@ async fn test_reaction() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
@@ -190,7 +190,7 @@ async fn test_redacted_message() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
@@ -248,7 +248,7 @@ async fn test_redact_message() {
     server.mock_room_state_encryption().plain().mount().await;
 
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let factory = EventFactory::new();
     factory.set_next_ts(MilliSecondsSinceUnixEpoch::now().get().into());
@@ -327,7 +327,7 @@ async fn test_redact_local_sent_message() {
     server.mock_room_state_encryption().plain().mount().await;
 
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     // Mock event sending.
     server.mock_room_send().ok(event_id!("$wWgymRfo7ri1uQx0NXO40vLJ")).mock_once().mount().await;
@@ -420,7 +420,7 @@ async fn test_read_marker() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         sync_timeline_event!({
@@ -510,7 +510,7 @@ async fn test_sync_highlighted() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         sync_timeline_event!({
@@ -762,7 +762,7 @@ async fn test_timeline_without_encryption_info() {
     // Previously this would have panicked.
     let timeline = room.timeline().await.unwrap();
 
-    let (items, _) = timeline.subscribe_batched().await;
+    let (items, _) = timeline.subscribe().await;
     assert_eq!(items.len(), 2);
     assert!(items[0].as_virtual().is_some());
     // No encryption, no shields
@@ -794,7 +794,7 @@ async fn test_timeline_without_encryption_can_update() {
     // encryption changes
     let timeline = Timeline::builder(&room).build().await.unwrap();
 
-    let (items, mut stream) = timeline.subscribe_batched().await;
+    let (items, mut stream) = timeline.subscribe().await;
     assert_eq!(items.len(), 2);
     assert!(items[0].as_virtual().is_some());
     // No encryption, no shields

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -63,7 +63,7 @@ async fn test_back_pagination() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
     let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
     Mock::given(method("GET"))
@@ -178,7 +178,7 @@ async fn test_back_pagination_highlighted() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let response_json = json!({
         "chunk": [
@@ -579,7 +579,7 @@ async fn test_empty_chunk() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
     let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
     // It should try to do another request after the empty chunk.
@@ -681,7 +681,7 @@ async fn test_until_num_items_with_empty_chunk() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
     let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
     Mock::given(method("GET"))

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -80,7 +80,7 @@ async fn test_new_pinned_events_are_added_on_sync() {
     );
 
     // Load timeline items
-    let (items, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
 
     assert_eq!(items.len(), 1 + 1); // event item + a date divider
     assert!(items[0].is_date_divider());
@@ -171,7 +171,7 @@ async fn test_new_pinned_event_ids_reload_the_timeline() {
         "there should be no live back-pagination status for a focused timeline"
     );
 
-    let (items, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
 
     assert_eq!(items.len(), 1 + 1); // event item + a date divider
     assert!(items[0].is_date_divider());
@@ -282,7 +282,7 @@ async fn test_cached_events_are_kept_for_different_room_instances() {
         "there should be no live back-pagination status for a focused timeline"
     );
 
-    let (items, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
 
     assert!(!items.is_empty()); // We just loaded some events
     assert_pending!(timeline_stream);
@@ -306,7 +306,7 @@ async fn test_cached_events_are_kept_for_different_room_instances() {
     let timeline =
         Timeline::builder(&room).with_focus(pinned_events_focus(2)).build().await.unwrap();
 
-    let (items, _) = timeline.subscribe_batched().await;
+    let (items, _) = timeline.subscribe().await;
     assert!(!items.is_empty()); // These events came from the cache
     assert!(room_cache.event(event_id!("$1")).await.is_some());
 
@@ -367,7 +367,7 @@ async fn test_pinned_timeline_with_no_pinned_event_ids_is_just_empty() {
 
     // The timeline couldn't load any events, but it expected none, so it just
     // returns an empty list
-    let (items, _) = timeline.subscribe_batched().await;
+    let (items, _) = timeline.subscribe().await;
     assert!(items.is_empty());
 }
 
@@ -395,7 +395,7 @@ async fn test_pinned_timeline_with_no_pinned_events_and_an_utd_on_sync_is_just_e
 
     // The timeline couldn't load any events, but it expected none, so it just
     // returns an empty list
-    let (items, _) = timeline.subscribe_batched().await;
+    let (items, _) = timeline.subscribe().await;
     assert!(items.is_empty());
 }
 
@@ -418,7 +418,7 @@ async fn test_pinned_timeline_with_no_pinned_events_on_pagination_is_just_empty(
 
     // The timeline couldn't load any events, but it expected none, so it just
     // returns an empty list
-    let (pinned_items, mut pinned_events_stream) = pinned_timeline.subscribe_batched().await;
+    let (pinned_items, mut pinned_events_stream) = pinned_timeline.subscribe().await;
     assert!(pinned_items.is_empty());
 
     // Create a non-pinned event to return in the pagination
@@ -485,7 +485,7 @@ async fn test_pinned_timeline_with_pinned_utd_on_sync_contains_it() {
         Timeline::builder(&room).with_focus(pinned_events_focus(1)).build().await.unwrap();
 
     // The timeline loaded with just a day divider and the pinned UTD
-    let (items, _) = timeline.subscribe_batched().await;
+    let (items, _) = timeline.subscribe().await;
     assert_eq!(items.len(), 2);
     let pinned_utd_event = items.last().unwrap().as_event().unwrap();
     assert_eq!(pinned_utd_event.event_id().unwrap(), event_id);
@@ -523,7 +523,7 @@ async fn test_edited_events_are_reflected_in_sync() {
     );
 
     // Load timeline items
-    let (items, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
 
     assert_eq!(items.len(), 1 + 1); // event item + a date divider
     assert!(items[0].is_date_divider());
@@ -609,7 +609,7 @@ async fn test_redacted_events_are_reflected_in_sync() {
     );
 
     // Load timeline items
-    let (items, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
 
     assert_eq!(items.len(), 1 + 1); // event item + a date divider
     assert!(items[0].is_date_divider());
@@ -685,7 +685,7 @@ async fn test_edited_events_survive_pinned_event_ids_change() {
     );
 
     // Load timeline items
-    let (items, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
 
     assert_eq!(items.len(), 1 + 1); // event item + a date divider
     assert!(items[0].is_date_divider());

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -329,7 +329,7 @@ async fn test_clear_with_echoes() {
 
     // Send a message without mocking the server response.
     {
-        let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+        let (_, mut timeline_stream) = timeline.subscribe().await;
 
         timeline.send(RoomMessageEventContent::text_plain("Send failure").into()).await.unwrap();
 
@@ -408,7 +408,7 @@ async fn test_no_duplicate_date_divider() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     // Response for first message takes 200ms to respond.
     Mock::given(method("PUT"))

--- a/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
@@ -47,7 +47,7 @@ async fn test_abort_before_being_sent() {
     server.mock_room_state_encryption().plain().mount().await;
 
     let timeline = room.timeline().await.unwrap();
-    let (initial_items, mut stream) = timeline.subscribe_batched().await;
+    let (initial_items, mut stream) = timeline.subscribe().await;
 
     assert!(initial_items.is_empty());
 
@@ -202,7 +202,7 @@ async fn test_redact_failed() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (initial_items, mut stream) = timeline.subscribe_batched().await;
+    let (initial_items, mut stream) = timeline.subscribe().await;
 
     assert!(initial_items.is_empty());
 
@@ -288,7 +288,7 @@ async fn test_local_reaction_to_local_echo() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (initial_items, mut stream) = timeline.subscribe_batched().await;
+    let (initial_items, mut stream) = timeline.subscribe().await;
 
     assert!(initial_items.is_empty());
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -76,7 +76,7 @@ async fn test_read_receipts_updates() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (items, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
     let mut own_receipts_subscriber = timeline.subscribe_own_user_read_receipts_changed().await;
 
     assert!(items.is_empty());
@@ -319,7 +319,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline_builder().event_filter(filter_notice).build().await.unwrap();
-    let (items, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
 
     assert!(items.is_empty());
 
@@ -1206,7 +1206,7 @@ async fn test_latest_user_read_receipt() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (items, _) = timeline.subscribe_batched().await;
+    let (items, _) = timeline.subscribe().await;
 
     assert!(items.is_empty());
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -50,7 +50,7 @@ async fn test_in_reply_to_details() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     // The event doesn't exist.
     assert_matches!(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -289,7 +289,7 @@ async fn timeline_test_helper(
 
     let timeline = Timeline::builder(&sdk_room).track_read_marker_and_receipts().build().await?;
 
-    Ok(timeline.subscribe_batched().await)
+    Ok(timeline.subscribe().await)
 }
 
 struct SlidingSyncMatcher;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -52,7 +52,7 @@ async fn test_batched() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline_builder().event_filter(|_, _| true).build().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let hdl = tokio::spawn(async move {
         let next_batch = timeline_stream.next().await.unwrap();
@@ -93,7 +93,7 @@ async fn test_event_filter() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline_builder().event_filter(|_, _| true).build().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let first_event_id = event_id!("$YTQwYl2ply");
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
@@ -211,7 +211,7 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline_builder().build().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let alice = user_id!("@alice:example.org");
     let bob = user_id!("@bob:example.org");
@@ -329,7 +329,7 @@ async fn test_profile_updates() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline_builder().build().await.unwrap();
-    let (_, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let alice = "@alice:example.org";
     let bob = "@bob:example.org";

--- a/examples/timeline/src/main.rs
+++ b/examples/timeline/src/main.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
     // Get the timeline stream and listen to it.
     let room = client.get_room(&room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
-    let (timeline_items, mut timeline_stream) = timeline.subscribe_batched().await;
+    let (timeline_items, mut timeline_stream) = timeline.subscribe().await;
 
     println!("Initial timeline items: {timeline_items:#?}");
     tokio::spawn(async move {

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -267,7 +267,7 @@ impl App {
 
                     // Save the timeline in the cache.
                     let sdk_timeline = ui_room.timeline().unwrap();
-                    let (items, stream) = sdk_timeline.subscribe_batched().await;
+                    let (items, stream) = sdk_timeline.subscribe().await;
                     let items = Arc::new(Mutex::new(items));
 
                     // Spawn a timeline task that will listen to all the timeline item changes.

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -893,7 +893,7 @@ async fn test_delayed_invite_response_and_sent_message_decryption() {
 
     // Join the room from Bob's client.
     let bob_timeline = bob_room.timeline().await.unwrap();
-    let (_, timeline_stream) = bob_timeline.subscribe_batched().await;
+    let (_, timeline_stream) = bob_timeline.subscribe().await;
     pin_mut!(timeline_stream);
 
     info!("Bob joins the room.");

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -91,7 +91,7 @@ async fn test_toggling_reaction() -> Result<()> {
     // waiting for it.
 
     let timeline = room.timeline().await.unwrap();
-    let (mut items, mut stream) = timeline.subscribe_batched().await;
+    let (mut items, mut stream) = timeline.subscribe().await;
 
     let event_id_task: JoinHandle<Result<_>> = spawn(async move {
         let find_event_id = |items: &Vector<Arc<TimelineItem>>| {
@@ -146,7 +146,7 @@ async fn test_toggling_reaction() -> Result<()> {
     // Give a bit of time for the timeline to process all sync updates.
     sleep(Duration::from_secs(1)).await;
 
-    let (mut items, mut stream) = timeline.subscribe_batched().await;
+    let (mut items, mut stream) = timeline.subscribe().await;
 
     // Skip all stream updates that have happened so far.
     debug!("Skipping all other stream updates…");


### PR DESCRIPTION
This patch renames `Timeline::subscribe_batched` to
`Timeline::subscribe`. Since the `Timeline::subscribe` method has been
removed because unused, it no longer makes sense to have a “batched”
variant here. Let's simplify things!

---

* Follow up of https://github.com/matrix-org/matrix-rust-sdk/pull/4567/.
* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280.