### PR TITLE
refactor(timeline): simplify transition from unencrypted to encrypted

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -163,7 +163,7 @@ impl TimelineBuilder {
         let (_, mut event_subscriber) = room_event_cache.subscribe().await?;
 
         let is_pinned_events = matches!(focus, TimelineFocus::PinnedEvents { .. });
-        let is_room_encrypted = room.is_encrypted().await.ok();
+        let is_room_encrypted = room.is_encrypted().await.ok().unwrap_or_default();
 
         let controller = TimelineController::new(
             room,

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -48,7 +48,9 @@ pub(in crate::timeline) struct TimelineMetadata {
 
     /// A boolean indicating whether the room the timeline is attached to is
     /// actually encrypted or not.
-    pub is_room_encrypted: Option<bool>,
+    ///
+    /// May be false until we fetch the actual room encryption state.
+    pub is_room_encrypted: bool,
 
     /// Matrix room version of the timeline's room, or a sensible default.
     ///
@@ -104,7 +106,7 @@ impl TimelineMetadata {
         room_version: RoomVersionId,
         internal_id_prefix: Option<String>,
         unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
-        is_room_encrypted: Option<bool>,
+        is_room_encrypted: bool,
     ) -> Self {
         Self {
             subscriber_skip_count: SkipCount::new(),

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -14,7 +14,7 @@
 
 use std::{num::NonZeroUsize, sync::Arc};
 
-use matrix_sdk::{locks::RwLock, ring_buffer::RingBuffer};
+use matrix_sdk::ring_buffer::RingBuffer;
 use ruma::{EventId, OwnedEventId, OwnedUserId, RoomVersionId};
 use tracing::trace;
 
@@ -48,7 +48,7 @@ pub(in crate::timeline) struct TimelineMetadata {
 
     /// A boolean indicating whether the room the timeline is attached to is
     /// actually encrypted or not.
-    pub is_room_encrypted: Arc<RwLock<Option<bool>>>,
+    pub is_room_encrypted: Option<bool>,
 
     /// Matrix room version of the timeline's room, or a sensible default.
     ///
@@ -120,7 +120,7 @@ impl TimelineMetadata {
             room_version,
             unable_to_decrypt_hook,
             internal_id_prefix,
-            is_room_encrypted: Arc::new(RwLock::new(is_room_encrypted)),
+            is_room_encrypted,
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -270,13 +270,11 @@ impl TimelineState {
         txn.commit();
     }
 
-    pub(super) fn update_all_events_is_room_encrypted(&mut self) {
-        let is_room_encrypted = *self.meta.is_room_encrypted.read();
-
+    pub(super) fn mark_all_events_as_encrypted(&mut self) {
         // When this transaction finishes, all items in the timeline will be emitted
-        // again with the updated encryption value
+        // again with the updated encryption value.
         let mut txn = self.transaction();
-        txn.update_all_events_is_room_encrypted(is_room_encrypted);
+        txn.mark_all_events_as_encrypted();
         txn.commit();
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -64,7 +64,7 @@ impl TimelineState {
         room_version: RoomVersionId,
         internal_id_prefix: Option<String>,
         unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
-        is_room_encrypted: Option<bool>,
+        is_room_encrypted: bool,
     ) -> Self {
         Self {
             items: ObservableItems::new(),

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -575,8 +575,12 @@ impl<'a> TimelineStateTransaction<'a> {
             let item = &self.items[idx];
 
             if let Some(event) = item.as_event() {
+                if event.is_room_encrypted {
+                    continue;
+                }
+
                 let mut cloned_event = event.clone();
-                cloned_event.is_room_encrypted = Some(true);
+                cloned_event.is_room_encrypted = true;
 
                 // Replace the existing item with a new version with the right encryption flag
                 let item = item.with_kind(cloned_event);

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -570,13 +570,13 @@ impl<'a> TimelineStateTransaction<'a> {
     /// This method replaces the `is_room_encrypted` value for all timeline
     /// items to its updated version and creates a `VectorDiff::Set` operation
     /// for each item which will be added to this transaction.
-    pub(super) fn update_all_events_is_room_encrypted(&mut self, is_encrypted: Option<bool>) {
+    pub(super) fn mark_all_events_as_encrypted(&mut self) {
         for idx in 0..self.items.len() {
             let item = &self.items[idx];
 
             if let Some(event) = item.as_event() {
                 let mut cloned_event = event.clone();
-                cloned_event.is_room_encrypted = is_encrypted;
+                cloned_event.is_room_encrypted = Some(true);
 
                 // Replace the existing item with a new version with the right encryption flag
                 let item = item.with_kind(cloned_event);

--- a/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
@@ -672,13 +672,7 @@ mod tests {
     }
 
     fn test_metadata() -> TimelineMetadata {
-        TimelineMetadata::new(
-            owned_user_id!("@a:b.c"),
-            ruma::RoomVersionId::V11,
-            None,
-            None,
-            Some(false),
-        )
+        TimelineMetadata::new(owned_user_id!("@a:b.c"), ruma::RoomVersionId::V11, None, None, false)
     }
 
     #[test]

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -1021,7 +1021,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             }
         };
 
-        let is_room_encrypted = self.meta.is_room_encrypted.unwrap_or_default();
+        let is_room_encrypted = self.meta.is_room_encrypted;
 
         let mut item = EventTimelineItem::new(
             sender,

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -1021,7 +1021,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             }
         };
 
-        let is_room_encrypted = self.meta.is_room_encrypted.read().unwrap_or_default();
+        let is_room_encrypted = self.meta.is_room_encrypted.unwrap_or_default();
 
         let mut item = EventTimelineItem::new(
             sender,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -78,9 +78,8 @@ pub struct EventTimelineItem {
     pub(super) kind: EventTimelineItemKind,
     /// Whether or not the event belongs to an encrypted room.
     ///
-    /// When `None` it is unknown if the room is encrypted and the item won't
-    /// return a ShieldState.
-    pub(super) is_room_encrypted: Option<bool>,
+    /// May be false when we don't know about the room encryption status yet.
+    pub(super) is_room_encrypted: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -120,7 +119,6 @@ impl EventTimelineItem {
         kind: EventTimelineItemKind,
         is_room_encrypted: bool,
     ) -> Self {
-        let is_room_encrypted = Some(is_room_encrypted);
         Self { sender, sender_profile, timestamp, content, kind, is_room_encrypted }
     }
 
@@ -211,7 +209,7 @@ impl EventTimelineItem {
             TimelineDetails::Unavailable
         };
 
-        Some(Self { sender, sender_profile, timestamp, content, kind, is_room_encrypted: None })
+        Some(Self { sender, sender_profile, timestamp, content, kind, is_room_encrypted: false })
     }
 
     /// Check whether this item is a local echo.
@@ -398,7 +396,7 @@ impl EventTimelineItem {
     /// Gets the [`ShieldState`] which can be used to decorate messages in the
     /// recommended way.
     pub fn get_shield(&self, strict: bool) -> Option<ShieldState> {
-        if self.is_room_encrypted != Some(true) || self.is_local_echo() {
+        if !self.is_room_encrypted || self.is_local_echo() {
             return None;
         }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -39,7 +39,7 @@ use super::TestTimeline;
 use crate::timeline::{
     controller::TimelineSettings,
     event_item::{AnyOtherFullStateEventContent, RemoteEventOrigin},
-    tests::{ReadReceiptMap, TestRoomDataProvider},
+    tests::{ReadReceiptMap, TestRoomDataProvider, TestTimelineBuilder},
     MembershipChange, TimelineDetails, TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
 };
 
@@ -86,13 +86,15 @@ async fn test_replace_with_initial_events_and_read_marker() {
         .entry(ALICE.to_owned())
         .or_insert_with(|| (event_id.to_owned(), Receipt::new(MilliSecondsSinceUnixEpoch::now())));
 
-    let timeline = TestTimeline::with_room_data_provider(
-        TestRoomDataProvider::default()
-            // Also add a fully read marker.
-            .with_fully_read_marker(event_id)
-            .with_initial_user_receipts(receipts),
-    )
-    .with_settings(TimelineSettings { track_read_receipts: true, ..Default::default() });
+    let timeline = TestTimelineBuilder::new()
+        .provider(
+            TestRoomDataProvider::default()
+                // Also add a fully read marker.
+                .with_fully_read_marker(event_id)
+                .with_initial_user_receipts(receipts),
+        )
+        .settings(TimelineSettings { track_read_receipts: true, ..Default::default() })
+        .build();
 
     let f = &timeline.factory;
     let ev = f.text_msg("hey").sender(*ALICE).into_event();
@@ -279,7 +281,7 @@ async fn test_other_state() {
 
 #[async_test]
 async fn test_internal_id_prefix() {
-    let timeline = TestTimeline::with_internal_id_prefix("le_prefix_".to_owned());
+    let timeline = TestTimelineBuilder::new().internal_id_prefix("le_prefix_".to_owned()).build();
 
     let f = &timeline.factory;
     let ev_a = f.text_msg("A").sender(*ALICE).into_event();
@@ -447,8 +449,10 @@ async fn test_thread() {
 
 #[async_test]
 async fn test_replace_with_initial_events_when_batched() {
-    let timeline = TestTimeline::with_room_data_provider(TestRoomDataProvider::default())
-        .with_settings(TimelineSettings::default());
+    let timeline = TestTimelineBuilder::new()
+        .provider(TestRoomDataProvider::default())
+        .settings(TimelineSettings::default())
+        .build();
 
     let f = &timeline.factory;
     let ev = f.text_msg("hey").sender(*ALICE).into_event();

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -30,7 +30,7 @@ use super::TestTimeline;
 use crate::timeline::{
     controller::TimelineSettings,
     event_item::{EventSendState, RemoteEventOrigin},
-    tests::TestRoomDataProvider,
+    tests::{TestRoomDataProvider, TestTimelineBuilder},
 };
 
 #[async_test]
@@ -235,10 +235,10 @@ async fn test_date_divider_removed_after_local_echo_disappeared() {
 async fn test_no_read_marker_with_local_echo() {
     let event_id = event_id!("$1");
 
-    let timeline = TestTimeline::with_room_data_provider(
-        TestRoomDataProvider::default().with_fully_read_marker(event_id.to_owned()),
-    )
-    .with_settings(TimelineSettings { track_read_receipts: true, ..Default::default() });
+    let timeline = TestTimelineBuilder::new()
+        .provider(TestRoomDataProvider::default().with_fully_read_marker(event_id.to_owned()))
+        .settings(TimelineSettings { track_read_receipts: true, ..Default::default() })
+        .build();
 
     let f = &timeline.factory;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -48,7 +48,9 @@ use tokio::time::sleep;
 
 use super::TestTimeline;
 use crate::{
-    timeline::{EncryptedMessage, TimelineDetails, TimelineItemContent},
+    timeline::{
+        tests::TestTimelineBuilder, EncryptedMessage, TimelineDetails, TimelineItemContent,
+    },
     unable_to_decrypt_hook::{UnableToDecryptHook, UnableToDecryptInfo, UtdHookManager},
 };
 
@@ -84,7 +86,7 @@ async fn test_retry_message_decryption() {
     let client = test_client_builder(None).build().await.unwrap();
     let utd_hook = Arc::new(UtdHookManager::new(hook.clone(), client));
 
-    let timeline = TestTimeline::with_unable_to_decrypt_hook(utd_hook.clone());
+    let timeline = TestTimelineBuilder::new().unable_to_decrypt_hook(utd_hook.clone()).build();
     let mut stream = timeline.subscribe().await;
 
     let f = &timeline.factory;
@@ -185,7 +187,7 @@ async fn test_false_positive_late_decryption_regression() {
     let utd_hook =
         Arc::new(UtdHookManager::new(hook.clone(), client).with_max_delay(Duration::from_secs(1)));
 
-    let timeline = TestTimeline::with_unable_to_decrypt_hook(utd_hook.clone());
+    let timeline = TestTimelineBuilder::new().unable_to_decrypt_hook(utd_hook.clone()).build();
 
     let f = &timeline.factory;
     timeline

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -30,8 +30,8 @@ use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
 use crate::timeline::{
-    controller::TimelineSettings, AnyOtherFullStateEventContent, TimelineEventTypeFilter,
-    TimelineItem, TimelineItemContent, TimelineItemKind,
+    controller::TimelineSettings, tests::TestTimelineBuilder, AnyOtherFullStateEventContent,
+    TimelineEventTypeFilter, TimelineItem, TimelineItemContent, TimelineItemKind,
 };
 
 #[async_test]
@@ -92,10 +92,9 @@ async fn test_default_filter() {
 
 #[async_test]
 async fn test_filter_always_false() {
-    let timeline = TestTimeline::new().with_settings(TimelineSettings {
-        event_filter: Arc::new(|_, _| false),
-        ..Default::default()
-    });
+    let timeline = TestTimelineBuilder::new()
+        .settings(TimelineSettings { event_filter: Arc::new(|_, _| false), ..Default::default() })
+        .build();
 
     let f = &timeline.factory;
     timeline.handle_live_event(f.text_msg("The first message").sender(&ALICE)).await;
@@ -112,10 +111,12 @@ async fn test_filter_always_false() {
 #[async_test]
 async fn test_custom_filter() {
     // Filter out all state events.
-    let timeline = TestTimeline::new().with_settings(TimelineSettings {
-        event_filter: Arc::new(|ev, _| matches!(ev, AnySyncTimelineEvent::MessageLike(_))),
-        ..Default::default()
-    });
+    let timeline = TestTimelineBuilder::new()
+        .settings(TimelineSettings {
+            event_filter: Arc::new(|ev, _| matches!(ev, AnySyncTimelineEvent::MessageLike(_))),
+            ..Default::default()
+        })
+        .build();
     let mut stream = timeline.subscribe().await;
 
     let f = &timeline.factory;
@@ -135,8 +136,9 @@ async fn test_custom_filter() {
 
 #[async_test]
 async fn test_hide_failed_to_parse() {
-    let timeline = TestTimeline::new()
-        .with_settings(TimelineSettings { add_failed_to_parse: false, ..Default::default() });
+    let timeline = TestTimelineBuilder::new()
+        .settings(TimelineSettings { add_failed_to_parse: false, ..Default::default() })
+        .build();
 
     // m.room.message events must have a msgtype and body in content, so this
     // event with an empty content object should fail to deserialize.
@@ -171,10 +173,12 @@ async fn test_event_type_filter_include_only_room_names() {
     // Only return room name events
     let event_filter = TimelineEventTypeFilter::Include(vec![TimelineEventType::RoomName]);
 
-    let timeline = TestTimeline::new().with_settings(TimelineSettings {
-        event_filter: Arc::new(move |event, _| event_filter.filter(event)),
-        ..Default::default()
-    });
+    let timeline = TestTimelineBuilder::new()
+        .settings(TimelineSettings {
+            event_filter: Arc::new(move |event, _| event_filter.filter(event)),
+            ..Default::default()
+        })
+        .build();
     let f = &timeline.factory;
 
     // Add a non-encrypted message event
@@ -201,10 +205,12 @@ async fn test_event_type_filter_exclude_messages() {
     // Don't return any messages
     let event_filter = TimelineEventTypeFilter::Exclude(vec![TimelineEventType::RoomMessage]);
 
-    let timeline = TestTimeline::new().with_settings(TimelineSettings {
-        event_filter: Arc::new(move |event, _| event_filter.filter(event)),
-        ..Default::default()
-    });
+    let timeline = TestTimelineBuilder::new()
+        .settings(TimelineSettings {
+            event_filter: Arc::new(move |event, _| event_filter.filter(event)),
+            ..Default::default()
+        })
+        .build();
     let f = &timeline.factory;
 
     // Add a message event

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -104,7 +104,7 @@ impl TestTimeline {
                 TimelineFocus::Live,
                 Some(prefix),
                 None,
-                Some(false),
+                false,
             ),
             factory: EventFactory::new(),
         }
@@ -117,7 +117,7 @@ impl TestTimeline {
                 TimelineFocus::Live,
                 None,
                 None,
-                Some(false),
+                false,
             ),
             factory: EventFactory::new(),
         }
@@ -130,7 +130,7 @@ impl TestTimeline {
                 TimelineFocus::Live,
                 None,
                 Some(hook),
-                Some(true),
+                true,
             ),
             factory: EventFactory::new(),
         }
@@ -144,7 +144,7 @@ impl TestTimeline {
                 TimelineFocus::Live,
                 None,
                 None,
-                Some(encrypted),
+                encrypted,
             ),
             factory: EventFactory::new(),
         }

--- a/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
@@ -16,7 +16,10 @@ use ruma::{
 };
 use stream_assert::{assert_next_matches, assert_pending};
 
-use crate::timeline::{tests::TestTimeline, EventSendState};
+use crate::timeline::{
+    tests::{TestTimeline, TestTimelineBuilder},
+    EventSendState,
+};
 
 #[async_test]
 async fn test_no_shield_in_unencrypted_room() {
@@ -33,7 +36,7 @@ async fn test_no_shield_in_unencrypted_room() {
 
 #[async_test]
 async fn test_sent_in_clear_shield() {
-    let timeline = TestTimeline::with_is_room_encrypted(true);
+    let timeline = TestTimelineBuilder::new().room_encrypted(true).build();
     let mut stream = timeline.subscribe().await;
 
     let f = &timeline.factory;
@@ -55,7 +58,7 @@ async fn test_sent_in_clear_shield() {
 /// sure the shield only appears once the remote echo is received.
 async fn test_local_sent_in_clear_shield() {
     // Given an encrypted timeline.
-    let timeline = TestTimeline::with_is_room_encrypted(true);
+    let timeline = TestTimelineBuilder::new().room_encrypted(true).build();
     let mut stream = timeline.subscribe().await;
 
     // When sending an unencrypted event.
@@ -133,7 +136,7 @@ async fn test_local_sent_in_clear_shield() {
 /// sent in clear` red warning.
 async fn test_utd_shield() {
     // Given we are in an encrypted room
-    let timeline = TestTimeline::with_is_room_encrypted(true);
+    let timeline = TestTimelineBuilder::new().room_encrypted(true).build();
     let mut stream = timeline.subscribe().await;
 
     let f = &timeline.factory;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -12,31 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{ops::Not, time::Duration};
+use std::ops::Not;
 
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{
-    config::SyncSettings,
     linked_chunk::{ChunkIdentifier, Position, Update},
-    test_utils::{logged_in_client_with_server, mocks::MatrixMockServer},
+    test_utils::mocks::MatrixMockServer,
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, sync_timeline_event,
-    JoinedRoomBuilder, RoomAccountDataTestEvent, StateTestEvent, SyncResponseBuilder, ALICE, BOB,
+    async_test, event_factory::EventFactory, JoinedRoomBuilder, RoomAccountDataTestEvent,
+    StateTestEvent, ALICE, BOB,
 };
 use matrix_sdk_ui::{
     timeline::{
         AnyOtherFullStateEventContent, Error, EventSendState, RedactError, RoomExt,
         TimelineEventItemId, TimelineItemContent, VirtualTimelineItem,
     },
-    RoomListService, Timeline,
+    Timeline,
 };
 use ruma::{
     event_id,
-    events::room::{encryption::RoomEncryptionEventContent, message::RoomMessageEventContent},
+    events::room::{
+        encryption::RoomEncryptionEventContent,
+        message::{RedactedRoomMessageEventContent, RoomMessageEventContent},
+    },
     owned_event_id, room_id, user_id, EventId, MilliSecondsSinceUnixEpoch,
 };
 use serde_json::json;
@@ -46,8 +48,6 @@ use wiremock::{
     matchers::{header, method, path_regex},
     Mock, ResponseTemplate,
 };
-
-use crate::mock_sync;
 
 mod echo;
 mod edit;
@@ -66,53 +66,31 @@ pub(crate) mod sliding_sync;
 
 #[async_test]
 async fn test_reaction() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let room = server.sync_joined_room(&client, room_id).await;
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    server.mock_room_state_encryption().plain().mount().await;
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(sync_timeline_event!({
-                "content": {
-                    "body": "hello",
-                    "msgtype": "m.text",
-                },
-                "event_id": "$TTvQUp1e17qkw41rBSjpZ",
-                "origin_server_ts": 152037280,
-                "sender": "@alice:example.org",
-                "type": "m.room.message",
-            }))
-            .add_timeline_event(sync_timeline_event!({
-                "content": {
-                    "m.relates_to": {
-                        "event_id": "$TTvQUp1e17qkw41rBSjpZ",
-                        "key": "👍",
-                        "rel_type": "m.annotation",
-                    },
-                },
-                "event_id": "$031IXQRi27504",
-                "origin_server_ts": 152038300,
-                "sender": "@bob:example.org",
-                "type": "m.reaction",
-            })),
-    );
+    let msg_event_id = event_id!("$msg");
+    let reaction_event_id = event_id!("$reaction");
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    let f = EventFactory::new();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.text_msg("hello").sender(&ALICE).event_id(msg_event_id))
+                .add_timeline_event(
+                    f.reaction(msg_event_id, "👍").sender(&BOB).event_id(reaction_event_id),
+                ),
+        )
+        .await;
 
     assert_let!(Some(timeline_updates) = timeline_stream.next().await);
     assert_eq!(timeline_updates.len(), 4);
@@ -142,26 +120,21 @@ async fn test_reaction() {
     let group = &event_item.content().reactions()["👍"];
     assert_eq!(group.len(), 1);
     let senders: Vec<_> = group.keys().collect();
-    assert_eq!(senders.as_slice(), [user_id!("@bob:example.org")]);
+    assert_eq!(senders.as_slice(), [*BOB]);
 
     // The date divider.
     assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[3]);
     assert!(date_divider.is_date_divider());
 
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
-        sync_timeline_event!({
-            "content": {},
-            "redacts": "$031IXQRi27504",
-            "event_id": "$N6eUCBc3vu58PL8TobGaVQzM",
-            "sender": "@bob:example.org",
-            "origin_server_ts": 152037280,
-            "type": "m.room.redaction",
-        }),
-    ));
+    assert_pending!(timeline_stream);
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.redaction(reaction_event_id).sender(&BOB)),
+        )
+        .await;
 
     assert_let!(Some(timeline_updates) = timeline_stream.next().await);
     assert_eq!(timeline_updates.len(), 1);
@@ -177,55 +150,29 @@ async fn test_reaction() {
 
 #[async_test]
 async fn test_redacted_message() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let room = server.sync_joined_room(&client, room_id).await;
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    server.mock_room_state_encryption().plain().mount().await;
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(sync_timeline_event!({
-                "content": {},
-                "event_id": "$eeG0HA0FAZ37wP8kXlNkxx3I",
-                "origin_server_ts": 152035910,
-                "sender": "@alice:example.org",
-                "type": "m.room.message",
-                "unsigned": {
-                    "redacted_because": {
-                        "content": {},
-                        "redacts": "$eeG0HA0FAZ37wP8kXlNkxx3I",
-                        "event_id": "$N6eUCBc3vu58PL8TobGaVQzM",
-                        "sender": "@alice:example.org",
-                        "origin_server_ts": 152037280,
-                        "type": "m.room.redaction",
-                    },
-                },
-            }))
-            .add_timeline_event(sync_timeline_event!({
-                "content": {},
-                "redacts": "$eeG0HA0FAZ37wP8kXlNkxx3I",
-                "event_id": "$N6eUCBc3vu58PL8TobGaVQzM",
-                "sender": "@alice:example.org",
-                "origin_server_ts": 152037280,
-                "type": "m.room.redaction",
-            })),
-    );
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    let event_id = event_id!("$eeG0HA0FAZ37wP8kXlNkxx3I");
+    let f = EventFactory::new();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    f.redacted(*ALICE, RedactedRoomMessageEventContent::new()).event_id(event_id),
+                )
+                .add_timeline_event(f.redaction(event_id).sender(&ALICE)),
+        )
+        .await;
 
     assert_let!(Some(timeline_updates) = timeline_stream.next().await);
     assert_eq!(timeline_updates.len(), 2);
@@ -377,21 +324,14 @@ async fn test_redact_local_sent_message() {
 
 #[async_test]
 async fn test_redact_nonexisting_item() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
+    let room = server.sync_joined_room(&client, room_id).await;
 
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    server.mock_room_state_encryption().plain().mount().await;
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
 
     let error = timeline
@@ -407,39 +347,26 @@ async fn test_redact_nonexisting_item() {
 
 #[async_test]
 async fn test_read_marker() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let room = server.sync_joined_room(&client, room_id).await;
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    server.mock_room_state_encryption().plain().mount().await;
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
-        sync_timeline_event!({
-            "content": {
-                "body": "hello",
-                "msgtype": "m.text",
-            },
-            "event_id": "$someplace:example.org",
-            "origin_server_ts": 152037280,
-            "sender": "@alice:example.org",
-            "type": "m.room.message",
-        }),
-    ));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    let f = EventFactory::new();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(
+                f.text_msg("hello").sender(&ALICE).event_id(event_id!("$someplace:example.org")),
+            ),
+        )
+        .await;
 
     assert_let!(Some(timeline_updates) = timeline_stream.next().await);
     assert_eq!(timeline_updates.len(), 2);
@@ -450,32 +377,26 @@ async fn test_read_marker() {
     assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[1]);
     assert!(date_divider.is_date_divider());
 
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id).add_account_data(RoomAccountDataTestEvent::FullyRead),
-    );
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_account_data(RoomAccountDataTestEvent::FullyRead),
+        )
+        .await;
 
     // Nothing should happen, the marker cannot be added at the end.
+    assert_pending!(timeline_stream);
 
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
-        sync_timeline_event!({
-            "content": {
-                "body": "hello to you!",
-                "msgtype": "m.text",
-            },
-            "event_id": "$someotherplace:example.org",
-            "origin_server_ts": 152067280,
-            "sender": "@bob:example.org",
-            "type": "m.room.message",
-        }),
-    ));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(
+                f.text_msg("hello to you!")
+                    .sender(&BOB)
+                    .event_id(event_id!("$someotherplace:example.org")),
+            ),
+        )
+        .await;
 
     assert_let!(Some(timeline_updates) = timeline_stream.next().await);
     assert_eq!(timeline_updates.len(), 2);
@@ -491,45 +412,34 @@ async fn test_read_marker() {
 
 #[async_test]
 async fn test_sync_highlighted() {
-    let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder
-        // We need the member event and power levels locally so the push rules processor works.
-        .add_joined_room(
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let room = server
+        .sync_room(
+            &client,
+            // We need the member event and power levels locally so the push rules processor works.
             JoinedRoomBuilder::new(room_id)
                 .add_state_event(StateTestEvent::Member)
                 .add_state_event(StateTestEvent::PowerLevels),
-        );
+        )
+        .await;
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
-        sync_timeline_event!({
-            "content": {
-                "body": "hello",
-                "msgtype": "m.text",
-            },
-            "event_id": "$msda7m0df9E9op3",
-            "origin_server_ts": 152037280,
-            "sender": "@example:localhost",
-            "type": "m.room.message",
-        }),
-    ));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    let f = EventFactory::new();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(
+                f.text_msg("hello").sender(&ALICE).event_id(event_id!("$msda7m0df9E9op3")),
+            ),
+        )
+        .await;
 
     assert_let!(Some(timeline_updates) = timeline_stream.next().await);
     assert_eq!(timeline_updates.len(), 2);
@@ -542,23 +452,15 @@ async fn test_sync_highlighted() {
     assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[1]);
     assert!(date_divider.is_date_divider());
 
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
-        sync_timeline_event!({
-            "content": {
-                "body": "This room has been replaced",
-                "replacement_room": "!newroom:localhost",
-            },
-            "event_id": "$foun39djjod0f",
-            "origin_server_ts": 152039280,
-            "sender": "@bob:localhost",
-            "state_key": "",
-            "type": "m.room.tombstone",
-        }),
-    ));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(
+                f.room_tombstone("This room has been replaced", room_id!("!newroom:localhost"))
+                    .sender(&BOB),
+            ),
+        )
+        .await;
 
     assert_let!(Some(timeline_updates) = timeline_stream.next().await);
     assert_eq!(timeline_updates.len(), 1);
@@ -573,20 +475,14 @@ async fn test_sync_highlighted() {
 
 #[async_test]
 async fn test_duplicate_maintains_correct_order() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let room = server.sync_joined_room(&client, room_id).await;
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    server.mock_room_state_encryption().plain().mount().await;
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await.unwrap();
 
     // At the beginning, the timeline is empty.
@@ -595,14 +491,13 @@ async fn test_duplicate_maintains_correct_order() {
     let f = EventFactory::new().sender(user_id!("@a:b.c"));
 
     // We receive an event F, from a sliding sync with timeline limit=1.
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(f.text_msg("C").event_id(event_id!("$c")).into_raw_sync()),
-    );
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.text_msg("C").event_id(event_id!("$c")).into_raw_sync()),
+        )
+        .await;
 
     // The timeline item represents the message we just received.
     let items = timeline.items().await;
@@ -614,16 +509,15 @@ async fn test_duplicate_maintains_correct_order() {
 
     // We receive multiple events, and C is now the last one (because we supposedly
     // increased the timeline limit).
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(f.text_msg("A").event_id(event_id!("$a")).into_raw_sync())
-            .add_timeline_event(f.text_msg("B").event_id(event_id!("$b")).into_raw_sync())
-            .add_timeline_event(f.text_msg("C").event_id(event_id!("$c")).into_raw_sync()),
-    );
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.text_msg("A").event_id(event_id!("$a")).into_raw_sync())
+                .add_timeline_event(f.text_msg("B").event_id(event_id!("$b")).into_raw_sync())
+                .add_timeline_event(f.text_msg("C").event_id(event_id!("$c")).into_raw_sync()),
+        )
+        .await;
 
     let items = timeline.items().await;
     assert_eq!(items.len(), 4, "{items:?}");
@@ -646,16 +540,10 @@ async fn test_pin_event_is_sent_successfully() {
     assert!(!timeline.items().await.is_empty());
 
     // Pinning a remote event succeeds.
-    setup
-        .mock_pin_unpin_response(ResponseTemplate::new(200).set_body_json(json!({
-            "event_id": "$42"
-        })))
-        .await;
+    setup.server.mock_set_room_pinned_events().ok(owned_event_id!("$42")).mock_once().mount().await;
 
     let event_id = setup.event_id();
     assert!(timeline.pin_event(event_id).await.unwrap());
-
-    setup.reset_server().await;
 }
 
 #[async_test]
@@ -668,8 +556,6 @@ async fn test_pin_event_is_returning_false_because_is_already_pinned() {
 
     let event_id = setup.event_id();
     assert!(!timeline.pin_event(event_id).await.unwrap());
-
-    setup.reset_server().await;
 }
 
 #[async_test]
@@ -681,12 +567,10 @@ async fn test_pin_event_is_returning_an_error() {
     assert!(!timeline.items().await.is_empty());
 
     // Pinning a remote event fails.
-    setup.mock_pin_unpin_response(ResponseTemplate::new(400)).await;
+    setup.server.mock_set_room_pinned_events().unauthorized().mock_once().mount().await;
 
     let event_id = setup.event_id();
     assert!(timeline.pin_event(event_id).await.is_err());
-
-    setup.reset_server().await;
 }
 
 #[async_test]
@@ -698,16 +582,10 @@ async fn test_unpin_event_is_sent_successfully() {
     assert!(!timeline.items().await.is_empty());
 
     // Unpinning a remote event succeeds.
-    setup
-        .mock_pin_unpin_response(ResponseTemplate::new(200).set_body_json(json!({
-            "event_id": "$42"
-        })))
-        .await;
+    setup.server.mock_set_room_pinned_events().ok(owned_event_id!("$42")).mock_once().mount().await;
 
     let event_id = setup.event_id();
     assert!(timeline.unpin_event(event_id).await.unwrap());
-
-    setup.reset_server().await;
 }
 
 #[async_test]
@@ -720,8 +598,6 @@ async fn test_unpin_event_is_returning_false_because_is_not_pinned() {
 
     let event_id = setup.event_id();
     assert!(!timeline.unpin_event(event_id).await.unwrap());
-
-    setup.reset_server().await;
 }
 
 #[async_test]
@@ -733,67 +609,62 @@ async fn test_unpin_event_is_returning_an_error() {
     assert!(!timeline.items().await.is_empty());
 
     // Unpinning a remote event fails.
-    setup.mock_pin_unpin_response(ResponseTemplate::new(400)).await;
+    setup.server.mock_set_room_pinned_events().unauthorized().mock_once().mount().await;
 
     let event_id = setup.event_id();
     assert!(timeline.unpin_event(event_id).await.is_err());
-
-    setup.reset_server().await;
 }
 
 #[async_test]
 async fn test_timeline_without_encryption_info() {
-    // No encryption is mocked for this client/server pair
-    let (client, server) = logged_in_client_with_server().await;
-    let _ = RoomListService::new(client.clone()).await.unwrap();
+    // The room encryption state is NOT mocked on purpose.
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    client.event_cache().subscribe().unwrap();
 
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
-    let f = EventFactory::new().room(room_id).sender(*BOB);
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id).add_timeline_event(f.text_msg("A message").into_raw_sync()),
-    );
+    let f = EventFactory::new();
+    let room = server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.text_msg("A message").sender(*BOB)),
+        )
+        .await;
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    let room = client.get_room(room_id).unwrap();
     // Previously this would have panicked.
     let timeline = room.timeline().await.unwrap();
 
     let (items, _) = timeline.subscribe().await;
     assert_eq!(items.len(), 2);
     assert!(items[0].as_virtual().is_some());
-    // No encryption, no shields
+    // No encryption, no shields.
     assert!(items[1].as_event().unwrap().get_shield(false).is_none());
 }
 
 #[async_test]
 async fn test_timeline_without_encryption_can_update() {
-    // No encryption is mocked for this client/server pair
-    let (client, server) = logged_in_client_with_server().await;
-    let _ = RoomListService::new(client.clone()).await.unwrap();
+    // The room encryption state is NOT mocked on purpose.
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    client.event_cache().subscribe().unwrap();
 
     let room_id = room_id!("!jEsUZKDJdhlrceRyVU:example.org");
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
     let f = EventFactory::new().room(room_id).sender(*BOB);
+    let room = server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(f.text_msg("A message")),
+        )
+        .await;
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id).add_timeline_event(f.text_msg("A message").into_raw_sync()),
-    );
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    let room = client.get_room(room_id).unwrap();
     // Previously this would have panicked.
     // We're creating a timeline without read receipts tracking to check only the
-    // encryption changes
+    // encryption changes.
     let timeline = Timeline::builder(&room).build().await.unwrap();
 
     let (items, mut stream) = timeline.subscribe().await;
@@ -803,30 +674,30 @@ async fn test_timeline_without_encryption_can_update() {
     assert!(items[1].as_event().unwrap().get_shield(false).is_none());
 
     let encryption_event_content = RoomEncryptionEventContent::with_recommended_defaults();
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(f.event(encryption_event_content).state_key("").into_raw_sync())
-            .add_timeline_event(f.text_msg("An encrypted message").into_raw_sync()),
-    );
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.event(encryption_event_content).state_key("").into_raw_sync())
+                .add_timeline_event(f.text_msg("An encrypted message").into_raw_sync()),
+        )
+        .await;
 
     assert_let!(Some(timeline_updates) = stream.next().await);
     assert_eq!(timeline_updates.len(), 3);
 
-    // Previous timeline event now has a shield
+    // Previous timeline event now has a shield.
     assert_let!(VectorDiff::Set { index, value } = &timeline_updates[0]);
     assert_eq!(*index, 1);
     assert!(value.as_event().unwrap().get_shield(false).is_some());
 
-    // Room encryption event is received
+    // Room encryption event is received.
     assert_let!(VectorDiff::PushBack { value } = &timeline_updates[1]);
     assert_let!(TimelineItemContent::OtherState(other_state) = value.as_event().unwrap().content());
     assert_let!(AnyOtherFullStateEventContent::RoomEncryption(_) = other_state.content());
     assert!(value.as_event().unwrap().get_shield(false).is_some());
 
-    // New message event is received and has a shield
+    // New message event is received and has a shield.
     assert_let!(VectorDiff::PushBack { value } = &timeline_updates[2]);
     assert!(value.as_event().unwrap().get_shield(false).is_some());
 
@@ -914,73 +785,49 @@ struct PinningTestSetup<'a> {
     event_id: &'a EventId,
     room_id: &'a ruma::RoomId,
     client: matrix_sdk::Client,
-    server: wiremock::MockServer,
-    sync_settings: SyncSettings,
-    sync_builder: SyncResponseBuilder,
+    server: MatrixMockServer,
 }
 
 impl PinningTestSetup<'_> {
     async fn new() -> Self {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
         let room_id = room_id!("!a98sd12bjh:example.org");
-        let (client, server) = logged_in_client_with_server().await;
-        let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+        server.sync_joined_room(&client, room_id).await;
 
-        let mut sync_builder = SyncResponseBuilder::new();
-        let event_id = event_id!("$a");
-        sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-        mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-        let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-        server.reset().await;
-
-        let setup = Self { event_id, room_id, client, server, sync_settings, sync_builder };
+        server.mock_room_state_encryption().plain().mount().await;
 
         // This is necessary to get an empty list of pinned events when there are no
         // pinned events state event in the required state
-        setup.mock_get_empty_pinned_events_state_response().await;
-
-        setup
-    }
-
-    async fn timeline(&self) -> Timeline {
-        mock_encryption_state(&self.server, false).await;
-        let room = self.client.get_room(self.room_id).unwrap();
-        room.timeline().await.unwrap()
-    }
-
-    async fn reset_server(&self) {
-        self.server.reset().await;
-    }
-
-    async fn mock_pin_unpin_response(&self, response: ResponseTemplate) {
-        Mock::given(method("PUT"))
-            .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/m.room.pinned_events/.*?"))
-            .and(header("authorization", "Bearer 1234"))
-            .respond_with(response)
-            .mount(&self.server)
-            .await;
-    }
-
-    async fn mock_get_empty_pinned_events_state_response(&self) {
         Mock::given(method("GET"))
             .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/m.room.pinned_events/.*"))
             .and(header("authorization", "Bearer 1234"))
             .respond_with(ResponseTemplate::new(404).set_body_json(json!({})))
-            .mount(&self.server)
+            .mount(server.server())
             .await;
+
+        let event_id = event_id!("$a");
+        Self { event_id, room_id, client, server }
+    }
+
+    async fn timeline(&self) -> Timeline {
+        let room = self.client.get_room(self.room_id).unwrap();
+        room.timeline().await.unwrap()
     }
 
     async fn mock_sync(&mut self, is_using_pinned_state_event: bool) {
         let f = EventFactory::new().sender(user_id!("@a:b.c"));
+
         let mut joined_room_builder = JoinedRoomBuilder::new(self.room_id)
             .add_timeline_event(f.text_msg("A").event_id(self.event_id).into_raw_sync());
+
         if is_using_pinned_state_event {
             joined_room_builder =
                 joined_room_builder.add_state_event(StateTestEvent::RoomPinnedEvents);
         }
-        self.sync_builder.add_joined_room(joined_room_builder);
-        mock_sync(&self.server, self.sync_builder.build_json_sync_response(), None).await;
-        let _response = self.client.sync_once(self.sync_settings.clone()).await.unwrap();
+
+        self.server.sync_room(&self.client, joined_room_builder).await;
     }
 
     fn event_id(&self) -> &EventId {

--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -931,6 +931,15 @@ impl MatrixMockServer {
             .and(path_regex(r"^/_matrix/client/unstable/im.nheko.summary/rooms/.*/summary"));
         MockEndpoint { mock, server: &self.server, endpoint: RoomSummaryEndpoint }
     }
+
+    /// Creates a prebuilt mock for the endpoint used to set a room's pinned
+    /// events.
+    pub fn mock_set_room_pinned_events(&self) -> MockEndpoint<'_, SetRoomPinnedEventsEndpoint> {
+        let mock = Mock::given(method("PUT"))
+            .and(path_regex(r"^/_matrix/client/v3/rooms/.*/state/m.room.pinned_events/.*?"))
+            .and(header("authorization", "Bearer 1234"));
+        MockEndpoint { mock, server: &self.server, endpoint: SetRoomPinnedEventsEndpoint }
+    }
 }
 
 /// Parameter to [`MatrixMockServer::sync_room`].
@@ -2308,6 +2317,24 @@ impl<'a> MockEndpoint<'a, RoomSummaryEndpoint> {
             "world_readable": true,
             "join_rule": "public",
         })));
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+/// A prebuilt mock to set a room's pinned events.
+pub struct SetRoomPinnedEventsEndpoint;
+
+impl<'a> MockEndpoint<'a, SetRoomPinnedEventsEndpoint> {
+    /// Returns a successful response with a given event id.
+    /// id.
+    pub fn ok(self, event_id: OwnedEventId) -> MatrixMock<'a> {
+        self.ok_with_event_id(event_id)
+    }
+
+    /// Returns an error response with a generic error code indicating the
+    /// client is not authorized to set pinned events.
+    pub fn unauthorized(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(400));
         MatrixMock { server: self.server, mock }
     }
 }

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -47,6 +47,7 @@ use ruma::{
             },
             name::RoomNameEventContent,
             redaction::RoomRedactionEventContent,
+            tombstone::RoomTombstoneEventContent,
             topic::RoomTopicEventContent,
         },
         AnySyncTimelineEvent, AnyTimelineEvent, BundledMessageLikeRelations, EventContent,
@@ -459,6 +460,18 @@ impl EventFactory {
 
         event.state_key = Some(member.to_string());
 
+        event
+    }
+
+    /// Create a tombstone state event for the room.
+    pub fn room_tombstone(
+        &self,
+        body: impl Into<String>,
+        replacement: &RoomId,
+    ) -> EventBuilder<RoomTombstoneEventContent> {
+        let mut event =
+            self.event(RoomTombstoneEventContent::new(body.into(), replacement.to_owned()));
+        event.state_key = Some("".to_owned());
         event
     }
 


### PR DESCRIPTION
Oh, and make more use of the `MatrixMockServer` and `EventFactory` btw.