### PR TITLE
feat(base): Add automatic media cache cleanups to MediaService

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/media/media_service.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/media/media_service.rs
@@ -247,7 +247,7 @@ where
 /// over the `SystemTime`s provided to the store.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait EventCacheStoreMedia: AsyncTraitDeps {
+pub trait EventCacheStoreMedia: AsyncTraitDeps + Clone {
     /// The error type used by this media cache store.
     type Error: fmt::Debug + Into<EventCacheStoreError>;
 
@@ -418,7 +418,10 @@ impl TimeProvider for DefaultTimeProvider {
 
 #[cfg(test)]
 mod tests {
-    use std::{fmt, sync::MutexGuard};
+    use std::{
+        fmt,
+        sync::{Arc, MutexGuard},
+    };
 
     use async_trait::async_trait;
     use matrix_sdk_common::locks::Mutex;
@@ -436,9 +439,9 @@ mod tests {
         media::{MediaFormat, MediaRequestParameters, UniqueKey},
     };
 
-    #[derive(Debug, Default)]
+    #[derive(Debug, Default, Clone)]
     struct MockEventCacheStoreMedia {
-        inner: Mutex<MockEventCacheStoreMediaInner>,
+        inner: Arc<Mutex<MockEventCacheStoreMediaInner>>,
     }
 
     impl MockEventCacheStoreMedia {

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -80,17 +80,20 @@ const NUMBER_OF_MEDIAS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(20) 
 
 impl Default for MemoryStore {
     fn default() -> Self {
+        // Given that the store is empty, we won't need to clean it up right away.
+        let last_media_cleanup_time = SystemTime::now();
+        let media_service = MediaService::new();
+        media_service.restore(None, Some(last_media_cleanup_time));
+
         Self {
             inner: Arc::new(StdRwLock::new(MemoryStoreInner {
                 media: RingBuffer::new(NUMBER_OF_MEDIAS),
                 leases: Default::default(),
                 events: RelationalLinkedChunk::new(),
                 media_retention_policy: None,
-                // Given that the store is empty, we won't need to clean it up right away.
-                last_media_cleanup_time: SystemTime::now(),
+                last_media_cleanup_time,
             })),
-            // No need to call `restore()` since nothing is persisted.
-            media_service: MediaService::new(),
+            media_service,
         }
     }
 }

--- a/crates/matrix-sdk-common/src/executor.rs
+++ b/crates/matrix-sdk-common/src/executor.rs
@@ -62,6 +62,10 @@ impl<T> JoinHandle<T> {
     pub fn abort(&self) {
         self.abort_handle.abort();
     }
+
+    pub fn is_finished(&self) -> bool {
+        self.abort_handle.is_aborted()
+    }
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -117,7 +117,8 @@ impl SqliteEventCacheStore {
 
         let media_service = MediaService::new();
         let media_retention_policy = conn.get_serialized_kv(keys::MEDIA_RETENTION_POLICY).await?;
-        media_service.restore(media_retention_policy);
+        let last_media_cleanup_time = conn.get_serialized_kv(keys::LAST_MEDIA_CLEANUP_TIME).await?;
+        media_service.restore(media_retention_policy, last_media_cleanup_time);
 
         Ok(Self { store_cipher, pool, media_service })
     }

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -78,7 +78,7 @@ const CHUNK_TYPE_GAP_TYPE_STRING: &str = "G";
 pub struct SqliteEventCacheStore {
     store_cipher: Option<Arc<StoreCipher>>,
     pool: SqlitePool,
-    media_service: Arc<MediaService>,
+    media_service: MediaService,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -119,7 +119,7 @@ impl SqliteEventCacheStore {
         let media_retention_policy = conn.get_serialized_kv(keys::MEDIA_RETENTION_POLICY).await?;
         media_service.restore(media_retention_policy);
 
-        Ok(Self { store_cipher, pool, media_service: Arc::new(media_service) })
+        Ok(Self { store_cipher, pool, media_service })
     }
 
     fn encode_value(&self, value: Vec<u8>) -> Result<Vec<u8>> {

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -52,6 +52,7 @@ use crate::{
 mod keys {
     // Entries in Key-value store
     pub const MEDIA_RETENTION_POLICY: &str = "media_retention_policy";
+    pub const LAST_MEDIA_CLEANUP_TIME: &str = "last_media_cleanup_time";
 
     // Tables
     pub const LINKED_CHUNKS: &str = "linked_chunks";
@@ -948,6 +949,8 @@ impl EventCacheStoreMedia for SqliteEventCacheStore {
                     }
                 }
 
+                txn.set_serialized_kv(keys::LAST_MEDIA_CLEANUP_TIME, current_time)?;
+
                 Ok(removed)
             })
             .await?;
@@ -968,6 +971,11 @@ impl EventCacheStoreMedia for SqliteEventCacheStore {
         }
 
         Ok(())
+    }
+
+    async fn last_media_cleanup_time_inner(&self) -> Result<Option<SystemTime>, Self::Error> {
+        let conn = self.acquire().await?;
+        conn.get_serialized_kv(keys::LAST_MEDIA_CLEANUP_TIME).await
     }
 }
 


### PR DESCRIPTION
Follow up to #4571, this time we offer to run periodic automatic cleanups. This requires a few more bounds on the types to be able to send them into a new task.

This can be reviewed commit by commit.