### PR TITLE
doc(timeline): fix a broken link to all_remote_events

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -984,7 +984,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
     /// # Safety
     ///
     /// This method is not marked as unsafe **but** it manipulates
-    /// [`TimelineMetadata::all_remote_events`]. 2 rules **must** be respected:
+    /// [`ObservableItemsTransaction::all_remote_events`]. 2 rules **must** be
+    /// respected:
     ///
     /// 1. the remote event of the item being added **must** be present in
     ///    `all_remote_events`,


### PR DESCRIPTION
Extracted from #4677. Some good came out of that pull request, after all.