### PR TITLE
feat(auth): get rid of the cargo feature flag for OIDC :fire: 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
       fail-fast: true
       matrix:
         name:
-          - experimental-oidc
           - no-encryption
           - no-sqlite
           - no-encryption-and-sqlite

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -55,7 +55,6 @@ workspace = true
 features = [
     "anyhow",
     "e2e-encryption",
-    "experimental-oidc",
     "experimental-widgets",
     "markdown",
     "rustls-tls", # note: differ from block below
@@ -69,7 +68,6 @@ workspace = true
 features = [
     "anyhow",
     "e2e-encryption",
-    "experimental-oidc",
     "experimental-widgets",
     "markdown",
     "native-tls", # note: differ from block above

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - The `MediaRetentionPolicy` can now trigger regular cleanups with its new
   `cleanup_frequency` setting.
   ([#4603](https://github.com/matrix-org/matrix-rust-sdk/pull/4603))
+- **breaking**: the `experimental-oidc` Cargo feature has been removed and is no longer required,
+  as its functionality has now been enabled by default.
+  ([#4635](https://github.com/matrix-org/matrix-rust-sdk/pull/4635))
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -40,22 +40,11 @@ markdown = ["ruma/markdown"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 socks = ["reqwest/socks"]
-sso-login = ["dep:axum", "dep:rand", "dep:tower"]
+sso-login = ["dep:axum"]
 
 uniffi = ["dep:uniffi", "matrix-sdk-base/uniffi", "dep:matrix-sdk-ffi-macros"]
 
-experimental-oidc = [
-    "ruma/unstable-msc2967",
-    "ruma/unstable-msc4108",
-    "dep:chrono",
-    "dep:language-tags",
-    "dep:mas-oidc-client",
-    "dep:rand",
-    "dep:sha2",
-    "dep:tower",
-    "dep:openidconnect",
-]
-experimental-widgets = ["dep:language-tags", "dep:uuid"]
+experimental-widgets = ["dep:uuid"]
 
 docsrs = ["e2e-encryption", "sqlite", "indexeddb", "sso-login", "qrcode"]
 
@@ -71,7 +60,7 @@ async-trait = { workspace = true }
 axum = { version = "0.8.1", optional = true }
 bytes = "1.9.0"
 bytesize = "1.3.0"
-chrono = { workspace = true, optional = true }
+chrono = { workspace = true }
 event-listener = "5.4.0"
 eyeball = { workspace = true }
 eyeball-im = { workspace = true }
@@ -83,8 +72,8 @@ http = { workspace = true }
 imbl = { workspace = true, features = ["serde"] }
 indexmap = { workspace = true }
 js_int = "0.2.2"
-language-tags = { version = "0.3.2", optional = true }
-mas-oidc-client = { version = "0.11.0", default-features = false, optional = true }
+language-tags = { version = "0.3.2" }
+mas-oidc-client = { version = "0.11.0", default-features = false }
 matrix-sdk-base = { workspace = true }
 matrix-sdk-common = { workspace = true }
 matrix-sdk-ffi-macros = { workspace = true, optional = true }
@@ -96,24 +85,26 @@ mime2ext = "0.1.53"
 once_cell = { workspace = true }
 percent-encoding = "2.3.1"
 pin-project-lite = { workspace = true }
-rand = { workspace = true , optional = true }
+rand = { workspace = true }
 ruma = { workspace = true, features = [
     "rand",
     "unstable-msc2448",
     "unstable-msc2965",
+    "unstable-msc2967",
     "unstable-msc3930",
     "unstable-msc3245-v1-compat",
     "unstable-msc2867",
+    "unstable-msc4108",
     "unstable-msc4230",
 ] }
 serde = { workspace = true }
 serde_html_form = { workspace = true }
 serde_json = { workspace = true }
-sha2 = { workspace = true, optional = true }
+sha2 = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio-stream = { workspace = true, features = ["sync"] }
-tower = { version = "0.5.2", features = ["util"], optional = true }
+tower = { version = "0.5.2", features = ["util"] }
 tracing = { workspace = true, features = ["attributes"] }
 uniffi = { workspace = true, optional = true }
 url = { workspace = true, features = ["serde"] }
@@ -129,7 +120,7 @@ tokio = { workspace = true, features = ["macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }
-openidconnect = { version = "4.0.0", optional = true }
+openidconnect = { version = "4.0.0" }
 # only activate reqwest's stream feature on non-wasm, the wasm part seems to not
 # support *sending* streams, which makes it useless for us.
 reqwest = { workspace = true, features = ["stream", "gzip", "http2"] }

--- a/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
@@ -262,7 +262,7 @@ pub enum CrossProcessRefreshLockError {
     DuplicatedLock,
 }
 
-#[cfg(all(test, feature = "e2e-encryption"))]
+#[cfg(all(test, feature = "e2e-encryption", feature = "sqlite"))]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::sync::Arc;
 
 use matrix_sdk_base::crypto::{

--- a/crates/matrix-sdk/src/authentication/oidc/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/mod.rs
@@ -27,11 +27,9 @@
 //! limited to the Authorization Code flow. It also uses some OAuth 2.0
 //! extensions.
 //!
-//! # Setup
-//!
-//! To enable support for OpenID Connect on the [`Client`], simply enable the
-//! `experimental-oidc` cargo feature for the `matrix-sdk` crate. Then this
-//! authentication API is available with [`Client::oidc()`].
+//! Support for OpenID Connect on the [`Client`] is always enabled by default
+//! for the `matrix-sdk` crate. Its main API object can be obtained through the
+//! authentication API available with [`Client::oidc()`].
 //!
 //! # Homeserver support
 //!

--- a/crates/matrix-sdk/src/authentication/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/qrcode/login.rs
@@ -211,6 +211,7 @@ impl<'a> IntoFuture for LoginWithQrCode<'a> {
                 .await
                 .map_err(QRCodeLoginError::SessionTokens)?;
 
+            #[cfg(feature = "e2e-encryption")]
             self.client.oidc().enable_cross_process_lock().await?;
 
             // Tell the existing device that we're logged in.

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -28,8 +28,6 @@ use tokio::sync::{broadcast, Mutex, OnceCell};
 use tracing::{debug, field::debug, instrument, Span};
 
 use super::{Client, ClientInner};
-#[cfg(feature = "experimental-oidc")]
-use crate::authentication::oidc::OidcCtx;
 #[cfg(feature = "e2e-encryption")]
 use crate::crypto::{CollectStrategy, TrustRequirement};
 #[cfg(feature = "e2e-encryption")]
@@ -37,9 +35,14 @@ use crate::encryption::EncryptionSettings;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::http_client::HttpSettings;
 use crate::{
-    authentication::AuthCtx, client::ClientServerCapabilities, config::RequestConfig,
-    error::RumaApiError, http_client::HttpClient, send_queue::SendQueueData,
-    sliding_sync::VersionBuilder as SlidingSyncVersionBuilder, HttpError, IdParseError,
+    authentication::{oidc::OidcCtx, AuthCtx},
+    client::ClientServerCapabilities,
+    config::RequestConfig,
+    error::RumaApiError,
+    http_client::HttpClient,
+    send_queue::SendQueueData,
+    sliding_sync::VersionBuilder as SlidingSyncVersionBuilder,
+    HttpError, IdParseError,
 };
 
 /// Builder that allows creating and configuring various parts of a [`Client`].
@@ -510,7 +513,6 @@ impl ClientBuilder {
             version
         };
 
-        #[cfg(feature = "experimental-oidc")]
         let allow_insecure_oidc = homeserver.scheme() == "http";
 
         let auth_ctx = Arc::new(AuthCtx {
@@ -520,7 +522,6 @@ impl ClientBuilder {
             auth_data: OnceCell::default(),
             reload_session_callback: OnceCell::default(),
             save_session_callback: OnceCell::default(),
-            #[cfg(feature = "experimental-oidc")]
             oidc: OidcCtx::new(allow_insecure_oidc),
         });
 

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -19,7 +19,6 @@ use std::{fmt::Debug, future::IntoFuture};
 use eyeball::SharedObservable;
 #[cfg(not(target_arch = "wasm32"))]
 use eyeball::Subscriber;
-#[cfg(feature = "experimental-oidc")]
 use mas_oidc_client::{
     error::{
         Error as OidcClientError, ErrorBody as OidcErrorBody, HttpError as OidcHttpError,
@@ -29,14 +28,11 @@ use mas_oidc_client::{
 };
 use matrix_sdk_common::boxed_into_future;
 use ruma::api::{client::error::ErrorKind, error::FromHttpResponseError, OutgoingRequest};
-#[cfg(feature = "experimental-oidc")]
-use tracing::error;
-use tracing::trace;
+use tracing::{error, trace};
 
 use super::super::Client;
-#[cfg(feature = "experimental-oidc")]
-use crate::authentication::oidc::OidcError;
 use crate::{
+    authentication::oidc::OidcError,
     config::RequestConfig,
     error::{HttpError, HttpResult},
     RefreshTokenError, TransmissionProgress,
@@ -134,7 +130,6 @@ where
                             client.broadcast_unknown_token(soft_logout);
                         }
 
-                        #[cfg(feature = "experimental-oidc")]
                         RefreshTokenError::Oidc(oidc_error) => {
                             match **oidc_error {
                                 OidcError::Oidc(OidcClientError::TokenRefresh(

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -320,16 +320,12 @@ impl CrossSigningResetAuthType {
         error: &HttpError,
     ) -> Result<Option<Self>> {
         if let Some(auth_info) = error.as_uiaa_response() {
-            #[cfg(feature = "experimental-oidc")]
             if client.oidc().issuer().is_some() {
                 OidcCrossSigningResetInfo::from_auth_info(client, auth_info)
                     .map(|t| Some(CrossSigningResetAuthType::Oidc(t)))
             } else {
                 Ok(Some(CrossSigningResetAuthType::Uiaa(auth_info.clone())))
             }
-
-            #[cfg(not(feature = "experimental-oidc"))]
-            Ok(Some(CrossSigningResetAuthType::Uiaa(auth_info.clone())))
         } else {
             Ok(None)
         }
@@ -345,7 +341,6 @@ pub struct OidcCrossSigningResetInfo {
 }
 
 impl OidcCrossSigningResetInfo {
-    #[cfg(feature = "experimental-oidc")]
     fn from_auth_info(
         // This is used if the OIDC feature is enabled.
         #[allow(unused_variables)] client: &Client,
@@ -360,7 +355,6 @@ impl OidcCrossSigningResetInfo {
 
 /// The parsed `parameters` part of a [`ruma::api::client::uiaa::UiaaInfo`]
 /// response
-#[cfg(feature = "experimental-oidc")]
 #[derive(Debug, Deserialize)]
 struct OidcCrossSigningResetUiaaParameters {
     /// The URL where the user can approve the reset of the cross-signing keys.
@@ -370,7 +364,6 @@ struct OidcCrossSigningResetUiaaParameters {
 
 /// The `org.matrix.cross_signing_reset` part of the Uiaa response `parameters``
 /// dictionary.
-#[cfg(feature = "experimental-oidc")]
 #[derive(Debug, Deserialize)]
 struct OidcCrossSigningResetUiaaResetParameter {
     /// The URL where the user can approve the reset of the cross-signing keys.
@@ -729,7 +722,6 @@ impl Encryption {
         }
     }
 
-    #[cfg(feature = "experimental-oidc")]
     pub(crate) async fn import_secrets_bundle(
         &self,
         bundle: &matrix_sdk_base::crypto::types::SecretsBundle,
@@ -1697,7 +1689,6 @@ impl Encryption {
     /// **Warning**: Do not use this method if we're already calling
     /// [`Client::send_outgoing_request()`]. This method is intended for
     /// explicitly uploading the device keys before starting a sync.
-    #[cfg(feature = "experimental-oidc")]
     pub(crate) async fn ensure_device_keys_upload(&self) -> Result<()> {
         let olm = self.client.olm_machine().await;
         let olm = olm.as_ref().ok_or(Error::NoOlmMachine)?;

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -352,7 +352,6 @@ pub enum Error {
     MultipleSessionCallbacks,
 
     /// An error occurred interacting with the OpenID Connect API.
-    #[cfg(feature = "experimental-oidc")]
     #[error(transparent)]
     Oidc(#[from] crate::authentication::oidc::OidcError),
 
@@ -559,7 +558,6 @@ pub enum RefreshTokenError {
     MatrixAuth(Arc<HttpError>),
 
     /// An error occurred interacting with the OpenID Connect API.
-    #[cfg(feature = "experimental-oidc")]
     #[error(transparent)]
     Oidc(#[from] Arc<crate::authentication::oidc::OidcError>),
 }

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -257,7 +257,6 @@ async fn response_to_http_response(
     Ok(http_builder.body(body).expect("Can't construct a response using the given body"))
 }
 
-#[cfg(feature = "experimental-oidc")]
 impl tower::Service<http::Request<Bytes>> for HttpClient {
     type Response = http::Response<Bytes>;
     type Error = tower::BoxError;

--- a/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
@@ -114,7 +114,6 @@ async fn test_reset_legacy_auth() {
     );
 }
 
-#[cfg(feature = "experimental-oidc")]
 #[async_test]
 async fn test_reset_oidc() {
     use std::sync::{

--- a/examples/oidc_cli/Cargo.toml
+++ b/examples/oidc_cli/Cargo.toml
@@ -25,7 +25,6 @@ url = { workspace = true }
 
 [dependencies.matrix-sdk]
 path = "../../crates/matrix-sdk"
-features = ["experimental-oidc"]
 
 [lints]
 workspace = true

--- a/examples/qr-login/Cargo.toml
+++ b/examples/qr-login/Cargo.toml
@@ -21,7 +21,6 @@ url = "2.3.1"
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.
 path = "../../crates/matrix-sdk"
-features = ["experimental-oidc"]
 
 [package.metadata.release]
 release = false

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -231,7 +231,6 @@ fn run_feature_tests(cmd: Option<FeatureSet>) -> Result<()> {
         (FeatureSet::Markdown, "--features markdown,testing"),
         (FeatureSet::Socks, "--features socks,testing"),
         (FeatureSet::SsoLogin, "--features sso-login,testing"),
-        (FeatureSet::ExperimentalOidc, "--features experimental-oidc"),
     ]);
 
     let sh = sh();


### PR DESCRIPTION
OIDC authentication has been used in production in multiple embeddings of the Matrix Rust SDK, some of them for months already, and they're considered stable for everyday use. As such, the feature is not considered experimental anymore, especially since the future of authentication will rely on OIDC and related mechanisms.

---

The cross-process lock used for OIDC relies on the encryption crate, which implements a cross-process locking mechanism. So lots of code have to be guarded against the `e2e-encryption` feature flag, as we need to have access to the crypto features to enable the cross-process lock, unfortunately. This dependency should go away as soon as we generalize the concept of the cross-process lock, so it doesn't make use of the crypto store for that purpose.