### PR TITLE
refactor(event cache): don't keep an instance of `Paginator` in `RoomEventCache`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -25,11 +25,12 @@ use matrix_sdk::{
         BaseVideoInfo, Thumbnail,
     },
     deserialized_responses::{ShieldState as SdkShieldState, ShieldStateCode},
+    event_cache::RoomPaginationStatus,
     room::edit::EditedContent as SdkEditedContent,
     Error,
 };
 use matrix_sdk_ui::timeline::{
-    self, EventItemOrigin, LiveBackPaginationStatus, Profile, RepliedToEvent, TimelineDetails,
+    self, EventItemOrigin, Profile, RepliedToEvent, TimelineDetails,
     TimelineUniqueId as SdkTimelineUniqueId,
 };
 use mime::Mime;
@@ -757,7 +758,7 @@ pub trait TimelineListener: Sync + Send {
 
 #[matrix_sdk_ffi_macros::export(callback_interface)]
 pub trait PaginationStatusListener: Sync + Send {
-    fn on_update(&self, status: LiveBackPaginationStatus);
+    fn on_update(&self, status: RoomPaginationStatus);
 }
 
 #[derive(Clone, uniffi::Object)]

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -92,7 +92,6 @@ pub use self::{
     },
     event_type_filter::TimelineEventTypeFilter,
     item::{TimelineItem, TimelineItemKind, TimelineUniqueId},
-    pagination::LiveBackPaginationStatus,
     traits::RoomExt,
     virtual_item::VirtualTimelineItem,
 };

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -387,14 +387,6 @@ impl RoomPagination {
     pub fn hit_timeline_start(&self) -> bool {
         self.inner.paginator.hit_timeline_start()
     }
-
-    /// Returns whether we've hit the end of the timeline.
-    ///
-    /// This is true if, and only if, we didn't have a next-batch token and
-    /// running forwards pagination would be useless.
-    pub fn hit_timeline_end(&self) -> bool {
-        self.inner.paginator.hit_timeline_end()
-    }
 }
 
 /// Pagination token data, indicating in which state is the current pagination.

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -212,10 +212,10 @@ impl RoomPagination {
 
     /// Run a single pagination request (/messages) to the server.
     ///
-    /// If there's no previous-batch token, it will wait for one for a short
-    /// while to get one, or if it's already done so or seen a
-    /// previous-batch token before, it will immediately indicate
-    /// it's reached the end of the timeline.
+    /// If there are no previous-batch tokens, it will wait for one for a short
+    /// while to get one, or if it's already done so or if it's seen a
+    /// previous-batch token before, it will immediately indicate it's
+    /// reached the end of the timeline.
     async fn paginate_backwards_with_network(
         &self,
         batch_size: u16,
@@ -262,9 +262,11 @@ impl RoomPagination {
 
             if gap_id.is_none() {
                 // We got a previous-batch token from the linked chunk *before* running the
-                // request, which is missing from the linked chunk *after* completing the
-                // request. It may be a sign the linked chunk has been reset,
-                // and it's an error in any case.
+                // request, but it is missing *after* completing the
+                // request.
+                //
+                // It may be a sign the linked chunk has been reset, but it's fine, per this
+                // function's contract.
                 return Ok(None);
             }
 

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -306,7 +306,7 @@ impl RoomPagination {
             events.clear();
         }
 
-        let ((), sync_timeline_events_diffs) = state
+        let sync_timeline_events_diffs = state
             .with_events_mut(|room_events| {
             // Reverse the order of the events as `/messages` has been called with `dir=b`
             // (backwards). The `RoomEvents` API expects the first event to be the oldest.

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -186,12 +186,12 @@ impl RoomPagination {
 
             LoadMoreEventsBackwardsOutcome::Events {
                 events,
-                sync_timeline_events_diffs,
+                timeline_event_diffs,
                 reached_start,
             } => {
-                if !sync_timeline_events_diffs.is_empty() {
+                if !timeline_event_diffs.is_empty() {
                     let _ = self.inner.sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
-                        diffs: sync_timeline_events_diffs,
+                        diffs: timeline_event_diffs,
                         origin: EventsOrigin::Pagination,
                     });
                 }
@@ -306,7 +306,7 @@ impl RoomPagination {
             events.clear();
         }
 
-        let sync_timeline_events_diffs = state
+        let timeline_event_diffs = state
             .with_events_mut(|room_events| {
             // Reverse the order of the events as `/messages` has been called with `dir=b`
             // (backwards). The `RoomEvents` API expects the first event to be the oldest.
@@ -392,9 +392,9 @@ impl RoomPagination {
 
         let backpagination_outcome = BackPaginationOutcome { events, reached_start };
 
-        if !sync_timeline_events_diffs.is_empty() {
+        if !timeline_event_diffs.is_empty() {
             let _ = self.inner.sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
-                diffs: sync_timeline_events_diffs,
+                diffs: timeline_event_diffs,
                 origin: EventsOrigin::Pagination,
             });
         }

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -848,8 +848,6 @@ mod private {
                     Ok(None) => {
                         // No previous chunk: no events to insert. Better, it means we've reached
                         // the start of the timeline!
-                        self.pagination_status
-                            .set(RoomPaginationStatus::Idle { hit_timeline_start: true });
                         return Ok(LoadMoreEventsBackwardsOutcome::StartOfTimeline);
                     }
 

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -547,7 +547,7 @@ impl RoomEventCacheInner {
 
             // Add the previous back-pagination token (if present), followed by the timeline
             // events themselves.
-            let ((), sync_timeline_events_diffs_next) = state
+            let sync_timeline_events_diffs_next = state
                 .with_events_mut(|room_events| {
                     // If we only received duplicated events, we don't need to store the gap: if
                     // there was a gap, we'd have received an unknown event at the tail of
@@ -1052,7 +1052,7 @@ mod private {
             }
 
             // In-memory events.
-            let ((), timeline_event_diffs) = self
+            let timeline_event_diffs = self
                 .with_events_mut(|room_events| {
                     // `remove_events_by_position` sorts the positions by itself.
                     room_events
@@ -1186,14 +1186,14 @@ mod private {
         /// linked chunk, as vector diff, so the caller may propagate
         /// such updates, if needs be.
         #[must_use = "Updates as `VectorDiff` must probably be propagated via `RoomEventCacheUpdate`"]
-        pub async fn with_events_mut<O, F: FnOnce(&mut RoomEvents) -> O>(
+        pub async fn with_events_mut<F: FnOnce(&mut RoomEvents)>(
             &mut self,
             func: F,
-        ) -> Result<(O, Vec<VectorDiff<TimelineEvent>>), EventCacheError> {
-            let output = func(&mut self.events);
+        ) -> Result<Vec<VectorDiff<TimelineEvent>>, EventCacheError> {
+            func(&mut self.events);
             self.propagate_changes().await?;
             let updates_as_vector_diffs = self.events.updates_as_vector_diffs();
-            Ok((output, updates_as_vector_diffs))
+            Ok(updates_as_vector_diffs)
         }
     }
 }


### PR DESCRIPTION
The important part of this refactor is that we avoid holding onto a `Paginator` instance in the `RoomEventCacheInner` data structure. Instead, we create it on the fly when we need it, and drop it after the fact.

It makes for a tidier state: we don't need to manually remember to reset the `Paginator` state in multiple places. Now, instead, we have to maintain the pagination status by ourselves (since there's no way to subscribe to a `Paginator` that's transient, remember?). This is fine, because 1) the timeline already wanted to simplified pagination status that included whether we've hit the start of the timeline or not, and 2) we couldn't reach two of the states of `PaginatorStatus` anyways, theoretically.

And even better: in the future, the timeline might have a start-of-timeline item, and we would probably not need the paginator status *at all* in this case (or at least, it wouldn't need to include the special `hit_timeline_start` value).