### PR TITLE
FFI: Correctly indicate OIDC support when fetching metadata fails.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -296,7 +296,7 @@ impl Client {
             }
             Err(error) => {
                 error!("Failed to fetch OIDC provider metadata: {error}");
-                (true, Default::default())
+                (false, Default::default())
             }
         };
 


### PR DESCRIPTION
There was a small regression introduced into the FFI layer in #4673 where an error that returned `false` was updated to return `true`. This PR fixes it.