### PR TITLE
fix(sdk): `maybe_apply_new_redaction` updates in-store events

### DIFF
--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -717,13 +717,6 @@ impl EventCacheInner {
                 let pagination_status =
                     SharedObservable::new(RoomPaginationStatus::Idle { hit_timeline_start: false });
 
-                let room_state = RoomEventCacheState::new(
-                    room_id.to_owned(),
-                    self.store.clone(),
-                    pagination_status.clone(),
-                )
-                .await?;
-
                 let room_version = self
                     .client
                     .get()
@@ -734,6 +727,14 @@ impl EventCacheInner {
                         warn!("unknown room version for {room_id}, using default V1");
                         RoomVersionId::V1
                     });
+
+                let room_state = RoomEventCacheState::new(
+                    room_id.to_owned(),
+                    room_version,
+                    self.store.clone(),
+                    pagination_status.clone(),
+                )
+                .await?;
 
                 // SAFETY: we must have subscribed before reaching this coed, otherwise
                 // something is very wrong.
@@ -747,7 +748,6 @@ impl EventCacheInner {
                     room_state,
                     pagination_status,
                     room_id.to_owned(),
-                    room_version,
                     self.all_events.clone(),
                     auto_shrink_sender,
                 );

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -27,9 +27,7 @@ use tracing::{debug, instrument, trace};
 
 use super::{
     deduplicator::DeduplicationOutcome,
-    room::{
-        events::Gap, EventsPostProcessing, LoadMoreEventsBackwardsOutcome, RoomEventCacheInner,
-    },
+    room::{events::Gap, LoadMoreEventsBackwardsOutcome, RoomEventCacheInner},
     BackPaginationOutcome, EventsOrigin, Result, RoomEventCacheState, RoomEventCacheUpdate,
 };
 use crate::{event_cache::EventCacheError, room::MessagesOptions};
@@ -419,7 +417,7 @@ impl RoomPagination {
                 debug!("not storing previous batch token, because we deduplicated all new back-paginated events");
             }
 
-            EventsPostProcessing::HaveBeenInserted(reversed_events)
+            reversed_events
         })
         .await?;
 

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -27,7 +27,9 @@ use tracing::{debug, instrument, trace};
 
 use super::{
     deduplicator::DeduplicationOutcome,
-    room::{events::Gap, LoadMoreEventsBackwardsOutcome, RoomEventCacheInner},
+    room::{
+        events::Gap, EventsPostProcessing, LoadMoreEventsBackwardsOutcome, RoomEventCacheInner,
+    },
     BackPaginationOutcome, EventsOrigin, Result, RoomEventCacheState, RoomEventCacheUpdate,
 };
 use crate::{event_cache::EventCacheError, room::MessagesOptions};
@@ -417,7 +419,7 @@ impl RoomPagination {
                 debug!("not storing previous batch token, because we deduplicated all new back-paginated events");
             }
 
-            room_events.on_new_events(&self.inner.room_version, reversed_events.iter());
+            EventsPostProcessing::HaveBeenInserted(reversed_events)
         })
         .await?;
 

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -102,7 +102,11 @@ impl RoomEvents {
     /// If the given event is a redaction, try to retrieve the to-be-redacted
     /// event in the chunk, and replace it by the redacted form.
     #[instrument(skip_all)]
-    fn maybe_apply_new_redaction(&mut self, room_version: &RoomVersionId, event: &Event) {
+    pub(super) fn maybe_apply_new_redaction(
+        &mut self,
+        room_version: &RoomVersionId,
+        event: &Event,
+    ) {
         let raw_event = event.raw();
 
         // Do not deserialise the entire event if we aren't certain it's a
@@ -176,17 +180,6 @@ impl RoomEvents {
         }
 
         // TODO: remove all related events too!
-    }
-
-    /// Callback to call whenever we touch events in the database.
-    pub fn on_new_events<'a>(
-        &mut self,
-        room_version: &RoomVersionId,
-        events: impl Iterator<Item = &'a Event>,
-    ) {
-        for ev in events {
-            self.maybe_apply_new_redaction(room_version, ev);
-        }
     }
 
     /// Push events after all events or gaps.

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1356,13 +1356,21 @@ mod private {
     }
 }
 
+/// Output of the callback passed to `RoomEventCacheState::with_events_mut`.
 pub(super) enum EventsPostProcessing {
+    /// Trigger the post-processing when new events have been inserted.
     HaveBeenInserted(Vec<TimelineEvent>),
+
+    /// No post-processing.
     None,
 }
 
