### PR TITLE
refactor(oidc): Use oauth2 for token revocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,7 +3193,6 @@ dependencies = [
  "backoff",
  "bytes",
  "bytesize",
- "chrono",
  "dirs 6.0.0",
  "event-listener",
  "eyeball",

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -47,10 +47,8 @@ uniffi = ["dep:uniffi", "matrix-sdk-base/uniffi", "dep:matrix-sdk-ffi-macros"]
 experimental-oidc = [
     "ruma/unstable-msc2967",
     "ruma/unstable-msc4108",
-    "dep:chrono",
     "dep:language-tags",
     "dep:mas-oidc-client",
-    "dep:rand",
     "dep:sha2",
     "dep:tower",
     "dep:oauth2",
@@ -71,7 +69,6 @@ async-trait = { workspace = true }
 axum = { version = "0.8.1", optional = true }
 bytes = "1.9.0"
 bytesize = "1.3.0"
-chrono = { workspace = true, optional = true }
 event-listener = "5.4.0"
 eyeball = { workspace = true }
 eyeball-im = { workspace = true }

--- a/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
@@ -539,12 +539,18 @@ mod tests {
         let server = MatrixMockServer::new().await;
 
         let oauth_server = server.oauth();
-        oauth_server.mock_server_metadata().ok().expect(1..).named("server_metadata").mount().await;
-        oauth_server.mock_revocation().ok().expect(1).named("token").mount().await;
+        oauth_server
+            .mock_server_metadata()
+            .ok_https()
+            .expect(1..)
+            .named("server_metadata")
+            .mount()
+            .await;
+        oauth_server.mock_revocation().ok().expect(1).named("revocation").mount().await;
 
         let tmp_dir = tempfile::tempdir()?;
         let client = server.client_builder().sqlite_store(&tmp_dir).unlogged().build().await;
-        let oidc = client.oidc();
+        let oidc = client.oidc().insecure_rewrite_https_to_http();
 
         // Enable cross-process lock.
         oidc.enable_cross_process_refresh_lock("lock".to_owned()).await?;

--- a/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
@@ -119,6 +119,21 @@ impl<'a> MockEndpoint<'a, ServerMetadataEndpoint> {
         MatrixMock { server: self.server, mock }
     }
 
+    /// Returns a successful metadata response with all the supported endpoints
+    /// using HTTPS URLs.
+    ///
+    /// This should be used with
+    /// `MockClientBuilder::insecure_rewrite_https_to_http()` to bypass checks
+    /// from the oauth2 crate.
+    pub fn ok_https(self) -> MatrixMock<'a> {
+        let issuer = self.server.uri().replace("http://", "https://");
+
+        let metadata = MockServerMetadataBuilder::new(&issuer).build();
+        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(metadata));
+
+        MatrixMock { server: self.server, mock }
+    }
+
     /// Returns a successful metadata response without the device authorization
     /// endpoint.
     pub fn ok_without_device_authorization(self) -> MatrixMock<'a> {


### PR DESCRIPTION
With a dirty hack to pass tests.