### PR TITLE
perf(timeline): avoid linear searches for an event, and use a reverse mapping from event-id to index instead

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/algorithms.rs
+++ b/crates/matrix-sdk-ui/src/timeline/algorithms.rs
@@ -52,10 +52,13 @@ impl Deref for EventTimelineItemWithId<'_> {
     }
 }
 
-#[inline(always)]
-fn rfind_event_item_internal(
+/// Finds an item in the vector of `items` given a predicate `f`.
+///
+/// WARNING/FIXME: this does a linear scan of the items, so this can be slow if
+/// there are many items in the timeline.
+pub(super) fn rfind_event_item(
     items: &Vector<Arc<TimelineItem>>,
-    mut f: impl FnMut(&EventTimelineItemWithId<'_>) -> bool,
+    mut f: impl FnMut(&EventTimelineItem) -> bool,
 ) -> Option<(usize, EventTimelineItemWithId<'_>)> {
     items
         .iter()
@@ -66,18 +69,7 @@ fn rfind_event_item_internal(
                 EventTimelineItemWithId { inner: item.as_event()?, internal_id: &item.internal_id },
             ))
         })
-        .rfind(|(_, it)| f(it))
-}
-
-/// Finds an item in the vector of `items` given a predicate `f`.
-///
-/// WARNING/FIXME: this does a linear scan of the items, so this can be slow if
-/// there are many items in the timeline.
-pub(super) fn rfind_event_item(
-    items: &Vector<Arc<TimelineItem>>,
-    mut f: impl FnMut(&EventTimelineItem) -> bool,
-) -> Option<(usize, EventTimelineItemWithId<'_>)> {
-    rfind_event_item_internal(items, |item_with_id| f(item_with_id.inner))
+        .rfind(|(_, it)| f(it.inner))
 }
 
 /// Find the timeline item that matches the given item (event or transaction)

--- a/crates/matrix-sdk-ui/src/timeline/algorithms.rs
+++ b/crates/matrix-sdk-ui/src/timeline/algorithms.rs
@@ -15,7 +15,6 @@
 use std::{ops::Deref, sync::Arc};
 
 use imbl::Vector;
-use ruma::EventId;
 
 #[cfg(doc)]
 use super::controller::TimelineMetadata;
@@ -81,17 +80,6 @@ pub(super) fn rfind_event_item(
     rfind_event_item_internal(items, |item_with_id| f(item_with_id.inner))
 }
 
-/// Find the timeline item that matches the given event id, if any.
-///
-/// WARNING: Linear scan of the items, see documentation of
-/// [`rfind_event_item`].
-pub(super) fn rfind_event_by_id<'a>(
-    items: &'a Vector<Arc<TimelineItem>>,
-    event_id: &EventId,
-) -> Option<(usize, EventTimelineItemWithId<'a>)> {
-    rfind_event_item(items, |it| it.event_id() == Some(event_id))
-}
-
 /// Find the timeline item that matches the given item (event or transaction)
 /// id, if any.
 ///
@@ -110,6 +98,8 @@ pub(super) fn rfind_event_by_item_id<'a>(
                 }
             })
         }
-        TimelineEventItemId::EventId(event_id) => rfind_event_by_id(items, event_id),
+        TimelineEventItemId::EventId(event_id) => {
+            rfind_event_item(items, |it| it.event_id() == Some(event_id))
+        }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -23,10 +23,7 @@ use ruma::{EventId, OwnedEventId, OwnedUserId, RoomVersionId};
 use tracing::trace;
 
 use super::{
-    super::{
-        rfind_event_by_id, subscriber::skip::SkipCount, TimelineItem, TimelineItemKind,
-        TimelineUniqueId,
-    },
+    super::{subscriber::skip::SkipCount, TimelineItem, TimelineItemKind, TimelineUniqueId},
     read_receipts::ReadReceipts,
     Aggregations, AllRemoteEvents, ObservableItemsTransaction, PendingEdit,
 };
