### PR TITLE
chore(ffi): Remove useless `block_on`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -666,10 +666,8 @@ impl Client {
     }
 
     /// Retrieves an avatar cached from a previous call to [`Self::avatar_url`].
-    pub fn cached_avatar_url(&self) -> Result<Option<String>, ClientError> {
-        Ok(get_runtime_handle()
-            .block_on(self.inner.account().get_cached_avatar_url())?
-            .map(Into::into))
+    pub async fn cached_avatar_url(&self) -> Result<Option<String>, ClientError> {
+        Ok(self.inner.account().get_cached_avatar_url().await?.map(Into::into))
     }
 
     pub fn device_id(&self) -> Result<String, ClientError> {
@@ -931,8 +929,8 @@ impl Client {
         SyncServiceBuilder::new((*self.inner).clone())
     }
 
-    pub fn get_notification_settings(&self) -> Arc<NotificationSettings> {
-        let inner = get_runtime_handle().block_on(self.inner.notification_settings());
+    pub async fn get_notification_settings(&self) -> Arc<NotificationSettings> {
+        let inner = self.inner.notification_settings().await;
 
         Arc::new(NotificationSettings::new((*self.inner).clone(), inner))
     }

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -110,8 +110,8 @@ impl Room {
         self.inner.avatar_url().map(|m| m.to_string())
     }
 
-    pub fn is_direct(&self) -> bool {
-        get_runtime_handle().block_on(self.inner.is_direct()).unwrap_or(false)
+    pub async fn is_direct(&self) -> bool {
+        self.inner.is_direct().await.unwrap_or(false)
     }
 
     pub fn is_public(&self) -> bool {

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -557,8 +557,8 @@ impl RoomListItem {
         self.inner.avatar_url().map(|uri| uri.to_string())
     }
 
-    fn is_direct(&self) -> bool {
-        get_runtime_handle().block_on(self.inner.inner_room().is_direct()).unwrap_or(false)
+    async fn is_direct(&self) -> bool {
+        self.inner.inner_room().is_direct().await.unwrap_or(false)
     }
 
     fn canonical_alias(&self) -> Option<String> {


### PR DESCRIPTION
This patch removes the last `block_on` calls in `matrix-sdk-ffi`.

By reducing the number of blocking contexts, we are reducing the number of blocking threads, which is good performance wide. See https://github.com/matrix-org/matrix-rust-sdk/pull/4766 and https://github.com/matrix-org/matrix-rust-sdk/pull/4786.

---

* Address https://github.com/element-hq/element-x-ios/issues/3785