### PR TITLE
task(base): Update `EventCacheStore` to add `load_last_chunk` and `load_previous_chunk`

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -355,7 +355,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         .unwrap();
 
         // The linked chunk is correctly reloaded.
-        let raws = self.reload_linked_chunk(room_id).await.unwrap();
+        let raws = self.load_all_chunks(room_id).await.unwrap();
         let lc = rebuild_linked_chunk(raws).expect("linked chunk not empty");
 
         let mut chunks = lc.chunks();
@@ -397,7 +397,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
     async fn test_rebuild_empty_linked_chunk(&self) {
         // When I rebuild a linked chunk from an empty store, it's empty.
-        let raw_parts = self.reload_linked_chunk(&DEFAULT_TEST_ROOM_ID).await.unwrap();
+        let raw_parts = self.load_all_chunks(&DEFAULT_TEST_ROOM_ID).await.unwrap();
         assert!(rebuild_linked_chunk(raw_parts).is_none());
     }
 
@@ -447,15 +447,15 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         .unwrap();
 
         // Sanity check: both linked chunks can be reloaded.
-        assert!(rebuild_linked_chunk(self.reload_linked_chunk(r0).await.unwrap()).is_some());
-        assert!(rebuild_linked_chunk(self.reload_linked_chunk(r1).await.unwrap()).is_some());
+        assert!(rebuild_linked_chunk(self.load_all_chunks(r0).await.unwrap()).is_some());
+        assert!(rebuild_linked_chunk(self.load_all_chunks(r1).await.unwrap()).is_some());
 
         // Clear the chunks.
         self.clear_all_rooms_chunks().await.unwrap();
 
         // Both rooms now have no linked chunk.
-        assert!(rebuild_linked_chunk(self.reload_linked_chunk(r0).await.unwrap()).is_none());
-        assert!(rebuild_linked_chunk(self.reload_linked_chunk(r1).await.unwrap()).is_none());
+        assert!(rebuild_linked_chunk(self.load_all_chunks(r0).await.unwrap()).is_none());
+        assert!(rebuild_linked_chunk(self.load_all_chunks(r1).await.unwrap()).is_none());
     }
 
     async fn test_remove_room(&self) {
@@ -498,11 +498,11 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         self.remove_room(r0).await.unwrap();
 
         // Check that r0 doesn't have a linked chunk anymore.
-        let r0_linked_chunk = self.reload_linked_chunk(r0).await.unwrap();
+        let r0_linked_chunk = self.load_all_chunks(r0).await.unwrap();
         assert!(r0_linked_chunk.is_empty());
 
         // Check that r1 is unaffected.
-        let r1_linked_chunk = self.reload_linked_chunk(r1).await.unwrap();
+        let r1_linked_chunk = self.load_all_chunks(r1).await.unwrap();
         assert!(!r1_linked_chunk.is_empty());
     }
 

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -1009,7 +1009,8 @@ unsafe impl<const CAP: usize, Item: Sync, Gap: Sync> Sync for LinkedChunk<CAP, I
 /// (see [`ChunkIdentifier`]). Generating a new unique identifier boils down to
 /// incrementing by one the previous identifier. Note that this is not an index:
 /// it _is_ an identifier.
