### PR TITLE
fix(ui): Demote aggregation target not found log to TRACE level

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
@@ -399,7 +399,7 @@ pub(crate) fn find_item_and_apply_aggregation(
     aggregation: Aggregation,
 ) -> bool {
     let Some((idx, event_item)) = rfind_event_by_item_id(items, target) else {
-        warn!("couldn't find aggregation's target {target:?}");
+        trace!("couldn't find aggregation's target {target:?}");
         return false;
     };
 


### PR DESCRIPTION
We encountered this warning a lot in the logs after upgrading the SDK today. This comes from https://github.com/matrix-org/matrix-rust-sdk/pull/4576.

My understanding is that this path is expected if the target event is not yet in the timeline, which can happen often when paginating backwards, so it's nothing to warn about.

cc @bnjbvr 