### PR TITLE
refactor(common): `builder::LinkedChunkBuilder::*` becomes `lazy_loader::*`

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -22,8 +22,8 @@ use matrix_sdk_common::{
         VerificationState,
     },
     linked_chunk::{
-        ChunkContent, ChunkIdentifier as CId, LinkedChunk, LinkedChunkBuilder,
-        LinkedChunkBuilderTest, Position, RawChunk, Update,
+        lazy_loader, ChunkContent, ChunkIdentifier as CId, LinkedChunk, LinkedChunkBuilderTest,
+        Position, RawChunk, Update,
     },
 };
 use matrix_sdk_test::{event_factory::EventFactory, ALICE, DEFAULT_TEST_ROOM_ID};
@@ -448,7 +448,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
             assert_eq!(chunk_identifier_generator.current(), 2);
 
-            let linked_chunk = LinkedChunkBuilder::from_last_chunk::<DEFAULT_CHUNK_CAPACITY, _, _>(
+            let linked_chunk = lazy_loader::from_last_chunk::<DEFAULT_CHUNK_CAPACITY, _, _>(
                 last_chunk,
                 chunk_identifier_generator,
             )
@@ -483,8 +483,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             // Pretend it's the first chunk.
             previous_chunk.previous = None;
 
-            let _ = LinkedChunkBuilder::insert_new_first_chunk(&mut linked_chunk, previous_chunk)
-                .unwrap();
+            let _ = lazy_loader::insert_new_first_chunk(&mut linked_chunk, previous_chunk).unwrap();
 
             let mut rchunks = linked_chunk.rchunks();
 
@@ -519,8 +518,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             let previous_chunk =
                 self.load_previous_chunk(room_id, first_chunk).await.unwrap().unwrap();
 
-            let _ = LinkedChunkBuilder::insert_new_first_chunk(&mut linked_chunk, previous_chunk)
-                .unwrap();
+            let _ = lazy_loader::insert_new_first_chunk(&mut linked_chunk, previous_chunk).unwrap();
 
             let mut rchunks = linked_chunk.rchunks();
 

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -92,7 +92,7 @@ macro_rules! assert_items_eq {
 }
 
 mod as_vector;
-mod builder;
+pub mod lazy_loader;
 pub mod relational;
 mod updates;
 
@@ -105,7 +105,7 @@ use std::{
 };
 
 pub use as_vector::*;
-pub use builder::*;
+pub use lazy_loader::{LinkedChunkBuilderTest, LinkedChunkBuilderTestError};
 pub use updates::*;
 
 /// Errors of [`LinkedChunk`].

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -38,7 +38,7 @@ use eyeball_im::VectorDiff;
 use matrix_sdk_base::{
     deserialized_responses::{AmbiguityChange, TimelineEvent},
     event_cache::store::{EventCacheStoreError, EventCacheStoreLock},
-    linked_chunk::LinkedChunkBuilderError,
+    linked_chunk::lazy_loader::LazyLoaderError,
     store_locks::LockStoreError,
     sync::RoomUpdates,
 };
@@ -111,11 +111,12 @@ pub enum EventCacheError {
     #[error("The owning client of the event cache has been dropped.")]
     ClientDropped,
 
-    /// An error happening when interacting with the [`LinkedChunkBuilder`].
+    /// An error happening when interacting with the [`LinkedChunk`]'s lazy
+    /// loader.
     ///
-    /// [`LinkedChunkBuilder`]: matrix_sdk_common::linked_chunk::LinkedChunkBuilder
+    /// [`LinkedChunk`]: matrix_sdk_common::linked_chunk::LinkedChunk
     #[error(transparent)]
-    LinkedChunkBuilder(#[from] LinkedChunkBuilderError),
+    LinkedChunkLoader(#[from] LazyLoaderError),
 }
 
 /// A result using the [`EventCacheError`].

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -17,7 +17,10 @@ pub use matrix_sdk_base::event_cache::{Event, Gap};
 use matrix_sdk_base::{
     apply_redaction,
     event_cache::store::DEFAULT_CHUNK_CAPACITY,
-    linked_chunk::{ChunkContent, LinkedChunkBuilder, LinkedChunkBuilderError, RawChunk},
+    linked_chunk::{
+        lazy_loader::{self, LazyLoaderError},
+        ChunkContent, RawChunk,
+    },
 };
 use matrix_sdk_common::linked_chunk::{
     AsVector, Chunk, ChunkIdentifier, EmptyChunk, Error, Iter, IterBackward, LinkedChunk,
@@ -335,8 +338,8 @@ impl RoomEvents {
     pub(super) fn insert_new_chunk_as_first(
         &mut self,
         raw_new_first_chunk: RawChunk<Event, Gap>,
-    ) -> Result<(), LinkedChunkBuilderError> {
-        LinkedChunkBuilder::insert_new_first_chunk(&mut self.chunks, raw_new_first_chunk)
+    ) -> Result<(), LazyLoaderError> {
+        lazy_loader::insert_new_first_chunk(&mut self.chunks, raw_new_first_chunk)
     }
 }
 

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -524,7 +524,7 @@ mod private {
     use matrix_sdk_base::{
         deserialized_responses::{TimelineEvent, TimelineEventKind},
         event_cache::{store::EventCacheStoreLock, Event},
-        linked_chunk::{ChunkContent, LinkedChunkBuilder, Update},
+        linked_chunk::{lazy_loader, ChunkContent, Update},
     };
     use matrix_sdk_common::executor::spawn;
     use once_cell::sync::OnceCell;
@@ -583,7 +583,7 @@ mod private {
                     .await
                     .map_err(EventCacheError::from)
                     .and_then(|(last_chunk, chunk_identifier_generator)| {
-                        LinkedChunkBuilder::from_last_chunk(last_chunk, chunk_identifier_generator)
+                        lazy_loader::from_last_chunk(last_chunk, chunk_identifier_generator)
                             .map_err(EventCacheError::from)
                     }) {
                     Ok(linked_chunk) => linked_chunk,


### PR DESCRIPTION
This patch renames the `builder` module to `lazy_loader`. The `LinkedChunkBuilder`'s methods are now functions. The `LinkedChunkBuilder` struct is removed. Finally, `LinkedChunkBuilderError` is renamed `LazyLoaderError`.

The `LinkedChunkBuilderTest` struct is kept for the moment. It's going to be replaced soon.

Easier to review without whitespace in the diffs.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280
* Follow up of #4632