### PR TITLE
test(sdk): Run integration tests for experimental-oidc feature too

### DIFF
--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -231,7 +231,7 @@ fn run_feature_tests(cmd: Option<FeatureSet>) -> Result<()> {
         (FeatureSet::Markdown, "--features markdown,testing"),
         (FeatureSet::Socks, "--features socks,testing"),
         (FeatureSet::SsoLogin, "--features sso-login,testing"),
-        (FeatureSet::ExperimentalOidc, "--features experimental-oidc"),
+        (FeatureSet::ExperimentalOidc, "--features experimental-oidc,testing"),
     ]);
 
     let sh = sh();


### PR DESCRIPTION
There is one test that I know of :stuck_out_tongue:.
