### PR TITLE
WidgetDriver: Use `matrix_sdk_common::executor::spawn` instead of `tokio::spawn` to make it wasm compatible.

### DIFF
--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -16,26 +16,41 @@ features = ["docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["e2e-encryption", "automatic-room-key-forwarding", "sqlite", "native-tls"]
-testing = ["matrix-sdk-sqlite?/testing", "matrix-sdk-indexeddb?/testing", "matrix-sdk-base/testing", "wiremock", "matrix-sdk-test", "assert_matches2"]
+default = [
+    "e2e-encryption",
+    "automatic-room-key-forwarding",
+    "sqlite",
+    "native-tls",
+]
+testing = [
+    "matrix-sdk-sqlite?/testing",
+    "matrix-sdk-indexeddb?/testing",
+    "matrix-sdk-base/testing",
+    "wiremock",
+    "matrix-sdk-test",
+    "assert_matches2",
+]
 
 e2e-encryption = [
     "matrix-sdk-base/e2e-encryption",
-    "matrix-sdk-sqlite?/crypto-store",        # activate crypto-store on sqlite if given
-    "matrix-sdk-indexeddb?/e2e-encryption",   # activate on indexeddb if given
+    "matrix-sdk-sqlite?/crypto-store",      # activate crypto-store on sqlite if given
+    "matrix-sdk-indexeddb?/e2e-encryption", # activate on indexeddb if given
 ]
 js = ["matrix-sdk-common/js", "matrix-sdk-base/js"]
 
 sqlite = [
     "dep:matrix-sdk-sqlite",
     "matrix-sdk-sqlite?/state-store",
-    "matrix-sdk-sqlite?/event-cache"
+    "matrix-sdk-sqlite?/event-cache",
 ]
 bundled-sqlite = ["sqlite", "matrix-sdk-sqlite?/bundled"]
 indexeddb = ["matrix-sdk-indexeddb/state-store"]
 
 qrcode = ["e2e-encryption", "matrix-sdk-base/qrcode"]
-automatic-room-key-forwarding = ["e2e-encryption", "matrix-sdk-base/automatic-room-key-forwarding"]
+automatic-room-key-forwarding = [
+    "e2e-encryption",
+    "matrix-sdk-base/automatic-room-key-forwarding",
+]
 markdown = ["ruma/markdown"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
@@ -96,7 +111,7 @@ mime2ext = "0.1.53"
 once_cell = { workspace = true }
 percent-encoding = "2.3.1"
 pin-project-lite = { workspace = true }
-rand = { workspace = true , optional = true }
+rand = { workspace = true, optional = true }
 ruma = { workspace = true, features = [
     "rand",
     "unstable-msc2448",
@@ -121,6 +136,7 @@ urlencoding = "2.1.3"
 uuid = { workspace = true, features = ["serde", "v4"], optional = true }
 vodozemac = { workspace = true }
 zeroize = { workspace = true }
+tokio-util = "0.7.13"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { workspace = true, features = ["futures"] }
@@ -129,12 +145,13 @@ tokio = { workspace = true, features = ["macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }
-oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"], optional = true }
+oauth2 = { version = "5.0.0", default-features = false, features = [
+    "reqwest",
+], optional = true }
 # only activate reqwest's stream feature on non-wasm, the wasm part seems to not
 # support *sending* streams, which makes it useless for us.
 reqwest = { workspace = true, features = ["stream", "gzip", "http2"] }
 tokio = { workspace = true, features = ["fs", "rt", "macros"] }
-tokio-util = "0.7.13"
 wiremock = { workspace = true, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Using the `executer::spawn` will select `tokio::spawn` or `wasm_bindgen_futures::spawn_local` based on what platform we are on.

They behave differently in that `tokio` actually starts the async block inside the spawn but the wasm `spawn` wrapper will only start the part that is not inside the `async` block and the join handle needs to be awaited for it to work.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
