### PR TITLE
feat(ffi): add support for starting and responding to user verification requests

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -252,13 +252,13 @@ impl Room {
     }
 
     pub async fn member(&self, user_id: String) -> Result<RoomMember, ClientError> {
-        let user_id = UserId::parse(&*user_id).context("Invalid user id.")?;
+        let user_id = UserId::parse(&*user_id)?;
         let member = self.inner.get_member(&user_id).await?.context("User not found")?;
         Ok(member.try_into().context("Unknown state membership")?)
     }
 
     pub async fn member_avatar_url(&self, user_id: String) -> Result<Option<String>, ClientError> {
-        let user_id = UserId::parse(&*user_id).context("Invalid user id.")?;
+        let user_id = UserId::parse(&*user_id)?;
         let member = self.inner.get_member(&user_id).await?.context("User not found")?;
         let avatar_url_string = member.avatar_url().map(|m| m.to_string());
         Ok(avatar_url_string)
@@ -268,7 +268,7 @@ impl Room {
         &self,
         user_id: String,
     ) -> Result<Option<String>, ClientError> {
-        let user_id = UserId::parse(&*user_id).context("Invalid user id.")?;
+        let user_id = UserId::parse(&*user_id)?;
         let member = self.inner.get_member(&user_id).await?.context("User not found")?;
         let avatar_url_string = member.display_name().map(|m| m.to_owned());
         Ok(avatar_url_string)


### PR DESCRIPTION
This patch expands on the existing device verification flows to add support for verifying users as well. 

It does so by:
- moving incoming request detection to the Client level so that it works for both to-device events as well as timeline ones. The client then forwards the data through the generic `process_incoming_verification_request` method
- exposing a new `request_user_verification` method next to the (renamed) `request_device_verification` one on the `SessionVerificationController`
- consolidating subscription logic within `set_ongoing_verification_request`
- overall the mecanisms are very similar which should make it easy to adopt in the final clients