### PR TITLE
ci: Fix benchmark compilation and compile them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,3 +402,24 @@ jobs:
           SLIDING_SYNC_PROXY_URL: "http://localhost:8118"
         run: |
           cargo nextest run -p matrix-sdk-integration-testing
+
+  compile-bench:
+    name: 🚄 Compile benchmarks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Load cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Compile benchmarks (no run)
+        run: |
+          cargo bench --profile dev --no-run
+

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -14,7 +14,7 @@ matrix-sdk-crypto = { workspace = true }
 matrix-sdk-sqlite = { workspace = true, features = ["crypto-store"] }
 matrix-sdk-test = { workspace = true }
 matrix-sdk-ui = { workspace = true }
-matrix-sdk = { workspace = true, features = ["native-tls", "e2e-encryption", "sqlite"] }
+matrix-sdk = { workspace = true, features = ["native-tls", "e2e-encryption", "sqlite", "testing"] }
 ruma = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -1,14 +1,12 @@
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
+use matrix_sdk::test_utils::mocks::MatrixMockServer;
 use matrix_sdk_base::{
     store::StoreConfig, BaseClient, RoomInfo, RoomState, SessionMeta, StateChanges, StateStore,
 };
 use matrix_sdk_sqlite::SqliteStateStore;
-use matrix_sdk_test::{
-    event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder,
-};
+use matrix_sdk_test::{event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent};
 use matrix_sdk_ui::{timeline::TimelineFocus, Timeline};
 use ruma::{
     api::client::membership::get_member_events,
@@ -18,13 +16,9 @@ use ruma::{
     serde::Raw,
     user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId,
 };
-use serde::Serialize;
 use serde_json::json;
 use tokio::runtime::Builder;
-use wiremock::{
-    matchers::{header, method, path, path_regex, query_param, query_param_is_missing},
-    Mock, MockServer, Request, ResponseTemplate,
-};
+use wiremock::{Request, ResponseTemplate};
 
 pub fn receive_all_members_benchmark(c: &mut Criterion) {
     const MEMBERS_IN_ROOM: usize = 100000;
@@ -109,9 +103,7 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
     let sender_id = owned_user_id!("@sender:example.com");
 
     let f = EventFactory::new().room(&room_id).sender(&sender_id);
-    let (client, server) = runtime.block_on(logged_in_client_with_server());
 
-    let mut sync_response_builder = SyncResponseBuilder::new();
     let mut joined_room_builder =
         JoinedRoomBuilder::new(&room_id).add_state_event(StateTestEvent::Encryption);
 
@@ -133,17 +125,15 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
             }
         }
     )));
-    let response_json =
-        sync_response_builder.add_joined_room(joined_room_builder).build_json_sync_response();
-    runtime.block_on(mock_sync(&server, response_json, None));
 
-    let sync_settings = SyncSettings::default();
-    runtime.block_on(client.sync_once(sync_settings)).expect("Could not sync");
-    runtime.block_on(server.reset());
+    let (server, client, room) = runtime.block_on(async move {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
 
-    runtime.block_on(
-        Mock::given(method("GET"))
-            .and(path_regex(r"/_matrix/client/r0/rooms/.*/event/.*"))
+        let room = server.sync_room(&client, joined_room_builder).await;
+
+        server
+            .mock_room_event()
             .respond_with(move |r: &Request| {
                 let segments: Vec<&str> = r.url.path_segments().expect("Invalid path").collect();
                 let event_id_str = segments[6];
@@ -157,10 +147,14 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
                     .set_delay(Duration::from_millis(50))
                     .set_body_json(event.json())
             })
-            .mount(&server),
-    );
+            .mount()
+            .await;
 
-    let room = client.get_room(&room_id).expect("Room not found");
+        client.event_cache().subscribe().unwrap();
+
+        (server, client, room)
+    });
+
     let pinned_event_ids = room.pinned_event_ids().unwrap_or_default();
     assert!(!pinned_event_ids.is_empty());
     assert_eq!(pinned_event_ids.len(), PINNED_EVENTS_COUNT);
@@ -170,15 +164,6 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("Test");
     group.throughput(Throughput::Elements(count as u64));
     group.sample_size(10);
-
-    let client = Arc::new(client);
-
-    {
-        let client = client.clone();
-        runtime.spawn_blocking(move || {
-            client.event_cache().subscribe().unwrap();
-        });
-    }
 
     group.bench_function(BenchmarkId::new("load_pinned_events", name), |b| {
         b.to_async(&runtime).iter(|| async {
@@ -206,40 +191,21 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
 
     {
         let _guard = runtime.enter();
-        runtime.block_on(server.reset());
         drop(server);
     }
 
     group.finish();
 }
 
-async fn mock_sync(server: &MockServer, response_body: impl Serialize, since: Option<String>) {
-    let mut mock_builder = Mock::given(method("GET"))
-        .and(path("/_matrix/client/r0/sync"))
-        .and(header("authorization", "Bearer 1234"));
-
-    if let Some(since) = since {
-        mock_builder = mock_builder.and(query_param("since", since));
-    } else {
-        mock_builder = mock_builder.and(query_param_is_missing("since"));
-    }
-
-    mock_builder
-        .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
-        .mount(server)
-        .await;
-}
-
 fn criterion() -> Criterion {
-    #[cfg(target_os = "linux")]
-    let criterion = Criterion::default().with_profiler(pprof::criterion::PProfProfiler::new(
-        100,
-        pprof::criterion::Output::Flamegraph(None),
-    ));
-    #[cfg(not(target_os = "linux"))]
-    let criterion = Criterion::default();
-
-    criterion
+    if cfg!(target_os = "linux") {
+        Criterion::default().with_profiler(pprof::criterion::PProfProfiler::new(
+            100,
+            pprof::criterion::Output::Flamegraph(None),
+        ))
+    } else {
+        Criterion::default()
+    }
 }
 
 criterion_group! {

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -100,7 +100,7 @@ pub fn check_test_event(event: &TimelineEvent, text: &str) {
 /// `EventCacheStore` integration tests.
 ///
 /// This trait is not meant to be used directly, but will be used with the
-/// [`event_cache_store_integration_tests!`] macro.
+/// `event_cache_store_integration_tests!` macro.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait EventCacheStoreIntegrationTests {

--- a/crates/matrix-sdk-base/src/event_cache/store/media/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/media/integration_tests.rs
@@ -30,7 +30,7 @@ use crate::media::{MediaFormat, MediaRequestParameters};
 /// [`EventCacheStoreMedia`] integration tests.
 ///
 /// This trait is not meant to be used directly, but will be used with the
-/// [`event_cache_store_media_integration_tests!`] macro.
+/// `event_cache_store_media_integration_tests!` macro.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait EventCacheStoreMediaIntegrationTests {

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -47,7 +47,7 @@ use crate::{
 /// `StateStore` integration tests.
 ///
 /// This trait is not meant to be used directly, but will be used with the
-/// [`statestore_integration_tests!`] macro.
+/// `statestore_integration_tests!` macro.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait StateStoreIntegrationTests {


### PR DESCRIPTION
This makes the `room_bench` benchmark compile, simplifies it a bit by reusing our test helpers, and adds a CI task to compile (without running) benchmarks on CI.