### PR TITLE
fix(ui): Do not filter out own receipts in load_read_receipts_for_event

### DIFF
--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
   ([#4448](https://github.com/matrix-org/matrix-rust-sdk/pull/4448))
 - Fix `EventTimelineItem::latest_edit_json()` when it is populated by a live
   edit. ([#4552](https://github.com/matrix-org/matrix-rust-sdk/pull/4552))
+- Fix our own explicit read receipt being ignored when loading it from the
+  state store, which resulted in our own read receipt being wrong sometimes.
+  ([#4600](https://github.com/matrix-org/matrix-rust-sdk/pull/4600))
 
 ### Features
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -395,10 +395,7 @@ impl TimelineStateTransaction<'_> {
         room_data_provider: &P,
     ) {
         let read_receipts = room_data_provider.load_event_receipts(event_id).await;
-
-        // Filter out receipts for our own user.
         let own_user_id = room_data_provider.own_user_id();
-        let read_receipts = read_receipts.into_iter().filter(|(user_id, _)| user_id != own_user_id);
 
         // Since they are explicit read receipts, we need to check if they are
         // superseded by implicit read receipts.

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -37,9 +37,8 @@ use matrix_sdk::{
 use matrix_sdk_base::{
     crypto::types::events::CryptoContextInfo, latest_event::LatestEvent, RoomInfo, RoomState,
 };
-use matrix_sdk_test::{event_factory::EventFactory, ALICE, BOB, DEFAULT_TEST_ROOM_ID};
+use matrix_sdk_test::{event_factory::EventFactory, ALICE, DEFAULT_TEST_ROOM_ID};
 use ruma::{
-    event_id,
     events::{
         reaction::ReactionEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
@@ -353,11 +352,17 @@ impl RoomDataProvider for TestRoomDataProvider {
         &'a self,
         event_id: &'a EventId,
     ) -> IndexMap<OwnedUserId, Receipt> {
-        if event_id == event_id!("$event_with_bob_receipt") {
-            [(BOB.to_owned(), Receipt::new(MilliSecondsSinceUnixEpoch(uint!(10))))].into()
-        } else {
-            IndexMap::new()
+        let mut map = IndexMap::new();
+
+        for (user_id, (receipt_event_id, receipt)) in
+            self.initial_user_receipts.values().flat_map(|m| m.values()).flatten()
+        {
+            if receipt_event_id == event_id {
+                map.insert(user_id.clone(), receipt.clone());
+            }
         }
+
+        map
     }
 
     async fn push_rules_and_context(&self) -> Option<(Ruleset, PushConditionRoomCtx)> {

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -693,36 +693,33 @@ async fn test_implicit_read_receipt_before_explicit_read_receipt() {
     assert_eq!(receipt_event_id, carol_event_id);
 
     // Add the events.
-    let carol_event_content = RoomMessageEventContent::text_plain("I am Carol!");
     timeline
         .handle_back_paginated_event(
             timeline
                 .factory
-                .event(carol_event_content)
+                .text_msg("I am Carol!")
                 .sender(*CAROL)
                 .room(room_id)
                 .event_id(&carol_event_id)
                 .into_raw_timeline(),
         )
         .await;
-    let bob_event_content = RoomMessageEventContent::text_plain("I am Bob!");
     timeline
         .handle_back_paginated_event(
             timeline
                 .factory
-                .event(bob_event_content)
+                .text_msg("I am Bob!")
                 .sender(*BOB)
                 .room(room_id)
                 .event_id(&bob_event_id)
                 .into_raw_timeline(),
         )
         .await;
-    let alice_event_content = RoomMessageEventContent::text_plain("I am Alice!");
     timeline
         .handle_back_paginated_event(
             timeline
                 .factory
-                .event(alice_event_content)
+                .text_msg("I am Alice!")
                 .sender(*ALICE)
                 .room(room_id)
                 .event_id(&alice_event_id)


### PR DESCRIPTION
Fixes #4517.

It turns out that the bugs found in that test were due to 2 causes:

- First commit: `TestRoomDataProvider` didn't use `initial_user_receipts` but returned hardcoded values.
- Second commit: Our own read receipts were ignored in `TimelineStateTransaction::load_read_receipts_for_event`, although we need to process all read receipts via `ReadReceipts::maybe_update_read_receipt` because it knows how to filter out our own read receipts were needed.

