### PR TITLE
feat(ffi): Add FFI bindings to `Room::forget`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -1033,6 +1033,16 @@ impl Room {
             }
         })))
     }
+
+    /// Forget this room.
+    ///
+    /// This communicates to the homeserver that it should forget the room.
+    ///
+    /// Only left or banned-from rooms can be forgotten.
+    pub async fn forget(&self) -> Result<(), ClientError> {
+        self.inner.forget().await?;
+        Ok(())
+    }
 }
 
 /// A listener for receiving new live location shares in a room.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2896,11 +2896,14 @@ impl Room {
     ///
     /// This communicates to the homeserver that it should forget the room.
     ///
-    /// Only left rooms can be forgotten.
+    /// Only left or banned-from rooms can be forgotten.
     pub async fn forget(&self) -> Result<()> {
         let state = self.state();
-        if state != RoomState::Left {
-            return Err(Error::WrongRoomState(WrongRoomState::new("Left", state)));
+        match state {
+            RoomState::Joined | RoomState::Invited | RoomState::Knocked => {
+                return Err(Error::WrongRoomState(WrongRoomState::new("Left / Banned", state)));
+            }
+            RoomState::Left | RoomState::Banned => {}
         }
 
         let request = forget_room::v3::Request::new(self.inner.room_id().to_owned());


### PR DESCRIPTION
This PR adds bindings for `Room::forget` and makes sure you can also forget rooms with `Banned` state.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
