### PR TITLE
fix(sqlite): `SqliteEventCacheStore` is 35 times faster

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -30,6 +30,10 @@ name = "crypto_bench"
 harness = false
 
 [[bench]]
+name = "linked_chunk"
+harness = false
+
+[[bench]]
 name = "store_bench"
 harness = false
 

--- a/benchmarks/benches/linked_chunk.rs
+++ b/benchmarks/benches/linked_chunk.rs
@@ -1,0 +1,156 @@
+use std::{sync::Arc, time::Duration};
+
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use matrix_sdk::{
+    linked_chunk::{LinkedChunk, Update},
+    SqliteEventCacheStore,
+};
+use matrix_sdk_base::event_cache::{
+    store::{DynEventCacheStore, IntoEventCacheStore, MemoryStore, DEFAULT_CHUNK_CAPACITY},
+    Event, Gap,
+};
+use matrix_sdk_test::{event_factory::EventFactory, ALICE};
+use ruma::{room_id, EventId};
+use tempfile::tempdir;
+use tokio::runtime::Builder;
+
+#[derive(Clone, Debug)]
+enum Operation {
+    PushItemsBack(Vec<Event>),
+    PushGapBack(Gap),
+}
+
+pub fn writing(c: &mut Criterion) {
+    // Create a new asynchronous runtime.
+    let runtime = Builder::new_multi_thread()
+        .enable_time()
+        .enable_io()
+        .build()
+        .expect("Failed to create an asynchronous runtime");
+
+    let room_id = room_id!("!foo:bar.baz");
+    let event_factory = EventFactory::new().room(room_id).sender(&ALICE);
+
+    let mut group = c.benchmark_group("writing");
+    group.sample_size(10).measurement_time(Duration::from_secs(30));
+
+    for number_of_events in [10, 100, 1000, 10_000, 100_000] {
+        let sqlite_temp_dir = tempdir().unwrap();
+
+        // Declare new stores for this set of events.
+        let stores: [(&str, Option<Arc<DynEventCacheStore>>); 3] = [
+            ("none", None),
+            ("memory store", Some(MemoryStore::default().into_event_cache_store())),
+            (
+                "sqlite store",
+                runtime.block_on(async {
+                    Some(
+                        SqliteEventCacheStore::open(sqlite_temp_dir.path().join("bench"), None)
+                            .await
+                            .unwrap()
+                            .into_event_cache_store(),
+                    )
+                }),
+            ),
+        ];
+
+        for (store_name, store) in stores {
+            // Create the operations we want to bench.
+            let mut operations = Vec::new();
+
+            {
+                let mut events = (0..number_of_events)
+                    .map(|nth| {
+                        event_factory
+                            .text_msg("foo")
+                            .event_id(&EventId::parse(format!("$ev{nth}")).unwrap())
+                            .into_event()
+                    })
+                    .peekable();
+
+                let mut gap_nth = 0;
+
+                while events.peek().is_some() {
+                    {
+                        let events_to_push_back = events.by_ref().take(80).collect::<Vec<_>>();
+
+                        if events_to_push_back.is_empty() {
+                            break;
+                        }
+
+                        operations.push(Operation::PushItemsBack(events_to_push_back));
+                    }
+
+                    {
+                        operations.push(Operation::PushGapBack(Gap {
+                            prev_token: format!("gap{gap_nth}"),
+                        }));
+                        gap_nth += 1;
+                    }
+                }
+            }
+
+            // Define the throughput.
+            group.throughput(Throughput::Elements(number_of_events));
+
+            // Get a bencher.
+            group.bench_with_input(
+                BenchmarkId::new(store_name, number_of_events),
+                &operations,
+                |bencher, operations| {
+                    // Bench the routine.
+                    bencher.to_async(&runtime).iter_batched(
+                        || operations.clone(),
+                        |operations| async {
+                            // The routine to bench!
+
+                            let mut linked_chunk = LinkedChunk::<DEFAULT_CHUNK_CAPACITY, Event, Gap>::new_with_update_history();
+
+                            for operation in operations {
+                                match operation {
+                                    Operation::PushItemsBack(events) => linked_chunk.push_items_back(events),
+                                    Operation::PushGapBack(gap) => linked_chunk.push_gap_back(gap),
+                                }
+                            }
+
+                            if let Some(store) = &store {
+                                let updates = linked_chunk.updates().unwrap().take();
+                                store.handle_linked_chunk_updates(room_id, updates).await.unwrap();
+                                // Empty the store.
+                                store.handle_linked_chunk_updates(room_id, vec![Update::Clear]).await.unwrap();
+                            }
+
+                        },
+                        BatchSize::SmallInput
+                    )
+                },
+            );
+
+            {
+                let _guard = runtime.enter();
+                drop(store);
+            }
+        }
+    }
+
+    group.finish()
+}
+
+fn criterion() -> Criterion {
+    #[cfg(target_os = "linux")]
+    let criterion = Criterion::default().with_profiler(pprof::criterion::PProfProfiler::new(
+        100,
+        pprof::criterion::Output::Flamegraph(None),
+    ));
+    #[cfg(not(target_os = "linux"))]
+    let criterion = Criterion::default();
+
+    criterion
+}
+
+criterion_group! {
+    name = event_cache;
+    config = criterion();
+    targets = writing,
+}
+criterion_main!(event_cache);

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/006_events.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/006_events.sql
@@ -1,0 +1,69 @@
+DROP INDEX "linked_chunks_id_and_room_id";
+DROP INDEX "linked_chunks_event_id_and_room_id";
+DROP TABLE "events";
+DROP TABLE "gaps";
+DROP TABLE "linked_chunks";
+
+CREATE TABLE "linked_chunks" (
+    -- Which room does this chunk belong to? (hashed key shared with the two other tables)
+    "room_id" BLOB NOT NULL,
+    -- Identifier of the chunk, unique per room. Corresponds to a `ChunkIdentifier`.
+    "id" INTEGER NOT NULL,
+
+    -- Previous chunk in the linked list. Corresponds to a `ChunkIdentifier`.
+    "previous" INTEGER,
+    -- Next chunk in the linked list. Corresponds to a `ChunkIdentifier`.
+    "next" INTEGER,
+    -- Type of underlying entries: E for events, G for gaps
+    "type" TEXT CHECK("type" IN ('E', 'G')) NOT NULL,
+
+    -- Primary key is composed of the room ID and the chunk identifier.
+    -- Such pairs must be unique.
+    PRIMARY KEY (room_id, id)
+)
+WITHOUT ROWID;
+
+CREATE TABLE "gaps" (
+    -- Which room does this event belong to? (hashed key shared with linked_chunks)
+    "room_id" BLOB NOT NULL,
+    -- Which chunk does this gap refer to? Corresponds to a `ChunkIdentifier`.
+    "chunk_id" INTEGER NOT NULL,
+
+    -- The previous batch token of a gap (encrypted value).
+    "prev_token" BLOB NOT NULL,
+
+    -- Primary key is composed of the room ID and the chunk identifier.
+    -- Such pairs must be unique.
+    PRIMARY KEY (room_id, chunk_id),
+
+    -- If the owning chunk gets deleted, delete the entry too.
+    FOREIGN KEY (chunk_id, room_id) REFERENCES linked_chunks(id, room_id) ON DELETE CASCADE
+)
+WITHOUT ROWID;
+
+-- Items for an event chunk.
+CREATE TABLE "events" (
+    -- Which room does this event belong to? (hashed key shared with linked_chunks)
+    "room_id" BLOB NOT NULL,
+    -- Which chunk does this event refer to? Corresponds to a `ChunkIdentifier`.
+    "chunk_id" INTEGER NOT NULL,
+
+    -- `OwnedEventId` for events.
+    "event_id" BLOB NOT NULL,
+    -- JSON serialized `TimelineEvent` (encrypted value).
+    "content" BLOB NOT NULL,
+    -- Position (index) in the chunk.
+    "position" INTEGER NOT NULL,
+
+    -- Primary key is the event ID.
+    PRIMARY KEY (event_id),
+
+    -- We need a uniqueness constraint over the `room_id`, `chunk_id` and
+    -- `position` tuple because (i) they must be unique, (ii) it dramatically
+    -- improves the performance.
+    UNIQUE (room_id, chunk_id, position),
+
+    -- If the owning chunk gets deleted, delete the entry too.
+    FOREIGN KEY (room_id, chunk_id) REFERENCES linked_chunks(room_id, id) ON DELETE CASCADE
+)
+WITHOUT ROWID;


