### PR TITLE
test: Fix flaky `test_publishing_room_alias`

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/tests/room_privacy.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room_privacy.rs
@@ -109,17 +109,18 @@ async fn test_publishing_room_alias() -> anyhow::Result<()> {
     let canonical_alias = room.canonical_alias();
     assert!(canonical_alias.is_none());
 
-    // We update the canonical alias now
-    room.privacy_settings()
-        .update_canonical_alias(Some(room_alias.clone()), vec![alt_alias.clone()])
-        .await?;
-
     // Wait until we receive the canonical alias event through sync
     let (tx, mut rx) = unbounded_channel();
     let handle = room.add_event_handler(move |_: Raw<SyncRoomCanonicalAliasEvent>| {
         let _ = tx.send(());
         async {}
     });
+
+    // We update the canonical alias now
+    room.privacy_settings()
+        .update_canonical_alias(Some(room_alias.clone()), vec![alt_alias.clone()])
+        .await?;
+
     let _ = tokio::time::timeout(Duration::from_secs(2), rx.recv()).await?;
     client.remove_event_handler(handle);
 


### PR DESCRIPTION
What the tin says: hopefully, registering the handler before a sync can return the expected item should fix the issue.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/4638.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
