### PR TITLE
chore(sdk): Increase log level and log all updates

### DIFF
--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1102,9 +1102,9 @@ mod private {
             spawn(async move {
                 let store = store.lock().await?;
 
-                trace!("applying {} updates", updates.len());
+                trace!(?updates, "sending linked chunk updates to the store");
                 store.handle_linked_chunk_updates(&room_id, updates).await?;
-                trace!("done applying store changes");
+                trace!("linked chunk updates applied");
 
                 super::Result::Ok(())
             })


### PR DESCRIPTION
This patch helps to trace updates that are sent from the event cache to its store. It is central to sync or pagination.