### PR TITLE
feat(base): Add `EventCacheStore::filter_duplicated_events`

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -123,6 +123,9 @@ pub trait EventCacheStoreIntegrationTests {
 
     /// Test that removing a room from storage empties all associated data.
     async fn test_remove_room(&self);
+
+    /// Test that filtering duplicated events works as expected.
+    async fn test_filter_duplicated_events(&self);
 }
 
 fn rebuild_linked_chunk(raws: Vec<RawChunk<Event, Gap>>) -> Option<LinkedChunk<3, Event, Gap>> {
@@ -502,6 +505,79 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         let r1_linked_chunk = self.reload_linked_chunk(r1).await.unwrap();
         assert!(!r1_linked_chunk.is_empty());
     }
+
+    async fn test_filter_duplicated_events(&self) {
+        let room_id = room_id!("!r0:matrix.org");
+        let another_room_id = room_id!("!r1:matrix.org");
+        let event = |msg: &str| make_test_event(room_id, msg);
+
+        let event_comte = event("comté");
+        let event_brigand = event("brigand du jorat");
+        let event_raclette = event("raclette");
+        let event_morbier = event("morbier");
+        let event_gruyere = event("gruyère");
+        let event_tome = event("tome");
+        let event_mont_dor = event("mont d'or");
+
+        self.handle_linked_chunk_updates(
+            room_id,
+            vec![
+                Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
+                Update::PushItems {
+                    at: Position::new(CId::new(0), 0),
+                    items: vec![event_comte.clone(), event_brigand.clone()],
+                },
+                Update::NewGapChunk {
+                    previous: Some(CId::new(0)),
+                    new: CId::new(1),
+                    next: None,
+                    gap: Gap { prev_token: "brillat-savarin".to_owned() },
+                },
+                Update::NewItemsChunk { previous: Some(CId::new(1)), new: CId::new(2), next: None },
+                Update::PushItems {
+                    at: Position::new(CId::new(2), 0),
+                    items: vec![event_morbier.clone(), event_mont_dor.clone()],
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        // Add other events in another room, to ensure filtering take the `room_id` into
+        // account.
+        self.handle_linked_chunk_updates(
+            another_room_id,
+            vec![
+                Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
+                Update::PushItems {
+                    at: Position::new(CId::new(0), 0),
+                    items: vec![event_tome.clone()],
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        let duplicated_events = self
+            .filter_duplicated_events(
+                room_id,
+                vec![
+                    event_comte.event_id().unwrap().to_owned(),
+                    event_raclette.event_id().unwrap().to_owned(),
+                    event_morbier.event_id().unwrap().to_owned(),
+                    event_gruyere.event_id().unwrap().to_owned(),
+                    event_tome.event_id().unwrap().to_owned(),
+                    event_mont_dor.event_id().unwrap().to_owned(),
+                ],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(duplicated_events.len(), 3);
+        assert_eq!(duplicated_events[0], event_comte.event_id().unwrap());
+        assert_eq!(duplicated_events[1], event_morbier.event_id().unwrap());
+        assert_eq!(duplicated_events[2], event_mont_dor.event_id().unwrap());
+    }
 }
 
 /// Macro building to allow your `EventCacheStore` implementation to run the
@@ -583,6 +659,13 @@ macro_rules! event_cache_store_integration_tests {
                 let event_cache_store =
                     get_event_cache_store().await.unwrap().into_event_cache_store();
                 event_cache_store.test_remove_room().await;
+            }
+
+            #[async_test]
+            async fn test_filter_duplicated_events() {
+                let event_cache_store =
+                    get_event_cache_store().await.unwrap().into_event_cache_store();
+                event_cache_store.test_filter_duplicated_events().await;
             }
         }
     };

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -164,10 +164,10 @@ impl EventCacheStore for MemoryStore {
                 break;
             }
 
-            if let Some(event_id_a) = event.event_id() {
+            if let Some(known_event_id) = event.event_id() {
                 // This event exists in the store event!
                 if let Some(position) =
-                    events.iter().position(|event_id_b| &event_id_a == event_id_b)
+                    events.iter().position(|new_event_id| &known_event_id == new_event_id)
                 {
                     duplicated_events.push(events.remove(position));
                 }

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -19,7 +19,7 @@ use matrix_sdk_common::{
     linked_chunk::{RawChunk, Update},
     AsyncTraitDeps,
 };
-use ruma::{MxcUri, RoomId};
+use ruma::{MxcUri, OwnedEventId, RoomId};
 
 use super::{
     media::{IgnoreMediaRetentionPolicy, MediaRetentionPolicy},
@@ -79,6 +79,14 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// This will empty and remove all the linked chunks stored previously,
     /// using the above [`Self::handle_linked_chunk_updates`] methods.
     async fn clear_all_rooms_chunks(&self) -> Result<(), Self::Error>;
+
+    /// Given a set of event ID, remove the unique events and return the
+    /// duplicated events.
+    async fn filter_duplicated_events(
+        &self,
+        room_id: &RoomId,
+        events: Vec<OwnedEventId>,
+    ) -> Result<Vec<OwnedEventId>, Self::Error>;
 
     /// Add a media file's content in the media store.
     ///
@@ -245,6 +253,14 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
 
     async fn clear_all_rooms_chunks(&self) -> Result<(), Self::Error> {
         self.0.clear_all_rooms_chunks().await.map_err(Into::into)
+    }
+
+    async fn filter_duplicated_events(
+        &self,
+        room_id: &RoomId,
+        events: Vec<OwnedEventId>,
+    ) -> Result<Vec<OwnedEventId>, Self::Error> {
+        self.0.filter_duplicated_events(room_id, events).await.map_err(Into::into)
     }
 
     async fn add_media_content(


### PR DESCRIPTION
This patch adds and implements the
`EventCacheStore::filter_duplicated_events` method. It is implemented on the `MemoryStore` and the `SqliteEventCacheStore`.

This method remove the unique events and return the duplicated events.

On the `MemoryStore`, it iterates over events only once.
On the `SqliteEventCacheStore`, it runs a single query (modulo the size of events to check, see
`chunk_large_query_over`).

---

* Address #3280
* Unblock #4632