### PR TITLE
fix(ui): Fix performance of `AllRemoteEvents::(in|de)crement_all_timeline_item_index_after`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -1254,10 +1254,20 @@ impl AllRemoteEvents {
     /// Shift to the right all timeline item indexes that are equal to or
     /// greater than `new_timeline_item_index`.
     fn increment_all_timeline_item_index_after(&mut self, new_timeline_item_index: usize) {
-        for event_meta in self.0.iter_mut() {
+        // Traverse items from back to front because:
+        // - if `new_timeline_item_index` is 0, we need to shift all items anyways, so
+        //   all items must be traversed,
+        // - otherwise, it's unlikely we want to traverse all items: the item has been
+        //   either inserted or pushed back, so there is no need to traverse the first
+        //   items; we can also break the iteration as soon as all timeline item index
+        //   after `new_timeline_item_index` has been updated.
+        for event_meta in self.0.iter_mut().rev() {
             if let Some(timeline_item_index) = event_meta.timeline_item_index.as_mut() {
                 if *timeline_item_index >= new_timeline_item_index {
                     *timeline_item_index += 1;
+                } else {
+                    // Items are ordered.
+                    break;
                 }
             }
         }
@@ -1266,10 +1276,20 @@ impl AllRemoteEvents {
     /// Shift to the left all timeline item indexes that are greater than
     /// `removed_wtimeline_item_index`.
     fn decrement_all_timeline_item_index_after(&mut self, removed_timeline_item_index: usize) {
-        for event_meta in self.0.iter_mut() {
+        // Traverse items from back to front because:
+        // - if `new_timeline_item_index` is 0, we need to shift all items anyways, so
+        //   all items must be traversed,
+        // - otherwise, it's unlikely we want to traverse all items: the item has been
+        //   either inserted or pushed back, so there is no need to traverse the first
+        //   items; we can also break the iteration as soon as all timeline item index
+        //   after `new_timeline_item_index` has been updated.
+        for event_meta in self.0.iter_mut().rev() {
             if let Some(timeline_item_index) = event_meta.timeline_item_index.as_mut() {
                 if *timeline_item_index > removed_timeline_item_index {
                     *timeline_item_index -= 1;
+                } else {
+                    // Items are ordered.
+                    break;
                 }
             }
         }


### PR DESCRIPTION
This patch fixes the performance of
`AllRemoteEvents::increment_all_timeline_item_index_after` and
`decrment_all_timeline_item_index_after`.

It appears that the code was previously iterating over all items. This
is a waste of time. This patch updates the code to iterate over all
items in reverse order:

- if `new_timeline_item_index` is 0, we need to shift all items anyways,
  so all items must be traversed, the iterator direction doesn't matter,
- otherwise, it's unlikely we want to traverse all items: the item has
  been either inserted or pushed back, so there is no need to traverse
  the first items; we can also break the iteration as soon as all
  timeline item index after `new_timeline_item_index` has been updated.

I'm testing this patch with the `test_lazy_back_pagination` test in
https://github.com/matrix-org/matrix-rust-sdk/pull/4594. With 10_000
events in the sync, the `ObservableItems::push_back` method (that uses
`AllRemoteEvents::increment_all_timeline_item_index_after`) was taking
7% of the whole execution time. With this patch, it takes 0.7%.

The call tree of `TimelineEventHandler::add_item` and its flamegraph
before this patch…

<img width="983" alt="Screenshot 2025-02-03 at 10 01 13" src="https://github.com/user-attachments/assets/46dd69d9-0a2e-466b-8c4c-f07511ea633b" />

<img width="1422" alt="Screenshot 2025-02-03 at 10 02 38" src="https://github.com/user-attachments/assets/71d7c0f5-4772-40e1-b49a-5165fcdf36f1" />

… and after this patch:

<img width="992" alt="Screenshot 2025-02-03 at 10 01 34" src="https://github.com/user-attachments/assets/91458062-93d8-43c0-8c3c-f3db3754bb2f" />

<img width="1409" alt="Screenshot 2025-02-03 at 10 02 25" src="https://github.com/user-attachments/assets/d2ada369-7a6b-462d-bf30-dc655e470a32" />

---

* ~This patch is based on https://github.com/matrix-org/matrix-rust-sdk/pull/4601. This patch must be merged after.~
* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280.