### PR TITLE
doc(changelog): Add entries for the performance improvement patches

### DIFF
--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -12,8 +12,10 @@ All notable changes to this project will be documented in this file.
   introduced due to the introduction of the banned state for rooms, and the
   non-left room filter did not take the new room stat into account.
   ([#4448](https://github.com/matrix-org/matrix-rust-sdk/pull/4448))
+
 - Fix `EventTimelineItem::latest_edit_json()` when it is populated by a live
   edit. ([#4552](https://github.com/matrix-org/matrix-rust-sdk/pull/4552))
+
 - Fix our own explicit read receipt being ignored when loading it from the
   state store, which resulted in our own read receipt being wrong sometimes.
   ([#4600](https://github.com/matrix-org/matrix-rust-sdk/pull/4600))
@@ -35,10 +37,17 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- Drastically improve the performance of the `Timeline` when it receives
+  hundreds and hundreds of events (approximately 10 times faster).
+  ([#4601](https://github.com/matrix-org/matrix-rust-sdk/pull/4601),
+  [#4608](https://github.com/matrix-org/matrix-rust-sdk/pull/4608),
+  [#4612](https://github.com/matrix-org/matrix-rust-sdk/pull/4612))
+
 - [**breaking**] `Timeline::paginate_forwards` and `Timeline::paginate_backwards`
   are unified to work on a live or focused timeline.
   `Timeline::live_paginate_*` and `Timeline::focused_paginate_*` have been
   removed ([#4584](https://github.com/matrix-org/matrix-rust-sdk/pull/4584)).
+
 - [**breaking**] `Timeline::subscribe_batched` replaces
   `Timeline::subscribe`. `subscribe` has been removed in
   [#4567](https://github.com/matrix-org/matrix-rust-sdk/pull/4567),

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -33,6 +33,9 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- Improve the performance of `EventCache` (approximately 4.5 times faster).
+  ([#4616](https://github.com/matrix-org/matrix-rust-sdk/pull/4616))
+
 - [**breaking**]: The reexported types `SyncTimelineEvent` and `TimelineEvent` have been fused into a single type
   `TimelineEvent`, and its field `push_actions` has been made `Option`al (it is set to `None` when
   we couldn't compute the push actions, because we lacked some information).


### PR DESCRIPTION
This patch adds #4601, #4608, #4612 and #4616 in their respective `CHANGELOG.md`s.
