### PR TITLE
ffi: make room and timeline creation orthogonal

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -94,11 +94,6 @@ impl Timeline {
         Arc::new(Self { inner })
     }
 
-    pub(crate) fn from_arc(inner: Arc<matrix_sdk_ui::timeline::Timeline>) -> Arc<Self> {
-        // SAFETY: repr(transparent) means transmuting the arc this way is allowed
-        unsafe { Arc::from_raw(Arc::into_raw(inner) as _) }
-    }
-
     fn send_attachment(
         self: Arc<Self>,
         params: UploadParameters,
@@ -297,6 +292,9 @@ impl Timeline {
     /// This works even if the latest event belongs to a thread, as a threaded
     /// reply also belongs to the unthreaded timeline. No threaded receipt
     /// will be sent here (see also #3123).
+    ///
+    /// Note: this does NOT unset the unread flag; it's the caller's
+    /// responsibility to do so, if needs be.
     pub async fn mark_as_read(&self, receipt_type: ReceiptType) -> Result<(), ClientError> {
         self.inner.mark_as_read(receipt_type.into()).await?;
         Ok(())

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -43,7 +43,7 @@ impl WidgetDriver {
         };
 
         let capabilities_provider = CapabilitiesProviderWrap(capabilities_provider.into());
-        if let Err(()) = driver.run(room.inner.clone(), capabilities_provider).await {
+        if let Err(()) = driver.run(room.sdk().clone(), capabilities_provider).await {
             // TODO
         }
     }
@@ -105,7 +105,7 @@ pub async fn generate_webview_url(
 ) -> Result<String, ParseError> {
     Ok(matrix_sdk::widget::WidgetSettings::generate_webview_url(
         &widget_settings.clone().try_into()?,
-        &room.inner,
+        room.sdk(),
         props.into(),
     )
     .await


### PR DESCRIPTION
This gets rid of the `Timeline` stored in an FFI `Room`. There's no good reason why we should create and hold on to a live timeline instance when we have a `Room` instance, since we might want a `Room` to only perform `Room`-related operations.

In general, holding onto live timelines in scattered places may lead to having the [auto-linked-chunk-shrink optimization](https://github.com/matrix-org/matrix-rust-sdk/pull/4703) **not** trigger, so we need to be careful and minimize the number of live timelines at all costs.

As a result, this gets rid of `Room::timeline`, which would return the cached timeline instance. `Room::timeline_with_configuration()` can be used to create a new timeline instance for a given room, or `RoomListItem::init_timeline()` and then `RoomListItem::timeline()`.

Also renamed the FFI `Room::inner` (which is a… SDK Room) to `Room::sdk`. Is this too cute? :pleading_face: 

cc @jmartinesp @stefanceriu, if you could test it out please :-)