### PR TITLE
fix(ui): Fix performance of `TimelineEventHandler::deduplicate_local_timeline_item`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-members = ["benchmarks", "crates/*", "labs/*"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.82"
+rust-version = "1.83"
 
 [workspace.dependencies]
 anyhow = "1.0.95"


### PR DESCRIPTION
This patch drastically improves the performance of `TimelineEventHandler::deduplicate_local_timeline_item`.

Before this patch, `rfind_event_item` was used to iterate over all timeline items: for each item in reverse order, if it was an event timeline item, and if it was a local event timeline item, and if it was matching the event ID or transaction ID, then a duplicate was found.

The problem is the following: all items are traversed.

However, local event timeline items are always at the back of the items. Even virtual timeline items are before local event timeline items. Thus, it is not necessary to traverse all items. It is possible to stop the iteration as soon as (i) a non event timeline item is met, or (ii) a non local event timeline item is met.

This patch updates
`TimelineEventHandler::deduplicate_local_timeline_item` to replace to use of `rfind_event_item` by a custom iterator that stops as soon as a non event timeline item, or a non local event timeline item, is met, or —of course— when a local event timeline item is a duplicate.

To do so, [`Iterator::try_fold`] is probably the best companion. [`Iterator::try_find`] would have been nice, but it is available on nightlies, not on stable versions of Rust. However, many methods in `Iterator` are using `try_fold`, like `find` or any other methods that need to do a “short-circuit”. Anyway, `try_fold` works pretty nice here, and does exactly what we need.

Our use of `try_fold` is to return a `ControlFlow<Option<(usize, TimelineItem)>, ()>`. After `try_fold`, we call
`ControlFlow::break_value`, which returns an `Option`. Hence the need to call `Option::flatten` at the end to get a single `Option` instead of having an `Option<Option<(usize, TimelineItem)>>`.

I'm testing this patch with the `test_lazy_back_pagination` test in https://github.com/matrix-org/matrix-rust-sdk/pull/4594. With 10_000 events in the sync, the test was taking 13s to run on my machine. With this patch, it takes 10s to run. It's a 23% improvement. This `deduplicate_local_timeline_item` method was taking a large part of the computation according to the profiler. With this patch, this method is barely visible in the profiler it is so small.

Flamegraph of the `TimelineEventHandler::add_item` method (that calls `deduplicate_local_timeline_item`), before this patch:

<img width="1417" alt="Screenshot 2025-02-01 at 11 59 37" src="https://github.com/user-attachments/assets/071d1099-0da7-40e4-9372-ceecb8adb10f" />

And after:

<img width="1420" alt="Screenshot 2025-02-01 at 11 26 08" src="https://github.com/user-attachments/assets/2bd1aff7-bb80-45c2-81d0-acfff6c67bf0" />

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280.


[`Iterator::try_fold`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.try_fold
[`Iterator::try_find`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.try_find