### PR TITLE
refactor(oidc): Start replacing mas-oidc-client with oauth2

### DIFF
--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -6,6 +6,7 @@ use std::{
 
 use matrix_sdk::{
     authentication::oidc::{
+        error::OauthAuthorizationCodeError,
         registrations::OidcRegistrationsError,
         types::{
             iana::oauth::OAuthClientAuthenticationMethod,
@@ -198,9 +199,13 @@ impl From<SdkOidcError> for OidcError {
         match e {
             SdkOidcError::Discovery(error) if error.is_not_supported() => OidcError::NotSupported,
             SdkOidcError::MissingRedirectUri => OidcError::MetadataInvalid,
-            SdkOidcError::InvalidCallbackUrl => OidcError::CallbackUrlInvalid,
-            SdkOidcError::InvalidState => OidcError::CallbackUrlInvalid,
-            SdkOidcError::CancelledAuthorization => OidcError::Cancelled,
+            SdkOidcError::AuthorizationCode(OauthAuthorizationCodeError::RedirectUri(_))
+            | SdkOidcError::AuthorizationCode(OauthAuthorizationCodeError::InvalidState) => {
+                OidcError::CallbackUrlInvalid
+            }
+            SdkOidcError::AuthorizationCode(OauthAuthorizationCodeError::Cancelled) => {
+                OidcError::Cancelled
+            }
             _ => OidcError::Generic { message: e.to_string() },
         }
     }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -411,7 +411,7 @@ impl Client {
                     tracing::error!("Failed to parse {:?}", issuer);
                     return None;
                 };
-                Some((issuer, ClientId(client_id.clone())))
+                Some((issuer, ClientId::new(client_id.clone())))
             })
             .collect::<HashMap<_, _>>();
         let registrations = OidcRegistrations::new(
@@ -1611,7 +1611,7 @@ impl Session {
                         },
                     issuer,
                 } = api.user_session().context("Missing session")?;
-                let client_id = api.client_id().context("OIDC client ID is missing.")?.0.clone();
+                let client_id = api.client_id().context("OIDC client ID is missing.")?.clone();
                 let oidc_data = OidcSessionData { client_id, issuer };
 
                 let oidc_data = serde_json::to_string(&oidc_data).ok();
@@ -1659,8 +1659,7 @@ impl TryFrom<Session> for AuthSession {
                 issuer: oidc_data.issuer,
             };
 
-            let session =
-                OidcSession { client_id: ClientId(oidc_data.client_id), user: user_session };
+            let session = OidcSession { client_id: oidc_data.client_id, user: user_session };
 
             Ok(AuthSession::Oidc(session.into()))
         } else {
@@ -1686,13 +1685,13 @@ impl TryFrom<Session> for AuthSession {
 #[derive(Serialize, Deserialize)]
 #[serde(try_from = "OidcSessionDataDeHelper")]
 pub(crate) struct OidcSessionData {
-    client_id: String,
+    client_id: ClientId,
     issuer: String,
 }
 
 #[derive(Deserialize)]
 struct OidcSessionDataDeHelper {
-    client_id: String,
+    client_id: ClientId,
     issuer_info: Option<AuthenticationServerInfo>,
     issuer: Option<String>,
 }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -397,6 +397,16 @@ impl Client {
     /// view has succeeded, call `login_with_oidc_callback` with the callback it
     /// returns. If a failure occurs and a callback isn't available, make sure
     /// to call `abort_oidc_auth` to inform the client of this.
+    ///
+    /// # Arguments
+    ///
+    /// * `oidc_configuration` - The configuration used to load the credentials
+    ///   of the client if it is already registered with the authorization
+    ///   server, or register the client and store its credentials if it isn't.
+    ///
+    /// * `prompt` - The desired user experience in the web UI. No value means
+    ///   that the user wishes to login into an existing account, and a value of
+    ///   `Create` means that the user wishes to register a new account.
     pub async fn url_for_oidc(
         &self,
         oidc_configuration: &OidcConfiguration,

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -98,6 +98,21 @@ simpler methods:
   - `Oidc::restore_registered_client()` doesn't take a `VerifiedClientMetadata`
     anymore.
   - `Oidc::latest_id_token()` and `Oidc::client_metadata()` were removed.
+- [**breaking**]: The `Oidc` API makes use of the oauth2 crate rather than
+  mas-oidc-client.
+  ([#4761](https://github.com/matrix-org/matrix-rust-sdk/pull/4761))
+  - `ClientId` is a different type reexported from the oauth2 crate.
+  - The error types that were in the `oidc` module have been moved to the
+    `oidc::error` module.
+  - The `prompt` parameter of `Oidc::url_for_oidc()` is now optional, and
+    `Prompt` is a different type reexported from Ruma, that only supports the
+    `create` value.
+  - The `device_id` parameter of `Oidc::login` is now an `Option<OwnedDeviceId>`.
+  - The `state` field of `OidcAuthorizationData` and `AuthorizationCode`, and
+    the parameter of the same name in `Oidc::abort_authorization()` now use
+    `CsrfToken`.
+  - The `error` field of `AuthorizationError` uses an error type from the oauth2
+    crate rather than one from mas-oidc-client.
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -93,6 +93,7 @@ matrix-sdk-sqlite = { workspace = true, optional = true }
 matrix-sdk-test = { workspace = true, optional = true }
 mime = { workspace = true }
 mime2ext = "0.1.53"
+oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"], optional = true }
 once_cell = { workspace = true }
 percent-encoding = "2.3.1"
 pin-project-lite = { workspace = true }
@@ -129,7 +130,6 @@ tokio = { workspace = true, features = ["macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }
-oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"], optional = true }
 # only activate reqwest's stream feature on non-wasm, the wasm part seems to not
 # support *sending* streams, which makes it useless for us.
 reqwest = { workspace = true, features = ["stream", "gzip", "http2"] }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -93,7 +93,7 @@ matrix-sdk-sqlite = { workspace = true, optional = true }
 matrix-sdk-test = { workspace = true, optional = true }
 mime = { workspace = true }
 mime2ext = "0.1.53"
-oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"], optional = true }
+oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest", "timing-resistant-secret-traits"], optional = true }
 once_cell = { workspace = true }
 percent-encoding = "2.3.1"
 pin-project-lite = { workspace = true }

--- a/crates/matrix-sdk/src/authentication/oidc/auth_code_builder.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/auth_code_builder.rs
@@ -84,7 +84,7 @@ impl OidcAuthCodeUrlBuilder {
         let provider_metadata = oidc.provider_metadata().await?;
 
         let mut authorization_data =
-            AuthorizationRequestData::new(data.client_id.0.clone(), scope, redirect_uri);
+            AuthorizationRequestData::new(data.client_id.as_str().to_owned(), scope, redirect_uri);
         authorization_data.code_challenge_methods_supported =
             provider_metadata.code_challenge_methods_supported.clone();
         authorization_data.prompt = prompt;

--- a/crates/matrix-sdk/src/authentication/oidc/error.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/error.rs
@@ -1,0 +1,147 @@
+// Copyright 2025 Kévin Commaille
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Error types used in the [`Oidc`](super::Oidc) API.
+
+pub use mas_oidc_client::error::*;
+
+pub use super::cross_process::CrossProcessRefreshLockError;
+
+/// An error when trying to parse the query of a redirect URI.
+#[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
+pub enum RedirectUriQueryParseError {
+    /// There is no query part in the URI.
+    #[error("No query in URI")]
+    MissingQuery,
+
+    /// Deserialization failed.
+    #[error("Query is not using one of the defined formats")]
+    UnknownFormat,
+}
+
+/// All errors that can occur when using the OpenID Connect API.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum OidcError {
+    /// An error occurred when interacting with the provider.
+    #[error(transparent)]
+    Oidc(Error),
+
+    /// An error occurred when discovering the authorization server's issuer.
+    #[error("authorization server discovery failed: {0}")]
+    Discovery(#[from] OauthDiscoveryError),
+
+    /// The OpenID Connect Provider doesn't support dynamic client registration.
+    ///
+    /// The provider probably offers another way to register clients.
+    #[error("no dynamic registration support")]
+    NoRegistrationSupport,
+
+    /// The client has not registered while the operation requires it.
+    #[error("client not registered")]
+    NotRegistered,
+
+    /// The supplied redirect URIs are missing or empty.
+    #[error("missing or empty redirect URIs")]
+    MissingRedirectUri,
+
+    /// The device ID was not returned by the homeserver after login.
+    #[error("missing device ID in response")]
+    MissingDeviceId,
+
+    /// The client is not authenticated while the request requires it.
+    #[error("client not authenticated")]
+    NotAuthenticated,
+
+    /// The state used to complete authorization doesn't match an original
+    /// value.
+    #[error("the supplied state is unexpected")]
+    InvalidState,
+
+    /// The user cancelled authorization in the web view.
+    #[error("authorization cancelled")]
+    CancelledAuthorization,
+
+    /// The login was completed with an invalid callback.
+    #[error("the supplied callback URL is invalid")]
+    InvalidCallbackUrl,
+
+    /// An error occurred during authorization.
+    #[error("authorization failed")]
+    Authorization(super::AuthorizationError),
+
+    /// The device ID is invalid.
+    #[error("invalid device ID")]
+    InvalidDeviceId,
+
+    /// The OpenID Connect Provider doesn't support token revocation, aka
+    /// logging out.
+    #[error("no token revocation support")]
+    NoRevocationSupport,
+
+    /// An error occurred generating a random value.
+    #[error(transparent)]
+    Rand(rand::Error),
+
+    /// An error occurred parsing a URL.
+    #[error(transparent)]
+    Url(url::ParseError),
+
+    /// An error occurred caused by the cross-process locks.
+    #[error(transparent)]
+    LockError(#[from] CrossProcessRefreshLockError),
+
+    /// An unknown error occurred.
+    #[error("unknown error")]
+    UnknownError(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl<E> From<E> for OidcError
+where
+    E: Into<Error>,
+{
+    fn from(value: E) -> Self {
+        Self::Oidc(value.into())
+    }
+}
+
+/// All errors that can occur when discovering the OAuth 2.0 server metadata.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum OauthDiscoveryError {
+    /// OAuth 2.0 is not supported by the homeserver.
+    #[error("OAuth 2.0 is not supported by the homeserver")]
+    NotSupported,
+
+    /// An error occurred when making a request to the homeserver.
+    #[error(transparent)]
+    Http(#[from] crate::HttpError),
+
+    /// The server metadata is invalid.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    /// An error occurred when making a request to the OpenID Connect provider.
+    #[error(transparent)]
+    Oidc(#[from] DiscoveryError),
+}
+
+impl OauthDiscoveryError {
+    /// Whether this error occurred because OAuth 2.0 is not supported by the
+    /// homeserver.
+    pub fn is_not_supported(&self) -> bool {
+        matches!(self, Self::NotSupported)
+    }
+}

--- a/crates/matrix-sdk/src/authentication/oidc/error.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/error.rs
@@ -15,6 +15,10 @@
 //! Error types used in the [`Oidc`](super::Oidc) API.
 
 pub use mas_oidc_client::error::*;
+pub use oauth2::{
+    basic::{BasicErrorResponse, BasicErrorResponseType, BasicRequestTokenError},
+    HttpClientError, RequestTokenError, StandardErrorResponse,
+};
 
 pub use super::cross_process::CrossProcessRefreshLockError;
 
@@ -85,6 +89,11 @@ pub enum OidcError {
     /// The device ID is invalid.
     #[error("invalid device ID")]
     InvalidDeviceId,
+
+    /// An error occurred interacting with the OAuth 2.0 authorization server
+    /// while refreshing the access token.
+    #[error("failed to refresh token: {0}")]
+    RefreshToken(BasicRequestTokenError<HttpClientError<reqwest::Error>>),
 
     /// The OpenID Connect Provider doesn't support token revocation, aka
     /// logging out.

--- a/crates/matrix-sdk/src/authentication/oidc/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/mod.rs
@@ -246,7 +246,7 @@ pub(crate) struct OidcAuthData {
 impl OidcAuthData {
     /// Get the credentials of client.
     fn credentials(&self) -> ClientCredentials {
-        ClientCredentials::None { client_id: self.client_id.0.clone() }
+        ClientCredentials::None { client_id: self.client_id.as_str().to_owned() }
     }
 }
 
@@ -892,7 +892,7 @@ impl Oidc {
     /// );
     ///
     /// // The API only supports clients without secrets.
-    /// let client_id = ClientId(response.client_id);
+    /// let client_id = ClientId::new(response.client_id);
     /// let issuer = oidc.issuer().expect("issuer should be set after registration");
     ///
     /// persist_client_registration(issuer, &client_metadata, &client_id);
@@ -924,7 +924,7 @@ impl Oidc {
         // was sent. Public clients only get a client ID.
         self.restore_registered_client(
             provider_metadata.issuer().to_owned(),
-            ClientId(registration_response.client_id.clone()),
+            ClientId::new(registration_response.client_id.clone()),
         );
 
         Ok(registration_response)
@@ -1324,8 +1324,7 @@ impl Oidc {
             .into_iter()
             .map(|scope| oauth2::Scope::new(scope.to_string()));
 
-        let client_id =
-            oauth2::ClientId::new(self.client_id().ok_or(OidcError::NotRegistered)?.0.clone());
+        let client_id = self.client_id().ok_or(OidcError::NotRegistered)?.clone();
 
         let server_metadata = self.provider_metadata().await.map_err(OidcError::from)?;
         let device_authorization_url = server_metadata
@@ -1352,8 +1351,7 @@ impl Oidc {
     ) -> Result<(), qrcode::DeviceAuthorizationOauthError> {
         use oauth2::TokenResponse;
 
-        let client_id =
-            oauth2::ClientId::new(self.client_id().ok_or(OidcError::NotRegistered)?.0.clone());
+        let client_id = self.client_id().ok_or(OidcError::NotRegistered)?.clone();
 
         let server_metadata = self.provider_metadata().await.map_err(OidcError::from)?;
         let token_uri = oauth2::TokenUrl::from_url(server_metadata.token_endpoint().clone());

--- a/crates/matrix-sdk/src/authentication/oidc/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/mod.rs
@@ -438,6 +438,20 @@ impl Oidc {
     /// webview for a user to login to their account. Call
     /// [`Oidc::login_with_oidc_callback`] to finish the process when the
     /// webview is complete.
+    ///
+    /// # Arguments
+    ///
+    /// * `client_metadata` - The [`VerifiedClientMetadata`] to register, if
+    ///   needed.
+    ///
+    /// * `registrations` - The storage where the registered client ID will be
+    ///   loaded from, if the client is already registered, or stored into, if
+    ///   the client is not registered yet.
+    ///
+    /// * `prompt` - The desired user experience in the web UI. `None` means
+    ///   that the user wishes to login into an existing account, and
+    ///   `Some(Prompt::Create)` means that the user wishes to register a new
+    ///   account.
     pub async fn url_for_oidc(
         &self,
         client_metadata: VerifiedClientMetadata,

--- a/crates/matrix-sdk/src/authentication/oidc/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/qrcode/login.rs
@@ -294,7 +294,8 @@ impl<'a> LoginWithQrCode<'a> {
         device_id: Curve25519PublicKey,
     ) -> Result<StandardDeviceAuthorizationResponse, DeviceAuthorizationOauthError> {
         let oidc = self.client.oidc();
-        let response = oidc.request_device_authorization(Some(device_id.to_base64())).await?;
+        let response =
+            oidc.request_device_authorization(Some(device_id.to_base64().into())).await?;
         Ok(response)
     }
 

--- a/crates/matrix-sdk/src/authentication/oidc/registrations.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/registrations.rs
@@ -31,6 +31,7 @@ use std::{
 use mas_oidc_client::types::registration::{
     ClientMetadata, ClientMetadataVerificationError, VerifiedClientMetadata,
 };
+pub use oauth2::ClientId;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -44,10 +45,6 @@ pub enum OidcRegistrationsError {
     #[error("Failed to save the registration data {0}.")]
     SaveFailure(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
-
-/// A client ID that has been registered with an OpenID Connect provider.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct ClientId(pub String);
 
 /// The data needed to restore an OpenID Connect session.
 #[derive(Debug)]
@@ -214,9 +211,9 @@ mod tests {
         let registrations_file = dir.path().join("oidc").join("registrations.json");
 
         let static_url = Url::parse("https://example.com").unwrap();
-        let static_id = ClientId("static_client_id".to_owned());
+        let static_id = ClientId::new("static_client_id".to_owned());
         let dynamic_url = Url::parse("https://example.org").unwrap();
-        let dynamic_id = ClientId("dynamic_client_id".to_owned());
+        let dynamic_id = ClientId::new("dynamic_client_id".to_owned());
 
         let mut static_registrations = HashMap::new();
         static_registrations.insert(static_url.clone(), static_id.clone());
@@ -246,9 +243,9 @@ mod tests {
         let registrations_file = dir.path().join("oidc").join("registrations.json");
 
         let static_url = Url::parse("https://example.com").unwrap();
-        let static_id = ClientId("static_client_id".to_owned());
+        let static_id = ClientId::new("static_client_id".to_owned());
         let dynamic_url = Url::parse("https://example.org").unwrap();
-        let dynamic_id = ClientId("dynamic_client_id".to_owned());
+        let dynamic_id = ClientId::new("dynamic_client_id".to_owned());
 
         let oidc_metadata = mock_metadata("Example".to_owned());
 

--- a/crates/matrix-sdk/src/authentication/oidc/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/tests.rs
@@ -314,7 +314,7 @@ async fn test_oidc_session() -> anyhow::Result<()> {
 
     let full_session = oidc.full_session().unwrap();
 
-    assert_eq!(full_session.client_id.0, "test_client_id");
+    assert_eq!(full_session.client_id.as_str(), "test_client_id");
     assert_eq!(full_session.user.meta, session.user.meta);
     assert_eq!(full_session.user.tokens, tokens);
     assert_eq!(full_session.user.issuer, issuer);
@@ -409,7 +409,7 @@ async fn test_register_client() {
     // There is a difference of ending slash between the strings so we parse them
     // with `Url` which will normalize that.
     assert_eq!(Url::parse(&auth_data.issuer), Url::parse(&server.server().uri()));
-    assert_eq!(auth_data.client_id.0, response.client_id);
+    assert_eq!(auth_data.client_id.as_str(), response.client_id);
 }
 
 #[async_test]

--- a/crates/matrix-sdk/src/authentication/oidc/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/tests.rs
@@ -3,14 +3,15 @@ use std::collections::HashMap;
 use anyhow::Context as _;
 use assert_matches::assert_matches;
 use mas_oidc_client::{
-    requests::{
-        account_management::AccountManagementActionFull,
-        authorization_code::AuthorizationValidationData,
-    },
-    types::{errors::ClientErrorCode, registration::VerifiedClientMetadata, requests::Prompt},
+    requests::account_management::AccountManagementActionFull,
+    types::registration::VerifiedClientMetadata,
 };
 use matrix_sdk_test::async_test;
-use ruma::ServerName;
+use oauth2::{CsrfToken, PkceCodeChallenge, RedirectUrl};
+use ruma::{
+    api::client::discovery::get_authorization_server_metadata::msc2965::Prompt, owned_device_id,
+    ServerName,
+};
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
 use tempfile::tempdir;
@@ -25,6 +26,10 @@ use super::{
     Oidc, OidcError, OidcSessionTokens, RedirectUriQueryParseError,
 };
 use crate::{
+    authentication::oidc::{
+        error::AuthorizationCodeErrorResponseType, AuthorizationValidationData,
+        OauthAuthorizationCodeError,
+    },
     test_utils::{
         client::{
             oauth::{mock_client_metadata, mock_session, mock_session_tokens},
@@ -76,7 +81,7 @@ async fn test_high_level_login() -> anyhow::Result<()> {
 
     // When getting the OIDC login URL.
     let authorization_data =
-        oidc.url_for_oidc(metadata.clone(), registrations, Prompt::Login).await.unwrap();
+        oidc.url_for_oidc(metadata.clone(), registrations, Some(Prompt::Create)).await.unwrap();
 
     // Then the client should be configured correctly.
     assert!(oidc.issuer().is_some());
@@ -84,7 +89,7 @@ async fn test_high_level_login() -> anyhow::Result<()> {
 
     // When completing the login with a valid callback.
     let mut callback_uri = metadata.redirect_uris.clone().unwrap().first().unwrap().clone();
-    callback_uri.set_query(Some(&format!("code=42&state={}", authorization_data.state)));
+    callback_uri.set_query(Some(&format!("code=42&state={}", authorization_data.state.secret())));
 
     // Then the login should succeed.
     oidc.login_with_oidc_callback(&authorization_data, callback_uri).await?;
@@ -97,20 +102,25 @@ async fn test_high_level_login_cancellation() -> anyhow::Result<()> {
     // Given a client ready to complete login.
     let (oidc, _server, metadata, registrations) = mock_environment().await.unwrap();
     let authorization_data =
-        oidc.url_for_oidc(metadata.clone(), registrations, Prompt::Login).await.unwrap();
+        oidc.url_for_oidc(metadata.clone(), registrations, None).await.unwrap();
 
     assert!(oidc.issuer().is_some());
     assert!(oidc.client_id().is_some());
 
     // When completing login with a cancellation callback.
     let mut callback_uri = metadata.redirect_uris.clone().unwrap().first().unwrap().clone();
-    callback_uri
-        .set_query(Some(&format!("error=access_denied&state={}", authorization_data.state)));
+    callback_uri.set_query(Some(&format!(
+        "error=access_denied&state={}",
+        authorization_data.state.secret()
+    )));
 
     let error = oidc.login_with_oidc_callback(&authorization_data, callback_uri).await.unwrap_err();
 
     // Then a cancellation error should be thrown.
-    assert_matches!(error, Error::Oidc(OidcError::CancelledAuthorization));
+    assert_matches!(
+        error,
+        Error::Oidc(OidcError::AuthorizationCode(OauthAuthorizationCodeError::Cancelled))
+    );
 
     Ok(())
 }
@@ -120,7 +130,7 @@ async fn test_high_level_login_invalid_state() -> anyhow::Result<()> {
     // Given a client ready to complete login.
     let (oidc, _server, metadata, registrations) = mock_environment().await.unwrap();
     let authorization_data =
-        oidc.url_for_oidc(metadata.clone(), registrations, Prompt::Login).await.unwrap();
+        oidc.url_for_oidc(metadata.clone(), registrations, None).await.unwrap();
 
     assert!(oidc.issuer().is_some());
     assert!(oidc.client_id().is_some());
@@ -132,7 +142,10 @@ async fn test_high_level_login_invalid_state() -> anyhow::Result<()> {
     let error = oidc.login_with_oidc_callback(&authorization_data, callback_uri).await.unwrap_err();
 
     // Then the login should fail by flagging the invalid state.
-    assert_matches!(error, Error::Oidc(OidcError::InvalidState));
+    assert_matches!(
+        error,
+        Error::Oidc(OidcError::AuthorizationCode(OauthAuthorizationCodeError::InvalidState))
+    );
 
     Ok(())
 }
@@ -148,7 +161,7 @@ async fn test_login() -> anyhow::Result<()> {
     let client = server.client_builder().registered_with_oauth(server.server().uri()).build().await;
     let oidc = client.oidc();
 
-    let device_id = "D3V1C31D".to_owned(); // yo this is 1999 speaking
+    let device_id = owned_device_id!("D3V1C31D"); // yo this is 1999 speaking
 
     let redirect_uri_str = REDIRECT_URI_STRING;
     let redirect_uri = Url::parse(redirect_uri_str)?;
@@ -156,8 +169,8 @@ async fn test_login() -> anyhow::Result<()> {
 
     tracing::debug!("authorization data URL = {}", authorization_data.url);
 
-    let mut num_expected = 6;
-    let mut nonce = None;
+    let mut num_expected = 7;
+    let mut code_challenge = None;
 
     for (key, val) in authorization_data.url.query_pairs() {
         match &*key {
@@ -174,16 +187,20 @@ async fn test_login() -> anyhow::Result<()> {
                 num_expected -= 1;
             }
             "scope" => {
-                assert_eq!(val, format!("openid urn:matrix:org.matrix.msc2967.client:api:* urn:matrix:org.matrix.msc2967.client:device:{device_id}"));
+                assert_eq!(val, format!("urn:matrix:org.matrix.msc2967.client:api:* urn:matrix:org.matrix.msc2967.client:device:{device_id}"));
                 num_expected -= 1;
             }
             "state" => {
                 num_expected -= 1;
-                assert_eq!(val, authorization_data.state);
+                assert_eq!(val, authorization_data.state.secret().as_str());
             }
-            "nonce" => {
+            "code_challenge" => {
+                code_challenge = Some(val);
                 num_expected -= 1;
-                nonce = Some(val);
+            }
+            "code_challenge_method" => {
+                assert_eq!(val, "S256");
+                num_expected -= 1;
             }
             _ => panic!("unexpected query parameter: {key}={val}"),
         }
@@ -195,8 +212,11 @@ async fn test_login() -> anyhow::Result<()> {
     let authorization_data_guard = data.authorization_data.lock().await;
 
     let state = authorization_data_guard.get(&authorization_data.state).context("missing state")?;
-    let nonce = nonce.context("missing nonce")?;
-    assert_eq!(nonce, state.nonce);
+    let code_challenge = code_challenge.context("missing code_challenge")?;
+    assert_eq!(
+        code_challenge,
+        PkceCodeChallenge::from_code_verifier_sha256(&state.pkce_verifier).as_str()
+    );
 
     assert!(authorization_data.url.as_str().starts_with(&issuer));
     assert_eq!(authorization_data.url.path(), "/oauth2/authorize");
@@ -217,17 +237,17 @@ fn test_authorization_response() -> anyhow::Result<()> {
         AuthorizationResponse::parse_uri(&uri),
         Ok(AuthorizationResponse::Success(AuthorizationCode { code, state })) => {
             assert_eq!(code, "123");
-            assert_eq!(state, "456");
+            assert_eq!(state.secret(), "456");
         }
     );
 
-    let uri = Url::parse("https://example.com?error=invalid_grant&state=456")?;
+    let uri = Url::parse("https://example.com?error=invalid_scope&state=456")?;
     assert_matches!(
         AuthorizationResponse::parse_uri(&uri),
         Ok(AuthorizationResponse::Error(AuthorizationError { error, state })) => {
-            assert_eq!(error.error, ClientErrorCode::InvalidGrant);
-            assert_eq!(error.error_description, None);
-            assert_eq!(state, "456");
+            assert_eq!(*error.error(), AuthorizationCodeErrorResponseType::InvalidScope);
+            assert_eq!(error.error_description(), None);
+            assert_eq!(state.secret(), "456");
         }
     );
 
@@ -247,27 +267,30 @@ async fn test_finish_authorization() -> anyhow::Result<()> {
 
     // If the state is missing, then any attempt to finish authorizing will fail.
     let res = oidc
-        .finish_authorization(AuthorizationCode { code: "42".to_owned(), state: "none".to_owned() })
+        .finish_authorization(AuthorizationCode {
+            code: "42".to_owned(),
+            state: CsrfToken::new("none".to_owned()),
+        })
         .await;
 
-    assert_matches!(res, Err(OidcError::InvalidState));
+    assert_matches!(
+        res,
+        Err(OidcError::AuthorizationCode(OauthAuthorizationCodeError::InvalidState))
+    );
     assert!(oidc.session_tokens().is_none());
 
     // Assuming a non-empty state "123"...
-    let state = "state".to_owned();
+    let state = CsrfToken::new("state".to_owned());
     let redirect_uri = REDIRECT_URI_STRING;
+    let (_pkce_code_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
     let auth_validation_data = AuthorizationValidationData {
-        state: state.clone(),
-        nonce: "nonce".to_owned(),
-        redirect_uri: Url::parse(redirect_uri)?,
-        code_challenge_verifier: None,
+        redirect_uri: RedirectUrl::new(redirect_uri.to_owned())?,
+        pkce_verifier,
     };
 
     {
         let data = oidc.data().context("missing data")?;
-        let prev = data.authorization_data.lock().await.insert(state.clone(), {
-            AuthorizationValidationData { ..auth_validation_data.clone() }
-        });
+        let prev = data.authorization_data.lock().await.insert(state.clone(), auth_validation_data);
         assert!(prev.is_none());
     }
 
@@ -275,11 +298,14 @@ async fn test_finish_authorization() -> anyhow::Result<()> {
     let res = oidc
         .finish_authorization(AuthorizationCode {
             code: "1337".to_owned(),
-            state: "none".to_owned(),
+            state: CsrfToken::new("none".to_owned()),
         })
         .await;
 
-    assert_matches!(res, Err(OidcError::InvalidState));
+    assert_matches!(
+        res,
+        Err(OidcError::AuthorizationCode(OauthAuthorizationCodeError::InvalidState))
+    );
     assert!(oidc.session_tokens().is_none());
     assert!(oidc.data().unwrap().authorization_data.lock().await.get(&state).is_some());
 

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -162,7 +162,7 @@ pub mod oauth {
 
     /// An OAuth 2.0 `ClientId`, for unit or integration tests.
     pub fn mock_client_id() -> ClientId {
-        ClientId("test_client_id".to_owned())
+        ClientId::new("test_client_id".to_owned())
     }
 
     /// `VerifiedClientMetadata` that should be valid in most cases, for unit or

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -118,7 +118,7 @@ struct ClientSession {
 #[derive(Debug, Serialize, Deserialize)]
 struct Credentials {
     /// The client ID obtained after registration.
-    client_id: String,
+    client_id: ClientId,
 }
 
 /// The full session to persist.
@@ -189,7 +189,7 @@ impl OidcCli {
     /// Register the OIDC client with the provider.
     ///
     /// Returns the ID of the client returned by the provider.
-    async fn register_client(&self) -> anyhow::Result<String> {
+    async fn register_client(&self) -> anyhow::Result<ClientId> {
         let oidc = self.client.oidc();
 
         let provider_metadata = oidc.provider_metadata().await?;
@@ -214,7 +214,7 @@ impl OidcCli {
 
         println!("\nRegistered successfully");
 
-        Ok(res.client_id)
+        Ok(ClientId::new(res.client_id))
     }
 
     /// Login via the OIDC Authorization Code flow.
@@ -283,8 +283,7 @@ impl OidcCli {
 
         println!("Restoring session for {}…", user_session.meta.user_id);
 
-        let session =
-            OidcSession { client_id: ClientId(client_credentials.client_id), user: user_session };
+        let session = OidcSession { client_id: client_credentials.client_id, user: user_session };
         // Restore the Matrix user session.
         client.restore_session(session).await?;
 


### PR DESCRIPTION
This makes use of the oauth2 crate for the authorization code grant and the refresh token grant.

There is still the token revocation that can use oauth2, but it requires changes in the HTTP client so it will be done separately. And the remaining parts (account management URL, fallback discovery, registration) will need to be included in the SDK to get rid of mas-oidc-client.
