### PR TITLE
feat: Add a method to remove the room topic.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -428,6 +428,12 @@ impl Room {
         Ok(())
     }
 
+    /// Removes the topic from the room if one is set.
+    pub async fn remove_topic(&self) -> Result<(), ClientError> {
+        self.inner.remove_room_topic().await?;
+        Ok(())
+    }
+
     /// Upload and set the room's avatar.
     ///
     /// This will upload the data produced by the reader to the homeserver's

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2270,6 +2270,19 @@ impl Room {
         self.send_state_event(RoomTopicEventContent::new(topic.into())).await
     }
 
+    /// Removes the topic from this room if one is set.
+    pub async fn remove_room_topic(&self) -> Result<()> {
+        let event = self
+            .get_state_event_static::<RoomTopicEventContent>()
+            .await?
+            .ok_or(Error::InsufficientData)?
+            .deserialize()?;
+        let event_id = event.event_id().ok_or(Error::InsufficientData)?;
+
+        self.redact(event_id, None, None).await.map_err(Error::Http)?;
+        Ok(())
+    }
+
     /// Sets the new avatar url for this room.
     ///
     /// # Arguments


### PR DESCRIPTION
This PR adds `Room::remove_room_topic` to allow clients to redact the topic instead of setting it to an empty string.

Closes #4588.