### PR TITLE
feat(event cache): unload a linked chunk whenever we get a limited sync

### DIFF
--- a/crates/matrix-sdk-common/src/linked_chunk/as_vector.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/as_vector.rs
@@ -266,11 +266,10 @@ impl UpdateToVectorDiff {
                 | Update::NewGapChunk { previous, new, next, .. } => {
                     match (previous, next) {
                         // New chunk at the end.
-                        (Some(previous), None) => {
-                            debug_assert!(
-                                matches!(self.chunks.back(), Some((p, _)) if p == previous),
-                                "Inserting new chunk at the end: The previous chunk is invalid"
-                            );
+                        (Some(_previous), None) => {
+                            // No need to check `previous`. It's possible that the linked chunk is
+                            // lazily loaded, chunk by chunk. The `next` is always reliable, but the
+                            // `previous` might not exist in-memory yet.
 
                             self.chunks.push_back((*new, 0));
                         }

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -1270,6 +1270,14 @@ impl<const CAPACITY: usize, Item, Gap> Chunk<CAPACITY, Item, Gap> {
         self.next.is_none()
     }
 
+    /// Return the link to the previous chunk, if it was loaded lazily.
+    ///
+    /// Doc hidden because this is mostly for internal debugging purposes.
+    #[doc(hidden)]
+    pub fn lazy_previous(&self) -> Option<ChunkIdentifier> {
+        self.lazy_previous
+    }
+
     /// Get the unique identifier of the chunk.
     pub fn identifier(&self) -> ChunkIdentifier {
         self.identifier

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -1260,6 +1260,12 @@ impl<const CAPACITY: usize, Item, Gap> Chunk<CAPACITY, Item, Gap> {
         !self.is_gap()
     }
 
+    /// Is this the definitive first chunk, even in the presence of
+    /// lazy-loading?
+    pub fn is_definitive_head(&self) -> bool {
+        self.previous.is_none() && self.lazy_previous.is_none()
+    }
+
     /// Check whether this current chunk is the first chunk.
     fn is_first_chunk(&self) -> bool {
         self.previous.is_none()

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -341,7 +341,12 @@ impl RoomEvents {
 
         for chunk in self.chunks() {
             let content = chunk_debug_string(chunk.content());
-            let line = format!("chunk #{}: {content}", chunk.identifier().index());
+            let lazy_previous = if let Some(cid) = chunk.lazy_previous() {
+                format!(" (lazy previous = {})", cid.index())
+            } else {
+                "".to_owned()
+            };
+            let line = format!("chunk #{}{lazy_previous}: {content}", chunk.identifier().index());
 
             result.push(line);
         }

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -312,8 +312,13 @@ impl RoomEvents {
     }
 
     /// Get a mutable reference to the [`LinkedChunk`] updates, aka
-    /// [`ObservableUpdates`].
-    pub(super) fn updates(&mut self) -> &mut ObservableUpdates<Event, Gap> {
+    /// [`ObservableUpdates`] to be consumed by the store.
+    ///
+    /// These updates are expected to be *only* forwarded to storage, as they
+    /// might hide some underlying updates to the in-memory chunk; those
+    /// updates should be reflected with manual updates to
+    /// [`Self::chunks_updates_as_vectordiffs`].
+    pub(super) fn store_updates(&mut self) -> &mut ObservableUpdates<Event, Gap> {
         self.chunks.updates().expect("this is always built with an update history in the ctor")
     }
 

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -19,7 +19,7 @@ use matrix_sdk_base::{
     event_cache::store::DEFAULT_CHUNK_CAPACITY,
     linked_chunk::{
         lazy_loader::{self, LazyLoaderError},
-        ChunkContent, RawChunk,
+        ChunkContent, ChunkIdentifierGenerator, RawChunk,
     },
 };
 use matrix_sdk_common::linked_chunk::{
@@ -84,6 +84,18 @@ impl RoomEvents {
     /// the ether, forever.
     pub fn reset(&mut self) {
         self.chunks.clear();
+    }
+
+    /// Replace the events with the given last chunk of events and generator.
+    ///
+    /// This clears all the chunks in memory before resetting to the new chunk,
+    /// if provided.
+    pub(super) fn replace_with(
+        &mut self,
+        last_chunk: Option<RawChunk<Event, Gap>>,
+        chunk_identifier_generator: ChunkIdentifierGenerator,
+    ) -> Result<(), LazyLoaderError> {
+        lazy_loader::replace_with(&mut self.chunks, last_chunk, chunk_identifier_generator)
     }
 
     /// If the given event is a redaction, try to retrieve the to-be-redacted

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -437,8 +437,14 @@ impl RoomEventCacheInner {
             // events themselves.
             let (_, sync_timeline_events_diffs) = state
                 .with_events_mut(|room_events| {
-                    if let Some(prev_token) = &prev_batch {
-                        room_events.push_gap(Gap { prev_token: prev_token.clone() });
+                    // If we only received duplicated events, we don't need to store the gap: if
+                    // there was a gap, we'd have received an unknown event at the tail of
+                    // the room's timeline (unless the server reordered sync events since the last
+                    // time we sync'd).
+                    if !all_duplicates {
+                        if let Some(prev_token) = &prev_batch {
+                            room_events.push_gap(Gap { prev_token: prev_token.clone() });
+                        }
                     }
 
                     // Remove the old duplicated events.

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -721,7 +721,7 @@ mod private {
 
             // ⚠️ Let's not propagate the updates to the store! We already have these data
             // in the store! Let's drain them.
-            let _ = self.events.updates().take();
+            let _ = self.events.store_updates().take();
 
             // However, we want to get updates as `VectorDiff`s.
             let updates_as_vector_diffs = self.events.updates_as_vector_diffs();
@@ -733,6 +733,7 @@ mod private {
                 }
             })
         }
+
         /// Removes the bundled relations from an event, if they were present.
         ///
         /// Only replaces the present if it contained bundled relations.
@@ -780,7 +781,7 @@ mod private {
         /// Propagate changes to the underlying storage.
         #[instrument(skip_all)]
         async fn propagate_changes(&mut self) -> Result<(), EventCacheError> {
-            let mut updates = self.events.updates().take();
+            let mut updates = self.events.store_updates().take();
 
             if updates.is_empty() {
                 return Ok(());

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -1302,15 +1302,16 @@ async fn test_no_gap_stored_after_deduplicated_backpagination() {
     assert_let_timeout!(
         Ok(RoomEventCacheUpdate::UpdateTimelineEvents { diffs, .. }) = stream.recv()
     );
-    assert_eq!(diffs.len(), 2);
+    assert_eq!(diffs.len(), 4);
 
-    // The linked chunk is unloaded, because of the limited sync with a gap:
-    // It's first cleared…
-    assert_matches!(&diffs[0], VectorDiff::Clear);
+    // The first two diffs are for the gap and the new events, but they don't really
+    // matter in this test, because then, the linked chunk is unloaded, causing
+    // a clear:
+    assert_matches!(&diffs[2], VectorDiff::Clear);
 
     // Then the latest event chunk is reloaded.
     // `$ev1`, `$ev2` and `$ev3` are added.
-    assert_matches!(&diffs[1], VectorDiff::Append { values: events } => {
+    assert_matches!(&diffs[3], VectorDiff::Append { values: events } => {
         assert_eq!(events.len(), 3);
         assert_eq!(events[0].event_id().unwrap().as_str(), "$1");
         assert_eq!(events[1].event_id().unwrap().as_str(), "$2");


### PR DESCRIPTION
This implements unloading the linked chunk, so as to free memory on the one hand, and avoid some weird corner cases like #4684 on the other hand.

Unloading a linked chunk happens in two steps:

- first, load the last chunk from storage,
- then, replace the current linked chunk with that last chunk.

Then, we make use of that functionality whenever we receive a gap via sync. This resolves the situation where we start with a hot cache store, that has one old event E1; the room's state is actually [E1, E2, E3], and the last sync returns [Gap, E3]. In this case, since we don't render gaps yet in the timeline, the timeline would show [E1, E3], making it look like we missed event E2; although the next pagination would make it appear. Instead, we here unload the linked chunk to its last chunk (E3), so that it clears [E1] from rendering, and the next paginations will start from the latest gap.

Fixes #4684.
Part of #3280.