-struct ChunkIdentifierGenerator {
+#[derive(Debug)]
+pub struct ChunkIdentifierGenerator {
     next: AtomicU64,
 }
 
@@ -1033,7 +1034,7 @@ impl ChunkIdentifierGenerator {
     ///
     /// Note that it can fail if there is no more unique identifier available.
     /// In this case, this method will panic.
-    pub fn next(&self) -> ChunkIdentifier {
+    fn next(&self) -> ChunkIdentifier {
         let previous = self.next.fetch_add(1, Ordering::Relaxed);
 
         // Check for overflows.
@@ -1043,6 +1044,14 @@ impl ChunkIdentifierGenerator {
         }
 
         ChunkIdentifier(previous + 1)
+    }
+
+    /// Get the current chunk identifier.
+    //
+    // This is hidden because it's used only in the tests.
+    #[doc(hidden)]
+    pub fn current(&self) -> ChunkIdentifier {
+        ChunkIdentifier(self.next.load(Ordering::Relaxed))
     }
 }
 

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -670,7 +670,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                     )
                     .optional()?
                 else {
-                    // Chunk is not found and there is zero chunk for this room, this is consistent, all
+                    // Chunk is not found and there are zero chunks for this room, this is consistent, all
                     // good.
                     if number_of_chunks == 0 {
                         return Ok((None, chunk_identifier_generator));
@@ -2093,7 +2093,7 @@ mod tests {
         let event = |msg: &str| make_test_event(room_id, msg);
         let store = get_event_cache_store().await.expect("creating cache store failed");
 
-        // Case #1: no chunk at all, equivalent to having an inexistent
+        // Case #1: no chunk at all, equivalent to having an nonexistent
         // `before_chunk_identifier`.
         {
             let previous_chunk =
@@ -2123,7 +2123,7 @@ mod tests {
             assert!(previous_chunk.is_none());
         }
 
-        // Case #3: there is two chunks.
+        // Case #3: there are two chunks.
         {
             store
                 .handle_linked_chunk_updates(

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1513,6 +1513,13 @@ mod tests {
         let room_id = room_id!("!galette:saucisse.bzh");
         let event_cache_store = Arc::new(MemoryStore::new());
 
+        let event = EventFactory::new()
+            .room(room_id)
+            .sender(user_id!("@ben:saucisse.bzh"))
+            .text_msg("foo")
+            .event_id(event_id!("$42"))
+            .into_event();
+
         // Prefill the store with invalid data: two chunks that form a cycle.
         event_cache_store
             .handle_linked_chunk_updates(
@@ -1522,6 +1529,10 @@ mod tests {
                         previous: None,
                         new: ChunkIdentifier::new(0),
                         next: None,
+                    },
+                    Update::PushItems {
+                        at: Position::new(ChunkIdentifier::new(0), 0),
+                        items: vec![event],
                     },
                     Update::NewItemsChunk {
                         previous: Some(ChunkIdentifier::new(0)),

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -575,7 +575,7 @@ mod private {
             locked: &EventCacheStoreLockGuard<'_>,
         ) -> Result<Option<LinkedChunk<DEFAULT_CHUNK_CAPACITY, Event, Gap>>, EventCacheError>
         {
-            let raw_chunks = locked.reload_linked_chunk(room).await?;
+            let raw_chunks = locked.load_all_chunks(room).await?;
 
             let mut builder = LinkedChunkBuilder::from_raw_parts(raw_chunks.clone());
 
@@ -1174,7 +1174,7 @@ mod tests {
             .await
             .unwrap();
 
-        let raws = event_cache_store.reload_linked_chunk(room_id).await.unwrap();
+        let raws = event_cache_store.load_all_chunks(room_id).await.unwrap();
         let linked_chunk =
             LinkedChunkBuilder::<3, _, _>::from_raw_parts(raws).build().unwrap().unwrap();
 
@@ -1264,7 +1264,7 @@ mod tests {
         }
 
         // The one in storage does not.
-        let raws = event_cache_store.reload_linked_chunk(room_id).await.unwrap();
+        let raws = event_cache_store.load_all_chunks(room_id).await.unwrap();
         let linked_chunk =
             LinkedChunkBuilder::<3, _, _>::from_raw_parts(raws).build().unwrap().unwrap();
 
@@ -1396,7 +1396,7 @@ mod tests {
         assert!(items.is_empty());
 
         // The event cache store too.
-        let raws = event_cache_store.reload_linked_chunk(room_id).await.unwrap();
+        let raws = event_cache_store.load_all_chunks(room_id).await.unwrap();
         let linked_chunk = LinkedChunkBuilder::<3, _, _>::from_raw_parts(raws).build().unwrap();
 
         // Note: while the event cache store could return `None` here, clearing it will
@@ -1559,7 +1559,7 @@ mod tests {
 
         // Storage doesn't contain anything. It would also be valid that it contains a
         // single initial empty items chunk.
-        let raw_chunks = event_cache_store.reload_linked_chunk(room_id).await.unwrap();
+        let raw_chunks = event_cache_store.load_all_chunks(room_id).await.unwrap();
         assert!(raw_chunks.is_empty());
     }
 

--- a/crates/matrix-sdk/tests/integration/room/left.rs
+++ b/crates/matrix-sdk/tests/integration/room/left.rs
@@ -58,7 +58,7 @@ async fn test_forget_non_direct_room() {
     {
         // There is some data in the cache store.
         let event_cache_store = client.event_cache_store().lock().await.unwrap();
-        let room_data = event_cache_store.reload_linked_chunk(&DEFAULT_TEST_ROOM_ID).await.unwrap();
+        let room_data = event_cache_store.load_all_chunks(&DEFAULT_TEST_ROOM_ID).await.unwrap();
         assert!(!room_data.is_empty());
     }
 
@@ -72,7 +72,7 @@ async fn test_forget_non_direct_room() {
     {
         // Data in the event cache store has been removed.
         let event_cache_store = client.event_cache_store().lock().await.unwrap();
-        let room_data = event_cache_store.reload_linked_chunk(&DEFAULT_TEST_ROOM_ID).await.unwrap();
+        let room_data = event_cache_store.load_all_chunks(&DEFAULT_TEST_ROOM_ID).await.unwrap();
         assert!(room_data.is_empty());
     }
 }
@@ -115,7 +115,7 @@ async fn test_forget_banned_room() {
     {
         // There is some data in the cache store.
         let event_cache_store = client.event_cache_store().lock().await.unwrap();
-        let room_data = event_cache_store.reload_linked_chunk(&DEFAULT_TEST_ROOM_ID).await.unwrap();
+        let room_data = event_cache_store.load_all_chunks(&DEFAULT_TEST_ROOM_ID).await.unwrap();
         assert!(!room_data.is_empty());
     }
 
@@ -133,7 +133,7 @@ async fn test_forget_banned_room() {
     {
         // Data in the event cache store has been removed.
         let event_cache_store = client.event_cache_store().lock().await.unwrap();
-        let room_data = event_cache_store.reload_linked_chunk(&DEFAULT_TEST_ROOM_ID).await.unwrap();
+        let room_data = event_cache_store.load_all_chunks(&DEFAULT_TEST_ROOM_ID).await.unwrap();
         assert!(room_data.is_empty());
     }
 }


### PR DESCRIPTION
Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/4632 for the sake of easy review.