### PR TITLE
fix(oidc): Match the proper error type for invalid refresh token

### DIFF
--- a/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
@@ -260,10 +260,10 @@ mod tests {
 
     use super::compute_session_hash;
     use crate::{
-        authentication::oidc::{cross_process::SessionHash, tests::prev_session_tokens},
+        authentication::oidc::cross_process::SessionHash,
         test_utils::{
             client::{
-                oauth::{mock_session, mock_session_tokens},
+                oauth::{mock_prev_session_tokens, mock_session, mock_session_tokens},
                 MockClientBuilder,
             },
             mocks::MatrixMockServer,
@@ -392,7 +392,8 @@ mod tests {
         oidc.enable_cross_process_refresh_lock("lock".to_owned()).await?;
 
         // Restore the session.
-        oidc.restore_session(mock_session(prev_session_tokens(), server.server().uri())).await?;
+        oidc.restore_session(mock_session(mock_prev_session_tokens(), server.server().uri()))
+            .await?;
 
         // Immediately try to refresh the access token twice in parallel.
         for result in join_all([oidc.refresh_access_token(), oidc.refresh_access_token()]).await {
@@ -423,7 +424,7 @@ mod tests {
         oauth_server.mock_server_metadata().ok().expect(1..).named("server_metadata").mount().await;
         oauth_server.mock_token().ok().expect(1).named("token").mount().await;
 
-        let prev_tokens = prev_session_tokens();
+        let prev_tokens = mock_prev_session_tokens();
         let next_tokens = mock_session_tokens();
 
         // Create the first client.

--- a/crates/matrix-sdk/src/authentication/oidc/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/tests.rs
@@ -24,7 +24,7 @@ use wiremock::{
 
 use super::{
     registrations::OidcRegistrations, AuthorizationCode, AuthorizationError, AuthorizationResponse,
-    Oidc, OidcAuthorizationData, OidcError, OidcSessionTokens, RedirectUriQueryParseError,
+    Oidc, OidcAuthorizationData, OidcError, RedirectUriQueryParseError,
 };
 use crate::{
     authentication::oidc::{
@@ -33,7 +33,9 @@ use crate::{
     },
     test_utils::{
         client::{
-            oauth::{mock_client_metadata, mock_session, mock_session_tokens},
+            oauth::{
+                mock_client_metadata, mock_prev_session_tokens, mock_session, mock_session_tokens,
+            },
             MockClientBuilder,
         },
         mocks::{oauth::MockServerMetadataBuilder, MatrixMockServer},
@@ -42,15 +44,6 @@ use crate::{
 };
 
 const REDIRECT_URI_STRING: &str = "http://127.0.0.1:6778/oidc/callback";
-
-/// Different session tokens than the ones returned by the mock server's
-/// token endpoint.
-pub(crate) fn prev_session_tokens() -> OidcSessionTokens {
-    OidcSessionTokens {
-        access_token: "prev-access-token".to_owned(),
-        refresh_token: Some("prev-refresh-token".to_owned()),
-    }
-}
 
 async fn mock_environment(
 ) -> anyhow::Result<(Oidc, MatrixMockServer, VerifiedClientMetadata, OidcRegistrations)> {
@@ -439,7 +432,7 @@ async fn test_insecure_clients() -> anyhow::Result<()> {
     oauth_server.mock_server_metadata().ok().expect(2..).named("server_metadata").mount().await;
     oauth_server.mock_token().ok().expect(2).named("token").mount().await;
 
-    let prev_tokens = prev_session_tokens();
+    let prev_tokens = mock_prev_session_tokens();
     let next_tokens = mock_session_tokens();
 
     for client in [

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -79,6 +79,12 @@ impl MockClientBuilder {
         self
     }
 
+    /// Handle refreshing access tokens automatically.
+    pub fn handle_refresh_tokens(mut self) -> Self {
+        self.builder = self.builder.handle_refresh_tokens();
+        self
+    }
+
     /// Finish building the client into the final [`Client`] instance.
     pub async fn build(self) -> Client {
         let client = self.builder.build().await.expect("building client failed");
@@ -194,6 +200,15 @@ pub mod oauth {
         OidcSessionTokens {
             access_token: "1234".to_owned(),
             refresh_token: Some("ZYXWV".to_owned()),
+        }
+    }
+
+    /// Different session tokens than the ones returned by
+    /// [`mock_session_tokens()`].
+    pub fn mock_prev_session_tokens() -> OidcSessionTokens {
+        OidcSessionTokens {
+            access_token: "prev-access-token".to_owned(),
+            refresh_token: Some("prev-refresh-token".to_owned()),
         }
     }
 

--- a/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
@@ -303,6 +303,15 @@ impl<'a> MockEndpoint<'a, TokenEndpoint> {
 
         MatrixMock { server: self.server, mock }
     }
+
+    /// Returns an error response when the token in the request is invalid.
+    pub fn invalid_grant(self) -> MatrixMock<'a> {
+        let mock = self.mock.respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": "invalid_grant",
+        })));
+
+        MatrixMock { server: self.server, mock }
+    }
 }
 
 /// A prebuilt mock for a `POST /oauth/revoke` request.


### PR DESCRIPTION
This was forgotten in #4761. Since we do not use mas-oidc-client anymore, the error to match has changed.

The second commit adds tests that would have catched the regression.