### PR TITLE
chore(ffi): reduce the verbosity of the store locks and ambiguity map

### DIFF
--- a/bindings/matrix-sdk-ffi/src/platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform.rs
@@ -247,6 +247,9 @@ enum LogTarget {
     MatrixSdkEventCache,
     MatrixSdkBaseEventCache,
     MatrixSdkEventCacheStore,
+
+    MatrixSdkCommonStoreLocks,
+    MatrixSdkBaseStoreAmbiguityMap,
 }
 
 impl LogTarget {
@@ -266,6 +269,9 @@ impl LogTarget {
             LogTarget::MatrixSdkEventCache => "matrix_sdk::event_cache",
             LogTarget::MatrixSdkBaseEventCache => "matrix_sdk_base::event_cache",
             LogTarget::MatrixSdkEventCacheStore => "matrix_sdk_sqlite::event_cache_store",
+
+            LogTarget::MatrixSdkCommonStoreLocks => "matrix_sdk_common::store_locks",
+            LogTarget::MatrixSdkBaseStoreAmbiguityMap => "matrix_sdk_base::store::ambiguity_map",
         }
     }
 }
@@ -285,12 +291,16 @@ const DEFAULT_TARGET_LOG_LEVELS: &[(LogTarget, LogLevel)] = &[
     (LogTarget::MatrixSdkEventCache, LogLevel::Info),
     (LogTarget::MatrixSdkBaseEventCache, LogLevel::Info),
     (LogTarget::MatrixSdkEventCacheStore, LogLevel::Info),
+    (LogTarget::MatrixSdkCommonStoreLocks, LogLevel::Warn),
+    (LogTarget::MatrixSdkBaseStoreAmbiguityMap, LogLevel::Warn),
 ];
 
 const IMMUTABLE_TARGET_LOG_LEVELS: &[LogTarget] = &[
-    LogTarget::Hyper,        // Too verbose
-    LogTarget::MatrixSdk,    // Too generic
-    LogTarget::MatrixSdkFfi, // Too verbose
+    LogTarget::Hyper,                          // Too verbose
+    LogTarget::MatrixSdk,                      // Too generic
+    LogTarget::MatrixSdkFfi,                   // Too verbose
+    LogTarget::MatrixSdkCommonStoreLocks,      // Too verbose
+    LogTarget::MatrixSdkBaseStoreAmbiguityMap, // Too verbose
 ];
 
 #[derive(uniffi::Record)]
@@ -380,6 +390,8 @@ mod tests {
             matrix_sdk::event_cache=info,\
             matrix_sdk_base::event_cache=info,\
             matrix_sdk_sqlite::event_cache_store=info,\
+            matrix_sdk_common::store_locks=warn,\
+            matrix_sdk_base::store::ambiguity_map=warn,\
             super_duper_app=error"
         );
     }
@@ -412,6 +424,8 @@ mod tests {
             matrix_sdk::event_cache=trace,\
             matrix_sdk_base::event_cache=trace,\
             matrix_sdk_sqlite::event_cache_store=trace,\
+            matrix_sdk_common::store_locks=warn,\
+            matrix_sdk_base::store::ambiguity_map=warn,\
             super_duper_app=trace,\
             some_other_span=trace"
         );


### PR DESCRIPTION
They produce hundreds of logs like

```
2025-02-05T12:25:02.584637Z  INFO matrix_sdk_base::store::ambiguity_map: return=false | crates/matrix-sdk-base/src/store/ambiguity_map.rs:89 | spans: live_update_handler{room_id="!XBZZPIcqcoInXjgKdL:matrix.org" focus="live"} > is_display_name_ambiguous{display_name=DisplayName { raw: "Doug", decancered: Some("doug") } users_with_display_name={"@douge:matrix.org"}}
```

and

```
2025-02-05T12:23:21.894300Z  INFO matrix_sdk_common::store_locks: aborting the previous renew task | crates/matrix-sdk-common/src/store_locks.rs:219 | spans: root > spin_lock{max_backoff=None self.lock_key="default" self.lock_holder="io.element.elementx"} > try_lock_once{self.lock_key="default" self.lock_holder="io.element.elementx"}
```