### PR TITLE
chore(common): Remove `LinkedChunkBuilderTest`

### DIFF
--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -105,7 +105,6 @@ use std::{
 };
 
 pub use as_vector::*;
-pub use lazy_loader::{LinkedChunkBuilderTest, LinkedChunkBuilderTestError};
 pub use updates::*;
 
 /// Errors of [`LinkedChunk`].

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -499,8 +499,7 @@ mod tests {
     use assert_matches::assert_matches;
     use ruma::room_id;
 
-    use super::{ChunkIdentifier as CId, *};
-    use crate::linked_chunk::LinkedChunkBuilderTest;
+    use super::{super::lazy_loader::from_all_chunks, ChunkIdentifier as CId, *};
 
     #[test]
     fn test_new_items_chunk() {
@@ -1011,11 +1010,10 @@ mod tests {
         );
 
         // It correctly gets reloaded as such.
-        let raws = relational_linked_chunk.load_all_chunks(room_id).unwrap();
-        let lc = LinkedChunkBuilderTest::<3, _, _>::from_raw_parts(raws)
-            .build()
-            .expect("building succeeds")
-            .expect("this leads to a non-empty linked chunk");
+        let lc =
+            from_all_chunks::<3, _, _>(relational_linked_chunk.load_all_chunks(room_id).unwrap())
+                .expect("building succeeds")
+                .expect("this leads to a non-empty linked chunk");
 
         assert_items_eq!(lc, []);
     }
@@ -1046,11 +1044,10 @@ mod tests {
             ],
         );
 
-        let raws = relational_linked_chunk.load_all_chunks(room_id).unwrap();
-        let lc = LinkedChunkBuilderTest::<3, _, _>::from_raw_parts(raws)
-            .build()
-            .expect("building succeeds")
-            .expect("this leads to a non-empty linked chunk");
+        let lc =
+            from_all_chunks::<3, _, _>(relational_linked_chunk.load_all_chunks(room_id).unwrap())
+                .expect("building succeeds")
+                .expect("this leads to a non-empty linked chunk");
 
         // The linked chunk is correctly reloaded.
         assert_items_eq!(lc, ['a', 'b', 'c'] [-] ['d', 'e', 'f']);

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1137,7 +1137,7 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))] // This uses the cross-process lock, so needs time support.
     #[async_test]
     async fn test_write_to_storage() {
-        use matrix_sdk_base::linked_chunk::LinkedChunkBuilderTest;
+        use matrix_sdk_base::linked_chunk::lazy_loader::from_all_chunks;
 
         let room_id = room_id!("!galette:saucisse.bzh");
         let f = EventFactory::new().room(room_id).sender(user_id!("@ben:saucisse.bzh"));
@@ -1175,9 +1175,10 @@ mod tests {
             .await
             .unwrap();
 
-        let raws = event_cache_store.load_all_chunks(room_id).await.unwrap();
         let linked_chunk =
-            LinkedChunkBuilderTest::<3, _, _>::from_raw_parts(raws).build().unwrap().unwrap();
+            from_all_chunks::<3, _, _>(event_cache_store.load_all_chunks(room_id).await.unwrap())
+                .unwrap()
+                .unwrap();
 
         assert_eq!(linked_chunk.chunks().count(), 3);
 
@@ -1208,7 +1209,7 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))] // This uses the cross-process lock, so needs time support.
     #[async_test]
     async fn test_write_to_storage_strips_bundled_relations() {
-        use matrix_sdk_base::linked_chunk::LinkedChunkBuilderTest;
+        use matrix_sdk_base::linked_chunk::lazy_loader::from_all_chunks;
         use ruma::events::BundledMessageLikeRelations;
 
         let room_id = room_id!("!galette:saucisse.bzh");
@@ -1265,9 +1266,10 @@ mod tests {
         }
 
         // The one in storage does not.
-        let raws = event_cache_store.load_all_chunks(room_id).await.unwrap();
         let linked_chunk =
-            LinkedChunkBuilderTest::<3, _, _>::from_raw_parts(raws).build().unwrap().unwrap();
+            from_all_chunks::<3, _, _>(event_cache_store.load_all_chunks(room_id).await.unwrap())
+                .unwrap()
+                .unwrap();
 
         assert_eq!(linked_chunk.chunks().count(), 1);
 
@@ -1293,7 +1295,7 @@ mod tests {
         use std::ops::ControlFlow;
 
         use eyeball_im::VectorDiff;
-        use matrix_sdk_base::linked_chunk::LinkedChunkBuilderTest;
+        use matrix_sdk_base::linked_chunk::lazy_loader::from_all_chunks;
 
         use crate::{assert_let_timeout, event_cache::RoomEventCacheUpdate};
 
@@ -1424,13 +1426,14 @@ mod tests {
         assert!(items.is_empty());
 
         // The event cache store too.
-        let raws = event_cache_store.load_all_chunks(room_id).await.unwrap();
-        let linked_chunk = LinkedChunkBuilderTest::<3, _, _>::from_raw_parts(raws).build().unwrap();
+        let linked_chunk =
+            from_all_chunks::<3, _, _>(event_cache_store.load_all_chunks(room_id).await.unwrap())
+                .unwrap()
+                .unwrap();
 
         // Note: while the event cache store could return `None` here, clearing it will
         // reset it to its initial form, maintaining the invariant that it
         // contains a single items chunk that's empty.
-        let linked_chunk = linked_chunk.unwrap();
         assert_eq!(linked_chunk.num_items(), 0);
     }
 


### PR DESCRIPTION
This patch adds the new `from_all_chunks` function in the
`linked_chunk::lazy_loader` module. It is only used for testing
purposes. It aims at replacing `LinkedChunkBuilderTest`.
Why? Because `from_all_chunks` uses `from_last_chunk` and
`insert_new_first_chunk`: if `from_all_chunks` is able to find all
errors that `LinkedChunkBuilderTest` finds, it's a bingo. Transitively,
it proves that `from_last_chunk` and `insert_new_first_chunk` are
correct!

The other patches replaces `LinkedChunkBuilderTest` and remove it.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280
* Follow up of #4632