### PR TITLE
test(oidc): Use MatrixMockServer and MockClientBuilder where possible

### DIFF
--- a/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
@@ -258,21 +258,22 @@ mod tests {
     use matrix_sdk_base::SessionMeta;
     use matrix_sdk_test::async_test;
     use ruma::{owned_device_id, owned_user_id};
-    use wiremock::{
-        matchers::{method, path},
-        Mock, MockServer, ResponseTemplate,
-    };
 
     use super::compute_session_hash;
     use crate::{
         authentication::oidc::{
             backend::mock::{MockImpl, ISSUER_URL},
             cross_process::SessionHash,
-            tests,
-            tests::mock_registered_client_data,
-            Oidc, OidcSessionTokens,
+            tests::prev_session_tokens,
+            Oidc,
         },
-        test_utils::test_client_builder,
+        test_utils::{
+            client::{
+                oauth::{mock_session, mock_session_tokens},
+                MockClientBuilder,
+            },
+            mocks::MatrixMockServer,
+        },
         Error,
     };
 
@@ -281,17 +282,13 @@ mod tests {
         // Create a client that will use sqlite databases.
 
         let tmp_dir = tempfile::tempdir()?;
-        let client = test_client_builder(Some("https://example.org".to_owned()))
-            .sqlite_store(&tmp_dir, None)
+        let client = MockClientBuilder::new("https://example.org".to_owned())
+            .sqlite_store(&tmp_dir)
+            .unlogged()
             .build()
-            .await
-            .unwrap();
+            .await;
 
-        let tokens = OidcSessionTokens {
-            access_token: "prev-access-token".to_owned(),
-            refresh_token: Some("prev-refresh-token".to_owned()),
-            latest_id_token: None,
-        };
+        let tokens = mock_session_tokens();
 
         client.oidc().enable_cross_process_refresh_lock("test".to_owned()).await?;
 
@@ -305,7 +302,7 @@ mod tests {
         )?;
 
         let session_hash = compute_session_hash(&tokens);
-        client.oidc().restore_session(tests::mock_session(tokens.clone())).await?;
+        client.oidc().restore_session(mock_session(tokens.clone(), ISSUER_URL.to_owned())).await?;
 
         assert_eq!(client.oidc().session_tokens().unwrap(), tokens);
 
@@ -328,37 +325,23 @@ mod tests {
 
     #[async_test]
     async fn test_finish_login() -> anyhow::Result<()> {
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/_matrix/client/r0/account/whoami"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "user_id": "@joe:example.org",
-                "device_id": "D3V1C31D",
-            })))
-            .expect(1)
-            .named("`GET /whoami` good token")
-            .mount(&server)
-            .await;
+        let server = MatrixMockServer::new().await;
+        server.mock_who_am_i().ok().expect(1).named("whoami").mount().await;
 
         let tmp_dir = tempfile::tempdir()?;
-        let client =
-            test_client_builder(Some(server.uri())).sqlite_store(&tmp_dir, None).build().await?;
-
-        let oidc = Oidc { client: client.clone(), backend: Arc::new(MockImpl::new()) };
-
-        // Restore registered client.
-        let (client_credentials, client_metadata) = mock_registered_client_data();
-        oidc.restore_registered_client(ISSUER_URL.to_owned(), client_metadata, client_credentials);
+        let client = server
+            .client_builder()
+            .sqlite_store(&tmp_dir)
+            .registered_with_oauth(server.server().uri())
+            .build()
+            .await;
+        let oidc = client.oidc();
 
         // Enable cross-process lock.
         oidc.enable_cross_process_refresh_lock("lock".to_owned()).await?;
 
         // Simulate we've done finalize_authorization / restore_session before.
-        let session_tokens = OidcSessionTokens {
-            access_token: "access".to_owned(),
-            refresh_token: Some("refresh".to_owned()),
-            latest_id_token: None,
-        };
+        let session_tokens = mock_session_tokens();
         oidc.set_session_tokens(session_tokens.clone());
 
         // Now, finishing logging will get the user and device ids.
