### PR TITLE
feat(timeline): Provide is_utd on EventTimelineItem

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -233,6 +233,11 @@ impl EventTimelineItem {
         matches!(self.kind, EventTimelineItemKind::Remote(_))
     }
 
+    /// Check whether this item's content is UTD (unable to decrypt).
+    pub fn is_utd(&self) -> bool {
+        matches!(self.content(), TimelineItemContent::UnableToDecrypt(_))
+    }
+
     /// Get the `LocalEventTimelineItem` if `self` is `Local`.
     pub(super) fn as_local(&self) -> Option<&LocalEventTimelineItem> {
         as_variant!(&self.kind, EventTimelineItemKind::Local(local_event_item) => local_event_item)

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -920,13 +920,11 @@ async fn test_delayed_invite_response_and_sent_message_decryption() {
                         continue;
                     };
 
-                    let content = event.content();
-
-                    if content.as_unable_to_decrypt().is_some() {
+                    if event.is_utd() {
                         info!("Observed UTD for {}", event.event_id().unwrap());
                     }
 
-                    if let Some(message) = content.as_message() {
+                    if let Some(message) = event.content().as_message() {
                         assert_eq!(message.body(), "hello world");
                         return;
                     }


### PR DESCRIPTION
Adds a little utility method. I didn't add tests because the nearby similar methods don't have them, but happy to add them if we want.

See https://github.com/matrix-org/matrix-rust-sdk/pull/4644#discussion_r1984968706 for a context where this is useful.