### PR TITLE
refactor(event cache): remove an empty events chunk after pushing a gap in sync

### DIFF
--- a/crates/matrix-sdk-common/src/linked_chunk/as_vector.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/as_vector.rs
@@ -473,7 +473,7 @@ mod tests {
     use imbl::{vector, Vector};
 
     use super::{
-        super::{Chunk, ChunkIdentifierGenerator, EmptyChunkRule, LinkedChunk, Update},
+        super::{Chunk, ChunkIdentifierGenerator, LinkedChunk, Update},
         VectorDiff,
     };
 
@@ -630,10 +630,7 @@ mod tests {
         );
 
         let removed_item = linked_chunk
-            .remove_item_at(
-                linked_chunk.item_position(|item| *item == 'c').unwrap(),
-                EmptyChunkRule::Remove,
-            )
+            .remove_item_at(linked_chunk.item_position(|item| *item == 'c').unwrap())
             .unwrap();
         assert_eq!(removed_item, 'c');
         assert_items_eq!(
@@ -653,10 +650,7 @@ mod tests {
         apply_and_assert_eq(&mut accumulator, as_vector.take(), &[VectorDiff::Remove { index: 7 }]);
 
         let removed_item = linked_chunk
-            .remove_item_at(
-                linked_chunk.item_position(|item| *item == 'z').unwrap(),
-                EmptyChunkRule::Remove,
-            )
+            .remove_item_at(linked_chunk.item_position(|item| *item == 'z').unwrap())
             .unwrap();
         assert_eq!(removed_item, 'z');
         assert_items_eq!(
@@ -886,10 +880,7 @@ mod tests {
 
         // Empty a chunk, and remove it once it is empty.
         linked_chunk
-            .remove_item_at(
-                linked_chunk.item_position(|item| *item == 'c').unwrap(),
-                EmptyChunkRule::Remove,
-            )
+            .remove_item_at(linked_chunk.item_position(|item| *item == 'c').unwrap())
             .unwrap();
 
         assert_items_eq!(linked_chunk, ['a', 'b'] [-] [-] ['d', 'e', 'f'] ['g']);
@@ -1008,7 +999,7 @@ mod tests {
                                 continue;
                             };
 
-                            linked_chunk.remove_item_at(position, EmptyChunkRule::Remove).expect("Failed to remove an item");
+                            linked_chunk.remove_item_at(position).expect("Failed to remove an item");
                         }
                     }
                 }

--- a/crates/matrix-sdk-common/src/linked_chunk/as_vector.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/as_vector.rs
@@ -906,7 +906,9 @@ mod tests {
         apply_and_assert_eq(&mut accumulator, as_vector.take(), &[VectorDiff::Remove { index: 2 }]);
 
         // Remove a gap.
-        linked_chunk.remove_gap_at(linked_chunk.chunk_identifier(Chunk::is_gap).unwrap()).unwrap();
+        linked_chunk
+            .remove_empty_chunk_at(linked_chunk.chunk_identifier(Chunk::is_gap).unwrap())
+            .unwrap();
 
         assert_items_eq!(linked_chunk, ['a', 'b'] [-] ['d', 'e', 'f'] ['g']);
 

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -131,6 +131,13 @@ pub enum Error {
         identifier: ChunkIdentifier,
     },
 
+    /// A chunk is an items chunk, and it was expected to be empty.
+    #[error("The chunk is a non-empty item chunk: `{identifier:?}`")]
+    RemovingNonEmptyItemsChunk {
+        /// The chunk identifier.
+        identifier: ChunkIdentifier,
+    },
+
     /// An item index is invalid.
     #[error("The item index is invalid: `{index}`")]
     InvalidItemIndex {
@@ -687,7 +694,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
     ///
     /// This returns the next insert position, viz. the start of the next
     /// chunk, if any, or none if there was no next chunk.
-    pub fn remove_gap_at(
+    pub fn remove_empty_chunk_at(
         &mut self,
         chunk_identifier: ChunkIdentifier,
     ) -> Result<Option<Position>, Error> {
@@ -696,9 +703,16 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
             .chunk_mut(chunk_identifier)
             .ok_or(Error::InvalidChunkIdentifier { identifier: chunk_identifier })?;
 
-        if chunk.is_items() {
-            return Err(Error::ChunkIsItems { identifier: chunk_identifier });
-        };
+        match chunk.content() {
+            ChunkContent::Items(items) if !items.is_empty() => {
+                if chunk.is_items() {
+                    return Err(Error::RemovingNonEmptyItemsChunk { identifier: chunk_identifier });
+                };
+            }
+            _ => {
+                // Either a gap or an empty items chunk: continue.
+            }
+        }
 
         let chunk_was_first = chunk.is_first_chunk();
         let chunk_was_last = chunk.is_last_chunk();
@@ -3276,16 +3290,16 @@ mod tests {
             ]
         );
 
-        // Try to remove a gap that's not a gap.
-        let err = linked_chunk.remove_gap_at(ChunkIdentifier(0)).unwrap_err();
-        assert_matches!(err, Error::ChunkIsItems { .. });
+        // Try to remove a chunk that's not empty.
+        let err = linked_chunk.remove_empty_chunk_at(ChunkIdentifier(0)).unwrap_err();
+        assert_matches!(err, Error::RemovingNonEmptyItemsChunk { .. });
 
         // Try to remove an unknown gap chunk.
-        let err = linked_chunk.remove_gap_at(ChunkIdentifier(42)).unwrap_err();
+        let err = linked_chunk.remove_empty_chunk_at(ChunkIdentifier(42)).unwrap_err();
         assert_matches!(err, Error::InvalidChunkIdentifier { .. });
 
         // Remove the gap in the middle.
-        let maybe_next = linked_chunk.remove_gap_at(ChunkIdentifier(2)).unwrap();
+        let maybe_next = linked_chunk.remove_empty_chunk_at(ChunkIdentifier(2)).unwrap();
         let next = maybe_next.unwrap();
         // The next insert position at the start of the next chunk.
         assert_eq!(next.chunk_identifier(), ChunkIdentifier(3));
@@ -3294,14 +3308,14 @@ mod tests {
         assert_eq!(linked_chunk.updates().unwrap().take(), &[RemoveChunk(ChunkIdentifier(2))]);
 
         // Remove the gap at the end.
-        let next = linked_chunk.remove_gap_at(ChunkIdentifier(4)).unwrap();
+        let next = linked_chunk.remove_empty_chunk_at(ChunkIdentifier(4)).unwrap();
         // It was the last chunk, so there's no next insert position.
         assert!(next.is_none());
         assert_items_eq!(linked_chunk, [-] ['a', 'b'] ['l', 'm']);
         assert_eq!(linked_chunk.updates().unwrap().take(), &[RemoveChunk(ChunkIdentifier(4))]);
 
         // Remove the gap at the beginning.
-        let maybe_next = linked_chunk.remove_gap_at(ChunkIdentifier(1)).unwrap();
+        let maybe_next = linked_chunk.remove_empty_chunk_at(ChunkIdentifier(1)).unwrap();
         let next = maybe_next.unwrap();
         assert_eq!(next.chunk_identifier(), ChunkIdentifier(0));
         assert_eq!(next.index(), 0);

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -463,14 +463,8 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
     /// `Err`.
     ///
     /// The chunk containing the item represented by `position` may be empty
-    /// once the item has been removed. In this case, the chunk can be removed
-    /// if `empty_chunk_rule` contains [`EmptyChunkRule::Remove`], otherwise the
-    /// chunk is kept if `empty_chunk_rule` contains [`EmptyChunkRule::Keep`].
-    pub fn remove_item_at(
-        &mut self,
-        position: Position,
-        empty_chunk_rule: EmptyChunkRule,
-    ) -> Result<Item, Error> {
+    /// once the item has been removed. In this case, the chunk will be removed.
+    pub fn remove_item_at(&mut self, position: Position) -> Result<Item, Error> {
         let chunk_identifier = position.chunk_identifier();
         let item_index = position.index();
 
@@ -508,7 +502,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
             // If removing empty chunk is desired, and if the `chunk` can be unlinked, and
             // if the `chunk` is not the first one, we can remove it.
-            if empty_chunk_rule.remove() && can_unlink_chunk && chunk.is_first_chunk().not() {
+            if can_unlink_chunk && chunk.is_first_chunk().not() {
                 // Unlink `chunk`.
                 chunk.unlink(self.updates.as_mut());
 
@@ -1605,22 +1599,6 @@ where
     }
 }
 
-/// A type representing what to do when the system has to handle an empty chunk.
-#[derive(Debug)]
-pub enum EmptyChunkRule {
-    /// Keep the empty chunk.
-    Keep,
-
-    /// Remove the empty chunk.
-    Remove,
-}
-
-impl EmptyChunkRule {
-    fn remove(&self) -> bool {
-        matches!(self, Self::Remove)
-    }
-}
-
 /// The raw representation of a linked chunk, as persisted in storage.
 ///
 /// It may rebuilt into [`Chunk`] and shares the same internal representation,
@@ -1651,8 +1629,8 @@ mod tests {
     use assert_matches::assert_matches;
 
     use super::{
-        Chunk, ChunkContent, ChunkIdentifier, ChunkIdentifierGenerator, EmptyChunkRule, Error,
-        LinkedChunk, Position,
+        Chunk, ChunkContent, ChunkIdentifier, ChunkIdentifierGenerator, Error, LinkedChunk,
+        Position,
     };
 
     #[test]
@@ -2590,24 +2568,21 @@ mod tests {
         // that. The chunk is removed.
         {
             let position_of_f = linked_chunk.item_position(|item| *item == 'f').unwrap();
-            let removed_item =
-                linked_chunk.remove_item_at(position_of_f, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(position_of_f)?;
 
             assert_eq!(removed_item, 'f');
             assert_items_eq!(linked_chunk, ['a', 'b', 'c'] ['d', 'e'] ['g', 'h', 'i'] ['j', 'k']);
             assert_eq!(linked_chunk.num_items(), 10);
 
             let position_of_e = linked_chunk.item_position(|item| *item == 'e').unwrap();
-            let removed_item =
-                linked_chunk.remove_item_at(position_of_e, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(position_of_e)?;
 
             assert_eq!(removed_item, 'e');
             assert_items_eq!(linked_chunk, ['a', 'b', 'c'] ['d'] ['g', 'h', 'i'] ['j', 'k']);
             assert_eq!(linked_chunk.num_items(), 9);
 
             let position_of_d = linked_chunk.item_position(|item| *item == 'd').unwrap();
-            let removed_item =
-                linked_chunk.remove_item_at(position_of_d, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(position_of_d)?;
 
             assert_eq!(removed_item, 'd');
             assert_items_eq!(linked_chunk, ['a', 'b', 'c'] ['g', 'h', 'i'] ['j', 'k']);
@@ -2628,22 +2603,19 @@ mod tests {
         // that. The chunk is NOT removed because it's the first chunk.
         {
             let first_position = linked_chunk.item_position(|item| *item == 'a').unwrap();
-            let removed_item =
-                linked_chunk.remove_item_at(first_position, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
 
             assert_eq!(removed_item, 'a');
             assert_items_eq!(linked_chunk, ['b', 'c'] ['g', 'h', 'i'] ['j', 'k']);
             assert_eq!(linked_chunk.num_items(), 7);
 
-            let removed_item =
-                linked_chunk.remove_item_at(first_position, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
 
             assert_eq!(removed_item, 'b');
             assert_items_eq!(linked_chunk, ['c'] ['g', 'h', 'i'] ['j', 'k']);
             assert_eq!(linked_chunk.num_items(), 6);
 
-            let removed_item =
-                linked_chunk.remove_item_at(first_position, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
 
             assert_eq!(removed_item, 'c');
             assert_items_eq!(linked_chunk, [] ['g', 'h', 'i'] ['j', 'k']);
@@ -2663,22 +2635,19 @@ mod tests {
         // that. The chunk is removed.
         {
             let first_position = linked_chunk.item_position(|item| *item == 'g').unwrap();
-            let removed_item =
-                linked_chunk.remove_item_at(first_position, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
 
             assert_eq!(removed_item, 'g');
             assert_items_eq!(linked_chunk, [] ['h', 'i'] ['j', 'k']);
             assert_eq!(linked_chunk.num_items(), 4);
 
-            let removed_item =
-                linked_chunk.remove_item_at(first_position, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
 
             assert_eq!(removed_item, 'h');
             assert_items_eq!(linked_chunk, [] ['i'] ['j', 'k']);
             assert_eq!(linked_chunk.num_items(), 3);
 
-            let removed_item =
-                linked_chunk.remove_item_at(first_position, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
 
             assert_eq!(removed_item, 'i');
             assert_items_eq!(linked_chunk, [] ['j', 'k']);
@@ -2699,8 +2668,7 @@ mod tests {
         // The chunk is removed.
         {
             let position_of_k = linked_chunk.item_position(|item| *item == 'k').unwrap();
-            let removed_item =
-                linked_chunk.remove_item_at(position_of_k, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(position_of_k)?;
 
             assert_eq!(removed_item, 'k');
             #[rustfmt::skip]
@@ -2708,8 +2676,7 @@ mod tests {
             assert_eq!(linked_chunk.num_items(), 1);
 
             let position_of_j = linked_chunk.item_position(|item| *item == 'j').unwrap();
-            let removed_item =
-                linked_chunk.remove_item_at(position_of_j, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(position_of_j)?;
 
             assert_eq!(removed_item, 'j');
             assert_items_eq!(linked_chunk, []);
@@ -2743,31 +2710,27 @@ mod tests {
             let _ = linked_chunk.updates().unwrap().take();
 
             let position_of_c = linked_chunk.item_position(|item| *item == 'c').unwrap();
-            let removed_item =
-                linked_chunk.remove_item_at(position_of_c, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(position_of_c)?;
 
             assert_eq!(removed_item, 'c');
             assert_items_eq!(linked_chunk, ['a', 'b'] [-] ['d']);
             assert_eq!(linked_chunk.num_items(), 3);
 
             let position_of_d = linked_chunk.item_position(|item| *item == 'd').unwrap();
-            let removed_item =
-                linked_chunk.remove_item_at(position_of_d, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(position_of_d)?;
 
             assert_eq!(removed_item, 'd');
             assert_items_eq!(linked_chunk, ['a', 'b'] [-]);
             assert_eq!(linked_chunk.num_items(), 2);
 
             let first_position = linked_chunk.item_position(|item| *item == 'a').unwrap();
-            let removed_item =
-                linked_chunk.remove_item_at(first_position, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
 
             assert_eq!(removed_item, 'a');
             assert_items_eq!(linked_chunk, ['b'] [-]);
             assert_eq!(linked_chunk.num_items(), 1);
 
-            let removed_item =
-                linked_chunk.remove_item_at(first_position, EmptyChunkRule::Remove)?;
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
 
             assert_eq!(removed_item, 'b');
             assert_items_eq!(linked_chunk, [] [-]);
@@ -2780,114 +2743,6 @@ mod tests {
                     RemoveChunk(ChunkIdentifier(6)),
                     RemoveItem { at: Position(ChunkIdentifier(4), 0) },
                     RemoveChunk(ChunkIdentifier(4)),
-                    RemoveItem { at: Position(ChunkIdentifier(0), 0) },
-                    RemoveItem { at: Position(ChunkIdentifier(0), 0) },
-                ]
-            );
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_remove_item_at_and_keep_empty_chunks() -> Result<(), Error> {
-        use super::Update::*;
-
-        let mut linked_chunk = LinkedChunk::<3, char, ()>::new_with_update_history();
-
-        // Ignore initial update.
-        let _ = linked_chunk.updates().unwrap().take();
-
-        linked_chunk.push_items_back(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']);
-        assert_items_eq!(linked_chunk, ['a', 'b', 'c'] ['d', 'e', 'f'] ['g', 'h']);
-        assert_eq!(linked_chunk.num_items(), 8);
-
-        // Ignore previous updates.
-        let _ = linked_chunk.updates().unwrap().take();
-
-        // Remove all items from the same chunk. The chunk is empty after that. The
-        // chunk is NOT removed because we asked to keep it.
-        {
-            let position = linked_chunk.item_position(|item| *item == 'd').unwrap();
-            let removed_item = linked_chunk.remove_item_at(position, EmptyChunkRule::Keep)?;
-
-            assert_eq!(removed_item, 'd');
-            assert_items_eq!(linked_chunk, ['a', 'b', 'c'] ['e', 'f'] ['g', 'h']);
-            assert_eq!(linked_chunk.num_items(), 7);
-
-            let removed_item = linked_chunk.remove_item_at(position, EmptyChunkRule::Keep)?;
-
-            assert_eq!(removed_item, 'e');
-            assert_items_eq!(linked_chunk, ['a', 'b', 'c'] ['f'] ['g', 'h']);
-            assert_eq!(linked_chunk.num_items(), 6);
-
-            let removed_item = linked_chunk.remove_item_at(position, EmptyChunkRule::Keep)?;
-
-            assert_eq!(removed_item, 'f');
-            assert_items_eq!(linked_chunk, ['a', 'b', 'c'] [] ['g', 'h']);
-            assert_eq!(linked_chunk.num_items(), 5);
-
-            assert_eq!(
-                linked_chunk.updates().unwrap().take(),
-                &[
-                    RemoveItem { at: Position(ChunkIdentifier(1), 0) },
-                    RemoveItem { at: Position(ChunkIdentifier(1), 0) },
-                    RemoveItem { at: Position(ChunkIdentifier(1), 0) },
-                ]
-            );
-        }
-
-        // Remove all items from the same chunk. The chunk is empty after that. The
-        // chunk is NOT removed because we asked to keep it.
-        {
-            let position = linked_chunk.item_position(|item| *item == 'g').unwrap();
-            let removed_item = linked_chunk.remove_item_at(position, EmptyChunkRule::Keep)?;
-
-            assert_eq!(removed_item, 'g');
-            assert_items_eq!(linked_chunk, ['a', 'b', 'c'] [] ['h']);
-            assert_eq!(linked_chunk.num_items(), 4);
-
-            let removed_item = linked_chunk.remove_item_at(position, EmptyChunkRule::Keep)?;
-
-            assert_eq!(removed_item, 'h');
-            assert_items_eq!(linked_chunk, ['a', 'b', 'c'] [] []);
-            assert_eq!(linked_chunk.num_items(), 3);
-
-            assert_eq!(
-                linked_chunk.updates().unwrap().take(),
-                &[
-                    RemoveItem { at: Position(ChunkIdentifier(2), 0) },
-                    RemoveItem { at: Position(ChunkIdentifier(2), 0) },
-                ]
-            );
-        }
-
-        // Remove all items from the same chunk. The chunk is empty after that. The
-        // chunk is NOT removed because we asked to keep it.
-        {
-            let position = linked_chunk.item_position(|item| *item == 'a').unwrap();
-            let removed_item = linked_chunk.remove_item_at(position, EmptyChunkRule::Keep)?;
-
-            assert_eq!(removed_item, 'a');
-            assert_items_eq!(linked_chunk, ['b', 'c'] [] []);
-            assert_eq!(linked_chunk.num_items(), 2);
-
-            let removed_item = linked_chunk.remove_item_at(position, EmptyChunkRule::Keep)?;
-
-            assert_eq!(removed_item, 'b');
-            assert_items_eq!(linked_chunk, ['c'] [] []);
-            assert_eq!(linked_chunk.num_items(), 1);
-
-            let removed_item = linked_chunk.remove_item_at(position, EmptyChunkRule::Keep)?;
-
-            assert_eq!(removed_item, 'c');
-            assert_items_eq!(linked_chunk, [] [] []);
-            assert_eq!(linked_chunk.num_items(), 0);
-
-            assert_eq!(
-                linked_chunk.updates().unwrap().take(),
-                &[
-                    RemoveItem { at: Position(ChunkIdentifier(0), 0) },
                     RemoveItem { at: Position(ChunkIdentifier(0), 0) },
                     RemoveItem { at: Position(ChunkIdentifier(0), 0) },
                 ]

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -344,7 +344,7 @@ impl RoomPagination {
                     // All the events were duplicated; don't act upon them, and only remove the
                     // prior gap that we just filled.
                     trace!("removing previous gap, as all events have been deduplicated");
-                    room_events.remove_gap_at(gap_id).expect("gap identifier is a valid gap chunk id we read previously")
+                    room_events.remove_empty_chunk_at(gap_id).expect("gap identifier is a valid gap chunk id we read previously")
                 } else {
                     trace!("replacing previous gap with the back-paginated events");
 

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -219,12 +219,17 @@ impl RoomEvents {
         self.chunks.insert_gap_at(gap, position)
     }
 
-    /// Remove a gap at the given position.
+    /// Remove an empty chunk at the given position.
     ///
-    /// Returns the next insert position, if any, left after the gap that has
+    /// Note: the chunk must either be a gap, or an empty items chunk.
+    ///
+    /// Returns the next insert position, if any, left after the chunk that has
     /// just been removed.
-    pub fn remove_gap_at(&mut self, gap: ChunkIdentifier) -> Result<Option<Position>, Error> {
-        self.chunks.remove_gap_at(gap)
+    pub fn remove_empty_chunk_at(
+        &mut self,
+        gap: ChunkIdentifier,
+    ) -> Result<Option<Position>, Error> {
+        self.chunks.remove_empty_chunk_at(gap)
     }
 
     /// Replace the gap identified by `gap_identifier`, by events.
@@ -242,7 +247,7 @@ impl RoomEvents {
         let next_pos = if events.is_empty() {
             // There are no new events, so there's no need to create a new empty items
             // chunk; instead, remove the gap.
-            self.chunks.remove_gap_at(gap_identifier)?
+            self.chunks.remove_empty_chunk_at(gap_identifier)?
         } else {
             // Replace the gap by new events.
             Some(self.chunks.replace_gap_at(events, gap_identifier)?.first_position())

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -23,8 +23,8 @@ use matrix_sdk_base::{
     },
 };
 use matrix_sdk_common::linked_chunk::{
-    AsVector, Chunk, ChunkIdentifier, EmptyChunkRule, Error, Iter, IterBackward, LinkedChunk,
-    ObservableUpdates, Position,
+    AsVector, Chunk, ChunkIdentifier, Error, Iter, IterBackward, LinkedChunk, ObservableUpdates,
+    Position,
 };
 use ruma::{
     events::{room::redaction::SyncRoomRedactionEvent, AnySyncTimelineEvent, MessageLikeEventType},
@@ -263,11 +263,7 @@ impl RoomEvents {
         sort_positions_descending(&mut positions);
 
         for position in positions {
-            self.chunks.remove_item_at(
-                position,
-                // If removing an event results in an empty chunk, the empty chunk is removed.
-                EmptyChunkRule::Remove,
-            )?;
+            self.chunks.remove_item_at(position)?;
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -29,6 +29,7 @@ use eyeball::SharedObservable;
 use eyeball_im::VectorDiff;
 use matrix_sdk_base::{
     deserialized_responses::{AmbiguityChange, TimelineEvent},
+    linked_chunk::ChunkContent,
     sync::{JoinedRoomUpdate, LeftRoomUpdate, Timeline},
 };
 use ruma::{
@@ -555,7 +556,25 @@ impl RoomEventCacheInner {
                     // time we sync'd).
                     if !all_duplicates {
                         if let Some(prev_token) = &prev_batch {
+                            // As a tiny optimization: remove the last chunk if it's an empty event
+                            // one, as it's not useful to keep it before a gap.
+                            let prev_chunk_to_remove =
+                                room_events.rchunks().next().and_then(|chunk| {
+                                    match chunk.content() {
+                                        ChunkContent::Items(events) if events.is_empty() => {
+                                            Some(chunk.identifier())
+                                        }
+                                        _ => None,
+                                    }
+                                });
+
                             room_events.push_gap(Gap { prev_token: prev_token.clone() });
+
+                            if let Some(prev_chunk_to_remove) = prev_chunk_to_remove {
+                                room_events.remove_empty_chunk_at(prev_chunk_to_remove).expect(
+                                    "we just checked the chunk is there, and an empty item chunk",
+                                );
+                            }
                         }
                     }
 
@@ -1525,16 +1544,11 @@ mod tests {
                 .unwrap()
                 .unwrap();
 
-        assert_eq!(linked_chunk.chunks().count(), 3);
+        assert_eq!(linked_chunk.chunks().count(), 2);
 
         let mut chunks = linked_chunk.chunks();
 
-        // Invariant: there's always an empty items chunk at the beginning.
-        assert_matches!(chunks.next().unwrap().content(), ChunkContent::Items(events) => {
-            assert_eq!(events.len(), 0)
-        });
-
-        // Then we have the gap.
+        // We start with the gap.
         assert_matches!(chunks.next().unwrap().content(), ChunkContent::Gap(gap) => {
             assert_eq!(gap.prev_token, "raclette");
         });

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -1256,14 +1256,8 @@ async fn test_no_gap_stored_after_deduplicated_sync() {
     // only contains the events returned by the sync.
     //
     // The first back-pagination will hit the network, and let us know we've reached
-    // the end of the room, but! we do have the default initial events chunk in
-    // storage.
+    // the end of the room.
 
-    let outcome = pagination.run_backwards_once(20).await.unwrap();
-    assert!(outcome.reached_start.not());
-    assert!(outcome.events.is_empty());
-
-    // Loading the default initial event chunk.
     let outcome = pagination.run_backwards_once(20).await.unwrap();
     assert!(outcome.reached_start);
     assert!(outcome.events.is_empty());
@@ -1403,13 +1397,6 @@ async fn test_no_gap_stored_after_deduplicated_backpagination() {
     assert!(outcome.events.is_empty());
     assert!(stream.is_empty());
 
-    // Next, we lazy-load a next chunk from the store, and get the initial, empty
-    // default events chunk.
-    let outcome = pagination.run_backwards_once(20).await.unwrap();
-    assert!(outcome.reached_start.not());
-    assert!(outcome.events.is_empty());
-    assert!(stream.is_empty());
-
     // For prev-batch, the back-pagination returns two events we already know, and a
     // previous batch token.
     server
@@ -1427,7 +1414,7 @@ async fn test_no_gap_stored_after_deduplicated_backpagination() {
     // Run pagination a second time: it will consume prev-batch, which is the least
     // recent token.
     let outcome = pagination.run_backwards_once(20).await.unwrap();
-    assert!(outcome.reached_start.not());
+    assert!(outcome.reached_start);
     assert!(outcome.events.is_empty());
     assert!(stream.is_empty());
 
@@ -1435,12 +1422,6 @@ async fn test_no_gap_stored_after_deduplicated_backpagination() {
     // that case, it means we stored the gap with the prev-batch3 token, while
     // we shouldn't have to, since it is useless; all events were deduplicated
     // from the previous pagination.
-
-    // Instead, we're lazy-loading the empty initial events chunks.
-    let outcome = pagination.run_backwards_once(20).await.unwrap();
-    assert!(outcome.reached_start);
-    assert!(outcome.events.is_empty());
-    assert!(stream.is_empty());
 
     let (events, stream) = room_event_cache.subscribe().await;
     assert_event_matches_msg(&events[0], "hello");


### PR DESCRIPTION
Small optimization: when we have an empty events chunk, and we're about to push a gap, remove the empty events chunk. It's the same code as for removing a gap chunk, so not much new code is introduced in the linked chunk code (nice!). This makes back-pagination indicate we've reached the start of the timeline quicker, because now they don't have to load an initial empty chunk.

Also, get rid of `EmptyChunkRule`, as it was always set to `::Remove` in the code, and only set to `::Keep` in tests. In the worst case where we'd find that having `::Keep` is useful, we can still revert the commit individually in the future.

Part of #3280.