### PR TITLE
refactor(oidc): Use the `GET /auth_metadata` Matrix endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4873,8 +4873,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6fea33e3d17b9e009fefb3f175ca7fd40b1e7d1e72444478fd1b28611eb50a"
+source = "git+https://github.com/ruma/ruma?rev=7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39#7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39"
 dependencies = [
  "assign",
  "js_int",
@@ -4890,8 +4889,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23989b539eceeaad01ba089ad307788f90a29bac2e5f730ff0a523eeae3fa1d7"
+source = "git+https://github.com/ruma/ruma?rev=7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39#7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39"
 dependencies = [
  "as_variant",
  "assign",
@@ -4914,8 +4912,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1058c04b8dd62f4fba71c9f65112fb79bc332438d11aefe1e8edf67b7fb58a98"
+source = "git+https://github.com/ruma/ruma?rev=7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39#7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -4947,8 +4944,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1b8e15942e35ba56004429bc0845f481281f903e86957973a08ec08f8d06f0"
+source = "git+https://github.com/ruma/ruma?rev=7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39#7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39"
 dependencies = [
  "as_variant",
  "indexmap 2.7.1",
@@ -4973,8 +4969,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d70c3d37a8e42992aeaa5786cb406ad302bcd05c0e7e3073d5316b4574340dd"
+source = "git+https://github.com/ruma/ruma?rev=7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39#7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39"
 dependencies = [
  "http",
  "js_int",
@@ -4988,8 +4983,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3257ce3398e171ff15245767b1a3d201cfc5cce75f5af7ec7f6b8b5e1d2bdb"
+source = "git+https://github.com/ruma/ruma?rev=7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39#7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5001,8 +4995,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad674b5e5368c53a2c90fde7dac7e30747004aaf7b1827b72874a25fc06d4d8"
+source = "git+https://github.com/ruma/ruma?rev=7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39#7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39"
 dependencies = [
  "js_int",
  "thiserror 2.0.11",
@@ -5011,8 +5004,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1182e83ee5cd10121974f163337b16af68a93eedfc7cdbdbd52307ac7e1d743"
+source = "git+https://github.com/ruma/ruma?rev=7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39#7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ reqwest = { version = "0.12.12", default-features = false }
 rmp-serde = "1.3.0"
 # Be careful to use commits from the https://github.com/ruma/ruma/tree/ruma-0.12
 # branch until a proper release with breaking changes happens.
-ruma = { version = "0.12.1", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -75,7 +75,7 @@ ruma = { version = "0.12.1", features = [
     "unstable-msc4140",
     "unstable-msc4171",
 ] }
-ruma-common = { version = "0.15.1" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39" }
 serde = "1.0.217"
 serde_html_form = "0.2.7"
 serde_json = "1.0.138"

--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -196,7 +196,7 @@ pub enum OidcError {
 impl From<SdkOidcError> for OidcError {
     fn from(e: SdkOidcError) -> OidcError {
         match e {
-            SdkOidcError::MissingAuthenticationIssuer => OidcError::NotSupported,
+            SdkOidcError::NotSupported => OidcError::NotSupported,
             SdkOidcError::MissingRedirectUri => OidcError::MetadataInvalid,
             SdkOidcError::InvalidCallbackUrl => OidcError::CallbackUrlInvalid,
             SdkOidcError::InvalidState => OidcError::CallbackUrlInvalid,

--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -196,7 +196,7 @@ pub enum OidcError {
 impl From<SdkOidcError> for OidcError {
     fn from(e: SdkOidcError) -> OidcError {
         match e {
-            SdkOidcError::NotSupported => OidcError::NotSupported,
+            SdkOidcError::Discovery(error) if error.is_not_supported() => OidcError::NotSupported,
             SdkOidcError::MissingRedirectUri => OidcError::MetadataInvalid,
             SdkOidcError::InvalidCallbackUrl => OidcError::CallbackUrlInvalid,
             SdkOidcError::InvalidState => OidcError::CallbackUrlInvalid,

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -283,27 +283,18 @@ impl Client {
     /// Information about login options for the client's homeserver.
     pub async fn homeserver_login_details(&self) -> Arc<HomeserverLoginDetails> {
         let oidc = self.inner.oidc();
-        let (supports_oidc_login, supported_oidc_prompts) = match oidc
-            .fetch_authentication_issuer()
-            .await
-        {
-            Ok(issuer) => match &oidc.given_provider_metadata(&issuer).await {
-                Ok(metadata) => {
-                    let prompts = metadata
-                        .prompt_values_supported
-                        .as_ref()
-                        .map_or_else(Vec::new, |prompts| prompts.iter().map(Into::into).collect());
+        let (supports_oidc_login, supported_oidc_prompts) = match &oidc.provider_metadata().await {
+            Ok(metadata) => {
+                let prompts = metadata
+                    .prompt_values_supported
+                    .as_ref()
+                    .map_or_else(Vec::new, |prompts| prompts.iter().map(Into::into).collect());
 
-                    (true, prompts)
-                }
-                Err(error) => {
-                    error!("Failed to fetch OIDC provider metadata: {error}");
-                    (true, Default::default())
-                }
-            },
+                (true, prompts)
+            }
             Err(error) => {
-                error!("Failed to fetch authentication issuer: {error}");
-                (false, Default::default())
+                error!("Failed to fetch OIDC provider metadata: {error}");
+                (true, Default::default())
             }
         };
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -42,6 +42,21 @@ All notable changes to this project will be documented in this file.
 - [**breaking**]: The `authentication::qrcode` module now reexports types from
   `oauth2` rather than `openidconnect`. Some type names might have changed.
   ([#4604](https://github.com/matrix-org/matrix-rust-sdk/pull/4604))
+- [**breaking**]: The `Oidc` API uses the `GET /auth_metadata` endpoint from the
+  latest version of [MSC2965](https://github.com/matrix-org/matrix-spec-proposals/pull/2965)
+  by default. The previous `GET /auth_issuer` endpoint is still supported as a
+  fallback for now.
+  ([#4673](https://github.com/matrix-org/matrix-rust-sdk/pull/4673))
+  - It is not possible to provide a custom issuer anymore:
+    `Oidc::given_provider_metadata()` was removed, and the parameter was removed
+    from `Oidc::register_client()`.
+  - `Oidc::fetch_authentication_issuer()` was removed. To check if the
+    homeserver supports OAuth 2.0, use `Oidc::provider_metadata()`. To get the
+    issuer, use `VerifiedProviderMetadata::issuer()`.
+  - `Oidc::provider_metadata()` returns an `OauthDiscoveryError`. It has a
+    `NotSupported` variant and an `is_not_supported()` method to check if the
+    error is due to the server not supporting OAuth 2.0.
+  - `OidcError::MissingAuthenticationIssuer` was removed.
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/src/authentication/oidc/backend/mock.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/backend/mock.rs
@@ -19,10 +19,8 @@ use std::sync::{Arc, Mutex};
 use http::StatusCode;
 use mas_oidc_client::{
     error::{
-        DiscoveryError,
-        Error::{self as OidcClientError, Discovery},
-        ErrorBody as OidcErrorBody, HttpError as OidcHttpError, TokenRefreshError,
-        TokenRequestError,
+        DiscoveryError as OidcDiscoveryError, Error as OidcClientError, ErrorBody as OidcErrorBody,
+        HttpError as OidcHttpError, TokenRefreshError, TokenRequestError,
     },
     requests::authorization_code::{AuthorizationRequestData, AuthorizationValidationData},
     types::{
@@ -37,7 +35,7 @@ use mas_oidc_client::{
 use url::Url;
 
 use super::{OidcBackend, OidcError, RefreshedSessionTokens};
-use crate::authentication::oidc::{AuthorizationCode, OidcSessionTokens};
+use crate::authentication::oidc::{AuthorizationCode, OauthDiscoveryError, OidcSessionTokens};
 
 pub(crate) const ISSUER_URL: &str = "https://oidc.example.com/issuer";
 pub(crate) const AUTHORIZATION_URL: &str = "https://oidc.example.com/authorization";
@@ -131,14 +129,18 @@ impl MockImpl {
 
 #[async_trait::async_trait]
 impl OidcBackend for MockImpl {
-    async fn discover(&self, insecure: bool) -> Result<VerifiedProviderMetadata, OidcError> {
+    async fn discover(
+        &self,
+        insecure: bool,
+    ) -> Result<VerifiedProviderMetadata, OauthDiscoveryError> {
         if insecure != self.is_insecure {
-            return Err(OidcError::Oidc(Discovery(DiscoveryError::Validation(
+            return Err(OidcDiscoveryError::Validation(
                 ProviderMetadataVerificationError::UrlNonHttpsScheme(
                     "mocking backend",
                     Url::parse(&self.issuer).unwrap(),
                 ),
-            ))));
+            )
+            .into());
         }
 
         Ok(ProviderMetadata {
@@ -158,7 +160,7 @@ impl OidcBackend for MockImpl {
             ..Default::default()
         }
         .validate(&self.issuer)
-        .map_err(DiscoveryError::from)?)
+        .map_err(OidcDiscoveryError::from)?)
     }
 
     async fn trade_authorization_code_for_tokens(

--- a/crates/matrix-sdk/src/authentication/oidc/backend/mock.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/backend/mock.rs
@@ -131,11 +131,7 @@ impl MockImpl {
 
 #[async_trait::async_trait]
 impl OidcBackend for MockImpl {
-    async fn discover(
-        &self,
-        issuer: &str,
-        insecure: bool,
-    ) -> Result<VerifiedProviderMetadata, OidcError> {
+    async fn discover(&self, insecure: bool) -> Result<VerifiedProviderMetadata, OidcError> {
         if insecure != self.is_insecure {
             return Err(OidcError::Oidc(Discovery(DiscoveryError::Validation(
                 ProviderMetadataVerificationError::UrlNonHttpsScheme(
@@ -161,7 +157,7 @@ impl OidcBackend for MockImpl {
                 .map(|uri| Url::parse(uri).unwrap()),
             ..Default::default()
         }
-        .validate(issuer)
+        .validate(&self.issuer)
         .map_err(DiscoveryError::from)?)
     }
 

--- a/crates/matrix-sdk/src/authentication/oidc/backend/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/backend/mod.rs
@@ -42,11 +42,7 @@ pub(super) struct RefreshedSessionTokens {
 
 #[async_trait::async_trait]
 pub(super) trait OidcBackend: std::fmt::Debug + Send + Sync {
-    async fn discover(
-        &self,
-        issuer: &str,
-        insecure: bool,
-    ) -> Result<VerifiedProviderMetadata, OidcError>;
+    async fn discover(&self, insecure: bool) -> Result<VerifiedProviderMetadata, OidcError>;
 
     async fn register_client(
         &self,

--- a/crates/matrix-sdk/src/authentication/oidc/backend/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/backend/mod.rs
@@ -28,7 +28,7 @@ use mas_oidc_client::{
 };
 use url::Url;
 
-use super::{AuthorizationCode, OidcError, OidcSessionTokens};
+use super::{AuthorizationCode, OauthDiscoveryError, OidcError, OidcSessionTokens};
 
 pub(crate) mod server;
 
@@ -42,7 +42,10 @@ pub(super) struct RefreshedSessionTokens {
 
 #[async_trait::async_trait]
 pub(super) trait OidcBackend: std::fmt::Debug + Send + Sync {
-    async fn discover(&self, insecure: bool) -> Result<VerifiedProviderMetadata, OidcError>;
+    async fn discover(
+        &self,
+        insecure: bool,
+    ) -> Result<VerifiedProviderMetadata, OauthDiscoveryError>;
 
     async fn register_client(
         &self,

--- a/crates/matrix-sdk/src/authentication/oidc/backend/server.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/backend/server.rs
@@ -38,6 +38,7 @@ use mas_oidc_client::{
         IdToken,
     },
 };
+use ruma::api::client::discovery::get_authentication_issuer;
 use url::Url;
 
 use super::{OidcBackend, OidcError, RefreshedSessionTokens};
@@ -71,15 +72,15 @@ impl OidcServer {
 
 #[async_trait::async_trait]
 impl OidcBackend for OidcServer {
-    async fn discover(
-        &self,
-        issuer: &str,
-        insecure: bool,
-    ) -> Result<VerifiedProviderMetadata, OidcError> {
+    async fn discover(&self, insecure: bool) -> Result<VerifiedProviderMetadata, OidcError> {
+        #[allow(deprecated)]
+        let issuer =
+            self.client.send(get_authentication_issuer::msc2965::Request::new()).await?.issuer;
+
         if insecure {
-            insecure_discover(&self.http_service(), issuer).await.map_err(Into::into)
+            insecure_discover(&self.http_service(), &issuer).await.map_err(Into::into)
         } else {
-            discover(&self.http_service(), issuer).await.map_err(Into::into)
+            discover(&self.http_service(), &issuer).await.map_err(Into::into)
         }
     }
 

--- a/crates/matrix-sdk/src/authentication/oidc/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/mod.rs
@@ -464,7 +464,7 @@ impl Oidc {
                     .as_client_api_error()
                     .is_some_and(|err| err.status_code == StatusCode::NOT_FOUND)
                 {
-                    return Err(OidcError::MissingAuthenticationIssuer);
+                    return Err(OidcError::NotSupported);
                 } else {
                     return Err(OidcError::UnknownError(Box::new(error)));
                 }
@@ -554,7 +554,7 @@ impl Oidc {
         &self,
         registrations: &OidcRegistrations,
     ) -> std::result::Result<(), OidcError> {
-        let issuer = Url::parse(self.issuer().ok_or(OidcError::MissingAuthenticationIssuer)?)
+        let issuer = Url::parse(self.issuer().expect("issuer should be set after registration"))
             .map_err(OidcError::Url)?;
         let client_id = self.client_id().ok_or(OidcError::NotRegistered)?.to_owned();
 
@@ -1721,9 +1721,9 @@ pub enum OidcError {
     #[error("authorization server discovery failed: {0}")]
     Discovery(#[from] HttpError),
 
-    /// No authentication issuer was provided by the homeserver or by the user.
-    #[error("client missing authentication issuer")]
-    MissingAuthenticationIssuer,
+    /// OAuth 2.0 is not supported by the homeserver.
+    #[error("OAuth 2.0 is not supported by the homeserver")]
+    NotSupported,
 
     /// The OpenID Connect Provider doesn't support dynamic client registration.
     ///

--- a/crates/matrix-sdk/src/authentication/oidc/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/mod.rs
@@ -359,6 +359,7 @@ impl Oidc {
     ///
     /// [MSC3861]: https://github.com/matrix-org/matrix-spec-proposals/pull/3861
     pub async fn fetch_authentication_issuer(&self) -> Result<String, HttpError> {
+        #[allow(deprecated)]
         let response = self.client.send(get_authentication_issuer::msc2965::Request::new()).await?;
 
         Ok(response.issuer)

--- a/crates/matrix-sdk/src/authentication/oidc/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/tests.rs
@@ -465,14 +465,14 @@ async fn test_register_client() {
     let backend = Arc::new(MockImpl::new().registration_endpoint(None));
     let oidc = Oidc { client: client.clone(), backend };
 
-    let result = oidc.register_client(ISSUER_URL, client_metadata.clone(), None).await;
+    let result = oidc.register_client(client_metadata.clone(), None).await;
     assert_matches!(result, Err(OidcError::NoRegistrationSupport));
 
     // Server supports registration, it succeeds.
     let backend = Arc::new(MockImpl::new());
     let oidc = Oidc { client: client.clone(), backend };
 
-    let response = oidc.register_client(ISSUER_URL, client_metadata.clone(), None).await.unwrap();
+    let response = oidc.register_client(client_metadata.clone(), None).await.unwrap();
     assert_eq!(response.client_id, CLIENT_ID);
 
     let auth_data = oidc.data().unwrap();

--- a/crates/matrix-sdk/src/authentication/oidc/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/tests.rs
@@ -76,12 +76,6 @@ pub async fn mock_environment(
     let issuer_url = Url::parse(&issuer).unwrap();
 
     Mock::given(method("GET"))
-        .and(path("/_matrix/client/unstable/org.matrix.msc2965/auth_issuer"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"issuer": issuer})))
-        .mount(&server)
-        .await;
-
-    Mock::given(method("GET"))
         .and(path("/_matrix/client/r0/account/whoami"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "user_id": "@joe:example.org",

--- a/crates/matrix-sdk/src/authentication/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/qrcode/login.rs
@@ -293,16 +293,9 @@ impl<'a> LoginWithQrCode<'a> {
     async fn register_client(&self) -> Result<OauthClient, DeviceAuthorizationOauthError> {
         let oidc = self.client.oidc();
 
-        // Let's figure out the OAuth 2.0 issuer, this fetches the info from the
-        // homeserver.
-        let issuer = oidc
-            .fetch_authentication_issuer()
-            .await
-            .map_err(DeviceAuthorizationOauthError::AuthenticationIssuer)?;
-
         // Now we register the client with the OAuth 2.0 authorization server.
         let registration_response =
-            oidc.register_client(&issuer, self.client_metadata.clone(), None).await?;
+            oidc.register_client(self.client_metadata.clone(), None).await?;
 
         // We're now switching to the oauth2 crate, it has a bit of a strange API
         // where you need to provide the HTTP client in every call you make.
@@ -622,7 +615,7 @@ mod test {
                 "issuer": server.uri(),
 
             })))
-            .expect(1)
+            .expect(1..)
             .named("auth_issuer")
             .mount(server)
             .await;

--- a/crates/matrix-sdk/src/authentication/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/qrcode/login.rs
@@ -34,8 +34,11 @@ use super::{
 #[cfg(doc)]
 use crate::authentication::oidc::Oidc;
 use crate::{
-    authentication::qrcode::{
-        messages::QrAuthMessage, secure_channel::EstablishedSecureChannel, QRCodeLoginError,
+    authentication::{
+        oidc::OidcError,
+        qrcode::{
+            messages::QrAuthMessage, secure_channel::EstablishedSecureChannel, QRCodeLoginError,
+        },
     },
     Client,
 };
@@ -300,7 +303,7 @@ impl<'a> LoginWithQrCode<'a> {
         // We're now switching to the oauth2 crate, it has a bit of a strange API
         // where you need to provide the HTTP client in every call you make.
         let http_client = self.client.inner.http_client.clone();
-        let server_metadata = oidc.provider_metadata().await?;
+        let server_metadata = oidc.provider_metadata().await.map_err(OidcError::from)?;
 
         OauthClient::new(registration_response.client_id, &server_metadata, http_client)
     }
@@ -610,21 +613,10 @@ mod test {
         token_response: ResponseTemplate,
     ) {
         Mock::given(method("GET"))
-            .and(path("/_matrix/client/unstable/org.matrix.msc2965/auth_issuer"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "issuer": server.uri(),
-
-            })))
-            .expect(1..)
-            .named("auth_issuer")
-            .mount(server)
-            .await;
-
-        Mock::given(method("GET"))
-            .and(path("/.well-known/openid-configuration"))
+            .and(path("/_matrix/client/unstable/org.matrix.msc2965/auth_metadata"))
             .respond_with(ResponseTemplate::new(200).set_body_json(open_id_configuration(server)))
             .expect(1..)
-            .named("server_metadata")
+            .named("auth_metadata")
             .mount(server)
             .await;
 

--- a/crates/matrix-sdk/src/authentication/qrcode/mod.rs
+++ b/crates/matrix-sdk/src/authentication/qrcode/mod.rs
@@ -121,11 +121,6 @@ pub enum DeviceAuthorizationOauthError {
     #[error("OAuth 2.0 server doesn't support the device authorization grant")]
     NoDeviceAuthorizationEndpoint,
 
-    /// An error happened while we attempted to discover the authentication
-    /// issuer URL.
-    #[error(transparent)]
-    AuthenticationIssuer(HttpError),
-
     /// An error happened while we attempted to request a device authorization
     /// from the Oauth 2.0 authorization server.
     #[error(transparent)]


### PR DESCRIPTION
This is the method to get the server metadata in the latest draft of [MSC2965](https://github.com/matrix-org/matrix-spec-proposals/pull/2965).

We still keep the old behavior with `GET /auth_issuer` as fallback for now because it has wider server support.

There are some pre-main commit cleanups to simplify the main commit. This can be reviewed commit by commit.

The changes were tested with the oidc_cli example on beta.matrix.org.

Closes #4550.