@@ -394,22 +377,14 @@ mod tests {
         // refreshes whenever one spawns two refreshes around the same time.
 
         let tmp_dir = tempfile::tempdir()?;
-        let client = test_client_builder(Some("https://example.org".to_owned()))
-            .sqlite_store(&tmp_dir, None)
+        let client = MockClientBuilder::new("https://example.org".to_owned())
+            .sqlite_store(&tmp_dir)
+            .unlogged()
             .build()
-            .await?;
+            .await;
 
-        let prev_tokens = OidcSessionTokens {
-            access_token: "prev-access-token".to_owned(),
-            refresh_token: Some("prev-refresh-token".to_owned()),
-            latest_id_token: None,
-        };
-
-        let next_tokens = OidcSessionTokens {
-            access_token: "next-access-token".to_owned(),
-            refresh_token: Some("next-refresh-token".to_owned()),
-            latest_id_token: None,
-        };
+        let prev_tokens = prev_session_tokens();
+        let next_tokens = mock_session_tokens();
 
         let backend = Arc::new(
             MockImpl::new()
@@ -422,7 +397,7 @@ mod tests {
         oidc.enable_cross_process_refresh_lock("lock".to_owned()).await?;
 
         // Restore the session.
-        oidc.restore_session(tests::mock_session(prev_tokens.clone())).await?;
+        oidc.restore_session(mock_session(prev_tokens.clone(), ISSUER_URL.to_owned())).await?;
 
         // Immediately try to refresh the access token twice in parallel.
         for result in join_all([oidc.refresh_access_token(), oidc.refresh_access_token()]).await {
@@ -450,17 +425,8 @@ mod tests {
     #[async_test]
     async fn test_cross_process_concurrent_refresh() -> anyhow::Result<()> {
         // Create the backend.
-        let prev_tokens = OidcSessionTokens {
-            access_token: "prev-access-token".to_owned(),
-            refresh_token: Some("prev-refresh-token".to_owned()),
-            latest_id_token: None,
-        };
-
-        let next_tokens = OidcSessionTokens {
-            access_token: "next-access-token".to_owned(),
-            refresh_token: Some("next-refresh-token".to_owned()),
-            latest_id_token: None,
-        };
+        let prev_tokens = prev_session_tokens();
+        let next_tokens = mock_session_tokens();
 
         let backend = Arc::new(
             MockImpl::new()
@@ -470,35 +436,39 @@ mod tests {
 
         // Create the first client.
         let tmp_dir = tempfile::tempdir()?;
-        let client = test_client_builder(Some("https://example.org".to_owned()))
-            .sqlite_store(&tmp_dir, None)
+        let client = MockClientBuilder::new("https://example.org".to_owned())
+            .sqlite_store(&tmp_dir)
+            .unlogged()
             .build()
-            .await?;
+            .await;
 
         let oidc = Oidc { client: client.clone(), backend: backend.clone() };
         oidc.enable_cross_process_refresh_lock("client1".to_owned()).await?;
-        oidc.restore_session(tests::mock_session(prev_tokens.clone())).await?;
+
+        oidc.restore_session(mock_session(prev_tokens.clone(), ISSUER_URL.to_owned())).await?;
 
         // Create a second client, without restoring it, to test that a token update
         // before restoration doesn't cause new issues.
-        let unrestored_client = test_client_builder(Some("https://example.org".to_owned()))
-            .sqlite_store(&tmp_dir, None)
+        let unrestored_client = MockClientBuilder::new("https://example.org".to_owned())
+            .sqlite_store(&tmp_dir)
+            .unlogged()
             .build()
-            .await?;
+            .await;
         let unrestored_oidc = Oidc { client: unrestored_client.clone(), backend: backend.clone() };
         unrestored_oidc.enable_cross_process_refresh_lock("unrestored_client".to_owned()).await?;
 
         {
             // Create a third client that will run a refresh while the others two are doing
             // nothing.
-            let client3 = test_client_builder(Some("https://example.org".to_owned()))
-                .sqlite_store(&tmp_dir, None)
+            let client3 = MockClientBuilder::new("https://example.org".to_owned())
+                .sqlite_store(&tmp_dir)
+                .unlogged()
                 .build()
-                .await?;
+                .await;
 
             let oidc3 = Oidc { client: client3.clone(), backend: backend.clone() };
             oidc3.enable_cross_process_refresh_lock("client3".to_owned()).await?;
-            oidc3.restore_session(tests::mock_session(prev_tokens.clone())).await?;
+            oidc3.restore_session(mock_session(prev_tokens.clone(), ISSUER_URL.to_owned())).await?;
 
             // Run a refresh in the second client; this will invalidate the tokens from the
             // first token.
@@ -530,7 +500,7 @@ mod tests {
                 Box::new(|_| panic!("save_session_callback shouldn't be called here")),
             )?;
 
-            oidc.restore_session(tests::mock_session(prev_tokens.clone())).await?;
+            oidc.restore_session(mock_session(prev_tokens.clone(), ISSUER_URL.to_owned())).await?;
 
             // And this client is now aware of the latest tokens.
             let xp_manager =
@@ -588,35 +558,24 @@ mod tests {
 
     #[async_test]
     async fn test_logout() -> anyhow::Result<()> {
+        let server = MatrixMockServer::new().await;
+
+        let oauth_server = server.oauth();
+        oauth_server.mock_server_metadata().ok().expect(1..).named("server_metadata").mount().await;
+        oauth_server.mock_revocation().ok().expect(1).named("token").mount().await;
+
         let tmp_dir = tempfile::tempdir()?;
-        let client = test_client_builder(Some("https://example.org".to_owned()))
-            .sqlite_store(&tmp_dir, None)
-            .build()
-            .await?;
-
-        let tokens = OidcSessionTokens {
-            access_token: "prev-access-token".to_owned(),
-            refresh_token: Some("prev-refresh-token".to_owned()),
-            latest_id_token: None,
-        };
-
-        let backend = Arc::new(MockImpl::new());
-        let oidc = Oidc { client: client.clone(), backend: backend.clone() };
+        let client = server.client_builder().sqlite_store(&tmp_dir).unlogged().build().await;
+        let oidc = client.oidc();
 
         // Enable cross-process lock.
         oidc.enable_cross_process_refresh_lock("lock".to_owned()).await?;
 
         // Restore the session.
-        oidc.restore_session(tests::mock_session(tokens.clone())).await?;
+        let tokens = mock_session_tokens();
+        oidc.restore_session(mock_session(tokens.clone(), server.server().uri())).await?;
 
         oidc.logout().await?;
-
-        // The access token has been invalidated.
-        {
-            let revoked = backend.revoked_tokens.lock().unwrap();
-            assert_eq!(revoked.len(), 1);
-            assert_eq!(*revoked, &[tokens.access_token]);
-        }
 
         {
             // The cross process lock has been correctly updated, and all the hashes are

--- a/crates/matrix-sdk/src/authentication/oidc/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/qrcode/login.rs
@@ -502,48 +502,6 @@ mod test {
         })
     }
 
-    fn keys_json() -> Value {
-        json!({
-            "keys": [
-                {
-                    "e": "AQAB",
-                    "kid": "hxdHWoF9mn",
-                    "kty": "RSA",
-                    "n": "u4op7tDV41j-f_-DqsqjjCObiySB0q2CGS1JVjJXbV5jctHP6Wp_oMb2aIImMdHDcnTvxaID\
-                        WwuKA8o-0SBfkHFifMHHRvePz_l7NxxUMyGX8Bfu_EVkECe50BXpFydcEEl1eIIsPW-F0WJKFYR\
-                        5cscmBgRX3zv_w7WFbaOLh711S9DNu21epdSvFSrKRe9oG_FbeOFfDl-YU7BLGFvEozg9Z3hKF\
-                        SomOlz-t3ABvRUweGuLCpHFKsI6yhGCoqPyS7o5gpfenizdfHLqq-l7kgyr7lSbW_mTSyYutby\
-                        DpQ_HM98Lt-4a9zwlGfiqPS3svkH6KSd1mBcayCI0Cm9FuQ",
-                    "use": "sig"
-                },
-                {
-                    "crv": "P-256",
-                    "kid": "IRbxoGCBjs",
-                    "kty": "EC",
-                    "use": "sig",
-                    "x": "1AYfsklcgvscvJiNZ1Og7vQePzIBf-flJKlANWJ7D4g",
-                    "y": "L4b-jMZVZlnLhXCpV0EOc6zdEz1e6ONgKQZVE3jOBhY"
-                },
-                {
-                    "crv": "P-384",
-                    "kid": "FjEZp4JjqW",
-                    "kty": "EC",
-                    "use": "sig",
-                    "x": "bZP2bPUEQGeGaDICINswZSTCHdoVmDD3LIJE1Szxw27ruCJBW-sy_lY3dhA2FjWm",
-                    "y": "3HMgAu___-4JG9IXZFXwzr5nU_GUPvmWJHqgS7vzK1S91s0v1GXiqQMHwYA0keYG"
-                },
-                {
-                    "crv": "secp256k1",
-                    "kid": "7ohCuHzgqB",
-                    "kty": "EC",
-                    "use": "sig",
-                    "x": "80KXhBY8JBy8qO9-wMBaGtgOgtagowHJ4dDGfVr4eVw",
-                    "y": "0ALeT-J40AjdIS4S1YDgMrPkyE_rnw9wVm7Dvz_9Np4"
-                }
-            ]
-        })
-    }
-
     fn device_code(server: &MockServer) -> Value {
         let issuer_url =
             Url::parse(&server.uri()).expect("We should be able to parse the example homeserver");
@@ -565,17 +523,8 @@ mod test {
         json!({
             "access_token": "mat_z65RpDAbvR5aTr7MzD0aPw40xFbwch_09xTgn",
             "expires_in": 300,
-            "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6Imh4ZEhXb0Y5bW4ifQ.eyJhdWQiOiIwMUhZRlpEQ1\
-                BTV1dCREVWWkQyRlRBUVlFViIsInN1YiI6IjAxSFYxNzNTSjQxUDBGMFgxQ0FRU1lBVENQIiwiaWF0IjoxN\
-                zE2Mzc1NzIwLCJpc3MiOiJodHRwczovL2F1dGgtb2lkYy5sYWIuZWxlbWVudC5kZXYvIiwiZXhwIjoxNzE2\
-                Mzc5MzIwLCJhdF9oYXNoIjoieGZIS21qQW83cEVCRmUwTkM5ODJEQSJ9.HQs7Si5gU_5tm2hYaCa3jg0kPO\
-                MXGNdpV88MWzG6N9x3yXK0ZGgn58i38HiQTbiyPuhw8OH6baMSjbcVP-KXSDpsSPZbkmp7Ozb50dC0eIebD\
-                aVK0EyZ35KQRVc5BFPQBPbq0r_TrcUgjoLRKpoexvdmjfEb2dE-kKse25jfs-bTHKP6jeAyFgR9Emn0RfVx\
-                32He32-bRP1NfkBnPNnJse32tF1o8gs7zG-cm7kSUx1wiQbvfSGfETx_mJ-aFGABbVGKQlTrCe32HUTvNbp\
-                tT2WXa1t7d3eDuEV_6hZS9LFRdIXhgEcGIZMz_ss3WQsSOKN8Yq2NC8_bNxRAQ-1J3A",
             "refresh_token": "mar_CHFh124AMHsdishuHgLSx1svdKMVQA_080gj2",
-            "scope": "openid \
-                urn:matrix:org.matrix.msc2967.client:api:* \
+            "scope": "urn:matrix:org.matrix.msc2967.client:api:* \
                 urn:matrix:org.matrix.msc2967.client:device:\
                 lKa+6As0PSFtqOMKALottO6hlt3gCpZtaVfHanSUnEE",
             "token_type": "Bearer"
@@ -666,13 +615,6 @@ mod test {
             })))
             .expect(1)
             .named("registration_endpoint")
-            .mount(server)
-            .await;
-
-        Mock::given(method("GET"))
-            .and(path("/oauth2/keys.json"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(keys_json()))
-            .named("jwks")
             .mount(server)
             .await;
 

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -15,7 +15,7 @@
 //! Augmented [`ClientBuilder`] that can set up an already logged-in user.
 
 use matrix_sdk_base::{store::StoreConfig, SessionMeta};
-use ruma::{api::MatrixVersion, device_id, user_id};
+use ruma::{api::MatrixVersion, owned_device_id, owned_user_id};
 
 use crate::{
     authentication::matrix::{MatrixSession, MatrixSessionTokens},
@@ -27,7 +27,7 @@ use crate::{
 #[allow(missing_debug_implementations)]
 pub struct MockClientBuilder {
     builder: ClientBuilder,
-    logged_in: bool,
+    auth_state: AuthState,
 }
 
 impl MockClientBuilder {
@@ -36,18 +36,32 @@ impl MockClientBuilder {
     /// default).
     pub(crate) fn new(homeserver: String) -> Self {
         let default_builder = Client::builder()
-            .homeserver_url(homeserver)
+            .homeserver_url(&homeserver)
             .server_versions([MatrixVersion::V1_12])
             .request_config(RequestConfig::new().disable_retry());
 
-        Self { builder: default_builder, logged_in: true }
+        Self { builder: default_builder, auth_state: AuthState::LoggedInWithMatrixAuth }
     }
 
     /// Doesn't log-in a user.
     ///
     /// Authenticated requests will fail if this is called.
     pub fn unlogged(mut self) -> Self {
-        self.logged_in = false;
+        self.auth_state = AuthState::None;
+        self
+    }
+
+    /// The client is registered with the OAuth 2.0 API.
+    #[cfg(feature = "experimental-oidc")]
+    pub fn registered_with_oauth(mut self, issuer: impl Into<String>) -> Self {
+        self.auth_state = AuthState::RegisteredWithOauth { issuer: issuer.into() };
+        self
+    }
+
+    /// The user is already logged in with the OAuth 2.0 API.
+    #[cfg(feature = "experimental-oidc")]
+    pub fn logged_in_with_oauth(mut self, issuer: impl Into<String>) -> Self {
+        self.auth_state = AuthState::LoggedInWithOauth { issuer: issuer.into() };
         self
     }
 
@@ -57,27 +71,143 @@ impl MockClientBuilder {
         self
     }
 
+    /// Use an SQLite store at the given path for the underlying
+    /// [`ClientBuilder`].
+    #[cfg(feature = "sqlite")]
+    pub fn sqlite_store(mut self, path: impl AsRef<std::path::Path>) -> Self {
+        self.builder = self.builder.sqlite_store(path, None);
+        self
+    }
+
     /// Finish building the client into the final [`Client`] instance.
     pub async fn build(self) -> Client {
         let client = self.builder.build().await.expect("building client failed");
-
-        if self.logged_in {
-            client
-                .matrix_auth()
-                .restore_session(MatrixSession {
-                    meta: SessionMeta {
-                        user_id: user_id!("@example:localhost").to_owned(),
-                        device_id: device_id!("DEVICEID").to_owned(),
-                    },
-                    tokens: MatrixSessionTokens {
-                        access_token: "1234".to_owned(),
-                        refresh_token: None,
-                    },
-                })
-                .await
-                .unwrap();
-        }
+        self.auth_state.maybe_restore_client(&client).await;
 
         client
+    }
+}
+
+/// The possible authentication states of a [`Client`] built with
+/// [`MockClientBuilder`].
+enum AuthState {
+    /// The client is not logged in.
+    None,
+    /// The client is logged in with the native Matrix API.
+    LoggedInWithMatrixAuth,
+    /// The client is registered with the OAuth 2.0 API.
+    #[cfg(feature = "experimental-oidc")]
+    RegisteredWithOauth { issuer: String },
+    /// The client is logged in with the OAuth 2.0 API.
+    #[cfg(feature = "experimental-oidc")]
+    LoggedInWithOauth { issuer: String },
+}
+
+impl AuthState {
+    /// Restore the given [`Client`] according to this [`AuthState`], if
+    /// necessary.
+    async fn maybe_restore_client(self, client: &Client) {
+        match self {
+            AuthState::None => {}
+            AuthState::LoggedInWithMatrixAuth => {
+                client
+                    .matrix_auth()
+                    .restore_session(MatrixSession {
+                        meta: mock_session_meta(),
+                        tokens: MatrixSessionTokens {
+                            access_token: "1234".to_owned(),
+                            refresh_token: None,
+                        },
+                    })
+                    .await
+                    .unwrap();
+            }
+            #[cfg(feature = "experimental-oidc")]
+            AuthState::RegisteredWithOauth { issuer } => {
+                client.oidc().restore_registered_client(
+                    issuer,
+                    oauth::mock_client_metadata(),
+                    oauth::mock_client_id(),
+                );
+            }
+            #[cfg(feature = "experimental-oidc")]
+            AuthState::LoggedInWithOauth { issuer } => {
+                client
+                    .oidc()
+                    .restore_session(oauth::mock_session(oauth::mock_session_tokens(), issuer))
+                    .await
+                    .unwrap();
+            }
+        }
+    }
+}
+
+fn mock_session_meta() -> SessionMeta {
+    SessionMeta {
+        user_id: owned_user_id!("@example:localhost"),
+        device_id: owned_device_id!("DEVICEID"),
+    }
+}
+
+/// Mock client data for the OAuth 2.0 API.
+#[cfg(feature = "experimental-oidc")]
+pub mod oauth {
+    use mas_oidc_client::types::{
+        iana::oauth::OAuthClientAuthenticationMethod,
+        oidc::ApplicationType,
+        registration::{ClientMetadata, Localized, VerifiedClientMetadata},
+        requests::GrantType,
+    };
+    use url::Url;
+
+    use crate::authentication::oidc::{
+        registrations::ClientId, OidcSession, OidcSessionTokens, UserSession,
+    };
+
+    /// An OAuth 2.0 `ClientId`, for unit or integration tests.
+    pub fn mock_client_id() -> ClientId {
+        ClientId("test_client_id".to_owned())
+    }
+
+    /// `VerifiedClientMetadata` that should be valid in most cases, for unit or
+    /// integration tests.
+    pub fn mock_client_metadata() -> VerifiedClientMetadata {
+        let redirect_uri = Url::parse("http://127.0.0.1/").expect("redirect URI should be valid");
+        let client_uri = Url::parse("https://github.com/matrix-org/matrix-rust-sdk")
+            .expect("client URI should be valid");
+
+        ClientMetadata {
+            application_type: Some(ApplicationType::Native),
+            redirect_uris: Some(vec![redirect_uri]),
+            grant_types: Some(vec![
+                GrantType::AuthorizationCode,
+                GrantType::RefreshToken,
+                GrantType::DeviceCode,
+            ]),
+            token_endpoint_auth_method: Some(OAuthClientAuthenticationMethod::None),
+            client_name: Some(Localized::new("matrix-rust-sdk-test".to_owned(), [])),
+            client_uri: Some(Localized::new(client_uri, [])),
+            ..Default::default()
+        }
+        .validate()
+        .expect("client metadata should pass validation")
+    }
+
+    /// An [`OidcSessionTokens`], for unit or integration tests.
+    pub fn mock_session_tokens() -> OidcSessionTokens {
+        OidcSessionTokens {
+            access_token: "1234".to_owned(),
+            refresh_token: Some("ZYXWV".to_owned()),
+            latest_id_token: None,
+        }
+    }
+
+    /// An [`OidcSession`] to restore, for unit or integration tests.
+    pub fn mock_session(tokens: OidcSessionTokens, issuer: String) -> OidcSession {
+        OidcSession {
+            client_id: mock_client_id(),
+            metadata: mock_client_metadata(),
+            user: UserSession { meta: super::mock_session_meta(), tokens, issuer },
+        }
     }
 }

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -46,6 +46,9 @@ use wiremock::{
     Mock, MockBuilder, MockGuard, MockServer, Request, Respond, ResponseTemplate, Times,
 };
 
+#[cfg(feature = "experimental-oidc")]
+pub mod oauth;
+
 use super::client::MockClientBuilder;
 use crate::{Client, OwnedServerName, Room};
 
@@ -142,6 +145,12 @@ impl MatrixMockServer {
     /// Return the underlying [`wiremock`] server.
     pub fn server(&self) -> &MockServer {
         &self.server
+    }
+
+    /// Get an `OauthMockServer` that uses the same mock server as this one.
+    #[cfg(feature = "experimental-oidc")]
+    pub fn oauth(&self) -> oauth::OauthMockServer<'_> {
+        oauth::OauthMockServer::new(self.server())
     }
 
     /// Overrides the sync/ endpoint with knowledge that the given

--- a/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
@@ -1,0 +1,281 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Helpers to mock an OAuth 2.0 server for the purpose of integration tests.
+
+use mas_oidc_client::types::{
+    iana::{jose::JsonWebSignatureAlg, oauth::OAuthAuthorizationEndpointResponseType},
+    oidc::{ProviderMetadata, SubjectType},
+};
+use serde_json::json;
+use url::Url;
+use wiremock::{
+    matchers::{method, path_regex},
+    Mock, MockServer, ResponseTemplate,
+};
+
+use super::{MatrixMock, MockEndpoint};
+
+/// A [`wiremock`] [`MockServer`] along with useful methods to help mocking
+/// OAuth 2.0 API endpoints easily.
+///
+/// It implements mock endpoints, limiting the shared code as much as possible,
+/// so the mocks are still flexible to use as scoped/unscoped mounts, named, and
+/// so on.
+///
+/// It works like this:
+///
+/// * start by saying which endpoint you'd like to mock, e.g.
+///   [`Self::mock_server_metadata()`]. This returns a specialized
+///   [`MockEndpoint`] data structure, with its own impl. For this example, it's
+///   `MockEndpoint<ServerMetadataEndpoint>`.
+/// * configure the response on the endpoint-specific mock data structure. For
+///   instance, if you want the sending to result in a transient failure, call
+///   [`MockEndpoint::error500`]; if you want it to succeed and return the
+///   metadata, call [`MockEndpoint::ok()`]. It's still possible to call
+///   [`MockEndpoint::respond_with()`], as we do with wiremock MockBuilder, for
+///   maximum flexibility when the helpers aren't sufficient.
+/// * once the endpoint's response is configured, for any mock builder, you get
+///   a [`MatrixMock`]; this is a plain [`wiremock::Mock`] with the server
+///   curried, so one doesn't have to pass it around when calling
+///   [`MatrixMock::mount()`] or [`MatrixMock::mount_as_scoped()`]. As such, it
+///   mostly defers its implementations to [`wiremock::Mock`] under the hood.
+pub struct OauthMockServer<'a> {
+    server: &'a MockServer,
+}
+
+impl<'a> OauthMockServer<'a> {
+    pub(super) fn new(server: &'a MockServer) -> Self {
+        Self { server }
+    }
+}
+
+// Specific mount endpoints.
+impl OauthMockServer<'_> {
+    /// Creates a prebuilt mock for the Matrix endpoint used to query the
+    /// authorization server's metadata.
+    ///
+    /// Contrary to all the other endpoints of [`OauthMockServer`], this is an
+    /// endpoint from the Matrix API, but it is only used in the context of the
+    /// OAuth 2.0 API, which is why it is mocked here rather than on
+    /// [`MatrixMockServer`].
+    ///
+    /// [`MatrixMockServer`]: super::MatrixMockServer
+    pub fn mock_server_metadata(&self) -> MockEndpoint<'_, ServerMetadataEndpoint> {
+        let mock = Mock::given(method("GET"))
+            .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc2965/auth_metadata"));
+        MockEndpoint { mock, server: self.server, endpoint: ServerMetadataEndpoint }
+    }
+
+    /// Creates a prebuilt mock for the OAuth 2.0 endpoint used to register a
+    /// new client.
+    pub fn mock_registration(&self) -> MockEndpoint<'_, RegistrationEndpoint> {
+        let mock = Mock::given(method("POST")).and(path_regex(r"^/oauth2/registration"));
+        MockEndpoint { mock, server: self.server, endpoint: RegistrationEndpoint }
+    }
+
+    /// Creates a prebuilt mock for the OAuth 2.0 endpoint used to authorize a
+    /// device.
+    pub fn mock_device_authorization(&self) -> MockEndpoint<'_, DeviceAuthorizationEndpoint> {
+        let mock = Mock::given(method("POST")).and(path_regex(r"^/oauth2/device"));
+        MockEndpoint { mock, server: self.server, endpoint: DeviceAuthorizationEndpoint }
+    }
+
+    /// Creates a prebuilt mock for the OAuth 2.0 endpoint used to request an
+    /// access token.
+    pub fn mock_token(&self) -> MockEndpoint<'_, TokenEndpoint> {
+        let mock = Mock::given(method("POST")).and(path_regex(r"^/oauth2/token"));
+        MockEndpoint { mock, server: self.server, endpoint: TokenEndpoint }
+    }
+}
+
+/// A prebuilt mock for a `GET /auth_metadata` request.
+pub struct ServerMetadataEndpoint;
+
+impl<'a> MockEndpoint<'a, ServerMetadataEndpoint> {
+    /// Returns a successful metadata response with all the supported endpoints.
+    pub fn ok(self) -> MatrixMock<'a> {
+        let metadata = MockServerMetadataBuilder::new(&self.server.uri()).build();
+        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(metadata));
+
+        MatrixMock { server: self.server, mock }
+    }
+
+    /// Returns a successful metadata response without the device authorization
+    /// endpoint.
+    pub fn ok_without_device_authorization(self) -> MatrixMock<'a> {
+        let metadata = MockServerMetadataBuilder::new(&self.server.uri())
+            .without_device_authorization()
+            .build();
+        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(metadata));
+
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+/// Helper struct to construct a `ProviderMetadata` for integration tests.
+#[derive(Debug, Clone)]
+struct MockServerMetadataBuilder {
+    issuer: Url,
+    with_device_authorization: bool,
+}
+
+impl MockServerMetadataBuilder {
+    /// Construct a `MockServerMetadataBuilder` that will generate all the
+    /// supported fields.
+    fn new(issuer: &str) -> Self {
+        let issuer = Url::parse(issuer).expect("We should be able to parse the issuer");
+
+        Self { issuer, with_device_authorization: true }
+    }
+
+    /// Don't generate the field for the device authorization endpoint.
+    fn without_device_authorization(mut self) -> Self {
+        self.with_device_authorization = false;
+        self
+    }
+
+    /// The authorization endpoint of this server.
+    fn authorization_endpoint(&self) -> Url {
+        self.issuer.join("oauth2/authorize").unwrap()
+    }
+
+    /// The token endpoint of this server.
+    fn token_endpoint(&self) -> Url {
+        self.issuer.join("oauth2/token").unwrap()
+    }
+
+    /// The JWKS URI of this server.
+    fn jwks_uri(&self) -> Url {
+        self.issuer.join("oauth2/keys.json").unwrap()
+    }
+
+    /// The registration endpoint of this server.
+    fn registration_endpoint(&self) -> Url {
+        self.issuer.join("oauth2/registration").unwrap()
+    }
+
+    /// The account management URI of this server.
+    fn account_management_uri(&self) -> Url {
+        self.issuer.join("account").unwrap()
+    }
+
+    /// The device authorization endpoint of this server.
+    fn device_authorization_endpoint(&self) -> Url {
+        self.issuer.join("oauth2/device").unwrap()
+    }
+
+    /// The revocation endpoint of this server.
+    fn revocation_endpoint(&self) -> Url {
+        self.issuer.join("oauth2/revoke").unwrap()
+    }
+
+    /// Build the server metadata.
+    pub fn build(&self) -> ProviderMetadata {
+        let device_authorization_endpoint =
+            self.with_device_authorization.then(|| self.device_authorization_endpoint());
+
+        ProviderMetadata {
+            issuer: Some(self.issuer.to_string()),
+            authorization_endpoint: Some(self.authorization_endpoint()),
+            token_endpoint: Some(self.token_endpoint()),
+            jwks_uri: Some(self.jwks_uri()),
+            registration_endpoint: Some(self.registration_endpoint()),
+            revocation_endpoint: Some(self.revocation_endpoint()),
+            account_management_uri: Some(self.account_management_uri()),
+            device_authorization_endpoint,
+            response_types_supported: Some(vec![
+                OAuthAuthorizationEndpointResponseType::Code.into()
+            ]),
+            subject_types_supported: Some(vec![SubjectType::Public]),
+            id_token_signing_alg_values_supported: Some(vec![JsonWebSignatureAlg::Rs256]),
+            ..Default::default()
+        }
+    }
+}
+
+/// A prebuilt mock for a `POST /oauth/registration` request.
+pub struct RegistrationEndpoint;
+
+impl<'a> MockEndpoint<'a, RegistrationEndpoint> {
+    /// Returns a successful registration response.
+    pub fn ok(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "client_id": "test_client_id",
+            "client_id_issued_at": 1716375696,
+        })));
+
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+/// A prebuilt mock for a `POST /oauth/device` request.
+pub struct DeviceAuthorizationEndpoint;
+
+impl<'a> MockEndpoint<'a, DeviceAuthorizationEndpoint> {
+    /// Returns a successful device authorization response.
+    pub fn ok(self) -> MatrixMock<'a> {
+        let issuer_url = Url::parse(&self.server.uri())
+            .expect("We should be able to parse the wiremock server URI");
+        let verification_uri = issuer_url.join("link").unwrap();
+        let mut verification_uri_complete = issuer_url.join("link").unwrap();
+        verification_uri_complete.set_query(Some("code=N32YVC"));
+
+        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "device_code": "N8NAYD9fOhMulpm37mSthx0xSw2p7vdR",
+            "expires_in": 1200,
+            "interval": 5,
+            "user_code": "N32YVC",
+            "verification_uri": verification_uri,
+            "verification_uri_complete": verification_uri_complete,
+        })));
+
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+/// A prebuilt mock for a `POST /oauth/token` request.
+pub struct TokenEndpoint;
+
+impl<'a> MockEndpoint<'a, TokenEndpoint> {
+    /// Returns a successful token response.
+    pub fn ok(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "1234",
+            "expires_in": 300,
+            "refresh_token": "ZYXWV",
+            "token_type": "Bearer"
+        })));
+
+        MatrixMock { server: self.server, mock }
+    }
+
+    /// Returns an error response when the request was invalid.
+    pub fn access_denied(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": "access_denied",
+        })));
+
+        MatrixMock { server: self.server, mock }
+    }
+
+    /// Returns an error response when the token in the request has expired.
+    pub fn expired_token(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": "expired_token",
+        })));
+
+        MatrixMock { server: self.server, mock }
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/matrix-org/matrix-rust-sdk/pull/4687#discussion_r1967556139, we want to get rid of the `OidcBackend` trait to mock a real authorization server instead.

This implements an `OauthMockServer` to handle the OAuth 2.0-related endpoints and uses it as much as possible.

We keep the mock backend for now because mocking the server would require generating ID tokens on the fly (which involves encryption with private keys). Since ID tokens are only part of OpenID Connect, and not OAuth 2.0, we will remove support for them, so it doesn't seem worth it to add temporary code for this. We can remove support for them easily and get rid of the backend trait when this and #4699 are merged.

This can be reviewed commit by commit.