### PR TITLE
refactor(oidc): Remove support for deserializing previous `UserSession` format

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -46,6 +46,8 @@ All notable changes to this project will be documented in this file.
   case anymore, according to the latest version of
   [MSC2967](https://github.com/matrix-org/matrix-spec-proposals/pull/2967).
   ([#4664](https://github.com/matrix-org/matrix-rust-sdk/pull/4664))
+- The `UserSession` type cannot be deserialized from its old format anymore. The
+  old format used an `issuer_info` field instead of an `issuer` field.
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/src/authentication/oidc/data_serde.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/data_serde.rs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use matrix_sdk_base::SessionMeta;
-use ruma::api::client::discovery::discover_homeserver::AuthenticationServerInfo;
 use serde::{de, ser::SerializeStruct, Deserialize, Serialize};
 
-use super::{OidcSessionTokens, UserSession};
+use super::OidcSessionTokens;
 
 impl Serialize for OidcSessionTokens {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -62,32 +60,4 @@ struct SessionTokensDeHelper {
     pub access_token: String,
     pub refresh_token: Option<String>,
     pub latest_id_token: Option<String>,
-}
-
-/// Type used to deserialize `UserSession` with backwards compatibility for
-/// `issuer_info` field.
-#[derive(Deserialize)]
-struct UserSessionDeHelper {
-    #[serde(flatten)]
-    meta: SessionMeta,
-    #[serde(flatten)]
-    tokens: OidcSessionTokens,
-    issuer_info: Option<AuthenticationServerInfo>,
-    issuer: Option<String>,
-}
-
-impl<'de> Deserialize<'de> for UserSession {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let UserSessionDeHelper { meta, tokens, issuer_info, issuer } =
-            UserSessionDeHelper::deserialize(deserializer)?;
-
-        let issuer = issuer
-            .or(issuer_info.map(|info| info.issuer))
-            .ok_or_else(|| de::Error::missing_field("issuer"))?;
-
-        Ok(Self { meta, tokens, issuer })
-    }
 }

--- a/crates/matrix-sdk/src/authentication/oidc/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/mod.rs
@@ -1576,7 +1576,7 @@ pub struct OidcSession {
 }
 
 /// A user session for the OpenID Connect API.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserSession {
     /// The Matrix user session info.
     #[serde(flatten)]


### PR DESCRIPTION
The format changed 10 months ago and since it contains the tokens, it should have been re-serialized already in that time.

Afaict EX clients do not serialize that type, the bindings have their own `Session` type for that.

