### PR TITLE
fix(compilation): fix benchmark compilation on non-linux platforms

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -198,12 +198,16 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
 }
 
 fn criterion() -> Criterion {
-    if cfg!(target_os = "linux") {
+    #[cfg(target_os = "linux")]
+    {
         Criterion::default().with_profiler(pprof::criterion::PProfProfiler::new(
             100,
             pprof::criterion::Output::Flamegraph(None),
         ))
-    } else {
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
         Criterion::default()
     }
 }

--- a/benchmarks/benches/timeline.rs
+++ b/benchmarks/benches/timeline.rs
@@ -118,12 +118,16 @@ pub fn create_timeline_with_initial_events(c: &mut Criterion) {
 }
 
 fn criterion() -> Criterion {
-    if cfg!(target_os = "linux") {
+    #[cfg(target_os = "linux")]
+    {
         Criterion::default().with_profiler(pprof::criterion::PProfProfiler::new(
             100,
             pprof::criterion::Output::Flamegraph(None),
         ))
-    } else {
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
         Criterion::default()
     }
 }


### PR DESCRIPTION
This should help with compiling the benchmarks on platforms that aren't linux.