### PR TITLE
refactor(oidc): Remove method to authorize arbitrary scope

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -42,6 +42,10 @@ All notable changes to this project will be documented in this file.
 - [**breaking**]: The `authentication::qrcode` module now reexports types from
   `oauth2` rather than `openidconnect`. Some type names might have changed.
   ([#4604](https://github.com/matrix-org/matrix-rust-sdk/pull/4604))
+- [**breaking**] `Oidc::authorize_scope()` was removed because it has no use
+  case anymore, according to the latest version of
+  [MSC2967](https://github.com/matrix-org/matrix-spec-proposals/pull/2967).
+  ([#4664](https://github.com/matrix-org/matrix-rust-sdk/pull/4664))
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/src/authentication/oidc/auth_code_builder.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/auth_code_builder.rs
@@ -32,8 +32,7 @@ use crate::Result;
 /// Builder type used to configure optional settings for authorization with an
 /// OpenID Connect Provider via the Authorization Code flow.
 ///
-/// Created with [`Oidc::authorize_scope()`] or [`Oidc::login()`]. Finalized
-/// with [`Self::build()`].
+/// Created with [`Oidc::login()`]. Finalized with [`Self::build()`].
 #[allow(missing_debug_implementations)]
 pub struct OidcAuthCodeUrlBuilder {
     oidc: Oidc,

--- a/crates/matrix-sdk/src/authentication/oidc/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/mod.rs
@@ -124,24 +124,6 @@
 //! If this fails again, the client should assume to be logged out, and all
 //! local data should be erased.
 //!
-//! # Insufficient scope error
-//!
-//! _Note: This is not fully specced yet._
-//!
-//! Some API calls that deal with sensitive data require more privileges than
-//! others. In the current Matrix specification, those endpoints use the
-//! User-Interactive Authentication API.
-//!
-//! The OAuth 2.0 specification has the concept of scopes, and an access token
-//! is limited to a given scope when it is generated. Accessing those endpoints
-//! require a privileged scope, so a new authorization request is necessary to
-//! get a new access token.
-//!
-//! When the API endpoint returns an [`Error`] with an
-//! [`AuthenticateError::InsufficientScope`], the [`Oidc::authorize_scope()`]
-//! method can be used to authorize the required scope. It works just like
-//! [`Oidc::login()`].
-//!
 //! # Account management.
 //!
 //! The homeserver or provider might advertise a URL that allows the user to
@@ -187,7 +169,7 @@ use mas_oidc_client::{
         oidc::{AccountManagementAction, VerifiedProviderMetadata},
         registration::{ClientRegistrationResponse, VerifiedClientMetadata},
         requests::Prompt,
-        scope::{MatrixApiScopeToken, Scope, ScopeToken},
+        scope::{MatrixApiScopeToken, ScopeToken},
         IdToken,
     },
 };
@@ -1260,29 +1242,6 @@ impl Oidc {
         }
 
         Ok(())
-    }
-
-    /// Authorize a given scope with the Authorization Code flow.
-    ///
-    /// This should be used if a new scope is necessary to make a request. For
-    /// example, if the homeserver returns an [`Error`] with an
-    /// [`AuthenticateError::InsufficientScope`].
-    ///
-    /// This should be called after the registered client has been restored or
-    /// the client was logged in.
-    ///
-    /// # Arguments
-    ///
-    /// * `scope` - The scope to authorize.
-    ///
-    /// * `redirect_uri` - The URI where the end user will be redirected after
-    ///   authorizing the scope. It must be one of the redirect URIs sent in the
-    ///   client metadata during registration.
-    ///
-    /// [`Error`]: ruma::api::client::error::Error
-    /// [`AuthenticateError::InsufficientScope`]: ruma::api::client::error::AuthenticateError
-    pub fn authorize_scope(&self, scope: Scope, redirect_uri: Url) -> OidcAuthCodeUrlBuilder {
-        OidcAuthCodeUrlBuilder::new(self.clone(), scope, redirect_uri)
     }
 
     /// Finish the authorization process.


### PR DESCRIPTION
Only the scopes necessary during login are specified in MSC2967 now.

