### PR TITLE
feat(ui): Implement `Timeline` lazy pagination

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -64,6 +64,6 @@ allow-git = [
     # We can release vodozemac whenever we need but let's not block development
     # on releases.
     "https://github.com/matrix-org/vodozemac",
-    # Waiting for features to land in `eyeball .
-    "https://github.com/Hywan/eyeball",
+    # Waiting for features to be released.
+    "https://github.com/jplatte/eyeball",
 ]

--- a/.deny.toml
+++ b/.deny.toml
@@ -64,4 +64,6 @@ allow-git = [
     # We can release vodozemac whenever we need but let's not block development
     # on releases.
     "https://github.com/matrix-org/vodozemac",
+    # Waiting for features to land in `eyeball .
+    "https://github.com/Hywan/eyeball",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "eyeball"
 version = "0.8.8"
-source = "git+https://github.com/Hywan/eyeball?branch=feat-im-util-skip#23104aeb9acf128c5f7d3e8e73ddbca25e88d9f4"
+source = "git+https://github.com/jplatte/eyeball?branch=main#b4ca8997db0ee3767bbc08a2aec788cac05c55ac"
 dependencies = [
  "futures-core",
  "readlock",
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "eyeball-im"
 version = "0.6.0"
-source = "git+https://github.com/Hywan/eyeball?branch=feat-im-util-skip#23104aeb9acf128c5f7d3e8e73ddbca25e88d9f4"
+source = "git+https://github.com/jplatte/eyeball?branch=main#b4ca8997db0ee3767bbc08a2aec788cac05c55ac"
 dependencies = [
  "futures-core",
  "imbl",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "eyeball-im-util"
 version = "0.8.0"
-source = "git+https://github.com/Hywan/eyeball?branch=feat-im-util-skip#23104aeb9acf128c5f7d3e8e73ddbca25e88d9f4"
+source = "git+https://github.com/jplatte/eyeball?branch=main#b4ca8997db0ee3767bbc08a2aec788cac05c55ac"
 dependencies = [
  "arrayvec",
  "eyeball-im",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,8 +1755,7 @@ dependencies = [
 [[package]]
 name = "eyeball"
 version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93bd0ebf93d61d6332d3c09a96e97975968a44e19a64c947bde06e6baff383f"
+source = "git+https://github.com/Hywan/eyeball?branch=feat-im-util-skip#23104aeb9acf128c5f7d3e8e73ddbca25e88d9f4"
 dependencies = [
  "futures-core",
  "readlock",
@@ -1769,8 +1768,7 @@ dependencies = [
 [[package]]
 name = "eyeball-im"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad276eb017655257443d34f27455f60e8b02b839c6ebcaa8d6f06cc498784e8f"
+source = "git+https://github.com/Hywan/eyeball?branch=feat-im-util-skip#23104aeb9acf128c5f7d3e8e73ddbca25e88d9f4"
 dependencies = [
  "futures-core",
  "imbl",
@@ -1781,8 +1779,7 @@ dependencies = [
 [[package]]
 name = "eyeball-im-util"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac7f06ce388e4f64876ad3836b275d0972ab64ae8bd8456862d5ebdb7bec4f5"
+source = "git+https://github.com/Hywan/eyeball?branch=feat-im-util-skip#23104aeb9acf128c5f7d3e8e73ddbca25e88d9f4"
 dependencies = [
  "arrayvec",
  "eyeball-im",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ as_variant = "1.2.0"
 base64 = "0.22.1"
 byteorder = "1.5.0"
 chrono = "0.4.39"
-eyeball = { version = "0.8.8", features = ["tracing"] }
-eyeball-im = { version = "0.6.0", features = ["tracing"] }
-eyeball-im-util = "0.8.0"
+eyeball = { git = "https://github.com/Hywan/eyeball", branch = "feat-im-util-skip", features = ["tracing"] }
+eyeball-im = { git = "https://github.com/Hywan/eyeball", branch = "feat-im-util-skip", features = ["tracing"] }
+eyeball-im-util = { git = "https://github.com/Hywan/eyeball", branch = "feat-im-util-skip" }
 futures-core = "0.3.31"
 futures-executor = "0.3.31"
 futures-util = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ as_variant = "1.2.0"
 base64 = "0.22.1"
 byteorder = "1.5.0"
 chrono = "0.4.39"
-eyeball = { git = "https://github.com/Hywan/eyeball", branch = "feat-im-util-skip", features = ["tracing"] }
-eyeball-im = { git = "https://github.com/Hywan/eyeball", branch = "feat-im-util-skip", features = ["tracing"] }
-eyeball-im-util = { git = "https://github.com/Hywan/eyeball", branch = "feat-im-util-skip" }
+eyeball = { git = "https://github.com/jplatte/eyeball", branch = "main", features = ["tracing"] }
+eyeball-im = { git = "https://github.com/jplatte/eyeball", branch = "main", features = ["tracing"] }
+eyeball-im-util = { git = "https://github.com/jplatte/eyeball", branch = "main" }
 futures-core = "0.3.31"
 futures-executor = "0.3.31"
 futures-util = "0.3.31"

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -339,11 +339,11 @@ pub(in crate::timeline) struct EventMeta {
     /// +-------+-------------------+----------------------+
     /// | 0     | content of `$ev0` |                      |
     /// | 1     | content of `$ev2` | reaction with `$ev4` |
-    /// | 2     | day divider       |                      |
+    /// | 2     | date divider      |                      |
     /// | 3     | content of `$ev3` |                      |
     /// | 4     | content of `$ev5` |                      |
     ///
-    /// Note the day divider that is a virtual item. Also note `$ev4` which is
+    /// Note the date divider that is a virtual item. Also note `$ev4` which is
     /// a reaction to `$ev2`. Finally note that `$ev1` is not rendered in
     /// the timeline.
     ///

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -20,7 +20,8 @@ use tracing::trace;
 
 use super::{
     super::{
-        reactions::Reactions, rfind_event_by_id, TimelineItem, TimelineItemKind, TimelineUniqueId,
+        reactions::Reactions, rfind_event_by_id, subscriber::skip::SkipCount, TimelineItem,
+        TimelineItemKind, TimelineUniqueId,
     },
     read_receipts::ReadReceipts,
     state::PendingPollEvents,
@@ -36,6 +37,8 @@ pub(in crate::timeline) struct TimelineMetadata {
     ///
     /// This value is constant over the lifetime of the metadata.
     internal_id_prefix: Option<String>,
+
+    pub(super) subscriber_skip_count: SkipCount,
 
     /// The hook to call whenever we run into a unable-to-decrypt event.
     ///
@@ -107,6 +110,7 @@ impl TimelineMetadata {
         is_room_encrypted: Option<bool>,
     ) -> Self {
         Self {
+            subscriber_skip_count: SkipCount::new(),
             own_user_id,
             next_internal_id: Default::default(),
             reactions: Default::default(),

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -38,6 +38,8 @@ pub(in crate::timeline) struct TimelineMetadata {
     /// This value is constant over the lifetime of the metadata.
     internal_id_prefix: Option<String>,
 
+    /// The `count` value for the `Skip higher-order stream used by the
+    /// `TimelineSubscriber`. See its documentation to learn more.
     pub(super) subscriber_skip_count: SkipCount,
 
     /// The hook to call whenever we run into a unable-to-decrypt event.

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -317,7 +317,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
         match &*focus_guard {
             TimelineFocusData::Live => {
                 // Retrieve the cached events, and add them to the timeline.
-                let (events, _) =
+                let (events, _stream) =
                     room_event_cache.subscribe().await.map_err(Error::EventCacheError)?;
 
                 let has_events = !events.is_empty();

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -170,7 +170,7 @@ impl Default for TimelineSettings {
 }
 
 #[derive(Debug, Clone, Copy)]
-enum TimelineFocusKind {
+pub(super) enum TimelineFocusKind {
     Live,
     Event,
     PinnedEvents,

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -496,11 +496,15 @@ impl<P: RoomDataProvider> TimelineController<P> {
         (state.items.clone_items(), state.items.subscribe().into_stream())
     }
 
-    pub(super) async fn subscribe_batched(
+    pub(super) async fn subscribe_batched_and_limited(
         &self,
     ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>>) {
         let state = self.state.read().await;
-        state.items.subscribe().into_values_and_batched_stream()
+        state
+            .items
+            .subscribe()
+            .into_values_and_batched_stream()
+            .dynamic_skip_with_initial_count(0, state.meta.subscriber_skip_count.subscribe())
     }
 
     pub(super) async fn subscribe_filter_map<U, F>(

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -500,7 +500,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
         &self,
     ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>>) {
         let state = self.state.read().await;
-        (state.items.clone_items(), state.items.subscribe().into_batched_stream())
+        state.items.subscribe().into_values_and_batched_stream()
     }
 
     pub(super) async fn subscribe_filter_map<U, F>(

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -507,7 +507,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
     }
 
     #[cfg(test)]
-    pub(super) async fn subscribe(
+    pub(super) async fn subscribe_raw(
         &self,
     ) -> (
         Vector<Arc<TimelineItem>>,

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -58,7 +58,7 @@ pub(in crate::timeline) struct TimelineState {
     pub meta: TimelineMetadata,
 
     /// The kind of focus of this timeline.
-    pub(super) timeline_focus: TimelineFocusKind,
+    pub timeline_focus: TimelineFocusKind,
 }
 
 impl TimelineState {

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -58,7 +58,7 @@ pub(in crate::timeline) struct TimelineState {
     pub meta: TimelineMetadata,
 
     /// The kind of focus of this timeline.
-    timeline_focus: TimelineFocusKind,
+    pub(super) timeline_focus: TimelineFocusKind,
 }
 
 impl TimelineState {
@@ -285,15 +285,7 @@ impl TimelineState {
     }
 
     pub(super) fn transaction(&mut self) -> TimelineStateTransaction<'_> {
-        let items = self.items.transaction();
-        let meta = self.meta.clone();
-
-        TimelineStateTransaction {
-            items,
-            previous_meta: &mut self.meta,
-            meta,
-            timeline_focus: self.timeline_focus,
-        }
+        TimelineStateTransaction::new(&mut self.items, &mut self.meta, self.timeline_focus)
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -276,7 +276,7 @@ impl Timeline {
     pub async fn subscribe(
         &self,
     ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>>) {
-        let (items, stream) = self.controller.subscribe_batched().await;
+        let (items, stream) = self.controller.subscribe_batched_and_limited().await;
         let stream = TimelineWithDropHandle::new(stream, self.drop_handle.clone());
         (items, stream)
     }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -52,7 +52,7 @@ use ruma::{
     serde::Raw,
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, RoomVersionId, UserId,
 };
-use subscriber::TimelineStream;
+use subscriber::TimelineWithDropHandle;
 use thiserror::Error;
 use tracing::{error, instrument, trace, warn};
 
@@ -277,7 +277,7 @@ impl Timeline {
         &self,
     ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>>) {
         let (items, stream) = self.controller.subscribe_batched().await;
-        let stream = TimelineStream::new(stream, self.drop_handle.clone());
+        let stream = TimelineWithDropHandle::new(stream, self.drop_handle.clone());
         (items, stream)
     }
 
@@ -811,7 +811,7 @@ impl Timeline {
         f: impl Fn(Arc<TimelineItem>) -> Option<U>,
     ) -> (Vector<U>, impl Stream<Item = VectorDiff<U>>) {
         let (items, stream) = self.controller.subscribe_filter_map(f).await;
-        let stream = TimelineStream::new(stream, self.drop_handle.clone());
+        let stream = TimelineWithDropHandle::new(stream, self.drop_handle.clone());
         (items, stream)
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -276,7 +276,7 @@ impl Timeline {
     pub async fn subscribe(
         &self,
     ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>>) {
-        let (items, stream) = self.controller.subscribe_batched_and_limited().await;
+        let (items, stream) = self.controller.subscribe().await;
         let stream = TimelineWithDropHandle::new(stream, self.drop_handle.clone());
         (items, stream)
     }

--- a/crates/matrix-sdk-ui/src/timeline/subscriber.rs
+++ b/crates/matrix-sdk-ui/src/timeline/subscriber.rs
@@ -1,0 +1,49 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use futures_core::Stream;
+use pin_project_lite::pin_project;
+
+use super::TimelineDropHandle;
+
+pin_project! {
+    pub(super) struct TimelineStream<S> {
+        #[pin]
+        inner: S,
+        drop_handle: Arc<TimelineDropHandle>,
+    }
+}
+
+impl<S> TimelineStream<S> {
+    pub fn new(inner: S, drop_handle: Arc<TimelineDropHandle>) -> Self {
+        Self { inner, drop_handle }
+    }
+}
+
+impl<S> Stream for TimelineStream<S>
+where
+    S: Stream,
+{
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().inner.poll_next(cx)
+    }
+}

--- a/crates/matrix-sdk-ui/src/timeline/subscriber.rs
+++ b/crates/matrix-sdk-ui/src/timeline/subscriber.rs
@@ -24,20 +24,23 @@ use pin_project_lite::pin_project;
 use super::TimelineDropHandle;
 
 pin_project! {
-    pub(super) struct TimelineStream<S> {
+    /// A stream that wraps a [`TimelineDropHandle`] so that the `Timeline`
+    /// isn't dropped until the `Stream` is dropped.
+    pub(super) struct TimelineWithDropHandle<S> {
         #[pin]
         inner: S,
         drop_handle: Arc<TimelineDropHandle>,
     }
 }
 
-impl<S> TimelineStream<S> {
-    pub fn new(inner: S, drop_handle: Arc<TimelineDropHandle>) -> Self {
+impl<S> TimelineWithDropHandle<S> {
+    /// Create a new [`WithTimelineDropHandle`].
+    pub(super) fn new(inner: S, drop_handle: Arc<TimelineDropHandle>) -> Self {
         Self { inner, drop_handle }
     }
 }
 
-impl<S> Stream for TimelineStream<S>
+impl<S> Stream for TimelineWithDropHandle<S>
 where
     S: Stream,
 {

--- a/crates/matrix-sdk-ui/src/timeline/subscriber.rs
+++ b/crates/matrix-sdk-ui/src/timeline/subscriber.rs
@@ -59,7 +59,7 @@ pub mod skip {
 
     const MAXIMUM_NUMBER_OF_INITIAL_ITEMS: usize = 20;
 
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SkipCount {
         count: SharedObservable<usize>,
     }

--- a/crates/matrix-sdk-ui/src/timeline/subscriber.rs
+++ b/crates/matrix-sdk-ui/src/timeline/subscriber.rs
@@ -87,7 +87,12 @@ impl TimelineSubscriber {
         let (initial_values, stream) = observable_items
             .subscribe()
             .into_values_and_batched_stream()
-            .dynamic_skip_with_initial_count(0, observable_skip_count.subscribe());
+            .dynamic_skip_with_initial_count(
+                // The `SkipCount` value may have been modified before the subscriber is
+                // created. Let's use the current value instead of hardcoding it to 0.
+                observable_skip_count.get(),
+                observable_skip_count.subscribe(),
+            );
 
         (initial_values, Self { inner: stream })
     }

--- a/crates/matrix-sdk-ui/src/timeline/subscriber.rs
+++ b/crates/matrix-sdk-ui/src/timeline/subscriber.rs
@@ -50,3 +50,349 @@ where
         self.project().inner.poll_next(cx)
     }
 }
+
+pub mod skip {
+    use eyeball::SharedObservable;
+    use futures_core::Stream;
+
+    use super::super::controller::TimelineFocusKind;
+
+    const MAXIMUM_NUMBER_OF_INITIAL_ITEMS: usize = 20;
+
+    #[derive(Clone)]
+    pub struct SkipCount {
+        count: SharedObservable<usize>,
+    }
+
+    impl SkipCount {
+        pub fn new() -> Self {
+            Self { count: SharedObservable::new(0) }
+        }
+
+        /// Compute the `count` value for [the `Skip` higher-order
+        /// stream][`Skip`].
+        ///
+        /// This is useful when new items are inserted, removed and so on.
+        ///
+        /// [`Skip`]: eyeball_im_util::vector::Skip
+        pub fn compute_next(
+            &self,
+            previous_number_of_items: usize,
+            next_number_of_items: usize,
+        ) -> usize {
+            let current_count = self.count.get();
+
+            // Initial states: no items are present.
+            if previous_number_of_items == 0 {
+                // Adjust the count to provide a maximum number of initial items. We want to
+                // skip the first items until we get a certain number of items to display.
+                //
+                // | `next_number_of_items` | `MAX…` | output | will display |
+                // |------------------------|--------|--------|--------------|
+                // | 60                     | 20     | 40     | 20 items     |
+                // | 10                     | 20     | 0      | 10 items     |
+                // | 0                      | 20     | 0      | 0 item       |
+                //
+                next_number_of_items.saturating_sub(MAXIMUM_NUMBER_OF_INITIAL_ITEMS)
+            }
+            // Not the initial state: there are items.
+            else {
+                // There are less items than before. Shift to the left `count` by the difference
+                // between `previous_number_of_items` and `next_number_of_items` to keep the
+                // same number of items in the stream as much as possible.
+                //
+                // This is not a backwards pagination, it cannot “go below 0”, however this is
+                // necessary to handle the case where the timeline is cleared and
+                // the number of items becomes 0 for example.
+                if next_number_of_items < previous_number_of_items {
+                    current_count.saturating_sub(previous_number_of_items - next_number_of_items)
+                }
+                // Return `current_count` with no modification, we don't want to adjust the
+                // count, we want to see all initial items and new items.
+                else {
+                    current_count
+                }
+            }
+        }
+
+        /// Compute the `count` value for [the `Skip` higher-order
+        /// stream][`Skip`] when a backwards pagination is happening.
+        ///
+        /// It returns the new value for `count` in addition to
+        /// `Some(number_of_items)` to fulfill the page up to `page_size`,
+        /// `None` otherwise. For example, assuming a `page_size` of 15,
+        /// if the `count` moves from 10 to 0, then 10 new items will
+        /// appear in the stream, but 5 are missing because they aren't
+        /// present in the stream: the stream has reached its beginning:
+        /// `Some(5)` will be returned. This is useful
+        /// for the pagination mechanism to fill the timeline with more items,
+        /// either from a storage, or from the network.
+        ///
+        /// [`Skip`]: eyeball_im_util::vector::Skip
+        pub fn compute_next_when_paginating_backwards(
+            &self,
+            page_size: usize,
+        ) -> (usize, Option<usize>) {
+            let current_count = self.count.get();
+
+            // We skip the values from the start of the timeline; paginating backwards means
+            // we have to reduce the count until reaching 0.
+            //
+            // | `current_count` | `page_size` | output         |
+            // |-----------------|-------------|----------------|
+            // | 50              | 20          | (30, None)     |
+            // | 30              | 20          | (10, None)     |
+            // | 10              | 20          | (0, Some(10))  |
+            // | 0               | 20          | (0, Some(20))  |
+            //                                    ^  ^^^^^^^^
+            //                                    |  |
+            //                                    |  it needs 20 items to fulfill the
+            //                                    |  page size
+            //                                    count becomes 0
+            //
+            if current_count >= page_size {
+                (current_count - page_size, None)
+            } else {
+                (0, Some(page_size - current_count))
+            }
+        }
+
+        /// Compute the `count` value for [the `Skip` higher-order
+        /// stream][`Skip`] when a forwards pagination is happening.
+        ///
+        /// The `page_size` is present to mimic the
+        /// [`compute_count_when_paginating_backwards`] function but it is
+        /// actually useless for the current implementation.
+        ///
+        /// [`Skip`]: eyeball_im_util::vector::Skip
+        #[allow(unused)] // this is not used yet because only a live timeline is using it, but as soon as
+                         // other kind of timelines will use it, we would need it, it's better to have
+                         // this in case of; everything is tested, the logic is made more robust.
+        pub fn compute_next_when_paginating_forwards(&self, _page_size: usize) -> usize {
+            // Nothing to do, the count remains unchanged as we skip the first values, not
+            // the last values; paginating forwards will add items at the end, not at the
+            // start of the timeline.
+            self.count.get()
+        }
+
+        /// Get the current count value.
+        pub fn get(&self) -> usize {
+            self.count.get()
+        }
+
+        /// Subscribe to updates of the count value.
+        pub fn subscribe(&self) -> Subscriber<usize> {
+            self.count.subscribe()
+        }
+
+        /// Update the skip count if and only if the timeline has a live focus
+        /// ([`TimelineFocusKind::Live`]).
+        pub fn update(&self, count: usize, focus_kind: &TimelineFocusKind) {
+            if matches!(focus_kind, TimelineFocusKind::Live) {
+                self.count.set_if_not_eq(count);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::SkipCount;
+
+        #[test]
+        fn test_compute_count_from_underflowing_initial_states() {
+            let skip_count = SkipCount::new();
+
+            // Initial state with too few new items. None is skipped.
+            let previous_number_of_items = 0;
+            let next_number_of_items = previous_number_of_items + 10;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 0);
+            skip_count.count.set(count);
+
+            // Add 5 new items. The count stays at 0 because we don't want to skip the
+            // previous items.
+            let previous_number_of_items = next_number_of_items;
+            let next_number_of_items = previous_number_of_items + 5;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 0);
+            skip_count.count.set(count);
+
+            // Add 20 new items. The count stays at 0 because we don't want to
+            // skip the previous items.
+            let previous_number_of_items = next_number_of_items;
+            let next_number_of_items = previous_number_of_items + 20;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 0);
+            skip_count.count.set(count);
+
+            // Remove a certain number of items. The count stays at 0 because it was
+            // previously 0, no items are skipped, nothing to adjust.
+            let previous_number_of_items = next_number_of_items;
+            let next_number_of_items = previous_number_of_items - 4;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 0);
+            skip_count.count.set(count);
+
+            // Remove all items. The count goes to 0 (regardless it was 0 before).
+            let previous_number_of_items = next_number_of_items;
+            let next_number_of_items = 0;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 0);
+        }
+
+        #[test]
+        fn test_compute_count_from_overflowing_initial_states() {
+            let skip_count = SkipCount::new();
+
+            // Initial state with too much new items. Some are skipped.
+            let previous_number_of_items = 0;
+            let next_number_of_items = previous_number_of_items + 30;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 10);
+            skip_count.count.set(count);
+
+            // Add 5 new items. The count stays at 10 because we don't want to skip the
+            // previous items.
+            let previous_number_of_items = next_number_of_items;
+            let next_number_of_items = previous_number_of_items + 5;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 10);
+            skip_count.count.set(count);
+
+            // Add 20 new items. The count stays at 10 because we don't want to
+            // skip the previous items.
+            let previous_number_of_items = next_number_of_items;
+            let next_number_of_items = previous_number_of_items + 20;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 10);
+            skip_count.count.set(count);
+
+            // Remove a certain number of items. The count is reduced by 5 so that the same
+            // number of items are presented.
+            let previous_number_of_items = next_number_of_items;
+            let next_number_of_items = previous_number_of_items - 4;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 6);
+            skip_count.count.set(count);
+
+            // Remove all items. The count goes to 0 (regardless it was 6 before).
+            let previous_number_of_items = next_number_of_items;
+            let next_number_of_items = 0;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 0);
+        }
+
+        #[test]
+        fn test_compute_count_when_paginating_backwards_from_underflowing_initial_states() {
+            let skip_count = SkipCount::new();
+
+            // Initial state with too few new items. None is skipped.
+            let previous_number_of_items = 0;
+            let next_number_of_items = previous_number_of_items + 10;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 0);
+            skip_count.count.set(count);
+
+            // Add 30 new items. The count stays at 0 because we don't want to skip the
+            // previous items.
+            let previous_number_of_items = next_number_of_items;
+            let next_number_of_items = previous_number_of_items + 30;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 0);
+            skip_count.count.set(count);
+
+            let page_size = 20;
+
+            // Paginate backwards.
+            let (count, needs) = skip_count.compute_next_when_paginating_backwards(page_size);
+            assert_eq!(count, 0);
+            assert_eq!(needs, Some(20));
+        }
+
+        #[test]
+        fn test_compute_count_when_paginating_backwards_from_overflowing_initial_states() {
+            let skip_count = SkipCount::new();
+
+            // Initial state with too much new items. Some are skipped.
+            let previous_number_of_items = 0;
+            let next_number_of_items = previous_number_of_items + 50;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 30);
+            skip_count.count.set(count);
+
+            // Add 30 new items. The count stays at 30 because we don't want to
+            // skip the previous items.
+            let previous_number_of_items = next_number_of_items;
+            let next_number_of_items = previous_number_of_items + 30;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 30);
+            skip_count.count.set(count);
+
+            let page_size = 20;
+
+            // Paginate backwards. The count shifts by `page_size`, and the page is full.
+            let (count, needs) = skip_count.compute_next_when_paginating_backwards(page_size);
+            assert_eq!(count, 10);
+            assert_eq!(needs, None);
+            skip_count.count.set(count);
+
+            // Paginate backwards. The count shifts by `page_size` but reaches 0 before the
+            // page becomes full. It needs 10 more items to fulfill the page.
+            let (count, needs) = skip_count.compute_next_when_paginating_backwards(page_size);
+            assert_eq!(count, 0);
+            assert_eq!(needs, Some(10));
+        }
+
+        #[test]
+        fn test_compute_count_when_paginating_forwards_from_underflowing_initial_states() {
+            let skip_count = SkipCount::new();
+
+            // Initial state with too few new items. None is skipped.
+            let previous_number_of_items = 0;
+            let next_number_of_items = previous_number_of_items + 10;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 0);
+            skip_count.count.set(count);
+
+            // Add 30 new items. The count stays at 0 because we don't want to skip the
+            // previous items.
+            let previous_number_of_items = next_number_of_items;
+            let next_number_of_items = previous_number_of_items + 30;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 0);
+            skip_count.count.set(count);
+
+            let page_size = 20;
+
+            // Paginate forwards. The count remains unchanged.
+            let count = skip_count.compute_next_when_paginating_forwards(page_size);
+            assert_eq!(count, 0);
+        }
+
+        #[test]
+        fn test_compute_count_when_paginating_forwards_from_overflowing_initial_states() {
+            let skip_count = SkipCount::new();
+
+            // Initial state with too much new items. Some are skipped.
+            let previous_number_of_items = 0;
+            let next_number_of_items = previous_number_of_items + 50;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 30);
+            skip_count.count.set(count);
+
+            // Add 30 new items. The count stays at 30 because we don't want to
+            // skip the previous items.
+            let previous_number_of_items = next_number_of_items;
+            let next_number_of_items = previous_number_of_items + 30;
+            let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
+            assert_eq!(count, 30);
+            skip_count.count.set(count);
+
+            let page_size = 20;
+
+            // Paginate forwards. The count remains unchanged.
+            let count = skip_count.compute_next_when_paginating_forwards(page_size);
+            assert_eq!(count, 30);
+        }
+    }
+}

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -461,7 +461,7 @@ async fn test_replace_with_initial_events_when_batched() {
         )
         .await;
 
-    let (items, mut stream) = timeline.controller.subscribe_batched_and_limited().await;
+    let (items, mut stream) = timeline.controller.subscribe().await;
     assert_eq!(items.len(), 2);
     assert!(items[0].is_date_divider());
     assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "hey");

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -461,7 +461,7 @@ async fn test_replace_with_initial_events_when_batched() {
         )
         .await;
 
-    let (items, mut stream) = timeline.controller.subscribe_batched().await;
+    let (items, mut stream) = timeline.controller.subscribe_batched_and_limited().await;
     assert_eq!(items.len(), 2);
     assert!(items[0].is_date_divider());
     assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "hey");

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -155,7 +155,7 @@ impl TestTimeline {
     }
 
     async fn subscribe(&self) -> impl Stream<Item = VectorDiff<Arc<TimelineItem>>> {
-        let (items, stream) = self.controller.subscribe().await;
+        let (items, stream) = self.controller.subscribe_raw().await;
         assert_eq!(items.len(), 0, "Please subscribe to TestTimeline before adding items to it");
         stream
     }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
+use std::{ops::Not, time::Duration};
 
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
@@ -24,7 +24,7 @@ use matrix_sdk::{
 };
 use matrix_sdk_test::{
     async_test, event_factory::EventFactory, mocks::mock_encryption_state, sync_timeline_event,
-    JoinedRoomBuilder, RoomAccountDataTestEvent, StateTestEvent, SyncResponseBuilder, BOB,
+    JoinedRoomBuilder, RoomAccountDataTestEvent, StateTestEvent, SyncResponseBuilder, ALICE, BOB,
 };
 use matrix_sdk_ui::{
     timeline::{
@@ -36,9 +36,10 @@ use matrix_sdk_ui::{
 use ruma::{
     event_id,
     events::room::{encryption::RoomEncryptionEventContent, message::RoomMessageEventContent},
-    owned_event_id, room_id, user_id, MilliSecondsSinceUnixEpoch,
+    owned_event_id, room_id, user_id, EventId, MilliSecondsSinceUnixEpoch,
 };
 use serde_json::json;
+use sliding_sync::assert_timeline_stream;
 use stream_assert::assert_pending;
 use wiremock::{
     matchers::{header, method, path_regex},
@@ -831,8 +832,71 @@ async fn test_timeline_without_encryption_can_update() {
     assert_pending!(stream);
 }
 
+#[async_test]
+async fn test_timeline_receives_a_limited_number_of_events_when_subscribing() {
+    let room_id = room_id!("!foo:bar.baz");
+    let event_factory = EventFactory::new().room(room_id).sender(&ALICE);
+
+    let mock_server = MatrixMockServer::new().await;
+    let client = mock_server.client_builder().build().await;
+
+    mock_server.sync_joined_room(&client, room_id).await;
+
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    // The event cache contains 30 events.
+    event_cache
+        .add_initial_events(
+            room_id,
+            (0..30)
+                .map(|nth| {
+                    event_factory
+                        .text_msg("foo")
+                        .event_id(&EventId::parse(format!("$ev{nth}")).unwrap())
+                        .into_event()
+                })
+                .collect::<Vec<_>>(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let room = client.get_room(room_id).unwrap();
+
+    // The timeline is created.
+    let timeline = room.timeline().await.unwrap();
+    let (timeline_initial_items, mut timeline_stream) = timeline.subscribe().await;
+
+    // The timeline receives 20 initial values, not 30!
+    assert_eq!(timeline_initial_items.len(), 20);
+    assert_pending!(timeline_stream);
+
+    // To get the other, the timeline needs to paginate.
+
+    let _no_network_pagination =
+        mock_server.mock_room_messages().error500().never().mount_as_scoped().await;
+
+    // Now let's do a backwards pagination of 5 items.
+    let hit_end_of_timeline = timeline.paginate_backwards(5).await.unwrap();
+
+    assert!(hit_end_of_timeline.not());
+
+    // Oh, 5 new items, without even hitting the network because the timeline
+    // already has these!
+    assert_timeline_stream! {
+        [timeline_stream]
+        prepend "$ev9";
+        prepend "$ev8";
+        prepend "$ev7";
+        prepend "$ev6";
+        prepend "$ev5";
+    };
+    assert_pending!(timeline_stream);
+}
+
 struct PinningTestSetup<'a> {
-    event_id: &'a ruma::EventId,
+    event_id: &'a EventId,
     room_id: &'a ruma::RoomId,
     client: matrix_sdk::Client,
     server: wiremock::MockServer,
@@ -904,7 +968,7 @@ impl PinningTestSetup<'_> {
         let _response = self.client.sync_once(self.sync_settings.clone()).await.unwrap();
     }
 
-    fn event_id(&self) -> &ruma::EventId {
+    fn event_id(&self) -> &EventId {
         self.event_id
     }
 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -12,15 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{sync::Arc, time::Duration};
+use std::{ops::Not, sync::Arc, time::Duration};
 
+use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::{
     future::{join, join3},
     FutureExt, StreamExt as _,
 };
-use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
+use matrix_sdk::{
+    config::SyncSettings,
+    test_utils::{
+        logged_in_client_with_server,
+        mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
+    },
+};
 use matrix_sdk_test::{
     async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
     StateTestEvent, SyncResponseBuilder, ALICE, BOB,
@@ -31,7 +38,7 @@ use matrix_sdk_ui::timeline::{
 use once_cell::sync::Lazy;
 use ruma::{
     events::{room::message::MessageType, FullStateEventContent},
-    room_id,
+    room_id, EventId,
 };
 use serde_json::{json, Value as JsonValue};
 use stream_assert::{assert_next_eq, assert_pending};
@@ -44,7 +51,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::mock_sync;
+use crate::{mock_sync, timeline::sliding_sync::assert_timeline_stream};
 
 #[async_test]
 async fn test_back_pagination() {
@@ -841,4 +848,242 @@ async fn test_back_pagination_aborted() {
 
     // And there should be no other pending pagination status updates.
     assert!(back_pagination_status.next().now_or_never().is_none());
+}
+
+#[async_test]
+async fn test_lazy_back_pagination() {
+    let room_id = room_id!("!foo:bar.baz");
+    let event_factory = EventFactory::new().room(room_id).sender(&ALICE);
+
+    let mock_server = MatrixMockServer::new().await;
+    let client = mock_server.client_builder().build().await;
+
+    let room = mock_server.sync_joined_room(&client, room_id).await;
+    let timeline = room.timeline().await.unwrap();
+    let (timeline_initial_items, mut timeline_stream) = timeline.subscribe().await;
+
+    assert!(timeline_initial_items.is_empty());
+    assert_pending!(timeline_stream);
+
+    // Receive 30 events.
+    mock_server
+        .mock_sync()
+        .ok_and_run(&client, |sync_builder| {
+            sync_builder.add_joined_room({
+                let mut room = JoinedRoomBuilder::new(room_id);
+
+                for nth in 0..30 {
+                    room = room.add_timeline_event(
+                        event_factory
+                            .text_msg("foo")
+                            .event_id(&EventId::parse(format!("$ev{nth}")).unwrap()),
+                    );
+                }
+
+                room.set_timeline_prev_batch("back_pagination_token_1").set_timeline_limited()
+            });
+        })
+        .await;
+
+    // Only 20 items are broadcasted to the subscriber.
+    assert_timeline_stream! {
+        [timeline_stream]
+        // Huh?
+        // TODO: understand why
+        clear;
+        clear;
+
+        // `$ev11`, the 1st item.
+        append "$ev11";
+
+        // `$ev12` and the update of `$ev11` (because of read receipt)
+        update[0] "$ev11";
+        append "$ev12";
+
+        // and so on…
+        update[1] "$ev12";
+        append "$ev13";
+
+        update[2] "$ev13";
+        append "$ev14";
+
+        update[3] "$ev14";
+        append "$ev15";
+
+        update[4] "$ev15";
+        append "$ev16";
+
+        update[5] "$ev16";
+        append "$ev17";
+
+        update[6] "$ev17";
+        append "$ev18";
+
+        update[7] "$ev18";
+        append "$ev19";
+
+        update[8] "$ev19";
+        append "$ev20";
+
+        update[9] "$ev20";
+        append "$ev21";
+
+        update[10] "$ev21";
+        append "$ev22";
+
+        update[11] "$ev22";
+        append "$ev23";
+
+        update[12] "$ev23";
+        append "$ev24";
+
+        update[13] "$ev24";
+        append "$ev25";
+
+        update[14] "$ev25";
+        append "$ev26";
+
+        update[15] "$ev26";
+        append "$ev27";
+
+        update[16] "$ev27";
+        append "$ev28";
+
+        update[17] "$ev28";
+        // … until we receive `$ev29`: the last received event, and the 19th item.
+        append "$ev29";
+
+        // The day divider is inserted before `$ev0`, so it shifts items to
+        // the right: `$ev10` becomes part of the stream.
+        //
+        // This is the 20th item, hurray!
+        prepend "$ev10";
+    };
+
+    // Nothing more!
+    assert_pending!(timeline_stream);
+
+    // Now let's do a backwards pagination of 5 items.
+    {
+        let hit_end_of_timeline = timeline.paginate_backwards(5).await.unwrap();
+
+        assert!(hit_end_of_timeline.not());
+
+        // Oh, 5 new items, without even hitting the network because the timeline
+        // already has these!
+        assert_timeline_stream! {
+            [timeline_stream]
+            prepend "$ev9";
+            prepend "$ev8";
+            prepend "$ev7";
+            prepend "$ev6";
+            prepend "$ev5";
+        };
+        assert_pending!(timeline_stream);
+    }
+
+    // Let's do another backwards pagination of 3 items.
+    {
+        let hit_end_of_timeline = timeline.paginate_backwards(3).await.unwrap();
+
+        assert!(hit_end_of_timeline.not());
+
+        // Boooring, 3 new items, without even hitting the network, yet again.
+        assert_timeline_stream! {
+            [timeline_stream]
+            prepend "$ev4";
+            prepend "$ev3";
+            prepend "$ev2";
+        };
+        assert_pending!(timeline_stream);
+    }
+
+    // This time, let's run another backwards pagination of 6 items. 2 items are
+    // from in-memory events, 1 item is a virtual item, and 3 will be created from
+    // events fetched from the network.
+    {
+        let network_pagination = mock_server
+            .mock_room_messages()
+            .from("back_pagination_token_1")
+            .ok(RoomMessagesResponseTemplate::default()
+                .end_token("back_pagination_token_2")
+                .events({
+                    (100..103)
+                        .map(|nth| {
+                            event_factory
+                                .text_msg("foo")
+                                .event_id(&EventId::parse(format!("$ev{nth}")).unwrap())
+                        })
+                        .collect::<Vec<_>>()
+                }))
+            .mock_once()
+            .mount_as_scoped()
+            .await;
+
+        let hit_end_of_timeline = timeline.paginate_backwards(6).await.unwrap();
+
+        assert!(hit_end_of_timeline.not());
+
+        // Boooring, 3 new items from the in-memory timeline items.
+        assert_timeline_stream! {
+            [timeline_stream]
+            prepend "$ev1";
+            prepend "$ev0";
+            prepend --- date divider ---;
+        };
+        // And 3 other items representing the events received from the network backwards
+        // pagination.
+        //
+        // They are inserted after the date divider, hence the indices 1, 2 and 3.
+        assert_timeline_stream! {
+            [timeline_stream]
+            insert[1] "$ev102";
+            insert[2] "$ev101";
+            insert[3] "$ev100";
+        };
+        // Oh yeah B-).
+        assert_pending!(timeline_stream);
+
+        drop(network_pagination);
+    }
+
+    // Finally, let's run a last backwards pagination of 5 items, fully hitting the
+    // network, but 2 will be returned because the beginning of the timeline is
+    // reached.
+    {
+        let network_pagination = mock_server
+            .mock_room_messages()
+            .from("back_pagination_token_2")
+            .ok(RoomMessagesResponseTemplate::default()
+                // No previous batch token, the beginning of the timeline is reached.
+                .events({
+                    (200..202)
+                        .map(|nth| {
+                            event_factory
+                                .text_msg("foo")
+                                .event_id(&EventId::parse(format!("$ev{nth}")).unwrap())
+                        })
+                        .collect::<Vec<_>>()
+                }))
+            .mock_once()
+            .mount_as_scoped()
+            .await;
+
+        let hit_end_of_timeline = timeline.paginate_backwards(5).await.unwrap();
+
+        assert!(hit_end_of_timeline);
+
+        // Receive 3 new items.
+        //
+        // They are inserted after the date divider, hence the indices 1 and 2.
+        assert_timeline_stream! {
+            [timeline_stream]
+            insert[1] "$ev201";
+            insert[2] "$ev200";
+        };
+        // So cool.
+        assert_pending!(timeline_stream);
+
+        drop(network_pagination);
+    }
 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -25,7 +25,7 @@ use matrix_sdk::{
 };
 use matrix_sdk_test::{async_test, mocks::mock_encryption_state};
 use matrix_sdk_ui::{
-    timeline::{TimelineItem, TimelineItemKind, VirtualTimelineItem},
+    timeline::{TimelineItem, TimelineItemKind},
     Timeline,
 };
 use ruma::{room_id, user_id, RoomId};
@@ -81,11 +81,11 @@ macro_rules! assert_timeline_stream {
                 {
                     assert_matches!(
                         $iterator .next(),
-                        Some(VectorDiff::PushBack { value }) => {
+                        Some(eyeball_im::VectorDiff::PushBack { value }) => {
                             assert_matches!(
                                 **value,
-                                TimelineItemKind::Virtual(
-                                    VirtualTimelineItem::DateDivider(_)
+                                matrix_sdk_ui::timeline::TimelineItemKind::Virtual(
+                                    matrix_sdk_ui::timeline::VirtualTimelineItem::DateDivider(_)
                                 )
                             );
                         }
@@ -106,10 +106,10 @@ macro_rules! assert_timeline_stream {
                 {
                     assert_matches!(
                         $iterator .next(),
-                        Some(VectorDiff::PushBack { value }) => {
+                        Some(eyeball_im::VectorDiff::PushBack { value }) => {
                             assert_matches!(
                                 &**value,
-                                TimelineItemKind::Event(event_timeline_item) => {
+                                matrix_sdk_ui::timeline::TimelineItemKind::Event(event_timeline_item) => {
                                     assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
                                 }
                             );
@@ -131,10 +131,12 @@ macro_rules! assert_timeline_stream {
                 {
                     assert_matches!(
                         $iterator .next(),
-                        Some(VectorDiff::PushFront { value }) => {
+                        Some(eyeball_im::VectorDiff::PushFront { value }) => {
                             assert_matches!(
                                 &**value,
-                                TimelineItemKind::Virtual(VirtualTimelineItem::DateDivider(_)) => {}
+                                matrix_sdk_ui::timeline::TimelineItemKind::Virtual(
+                                    matrix_sdk_ui::timeline::VirtualTimelineItem::DateDivider(_)
+                                ) => {}
                             );
                         }
                     );
@@ -143,6 +145,30 @@ macro_rules! assert_timeline_stream {
         )
     };
 
+    // `prepend "$event_id"`
+    ( @_ [ $iterator:ident ] [ prepend $event_id:literal ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
+        assert_timeline_stream!(
+            @_
+            [ $iterator ]
+            [ $( $rest )* ]
+            [
+                $( $accumulator )*
+                {
+                    assert_matches!(
+                        $iterator .next(),
+                        Some(eyeball_im::VectorDiff::PushFront { value }) => {
+                            assert_matches!(
+                                &**value,
+                                matrix_sdk_ui::timeline::TimelineItemKind::Event(event_timeline_item) => {
+                                    assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
+                                }
+                            );
+                        }
+                    );
+                }
+            ]
+        )
+    };
 
     // `insert [$nth] "$event_id"`
     ( @_ [ $iterator:ident ] [ insert [$index:literal] $event_id:literal ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
@@ -155,10 +181,10 @@ macro_rules! assert_timeline_stream {
                 {
                     assert_matches!(
                         $iterator .next(),
-                        Some(VectorDiff::Insert { index: $index, value }) => {
+                        Some(eyeball_im::VectorDiff::Insert { index: $index, value }) => {
                             assert_matches!(
                                 &**value,
-                                TimelineItemKind::Event(event_timeline_item) => {
+                                matrix_sdk_ui::timeline::TimelineItemKind::Event(event_timeline_item) => {
                                     assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
                                 }
                             );
@@ -180,10 +206,10 @@ macro_rules! assert_timeline_stream {
                 {
                     assert_matches!(
                         $iterator .next(),
-                        Some(VectorDiff::Set { index: $index, value }) => {
+                        Some(eyeball_im::VectorDiff::Set { index: $index, value }) => {
                             assert_matches!(
                                 &**value,
-                                TimelineItemKind::Event(event_timeline_item) => {
+                                matrix_sdk_ui::timeline::TimelineItemKind::Event(event_timeline_item) => {
                                     assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
                                 }
                             );
@@ -205,15 +231,35 @@ macro_rules! assert_timeline_stream {
                 {
                     assert_matches!(
                         $iterator .next(),
-                        Some(VectorDiff::Remove { index: $index })
+                        Some(eyeball_im::VectorDiff::Remove { index: $index })
                     );
                 }
             ]
         )
     };
 
-    ( @_ [ $stream:ident ] [] [ $( $accumulator:tt )* ] ) => {
+    // `clear`
+    ( @_ [ $iterator:ident ] [ clear ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
+        assert_timeline_stream!(
+            @_
+            [ $iterator ]
+            [ $( $rest )* ]
+            [
+                $( $accumulator )*
+                {
+                    assert_matches!(
+                        $iterator .next(),
+                        Some(eyeball_im::VectorDiff::Clear)
+                    );
+                }
+            ]
+        )
+    };
+
+    ( @_ [ $iterator:ident ] [] [ $( $accumulator:tt )* ] ) => {
         $( $accumulator )*
+
+        assert!($iterator .next().is_none(), concat!(stringify!($iterator), " has not been entirely read"));
     };
 
     ( [ $stream:ident ] $( $all:tt )* ) => {

--- a/testing/matrix-sdk-test/src/sync_builder/joined_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/joined_room.rs
@@ -67,8 +67,8 @@ impl JoinedRoomBuilder {
     }
 
     /// Set the `prev_batch` of the timeline.
-    pub fn set_timeline_prev_batch(mut self, prev_batch: String) -> Self {
-        self.inner.timeline.prev_batch = Some(prev_batch);
+    pub fn set_timeline_prev_batch(mut self, prev_batch: impl Into<String>) -> Self {
+        self.inner.timeline.prev_batch = Some(prev_batch.into());
         self
     }
 


### PR DESCRIPTION
<figure role="presentation">
<p align="center"><img src="https://github.com/user-attachments/assets/8a2045a3-f938-4830-9c05-36435b38ca91" width="80%" /></p>
<figcaption><p align="center">A red fox, relaxing under the snow (credits <a href="https://www.roeselienraimond.com/red_foxes/">roeselienraimond.com</a>)</p></figcaption>
</figure>

---

These patches implement lazy pagination for a live `Timeline`. The idea is that `Timeline::subscribe()` keeps returning a `Stream` but [the `Skip` higher-order stream](https://github.com/jplatte/eyeball/pull/72) is applied to skip the first items, exactly the `count` first items:

- When new items are added in the `Timeline`, they will appear in the subscriber's stream (if they are not part of the skipped items, see `Skip`'s documentation to learn more).
- When the `Timeline` paginates backwards, the `Skip`'s `count` value decreases, revealing more items if there is such. When the `count` reaches 0, it fallbacks to the event cache pagination.

For the moment, the event cache reads **all** events from its storage and sends them to the `Timeline`. A follow up of this pull request is to prevent the event cache to read all events, but to read events chunk by chunk. Thus, the `Timeline` do a lazy pagination: when `count` reaches zero, it fallbacks to the event cache, which will load another chunk if possible, otherwise it will fallback to the network. See the documentation in this pull request to learn more. This is a general overview of the mechanism.

---

First off, the first patches do a bit of clean up (removing clones, move and rename `TimelineStream` into a new `subscriber` module).

After that, patches create a `SkipCount` type, and use it inside the `Timeline::subscribe()` flow.

Finally, the last patches add integration tests. Unit tests are already written.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280