+/// An enum representing where an event has been found.
 pub(super) enum EventLocation {
+    /// Event lives in memory (and likely in the store!).
     Memory,
+
+    /// Event lives in the store only, it has not been loaded in memory yet.
     Store,
 }
 

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1214,9 +1214,8 @@ mod private {
         /// Gives a temporary mutable handle to the underlying in-memory events,
         /// and will propagate changes to the storage once done.
         ///
-        /// Returns the output of the given callback, as well as updates to the
-        /// linked chunk, as vector diff, so the caller may propagate
-        /// such updates, if needs be.
+        /// Returns the updates to the linked chunk, as vector diffs, so the
+        /// caller may propagate such updates, if needs be.
         #[must_use = "Updates as `VectorDiff` must probably be propagated via `RoomEventCacheUpdate`"]
         pub async fn with_events_mut<F: FnOnce(&mut RoomEvents)>(
             &mut self,

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -196,7 +196,7 @@ impl RoomEventCache {
         };
 
         // Search in `AllEventsCache` for known events that are not stored.
-        if let Some(event) = maybe_position_and_event.map(|(_position, event)| event) {
+        if let Some(event) = maybe_position_and_event.map(|(_location, _position, event)| event) {
             Some(event)
         } else if let Some((room_id, event)) =
             self.inner.all_events.read().await.events.get(event_id).cloned()
@@ -676,7 +676,8 @@ mod private {
             EventCacheError,
         },
         events::RoomEvents,
-        sort_positions_descending, EventsPostProcessing, LoadMoreEventsBackwardsOutcome,
+        sort_positions_descending, EventLocation, EventsPostProcessing,
+        LoadMoreEventsBackwardsOutcome,
     };
     use crate::event_cache::RoomPaginationStatus;
 
@@ -1196,14 +1197,14 @@ mod private {
         pub async fn find_event(
             &self,
             event_id: &EventId,
-        ) -> Result<Option<(Position, TimelineEvent)>, EventCacheError> {
+        ) -> Result<Option<(EventLocation, Position, TimelineEvent)>, EventCacheError> {
             let room_id = self.room.as_ref();
 
             // There are supposedly fewer events loaded in memory than in the store. Let's
             // start by looking up in the `RoomEvents`.
             for (position, event) in self.events().revents() {
                 if event.event_id().as_deref() == Some(event_id) {
-                    return Ok(Some((position, event.clone())));
+                    return Ok(Some((EventLocation::Memory, position, event.clone())));
                 }
             }
 
@@ -1214,7 +1215,10 @@ mod private {
 
             let store = store.lock().await?;
 
-            Ok(store.find_event(room_id, event_id).await?)
+            Ok(store
+                .find_event(room_id, event_id)
+                .await?
+                .map(|(position, event)| (EventLocation::Store, position, event)))
         }
 
         /// Gives a temporary mutable handle to the underlying in-memory events,
@@ -1345,6 +1349,11 @@ mod private {
 pub(super) enum EventsPostProcessing {
     HaveBeenInserted(Vec<TimelineEvent>),
     None,
+}
+
+pub(super) enum EventLocation {
+    Memory,
+    Store,
 }
 
 pub(super) use private::RoomEventCacheState;

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -34,7 +34,7 @@ use matrix_sdk_base::{
 use ruma::{
     events::{relation::RelationType, AnyRoomAccountDataEvent, AnySyncEphemeralRoomEvent},
     serde::Raw,
-    EventId, OwnedEventId, OwnedRoomId, RoomVersionId,
+    EventId, OwnedEventId, OwnedRoomId,
 };
 use tokio::sync::{
     broadcast::{Receiver, Sender},
@@ -144,7 +144,6 @@ impl RoomEventCache {
         state: RoomEventCacheState,
         pagination_status: SharedObservable<RoomPaginationStatus>,
         room_id: OwnedRoomId,
-        room_version: RoomVersionId,
         all_events_cache: Arc<RwLock<AllEventsCache>>,
         auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
     ) -> Self {
@@ -154,7 +153,6 @@ impl RoomEventCache {
                 state,
                 pagination_status,
                 room_id,
-                room_version,
                 all_events_cache,
                 auto_shrink_sender,
             )),
@@ -295,9 +293,6 @@ pub(super) struct RoomEventCacheInner {
 
     pub weak_room: WeakRoom,
 
-    /// The room version for this room.
-    pub room_version: RoomVersionId,
-
     /// Sender part for subscribers to this room.
     pub sender: Sender<RoomEventCacheUpdate>,
 
@@ -330,7 +325,6 @@ impl RoomEventCacheInner {
         state: RoomEventCacheState,
         pagination_status: SharedObservable<RoomPaginationStatus>,
         room_id: OwnedRoomId,
-        room_version: RoomVersionId,
         all_events_cache: Arc<RwLock<AllEventsCache>>,
         auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
     ) -> Self {
@@ -339,7 +333,6 @@ impl RoomEventCacheInner {
         Self {
             room_id: weak_room.room_id().to_owned(),
             weak_room,
-            room_version,
             state: RwLock::new(state),
             all_events: all_events_cache,
             sender,
@@ -561,7 +554,7 @@ impl RoomEventCacheInner {
 
                     room_events.push_events(events.clone());
 
-                    room_events.on_new_events(&self.room_version, events.iter());
+                    EventsPostProcessing::HaveBeenInserted(events)
                 })
                 .await?;
 
@@ -668,7 +661,7 @@ mod private {
     };
     use matrix_sdk_common::executor::spawn;
     use once_cell::sync::OnceCell;
-    use ruma::{serde::Raw, EventId, OwnedEventId, OwnedRoomId};
+    use ruma::{serde::Raw, EventId, OwnedEventId, OwnedRoomId, RoomVersionId};
     use tracing::{debug, error, instrument, trace};
 
     use super::{
@@ -677,7 +670,7 @@ mod private {
             EventCacheError,
         },
         events::RoomEvents,
-        sort_positions_descending, LoadMoreEventsBackwardsOutcome,
+        sort_positions_descending, EventsPostProcessing, LoadMoreEventsBackwardsOutcome,
     };
     use crate::event_cache::RoomPaginationStatus;
 
@@ -688,6 +681,9 @@ mod private {
     pub struct RoomEventCacheState {
         /// The room this state relates to.
         room: OwnedRoomId,
+
+        /// The room version for this room.
+        room_version: RoomVersionId,
 
         /// Reference to the underlying backing store.
         ///
@@ -726,6 +722,7 @@ mod private {
         /// [`LinkedChunk`]: matrix_sdk_common::linked_chunk::LinkedChunk
         pub async fn new(
             room_id: OwnedRoomId,
+            room_version: RoomVersionId,
             store: Arc<OnceCell<EventCacheStoreLock>>,
             pagination_status: SharedObservable<RoomPaginationStatus>,
         ) -> Result<Self, EventCacheError> {
@@ -765,6 +762,7 @@ mod private {
 
             Ok(Self {
                 room: room_id,
+                room_version,
                 store,
                 events,
                 deduplicator,
@@ -1095,7 +1093,9 @@ mod private {
                                 .map(|(_event_id, position)| position)
                                 .collect(),
                         )
-                        .expect("failed to remove an event")
+                        .expect("failed to remove an event");
+
+                    EventsPostProcessing::None
                 })
                 .await?;
 
@@ -1217,13 +1217,27 @@ mod private {
         /// Returns the updates to the linked chunk, as vector diffs, so the
         /// caller may propagate such updates, if needs be.
         #[must_use = "Updates as `VectorDiff` must probably be propagated via `RoomEventCacheUpdate`"]
-        pub async fn with_events_mut<F: FnOnce(&mut RoomEvents)>(
+        pub async fn with_events_mut<F>(
             &mut self,
             func: F,
-        ) -> Result<Vec<VectorDiff<TimelineEvent>>, EventCacheError> {
-            func(&mut self.events);
+        ) -> Result<Vec<VectorDiff<TimelineEvent>>, EventCacheError>
+        where
+            F: FnOnce(&mut RoomEvents) -> EventsPostProcessing,
+        {
+            let post_processing = func(&mut self.events);
 
+            // Update the store before doing the post-processing.
             self.propagate_changes().await?;
+
+            match post_processing {
+                EventsPostProcessing::HaveBeenInserted(events) => {
+                    for event in &events {
+                        self.events.maybe_apply_new_redaction(&self.room_version, &event);
+                    }
+                }
+
+                EventsPostProcessing::None => {}
+            }
 
             // If we've never waited for an initial previous-batch token, and we now have at
             // least one gap in the chunk, no need to wait for a previous-batch token later.
@@ -1238,6 +1252,11 @@ mod private {
             Ok(updates_as_vector_diffs)
         }
     }
+}
+
+pub(super) enum EventsPostProcessing {
+    HaveBeenInserted(Vec<TimelineEvent>),
+    None,
 }
 
 pub(super) use private::RoomEventCacheState;

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1337,7 +1337,11 @@ mod private {
                                 .expect("should have been a valid position of an item");
                         }
                         EventLocation::Store => {
-                            todo!()
+                            self.send_updates_to_store(vec![Update::ReplaceItem {
+                                at: position,
+                                item: copy,
+                            }])
+                            .await?;
                         }
                     }
                 }

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1244,7 +1244,7 @@ mod private {
                     let room_version = self.room_version.clone();
 
                     for event in &events {
-                        self.maybe_apply_new_redaction(&room_version, &event).await?;
+                        self.maybe_apply_new_redaction(&room_version, event).await?;
                     }
                 }
 
@@ -1298,7 +1298,7 @@ mod private {
             };
 
             // Replace the redacted event by a redacted form, if we knew about it.
-            if let Some((location, position, target_event)) = self.find_event(&event_id).await? {
+            if let Some((location, position, target_event)) = self.find_event(event_id).await? {
                 // Don't redact already redacted events.
                 if let Ok(deserialized) = target_event.raw().deserialize() {
                     match deserialized {


### PR DESCRIPTION
This is the last known task required after the event cache lazy-loading feature.

This is unblocked by https://github.com/matrix-org/matrix-rust-sdk/pull/4708.

`maybe_apply_new_redaction` was looking for events only from `RoomEvents`, so only in-memory. And the redaction was only happening in-memory too. With this patch, `maybe_apply_new_redaction` handles in memory and in store.

This pull request should be reviewed patch by patch for the sake of clarity.

A clean up in the `Deduplicator` is possible by using the new `EventLocation` enum, but it's not part of this set of patches.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280