### PR TITLE
Release 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "anymap2",
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-base"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "as_variant",
  "assert_matches",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-common"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-crypto"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -3446,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-indexeddb"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-qrcode"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "byteorder",
  "image",
@@ -3526,7 +3526,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-sqlite"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-store-encryption"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-test"
-version = "0.7.0"
+version = "0.10.0"
 dependencies = [
  "as_variant",
  "ctor",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-test-macros"
-version = "0.7.0"
+version = "0.10.0"
 dependencies = [
  "quote",
  "syn",
@@ -3604,7 +3604,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-ui"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "as_variant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,17 +101,17 @@ web-sys = "0.3.69"
 wiremock = "0.6.2"
 zeroize = "1.8.1"
 
-matrix-sdk = { path = "crates/matrix-sdk", version = "0.9.0", default-features = false }
-matrix-sdk-base = { path = "crates/matrix-sdk-base", version = "0.9.0" }
-matrix-sdk-common = { path = "crates/matrix-sdk-common", version = "0.9.0" }
-matrix-sdk-crypto = { path = "crates/matrix-sdk-crypto", version = "0.9.0" }
+matrix-sdk = { path = "crates/matrix-sdk", version = "0.10.0", default-features = false }
+matrix-sdk-base = { path = "crates/matrix-sdk-base", version = "0.10.0" }
+matrix-sdk-common = { path = "crates/matrix-sdk-common", version = "0.10.0" }
+matrix-sdk-crypto = { path = "crates/matrix-sdk-crypto", version = "0.10.0" }
 matrix-sdk-ffi-macros = { path = "bindings/matrix-sdk-ffi-macros", version = "0.7.0" }
-matrix-sdk-indexeddb = { path = "crates/matrix-sdk-indexeddb", version = "0.9.0", default-features = false }
-matrix-sdk-qrcode = { path = "crates/matrix-sdk-qrcode", version = "0.9.0" }
-matrix-sdk-sqlite = { path = "crates/matrix-sdk-sqlite", version = "0.9.0", default-features = false }
-matrix-sdk-store-encryption = { path = "crates/matrix-sdk-store-encryption", version = "0.9.0" }
-matrix-sdk-test = { path = "testing/matrix-sdk-test", version = "0.7.0" }
-matrix-sdk-ui = { path = "crates/matrix-sdk-ui", version = "0.9.0", default-features = false }
+matrix-sdk-indexeddb = { path = "crates/matrix-sdk-indexeddb", version = "0.10.0", default-features = false }
+matrix-sdk-qrcode = { path = "crates/matrix-sdk-qrcode", version = "0.10.0" }
+matrix-sdk-sqlite = { path = "crates/matrix-sdk-sqlite", version = "0.10.0", default-features = false }
+matrix-sdk-store-encryption = { path = "crates/matrix-sdk-store-encryption", version = "0.10.0" }
+matrix-sdk-test = { path = "testing/matrix-sdk-test", version = "0.10.0" }
+matrix-sdk-ui = { path = "crates/matrix-sdk-ui", version = "0.10.0", default-features = false }
 
 # Default release profile, select with `--release`
 [profile.release]

--- a/bindings/matrix-sdk-ffi-macros/Cargo.toml
+++ b/bindings/matrix-sdk-ffi-macros/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version = { workspace = true }
 version = "0.7.0"
+publish = false
 
 [lib]
 proc-macro = true
@@ -22,3 +23,6 @@ syn = { version = "2.0.43", features = ["full", "extra-traits"] }
 
 [lints]
 workspace = true
+
+[package.metadata.release]
+release = false

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+## [0.10.0] - 2025-02-04
+
 ### Features
 
 - [**breaking**] `EventCacheStore` allows to control which media content is

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -9,7 +9,7 @@ name = "matrix-sdk-base"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version = { workspace = true }
-version = "0.9.0"
+version = "0.10.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/matrix-sdk-common/CHANGELOG.md
+++ b/crates/matrix-sdk-common/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+## [0.10.0] - 2025-02-04
+
 - [**breaking**]: `SyncTimelineEvent` and `TimelineEvent` have been fused into a single type
   `TimelineEvent`, and its field `push_actions` has been made `Option`al (it is set to `None` when
   we couldn't compute the push actions, because we lacked some information).

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -9,7 +9,7 @@ name = "matrix-sdk-common"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version = { workspace = true }
-version = "0.9.0"
+version = "0.10.0"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-unknown-linux-gnu"

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+## [0.10.0] - 2025-02-04
+
 ### Features
 
 - [**breaking**] `CollectStrategy::DeviceBasedStrategy` is now split into three

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -9,7 +9,7 @@ name = "matrix-sdk-crypto"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version = { workspace = true }
-version = "0.9.0"
+version = "0.10.0"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/matrix-sdk-indexeddb/CHANGELOG.md
+++ b/crates/matrix-sdk-indexeddb/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+## [0.10.0] - 2025-02-04
+
 ## [0.9.0] - 2024-12-18
 
 No notable changes in this release.

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-sdk-indexeddb"
-version = "0.9.0"
+version = "0.10.0"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 description = "Web's IndexedDB Storage backend for matrix-sdk"
 license = "Apache-2.0"

--- a/crates/matrix-sdk-qrcode/CHANGELOG.md
+++ b/crates/matrix-sdk-qrcode/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+## [0.10.0] - 2025-02-04
+
 ## [0.9.0] - 2024-12-18
 
 No notable changes in this release.

--- a/crates/matrix-sdk-qrcode/Cargo.toml
+++ b/crates/matrix-sdk-qrcode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "matrix-sdk-qrcode"
 description = "Library to encode and decode QR codes for interactive verifications in Matrix land"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 edition = "2021"
 homepage = "https://github.com/matrix-org/matrix-rust-sdk"

--- a/crates/matrix-sdk-sqlite/CHANGELOG.md
+++ b/crates/matrix-sdk-sqlite/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+## [0.10.0] - 2025-02-04
+
 ### Features
 
 - [**breaking**] `SqliteEventCacheStore` implements the new APIs of

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-sdk-sqlite"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 description = "Sqlite storage backend for matrix-sdk"

--- a/crates/matrix-sdk-store-encryption/CHANGELOG.md
+++ b/crates/matrix-sdk-store-encryption/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+## [0.10.0] - 2025-02-04
+
 ### Bug Fixes
 
 - Remove the usage of an unwrap in the `StoreCipher::import_with_key` method.

--- a/crates/matrix-sdk-store-encryption/Cargo.toml
+++ b/crates/matrix-sdk-store-encryption/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-sdk-store-encryption"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Helpers for encrypted storage keys for the Matrix SDK"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+## [0.10.0] - 2025-02-04
+
 ### Bug Fixes
 
 - Don't consider rooms in the banned state to be non-left rooms. This bug was

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "matrix-sdk-ui"
 description = "GUI-centric utilities on top of matrix-rust-sdk (experimental)."
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 license = "Apache-2.0"

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+## [0.10.0] - 2025-02-04
+
 ### Features
 
 - Allow to set and check whether an image is animated via its `ImageInfo`.

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -9,7 +9,7 @@ name = "matrix-sdk"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version = { workspace = true }
-version = "0.9.0"
+version = "0.10.0"
 
 [package.metadata.docs.rs]
 features = ["docsrs"]

--- a/testing/matrix-sdk-test-macros/CHANGELOG.md
+++ b/testing/matrix-sdk-test-macros/CHANGELOG.md
@@ -5,3 +5,5 @@ All notable changes to this project will be documented in this file.
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+
+## [0.10.0] - 2025-02-04

--- a/testing/matrix-sdk-test-macros/CHANGELOG.md
+++ b/testing/matrix-sdk-test-macros/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+<!-- next-header -->
+
+## [Unreleased] - ReleaseDate

--- a/testing/matrix-sdk-test-macros/Cargo.toml
+++ b/testing/matrix-sdk-test-macros/Cargo.toml
@@ -9,7 +9,7 @@ name = "matrix-sdk-test-macros"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version = { workspace = true }
-version = "0.7.0"
+version = "0.10.0"
 
 [lib]
 proc-macro = true

--- a/testing/matrix-sdk-test-macros/Cargo.toml
+++ b/testing/matrix-sdk-test-macros/Cargo.toml
@@ -24,4 +24,4 @@ syn = { version = "2.0.43", features = ["full", "extra-traits"] }
 workspace = true
 
 [package.metadata.release]
-release = false
+release = true

--- a/testing/matrix-sdk-test/CHANGELOG.md
+++ b/testing/matrix-sdk-test/CHANGELOG.md
@@ -5,3 +5,5 @@ All notable changes to this project will be documented in this file.
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+
+## [0.10.0] - 2025-02-04

--- a/testing/matrix-sdk-test/CHANGELOG.md
+++ b/testing/matrix-sdk-test/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+<!-- next-header -->
+
+## [Unreleased] - ReleaseDate

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 as_variant = { workspace = true }
 http = { workspace = true }
 insta = { workspace = true }
-matrix-sdk-common = { path = "../../crates/matrix-sdk-common" }
+matrix-sdk-common = { version = "0.9.0", path = "../../crates/matrix-sdk-common" }
 matrix-sdk-test-macros = { version = "0.7.0", path = "../matrix-sdk-test-macros" }
 once_cell = { workspace = true }
 # Enable the unstable feature for polls support.
@@ -43,4 +43,4 @@ wasm-bindgen-test = "0.3.33"
 workspace = true
 
 [package.metadata.release]
-release = false
+release = true

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -9,7 +9,7 @@ name = "matrix-sdk-test"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version = { workspace = true }
-version = "0.7.0"
+version = "0.10.0"
 
 [lib]
 test = false
@@ -19,8 +19,8 @@ doctest = false
 as_variant = { workspace = true }
 http = { workspace = true }
 insta = { workspace = true }
-matrix-sdk-common = { version = "0.9.0", path = "../../crates/matrix-sdk-common" }
-matrix-sdk-test-macros = { version = "0.7.0", path = "../matrix-sdk-test-macros" }
+matrix-sdk-common = { version = "0.10.0", path = "../../crates/matrix-sdk-common" }
+matrix-sdk-test-macros = { version = "0.10.0", path = "../matrix-sdk-test-macros" }
 once_cell = { workspace = true }
 # Enable the unstable feature for polls support.
 # "client-api-s" enables need the "server" feature of ruma-client-api, which is needed to serialize Response objects to JSON.

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -90,7 +90,7 @@ fn check_prerequisites() {
 
 fn prepare(version: ReleaseVersion, execute: bool) -> Result<()> {
     let sh = sh();
-    let cmd = cmd!(sh, "cargo release --no-publish --no-tag --no-push");
+    let cmd = cmd!(sh, "cargo release --workspace --no-publish --no-tag --no-push");
 
     let cmd = if execute { cmd.arg("--execute") } else { cmd };
     let cmd = cmd.arg(version.as_str());
@@ -111,15 +111,15 @@ fn prepare(version: ReleaseVersion, execute: bool) -> Result<()> {
 fn publish(execute: bool) -> Result<()> {
     let sh = sh();
 
-    let cmd = cmd!(sh, "cargo release tag");
+    let cmd = cmd!(sh, "cargo release tag --workspace");
     let cmd = if execute { cmd.arg("--execute") } else { cmd };
     cmd.run()?;
 
-    let cmd = cmd!(sh, "cargo release publish");
+    let cmd = cmd!(sh, "cargo release publish --workspace");
     let cmd = if execute { cmd.arg("--execute") } else { cmd };
     cmd.run()?;
 
-    let cmd = cmd!(sh, "cargo release push");
+    let cmd = cmd!(sh, "cargo release push --workspace");
     let cmd = if execute { cmd.arg("--execute") } else { cmd };
     cmd.run()?;
 


### PR DESCRIPTION
Another month, another release.

This will be the last release that contains the Sliding Sync Proxy ([MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575)) support.

We're also fixing one part of #4292, the testing crates are now part of the release.