### PR TITLE
Retry decryption from a long-lived async task, instead of lots of detached ones

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -1,0 +1,146 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::BTreeSet, sync::Arc};
+
+use matrix_sdk::deserialized_responses::TimelineEventKind as SdkTimelineEventKind;
+use tokio::sync::RwLock;
+use tracing::{
+    error,
+    field::{self, debug},
+    info, info_span, Instrument as _,
+};
+
+use crate::timeline::{
+    controller::{TimelineSettings, TimelineState},
+    traits::{Decryptor, RoomDataProvider},
+    EncryptedMessage, TimelineItem,
+};
+
+/// A long-running task spawned and owned by the TimelineController, and used to
+/// retry decryption of items in the timeline when new information about a
+/// session is received.
+pub struct DecryptionRetryTask<P: RoomDataProvider> {
+    state: Arc<RwLock<TimelineState>>,
+    settings: TimelineSettings,
+    room_data_provider: P,
+}
+
+impl<P: RoomDataProvider> DecryptionRetryTask<P> {
+    pub(crate) fn new(
+        state: Arc<RwLock<TimelineState>>,
+        settings: TimelineSettings,
+        room_data_provider: P,
+    ) -> Self {
+        Self { state, settings, room_data_provider }
+    }
+
+    pub(crate) async fn decrypt(
+        &self,
+        decryptor: impl Decryptor,
+        session_ids: Option<BTreeSet<String>>,
+        retry_indices: Vec<usize>,
+    ) {
+        let should_retry = move |session_id: &str| {
+            if let Some(session_ids) = &session_ids {
+                session_ids.contains(session_id)
+            } else {
+                true
+            }
+        };
+
+        let mut state = self.state.clone().write_owned().await;
+
+        let settings = self.settings.clone();
+        let room_data_provider = self.room_data_provider.clone();
+        let push_rules_context = self.room_data_provider.push_rules_and_context().await;
+        let unable_to_decrypt_hook = state.meta.unable_to_decrypt_hook.clone();
+
+        matrix_sdk::executor::spawn(async move {
+            let retry_one = |item: Arc<TimelineItem>| {
+                let decryptor = decryptor.clone();
+                let should_retry = &should_retry;
+                let unable_to_decrypt_hook = unable_to_decrypt_hook.clone();
+                async move {
+                    let event_item = item.as_event()?;
+
+                    let session_id = match event_item.content().as_unable_to_decrypt()? {
+                        EncryptedMessage::MegolmV1AesSha2 { session_id, .. }
+                            if should_retry(session_id) =>
+                        {
+                            session_id
+                        }
+                        EncryptedMessage::MegolmV1AesSha2 { .. }
+                        | EncryptedMessage::OlmV1Curve25519AesSha2 { .. }
+                        | EncryptedMessage::Unknown => return None,
+                    };
+
+                    tracing::Span::current().record("session_id", session_id);
+
+                    let Some(remote_event) = event_item.as_remote() else {
+                        error!("Key for unable-to-decrypt timeline item is not an event ID");
+                        return None;
+                    };
+
+                    tracing::Span::current().record("event_id", debug(&remote_event.event_id));
+
+                    let Some(original_json) = &remote_event.original_json else {
+                        error!("UTD item must contain original JSON");
+                        return None;
+                    };
+
+                    match decryptor.decrypt_event_impl(original_json).await {
+                        Ok(event) => {
+                            if let SdkTimelineEventKind::UnableToDecrypt { utd_info, .. } =
+                                event.kind
+                            {
+                                info!(
+                                    "Failed to decrypt event after receiving room key: {:?}",
+                                    utd_info.reason
+                                );
+                                None
+                            } else {
+                                // Notify observers that we managed to eventually decrypt an event.
+                                if let Some(hook) = unable_to_decrypt_hook {
+                                    hook.on_late_decrypt(&remote_event.event_id).await;
+                                }
+
+                                Some(event)
+                            }
+                        }
+                        Err(e) => {
+                            info!("Failed to decrypt event after receiving room key: {e}");
+                            None
+                        }
+                    }
+                }
+                .instrument(info_span!(
+                    "retry_one",
+                    session_id = field::Empty,
+                    event_id = field::Empty
+                ))
+            };
+
+            state
+                .retry_event_decryption(
+                    retry_one,
+                    retry_indices,
+                    push_rules_context,
+                    &room_data_provider,
+                    &settings,
+                )
+                .await;
+        });
+    }
+}

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -28,6 +28,7 @@ use imbl::vector;
 use indexmap::IndexMap;
 use matrix_sdk::{
     config::RequestConfig,
+    crypto::OlmMachine,
     deserialized_responses::TimelineEvent,
     event_cache::paginator::{PaginableRoom, PaginatorError},
     room::{EventWithContextResponse, Messages, MessagesOptions},
@@ -50,8 +51,8 @@ use ruma::{
     push::{PushConditionPowerLevelsCtx, PushConditionRoomCtx, Ruleset},
     room_id,
     serde::Raw,
-    uint, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
-    RoomVersionId, TransactionId, UInt, UserId,
+    uint, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
+    OwnedUserId, RoomVersionId, TransactionId, UInt, UserId,
 };
 use tokio::sync::RwLock;
 
@@ -136,7 +137,7 @@ impl TestTimelineBuilder {
 }
 
 struct TestTimeline {
-    controller: TimelineController<TestRoomDataProvider>,
+    controller: TimelineController<TestRoomDataProvider, (OlmMachine, OwnedRoomId)>,
 
     /// An [`EventFactory`] that can be used for creating events in this
     /// timeline.

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use eyeball_im::VectorDiff;
+use matrix_sdk::assert_next_matches_with_timeout;
 use matrix_sdk_test::{async_test, event_factory::EventFactory, ALICE, BOB, CAROL};
 use ruma::{
     event_id,
@@ -485,10 +486,9 @@ async fn test_read_receipts_updates_on_message_decryption() {
         )
         .await;
 
-    assert_eq!(timeline.controller.items().await.len(), 2);
-
     // The first event now has both receipts.
-    let clear_item = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let clear_item =
+        assert_next_matches_with_timeout!(stream, VectorDiff::Set { index: 1, value } => value);
     let clear_event = clear_item.as_event().unwrap();
     assert_matches!(clear_event.content(), TimelineItemContent::Message(_));
     assert_eq!(clear_event.read_receipts().len(), 2);
@@ -496,7 +496,7 @@ async fn test_read_receipts_updates_on_message_decryption() {
     assert!(clear_event.read_receipts().get(*BOB).is_some());
 
     // The second event is removed.
-    assert_next_matches!(stream, VectorDiff::Remove { index: 2 });
+    assert_next_matches_with_timeout!(stream, VectorDiff::Remove { index: 2 });
 
     assert_pending!(stream);
 }


### PR DESCRIPTION
Part of https://github.com/element-hq/element-meta/issues/2697

In response to a [comment on #4644](https://github.com/matrix-org/matrix-rust-sdk/pull/4644/files#r1963599148) - avoid spawning a detached async task every time we have some things to decrypt because some Megolm sessions updated.

Instead, we create one async task and hold it inside a new struct called `RetryDecryptionTask`. This struct holds one end of channel, and sends retry requests to the async task, which stops when the channel is closed, which will happen when the `RetryDecryptionTask` struct is dropped.

So we keep the feature that retrying decryption does not block the main processing, but we lose the spawning of lots of async tasks that are not kept track of.

As written, the task is not cancellable, but this could be added if we think we need it.

I strongly suggest reviewing commit by commit, since this is structured as a set of refactorings that hopefully make sense individually.