### PR TITLE
fix(timeline): deduplicate events when they're received from a back-pagination too

### DIFF
--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -326,32 +326,31 @@ impl RoomPagination {
             all_duplicates,
         ) = state.collect_valid_and_duplicated_events(events).await?;
 
-        // During a backwards pagination, when a duplicated event is found, the old
-        // event is kept and the new event is ignored. This is the opposite strategy
-        // than during a sync where the old event is removed and the new event is added.
-        if !all_duplicates {
-            // Let's forget the new events that are duplicated.
-            events.retain(|new_event| {
-                new_event
-                    .event_id()
-                    .map(|event_id| {
-                        !in_memory_duplicated_event_ids
-                            .iter()
-                            .chain(in_store_duplicated_event_ids.iter())
-                            .any(|(duplicated_event_id, _position)| {
-                                duplicated_event_id == &event_id
-                            })
-                    })
-                    // Forget event with no ID, should be unreachable because of
-                    // `collect_valid_and_duplicated_events` though.
-                    .unwrap_or(false)
-            });
+        // If not all the events have been back-paginated, we need to remove the
+        // previous ones, otherwise we can end up with misordered events.
+        //
+        // Consider the following scenario:
+        // - sync returns [D, E, F]
+        // - then sync returns [] with a previous batch token PB1, so the internal
+        //   linked chunk state is [D, E, F, PB1].
+        // - back-paginating with PB1 may return [A, B, C, D, E, F].
+        //
+        // Only inserting the new events when replacing PB1 would result in a timeline
+        // ordering of [D, E, F, A, B, C], which is incorrect. So we do have to remove
+        // all the events, in case this happens (see also #4746).
+
+        let mut event_diffs = if !all_duplicates {
+            // Let's forget all the previous events.
+            state
+                .remove_events(in_memory_duplicated_event_ids, in_store_duplicated_event_ids)
+                .await?
         } else {
             // All new events are duplicated, they can all be ignored.
             events.clear();
-        }
+            Default::default()
+        };
 
