### PR TITLE
Rename snapshots to reduce filename length

### DIFF
--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -676,7 +676,7 @@ mod tests {
 
     use assert_matches::assert_matches;
     use assert_matches2::assert_let;
-    use insta::assert_snapshot;
+    use insta::{assert_snapshot, with_settings};
     use matrix_sdk_common::deserialized_responses::WithheldCode;
     use matrix_sdk_test::{
         async_test, test_json,
@@ -746,7 +746,9 @@ mod tests {
     fn test_serialize_device_based_strategy() {
         let encryption_settings = all_devices_strategy_settings();
         let serialized = serde_json::to_string(&encryption_settings).unwrap();
-        assert_snapshot!(serialized);
+        with_settings!({prepend_module_to_snapshot => false}, {
+            assert_snapshot!(serialized)
+        });
     }
 
     /// [`CollectStrategy::AllDevices`] used to be known as
@@ -1340,11 +1342,8 @@ mod tests {
                 .with_dehydrated_device(bob_dehydrated_device_id, true)
                 .build_response();
             allow_duplicates! {
-                with_settings!({sort_maps => true}, {
-                    assert_json_snapshot!(
-                        "should_share_with_verified_dehydrated_device",
-                        ruma_response_to_json(keys_query.clone()),
-                    );
+                with_settings!({prepend_module_to_snapshot => false}, {
+                    assert_json_snapshot!(ruma_response_to_json(keys_query.clone()))
                 });
             }
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();
@@ -1399,11 +1398,8 @@ mod tests {
                 .with_dehydrated_device(bob_dehydrated_device_id, false)
                 .build_response();
             allow_duplicates! {
-                with_settings!({sort_maps => true}, {
-                    assert_json_snapshot!(
-                        "should_not_share_with_unverified_dehydrated_device",
-                        ruma_response_to_json(keys_query.clone()),
-                    );
+                with_settings!({prepend_module_to_snapshot => false}, {
+                    assert_json_snapshot!(ruma_response_to_json(keys_query.clone()))
                 });
             }
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();
@@ -1470,11 +1466,8 @@ mod tests {
                 .with_dehydrated_device(bob_dehydrated_device_id, true)
                 .build_response();
             allow_duplicates! {
-                with_settings!({sort_maps => true}, {
-                    assert_json_snapshot!(
-                        "should_share_with_verified_device_of_pin_violation_user",
-                        ruma_response_to_json(keys_query.clone()),
-                    );
+                with_settings!({prepend_module_to_snapshot => false}, {
+                    assert_json_snapshot!(ruma_response_to_json(keys_query.clone()))
                 });
             }
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();
@@ -1604,11 +1597,8 @@ mod tests {
                 .with_dehydrated_device(bob_dehydrated_device_id, true)
                 .build_response();
             allow_duplicates! {
-                with_settings!({sort_maps => true}, {
-                    assert_json_snapshot!(
-                        "prepare_machine_with_dehydrated_device_of_verification_violation_user",
-                        ruma_response_to_json(keys_query.clone()),
-                    );
+                with_settings!({prepend_module_to_snapshot => false}, {
+                    assert_json_snapshot!(ruma_response_to_json(keys_query.clone()))
                 });
             }
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -1342,7 +1342,7 @@ mod tests {
                 .with_dehydrated_device(bob_dehydrated_device_id, true)
                 .build_response();
             allow_duplicates! {
-                with_settings!({prepend_module_to_snapshot => false}, {
+                with_settings!({ sort_maps => true, prepend_module_to_snapshot => false }, {
                     assert_json_snapshot!(ruma_response_to_json(keys_query.clone()))
                 });
             }
@@ -1398,7 +1398,7 @@ mod tests {
                 .with_dehydrated_device(bob_dehydrated_device_id, false)
                 .build_response();
             allow_duplicates! {
-                with_settings!({prepend_module_to_snapshot => false}, {
+                with_settings!({ sort_maps => true, prepend_module_to_snapshot => false }, {
                     assert_json_snapshot!(ruma_response_to_json(keys_query.clone()))
                 });
             }
@@ -1466,7 +1466,7 @@ mod tests {
                 .with_dehydrated_device(bob_dehydrated_device_id, true)
                 .build_response();
             allow_duplicates! {
-                with_settings!({prepend_module_to_snapshot => false}, {
+                with_settings!({ sort_maps => true, prepend_module_to_snapshot => false }, {
                     assert_json_snapshot!(ruma_response_to_json(keys_query.clone()))
                 });
             }
@@ -1597,7 +1597,7 @@ mod tests {
                 .with_dehydrated_device(bob_dehydrated_device_id, true)
                 .build_response();
             allow_duplicates! {
-                with_settings!({prepend_module_to_snapshot => false}, {
+                with_settings!({ sort_maps => true, prepend_module_to_snapshot => false }, {
                     assert_json_snapshot!(ruma_response_to_json(keys_query.clone()))
                 });
             }

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -1340,7 +1340,12 @@ mod tests {
                 .with_dehydrated_device(bob_dehydrated_device_id, true)
                 .build_response();
             allow_duplicates! {
-                with_settings!({sort_maps => true}, { assert_json_snapshot!(ruma_response_to_json(keys_query.clone())) });
+                with_settings!({sort_maps => true}, {
+                    assert_json_snapshot!(
+                        "should_share_with_verified_dehydrated_device",
+                        ruma_response_to_json(keys_query.clone()),
+                    );
+                });
             }
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();
 
@@ -1394,7 +1399,12 @@ mod tests {
                 .with_dehydrated_device(bob_dehydrated_device_id, false)
                 .build_response();
             allow_duplicates! {
-                with_settings!({sort_maps => true}, { assert_json_snapshot!(ruma_response_to_json(keys_query.clone())) });
+                with_settings!({sort_maps => true}, {
+                    assert_json_snapshot!(
+                        "should_not_share_with_unverified_dehydrated_device",
+                        ruma_response_to_json(keys_query.clone()),
+                    );
+                });
             }
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();
 
@@ -1460,7 +1470,12 @@ mod tests {
                 .with_dehydrated_device(bob_dehydrated_device_id, true)
                 .build_response();
             allow_duplicates! {
-                with_settings!({sort_maps => true}, { assert_json_snapshot!(ruma_response_to_json(keys_query.clone())) });
+                with_settings!({sort_maps => true}, {
+                    assert_json_snapshot!(
+                        "should_share_with_verified_device_of_pin_violation_user",
+                        ruma_response_to_json(keys_query.clone()),
+                    );
+                });
             }
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();
 
@@ -1589,7 +1604,12 @@ mod tests {
                 .with_dehydrated_device(bob_dehydrated_device_id, true)
                 .build_response();
             allow_duplicates! {
-                with_settings!({sort_maps => true}, { assert_json_snapshot!(ruma_response_to_json(keys_query.clone())) });
+                with_settings!({sort_maps => true}, {
+                    assert_json_snapshot!(
+                        "prepare_machine_with_dehydrated_device_of_verification_violation_user",
+                        ruma_response_to_json(keys_query.clone()),
+                    );
+                });
             }
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();
 

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/prepare_machine_with_dehydrated_device_of_verification_violation_user.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/prepare_machine_with_dehydrated_device_of_verification_violation_user.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
 expression: ruma_response_to_json(keys_query.clone())
+snapshot_kind: text
 ---
 {
   "device_keys": {
@@ -29,11 +30,11 @@ expression: ruma_response_to_json(keys_query.clone())
   "master_keys": {
     "@bob:localhost": {
       "keys": {
-        "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY"
+        "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0"
       },
       "signatures": {
         "@bob:localhost": {
-          "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "vgFiLvyxYeiVxhpMV81Z4HTvjRhgmZgWn1ScnsLC+HojFwXckA6+/Aa9L/+sA1hzapNZJ4Vrbstl9c4Ep4nbAA"
+          "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "MalGqUfgScuZcEzFyBaJV0nXP6cBGaDz6LZtwrWmvAtfn3uDVatym+CX+YkKZmflog7XJogdeYtHuyn733tWBA"
         }
       },
       "usage": [
@@ -49,7 +50,7 @@ expression: ruma_response_to_json(keys_query.clone())
       },
       "signatures": {
         "@bob:localhost": {
-          "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "xQhtPoTJilhxKrruKAhrpQ1MJFKsCPh77R2WUrWHIB5Mi4sPbxpeU1MZvV/jCCfHrZ5ID40PG2EcEAPtPLYgAQ"
+          "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "h1sADa7kifsHyzGc0ZTGckzjEE15s2YVR9Tz6pdyOWoHJUUcOjBDz6aGNbDarcs/OY49rF3nNXUMsRXEW6ZCBA"
         }
       },
       "usage": [
@@ -65,7 +66,7 @@ expression: ruma_response_to_json(keys_query.clone())
       },
       "signatures": {
         "@bob:localhost": {
-          "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "d9lPdE5nqpl1euENWderCnPJRTClAcH11JMAIlKiPIWObL19U26zxuchBMEgVR4U7UN55ykDiWtPUlDCC7yvAg"
+          "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "gIfvMruwAbB7l7893w6bR/2dqTGTFM4qfSYWZWJ/i981zZYfTQv+8h91URCMhviKXQlelnVnMRrP6osssS8NAA"
         }
       },
       "usage": [

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/prepare_machine_with_dehydrated_device_of_verification_violation_user.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/prepare_machine_with_dehydrated_device_of_verification_violation_user.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
 expression: ruma_response_to_json(keys_query.clone())
-snapshot_kind: text
 ---
 {
   "device_keys": {

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/serialize_device_based_strategy.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/serialize_device_based_strategy.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
 expression: serialized
-snapshot_kind: text
 ---
 {"algorithm":"m.megolm.v1.aes-sha2","rotation_period":{"secs":604800,"nanos":0},"rotation_period_msgs":100,"history_visibility":"shared","sharing_strategy":"AllDevices"}

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/serialize_device_based_strategy.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/serialize_device_based_strategy.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
 expression: serialized
+snapshot_kind: text
 ---
 {"algorithm":"m.megolm.v1.aes-sha2","rotation_period":{"secs":604800,"nanos":0},"rotation_period_msgs":100,"history_visibility":"shared","sharing_strategy":"AllDevices"}

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/should_not_share_with_unverified_dehydrated_device.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/should_not_share_with_unverified_dehydrated_device.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
 expression: ruma_response_to_json(keys_query.clone())
-snapshot_kind: text
 ---
 {
   "device_keys": {

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/should_not_share_with_unverified_dehydrated_device.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/should_not_share_with_unverified_dehydrated_device.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
 expression: ruma_response_to_json(keys_query.clone())
+snapshot_kind: text
 ---
 {
   "device_keys": {

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/should_share_with_verified_dehydrated_device.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/should_share_with_verified_dehydrated_device.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
 expression: ruma_response_to_json(keys_query.clone())
-snapshot_kind: text
 ---
 {
   "device_keys": {

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/should_share_with_verified_dehydrated_device.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/should_share_with_verified_dehydrated_device.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
 expression: ruma_response_to_json(keys_query.clone())
+snapshot_kind: text
 ---
 {
   "device_keys": {
@@ -29,11 +30,11 @@ expression: ruma_response_to_json(keys_query.clone())
   "master_keys": {
     "@bob:localhost": {
       "keys": {
-        "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0"
+        "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY"
       },
       "signatures": {
         "@bob:localhost": {
-          "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "MalGqUfgScuZcEzFyBaJV0nXP6cBGaDz6LZtwrWmvAtfn3uDVatym+CX+YkKZmflog7XJogdeYtHuyn733tWBA"
+          "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "vgFiLvyxYeiVxhpMV81Z4HTvjRhgmZgWn1ScnsLC+HojFwXckA6+/Aa9L/+sA1hzapNZJ4Vrbstl9c4Ep4nbAA"
         }
       },
       "usage": [
@@ -49,7 +50,7 @@ expression: ruma_response_to_json(keys_query.clone())
       },
       "signatures": {
         "@bob:localhost": {
-          "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "h1sADa7kifsHyzGc0ZTGckzjEE15s2YVR9Tz6pdyOWoHJUUcOjBDz6aGNbDarcs/OY49rF3nNXUMsRXEW6ZCBA"
+          "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "xQhtPoTJilhxKrruKAhrpQ1MJFKsCPh77R2WUrWHIB5Mi4sPbxpeU1MZvV/jCCfHrZ5ID40PG2EcEAPtPLYgAQ"
         }
       },
       "usage": [
@@ -65,7 +66,7 @@ expression: ruma_response_to_json(keys_query.clone())
       },
       "signatures": {
         "@bob:localhost": {
-          "ed25519:QK24BHjZnsDxe8rfCBHieNRG3MDNCcCMjBNhKCfNuC0": "gIfvMruwAbB7l7893w6bR/2dqTGTFM4qfSYWZWJ/i981zZYfTQv+8h91URCMhviKXQlelnVnMRrP6osssS8NAA"
+          "ed25519:B2W5RIPXTnKtRhFATxcvrKzIOWVstpdNLkf2uOQNBOY": "d9lPdE5nqpl1euENWderCnPJRTClAcH11JMAIlKiPIWObL19U26zxuchBMEgVR4U7UN55ykDiWtPUlDCC7yvAg"
         }
       },
       "usage": [

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/should_share_with_verified_device_of_pin_violation_user.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/should_share_with_verified_device_of_pin_violation_user.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
 expression: ruma_response_to_json(keys_query.clone())
-snapshot_kind: text
 ---
 {
   "device_keys": {

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/should_share_with_verified_device_of_pin_violation_user.snap
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/snapshots/should_share_with_verified_device_of_pin_violation_user.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
 expression: ruma_response_to_json(keys_query.clone())
+snapshot_kind: text
 ---
 {
   "device_keys": {


### PR DESCRIPTION
Most core developers don't work in windows and they are creating snapshot files that file path is too long or contains the exceptional character.
Windows doesn't allow these issues.
I am working on windows, so I am suffering by file path issue on `git pull` when this repo contains long path issues.
Will fix them here.
And from @richvdh 's proposal, will implement file path checker in github actions CI, so that developer can find long path issue on every PR.