### PR TITLE
perf(timeline): make replacing replies much faster by indexing replies

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -235,6 +235,11 @@ impl<'observable_items> ObservableItemsTransaction<'observable_items> {
         self.all_remote_events.get_by_event_id_mut(event_id)
     }
 
+    /// Get a remote event by using an event ID.
+    pub fn get_remote_event_by_event_id(&self, event_id: &EventId) -> Option<&EventMeta> {
+        self.all_remote_events.get_by_event_id(event_id)
+    }
+
     /// Replace a timeline item at position `timeline_item_index` by
     /// `timeline_item`.
     pub fn replace(
@@ -346,11 +351,6 @@ pub struct ObservableItemsTransactionEntry<'observable_transaction_items, 'obser
 }
 
 impl ObservableItemsTransactionEntry<'_, '_> {
-    /// Replace the timeline item by `timeline_item`.
-    pub fn replace(this: &mut Self, timeline_item: Arc<TimelineItem>) -> Arc<TimelineItem> {
-        ObservableVectorTransactionEntry::set(&mut this.entry, timeline_item)
-    }
-
     /// Remove this timeline item.
     pub fn remove(this: Self) {
         let entry_index = ObservableVectorTransactionEntry::index(&this.entry);
@@ -1249,6 +1249,11 @@ impl AllRemoteEvents {
     /// Get a mutable reference to a specific remote event by its ID.
     pub fn get_by_event_id_mut(&mut self, event_id: &EventId) -> Option<&mut EventMeta> {
         self.0.iter_mut().rev().find(|event_meta| event_meta.event_id == event_id)
+    }
+
+    /// Get an immutable reference to a specific remote event by its ID.
+    pub fn get_by_event_id(&self, event_id: &EventId) -> Option<&EventMeta> {
+        self.0.iter().rev().find(|event_meta| event_meta.event_id == event_id)
     }
 
     /// Shift to the right all timeline item indexes that are equal to or

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -508,7 +508,7 @@ impl<'a> TimelineStateTransaction<'a> {
         self.items.commit();
     }
 
-    /// Add or update a remote  event in the
+    /// Add or update a remote event in the
     /// [`ObservableItems::all_remote_events`] collection.
     ///
     /// This method also adjusts read receipt if needed.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -409,7 +409,9 @@ async fn test_edit_to_replied_updates_reply() {
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
     let f = EventFactory::new();
-    let event_id = event_id!("$original_event");
+    let eid1 = event_id!("$original_event");
+    let eid2 = event_id!("$reply1");
+    let eid3 = event_id!("$reply2");
     let user_id = client.user_id().unwrap();
 
     // When a room has two messages, one is a reply to the other…
@@ -417,9 +419,11 @@ async fn test_edit_to_replied_updates_reply() {
         .sync_room(
             &client,
             JoinedRoomBuilder::new(room_id)
-                .add_timeline_event(f.text_msg("bonjour").sender(user_id).event_id(event_id))
-                .add_timeline_event(f.text_msg("hi back").reply_to(event_id).sender(*ALICE))
-                .add_timeline_event(f.text_msg("yo").reply_to(event_id).sender(*BOB)),
+                .add_timeline_event(f.text_msg("bonjour").sender(user_id).event_id(eid1))
+                .add_timeline_event(
+                    f.text_msg("hi back").reply_to(eid1).sender(*ALICE).event_id(eid2),
+                )
+                .add_timeline_event(f.text_msg("yo").reply_to(eid1).sender(*BOB).event_id(eid3)),
         )
         .await;
 
@@ -435,7 +439,7 @@ async fn test_edit_to_replied_updates_reply() {
         assert_eq!(reply_message.body(), "hi back");
 
         let in_reply_to = reply_message.in_reply_to().unwrap();
-        assert_eq!(in_reply_to.event_id, event_id);
+        assert_eq!(in_reply_to.event_id, eid1);
 
         assert_let!(TimelineDetails::Ready(replied_to) = &in_reply_to.event);
         assert_eq!(replied_to.content().as_message().unwrap().body(), "bonjour");
@@ -446,7 +450,7 @@ async fn test_edit_to_replied_updates_reply() {
         assert_eq!(reply_message.body(), "yo");
 
         let in_reply_to = reply_message.in_reply_to().unwrap();
-        assert_eq!(in_reply_to.event_id, event_id);
+        assert_eq!(in_reply_to.event_id, eid1);
 
         assert_let!(TimelineDetails::Ready(replied_to) = &in_reply_to.event);
         assert_eq!(replied_to.content().as_message().unwrap().body(), "bonjour");
@@ -474,7 +478,7 @@ async fn test_edit_to_replied_updates_reply() {
         assert!(!reply_message.is_edited());
 
         let in_reply_to = reply_message.in_reply_to().unwrap();
-        assert_eq!(in_reply_to.event_id, event_id);
+        assert_eq!(in_reply_to.event_id, eid1);
         assert_let!(TimelineDetails::Ready(replied_to) = &in_reply_to.event);
         assert_eq!(replied_to.content().as_message().unwrap().body(), "hello world");
     });
@@ -485,7 +489,7 @@ async fn test_edit_to_replied_updates_reply() {
         assert!(!reply_message.is_edited());
 
         let in_reply_to = reply_message.in_reply_to().unwrap();
-        assert_eq!(in_reply_to.event_id, event_id);
+        assert_eq!(in_reply_to.event_id, eid1);
         assert_let!(TimelineDetails::Ready(replied_to) = &in_reply_to.event);
         assert_eq!(replied_to.content().as_message().unwrap().body(), "hello world");
     });


### PR DESCRIPTION
`TimelineEventHandler::maybe_update_responses` was used after a message has been edited or redacted, so as to update replies to it. To find replies to a message, it would iterate over every single timeline item, find if it's an event item that's a message that's a reply, and look if the replied-to id matched the event that was redacted or edited.

This is super inefficient, because it may be doing work for nothing, if there's no such replies.

The alternative implemented in this patch is a classical memory / runtime speed tradeoff: every time we receive a new message that's a reply, we do insert it in a reverse mapping from `reply-target` to `set of replies`. Then, finding the replies to a message after it's edited/redacted becomes instant, because we can use this reverse mapping.

The reverse mapping will only be applied to events that are remote echo. This means that a local echo that's a reply may not get updated until it's remote echoed, if the original message is redacted/edited. We could implement that as well, if we wanted to, by reverting to a linear search in this case, as it should be less common; or storing a set of `TimelineEventItemId` in the reverse mapping (and maintaining it over time).

This reverse mapping will only grow over time. In theory, a redacted reply should cause the entry in the mapping to be removed to, but I haven't bothered with that: the code to update the reply can handle stale entries just fine, and will at worst log a warning in this case. We could try to do better and maintain it over time, though.

In the benchmark introduced in #4668, this lowers the total run time from 101ms to 65ms, a ~35% speedup.