### PR TITLE
refactor(timeline): replace `TimelineEventKind` with `TimelineAction`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,9 +521,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 dependencies = [
  "serde",
 ]
@@ -536,9 +536,9 @@ checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "blake3"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "shlex",
 ]
@@ -993,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1031,7 +1031,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -1434,12 +1434,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2702,7 +2702,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
  "libc",
 ]
 
@@ -2966,7 +2966,7 @@ dependencies = [
  "assert_matches2",
  "assign",
  "async-trait",
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
  "decancer",
  "eyeball",
  "eyeball-im",
@@ -3603,11 +3603,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3635,9 +3635,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",
@@ -3729,20 +3729,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.11"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
- "thiserror 1.0.63",
+ "thiserror 2.0.11",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.11"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3750,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.11"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3763,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.11"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -4022,7 +4022,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -4061,7 +4061,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
  "memchr",
  "pulldown-cmark-escape",
  "unicase",
@@ -4206,7 +4206,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -4262,7 +4262,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -4393,14 +4393,15 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.13"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
+ "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -4600,7 +4601,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -4641,7 +4642,7 @@ version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4757,7 +4758,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5002,6 +5003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5145,9 +5152,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5338,9 +5345,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5595,7 +5602,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743912880bcd21d1034063a1b5c6630d444d5a6cc9f90e2c0a200bbe278907c7"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
  "crossterm",
  "derive_builder",
  "itertools 0.14.0",
@@ -5638,9 +5645,9 @@ checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ulid"
@@ -6418,7 +6425,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -62,7 +62,7 @@ pub(in crate::timeline) struct TimelineMetadata {
     pub room_version: RoomVersionId,
 
     /// The own [`OwnedUserId`] of the client who opened the timeline.
-    own_user_id: OwnedUserId,
+    pub(crate) own_user_id: OwnedUserId,
 
     // **** DYNAMIC FIELDS ****
     /// The next internal identifier for timeline items, used for both local and

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -786,22 +786,11 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
         let sender = self.room_data_provider.own_user_id().to_owned();
         let profile = self.room_data_provider.profile_from_user_id(&sender).await;
 
-        // Only add new items if the timeline is live.
-        let should_add_new_items = self.is_live().await;
-
         let date_divider_mode = self.settings.date_divider_mode.clone();
 
         let mut state = self.state.write().await;
         state
-            .handle_local_event(
-                sender,
-                profile,
-                should_add_new_items,
-                date_divider_mode,
-                txn_id,
-                send_handle,
-                content,
-            )
+            .handle_local_event(sender, profile, date_divider_mode, txn_id, send_handle, content)
             .await;
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -64,7 +64,6 @@ pub(super) use self::{
 };
 use super::{
     algorithms::{rfind_event_by_id, rfind_event_item},
-    event_handler::TimelineEventKind,
     event_item::{ReactionStatus, RemoteEventOrigin},
     item::TimelineUniqueId,
     subscriber::TimelineSubscriber,
@@ -781,7 +780,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
     pub(super) async fn handle_local_event(
         &self,
         txn_id: OwnedTransactionId,
-        content: TimelineEventKind,
+        content: AnyMessageLikeEventContent,
         send_handle: Option<SendHandle>,
     ) {
         let sender = self.room_data_provider.own_user_id().to_owned();
@@ -1204,12 +1203,8 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                     }
                 };
 
-                self.handle_local_event(
-                    echo.transaction_id.clone(),
-                    TimelineEventKind::Message { content, relations: Default::default() },
-                    Some(send_handle),
-                )
-                .await;
+                self.handle_local_event(echo.transaction_id.clone(), content, Some(send_handle))
+                    .await;
 
                 if let Some(send_error) = send_error {
                     self.update_event_send_state(

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -557,7 +557,7 @@ impl TimelineStateTransaction<'_> {
     /// "implicit" read receipt, compared to the "explicit" ones sent by the
     /// client.
     pub(super) fn maybe_add_implicit_read_receipt(&mut self, event_meta: FullEventMeta<'_>) {
-        let FullEventMeta { event_id, sender, is_own_event, timestamp, .. } = event_meta;
+        let FullEventMeta { event_id, sender, timestamp, .. } = event_meta;
 
         let (Some(user_id), Some(timestamp)) = (sender, timestamp) else {
             // We cannot add a read receipt if we do not know the user or the timestamp.
@@ -569,6 +569,7 @@ impl TimelineStateTransaction<'_> {
         let full_receipt =
             FullReceipt { event_id, user_id, receipt_type: ReceiptType::Read, receipt: &receipt };
 
+        let is_own_event = sender.is_some_and(|sender| sender == self.meta.own_user_id);
         self.meta.read_receipts.maybe_update_read_receipt(
             full_receipt,
             is_own_event,

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -153,7 +153,6 @@ impl TimelineState {
             sender: own_user_id,
             sender_profile: own_profile,
             timestamp: MilliSecondsSinceUnixEpoch::now(),
-            is_own_event: true,
             read_receipts: Default::default(),
             // An event sent by ourselves is never matched against push rules.
             is_highlighted: false,

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -164,14 +164,14 @@ impl TimelineState {
 
         let mut date_divider_adjuster = DateDividerAdjuster::new(date_divider_mode);
 
-        TimelineEventHandler::new(&mut txn, ctx)
-            .handle_event(
-                &mut date_divider_adjuster,
-                TimelineEventKind::Message { content, relations: Default::default() },
-            )
-            .await;
-
-        txn.adjust_date_dividers(date_divider_adjuster);
+        if let Some(timeline_event_kind) =
+            TimelineEventKind::from_content(content, None, None, None, &txn.items, &mut txn.meta)
+        {
+            TimelineEventHandler::new(&mut txn, ctx)
+                .handle_event(&mut date_divider_adjuster, timeline_event_kind)
+                .await;
+            txn.adjust_date_dividers(date_divider_adjuster);
+        }
 
         txn.commit();
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -22,7 +22,7 @@ use ruma::{
     events::{
         poll::unstable_start::NewUnstablePollStartEventContentWithoutRelation,
         relation::Replacement, room::message::RoomMessageEventContentWithoutRelation,
-        AnySyncEphemeralRoomEvent, AnySyncTimelineEvent,
+        AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent, AnySyncTimelineEvent,
     },
     serde::Raw,
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
@@ -147,7 +147,7 @@ impl TimelineState {
         date_divider_mode: DateDividerMode,
         txn_id: OwnedTransactionId,
         send_handle: Option<SendHandle>,
-        content: TimelineEventKind,
+        content: AnyMessageLikeEventContent,
     ) {
         let ctx = TimelineEventContext {
             sender: own_user_id,
@@ -165,7 +165,10 @@ impl TimelineState {
         let mut date_divider_adjuster = DateDividerAdjuster::new(date_divider_mode);
 
         TimelineEventHandler::new(&mut txn, ctx)
-            .handle_event(&mut date_divider_adjuster, content)
+            .handle_event(
+                &mut date_divider_adjuster,
+                TimelineEventKind::Message { content, relations: Default::default() },
+            )
             .await;
 
         txn.adjust_date_dividers(date_divider_adjuster);

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -321,8 +321,6 @@ pub(crate) struct FullEventMeta<'a> {
     pub visible: bool,
     /// The sender of the event.
     pub sender: Option<&'a UserId>,
-    /// Whether this event was sent by our own user.
-    pub is_own_event: bool,
     /// The timestamp of the event.
     pub timestamp: Option<MilliSecondsSinceUnixEpoch>,
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -34,8 +34,7 @@ use super::{
     super::{
         date_dividers::DateDividerAdjuster,
         event_handler::{
-            Flow, TimelineEventContext, TimelineEventHandler, TimelineEventKind,
-            TimelineItemPosition,
+            Flow, TimelineAction, TimelineEventContext, TimelineEventHandler, TimelineItemPosition,
         },
         event_item::RemoteEventOrigin,
         traits::RoomDataProvider,
@@ -164,11 +163,11 @@ impl TimelineState {
 
         let mut date_divider_adjuster = DateDividerAdjuster::new(date_divider_mode);
 
-        if let Some(timeline_event_kind) =
-            TimelineEventKind::from_content(content, None, None, None, &txn.items, &mut txn.meta)
+        if let Some(timeline_action) =
+            TimelineAction::from_content(content, None, None, None, &txn.items, &mut txn.meta)
         {
             TimelineEventHandler::new(&mut txn, ctx)
-                .handle_event(&mut date_divider_adjuster, timeline_event_kind)
+                .handle_event(&mut date_divider_adjuster, timeline_action)
                 .await;
             txn.adjust_date_dividers(date_divider_adjuster);
         }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -142,12 +142,17 @@ impl TimelineState {
         &mut self,
         own_user_id: OwnedUserId,
         own_profile: Option<Profile>,
-        should_add_new_items: bool,
         date_divider_mode: DateDividerMode,
         txn_id: OwnedTransactionId,
         send_handle: Option<SendHandle>,
         content: AnyMessageLikeEventContent,
     ) {
+        // Only add new items if the timeline is live.
+        let should_add_new_items = match self.timeline_focus {
+            TimelineFocusKind::Live => true,
+            TimelineFocusKind::Event | TimelineFocusKind::PinnedEvents => false,
+        };
+
         let ctx = TimelineEventContext {
             sender: own_user_id,
             sender_profile: own_profile,

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -317,7 +317,7 @@ impl<'a> TimelineStateTransaction<'a> {
                         &raw,
                         room_data_provider,
                         utd_info,
-                        &self.meta,
+                        &mut self.meta,
                     )
                     .await,
                     should_add,

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -333,7 +333,7 @@ impl<'a> TimelineStateTransaction<'a> {
                     event.sender().to_owned(),
                     event.origin_server_ts(),
                     event.transaction_id().map(ToOwned::to_owned),
-                    TimelineEventKind::failed_to_parse(event, e),
+                    Some(TimelineEventKind::failed_to_parse(event, e)),
                     true,
                 ),
 
@@ -442,7 +442,13 @@ impl<'a> TimelineStateTransaction<'a> {
         };
 
         // Handle the event to create or update a timeline item.
-        TimelineEventHandler::new(self, ctx).handle_event(date_divider_adjuster, event_kind).await
+        if let Some(event_kind) = event_kind {
+            TimelineEventHandler::new(self, ctx)
+                .handle_event(date_divider_adjuster, event_kind)
+                .await
+        } else {
+            HandleEventResult::default()
+        }
     }
 
     /// Remove one timeline item by its `event_index`.

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -396,8 +396,6 @@ impl<'a> TimelineStateTransaction<'a> {
             },
         };
 
-        let is_own_event = sender == room_data_provider.own_user_id();
-
         let event_meta = FullEventMeta {
             event_id: &event_id,
             sender: Some(&sender),
@@ -414,7 +412,6 @@ impl<'a> TimelineStateTransaction<'a> {
             sender,
             sender_profile,
             timestamp,
-            is_own_event,
             read_receipts: if settings.track_read_receipts && should_add {
                 self.meta.read_receipts.compute_event_receipts(
                     &event_id,

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -337,11 +337,9 @@ impl<'a> TimelineStateTransaction<'a> {
                     let event_id = event.event_id();
                     warn!(%event_type, %event_id, "Failed to deserialize timeline event: {e}");
 
-                    let is_own_event = event.sender() == room_data_provider.own_user_id();
                     let event_meta = FullEventMeta {
                         event_id,
                         sender: Some(event.sender()),
-                        is_own_event,
                         timestamp: Some(event.origin_server_ts()),
                         visible: false,
                     };
@@ -372,15 +370,12 @@ impl<'a> TimelineStateTransaction<'a> {
 
                     if let Some(event_id) = &event_id {
                         let sender: Option<OwnedUserId> = raw.get_field("sender").ok().flatten();
-                        let is_own_event =
-                            sender.as_ref().is_some_and(|s| s == room_data_provider.own_user_id());
                         let timestamp: Option<MilliSecondsSinceUnixEpoch> =
                             raw.get_field("origin_server_ts").ok().flatten();
 
                         let event_meta = FullEventMeta {
                             event_id,
                             sender: sender.as_deref(),
-                            is_own_event,
                             timestamp,
                             visible: false,
                         };
@@ -406,7 +401,6 @@ impl<'a> TimelineStateTransaction<'a> {
         let event_meta = FullEventMeta {
             event_id: &event_id,
             sender: Some(&sender),
-            is_own_event,
             timestamp: Some(timestamp),
             visible: should_add,
         };

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -312,7 +312,14 @@ impl<'a> TimelineStateTransaction<'a> {
                     event.sender().to_owned(),
                     event.origin_server_ts(),
                     event.transaction_id().map(ToOwned::to_owned),
-                    TimelineEventKind::from_event(event, &raw, room_data_provider, utd_info).await,
+                    TimelineEventKind::from_event(
+                        event,
+                        &raw,
+                        room_data_provider,
+                        utd_info,
+                        &self.meta,
+                    )
+                    .await,
                     should_add,
                 )
             }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -317,6 +317,7 @@ impl<'a> TimelineStateTransaction<'a> {
                         &raw,
                         room_data_provider,
                         utd_info,
+                        &self.items,
                         &mut self.meta,
                     )
                     .await,

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -271,8 +271,7 @@ impl<'a> TimelineStateTransaction<'a> {
                         TimelineItemPosition::UpdateAt { timeline_item_index: idx } => self
                             .items
                             .get(idx)
-                            .and_then(|item| item.as_event())
-                            .and_then(|item| item.as_remote())
+                            .and_then(|item| item.as_event()?.as_remote())
                             .map_or(RemoteEventOrigin::Unknown, |item| item.origin),
                     };
 

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -123,18 +123,26 @@ pub(super) struct TimelineEventContext {
     pub(super) should_add_new_items: bool,
 }
 
+/// Which kind of aggregation (i.e. modification of a related event) are we
+/// going to handle?
 #[derive(Clone, Debug)]
 pub(super) enum HandleAggregationKind {
+    /// Adding a reaction to the related event.
     Reaction { key: String },
 
+    /// Redacting (removing) the related event.
     Redaction,
 
+    /// Editing (replacing) the related event with another one.
     Edit { replacement: Replacement<RoomMessageEventContentWithoutRelation> },
 
+    /// Responding to the related poll event.
     PollResponse { answers: Vec<String> },
 
+    /// Editing a related poll event's description.
     PollEdit { replacement: Replacement<NewUnstablePollStartEventContentWithoutRelation> },
 
+    /// Ending a related poll.
     PollEnd,
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -123,7 +123,6 @@ pub(super) struct TimelineEventContext {
     pub(super) sender_profile: Option<Profile>,
     /// The event's `origin_server_ts` field (or creation time for local echo).
     pub(super) timestamp: MilliSecondsSinceUnixEpoch,
-    pub(super) is_own_event: bool,
     pub(super) read_receipts: IndexMap<OwnedUserId, Receipt>,
     pub(super) is_highlighted: bool,
     pub(super) flow: Flow,
@@ -1087,7 +1086,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     event_id: event_id.clone(),
                     transaction_id: txn_id.clone(),
                     read_receipts: self.ctx.read_receipts.clone(),
-                    is_own: self.ctx.is_own_event,
+                    is_own: self.ctx.sender == self.meta.own_user_id,
                     is_highlighted: self.ctx.is_highlighted,
                     encryption_info: encryption_info.clone(),
                     original_json: Some(raw_event.clone()),

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -284,6 +284,24 @@ impl TimelineEventKind {
                             kind: HandleAggregationKind::PollEnd,
                         },
 
+                        AnyMessageLikeEventContent::CallInvite(_) => {
+                            Self::add_item(TimelineItemContent::CallInvite)
+                        }
+
+                        AnyMessageLikeEventContent::CallNotify(_) => {
+                            Self::add_item(TimelineItemContent::CallNotify)
+                        }
+
+                        AnyMessageLikeEventContent::Sticker(content) => {
+                            Self::add_item(TimelineItemContent::MsgLike(MsgLikeContent {
+                                kind: MsgLikeKind::Sticker(Sticker { content }),
+                                reactions: Default::default(),
+                                thread_root: None,
+                                in_reply_to: None,
+                                thread_summary: None,
+                            }))
+                        }
+
                         _ => {
                             // Default path: TODO remove
                             Self::Message { content, relations: ev.relations() }
@@ -502,38 +520,11 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     }
                 }
 
-                AnyMessageLikeEventContent::Sticker(content) => {
-                    if should_add {
-                        self.add_item(
-                            TimelineItemContent::MsgLike(MsgLikeContent {
-                                kind: MsgLikeKind::Sticker(Sticker { content }),
-                                reactions: Default::default(),
-                                thread_root: None,
-                                in_reply_to: None,
-                                thread_summary: None,
-                            }),
-                            None,
-                        );
-                    }
-                }
-
                 AnyMessageLikeEventContent::UnstablePollStart(
                     UnstablePollStartEventContent::New(c),
                 ) => {
                     if should_add {
                         self.handle_poll_start(c, relations)
-                    }
-                }
-
-                AnyMessageLikeEventContent::CallInvite(_) => {
-                    if should_add {
-                        self.add_item(TimelineItemContent::CallInvite, None);
-                    }
-                }
-
-                AnyMessageLikeEventContent::CallNotify(_) => {
-                    if should_add {
-                        self.add_item(TimelineItemContent::CallNotify, None)
                     }
                 }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -58,9 +58,8 @@ use tokio::sync::RwLock;
 
 use super::{
     algorithms::rfind_event_by_item_id, controller::TimelineSettings,
-    event_handler::TimelineEventKind, event_item::RemoteEventOrigin, traits::RoomDataProvider,
-    EventTimelineItem, Profile, TimelineController, TimelineEventItemId, TimelineFocus,
-    TimelineItem,
+    event_item::RemoteEventOrigin, traits::RoomDataProvider, EventTimelineItem, Profile,
+    TimelineController, TimelineEventItemId, TimelineFocus, TimelineItem,
 };
 use crate::{
     timeline::pinned_events_loader::PinnedEventsRoom, unable_to_decrypt_hook::UtdHookManager,
@@ -182,13 +181,7 @@ impl TestTimeline {
 
     async fn handle_local_event(&self, content: AnyMessageLikeEventContent) -> OwnedTransactionId {
         let txn_id = TransactionId::new();
-        self.controller
-            .handle_local_event(
-                txn_id.clone(),
-                TimelineEventKind::Message { content, relations: Default::default() },
-                None,
-            )
-            .await;
+        self.controller.handle_local_event(txn_id.clone(), content, None).await;
         txn_id
     }
 


### PR DESCRIPTION
This centralizes (and simplifies, IMO) the creation of new timeline items vs handling of aggregations. Before, this was done partly when creating the (type previously known as) `TimelineEventKind` and handling it later in the `TimelineEventHandler`. Now, the event is analyzed once, and analyzing the event results in three outcomes:

- either the event type is not supported: we do nothing
- or it would result in a new timeline item: the item is created and wrapped in `TimelineAction::AddItem`
- or it would result in a new aggregation: the aggregation is created and wrapped in `TimelineAction::HandleAggregation`

That way, it should be much simpler to handle aggregation-only events in non-live timelines, which will be handy for thread timelines.

Part of #4869.