### PR TITLE
feat(event cache): deduplicate using a store when available

### DIFF
--- a/crates/matrix-sdk/src/event_cache/deduplicator.rs
+++ b/crates/matrix-sdk/src/event_cache/deduplicator.rs
@@ -31,17 +31,17 @@ use super::room::events::{Event, RoomEvents};
 /// positive or not
 ///
 /// [bloom filter]: https://en.wikipedia.org/wiki/Bloom_filter
-pub struct Deduplicator {
+pub struct BloomFilterDeduplicator {
     bloom_filter: Mutex<GrowableBloom>,
 }
 
-impl fmt::Debug for Deduplicator {
+impl fmt::Debug for BloomFilterDeduplicator {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.debug_struct("Deduplicator").finish_non_exhaustive()
     }
 }
 
-impl Deduplicator {
+impl BloomFilterDeduplicator {
     // Note: don't use too high numbers here, or the amount of allocated memory will
     // explode. See https://github.com/matrix-org/matrix-rust-sdk/pull/4231 for details.
     const APPROXIMATED_MAXIMUM_NUMBER_OF_EVENTS: usize = 1_000;
@@ -179,7 +179,7 @@ mod tests {
         let event_1 = sync_timeline_event(&event_id_1);
         let event_2 = sync_timeline_event(&event_id_2);
 
-        let deduplicator = Deduplicator::new();
+        let deduplicator = BloomFilterDeduplicator::new();
         let existing_events = RoomEvents::new();
 
         let mut events =
@@ -205,7 +205,7 @@ mod tests {
         let event_0 = sync_timeline_event(&event_id_0);
         let event_1 = sync_timeline_event(&event_id_1);
 
-        let deduplicator = Deduplicator::new();
+        let deduplicator = BloomFilterDeduplicator::new();
         let existing_events = RoomEvents::new();
 
         let mut events = deduplicator.scan_and_learn(
@@ -240,7 +240,7 @@ mod tests {
         let event_1 = sync_timeline_event(&event_id_1);
         let event_2 = sync_timeline_event(&event_id_2);
 
-        let deduplicator = Deduplicator::new();
+        let deduplicator = BloomFilterDeduplicator::new();
         let mut existing_events = RoomEvents::new();
 
         // Simulate `event_1` is inserted inside `existing_events`.
@@ -305,7 +305,7 @@ mod tests {
         let mut dedups = Vec::with_capacity(num_rooms);
 
         for _ in 0..num_rooms {
-            let dedup = Deduplicator::new();
+            let dedup = BloomFilterDeduplicator::new();
             let existing_events = RoomEvents::new();
 
             for i in 0..num_events {

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -181,7 +181,7 @@ impl RoomPagination {
             .collect::<Vec<_>>();
 
         let (new_events, duplicated_event_ids, all_deduplicated) =
-            state.collect_valid_and_duplicated_events(sync_events.clone().into_iter()).await?;
+            state.collect_valid_and_duplicated_events(sync_events.clone()).await?;
 
         let (backpagination_outcome, sync_timeline_events_diffs) = state
             .with_events_mut(move |room_events| {

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -181,7 +181,7 @@ impl RoomPagination {
             .collect::<Vec<_>>();
 
         let (new_events, duplicated_event_ids, all_deduplicated) =
-            state.collect_valid_and_duplicated_events(sync_events.clone().into_iter());
+            state.collect_valid_and_duplicated_events(sync_events.clone().into_iter()).await?;
 
         let (backpagination_outcome, sync_timeline_events_diffs) = state
             .with_events_mut(move |room_events| {

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -544,7 +544,7 @@ mod private {
 
     use super::{chunk_debug_string, events::RoomEvents};
     use crate::event_cache::{
-        deduplicator::{Decoration, Deduplicator},
+        deduplicator::{BloomFilterDeduplicator, Decoration},
         EventCacheError,
     };
 
@@ -566,7 +566,7 @@ mod private {
         events: RoomEvents,
 
         /// The events deduplicator instance to help finding duplicates.
-        deduplicator: Deduplicator,
+        deduplicator: BloomFilterDeduplicator,
 
         /// Have we ever waited for a previous-batch-token to come from sync, in
         /// the context of pagination? We do this at most once per room,
@@ -628,8 +628,9 @@ mod private {
                 RoomEvents::default()
             };
 
-            let deduplicator =
-                Deduplicator::with_initial_events(events.events().map(|(_pos, event)| event));
+            let deduplicator = BloomFilterDeduplicator::with_initial_events(
+                events.events().map(|(_pos, event)| event),
+            );
 
             Ok(Self { room, store, events, deduplicator, waited_for_initial_prev_token: false })
         }

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -424,9 +424,8 @@ impl RoomEventCacheInner {
             return Ok(());
         }
 
-        let (events, duplicated_event_ids, all_duplicates) = state
-            .collect_valid_and_duplicated_events(sync_timeline_events.clone().into_iter())
-            .await?;
+        let (events, duplicated_event_ids, all_duplicates) =
+            state.collect_valid_and_duplicated_events(sync_timeline_events.clone()).await?;
 
         let sync_timeline_events_diffs = if all_duplicates {
             // No new events, thus no need to change the room events.
@@ -658,13 +657,10 @@ mod private {
         /// possibly misplace them. And we should not be missing
         /// events either: the already-known events would have their own
         /// previous-batch token (it might already be consumed).
-        pub async fn collect_valid_and_duplicated_events<'a, I>(
-            &'a mut self,
-            events: I,
-        ) -> Result<(Vec<Event>, Vec<OwnedEventId>, bool), EventCacheError>
-        where
-            I: Iterator<Item = Event> + 'a,
-        {
+        pub async fn collect_valid_and_duplicated_events(
+            &mut self,
+            events: Vec<Event>,
+        ) -> Result<(Vec<Event>, Vec<OwnedEventId>, bool), EventCacheError> {
             let (events, duplicated_event_ids) =
                 self.deduplicator.filter_duplicate_events(events, &self.events).await?;
 


### PR DESCRIPTION
Based on the glorious work of #4659 and #4656, this introduces a new way to deduplicate events, whether we have enabled storage or not, using a plain old sum type :nerd_face: When storage is enabled by default for everyone, we can get rid of the `BloomFilterDeduplicator` and replace `Deduplicator` with the store-based one.

Part of #3280.