### PR TITLE
chore: disable LTO on release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,10 +113,6 @@ matrix-sdk-store-encryption = { path = "crates/matrix-sdk-store-encryption", ver
 matrix-sdk-test = { path = "testing/matrix-sdk-test", version = "0.10.0" }
 matrix-sdk-ui = { path = "crates/matrix-sdk-ui", version = "0.10.0", default-features = false }
 
-# Default release profile, select with `--release`
-[profile.release]
-lto = true
-
 # Default development profile; default for most Cargo commands, otherwise
 # selected with `--debug`
 [profile.dev]


### PR DESCRIPTION
I have to disable LTO every time I'm building any final binary using the SDK, because otherwise, the builds can take easily more than 10 minutes to complete, killing iteration times, and making it almost impractical to use the programs (benchmarks, or multiverse).

I think it should be the decision of the final embedder to enable or disable LTO, and that for the purpose of our own binaries hosted in the SDK repository, we don't need the absolute best performance (or, for the sake of benchmarking, we can tweak the profiling profile).