### PR TITLE
refactor(event cache): extract deduplication out of `RoomEvents`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -29,7 +29,6 @@ use super::{
     },
     BackPaginationOutcome, EventsOrigin, Result, RoomEventCacheUpdate,
 };
-use crate::event_cache::RoomEventCacheState;
 
 /// An API object to run pagination queries on a [`super::RoomEventCache`].
 ///
@@ -181,13 +180,8 @@ impl RoomPagination {
             .cloned()
             .collect::<Vec<_>>();
 
-        let (new_events, duplicated_event_ids) =
+        let (new_events, duplicated_event_ids, all_deduplicated) =
             state.collect_valid_and_duplicated_events(sync_events.clone().into_iter());
-
-        let all_deduplicated = RoomEventCacheState::deduplicated_all_new_events(
-            events.len(),
-            duplicated_event_ids.len(),
-        );
 
         let (backpagination_outcome, sync_timeline_events_diffs) = state
             .with_events_mut(move |room_events| {

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -205,7 +205,7 @@ impl RoomPagination {
                         // We don't have to worry the removals can change the position of the existing
                         // events, because we are replacing a gap: its identifier will not change
                         // because of the removals.
-                        room_events.remove_events(duplicated_event_ids);
+                        room_events.remove_events_by_id(duplicated_event_ids);
 
                         // Replace the gap with the events we just deduplicated.
                         room_events.replace_gap_at(new_events.clone(), gap_id)
@@ -237,7 +237,7 @@ impl RoomPagination {
                     // We don't have to worry the removals can change the position of the existing
                     // events, because we are replacing a gap: its identifier will not change
                     // because of the removals.
-                    room_events.remove_events(duplicated_event_ids);
+                    room_events.remove_events_by_id(duplicated_event_ids);
 
                     room_events.push_events(new_events.clone());
 

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -29,6 +29,7 @@ use super::{
     },
     BackPaginationOutcome, EventsOrigin, Result, RoomEventCacheUpdate,
 };
+use crate::event_cache::room::events::deduplicated_all_new_events;
 
 /// An API object to run pagination queries on a [`super::RoomEventCache`].
 ///
@@ -184,36 +185,71 @@ impl RoomPagination {
 
                 let first_event_pos = room_events.events().next().map(|(item_pos, _)| item_pos);
 
+                let (new_events, duplicated_event_ids) = room_events.collect_valid_and_duplicated_events(sync_events.clone().into_iter());
+
+                let all_deduplicated = deduplicated_all_new_events(events.len(), duplicated_event_ids.len());
+
                 // First, insert events.
-                let (added_unique_events, insert_new_gap_pos) = if let Some(gap_id) = prev_gap_id {
+                let insert_new_gap_pos = if let Some(gap_id) = prev_gap_id {
                     // There is a prior gap, let's replace it by new events!
-                    trace!("replaced gap with new events from backpagination");
-                    room_events
-                        .replace_gap_at(sync_events.clone(), gap_id)
-                        .expect("gap_identifier is a valid chunk id we read previously")
-                } else if let Some(pos) = first_event_pos {
+                    if all_deduplicated {
+                        // All the events were duplicated; don't act upon them, and only remove the
+                        // prior gap that we just filled.
+                        trace!("removing previous gap, as all events have been deduplicated");
+                        room_events.remove_gap_at(gap_id).expect("gap identifier is a valid gap chunk id we read previously")
+                    } else {
+                        trace!("replacing previous gap with the back-paginated events");
+
+                        // Remove the _old_ duplicated events!
+                        //
+                        // We don't have to worry the removals can change the position of the existing
+                        // events, because we are replacing a gap: its identifier will not change
+                        // because of the removals.
+                        room_events.remove_events(duplicated_event_ids);
+
+                        // Replace the gap with the events we just deduplicated.
+                        room_events.replace_gap_at(new_events.clone(), gap_id)
+                            .expect("gap_identifier is a valid chunk id we read previously")
+                    }
+                } else if let Some(mut pos) = first_event_pos {
                     // No prior gap, but we had some events: assume we need to prepend events
                     // before those.
                     trace!("inserted events before the first known event");
-                    let report = room_events
-                        .insert_events_at(sync_events.clone(), pos)
+
+                    // Remove the _old_ duplicated events!
+                    //
+                    // We **have to worry* the removals can change the position of the
+                    // existing events. We **have** to update the `position`
+                    // argument value for each removal.
+                    room_events.remove_events_and_update_insert_position(duplicated_event_ids, &mut pos);
+
+                    room_events
+                        .insert_events_at(new_events.clone(), pos)
                         .expect("pos is a valid position we just read above");
-                    (report, Some(pos))
+
+                    Some(pos)
                 } else {
                     // No prior gap, and no prior events: push the events.
                     trace!("pushing events received from back-pagination");
-                    let report = room_events.push_events(sync_events.clone());
+
+                    // Remove the _old_ duplicated events!
+                    //
+                    // We don't have to worry the removals can change the position of the existing
+                    // events, because we are replacing a gap: its identifier will not change
+                    // because of the removals.
+                    room_events.remove_events(duplicated_event_ids);
+
+                    room_events.push_events(new_events.clone());
+
                     // A new gap may be inserted before the new events, if there are any.
-                    let next_pos = room_events.events().next().map(|(item_pos, _)| item_pos);
-                    (report, next_pos)
+                    room_events.events().next().map(|(item_pos, _)| item_pos)
                 };
 
                 // And insert the new gap if needs be.
                 //
-                // We only do this when at least one new, non-duplicated event, has been added
-                // to the chunk. Otherwise it means we've back-paginated all the
-                // known events.
-                if added_unique_events {
+                // We only do this when at least one new, non-duplicated event, has been added to
+                // the chunk. Otherwise it means we've back-paginated all the known events.
+                if !all_deduplicated {
                     if let Some(new_gap) = new_gap {
                         if let Some(new_pos) = insert_new_gap_pos {
                             room_events
@@ -227,7 +263,7 @@ impl RoomPagination {
                     debug!("not storing previous batch token, because we deduplicated all new back-paginated events");
                 }
 
-                room_events.on_new_events(&self.inner.room_version, sync_events.iter());
+                room_events.on_new_events(&self.inner.room_version, new_events.iter());
 
                 BackPaginationOutcome { events, reached_start }
             })

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -447,7 +447,7 @@ impl RoomEventCacheInner {
                     //
                     // We don't have to worry the removals can change the position of the existing
                     // events, because we are pushing all _new_ `events` at the back.
-                    room_events.remove_events(duplicated_event_ids);
+                    room_events.remove_events_by_id(duplicated_event_ids);
 
                     room_events.push_events(sync_timeline_events.clone());
 


### PR DESCRIPTION
Instead of having the `RoomEvents` own the `Deduplicator` instance, we put the `Deduplicator` outside of `RoomEvents`; the flow changes from "when doing an operation on the room events, first check for duplicates and do things based on that" to "deduplicate events first, then do operations on the room events".

This is a more orthogonal design, that makes adding future changes to the `Deduplicator` easier; for instance, if deduplication became asynchroneous, that means we won't have to change every single method of `RoomEvents` to make it async, as a result.

It also means that `RoomEvents` is "dumber", in the sense that it exposes simpler primitives to the caller. The caller now has more responsibilities (must check for duplicates *before* doing any operations on the room events), but we find this tradeoff is worth it for future changes we've planned to deduplication. It also avoids doing and undoing work, in one instance (prior to this patch, when receiving a gap from sync, we always inserted it first, and then later maybe we would decide to remove it, if all events had been deduplicated — we don't need to do this anymore).

Part of #3280.