### PR TITLE
test: rename some MatrixMockServer matcher functions

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2848,7 +2848,7 @@ async fn test_multiple_timeline_init() {
         .mock_room_messages()
         .ok(RoomMessagesResponseTemplate::default()
             .events(vec![f.text_msg("hello").into_raw_timeline()])
-            .delayed(Duration::from_millis(500)))
+            .with_delay(Duration::from_millis(500)))
         .mount()
         .await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -1001,7 +1001,7 @@ async fn test_lazy_back_pagination() {
     {
         let network_pagination = mock_server
             .mock_room_messages()
-            .from("back_pagination_token_1")
+            .match_from("back_pagination_token_1")
             .ok(RoomMessagesResponseTemplate::default()
                 .end_token("back_pagination_token_2")
                 .events({
@@ -1050,7 +1050,7 @@ async fn test_lazy_back_pagination() {
     {
         let network_pagination = mock_server
             .mock_room_messages()
-            .from("back_pagination_token_2")
+            .match_from("back_pagination_token_2")
             .ok(RoomMessagesResponseTemplate::default()
                 // No previous batch token, the beginning of the timeline is reached.
                 .events({

--- a/crates/matrix-sdk/src/test_utils/mocks.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks.rs
@@ -1332,6 +1332,8 @@ impl<'a> MockEndpoint<'a, RoomSendEndpoint> {
 
     /// Ensures the event was sent as a delayed event.
     ///
+    /// See also [the MSC](https://github.com/matrix-org/matrix-spec-proposals/pull/4140).
+    ///
     /// Note: works with *any* room.
     ///
     /// # Examples
@@ -1362,7 +1364,7 @@ impl<'a> MockEndpoint<'a, RoomSendEndpoint> {
     ///
     /// mock_server
     ///     .mock_room_send()
-    ///     .with_delay(Duration::from_millis(500))
+    ///     .match_delayed_event(Duration::from_millis(500))
     ///     .respond_with(ResponseTemplate::new(200).set_body_json(json!({"delay_id":"$some_id"})))
     ///     .mock_once()
     ///     .mount()
@@ -1387,7 +1389,7 @@ impl<'a> MockEndpoint<'a, RoomSendEndpoint> {
     /// assert_eq!("$some_id", response.delay_id);
     /// # anyhow::Ok(()) });
     /// ```
-    pub fn with_delay(self, delay: Duration) -> Self {
+    pub fn match_delayed_event(self, delay: Duration) -> Self {
         Self {
             mock: self
                 .mock
@@ -1563,6 +1565,8 @@ impl<'a> MockEndpoint<'a, RoomSendStateEndpoint> {
 
     /// Ensures the event was sent as a delayed event.
     ///
+    /// See also [the MSC](https://github.com/matrix-org/matrix-spec-proposals/pull/4140).
+    ///
     /// Note: works with *any* room.
     ///
     /// # Examples
@@ -1592,7 +1596,7 @@ impl<'a> MockEndpoint<'a, RoomSendStateEndpoint> {
     ///
     /// mock_server
     ///     .mock_room_send_state()
-    ///     .with_delay(Duration::from_millis(500))
+    ///     .match_delayed_event(Duration::from_millis(500))
     ///     .respond_with(ResponseTemplate::new(200).set_body_json(json!({"delay_id":"$some_id"})))
     ///     .mock_once()
     ///     .mount()
@@ -1615,7 +1619,7 @@ impl<'a> MockEndpoint<'a, RoomSendStateEndpoint> {
     ///
     /// # anyhow::Ok(()) });
     /// ```
-    pub fn with_delay(self, delay: Duration) -> Self {
+    pub fn match_delayed_event(self, delay: Duration) -> Self {
         Self {
             mock: self
                 .mock
@@ -1911,12 +1915,12 @@ pub struct RoomMessagesEndpoint;
 /// A prebuilt mock for getting a room messages in a room.
 impl<'a> MockEndpoint<'a, RoomMessagesEndpoint> {
     /// Expects an optional limit to be set on the request.
-    pub fn limit(self, limit: u32) -> Self {
+    pub fn match_limit(self, limit: u32) -> Self {
         Self { mock: self.mock.and(query_param("limit", limit.to_string())), ..self }
     }
 
     /// Expects an optional `from` to be set on the request.
-    pub fn from(self, from: &str) -> Self {
+    pub fn match_from(self, from: &str) -> Self {
         Self { mock: self.mock.and(query_param("from", from)), ..self }
     }
 
@@ -1971,7 +1975,7 @@ impl RoomMessagesResponseTemplate {
     }
 
     /// Respond with a given delay to the query.
-    pub fn delayed(mut self, delay: Duration) -> Self {
+    pub fn with_delay(mut self, delay: Duration) -> Self {
         self.delay = Some(delay);
         self
     }

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -259,7 +259,7 @@ async fn test_backpaginate_once() {
         // back-pagination.
         server
             .mock_room_messages()
-            .from("prev_batch")
+            .match_from("prev_batch")
             .ok(RoomMessagesResponseTemplate::default().events(vec![
                 f.text_msg("world").event_id(event_id!("$2")),
                 f.text_msg("hello").event_id(event_id!("$3")),
@@ -346,7 +346,7 @@ async fn test_backpaginate_many_times_with_many_iterations() {
     // The first back-pagination will return these two.
     server
         .mock_room_messages()
-        .from("prev_batch")
+        .match_from("prev_batch")
         .ok(RoomMessagesResponseTemplate::default().end_token("prev_batch2").events(vec![
             f.text_msg("world").event_id(event_id!("$2")),
             f.text_msg("hello").event_id(event_id!("$3")),
@@ -358,7 +358,7 @@ async fn test_backpaginate_many_times_with_many_iterations() {
     // The second round of back-pagination will return this one.
     server
         .mock_room_messages()
-        .from("prev_batch2")
+        .match_from("prev_batch2")
         .ok(RoomMessagesResponseTemplate::default()
             .events(vec![f.text_msg("oh well").event_id(event_id!("$4"))]))
         .mock_once()
@@ -472,7 +472,7 @@ async fn test_backpaginate_many_times_with_one_iteration() {
     // The first back-pagination will return these two.
     server
         .mock_room_messages()
-        .from("prev_batch")
+        .match_from("prev_batch")
         .ok(RoomMessagesResponseTemplate::default().end_token("prev_batch2").events(vec![
             f.text_msg("world").event_id(event_id!("$2")),
             f.text_msg("hello").event_id(event_id!("$3")),
@@ -484,7 +484,7 @@ async fn test_backpaginate_many_times_with_one_iteration() {
     // The second round of back-pagination will return this one.
     server
         .mock_room_messages()
-        .from("prev_batch2")
+        .match_from("prev_batch2")
         .ok(RoomMessagesResponseTemplate::default()
             .events(vec![f.text_msg("oh well").event_id(event_id!("$4"))]))
         .mock_once()
@@ -599,10 +599,10 @@ async fn test_reset_while_backpaginating() {
     // Mock the first back-pagination request, with a delay.
     server
         .mock_room_messages()
-        .from("first_backpagination")
+        .match_from("first_backpagination")
         .ok(RoomMessagesResponseTemplate::default()
             .events(vec![f.text_msg("lalala").into_raw_timeline()])
-            .delayed(Duration::from_millis(500)))
+            .with_delay(Duration::from_millis(500)))
         .mock_once()
         .mount()
         .await;
@@ -611,7 +611,7 @@ async fn test_reset_while_backpaginating() {
     // caused by the sync.
     server
         .mock_room_messages()
-        .from("second_backpagination")
+        .match_from("second_backpagination")
         .ok(RoomMessagesResponseTemplate::default()
             .end_token("third_backpagination")
             .events(vec![f.text_msg("finally!").into_raw_timeline()]))
@@ -951,7 +951,7 @@ async fn test_limited_timeline_without_storage() {
     // call, which checks this endpoint is called once.
     server
         .mock_room_messages()
-        .from("prev-batch")
+        .match_from("prev-batch")
         .ok(RoomMessagesResponseTemplate::default()
             .events(vec![f.text_msg("oh well").event_id(event_id!("$1"))]))
         .mock_once()
@@ -1022,7 +1022,7 @@ async fn test_backpaginate_with_no_initial_events() {
                 f.text_msg("world").event_id(event_id!("$3")).into_raw_timeline(),
                 f.text_msg("hello").event_id(event_id!("$2")).into_raw_timeline(),
             ])
-            .delayed(2 * wait_time))
+            .with_delay(2 * wait_time))
         .mock_once()
         .mount()
         .await;
@@ -1030,7 +1030,7 @@ async fn test_backpaginate_with_no_initial_events() {
     // The second round of back-pagination will return this one.
     server
         .mock_room_messages()
-        .from("prev_batch")
+        .match_from("prev_batch")
         .ok(RoomMessagesResponseTemplate::default()
             .events(vec![f.text_msg("oh well").event_id(event_id!("$1"))]))
         .mock_once()
@@ -1112,7 +1112,7 @@ async fn test_backpaginate_replace_empty_gap() {
     // The second round of back-pagination will return this one.
     server
         .mock_room_messages()
-        .from("prev_batch")
+        .match_from("prev_batch")
         .ok(RoomMessagesResponseTemplate::default()
             .events(vec![f.text_msg("hello").event_id(event_id!("$1"))]))
         .mock_once()
@@ -1290,7 +1290,7 @@ async fn test_no_gap_stored_after_deduplicated_backpagination() {
     // For prev-batch2, the back-pagination returns nothing.
     server
         .mock_room_messages()
-        .from("prev-batch2")
+        .match_from("prev-batch2")
         .ok(RoomMessagesResponseTemplate::default())
         .mock_once()
         .mount()
@@ -1300,7 +1300,7 @@ async fn test_no_gap_stored_after_deduplicated_backpagination() {
     // previous batch token.
     server
         .mock_room_messages()
-        .from("prev-batch")
+        .match_from("prev-batch")
         .ok(RoomMessagesResponseTemplate::default().end_token("prev-batch3").events(vec![
             // Items in reverse order, since this is back-pagination.
             f.text_msg("world").event_id(event_id!("$2")).into_raw_timeline(),
@@ -1386,7 +1386,7 @@ async fn test_dont_delete_gap_that_wasnt_inserted() {
     // Say the back-pagination doesn't return anything.
     server
         .mock_room_messages()
-        .from("prev-batch")
+        .match_from("prev-batch")
         .ok(RoomMessagesResponseTemplate::default())
         .mock_once()
         .mount()
@@ -1740,7 +1740,7 @@ async fn test_lazy_loading() {
     {
         let _network_pagination = mock_server
             .mock_room_messages()
-            .from("raclette")
+            .match_from("raclette")
             .ok(RoomMessagesResponseTemplate::default().end_token("numerobis").events(
                 (1..5) // Yes, the 0nth will be fetched with the next pagination.
                     // Backwards pagination implies events are in “reverse order”.
@@ -1809,7 +1809,7 @@ async fn test_lazy_loading() {
     {
         let _network_pagination = mock_server
             .mock_room_messages()
-            .from("numerobis")
+            .match_from("numerobis")
             .ok(RoomMessagesResponseTemplate::default().end_token("trois").events(vec![
                 // Backwards pagination implies events are in “reverse order”.
                 //
@@ -1869,7 +1869,7 @@ async fn test_lazy_loading() {
     {
         let _network_pagination = mock_server
             .mock_room_messages()
-            .from("trois")
+            .match_from("trois")
             .ok(RoomMessagesResponseTemplate::default().end_token("quattuor").events(
                 // Only events we already know about in the store.
                 (4..6)

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -237,7 +237,7 @@ async fn test_read_messages() {
         });
         mock_server
             .mock_room_messages()
-            .limit(2)
+            .match_limit(2)
             .respond_with(ResponseTemplate::new(200).set_body_json(response_json))
             .mock_once()
             .mount()
@@ -302,7 +302,7 @@ async fn test_read_messages_with_msgtype_capabilities() {
         ];
         mock_server
             .mock_room_messages()
-            .limit(3)
+            .match_limit(3)
             .ok(RoomMessagesResponseTemplate::default().end_token(end).events(chunk2))
             .mock_once()
             .mount()
@@ -539,7 +539,7 @@ async fn test_send_delayed_message_event() {
     .await;
     mock_server
         .mock_room_send()
-        .with_delay(Duration::from_millis(1000))
+        .match_delayed_event(Duration::from_millis(1000))
         .for_type(MessageLikeEventType::RoomMessage)
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "delay_id": "1234",
@@ -586,7 +586,7 @@ async fn test_send_delayed_state_event() {
 
     mock_server
         .mock_room_send_state()
-        .with_delay(Duration::from_millis(1000))
+        .match_delayed_event(Duration::from_millis(1000))
         .for_type(StateEventType::RoomName)
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "delay_id": "1234",


### PR DESCRIPTION
The `.from()`, `.with_delay()` and `.limit()` functions are not very explicit about what they did, and the `with_delay` one in particular led me to think that it would introduce a delay *in the response*, while it indicated a delay was expected as part of the matched URL.

Instead, this patch proposes to prefix all matchers with `match_`, to make it clearer that… they will match the incoming query: match_from, match_delay, match_limit.

Thanks to this change, the `RoomMessagesResponseTemplate` can be renamed from `delayed` to `with_delay`, which was my original intent, before I noticed another `with_delay` with totally different semantics.