### PR TITLE
chore(test): Increase the timeout for the sync service offline mode test

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sync_service.rs
@@ -230,7 +230,7 @@ async fn test_sync_service_offline_mode() {
 
     mock_server.mock_versions().ok().expect(1..).mount().await;
 
-    assert_next_eq_with_timeout!(states, State::Running, 500 ms,  "We should have continued to sync");
+    assert_next_eq_with_timeout!(states, State::Running, 1000 ms,  "We should have continued to sync");
 }
 
 #[async_test]


### PR DESCRIPTION
Might fix #4639.

I don't think there's anything else we can do.