-        let timeline_event_diffs = state
+        let next_diffs = state
             .with_events_mut(|room_events| {
             // Reverse the order of the events as `/messages` has been called with `dir=b`
             // (backwards). The `RoomEvents` API expects the first event to be the oldest.
@@ -421,6 +420,8 @@ impl RoomPagination {
         })
         .await?;
 
+        event_diffs.extend(next_diffs);
+
         // There could be an inconsistency between the network (which thinks we hit the
         // start of the timeline) and the disk (which has the initial empty
         // chunks), so tweak the `reached_start` value so that it reflects the disk
@@ -437,9 +438,9 @@ impl RoomPagination {
 
         let backpagination_outcome = BackPaginationOutcome { events, reached_start };
 
-        if !timeline_event_diffs.is_empty() {
+        if !event_diffs.is_empty() {
             let _ = self.inner.sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
-                diffs: timeline_event_diffs,
+                diffs: event_diffs,
                 origin: EventsOrigin::Pagination,
             });
         }

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -528,8 +528,7 @@ impl RoomEventCacheInner {
         ) = state.collect_valid_and_duplicated_events(sync_timeline_events.clone()).await?;
 
         // During a sync, when a duplicated event is found, the old event is removed and
-        // the new event is added. This is the opposite strategy than during a backwards
-        // pagination where the old event is kept and the new event is ignored.
+        // the new event is added.
         //
         // Let's remove the old events that are duplicated.
         let timeline_event_diffs = if all_duplicates {
@@ -1081,7 +1080,7 @@ mod private {
         /// This method is purposely isolated because it must ensure that
         /// positions are sorted appropriately or it can be disastrous.
         #[must_use = "Updates as `VectorDiff` must probably be propagated via `RoomEventCacheUpdate`"]
-        pub(super) async fn remove_events(
+        pub(crate) async fn remove_events(
             &mut self,
             in_memory_events: Vec<(OwnedEventId, Position)>,
             in_store_events: Vec<(OwnedEventId, Position)>,

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1169,7 +1169,7 @@ mod private {
             spawn(async move {
                 let store = store.lock().await?;
 
-                trace!(?updates, "sending linked chunk updates to the store");
+                trace!(%room_id, ?updates, "sending linked chunk updates to the store");
                 store.handle_linked_chunk_updates(&room_id, updates).await?;
                 trace!("linked chunk updates applied");
 

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -26,7 +26,7 @@ use ruma::{
     room_id, user_id, EventId, RoomVersionId,
 };
 use serde_json::json;
-use tokio::{spawn, sync::broadcast, time::sleep};
+use tokio::{spawn, sync::broadcast, task::yield_now, time::sleep};
 
 #[async_test]
 async fn test_must_explicitly_subscribe() {
@@ -2161,4 +2161,107 @@ async fn test_deduplication() {
             });
         });
     }
+}
+
+#[async_test]
+async fn test_timeline_then_empty_timeline_then_deduplication() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    client.event_cache().subscribe().unwrap();
+
+    let room_id = room_id!("!galette:saucisse.bzh");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    let f = EventFactory::new().room(room_id).sender(user_id!("@ben:saucisse.bzh"));
+
+    // Previous batch of events which will be received via /messages, in
+    // chronological order.
+    let previous_events = [
+        f.text_msg("previous1").event_id(event_id!("$prev1")).into_raw_timeline(),
+        f.text_msg("previous2").event_id(event_id!("$prev2")).into_raw_timeline(),
+        f.text_msg("previous3").event_id(event_id!("$prev3")).into_raw_timeline(),
+    ];
+
+    // Latest events which will be received via /sync, in chronological order.
+    let latest_events = [
+        f.text_msg("latest3").event_id(event_id!("$latest3")).into_raw_timeline(),
+        f.text_msg("latest2").event_id(event_id!("$latest2")).into_raw_timeline(),
+        f.text_msg("latest1").event_id(event_id!("$latest1")).into_raw_timeline(),
+    ];
+
+    let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
+    let (initial_events, mut subscriber) = room_event_cache.subscribe().await;
+    assert!(initial_events.is_empty());
+
+    // Receive a sync with only the latest events.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .set_timeline_prev_batch("token-before-latest")
+                .add_timeline_bulk(latest_events.clone().into_iter().map(ruma::serde::Raw::cast)),
+        )
+        .await;
+
+    assert_let_timeout!(
+        Ok(RoomEventCacheUpdate::UpdateTimelineEvents { diffs, .. }) = subscriber.recv()
+    );
+    assert_eq!(diffs.len(), 1);
+    assert_let!(VectorDiff::Append { values } = &diffs[0]);
+
+    assert_eq!(values.len(), 3);
+    assert_event_matches_msg(&values[0], "latest3");
+    assert_event_matches_msg(&values[1], "latest2");
+    assert_event_matches_msg(&values[2], "latest1");
+
+    // Receive a timeline without any items.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).set_timeline_prev_batch("token-after-latest"),
+        )
+        .await;
+
+    // Let the event cache handle the timeline result.
+    yield_now().await;
+
+    // No update happened.
+    assert!(subscriber.is_empty());
+
+    // Back-paginate.
+    let all_events = previous_events.into_iter().chain(latest_events).rev().collect::<Vec<_>>();
+
+    server
+        .mock_room_messages()
+        // The prev_batch from the second sync.
+        .match_from("token-after-latest")
+        .ok(RoomMessagesResponseTemplate::default().end_token("messages-end-2").events(all_events))
+        .named("messages-since-after-latest")
+        .mount()
+        .await;
+
+    room_event_cache.pagination().run_backwards_once(10).await.unwrap();
+
+    assert_let_timeout!(
+        Ok(RoomEventCacheUpdate::UpdateTimelineEvents { diffs, .. }) = subscriber.recv()
+    );
+    assert_eq!(diffs.len(), 4);
+
+    // Yay.
+    assert_matches!(&diffs[0], VectorDiff::Remove { index: 2 });
+    assert_matches!(&diffs[1], VectorDiff::Remove { index: 1 });
+    assert_matches!(&diffs[2], VectorDiff::Remove { index: 0 });
+
+    assert_let!(VectorDiff::Append { values } = &diffs[3]);
+    assert_eq!(values.len(), 6);
+    assert_event_matches_msg(&values[0], "previous1");
+    assert_event_matches_msg(&values[1], "previous2");
+    assert_event_matches_msg(&values[2], "previous3");
+    assert_event_matches_msg(&values[3], "latest3");
+    assert_event_matches_msg(&values[4], "latest2");
+    assert_event_matches_msg(&values[5], "latest1");
+
+    // That's all, folks!
+    assert!(subscriber.is_empty());
 }


### PR DESCRIPTION
Repeating the logic of the fix here: before the patch, when receiving a partially overlapping backpagination result, we would:

1. keep the duplicated events in their locations
2. replace the gap with only the non-duplicated events

This leads to incorrect orderings. Consider the following example:

- sync returns [D, E, F]
- then sync returns [] with a previous batch token PB1, so the internal linked chunk state is [D, E, F, PB1].
- back-paginating with PB1 may return [A, B, C, D, E, F], so we replace PB1 with those events.
- since DEF were duplicated, we replace PB1 with ABC
- we end up with [DEFABC], which is incorrect :exploding_head: 

The solution is thus to remove the duplicates (in-memory or from the store), and reinsert them in their rightful locations. Only one test's (the one for lazy loading) expectations needed to be updated, and it's nice that this test now shows that the removal happens in the store, even if the duplicate event is NOT in the live chunk.

Fixes #4746. Bunch of thanks to @zecakeh for the test case; credited you as its author in a separate commit.
