### PR TITLE
chore(sdk): Remove `RoomEventCacheUpdate::Clear`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -261,18 +261,6 @@ impl TimelineBuilder {
                             inner.handle_fully_read_marker(event_id).await;
                         }
 
-                        RoomEventCacheUpdate::Clear => {
-                            if !inner.is_live().await {
-                                // Ignore a clear for a timeline not in the live mode; the
-                                // focused-on-event mode doesn't add any new items to the timeline
-                                // anyways.
-                                continue;
-                            }
-
-                            trace!("Clearing the timeline.");
-                            inner.clear().await;
-                        }
-
                         RoomEventCacheUpdate::UpdateTimelineEvents { diffs, origin } => {
                             trace!("Received new timeline events diffs");
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -888,9 +888,6 @@ async fn test_lazy_back_pagination() {
     // Only 20 items are broadcasted to the subscriber.
     assert_timeline_stream! {
         [timeline_stream]
-        // Huh?
-        // TODO: understand why
-        clear;
         clear;
 
         // `$ev11`, the 1st item.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -291,22 +291,19 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     server.reset().await;
 
     assert_let!(Some(timeline_updates) = timeline_stream.next().await);
-    assert_eq!(timeline_updates.len(), 5);
+    assert_eq!(timeline_updates.len(), 4);
 
     // Timeline receives events as before.
-    assert_let!(VectorDiff::Clear = &timeline_updates[0]); // TODO: Remove `RoomEventCacheUpdate::Clear` as it creates double
-                                                           // `VectorDiff::Clear`.
-
-    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[1]);
+    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);
     assert_eq!(value.as_event().unwrap().event_id(), Some(fourth_event_id));
 
-    assert_let!(VectorDiff::Set { index: 0, value } = &timeline_updates[2]);
+    assert_let!(VectorDiff::Set { index: 0, value } = &timeline_updates[1]);
     assert_eq!(value.as_event().unwrap().event_id(), Some(fourth_event_id));
 
-    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[3]);
+    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[2]);
     assert_eq!(value.as_event().unwrap().event_id(), Some(fifth_event_id));
 
-    assert_let!(VectorDiff::PushFront { value } = &timeline_updates[4]);
+    assert_let!(VectorDiff::PushFront { value } = &timeline_updates[3]);
     assert!(value.is_date_divider());
 
     assert_pending!(timeline_stream);

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -35,6 +35,11 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- [**breaking**]: The `RoomEventCacheUpdate::Clear` variant has been removed, as
+  it is redundant with the `RoomEventCacheUpdate::UpdateTimelineEvents { diffs:
+  Vec<VectorDiff<_>>, .. }` where `VectorDiff` has its own `Clear` variant.
+  ([#4627](https://github.com/matrix-org/matrix-rust-sdk/pull/4627))
+
 - Improve the performance of `EventCache` (approximately 4.5 times faster).
   ([#4616](https://github.com/matrix-org/matrix-rust-sdk/pull/4616))
 

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -404,7 +404,7 @@ mod tests {
             assert_matches!(found, PaginationToken::None);
 
             // Reset waited_for_initial_prev_token and event state.
-            pagination.inner.state.write().await.reset().await.unwrap();
+            let _ = pagination.inner.state.write().await.reset().await.unwrap();
 
             // If I wait for a back-pagination token for 0 seconds,
             let before = Instant::now();
@@ -416,7 +416,7 @@ mod tests {
             assert!(waited.as_secs() < 1);
 
             // Reset waited_for_initial_prev_token state.
-            pagination.inner.state.write().await.reset().await.unwrap();
+            let _ = pagination.inner.state.write().await.reset().await.unwrap();
 
             // If I wait for a back-pagination token for 1 second,
             let before = Instant::now();


### PR DESCRIPTION
This patch removes the `Clear` variant of the `RoomEventCacheUpdate` enum. This one is not needed anymore since we have `UpdateTimelineEvents` which contains updates as `Vec<VectorDiff<_>>`. `VectorDiff` _has_ a `Clear` variant. It resulted in a double clear every time.

This patch updates `RoomEventCacheInner::reset` and `RoomEventCacheInner::with_events_mut` to annotate them with a `#[must_use]`. Since they return the updates as `VectorDiff`s, they **must** be broadcasted/propagated somewhere, likely with `RoomEventCacheUpdate`. This mechanism ensures to not miss updates.

---

* Address #3280 