### PR TITLE
fix(sdk): `RoomEventCache::event` looks inside the store

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -19,7 +19,7 @@ use matrix_sdk_common::{
     linked_chunk::{ChunkIdentifier, ChunkIdentifierGenerator, Position, RawChunk, Update},
     AsyncTraitDeps,
 };
-use ruma::{MxcUri, OwnedEventId, RoomId};
+use ruma::{EventId, MxcUri, OwnedEventId, RoomId};
 
 use super::{
     media::{IgnoreMediaRetentionPolicy, MediaRetentionPolicy},
@@ -108,6 +108,13 @@ pub trait EventCacheStore: AsyncTraitDeps {
         room_id: &RoomId,
         events: Vec<OwnedEventId>,
     ) -> Result<Vec<(OwnedEventId, Position)>, Self::Error>;
+
+    /// Find an event by its ID.
+    async fn find_event(
+        &self,
+        room_id: &RoomId,
+        event_id: &EventId,
+    ) -> Result<Option<(Position, Event)>, Self::Error>;
 
     /// Add a media file's content in the media store.
     ///
@@ -297,6 +304,14 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
         events: Vec<OwnedEventId>,
     ) -> Result<Vec<(OwnedEventId, Position)>, Self::Error> {
         self.0.filter_duplicated_events(room_id, events).await.map_err(Into::into)
+    }
+
+    async fn find_event(
+        &self,
+        room_id: &RoomId,
+        event_id: &EventId,
+    ) -> Result<Option<(Position, Event)>, Self::Error> {
+        self.0.find_event(room_id, event_id).await.map_err(Into::into)
     }
 
     async fn add_media_content(

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -293,9 +293,9 @@ impl<Item, Gap> RelationalLinkedChunk<Item, Gap> {
         }
     }
 
-    /// Return an iterator that yields events of a particular room with no
+    /// Return an iterator that yields items of a particular room with no
     /// particular order.
-    pub fn unordered_events<'a>(
+    pub fn unordered_items<'a>(
         &'a self,
         room_id: &'a RoomId,
     ) -> impl Iterator<Item = (&'a Item, Position)> {
@@ -305,6 +305,17 @@ impl<Item, Gap> RelationalLinkedChunk<Item, Gap> {
                     Either::Item(item) => Some((item, item_row.position)),
                     Either::Gap(..) => None,
                 }
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Return an iterator over all items.
+    pub fn items(&self) -> impl Iterator<Item = (Position, &Item, &RoomId)> {
+        self.items.iter().filter_map(|item_row| {
+            if let Either::Item(item) = &item_row.item {
+                Some((item_row.position, item, item_row.room_id.as_ref()))
             } else {
                 None
             }
@@ -1131,7 +1142,7 @@ mod tests {
             ],
         );
 
-        let mut events = relational_linked_chunk.unordered_events(room_id);
+        let mut events = relational_linked_chunk.unordered_items(room_id);
 
         assert_eq!(events.next().unwrap(), (&'a', Position::new(CId::new(0), 0)));
         assert_eq!(events.next().unwrap(), (&'b', Position::new(CId::new(0), 1)));


### PR DESCRIPTION
This patch fixes a bug in `RoomEventCache::event` since https://github.com/matrix-org/matrix-rust-sdk/pull/4632 has landed. `RoomEvents` now likely contains a partial view of the events, i.e. they are not all loaded from the store to memory.

A new `EventCacheStore::find_event` is added to look for an event in the store. `RoomEventCache::event` uses it to use the store, with a fallback to `AllEventsCache` because we can't get rid of it right now (see https://github.com/matrix-org/matrix-rust-sdk/issues/3886).