### PR TITLE
refactor: use `Option<&mut T>` instead of `&mut Option<T>`in a few places

### DIFF
--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -502,7 +502,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
             // if the `chunk` is not the first one, we can remove it.
             if empty_chunk.remove() && can_unlink_chunk && chunk.is_first_chunk().not() {
                 // Unlink `chunk`.
-                chunk.unlink(&mut self.updates);
+                chunk.unlink(self.updates.as_mut());
 
                 chunk_ptr = Some(chunk.as_ptr());
 
@@ -705,7 +705,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
         let previous_ptr = chunk.previous;
         let position_of_next = chunk.next().map(|next| next.first_position());
 
-        chunk.unlink(&mut self.updates);
+        chunk.unlink(self.updates.as_mut());
 
         let chunk_ptr = chunk.as_ptr();
 
@@ -783,7 +783,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
                 .unwrap();
 
             // Now that new items have been pushed, we can unlink the gap chunk.
-            chunk.unlink(&mut self.updates);
+            chunk.unlink(self.updates.as_mut());
 
             // Get the pointer to `chunk`.
             chunk_ptr = chunk.as_ptr();
@@ -1501,7 +1501,7 @@ impl<const CAPACITY: usize, Item, Gap> Chunk<CAPACITY, Item, Gap> {
     ///
     /// Be careful: `self` won't belong to `LinkedChunk` anymore, and should be
     /// dropped appropriately.
-    fn unlink(&mut self, updates: &mut Option<ObservableUpdates<Item, Gap>>) {
+    fn unlink(&mut self, updates: Option<&mut ObservableUpdates<Item, Gap>>) {
         let previous_ptr = self.previous;
         let next_ptr = self.next;
         // If `self` is not the first, `lazy_previous` might be set on its previous
@@ -1518,7 +1518,7 @@ impl<const CAPACITY: usize, Item, Gap> Chunk<CAPACITY, Item, Gap> {
             next.lazy_previous = lazy_previous;
         }
 
-        if let Some(updates) = updates.as_mut() {
+        if let Some(updates) = updates {
             updates.push(Update::RemoveChunk(self.identifier()));
         }
     }

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -602,7 +602,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
                     let new_chunk = chunk.insert_before(
                         Chunk::new_gap_leaked(self.chunk_identifier_generator.next(), content),
-                        &mut self.updates,
+                        self.updates.as_mut(),
                     );
 
                     let new_chunk_ptr = new_chunk.as_ptr();
@@ -1452,7 +1452,7 @@ impl<const CAPACITY: usize, Item, Gap> Chunk<CAPACITY, Item, Gap> {
     fn insert_before(
         &mut self,
         mut new_chunk_ptr: NonNull<Self>,
-        updates: &mut Option<ObservableUpdates<Item, Gap>>,
+        updates: Option<&mut ObservableUpdates<Item, Gap>>,
     ) -> &mut Self
     where
         Gap: Clone,
@@ -1478,7 +1478,7 @@ impl<const CAPACITY: usize, Item, Gap> Chunk<CAPACITY, Item, Gap> {
         // Link the new chunk to this one.
         new_chunk.next = Some(self.as_ptr());
 
-        if let Some(updates) = updates.as_mut() {
+        if let Some(updates) = updates {
             let previous = new_chunk.previous().map(Chunk::identifier).or(new_chunk.lazy_previous);
             let new = new_chunk.identifier();
             let next = new_chunk.next().map(Chunk::identifier);


### PR DESCRIPTION
This is generally a good practice, as it makes some APIs less awkward to call (in particular, callers don't have to pass `&mut None` when they're not interested in the optional value).

There are a few other instances of this in the code base, but after spending a few minutes trying to move them to `Option<&mut>`, turns out I couldn't:

- in matrix-sdk/src/sync.rs, the option is overridden at the end of the function with a new value.
- in matrix-sdk-crypto/src/identities/manager, we're actually overriding the passed `&mut Option` with a new `Option` value.
- in matrix-sdk-common/src/linked_chunk/mod.rs, the two remaining functions using `&mut Option` pass it multiple times, and strangely i can't clone a `Option<&mut T>`; I suspect the mutability makes it impossible, because it would be another live mutable alias to the inner value.