### PR TITLE
Use the `DecryptedOlmV1Event` when encrypting to-device events

### DIFF
--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -539,13 +539,15 @@ impl GossipMachine {
         device: &Device,
         content: SecretSendContent,
     ) -> OlmResult<Session> {
-        let event_type = content.event_type();
-        let (used_session, content) = device.encrypt(event_type, content).await?;
+        let event_type = content.event_type().to_owned();
+        let (used_session, content) = device.encrypt(&event_type, content).await?;
+
+        let encrypted_event_type = content.event_type().to_owned();
 
         let request = ToDeviceRequest::new(
             device.user_id(),
             device.device_id().to_owned(),
-            content.event_type(),
+            &encrypted_event_type,
             content.cast(),
         );
 
@@ -568,10 +570,12 @@ impl GossipMachine {
         let (used_session, content) =
             device.encrypt_room_key_for_forwarding(session.clone(), message_index).await?;
 
+        let event_type = content.event_type().to_owned();
+
         let request = ToDeviceRequest::new(
             device.user_id(),
             device.device_id().to_owned(),
-            content.event_type(),
+            &event_type,
             content.cast(),
         );
 

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -425,18 +425,19 @@ impl Device {
         session: InboundGroupSession,
         message_index: Option<u32>,
     ) -> OlmResult<(Session, Raw<ToDeviceEncryptedEventContent>)> {
-        let (event_type, content) = {
+        let content: ForwardedRoomKeyContent = {
             let export = if let Some(index) = message_index {
                 session.export_at_index(index).await
             } else {
                 session.export().await
             };
-            let content: ForwardedRoomKeyContent = export.try_into()?;
 
-            (content.event_type(), content)
+            export.try_into()?
         };
 
-        self.encrypt(event_type, content).await
+        let event_type = content.event_type().to_owned();
+
+        self.encrypt(&event_type, content).await
     }
 
     /// Encrypt an event for this device.
@@ -832,9 +833,9 @@ impl DeviceData {
     ) -> OlmResult<MaybeEncryptedRoomKey> {
         let content = session.as_content().await;
         let message_index = session.message_index().await;
-        let event_type = content.event_type();
+        let event_type = content.event_type().to_owned();
 
-        match self.encrypt(store, event_type, content).await {
+        match self.encrypt(store, &event_type, content).await {
             Ok((session, encrypted)) => Ok(MaybeEncryptedRoomKey::Encrypted {
                 share_info: ShareInfo::new_shared(
                     session.sender_key().to_owned(),

--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -16,7 +16,7 @@ use std::{fmt, sync::Arc};
 
 use ruma::{serde::Raw, SecondsSinceUnixEpoch};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::Value;
 use tokio::sync::Mutex;
 use tracing::{debug, Span};
 use vodozemac::{
@@ -29,7 +29,11 @@ use crate::types::events::room::encrypted::OlmV2Curve25519AesSha2Content;
 use crate::{
     error::{EventError, OlmResult, SessionUnpickleError},
     types::{
-        events::room::encrypted::{OlmV1Curve25519AesSha2Content, ToDeviceEncryptedEventContent},
+        events::{
+            olm_v1::DecryptedOlmV1Event,
+            room::encrypted::{OlmV1Curve25519AesSha2Content, ToDeviceEncryptedEventContent},
+            EventType,
+        },
         DeviceKeys, EventEncryptionAlgorithm,
     },
     DeviceData,
@@ -146,26 +150,59 @@ impl Session {
         content: impl Serialize,
         message_id: Option<String>,
     ) -> OlmResult<Raw<ToDeviceEncryptedEventContent>> {
+        #[derive(Debug)]
+        struct Content<'a> {
+            event_type: &'a str,
+            content: Raw<Value>,
+        }
+
+        impl EventType for Content<'_> {
+            // This is a bit of a hack, usually we just define the `EVENT_TYPE` and use the
+            // default implementation of `event_type()`, we can't do this here
+            // because the event type isn't static.
+            //
+            // So we just leave EVENT_TYPE out. This works because the serialization is
+            // using `event_type()` and this type is contained to this function.
+            const EVENT_TYPE: &'static str = "";
+
+            fn event_type(&self) -> &str {
+                self.event_type
+            }
+        }
+
+        impl Serialize for Content<'_> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                self.content.serialize(serializer)
+            }
+        }
+
         let plaintext = {
+            let content = serde_json::to_value(content)?;
+            let content = Content { event_type, content: Raw::new(&content)? };
+
             let recipient_signing_key =
                 recipient_device.ed25519_key().ok_or(EventError::MissingSigningKey)?;
 
-            let payload = json!({
-                "sender": &self.our_device_keys.user_id,
-                "sender_device": &self.our_device_keys.device_id,
-                "keys": {
-                    "ed25519": self.our_device_keys.ed25519_key().expect("Device doesn't have ed25519 key").to_base64(),
+            let content = DecryptedOlmV1Event {
+                sender: self.our_device_keys.user_id.clone(),
+                recipient: recipient_device.user_id().into(),
+                keys: crate::types::events::olm_v1::OlmV1Keys {
+                    ed25519: self
+                        .our_device_keys
+                        .ed25519_key()
+                        .expect("Our own device should have an Ed25519 public key"),
                 },
-                "org.matrix.msc4147.device_keys": self.our_device_keys,
-                "recipient": recipient_device.user_id(),
-                "recipient_keys": {
-                    "ed25519": recipient_signing_key.to_base64(),
+                recipient_keys: crate::types::events::olm_v1::OlmV1Keys {
+                    ed25519: recipient_signing_key,
                 },
-                "type": event_type,
-                "content": content,
-            });
+                sender_device_keys: Some(self.our_device_keys.clone()),
+                content,
+            };
 
-            serde_json::to_string(&payload)?
+            serde_json::to_string(&content)?
         };
 
         let ciphertext = self.encrypt_helper(&plaintext).await;

--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -157,12 +157,15 @@ impl Session {
         }
 
         impl EventType for Content<'_> {
-            // This is a bit of a hack, usually we just define the `EVENT_TYPE` and use the
-            // default implementation of `event_type()`, we can't do this here
+            // This is a bit of a hack: usually we just define the `EVENT_TYPE` and use the
+            // default implementation of `event_type()`. We can't do this here
             // because the event type isn't static.
             //
-            // So we just leave EVENT_TYPE out. This works because the serialization is
-            // using `event_type()` and this type is contained to this function.
+            // We have to provide `EVENT_TYPE` to conform to the `EventType` trait, but
+            // don't actually use it, so we just leave it empty.
+            //
+            // This works because the serialization uses `event_type()` and this type is
+            // contained to this function.
             const EVENT_TYPE: &'static str = "";
 
             fn event_type(&self) -> &str {

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -153,10 +153,12 @@ impl SessionManager {
                 let (_, content) =
                     device.encrypt("m.dummy", ToDeviceDummyEventContent::new()).await?;
 
+                let event_type = content.event_type().to_owned();
+
                 let request = ToDeviceRequest::new(
                     device.user_id(),
                     device.device_id().to_owned(),
-                    content.event_type(),
+                    &event_type,
                     content.cast(),
                 );
 

--- a/crates/matrix-sdk-crypto/src/types/events/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/mod.rs
@@ -40,8 +40,9 @@ pub trait EventType {
 
     /// Get the event type of the event content.
     ///
-    /// **Note**: This should never be implemented manually, this takes the
-    /// event type from the constant.
+    /// **Note**: This usually doesn't need to be implemented. The default
+    /// implementation will take the event type from the
+    /// [`EventType::EVENT_TYPE`] constant.
     fn event_type(&self) -> &str {
         Self::EVENT_TYPE
     }

--- a/crates/matrix-sdk-crypto/src/types/events/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/mod.rs
@@ -42,7 +42,7 @@ pub trait EventType {
     ///
     /// **Note**: This should never be implemented manually, this takes the
     /// event type from the constant.
-    fn event_type(&self) -> &'static str {
+    fn event_type(&self) -> &str {
         Self::EVENT_TYPE
     }
 }

--- a/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
@@ -163,7 +163,7 @@ impl AnyDecryptedOlmEvent {
 
 /// An `m.olm.v1.curve25519-aes-sha2` decrypted to-device event.
 ///
-/// **Note**: This event will reserialize events lossy, unknown fields will be
+/// **Note**: This event will reserialize events lossily; unknown fields will be
 /// lost during deserialization.
 #[derive(Clone, Debug, Deserialize)]
 pub struct DecryptedOlmV1Event<C>


### PR DESCRIPTION
This requires a bit of a hack, but I think the stronger typing and having the fields defined in a single place make this worth it.