### PR TITLE
feat(ui): `RoomListService` re-enables `share_pos`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -142,10 +142,9 @@ impl RoomListService {
             }))
             .with_typing_extension(assign!(http::request::Typing::default(), {
                 enabled: Some(true),
-            }));
-        // TODO: Re-enable once we know it creates slowness.
-        // // We don't deal with encryption device messages here so this is safe
-        // .share_pos();
+            }))
+            // We don't deal with encryption device messages here so this is safe
+            .share_pos();
 
         let sliding_sync = builder
             .add_cached_list(


### PR DESCRIPTION
WIP

The idea is the following: if we keep the sliding sync `pos`, first off, the homeservers will be happier because they don't have to re-compute a session every time, and second, the overall user experience may be better as we receive much less `limited` responses from the homeservers.