### PR TITLE
refactor(oidc): Align `OidcAuthCodeUrlBuilder` behavior with next-gen auth MSCs

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -80,6 +80,10 @@ simpler methods:
   - Only one request is made to revoke the access token, since the server is
     supposed to revoke both the access token and the associated refresh token
     when the request is made.
+- [**breaking**]: Remove most of the parameter methods of
+  `OidcAuthCodeUrlBuilder`, since they were parameters defined in OpenID
+  Connect. Only the `prompt` and `user_id_hint` parameters are still supported.
+  ([#4699](https://github.com/matrix-org/matrix-rust-sdk/pull/4699))
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/src/authentication/oidc/backend/mock.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/backend/mock.rs
@@ -22,7 +22,7 @@ use mas_oidc_client::{
         DiscoveryError as OidcDiscoveryError, Error as OidcClientError, ErrorBody as OidcErrorBody,
         HttpError as OidcHttpError, TokenRefreshError, TokenRequestError,
     },
-    requests::authorization_code::{AuthorizationRequestData, AuthorizationValidationData},
+    requests::authorization_code::AuthorizationValidationData,
     types::{
         client_credentials::ClientCredentials,
         errors::ClientErrorCode,
@@ -190,16 +190,6 @@ impl OidcBackend for MockImpl {
             client_id_issued_at: None,
             client_secret_expires_at: None,
         })
-    }
-
-    async fn build_par_authorization_url(
-        &self,
-        _client_credentials: ClientCredentials,
-        _par_endpoint: &Url,
-        _authorization_endpoint: Url,
-        _authorization_data: AuthorizationRequestData,
-    ) -> Result<(Url, AuthorizationValidationData), OidcError> {
-        unimplemented!()
     }
 
     async fn revoke_token(

--- a/crates/matrix-sdk/src/authentication/oidc/backend/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/backend/mod.rs
@@ -17,7 +17,7 @@
 //! Used mostly for testing purposes.
 
 use mas_oidc_client::{
-    requests::authorization_code::{AuthorizationRequestData, AuthorizationValidationData},
+    requests::authorization_code::AuthorizationValidationData,
     types::{
         client_credentials::ClientCredentials,
         iana::oauth::OAuthTokenTypeHint,
@@ -71,14 +71,6 @@ pub(super) trait OidcBackend: std::fmt::Debug + Send + Sync {
         refresh_token: String,
         latest_id_token: Option<IdToken<'static>>,
     ) -> Result<RefreshedSessionTokens, OidcError>;
-
-    async fn build_par_authorization_url(
-        &self,
-        client_credentials: ClientCredentials,
-        par_endpoint: &Url,
-        authorization_endpoint: Url,
-        authorization_data: AuthorizationRequestData,
-    ) -> Result<(Url, AuthorizationValidationData), OidcError>;
 
     async fn revoke_token(
         &self,

--- a/crates/matrix-sdk/src/authentication/oidc/backend/server.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/backend/server.rs
@@ -23,10 +23,7 @@ use mas_oidc_client::{
     http_service::HttpService,
     jose::jwk::PublicJsonWebKeySet,
     requests::{
-        authorization_code::{
-            access_token_with_authorization_code, build_par_authorization_url,
-            AuthorizationRequestData, AuthorizationValidationData,
-        },
+        authorization_code::{access_token_with_authorization_code, AuthorizationValidationData},
         discovery::{discover, insecure_discover},
         jose::{fetch_jwks, JwtVerificationData},
         refresh_token::refresh_access_token,
@@ -223,25 +220,6 @@ impl OidcBackend for OidcServer {
         )
         .await
         .map_err(Into::into)
-    }
-
-    async fn build_par_authorization_url(
-        &self,
-        client_credentials: ClientCredentials,
-        par_endpoint: &Url,
-        authorization_endpoint: Url,
-        authorization_data: AuthorizationRequestData,
-    ) -> Result<(Url, AuthorizationValidationData), OidcError> {
-        Ok(build_par_authorization_url(
-            &self.http_service(),
-            client_credentials,
-            par_endpoint,
-            authorization_endpoint,
-            authorization_data,
-            Utc::now(),
-            &mut rng()?,
-        )
-        .await?)
     }
 
     async fn revoke_token(


### PR DESCRIPTION
The first commit removes support for Pushed Authorization Requests. PAR is a small optimization that sends the parameters via a request first, and returns an ID that we used in the authorization URL instead of the parameters, so it only makes the authorization URL smaller by reducing the size of the query part. It is no mentioned in the next-gen auth MSCs and it is not supported by the oauth2 crate so let's remove it already.

The second commit removes most of the optional parameters of the authorization URL. All those parameters are specified in OpenID Connect, but the next-gen auth MSCs were downgraded to OAuth 2.0 which doesn't have those parameters.

Only the following parameters are defined in the MSCs:
- `prompt=create` is defined in [MSC2964](https://github.com/sandhose/matrix-spec-proposals/blob/msc/sandhose/oauth2-profile/proposals/2964-oauth2-profile.md#user-registration)
- `login_hint=mxid:@user:server.name` is defined in MSC4198