### PR TITLE
feat(ffi): Add `RoomPreview::forget` action in the FFI layer

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_preview.rs
+++ b/bindings/matrix-sdk-ffi/src/room_preview.rs
@@ -65,6 +65,14 @@ impl RoomPreview {
         invite_details.inviter.and_then(|m| m.try_into().ok())
     }
 
+    /// Forget the room if we had access to it, and it was left or banned.
+    pub async fn forget(&self) -> Result<(), ClientError> {
+        let room =
+            self.client.get_room(&self.inner.room_id).context("missing room for a room preview")?;
+        room.forget().await?;
+        Ok(())
+    }
+
     /// Get the membership details for the current user.
     pub async fn own_membership_details(&self) -> Option<RoomMembershipDetails> {
         let room = self.client.get_room(&self.inner.room_id)?;


### PR DESCRIPTION
This was previously added to `ffi::Room`, but the problem is in the clients we'd get the room from `RoomList::full_room`, which has a 'return only if joined' rule, so you would not be able to use this API unless you used `Client::rooms`  and looked for the room in the list instead, which is not ideal. So the forget function binding needs to live somewhere a non-joined room can be retrieved, that being `RoomPreview`.

At this point I'm even wondering if the `ffi::Room::forget` function makes sense or it should be removed, because that room is supposed to be a joined one (and if we should just rename that FFI 'Room' into 'JoinedRoom', sigh...), although I think this distinction is only done at the `RoomList::full_room` function.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