@@ -199,7 +196,7 @@ impl TimelineMetadata {
         let read_marker_idx = items.iter().rposition(|item| item.is_read_marker());
 
         let mut fully_read_event_idx =
-            rfind_event_by_id(items, fully_read_event).map(|(idx, _)| idx);
+            items.event_item_by_event_id(fully_read_event).map(|(idx, _)| idx);
 
         if let Some(i) = &mut fully_read_event_idx {
             // The item at position `i` is the first item that's fully read, we're about to

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -25,8 +25,8 @@ use tokio_stream::wrappers::WatchStream;
 use tracing::{debug, error, warn};
 
 use super::{
-    rfind_event_by_id, AllRemoteEvents, FullEventMeta, ObservableItemsTransaction,
-    RelativePosition, RoomDataProvider, TimelineMetadata, TimelineState,
+    AllRemoteEvents, FullEventMeta, ObservableItemsTransaction, RelativePosition, RoomDataProvider,
+    TimelineMetadata, TimelineState,
 };
 use crate::timeline::{controller::TimelineStateTransaction, TimelineItem};
 
@@ -521,7 +521,7 @@ impl TimelineStateTransaction<'_> {
         };
 
         let Some((prev_item_pos, prev_event_item)) =
-            rfind_event_by_id(&self.items, &prev_event_meta.event_id)
+            self.items.event_item_by_event_id(&prev_event_meta.event_id)
         else {
             error!("inconsistent state: timeline item of visible event was not found");
             return;

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -51,7 +51,7 @@ use ruma::{
 use tracing::{debug, error, field::debug, info, instrument, trace, warn};
 
 use super::{
-    algorithms::{rfind_event_by_id, rfind_event_by_item_id},
+    algorithms::rfind_event_by_item_id,
     controller::{
         find_item_and_apply_aggregation, Aggregation, AggregationKind, ApplyAggregationResult,
         ObservableItemsTransaction, PendingEdit, PendingEditKind, TimelineMetadata,
@@ -778,7 +778,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         &mut self,
         replacement: Replacement<NewUnstablePollStartEventContentWithoutRelation>,
     ) {
-        let Some((item_pos, item)) = rfind_event_by_id(self.items, &replacement.event_id) else {
+        let Some((item_pos, item)) = self.items.event_item_by_event_id(&replacement.event_id)
+        else {
             if let Flow::Remote { position, raw_event, .. } = &self.ctx.flow {
                 let replaced_event_id = replacement.event_id.clone();
                 let replacement = PendingEdit {
@@ -918,7 +919,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         }
 
         // General path: redact another kind of (non-reaction) event.
-        if let Some((idx, item)) = rfind_event_by_id(self.items, &redacted) {
+        if let Some((idx, item)) = self.items.event_item_by_event_id(&redacted) {
             if item.as_remote().is_some() {
                 if let TimelineItemContent::RedactedMessage = &item.content {
                     debug!("event item is already redacted");

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -984,7 +984,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
     /// # Safety
     ///
     /// This method is not marked as unsafe **but** it manipulates
-    /// [`TimelineMetadata::all_remote_events`]. 2 rules **must** be respected:
+    /// [`ObservableItemsTransaction::all_remote_events`]. 2 rules **must** be
+    /// respected:
     ///
     /// 1. the remote event of the item being added **must** be present in
     ///    `all_remote_events`,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -56,9 +56,7 @@ use subscriber::TimelineWithDropHandle;
 use thiserror::Error;
 use tracing::{error, instrument, trace, warn};
 
-use self::{
-    algorithms::rfind_event_by_id, controller::TimelineController, futures::SendAttachment,
-};
+use self::{controller::TimelineController, futures::SendAttachment};
 
 mod algorithms;
 mod builder;
@@ -247,14 +245,8 @@ impl Timeline {
     ///
     /// Will return a remote event, *or* a local echo that has been sent but not
     /// yet replaced by a remote echo.
-    ///
-    /// It's preferable to store the timeline items in the model for your UI, if
-    /// possible, instead of just storing IDs and coming back to the timeline
-    /// object to look up items.
     pub async fn item_by_event_id(&self, event_id: &EventId) -> Option<EventTimelineItem> {
-        let items = self.controller.items().await;
-        let (_, item) = rfind_event_by_id(&items, event_id)?;
-        Some(item.to_owned())
+        self.controller.event_item_by_event_id(event_id).await
     }
 
     /// Get the latest of the timeline's event items.


### PR DESCRIPTION
Before this PR, in the timeline, to know if an event id had an attached event timeline item, we'd do a linear search over the timeline items, from the end to the back.

This PR changes it so that we:

- maintain a mapping of event-id -> index in the `all_remote_events` array
- then use that mapping instead of doing the linear search

Supposedly, this should improve performance; there's now a benchmark to confirm this.