### PR TITLE
refactor(event cache): use Ruma's `is_redacted()` method instead of `original_content()`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1328,14 +1328,12 @@ mod private {
                 if let Ok(deserialized) = target_event.raw().deserialize() {
                     match deserialized {
                         AnySyncTimelineEvent::MessageLike(ev) => {
-                            if ev.original_content().is_none() {
-                                // Already redacted.
+                            if ev.is_redacted() {
                                 return Ok(());
                             }
                         }
                         AnySyncTimelineEvent::State(ev) => {
-                            if ev.original_content().is_none() {
-                                // Already redacted.
+                            if ev.is_redacted() {
                                 return Ok(());
                             }
                         }


### PR DESCRIPTION
This is cheaper, as it doesn't require cloning the content and
immediately throw it away. This method was introduced recently, thanks
to @zecakeh for it.