### PR TITLE
chore(sdk): Remove the `request_body` instrument's field

### DIFF
--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -140,7 +140,6 @@ impl HttpClient {
             uri,
             method,
             request_size,
-            request_body,
             request_id,
             status,
             response_size,


### PR DESCRIPTION
Many fields here are not argument of the `send` method, but are set later with `Span::record`. Grepping all these fields reveal they are all set except `request_body` apparently.