### PR TITLE
feat(timeline): handle more timeline item content kinds in replied-to details

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -681,7 +681,7 @@ pub struct Profile {
 /// [`sync_events`][ruma::api::client::sync::sync_events].
 #[derive(Clone, Debug)]
 pub enum TimelineDetails<T> {
-    /// The details are not available yet, and have not been request from the
+    /// The details are not available yet, and have not been requested from the
     /// server.
     Unavailable,
 


### PR DESCRIPTION
Right now, the replied-to details can only contain information about a room message, while we can have other timeline item contents for an item. In particular, the replied-to event could be still encrypted (UTD), and that shouldn't be considered an "unsupported kind", as in https://github.com/element-hq/element-x-ios/issues/3774. Instead, consumers can display the replied-to event was a UTD, and perform manual retries in the background later on (after a backup key has been downloaded, for instance).

Remaining tasks:

- [x] Add tests that a UTD can appear in the replied-to details.
- [x] (and other kinds of contents: poll…
- [x] (…sticker, and so on)
- ~~[ ] Since the code getting a `TimelineItemContent` from a Ruma event is so similar to the code used when handling an event, I'm planning to attempt to merge the two.~~
  - will be a followup