### PR TITLE
fix(client): Add `handle_verification_events` to `BaseClient`

### DIFF
--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
   - `EventCacheStoreMedia` has a new method `last_media_cleanup_time_inner`
   - There are new `'static` bounds in `MediaService` for the media cache stores
 - `event_cache::store::MemoryStore` implements `Clone`.
+- `BaseClient` now has a `handle_verification_events` field which is `true` by 
+  default and can be negated so the `NotificationClient` won't handle received 
+  verification events too, causing errors in the `VerificationMachine`.
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -29,6 +29,9 @@ simpler methods:
   [BCP 195](https://datatracker.ietf.org/doc/bcp195/).
   ([#4647](https://github.com/matrix-org/matrix-rust-sdk/pull/4647))
 - Add `Room::report_room` api. ([#4713](https://github.com/matrix-org/matrix-rust-sdk/pull/4713))
+- `Client::notification_client` will create a copy of the existing `Client`, but now it'll make sure 
+  it doesn't handle any verification events to avoid an issue with these events being received and 
+  processed twice if `NotificationProcessSetup` was `SingleSetup`.
 
 ### Bug Fixes
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2422,7 +2422,7 @@ impl Client {
                 self.inner.http_client.clone(),
                 self.inner
                     .base_client
-                    .clone_with_in_memory_state_store(&cross_process_store_locks_holder_name)
+                    .clone_with_in_memory_state_store(&cross_process_store_locks_holder_name, false)
                     .await?,
                 self.inner.caches.server_capabilities.read().await.clone(),
                 self.inner.respect_login_well_known,


### PR DESCRIPTION
<del>This can be used to ignore verification requests in this sliding sync instance, preventing issues found where several sliding sync instances with the same client process events simultaneously and re-process the same verification request events during their initial syncs.</del> We went with a solution based on `BaseClient` instead.

This is a blocker for user verification on Android clients, since both the normal sync and the one initiated to get the event for a notification will process the same verification request events and end up with conflicts, making the verification flow fail most of the time.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
