### PR TITLE
Introduce an offline mode for the SyncService

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -38,6 +38,7 @@ pub enum SyncServiceState {
     Running,
     Terminated,
     Error,
+    Offline,
 }
 
 impl From<MatrixSyncServiceState> for SyncServiceState {
@@ -47,6 +48,7 @@ impl From<MatrixSyncServiceState> for SyncServiceState {
             MatrixSyncServiceState::Running => Self::Running,
             MatrixSyncServiceState::Terminated => Self::Terminated,
             MatrixSyncServiceState::Error => Self::Error,
+            MatrixSyncServiceState::Offline => Self::Offline,
         }
     }
 }
@@ -71,8 +73,8 @@ impl SyncService {
         })
     }
 
-    pub async fn start(&self) {
-        self.inner.start().await;
+    pub async fn start(&self) -> Result<(), ClientError> {
+        Ok(self.inner.start().await?)
     }
 
     pub async fn stop(&self) -> Result<(), ClientError> {
@@ -115,6 +117,13 @@ impl SyncServiceBuilder {
     pub fn with_cross_process_lock(self: Arc<Self>) -> Arc<Self> {
         let this = unwrap_or_clone_arc(self);
         let builder = this.builder.with_cross_process_lock();
+        Arc::new(Self { client: this.client, builder, utd_hook: this.utd_hook })
+    }
+
+    /// Enable the "offline" mode for the [`SyncService`].
+    pub fn with_offline_mode(self: Arc<Self>) -> Arc<Self> {
+        let this = unwrap_or_clone_arc(self);
+        let builder = this.builder.with_offline_mode();
         Arc::new(Self { client: this.client, builder, utd_hook: this.utd_hook })
     }
 

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -73,12 +73,12 @@ impl SyncService {
         })
     }
 
-    pub async fn start(&self) -> Result<(), ClientError> {
-        Ok(self.inner.start().await?)
+    pub async fn start(&self) {
+        self.inner.start().await
     }
 
-    pub async fn stop(&self) -> Result<(), ClientError> {
-        Ok(self.inner.stop().await?)
+    pub async fn stop(&self) {
+        self.inner.stop().await
     }
 
     pub fn state(&self, listener: Box<dyn SyncServiceStateObserver>) -> Arc<TaskHandle> {

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file.
 - [**breaking**] Add an "offline" mode to the `SyncService`. This allows the
   `SyncService` to attempt to restart the sync automatically. It can be enabled
   with the `SyncServiceBuilder::with_offline_mode` method. Due to this addition,
-  the `SyncService::start` method now returns a `Result` type.
+  the `SyncService::stop` method has been made infallible.
   ([#4592](https://github.com/matrix-org/matrix-rust-sdk/pull/4592))
 
 ### Refactor

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -24,6 +24,12 @@ All notable changes to this project will be documented in this file.
   implement `Into<PathBuf>` also implement `Into<AttachmentSource>`.
   ([#4451](https://github.com/matrix-org/matrix-rust-sdk/pull/4451))
 
+- [**breaking**] Add an "offline" mode to the `SyncService`. This allows the
+  `SyncService` to attempt to restart the sync automatically. It can be enabled
+  with the `SyncServiceBuilder::with_offline_mode` method. Due to this addition,
+  the `SyncService::start` method now returns a `Result` type.
+  ([#4592](https://github.com/matrix-org/matrix-rust-sdk/pull/4592))
+
 ### Refactor
 
 - [**breaking**] `Timeline::paginate_forwards` and `Timeline::paginate_backwards`

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -163,7 +163,7 @@ impl SyncTaskSupervisor {
                     receiver.recv().await.unwrap_or_else(TerminationReport::supervisor_error);
 
                 match report.origin {
-                    TerminationOrigin::EncryptionSync | TerminationOrigin::RoomList => (),
+                    TerminationOrigin::EncryptionSync | TerminationOrigin::RoomList => {}
                     // Since the sync service aren't running anymore, we can only receive a report
                     // from the supervisor. It would have probably made sense to have separate
                     // channels for reports the sync services send and the user can send using the
@@ -634,7 +634,7 @@ impl SyncService {
         // Only (re)start the tasks if it's stopped or if we're in the offline mode.
         match inner.state.get() {
             // If we're already running, there's nothing to do.
-            State::Running => (),
+            State::Running => {}
             // If we're in the offline mode, first stop the service and then start it again.
             State::Offline => {
                 inner
@@ -664,7 +664,7 @@ impl SyncService {
                 // No need to stop if we were not running.
                 return;
             }
-            State::Running | State::Offline => (),
+            State::Running | State::Offline => {}
         }
 
         inner.stop().await

--- a/crates/matrix-sdk-ui/tests/integration/sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sync_service.rs
@@ -80,13 +80,13 @@ async fn test_sync_service_state() -> anyhow::Result<()> {
     assert!(sync_service.try_get_encryption_sync_permit().is_some());
 
     // After starting, the sync service is, well, running.
-    sync_service.start().await?;
+    sync_service.start().await;
     assert_next_matches!(state_stream, State::Running);
     assert!(sync_service.is_supervisor_running().await);
     assert!(sync_service.try_get_encryption_sync_permit().is_none());
 
     // Restarting while started doesn't change the current state.
-    sync_service.start().await?;
+    sync_service.start().await;
     assert_pending!(state_stream);
     assert!(sync_service.is_supervisor_running().await);
     assert!(sync_service.try_get_encryption_sync_permit().is_none());
@@ -95,7 +95,7 @@ async fn test_sync_service_state() -> anyhow::Result<()> {
     tokio::time::sleep(Duration::from_millis(300)).await;
 
     // Pausing will stop both syncs, after a bit of delay.
-    sync_service.stop().await?;
+    sync_service.stop().await;
     assert_next_matches!(state_stream, State::Idle);
     assert!(!sync_service.is_supervisor_running().await);
     assert!(sync_service.try_get_encryption_sync_permit().is_some());
@@ -150,7 +150,7 @@ async fn test_sync_service_state() -> anyhow::Result<()> {
 
     // When restarting and waiting a bit, the server gets new requests, starting at
     // the same position than just before being stopped.
-    sync_service.start().await?;
+    sync_service.start().await;
     assert_next_matches!(state_stream, State::Running);
     assert!(sync_service.is_supervisor_running().await);
     assert!(sync_service.try_get_encryption_sync_permit().is_none());
@@ -223,7 +223,7 @@ async fn test_sync_service_offline_mode() {
     {
         let _versions_guard = mock_server.mock_versions().error500().mount_as_scoped().await;
 
-        sync_service.start().await.expect("We should be able to start the sync service");
+        sync_service.start().await;
         assert_next_eq!(states, State::Running);
 
         let next_state = timeout(states.next(), Duration::from_millis(500))
@@ -259,7 +259,7 @@ async fn test_sync_service_offline_mode_stopping() {
         .await;
     mock_server.mock_versions().error500().mount().await;
 
-    sync_service.start().await.expect("We should be able to start the sync service");
+    sync_service.start().await;
     assert_next_eq!(states, State::Running);
 
     let next_state = timeout(states.next(), Duration::from_millis(500))
@@ -269,10 +269,7 @@ async fn test_sync_service_offline_mode_stopping() {
 
     assert_eq!(next_state, State::Offline, "We should have entered the offline mode");
 
-    sync_service
-        .stop()
-        .await
-        .expect("We should be able to stop the sync service when it's in the offline mode");
+    sync_service.stop().await;
 
     let next_state = timeout(states.next(), Duration::from_millis(500))
         .await
@@ -296,7 +293,7 @@ async fn test_sync_service_offline_mode_restarting() {
         .await;
     mock_server.mock_versions().error500().mount().await;
 
-    sync_service.start().await.expect("We should be able to start the sync service");
+    sync_service.start().await;
     assert_next_eq!(states, State::Running);
 
     let next_state = timeout(states.next(), Duration::from_millis(500))
@@ -306,10 +303,7 @@ async fn test_sync_service_offline_mode_restarting() {
 
     assert_eq!(next_state, State::Offline, "We should have entered the offline mode");
 
-    sync_service
-        .start()
-        .await
-        .expect("We should be able to restart the sync service when it's in the offline mode");
+    sync_service.start().await;
 
     let next_state = timeout(states.next(), Duration::from_millis(500))
         .await

--- a/crates/matrix-sdk-ui/tests/integration/sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sync_service.rs
@@ -77,13 +77,13 @@ async fn test_sync_service_state() -> anyhow::Result<()> {
     assert!(sync_service.try_get_encryption_sync_permit().is_some());
 
     // After starting, the sync service is, well, running.
-    sync_service.start().await;
+    sync_service.start().await?;
     assert_next_matches!(state_stream, State::Running);
     assert!(sync_service.is_supervisor_running().await);
     assert!(sync_service.try_get_encryption_sync_permit().is_none());
 
     // Restarting while started doesn't change the current state.
-    sync_service.start().await;
+    sync_service.start().await?;
     assert_pending!(state_stream);
     assert!(sync_service.is_supervisor_running().await);
     assert!(sync_service.try_get_encryption_sync_permit().is_none());
@@ -147,7 +147,7 @@ async fn test_sync_service_state() -> anyhow::Result<()> {
 
     // When restarting and waiting a bit, the server gets new requests, starting at
     // the same position than just before being stopped.
-    sync_service.start().await;
+    sync_service.start().await?;
     assert_next_matches!(state_stream, State::Running);
     assert!(sync_service.is_supervisor_running().await);
     assert!(sync_service.try_get_encryption_sync_permit().is_none());

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1651,7 +1651,7 @@ impl Client {
     }
 
     /// Fetches server capabilities from network; no caching.
-    async fn fetch_server_capabilities(
+    pub async fn fetch_server_capabilities(
         &self,
     ) -> HttpResult<(Box<[MatrixVersion]>, BTreeMap<String, bool>)> {
         let resp = self

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1653,13 +1653,14 @@ impl Client {
     /// Fetches server capabilities from network; no caching.
     pub async fn fetch_server_capabilities(
         &self,
+        request_config: Option<RequestConfig>,
     ) -> HttpResult<(Box<[MatrixVersion]>, BTreeMap<String, bool>)> {
         let resp = self
             .inner
             .http_client
             .send(
                 get_supported_versions::Request::new(),
-                None,
+                request_config,
                 self.homeserver().to_string(),
                 None,
                 &[MatrixVersion::V1_0],
@@ -1698,7 +1699,7 @@ impl Client {
             }
         }
 
-        let (versions, unstable_features) = self.fetch_server_capabilities().await?;
+        let (versions, unstable_features) = self.fetch_server_capabilities(None).await?;
 
         // Attempt to cache the result in storage.
         {

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -549,7 +549,9 @@ impl SlidingSync {
             request,
             // Configure long-polling. We need some time for the long-poll itself,
             // and extra time for the network delays.
-            RequestConfig::default().timeout(self.inner.poll_timeout + self.inner.network_timeout),
+            RequestConfig::default()
+                .timeout(self.inner.poll_timeout + self.inner.network_timeout)
+                .retry_limit(3),
             position_guard,
         ))
     }

--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -912,6 +912,12 @@ impl MatrixMockServer {
         let mock = Mock::given(method("POST")).and(path_regex(r"^/_matrix/client/v3/rooms/.*/ban"));
         MockEndpoint { mock, server: &self.server, endpoint: BanUserEndpoint }
     }
+
+    /// Creates a prebuilt mock for the `/_matrix/client/versions` endpoint.
+    pub fn mock_versions(&self) -> MockEndpoint<'_, VersionsEndpoint> {
+        let mock = Mock::given(method("GET")).and(path_regex(r"^/_matrix/client/versions"));
+        MockEndpoint { mock, server: &self.server, endpoint: VersionsEndpoint }
+    }
 }
 
 /// Parameter to [`MatrixMockServer::sync_room`].
@@ -2234,6 +2240,43 @@ impl<'a> MockEndpoint<'a, BanUserEndpoint> {
     /// Returns a successful ban user request.
     pub fn ok(self) -> MatrixMock<'a> {
         let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+/// A prebuilt mock for `GET /versions` request.
+pub struct VersionsEndpoint;
+
+impl<'a> MockEndpoint<'a, VersionsEndpoint> {
+    /// Returns a successful `/_matrix/client/versions` request.
+    ///
+    /// The response will return some commonly supported versions.
+    pub fn ok(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "unstable_features": {
+            },
+            "versions": [
+                "r0.0.1",
+                "r0.2.0",
+                "r0.3.0",
+                "r0.4.0",
+                "r0.5.0",
+                "r0.6.0",
+                "r0.6.1",
+                "v1.1",
+                "v1.2",
+                "v1.3",
+                "v1.4",
+                "v1.5",
+                "v1.6",
+                "v1.7",
+                "v1.8",
+                "v1.9",
+                "v1.10",
+                "v1.11"
+            ]
+        })));
+
         MatrixMock { server: self.server, mock }
     }
 }

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -491,7 +491,7 @@ impl OidcCli {
     async fn watch_sliding_sync(&self) -> anyhow::Result<()> {
         let sync_service = Arc::new(SyncService::builder(self.client.clone()).build().await?);
 
-        sync_service.start().await;
+        sync_service.start().await?;
 
         println!("press enter to exit the sync loop");
 
@@ -533,7 +533,7 @@ impl OidcCli {
                                     }
                                 }
 
-                                matrix_sdk_ui::sync_service::State::Error => {
+                                matrix_sdk_ui::sync_service::State::Error | matrix_sdk_ui::sync_service::State::Offline => {
                                     num_errors += 1;
                                     num_running = 0;
 
@@ -542,7 +542,7 @@ impl OidcCli {
                                         break;
                                     }
 
-                                    sync_service_clone.start().await;
+                                    sync_service_clone.start().await.expect("We should be able to start the sync service");
                                 }
                             }
                             println!("New sync service state update: {state:?}");

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -491,7 +491,7 @@ impl OidcCli {
     async fn watch_sliding_sync(&self) -> anyhow::Result<()> {
         let sync_service = Arc::new(SyncService::builder(self.client.clone()).build().await?);
 
-        sync_service.start().await?;
+        sync_service.start().await;
 
         println!("press enter to exit the sync loop");
 
@@ -542,7 +542,7 @@ impl OidcCli {
                                         break;
                                     }
 
-                                    sync_service_clone.start().await.expect("We should be able to start the sync service");
+                                    sync_service_clone.start().await;
                                 }
                             }
                             println!("New sync service state update: {state:?}");
@@ -553,10 +553,7 @@ impl OidcCli {
 
                     _ = stdin.read_line(&mut _unused) => {
                         println!("Stopping loop because of user request");
-
-                        if let Err(err) = sync_service.stop().await {
-                            println!("Error when stopping the sync service: {err}");
-                        }
+                        sync_service.stop().await;
 
                         break;
                     }

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -300,7 +300,7 @@ impl App {
 
         // This will sync (with encryption) until an error happens or the program is
         // stopped.
-        sync_service.start().await;
+        sync_service.start().await?;
 
         Ok(Self {
             sync_service,
@@ -479,7 +479,7 @@ impl App {
                                 }
                             }
 
-                            Char('s') => self.sync_service.start().await,
+                            Char('s') => self.sync_service.start().await?,
                             Char('S') => self.sync_service.stop().await?,
 
                             Char('Q') => {

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -300,7 +300,7 @@ impl App {
 
         // This will sync (with encryption) until an error happens or the program is
         // stopped.
-        sync_service.start().await?;
+        sync_service.start().await;
 
         Ok(Self {
             sync_service,
@@ -479,8 +479,8 @@ impl App {
                                 }
                             }
 
-                            Char('s') => self.sync_service.start().await?,
-                            Char('S') => self.sync_service.stop().await?,
+                            Char('s') => self.sync_service.start().await,
+                            Char('S') => self.sync_service.stop().await,
 
                             Char('Q') => {
                                 let q = self.client.send_queue();
@@ -565,7 +565,7 @@ impl App {
             }
         });
 
-        self.sync_service.stop().await?;
+        self.sync_service.stop().await;
         self.listen_task.abort();
         for timeline in self.timelines.lock().unwrap().values() {
             timeline.task.abort();

--- a/testing/matrix-sdk-integration-testing/src/tests/nse.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/nse.rs
@@ -309,21 +309,21 @@ impl ClientWrapper {
         F: Fn() -> R,
         R: Future<Output = Option<S>>,
     {
-        self.sync_service.start().await.expect("We should be able to start the sync service");
+        self.sync_service.start().await;
 
         // Repeatedly call f until it returns Some
         let end_time = Instant::now() + timeout();
         while Instant::now() < end_time {
             if let Some(ans) = f().await {
                 // We found what we were looking for
-                self.sync_service.stop().await.expect("Failed to stop sync service");
+                self.sync_service.stop().await;
                 return Some(ans);
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
 
         // We timed out
-        self.sync_service.stop().await.expect("Failed to stop sync service");
+        self.sync_service.stop().await;
         None
     }
 }

--- a/testing/matrix-sdk-integration-testing/src/tests/nse.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/nse.rs
@@ -309,7 +309,7 @@ impl ClientWrapper {
         F: Fn() -> R,
         R: Future<Output = Option<S>>,
     {
-        self.sync_service.start().await;
+        self.sync_service.start().await.expect("We should be able to start the sync service");
 
         // Repeatedly call f until it returns Some
         let end_time = Instant::now() + timeout();

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -564,7 +564,7 @@ async fn test_room_keys_received_on_notification_client_trigger_redecryption() {
 
     // Sync once to get access to the room.
     let sync_service = SyncService::builder(bob.clone()).build().await.expect("Wat");
-    sync_service.start().await;
+    sync_service.start().await.expect("We should be able to start the sync service");
 
     let bob_rooms = sync_service
         .room_list_service()

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -564,7 +564,7 @@ async fn test_room_keys_received_on_notification_client_trigger_redecryption() {
 
     // Sync once to get access to the room.
     let sync_service = SyncService::builder(bob.clone()).build().await.expect("Wat");
-    sync_service.start().await.expect("We should be able to start the sync service");
+    sync_service.start().await;
 
     let bob_rooms = sync_service
         .room_list_service()
@@ -610,7 +610,7 @@ async fn test_room_keys_received_on_notification_client_trigger_redecryption() {
         .expect("We should be able to load the room list");
 
     // Let's stop the sync so we don't receive the room key using the usual channel.
-    sync_service.stop().await.expect("We should be able to stop the sync service");
+    sync_service.stop().await;
 
     debug!("Alice sends the message");
     let event_id = alice_room


### PR DESCRIPTION
There are a couple of preparation commits before we come to the meat of this PR, due to this a review commit by commit is advised.

The offline mode attempts to allow users of the UI crate to delegate the restarting of the `SyncService` to the SDK itself. While in offline mode, we're attempting to see if the server is back online using the `/_matrix/client/versions` endpoint. Once we can find the homeserver using the `/versions` endpoint we attempt to sync again.