### PR TITLE
sqlite: Optimize the DB and the files sizes

### DIFF
--- a/crates/matrix-sdk-sqlite/CHANGELOG.md
+++ b/crates/matrix-sdk-sqlite/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file.
   `EventCacheStore` for `MediaRetentionPolicy`. See the changelog of
   `matrix-sdk-base` for more details.
   ([#4571](https://github.com/matrix-org/matrix-rust-sdk/pull/4571))
+- The SQLite databases are optimized during the construction of the stores. It
+  should improve the performance of the queries.
+  ([#4602](https://github.com/matrix-org/matrix-rust-sdk/pull/4602))
+- The size of the WAL files is now limited to 10MB. This avoids cases where the
+  WAL file takes as much space as the database.
+  ([#4602](https://github.com/matrix-org/matrix-rust-sdk/pull/4602))
 
 ## [0.9.0] - 2024-12-18
 

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -96,6 +96,8 @@ impl SqliteCryptoStore {
         let conn = pool.get().await?;
         let version = conn.db_version().await?;
         run_migrations(&conn, version).await?;
+        conn.optimize().await?;
+
         let store_cipher = match passphrase {
             Some(p) => Some(Arc::new(conn.get_or_create_store_cipher(p).await?)),
             None => None,

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -94,6 +94,8 @@ impl SqliteCryptoStore {
         passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {
         let conn = pool.get().await?;
+        conn.set_journal_size_limit().await?;
+
         let version = conn.db_version().await?;
         run_migrations(&conn, version).await?;
         conn.optimize().await?;

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -108,6 +108,7 @@ impl SqliteEventCacheStore {
         let conn = pool.get().await?;
         let version = conn.db_version().await?;
         run_migrations(&conn, version).await?;
+        conn.optimize().await?;
 
         let store_cipher = match passphrase {
             Some(p) => Some(Arc::new(conn.get_or_create_store_cipher(p).await?)),

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -106,6 +106,8 @@ impl SqliteEventCacheStore {
         passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {
         let conn = pool.get().await?;
+        conn.set_journal_size_limit().await?;
+
         let version = conn.db_version().await?;
         run_migrations(&conn, version).await?;
         conn.optimize().await?;

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -117,6 +117,7 @@ impl SqliteStateStore {
         };
         let this = Self { store_cipher, pool };
         this.run_migrations(&conn, version, None).await?;
+        conn.optimize().await?;
 
         Ok(this)
     }

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -104,6 +104,8 @@ impl SqliteStateStore {
         passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {
         let conn = pool.get().await?;
+        conn.set_journal_size_limit().await?;
+
         let mut version = conn.db_version().await?;
 
         if version == 0 {

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -103,6 +103,18 @@ pub(crate) trait SqliteAsyncConnExt {
     where
         Res: Send + 'static,
         Query: Fn(&Transaction<'_>, Vec<Key>) -> Result<Vec<Res>> + Send + 'static;
+
+    /// Optimize the database.
+    ///
+    /// [The SQLite docs] recommend to run this regularly and after any schema
+    /// change. The easiest is to do it consistently when the state store is
+    /// constructed, after eventual migrations.
+    ///
+    /// [The SQLite docs]: https://www.sqlite.org/pragma.html#pragma_optimize
+    async fn optimize(&self) -> Result<()> {
+        self.execute_batch("PRAGMA optimize=0x10002;").await?;
+        Ok(())
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
- First commit: run `VACUUM` on the `SqliteStateStore`. We should have done this when we moved the media cache to `SqlitEventCacheStore`, to defragment the file and reduce its size on the filesystem. Because of that there are databases from that time that still take much more space than they need.
- Second commit: run `PRAGMA optimize` after running the eventual migrations. The [SQLite docs](https://www.sqlite.org/pragma.html#pragma_optimize) recommend to do this regularly, especially after a schema change. Doing this consistently during construction seems to be the easiest solution.
- Third commit: limit the size of the WAL file. While the DB connections of the databases are open, [the size of the WAL file can keep increasing](https://www.sqlite.org/wal.html#avoiding_excessively_large_wal_files) depending on the size needed for the transactions. A critical case is `VACUUM` which basically writes the content of the DB file to the WAL file before writing it back to the DB file, so we end up taking twice the size of the database. The docs say that the WAL file is written to the database when it reaches 4MB, so 10MB seems like a good limit that shouldn't truncate the file too often.