### PR TITLE
ci: add a new feature set to test experimental-oidc too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       fail-fast: true
       matrix:
         name:
+          - experimental-oidc
           - no-encryption
           - no-sqlite
           - no-encryption-and-sqlite

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -69,6 +69,7 @@ enum FeatureSet {
     Markdown,
     Socks,
     SsoLogin,
+    ExperimentalOidc,
 }
 
 #[derive(Subcommand, PartialEq, Eq, PartialOrd, Ord)]
@@ -230,6 +231,7 @@ fn run_feature_tests(cmd: Option<FeatureSet>) -> Result<()> {
         (FeatureSet::Markdown, "--features markdown,testing"),
         (FeatureSet::Socks, "--features socks,testing"),
         (FeatureSet::SsoLogin, "--features sso-login,testing"),
+        (FeatureSet::ExperimentalOidc, "--features experimental-oidc"),
     ]);
 
     let sh = sh();


### PR DESCRIPTION
This would help find test failures specific to experimental-oidc, as well as doctests failing (which would have prevented the failures fixed in https://github.com/matrix-org/matrix-rust-sdk/pull/4614 to happen in the first place).

---

Let me know if it is preferred to reuse an existing feature set, rather than introduce one; I don't have any strong opinion there.
