### PR TITLE
fix(common): Shorten the name of the snapshot_test_encryption_info

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -1356,7 +1356,7 @@ mod tests {
             verification_state: VerificationState::Verified,
         };
 
-        with_settings!({sort_maps =>true}, {
+        with_settings!({ sort_maps => true, prepend_module_to_snapshot => false }, {
             assert_json_snapshot!(info)
         })
     }

--- a/crates/matrix-sdk-common/src/snapshots/snapshot_test_encryption_info.snap
+++ b/crates/matrix-sdk-common/src/snapshots/snapshot_test_encryption_info.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/matrix-sdk-common/src/deserialized_responses.rs
+assertion_line: 1360
 expression: info
 ---
 {


### PR DESCRIPTION
To prevent build errors like https://github.com/matrix-org/matrix-rust-sdk/actions/runs/13677044380/job/38239768600?pr=4644