### PR DESCRIPTION
This patch adds a benchmark for the `LinkedChunk` with the following matrix:

* Handling 10, 100, 1_000, 10_000 and 100_000 events,
* With no store, with the `MemoryStore`, with the `SqliteEventCacheStore`.

Before this patch, the case with no store and `MemoryStore` were not a blocker. I was surprisingly delighted to see that the `LinkedChunk` is able to handle a throughput of 9.3 millions events per second. With the `MemoryStore`, it drops at 4.5 millions events per second, not bad for a test-tailored store. However, for `SqliteEventCacheStore`, the story was clearly different… **7_300 events per second**, only. And it got worst with more events.

![Screenshot 2025-02-28 at 13 42 48](https://github.com/user-attachments/assets/f666e453-141e-4035-8517-26dcc1609f24)

I dug into this for 2 days, and found several things.

In the future we can improve the benchmark to test more operations, but I wanted to solve the performance issue first.

## Prepared statements for `Update::PushNewItems`

This is addressed as a standalone patch. I've replaced a `query()` in a loop by a `prepare()` outside the loop, then an `execute()` inside the loop.

Guess what? It barely improved the situation. I've reached **8_400 events per second**. Not really the improvement I was expecting. However, the performance was now linear with the number of events. Before that, it was totally unpredictable. That's a first step.

I've tried to use a bulk insertion to avoid to call `execute()` in a loop. A single `prepare()` + a single `execute()` like so:

```sql
INSERT INTO events VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?), …
```

Absolutely zero difference. Well. Time not well-spent on this one, but it was worth the try.

## Remove all tables: time for a new schema

The tables were fine but none of them contained primary keys. I hoped it could solve things. Sadly, [`ALTER TABLE`](https://sqlite.org/lang_altertable.html) doesn't allow to change the schema of tables, only a bit of renamings, and column changes.

The solution is to remove all indexes and all tables, and to recreate them. Same table names, same column names, but different semantics:

* `linked_chunks` has a primary key over `room_id` and `id` (the chunk identifier), this pair is necessarily unique (this uniqueness constraint was missing before),
* `gaps` has a primary key over `room_id` and `chunk_id`, same reason,
* `events` has a primary key composed of `room_id`, `chunk_id` and `position`. Again, this tuple is necessarily unique, and this constraint was missing. The uniqueness on `event_id` has been added in https://github.com/matrix-org/matrix-rust-sdk/pull/4685.

Why `events` cannot use `event_id` as its primary key? Because an `event_id` can be null if the event is invalid. After all, it's allowed in SQLite (because it was a bug in the past, buggy behaviours are kept).

> [!NOTE]
> Why an invalid event is stored in the database? It's still a mystery to me.
> cc @bnjbvr 

With this new schema, things have improved a bit. **14_000 events per second**, better!

## `WITHOUT ROWID`

Please read [Clustered Indexes and the `WITHOUT ROWID` Optimization](https://www.sqlite.org/withoutrowid.html).

In addition to the new schema, the 3 tables are marked as `WITHOUT ROWID`. It has dramatically improved the performance. We are reaching **178_000 events per second**!

I lied a bit in the previous section. At first, the primary key for `events` was `event_id`, and it did improved the performance, but `WITHOUT ROWID` expects the primary key to _NOT_ be null. So I had to find another unique key, hence the tuple `room_id`, `chunk_id` and `position`. And this whole re-designed was with `WITHOUT ROWID` in mind, but it's the result of several tries and failures.

## Restore the index over `events`

Finally, in the new schema, I re-create the index for `events.room_id` and `events.event_id`. And we are finally reaching **260_000 events per second**!!

## Results for 100_000 events

_(These results are a bit different because, at the time of publishing these patches, I re-run them on my laptop running on a low battery. The orders are the same though.)_

### No store

<img width="960" alt="Screenshot 2025-02-28 at 18 34 05" src="https://github.com/user-attachments/assets/74cea1e6-a6ea-4101-b058-eb3ffc66e34b" />

|            | Lower bound    | Estimate       | Upper bound    |
|------------|----------------|----------------|----------------|
| Slope      | 13.641 ms      | 15.264 ms      | 16.948 ms      |
| Throughput | 5.9003 Melem/s | 6.5513 Melem/s | 7.3308 Melem/s |
| R²         | 0.6328193      | 0.7358459      | 0.6261084      |
| Mean       | 13.285 ms      | 14.181 ms      | 15.422 ms      |
| Std. Dev.  | 548.23 µs      | 1.8684 ms      | 2.7520 ms      |
| Median     | 13.077 ms      | 13.206 ms      | 14.839 ms      |
| MAD        | 42.535 µs      | 299.56 µs      | 2.2939 ms      |

### `MemoryStore`

<img width="965" alt="Screenshot 2025-02-28 at 18 34 14" src="https://github.com/user-attachments/assets/f109e23e-4022-4f68-8e06-8f9bab61374b" />

|            | Lower bound    | Estimate       | Upper bound    |
|------------|----------------|----------------|----------------|
| Slope      | 32.587 ms      | 33.022 ms      | 33.414 ms      |
| Throughput | 2.9928 Melem/s | 3.0283 Melem/s | 3.0687 Melem/s |
| R²         | 0.9932222      | 0.9961436      | 0.9937653      |
| Mean       | 32.545 ms      | 32.748 ms      | 33.022 ms      |
| Std. Dev.  | 102.11 µs      | 417.19 µs      | 600.38 µs      |
| Median     | 32.490 ms      | 32.601 ms      | 32.891 ms      |
| MAD        | 50.689 µs      | 166.82 µs      | 458.06 µs      |

### `SqliteEventCacheStore`

<img width="973" alt="Screenshot 2025-02-28 at 18 34 21" src="https://github.com/user-attachments/assets/e858fa11-55a2-459d-803a-5b8baec44ebd" />

|            | Lower bound    | Estimate       | Upper bound    |
|------------|----------------|----------------|----------------|
| Slope      | 403.39 ms      | 403.88 ms      | 404.57 ms      |
| Throughput | 247.17 Kelem/s | 247.60 Kelem/s | 247.90 Kelem/s |
| R²         | 0.9998947      | 0.9999231      | 0.9998668      |
| Mean       | 403.77 ms      | 404.39 ms      | 405.02 ms      |
| Std. Dev.  | 643.36 µs      | 1.0718 ms      | 1.2887 ms      |
| Median     | 403.47 ms      | 404.15 ms      | 405.54 ms      |
| MAD        | 205.61 µs      | 1.3011 ms      | 1.8636 ms      |

## Cons

Migrating from version 5 to 6 will erase all existing caches. I consider it's okay since (i) it's a cache, (ii) it's not released yet.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280