### PR TITLE
feat(sqlite) Add an index on `events.event_id` and `.room_id`

### DIFF
--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/005_events_index_on_event_id.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/005_events_index_on_event_id.sql
@@ -1,0 +1,2 @@
+-- Create a unique index on `events.event_id` and `events.room_id` .
+CREATE UNIQUE INDEX "linked_chunks_event_id_and_room_id" ON events (event_id, room_id);


### PR DESCRIPTION
This patch adds an index on `events.event_id` and on `events.room_id` so that queries on this column are faster. It mostly happens in the `Deduplicator`, which runs for every backwards pagination or sync.

This patch also updates the query in `filter_duplicated_events` to sort event by their `chunk_id` and `position` so that the results are constant, it helps when testing.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280
* Follow up of #4632