### PR TITLE
feat(sdk): Only allow TLS 1.2 or newer

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - The `MediaRetentionPolicy` can now trigger regular cleanups with its new
   `cleanup_frequency` setting.
   ([#4603](https://github.com/matrix-org/matrix-rust-sdk/pull/4603))
+- The HTTP client only allows TLS 1.2 or newer, as recommended by BCP 195.
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -11,7 +11,9 @@ All notable changes to this project will be documented in this file.
 - The `MediaRetentionPolicy` can now trigger regular cleanups with its new
   `cleanup_frequency` setting.
   ([#4603](https://github.com/matrix-org/matrix-rust-sdk/pull/4603))
-- The HTTP client only allows TLS 1.2 or newer, as recommended by BCP 195.
+- [**breaking**] The HTTP client only allows TLS 1.2 or newer, as recommended by
+  [BCP 195](https://datatracker.ietf.org/doc/bcp195/).
+  ([#4647](https://github.com/matrix-org/matrix-rust-sdk/pull/4647))
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -24,7 +24,7 @@ use bytes::Bytes;
 use bytesize::ByteSize;
 use eyeball::SharedObservable;
 use http::header::CONTENT_LENGTH;
-use reqwest::Certificate;
+use reqwest::{tls, Certificate};
 use ruma::api::{error::FromHttpResponseError, IncomingResponse, OutgoingRequest};
 use tracing::{debug, info, warn};
 
@@ -148,8 +148,12 @@ impl HttpSettings {
     /// Build a client with the specified configuration.
     pub(crate) fn make_client(&self) -> Result<reqwest::Client, HttpError> {
         let user_agent = self.user_agent.clone().unwrap_or_else(|| "matrix-rust-sdk".to_owned());
-        let mut http_client =
-            reqwest::Client::builder().user_agent(user_agent).timeout(self.timeout);
+        let mut http_client = reqwest::Client::builder()
+            .user_agent(user_agent)
+            .timeout(self.timeout)
+            // As recommended by BCP 195.
+            // See: https://datatracker.ietf.org/doc/bcp195/
+            .min_tls_version(tls::Version::TLS_1_2);
 
         if self.disable_ssl_verification {
             warn!("SSL verification disabled in the HTTP client!");


### PR DESCRIPTION
As recommended by [BCP 195](https://datatracker.ietf.org/doc/bcp195/).

It think it's better if the SDK enforces best current security practices by default.

It shouldn't be a problem with rustls that only supports TLS 1.2 and 1.3, but with native-tls it depends on the implementation.