### PR TITLE
fix(ffi): `Room::is_encrypted` is now async

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -30,7 +30,10 @@ Breaking changes:
           or fails to present).
         - The rest of `AuthenticationError` is now found in the OidcError type.
 - `OidcAuthenticationData` is now called `OidcAuthorizationData`.
+
 - The `get_element_call_required_permissions` function now requires the device_id.
+
+- `Room::is_encrypted` is now async.
 
 Additions:
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -257,8 +257,8 @@ impl Room {
         self.inner.room_id().to_string()
     }
 
-    pub fn is_encrypted(&self) -> Result<bool, ClientError> {
-        Ok(RUNTIME.block_on(self.inner.is_encrypted())?)
+    pub async fn is_encrypted(&self) -> Result<bool, ClientError> {
+        Ok(self.inner.is_encrypted().await?)
     }
 
     pub async fn members(&self) -> Result<Arc<RoomMembersIterator>, ClientError> {


### PR DESCRIPTION
This patch updates `Room::is_encrypted` to be async, otherwise it could block forever in case of bad network or offline network.