### PR TITLE
chore(ui): Move to a single input API for the `Timeline`, and remove many types and methods

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1577,18 +1577,6 @@ impl TimelineController {
     }
 }
 
-#[derive(Debug, Default)]
-pub(super) struct HandleManyEventsResult {
-    /// The number of items that were added to the timeline.
-    ///
-    /// Note one can't assume anything about the position at which those were
-    /// added.
-    pub items_added: u64,
-
-    /// The number of items that were updated in the timeline.
-    pub items_updated: u64,
-}
-
 async fn fetch_replied_to_event(
     mut state: RwLockWriteGuard<'_, TimelineState>,
     index: usize,

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -712,7 +712,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
             state
                 .replace_with_remote_events(
                     events,
-                    TimelineNewItemPosition::End { origin },
+                    origin,
                     &self.room_data_provider,
                     &self.settings,
                 )

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -653,30 +653,6 @@ impl<P: RoomDataProvider> TimelineController<P> {
         Ok(false)
     }
 
-    /// Handle a list of events at the given end of the timeline.
-    ///
-    /// Note: when the `position` is [`TimelineEnd::Front`], prepended events
-    /// should be ordered in *reverse* topological order, that is, `events[0]`
-    /// is the most recent.
-    ///
-    /// Returns the number of timeline updates that were made.
-    pub(super) async fn add_events_at<Events>(
-        &self,
-        events: Events,
-        position: TimelineNewItemPosition,
-    ) -> HandleManyEventsResult
-    where
-        Events: IntoIterator + ExactSizeIterator,
-        <Events as IntoIterator>::Item: Into<TimelineEvent>,
-    {
-        if events.len() == 0 {
-            return Default::default();
-        }
-
-        let mut state = self.state.write().await;
-        state.add_remote_events_at(events, position, &self.room_data_provider, &self.settings).await
-    }
-
     /// Handle updates on events as [`VectorDiff`]s.
     pub(super) async fn handle_remote_events_with_diffs(
         &self,

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -62,8 +62,8 @@ pub(super) use self::{
         ObservableItemsTransactionEntry,
     },
     state::{
-        FullEventMeta, PendingEdit, PendingEditKind, TimelineMetadata, TimelineNewItemPosition,
-        TimelineState, TimelineStateTransaction,
+        FullEventMeta, PendingEdit, PendingEditKind, TimelineMetadata, TimelineState,
+        TimelineStateTransaction,
     },
 };
 use super::{

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -49,7 +49,7 @@ use super::{
         ObservableItemsTransactionEntry,
     },
     read_receipts::ReadReceipts,
-    DateDividerMode, HandleManyEventsResult, RelativePosition, TimelineFocusKind, TimelineSettings,
+    DateDividerMode, RelativePosition, TimelineFocusKind, TimelineSettings,
 };
 use crate::{
     events::SyncTimelineEventWithoutContent,

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -69,29 +69,6 @@ use crate::{
     unable_to_decrypt_hook::UtdHookManager,
 };
 
-/// This is a simplification of [`TimelineItemPosition`] which doesn't contain
-/// the [`TimelineItemPosition::UpdateDecrypted`] variant, because it is used
-/// only for **new** items.
-#[derive(Debug)]
-pub(crate) enum TimelineNewItemPosition {
-    /// One or more items are prepended to the timeline (i.e. they're the
-    /// oldest).
-    Start { origin: RemoteEventOrigin },
-
-    /// One or more items are appended to the timeline (i.e. they're the most
-    /// recent).
-    End { origin: RemoteEventOrigin },
-}
-
-impl From<TimelineNewItemPosition> for TimelineItemPosition {
-    fn from(value: TimelineNewItemPosition) -> Self {
-        match value {
-            TimelineNewItemPosition::Start { origin } => Self::Start { origin },
-            TimelineNewItemPosition::End { origin } => Self::End { origin },
-        }
-    }
-}
-
 #[derive(Debug)]
 pub(in crate::timeline) struct TimelineState {
     pub items: ObservableItems,

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -16,6 +16,7 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
+use imbl::vector;
 use matrix_sdk::deserialized_responses::TimelineEvent;
 use matrix_sdk_test::{
     async_test, event_factory::PreviousMembership, sync_timeline_event, ALICE, BOB, CAROL,
@@ -36,7 +37,7 @@ use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
 use crate::timeline::{
-    controller::{TimelineNewItemPosition, TimelineSettings},
+    controller::TimelineSettings,
     event_item::{AnyOtherFullStateEventContent, RemoteEventOrigin},
     tests::{ReadReceiptMap, TestRoomDataProvider},
     MembershipChange, TimelineDetails, TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
@@ -50,9 +51,14 @@ async fn test_initial_events() {
     let f = &timeline.factory;
     timeline
         .controller
-        .add_events_at(
-            [f.text_msg("A").sender(*ALICE), f.text_msg("B").sender(*BOB)].into_iter(),
-            TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
+        .handle_remote_events_with_diffs(
+            vec![VectorDiff::Append {
+                values: vector![
+                    f.text_msg("A").sender(*ALICE).into_event(),
+                    f.text_msg("B").sender(*BOB).into_event()
+                ],
+            }],
+            RemoteEventOrigin::Sync,
         )
         .await;
 
@@ -93,9 +99,9 @@ async fn test_replace_with_initial_events_and_read_marker() {
 
     timeline
         .controller
-        .add_events_at(
-            [ev].into_iter(),
-            TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
+        .handle_remote_events_with_diffs(
+            vec![VectorDiff::Append { values: vector![ev] }],
+            RemoteEventOrigin::Sync,
         )
         .await;
 
@@ -282,9 +288,9 @@ async fn test_internal_id_prefix() {
 
     timeline
         .controller
-        .add_events_at(
-            [ev_a, ev_b, ev_c].into_iter(),
-            TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
+        .handle_remote_events_with_diffs(
+            vec![VectorDiff::Append { values: vector![ev_a, ev_b, ev_c] }],
+            RemoteEventOrigin::Sync,
         )
         .await;
 
@@ -449,9 +455,9 @@ async fn test_replace_with_initial_events_when_batched() {
 
     timeline
         .controller
-        .add_events_at(
-            [ev].into_iter(),
-            TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
+        .handle_remote_events_with_diffs(
+            vec![VectorDiff::Append { values: vector![ev] }],
+            RemoteEventOrigin::Sync,
         )
         .await;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -15,6 +15,7 @@
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
+use imbl::vector;
 use matrix_sdk_test::{async_test, ALICE, BOB};
 use ruma::events::{
     reaction::RedactedReactionEventContent, room::message::OriginalSyncRoomMessageEvent,
@@ -24,8 +25,8 @@ use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
 use crate::timeline::{
-    controller::TimelineNewItemPosition, event_item::RemoteEventOrigin,
-    AnyOtherFullStateEventContent, TimelineDetails, TimelineItemContent,
+    event_item::RemoteEventOrigin, AnyOtherFullStateEventContent, TimelineDetails,
+    TimelineItemContent,
 };
 
 #[async_test]
@@ -129,9 +130,13 @@ async fn test_reaction_redaction_timeline_filter() {
     // Initialise a timeline with a redacted reaction.
     timeline
         .controller
-        .add_events_at(
-            [f.redacted(*ALICE, RedactedReactionEventContent::new())].into_iter(),
-            TimelineNewItemPosition::End { origin: RemoteEventOrigin::Sync },
+        .handle_remote_events_with_diffs(
+            vec![VectorDiff::Append {
+                values: vector![f
+                    .redacted(*ALICE, RedactedReactionEventContent::new())
+                    .into_event()],
+            }],
+            RemoteEventOrigin::Sync,
         )
         .await;
     // Timeline items are actually empty.


### PR DESCRIPTION
The `Timeline` contained 2 _input API_: `add_events_at` and `handle_remote_events_with_diffs`.

Refactoring after refactoring, the former was only used by tests and by some internal API. The first patches replace uses of `add_events_at` by `handle_remote_events_with_diff` until we can remove this method.

After that, I've noticed that `add_remote_events_at` may be in a similar position. The next patches replace uses of `add_remote_events_at` by `handle_remote_events_with_diff` until we can remove this method.

Finally, the `HandleManyEventsResult` and `TimelineNewItemPosition` types are unused, and can be removed.

Everything looks simpler and a single API is used: `handle_remote_events_with_diffs`.