### PR TITLE
feat(event cache): leaner updates when clearing/shrinking to the last chunk

### DIFF
--- a/crates/matrix-sdk-common/src/linked_chunk/lazy_loader.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/lazy_loader.rs
@@ -254,7 +254,7 @@ where
     if let Some(updates) = linked_chunk.updates.as_mut() {
         // Clear the previous updates, as we're about to insert a clear they would be
         // useless.
-        updates.clear();
+        updates.clear_pending();
         updates.push(Update::Clear);
 
         emit_new_first_chunk_updates(linked_chunk.links.first_chunk(), updates);

--- a/crates/matrix-sdk-common/src/linked_chunk/lazy_loader.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/lazy_loader.rs
@@ -252,8 +252,11 @@ where
     linked_chunk.links.replace_with(chunk_ptr);
 
     if let Some(updates) = linked_chunk.updates.as_mut() {
-        // TODO: clear updates first? (see same comment in `clear`).
+        // Clear the previous updates, as we're about to insert a clear they would be
+        // useless.
+        updates.clear();
         updates.push(Update::Clear);
+
         emit_new_first_chunk_updates(linked_chunk.links.first_chunk(), updates);
     }
 

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -307,7 +307,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
         if let Some(updates) = self.updates.as_mut() {
             // Clear the previous updates, as we're about to insert a clear they would be
             // useless.
-            updates.clear();
+            updates.clear_pending();
             updates.push(Update::Clear);
             updates.push(Update::NewItemsChunk {
                 previous: None,

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -305,7 +305,9 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
         // “Clear” `self.updates`.
         if let Some(updates) = self.updates.as_mut() {
-            // TODO: Optimisation: Do we want to clear all pending `Update`s in `updates`?
+            // Clear the previous updates, as we're about to insert a clear they would be
+            // useless.
+            updates.clear();
             updates.push(Update::Clear);
             updates.push(Update::NewItemsChunk {
                 previous: None,

--- a/crates/matrix-sdk-common/src/linked_chunk/updates.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/updates.rs
@@ -139,8 +139,8 @@ impl<Item, Gap> ObservableUpdates<Item, Gap> {
     }
 
     /// Clear all pending updates.
-    pub(super) fn clear(&mut self) {
-        self.inner.write().unwrap().clear();
+    pub(super) fn clear_pending(&mut self) {
+        self.inner.write().unwrap().clear_pending();
     }
 
     /// Take new updates.
@@ -248,7 +248,7 @@ impl<Item, Gap> UpdatesInner<Item, Gap> {
     }
 
     /// Clear all pending updates.
-    fn clear(&mut self) {
+    fn clear_pending(&mut self) {
         self.updates.clear();
 
         // Reset all the per-reader indices.

--- a/crates/matrix-sdk-common/src/linked_chunk/updates.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/updates.rs
@@ -138,6 +138,11 @@ impl<Item, Gap> ObservableUpdates<Item, Gap> {
         self.inner.write().unwrap().push(update);
     }
 
+    /// Clear all pending updates.
+    pub(super) fn clear(&mut self) {
+        self.inner.write().unwrap().clear();
+    }
+
     /// Take new updates.
     ///
     /// Updates that have been taken will not be read again.
@@ -240,6 +245,19 @@ impl<Item, Gap> UpdatesInner<Item, Gap> {
         for waker in self.wakers.drain(..) {
             waker.wake();
         }
+    }
+
+    /// Clear all pending updates.
+    fn clear(&mut self) {
+        self.updates.clear();
+
+        // Reset all the per-reader indices.
+        for idx in self.last_index_per_reader.values_mut() {
+            *idx = 0;
+        }
+
+        // No need to wake the wakers; they're waiting for a new update, and we
+        // just made them all disappear.
     }
 
     /// Take new updates; it considers the caller is the main reader, i.e. it

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -1339,16 +1339,13 @@ async fn test_no_gap_stored_after_deduplicated_backpagination() {
     assert_let_timeout!(
         Ok(RoomEventCacheUpdate::UpdateTimelineEvents { diffs, .. }) = stream.recv()
     );
-    assert_eq!(diffs.len(), 4);
+    assert_eq!(diffs.len(), 2);
 
-    // The first two diffs are for the gap and the new events, but they don't really
-    // matter in this test, because then, the linked chunk is unloaded, causing
-    // a clear:
-    assert_matches!(&diffs[2], VectorDiff::Clear);
+    assert_matches!(&diffs[0], VectorDiff::Clear);
 
     // Then the latest event chunk is reloaded.
     // `$ev1`, `$ev2` and `$ev3` are added.
-    assert_matches!(&diffs[3], VectorDiff::Append { values: events } => {
+    assert_matches!(&diffs[1], VectorDiff::Append { values: events } => {
         assert_eq!(events.len(), 3);
         assert_eq!(events[0].event_id().unwrap().as_str(), "$1");
         assert_eq!(events[1].event_id().unwrap().as_str(), "$2");


### PR DESCRIPTION
I wanted to look at what it'd take to implement the `TODO`s about clearing, and I think I got them right, in the first commit; the only thing to pay attention to was the `last_index_per_reader` that needed an update when clearing updates.

But this wasn't sufficient to actually get rid of the spurious updates I've introduced in a previous test, because we're _extending the previous updates with the ones caused by the shrink/reset_. Instead, I've tried passing the updates diff vector as a `&mut` parameter to reset/shrink etc., but it makes the APIs a bit uglier, but eventually it behaves as I expected. What do you think @Hywan?