### PR TITLE
logging(crypto): Add more logs when identity or devices change

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -31,7 +31,7 @@ use ruma::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::{instrument, trace, warn};
+use tracing::{debug, instrument, trace, warn};
 use vodozemac::{olm::SessionConfig, Curve25519PublicKey, Ed25519PublicKey};
 
 use super::{atomic_bool_deserializer, atomic_bool_serializer};
@@ -869,6 +869,13 @@ impl DeviceData {
                 device_keys.ed25519_key().map(Box::new),
             ))
         } else if self.device_keys.as_ref() != device_keys {
+            debug!(
+                user_id = ?self.user_id(),
+                device_id = ?self.device_id(),
+                keys = ?self.keys(),
+                "Updated a device",
+            );
+
             self.device_keys = device_keys.clone().into();
 
             Ok(true)

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -687,7 +687,7 @@ impl IdentityManager {
                 .await
             {
                 Ok(IdentityUpdateResult::Updated(identity)) => {
-                    trace!(?identity, "Updated a user identity");
+                    debug!(?identity, "Updated a user identity");
                     changes.changed.push(identity);
                 }
                 Ok(IdentityUpdateResult::Unchanged(identity)) => {

--- a/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
+++ b/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
@@ -175,7 +175,9 @@ impl CryptoStoreWrapper {
             if let Some(own_identity_after) = maybe_own_identity.as_ref() {
                 // Only do this if our identity is passing from not verified to verified,
                 // the previously_verified can only change in that case.
-                if !own_identity_was_verified_before_change && own_identity_after.is_verified() {
+                let own_identity_is_verified = own_identity_after.is_verified();
+
+                if !own_identity_was_verified_before_change && own_identity_is_verified {
                     debug!("Own identity is now verified, check all known identities for verification status changes");
                     // We need to review all the other identities to see if they are verified now
                     // and mark them as such
@@ -183,6 +185,12 @@ impl CryptoStoreWrapper {
                         own_identity_after,
                     )
                     .await?;
+                } else if own_identity_was_verified_before_change != own_identity_is_verified {
+                    // Log that the verification state of the identity changed.
+                    debug!(
+                        own_identity_is_verified,
+                        "The verification state of our own identity has changed",
+                    );
                 }
             }
 


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Add more logs for when device keys changes.
- Promotes an existing `trace!` log to debug
- Logs when a user device keys are updated (typically new signatures)
- Add a log when the current own identity verification status has changed

The new logs
```
2025-02-04T14:11:12.433085Z DEBUG matrix_sdk_crypto::identities::device: Updated a device user_id="@valere_test_reg:matrix.org" device_id="PCWFHVSKZM" keys={"curve25519:PCWFHVSKZM": Curve25519("curve25519:b3m+XIBCH+rMUcYeEcmAwm2JWH21lFPAkN3jazSVQm0"), "ed25519:PCWFHVSKZM": Ed25519("ed25519:iOt4FV1u10SQuCdInO1HwGyQCe+iSiFWKXL61Sn2TRs")} | crates/matrix-sdk-crypto/src/identities/device.rs:872 | spans: root
```

```
2025-02-04T14:11:12.433952Z DEBUG matrix_sdk_crypto::identities::manager: Updated a user identity identity=Own(OwnUserIdentityData { user_id: "@valere_test_reg:matrix.org", master_key: MasterPubkey(CrossSigningKey { user_id: "@valere_test_reg:matrix.org", usage: ["master"], keys: SigningKeys({"ed25519:TqMHBVPXue0QvfRjATCdnoHabsEKblC4LRkXvQtB37c": Ed25519("ed25519:TqMHBVPXue0QvfRjATCdnoHabsEKblC4LRkXvQtB37c")}), signatures: Signatures({"@valere_test_reg:matrix.org": {"ed25519:PCWFHVSKZM": Ok(Ed25519("ed25519:ONRrAUtA70bWG4w/w4FK/d7HYBGYA3zC4t+nEPrXMg65sz3++L3LOMWyZpWMn5yrkK8WDvvdkZEX+UDmbxFIDQ")), "ed25519:TqMHBVPXue0QvfRjATCdnoHabsEKblC4LRkXvQtB37c": Ok(Ed25519("ed25519:8b+WKGf1EEoK/okyup5qHDKOl76zTrHh0yAewle3ecgDIzAsf9hDkt2uD1BJftTUnV5oTlYgcmLZSiBei52UAQ"))}}), other: {} }), self_signing_key: SelfSigningPubkey(CrossSigningKey { user_id: "@valere_test_reg:matrix.org", usage: ["self_signing"], keys: SigningKeys({"ed25519:d4P3tUobKkTmjO/vk0pH1mD6PWXRWtVL1QTT8dENgZc": Ed25519("ed25519:d4P3tUobKkTmjO/vk0pH1mD6PWXRWtVL1QTT8dENgZc")}), signatures: Signatures({"@valere_test_reg:matrix.org": {"ed25519:TqMHBVPXue0QvfRjATCdnoHabsEKblC4LRkXvQtB37c": Ok(Ed25519("ed25519:viwT6WgcVOQLHgogzoM6NOwByZYfnvSWixehv/pt1fvmvuaGSWWOSfKzCr8IXZw7FcflwL5OYFWvRgDjfogfBg"))}}), other: {} }), user_signing_key: UserSigningPubkey(CrossSigningKey { user_id: "@valere_test_reg:matrix.org", usage: ["user_signing"], keys: SigningKeys({"ed25519:+Z8IUOC4G2HfD+s1XDgagRVnGArJRRv92dThp1nSrVU": Ed25519("ed25519:+Z8IUOC4G2HfD+s1XDgagRVnGArJRRv92dThp1nSrVU")}), signatures: Signatures({"@valere_test_reg:matrix.org": {"ed25519:TqMHBVPXue0QvfRjATCdnoHabsEKblC4LRkXvQtB37c": Ok(Ed25519("ed25519:/u7vDG/LlkMWmU2ZKZc78z2WZ3DmVUrYJANmEh19xIXPoLzImNoFkwy/wdZevaBTEaDRMhVqLm/8E4lo/aZQBw"))}}), other: {} }), verified: RwLock { data: VerificationViolation, poisoned: false, .. } }) | crates/matrix-sdk-crypto/src/identities/manager.rs:690 | spans: root > keys_query{request_id="0aa1487ce5aa4eb1b33174a313246648" device_keys={"@valere_test_reg:matrix.org": []}} > update_or_create_identity

```

and 
```
2025-02-04T14:11:12.435396Z DEBUG matrix_sdk_crypto::store::crypto_store_wrapper: Own identity trust has changed: isVerified: false | crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs:189 | spans: root > keys_query{request_id="0aa1487ce5aa4eb1b33174a313246648" device_keys={"@valere_test_reg:matrix.org": []}}
```



- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
