### PR TITLE
Simplify some tests with the assert_next_with_timeout macro

### DIFF
--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -785,16 +785,17 @@ impl MatrixMockServer {
     ///
     /// # Examples
     ///
-    /// ``` #
-    /// tokio_test::block_on(async {
-    /// use matrix_sdk_base::RoomMemberships;
-    /// use ruma::events::room::member::MembershipState;
-    /// use ruma::events::room::member::RoomMemberEventContent;
-    /// use ruma::user_id;
-    /// use matrix_sdk_test::event_factory::EventFactory;
+    /// ```
+    /// # tokio_test::block_on(async {
     /// use matrix_sdk::{
     ///     ruma::{event_id, room_id},
     ///     test_utils::mocks::MatrixMockServer,
+    /// };
+    /// use matrix_sdk_base::RoomMemberships;
+    /// use matrix_sdk_test::event_factory::EventFactory;
+    /// use ruma::{
+    ///     events::room::member::{MembershipState, RoomMemberEventContent},
+    ///     user_id,
     /// };
     /// let mock_server = MatrixMockServer::new().await;
     /// let client = mock_server.client_builder().build().await;
@@ -811,7 +812,12 @@ impl MatrixMockServer {
     ///     .into_raw_timeline()
     ///     .cast();
     ///
-    /// mock_server.mock_get_members().ok(vec![alice_knock_event]).mock_once().mount().await;
+    /// mock_server
+    ///     .mock_get_members()
+    ///     .ok(vec![alice_knock_event])
+    ///     .mock_once()
+    ///     .mount()
+    ///     .await;
     /// let room = mock_server.sync_joined_room(&client, room_id).await;
     ///
     /// let members = room.members(RoomMemberships::all()).await.unwrap();

--- a/crates/matrix-sdk/src/test_utils/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mod.rs
@@ -102,10 +102,38 @@ pub async fn logged_in_client_with_server() -> (Client, wiremock::MockServer) {
     (client, server)
 }
 
-/// Asserts the next item in a `Stream` or `Subscriber` can be loaded in the
-/// given timeout in the given timeout in milliseconds.
+/// Asserts that the next item in a `Stream` is received within a given timeout.
+///
+/// This macro waits for the next item from an asynchronous `Stream` or, if no
+/// item is received within the specified timeout, the macro panics.
+///
+/// # Parameters
+///
+/// - `$stream`: The `Stream` or `Subscriber` to poll for the next item.
+/// - `$timeout_ms` (optional): The timeout in milliseconds to wait for the next
+///   item. Defaults to 500ms if not provided.
+///
+/// # Example
+///
+/// ```rust
+/// use futures_util::{stream, StreamExt};
+/// use matrix_sdk::assert_next_with_timeout;
+///
+/// # async {
+/// let mut stream = stream::iter(vec![1, 2, 3]);
+/// let next_item = assert_next_with_timeout!(stream, 1000); // Waits up to 1000ms
+/// assert_eq!(next_item, 1);
+///
+/// // The timeout can be omitted, in which case it defaults to 500 ms.
+/// let next_item = assert_next_with_timeout!(stream); // Waits up to 500ms
+/// assert_eq!(next_item, 2);
+/// # };
+/// ```
 #[macro_export]
 macro_rules! assert_next_with_timeout {
+    ($stream:expr) => {
+        $crate::assert_next_with_timeout!($stream, 500)
+    };
     ($stream:expr, $timeout_ms:expr) => {{
         // Needed for subscribers, as they won't use the StreamExt features
         #[allow(unused_imports)]


### PR DESCRIPTION
While trying to figure out why #4596 fails, I noticed that some tests reimplement the `assert_next_with_timeout` macro using a function.

While I'm doing this I expanded the macro to make the timeout parameter optional and added some doc examples to the macro.

Additionally I noticed that one of our examples seems to contain a bug because of a misplaced `#`.

A review commit by commit makes the most sense.