### PR TITLE
refactor(oidc): Improvements to url_for_oidc

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -425,17 +425,10 @@ impl Client {
                 Some((issuer, ClientId::new(client_id.clone())))
             })
             .collect::<HashMap<_, _>>();
-        let registrations = OidcRegistrations::new(
-            registrations_file,
-            oidc_metadata.clone(),
-            static_registrations,
-        )?;
+        let registrations =
+            OidcRegistrations::new(registrations_file, oidc_metadata, static_registrations)?;
 
-        let data = self
-            .inner
-            .oidc()
-            .url_for_oidc(oidc_metadata, registrations, prompt.map(Into::into))
-            .await?;
+        let data = self.inner.oidc().url_for_oidc(registrations, prompt.map(Into::into)).await?;
 
         Ok(Arc::new(data))
     }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -413,6 +413,8 @@ impl Client {
         prompt: Option<OidcPrompt>,
     ) -> Result<Arc<OidcAuthorizationData>, OidcError> {
         let oidc_metadata: VerifiedClientMetadata = oidc_configuration.try_into()?;
+        let redirect_uri = oidc_configuration.redirect_uri()?;
+
         let registrations_file = Path::new(&oidc_configuration.dynamic_registrations_file);
         let static_registrations = oidc_configuration
             .static_registrations
@@ -428,7 +430,11 @@ impl Client {
         let registrations =
             OidcRegistrations::new(registrations_file, oidc_metadata, static_registrations)?;
 
-        let data = self.inner.oidc().url_for_oidc(registrations, prompt.map(Into::into)).await?;
+        let data = self
+            .inner
+            .oidc()
+            .url_for_oidc(registrations, redirect_uri, prompt.map(Into::into))
+            .await?;
 
         Ok(Arc::new(data))
     }

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -687,8 +687,9 @@ impl ClientBuilder {
             }
         })?;
 
-        let client_metadata =
-            oidc_configuration.try_into().map_err(|_| HumanQrLoginError::OidcMetadataInvalid)?;
+        let client_metadata = oidc_configuration
+            .client_metadata()
+            .map_err(|_| HumanQrLoginError::OidcMetadataInvalid)?;
 
         let oidc = client.inner.oidc();
         let login = oidc.login_with_qr_code(&qr_code_data.inner, client_metadata);

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -119,6 +119,11 @@ simpler methods:
   `(MatrixAuth/Oidc)::session_tokens_stream()`, can be replaced by
   `Client::subscribe_to_session_changes()` and then calling
   `Client::session_tokens()` on a `SessionChange::TokenRefreshed`.
+- [**breaking**] `Oidc::url_for_oidc()` doesn't take the `VerifiedClientMetadata`
+  to register as an argument, the one in `OidcRegistrations` is used instead.
+  However it now takes the redirect URI to use, instead of always using the
+  first one in the client metadata.
+  ([#4771](https://github.com/matrix-org/matrix-rust-sdk/pull/4771))
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/src/authentication/oidc/error.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/error.rs
@@ -64,10 +64,6 @@ pub enum OidcError {
     #[error("client not registered")]
     NotRegistered,
 
-    /// The supplied redirect URIs are missing or empty.
-    #[error("missing or empty redirect URIs")]
-    MissingRedirectUri,
-
     /// The device ID was not returned by the homeserver after login.
     #[error("missing device ID in response")]
     MissingDeviceId,

--- a/crates/matrix-sdk/src/authentication/oidc/registrations.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/registrations.rs
@@ -53,7 +53,7 @@ pub struct OidcRegistrations {
     file_path: PathBuf,
     /// The hash for the metadata used to register the client.
     /// This is used to check if the client needs to be re-registered.
-    verified_metadata: VerifiedClientMetadata,
+    pub(super) verified_metadata: VerifiedClientMetadata,
     /// Pre-configured registrations for use with issuers that don't support
     /// dynamic client registration.
     static_registrations: HashMap<Url, ClientId>,

--- a/crates/matrix-sdk/src/authentication/oidc/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/tests.rs
@@ -162,8 +162,7 @@ async fn test_high_level_login() -> anyhow::Result<()> {
     assert!(oidc.client_id().is_none());
 
     // When getting the OIDC login URL.
-    let authorization_data =
-        oidc.url_for_oidc(metadata.clone(), registrations, Some(Prompt::Create)).await.unwrap();
+    let authorization_data = oidc.url_for_oidc(registrations, Some(Prompt::Create)).await.unwrap();
 
     // Then the client should be configured correctly.
     assert_let!(Some(issuer) = oidc.issuer());
@@ -185,8 +184,7 @@ async fn test_high_level_login() -> anyhow::Result<()> {
 async fn test_high_level_login_cancellation() -> anyhow::Result<()> {
     // Given a client ready to complete login.
     let (oidc, _server, metadata, registrations) = mock_environment().await.unwrap();
-    let authorization_data =
-        oidc.url_for_oidc(metadata.clone(), registrations, None).await.unwrap();
+    let authorization_data = oidc.url_for_oidc(registrations, None).await.unwrap();
 
     assert_let!(Some(issuer) = oidc.issuer());
     assert!(oidc.client_id().is_some());
@@ -215,8 +213,7 @@ async fn test_high_level_login_cancellation() -> anyhow::Result<()> {
 async fn test_high_level_login_invalid_state() -> anyhow::Result<()> {
     // Given a client ready to complete login.
     let (oidc, _server, metadata, registrations) = mock_environment().await.unwrap();
-    let authorization_data =
-        oidc.url_for_oidc(metadata.clone(), registrations, None).await.unwrap();
+    let authorization_data = oidc.url_for_oidc(registrations, None).await.unwrap();
 
     assert_let!(Some(issuer) = oidc.issuer());
     assert!(oidc.client_id().is_some());

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -191,16 +191,20 @@ pub mod oauth {
         ClientId::new("test_client_id".to_owned())
     }
 
+    /// A redirect URI, for unit or integration tests.
+    pub fn mock_redirect_uri() -> Url {
+        Url::parse("http://127.0.0.1/").expect("redirect URI should be valid")
+    }
+
     /// `VerifiedClientMetadata` that should be valid in most cases, for unit or
     /// integration tests.
     pub fn mock_client_metadata() -> VerifiedClientMetadata {
-        let redirect_uri = Url::parse("http://127.0.0.1/").expect("redirect URI should be valid");
         let client_uri = Url::parse("https://github.com/matrix-org/matrix-rust-sdk")
             .expect("client URI should be valid");
 
         ClientMetadata {
             application_type: Some(ApplicationType::Native),
-            redirect_uris: Some(vec![redirect_uri]),
+            redirect_uris: Some(vec![mock_redirect_uri()]),
             grant_types: Some(vec![
                 GrantType::AuthorizationCode,
                 GrantType::RefreshToken,


### PR DESCRIPTION
This can be reviewed commit by commit:

1. Don't require the client metadata as an argument: we already hold it in `OidcRegistrations`, so we can lazily clone it when needed.
2. Require the redirect URI as an argument: the previous behavior, which used the first redirect URI in the client metadata doesn't fit every client. For example clients that need to bind a port on localhost need to provide a custom redirect URI each time. So we ask for the redirect URI, and keep the previous behavior only for the bindings.
3. (bonus) Refactor the way that types are constructed from `OidcConfiguration` in the FFI crate by moving them to methods on the type. This makes the login code easier to read in my opinion, and avoids the necessity to specify the type in some cases.
