### PR TITLE
refactor(sdk): Merge session tokens

### DIFF
--- a/benchmarks/benches/store_bench.rs
+++ b/benchmarks/benches/store_bench.rs
@@ -2,9 +2,8 @@ use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use matrix_sdk::{
-    authentication::matrix::{MatrixSession, MatrixSessionTokens},
-    config::StoreConfig,
-    Client, RoomInfo, RoomState, StateChanges,
+    authentication::matrix::MatrixSession, config::StoreConfig, Client, RoomInfo, RoomState,
+    SessionTokens, StateChanges,
 };
 use matrix_sdk_base::{store::MemoryStore, SessionMeta, StateStore as _};
 use matrix_sdk_sqlite::SqliteStateStore;
@@ -51,7 +50,7 @@ pub fn restore_session(c: &mut Criterion) {
             user_id: user_id!("@somebody:example.com").to_owned(),
             device_id: device_id!("DEVICE_ID").to_owned(),
         },
-        tokens: MatrixSessionTokens { access_token: "OHEY".to_owned(), refresh_token: None },
+        tokens: SessionTokens { access_token: "OHEY".to_owned(), refresh_token: None },
     };
 
     // Start the benchmark.

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -470,26 +470,17 @@ mod tests {
 
     use futures_util::{pin_mut, StreamExt};
     use matrix_sdk::{
-        authentication::matrix::{MatrixSession, MatrixSessionTokens},
-        config::RequestConfig,
-        Client, SlidingSyncMode,
+        config::RequestConfig, test_utils::client::mock_matrix_session, Client, SlidingSyncMode,
     };
-    use matrix_sdk_base::SessionMeta;
     use matrix_sdk_test::async_test;
-    use ruma::{api::MatrixVersion, device_id, user_id};
+    use ruma::api::MatrixVersion;
     use serde_json::json;
     use wiremock::{http::Method, Match, Mock, MockServer, Request, ResponseTemplate};
 
     use super::{Error, RoomListService, State, ALL_ROOMS_LIST_NAME};
 
     async fn new_client() -> (Client, MockServer) {
-        let session = MatrixSession {
-            meta: SessionMeta {
-                user_id: user_id!("@example:localhost").to_owned(),
-                device_id: device_id!("DEVICEID").to_owned(),
-            },
-            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-        };
+        let session = mock_matrix_session();
 
         let server = MockServer::start().await;
         let client = Client::builder()

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
@@ -8,17 +8,16 @@ use std::{
 
 use futures_util::{pin_mut, StreamExt as _};
 use matrix_sdk::{
-    authentication::matrix::{MatrixSession, MatrixSessionTokens},
     config::RequestConfig,
-    test_utils::{logged_in_client_with_server, test_client_builder_with_server},
-    SessionMeta,
+    test_utils::{
+        client::mock_matrix_session, logged_in_client_with_server, test_client_builder_with_server,
+    },
 };
 use matrix_sdk_base::crypto::store::Changes;
 use matrix_sdk_test::async_test;
 use matrix_sdk_ui::encryption_sync_service::{
     EncryptionSyncPermit, EncryptionSyncService, WithLocking,
 };
-use ruma::{device_id, user_id};
 use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::Mutex as AsyncMutex;
@@ -340,7 +339,6 @@ async fn test_notification_client_does_not_upload_duplicate_one_time_keys() -> a
     use tempfile::tempdir;
 
     let dir = tempdir().unwrap();
-    let user_id = user_id!("@example:morpheus.localhost");
 
     let (builder, server) = test_client_builder_with_server().await;
     let client = builder
@@ -350,10 +348,7 @@ async fn test_notification_client_does_not_upload_duplicate_one_time_keys() -> a
         .await
         .unwrap();
 
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = mock_matrix_session();
 
     client.restore_session(session.to_owned()).await.unwrap();
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -113,6 +113,12 @@ simpler methods:
     `CsrfToken`.
   - The `error` field of `AuthorizationError` uses an error type from the oauth2
     crate rather than one from mas-oidc-client.
+- [**breaking**]: `OidcSessionTokens` and `MatrixSessionTokens` have been merged
+  into `SessionTokens`. Methods to get and watch session tokens are now
+  available directly on `Client`.
+  `(MatrixAuth/Oidc)::session_tokens_stream()`, can be replaced by
+  `Client::subscribe_to_session_changes()` and then calling
+  `Client::session_tokens()` on a `SessionChange::TokenRefreshed`.
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
@@ -299,7 +299,7 @@ mod tests {
             ))
             .await?;
 
-        assert_eq!(client.oidc().session_tokens().unwrap(), tokens);
+        assert_eq!(client.session_tokens().unwrap(), tokens);
 
         let oidc = client.oidc();
         let xp_manager = oidc.ctx().cross_process_token_refresh_manager.get().unwrap();
@@ -337,7 +337,7 @@ mod tests {
 
         // Simulate we've done finalize_authorization / restore_session before.
         let session_tokens = mock_session_tokens_with_refresh();
-        oidc.set_session_tokens(session_tokens.clone());
+        client.auth_ctx().set_session_tokens(session_tokens.clone());
 
         // Now, finishing logging will get the user and device ids.
         oidc.finish_login().await?;
@@ -454,7 +454,7 @@ mod tests {
             // first token.
             oidc3.refresh_access_token().await?;
 
-            assert_eq!(oidc3.session_tokens(), Some(next_tokens.clone()));
+            assert_eq!(client3.session_tokens(), Some(next_tokens.clone()));
 
             // Reading from the cross-process lock for the second client only shows the new
             // tokens.

--- a/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::trace;
 
-use super::OidcSessionTokens;
+use crate::SessionTokens;
 
 /// Key in the database for the custom value holding the current session tokens
 /// hash.
@@ -50,7 +50,7 @@ impl std::fmt::Debug for SessionHash {
 }
 
 /// Compute a hash uniquely identifying the OIDC session tokens.
-fn compute_session_hash(tokens: &OidcSessionTokens) -> SessionHash {
+fn compute_session_hash(tokens: &SessionTokens) -> SessionHash {
     let mut hash = Sha256::new().chain_update(tokens.access_token.as_bytes());
     if let Some(refresh_token) = &tokens.refresh_token {
         hash = hash.chain_update(refresh_token.as_bytes());
@@ -118,7 +118,7 @@ impl CrossProcessRefreshManager {
         Ok(guard)
     }
 
-    pub async fn restore_session(&self, tokens: &OidcSessionTokens) {
+    pub async fn restore_session(&self, tokens: &SessionTokens) {
         let prev_tokens_hash = compute_session_hash(tokens);
         *self.known_session_hash.lock().await = Some(prev_tokens_hash);
     }
@@ -181,7 +181,7 @@ impl CrossProcessRefreshLockGuard {
     /// Must be called after a successful refresh.
     pub async fn save_in_memory_and_db(
         &mut self,
-        tokens: &OidcSessionTokens,
+        tokens: &SessionTokens,
     ) -> Result<(), CrossProcessRefreshLockError> {
         let hash = compute_session_hash(tokens);
         self.save_in_database(&hash).await?;
@@ -193,7 +193,7 @@ impl CrossProcessRefreshLockGuard {
     /// tokens we trust.
     pub async fn handle_mismatch(
         &mut self,
-        trusted_tokens: &OidcSessionTokens,
+        trusted_tokens: &SessionTokens,
     ) -> Result<(), CrossProcessRefreshLockError> {
         let new_hash = compute_session_hash(trusted_tokens);
         trace!("Trusted OIDC tokens have hash {new_hash:?}; db had {:?}", self.db_hash);
@@ -237,11 +237,6 @@ pub enum CrossProcessRefreshLockError {
     #[error("reload session callback must be set with Client::set_session_callbacks() for the cross-process lock to work")]
     MissingReloadSession,
 
-    /// Session tokens returned by the reload_session callback were not for
-    /// OIDC.
-    #[error("session tokens returned by the reload_session callback were not for OIDC")]
-    InvalidSessionTokens,
-
     /// The store has been created twice.
     #[error(
         "the cross-process lock has been set up twice with `enable_cross_process_refresh_lock`"
@@ -263,8 +258,8 @@ mod tests {
         authentication::oidc::cross_process::SessionHash,
         test_utils::{
             client::{
-                oauth::{mock_prev_session_tokens, mock_session, mock_session_tokens},
-                MockClientBuilder,
+                mock_prev_session_tokens_with_refresh, mock_session_tokens_with_refresh,
+                oauth::mock_session, MockClientBuilder,
             },
             mocks::MatrixMockServer,
         },
@@ -282,7 +277,7 @@ mod tests {
             .build()
             .await;
 
-        let tokens = mock_session_tokens();
+        let tokens = mock_session_tokens_with_refresh();
 
         client.oidc().enable_cross_process_refresh_lock("test".to_owned()).await?;
 
@@ -290,7 +285,7 @@ mod tests {
             Box::new({
                 // This is only called because of extra checks in the code.
                 let tokens = tokens.clone();
-                move |_| Ok(crate::authentication::SessionTokens::Oidc(tokens.clone()))
+                move |_| Ok(tokens.clone())
             }),
             Box::new(|_| panic!("save_session_callback shouldn't be called here")),
         )?;
@@ -341,7 +336,7 @@ mod tests {
         oidc.enable_cross_process_refresh_lock("lock".to_owned()).await?;
 
         // Simulate we've done finalize_authorization / restore_session before.
-        let session_tokens = mock_session_tokens();
+        let session_tokens = mock_session_tokens_with_refresh();
         oidc.set_session_tokens(session_tokens.clone());
 
         // Now, finishing logging will get the user and device ids.
@@ -386,14 +381,17 @@ mod tests {
         let client = server.client_builder().sqlite_store(&tmp_dir).unlogged().build().await;
         let oidc = client.oidc();
 
-        let next_tokens = mock_session_tokens();
+        let next_tokens = mock_session_tokens_with_refresh();
 
         // Enable cross-process lock.
         oidc.enable_cross_process_refresh_lock("lock".to_owned()).await?;
 
         // Restore the session.
-        oidc.restore_session(mock_session(mock_prev_session_tokens(), server.server().uri()))
-            .await?;
+        oidc.restore_session(mock_session(
+            mock_prev_session_tokens_with_refresh(),
+            server.server().uri(),
+        ))
+        .await?;
 
         // Immediately try to refresh the access token twice in parallel.
         for result in join_all([oidc.refresh_access_token(), oidc.refresh_access_token()]).await {
@@ -424,8 +422,8 @@ mod tests {
         oauth_server.mock_server_metadata().ok().expect(1..).named("server_metadata").mount().await;
         oauth_server.mock_token().ok().expect(1).named("token").mount().await;
 
-        let prev_tokens = mock_prev_session_tokens();
-        let next_tokens = mock_session_tokens();
+        let prev_tokens = mock_prev_session_tokens_with_refresh();
+        let next_tokens = mock_session_tokens_with_refresh();
 
         // Create the first client.
         let tmp_dir = tempfile::tempdir()?;
@@ -477,7 +475,7 @@ mod tests {
                 Box::new({
                     // This is only called because of extra checks in the code.
                     let tokens = next_tokens.clone();
-                    move |_| Ok(crate::authentication::SessionTokens::Oidc(tokens.clone()))
+                    move |_| Ok(tokens.clone())
                 }),
                 Box::new(|_| panic!("save_session_callback shouldn't be called here")),
             )?;
@@ -514,7 +512,7 @@ mod tests {
             Box::new({
                 // This is only called because of extra checks in the code.
                 let tokens = next_tokens.clone();
-                move |_| Ok(crate::authentication::SessionTokens::Oidc(tokens.clone()))
+                move |_| Ok(tokens.clone())
             }),
             Box::new(|_| panic!("save_session_callback shouldn't be called here")),
         )?;
@@ -557,7 +555,7 @@ mod tests {
         oidc.enable_cross_process_refresh_lock("lock".to_owned()).await?;
 
         // Restore the session.
-        let tokens = mock_session_tokens();
+        let tokens = mock_session_tokens_with_refresh();
         oidc.restore_session(mock_session(tokens.clone(), server.server().uri())).await?;
 
         oidc.logout().await?;

--- a/crates/matrix-sdk/src/authentication/oidc/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/tests.rs
@@ -33,9 +33,8 @@ use crate::{
     },
     test_utils::{
         client::{
-            oauth::{
-                mock_client_metadata, mock_prev_session_tokens, mock_session, mock_session_tokens,
-            },
+            mock_prev_session_tokens_with_refresh, mock_session_tokens_with_refresh,
+            oauth::{mock_client_metadata, mock_session},
             MockClientBuilder,
         },
         mocks::{oauth::MockServerMetadataBuilder, MatrixMockServer},
@@ -396,7 +395,7 @@ async fn test_oidc_session() -> anyhow::Result<()> {
     let client = MockClientBuilder::new("https://example.org".to_owned()).unlogged().build().await;
     let oidc = client.oidc();
 
-    let tokens = mock_session_tokens();
+    let tokens = mock_session_tokens_with_refresh();
     let issuer = "https://oidc.example.com/issuer";
     let session = mock_session(tokens.clone(), issuer.to_owned());
     oidc.restore_session(session.clone()).await?;
@@ -432,8 +431,8 @@ async fn test_insecure_clients() -> anyhow::Result<()> {
     oauth_server.mock_server_metadata().ok().expect(2..).named("server_metadata").mount().await;
     oauth_server.mock_token().ok().expect(2).named("token").mount().await;
 
-    let prev_tokens = mock_prev_session_tokens();
-    let next_tokens = mock_session_tokens();
+    let prev_tokens = mock_prev_session_tokens_with_refresh();
+    let next_tokens = mock_session_tokens_with_refresh();
 
     for client in [
         // Create an insecure client with the homeserver_url method.

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -516,6 +516,7 @@ impl ClientBuilder {
             refresh_token_lock: Arc::new(Mutex::new(Ok(()))),
             session_change_sender: broadcast::Sender::new(1),
             auth_data: OnceCell::default(),
+            tokens: OnceCell::default(),
             reload_session_callback: OnceCell::default(),
             save_session_callback: OnceCell::default(),
             #[cfg(feature = "experimental-oidc")]

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1760,13 +1760,12 @@ mod tests {
         time::Duration,
     };
 
-    use matrix_sdk_base::SessionMeta;
     use matrix_sdk_test::{
         async_test, test_json, GlobalAccountDataTestEvent, JoinedRoomBuilder, StateTestEvent,
         SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
     };
     use ruma::{
-        device_id, event_id,
+        event_id,
         events::{reaction::ReactionEventContent, relation::Annotation},
         user_id,
     };
@@ -1778,10 +1777,11 @@ mod tests {
 
     use crate::{
         assert_next_matches_with_timeout,
-        authentication::matrix::{MatrixSession, MatrixSessionTokens},
         config::RequestConfig,
         encryption::VerificationState,
-        test_utils::{logged_in_client, no_retry_test_client, set_client_session},
+        test_utils::{
+            client::mock_matrix_session, logged_in_client, no_retry_test_client, set_client_session,
+        },
         Client,
     };
 
@@ -1906,13 +1906,7 @@ mod tests {
     async fn test_generation_counter_invalidates_olm_machine() {
         // Create two clients using the same sqlite database.
         let sqlite_path = std::env::temp_dir().join("generation_counter_sqlite.db");
-        let session = MatrixSession {
-            meta: SessionMeta {
-                user_id: user_id!("@example:localhost").to_owned(),
-                device_id: device_id!("DEVICEID").to_owned(),
-            },
-            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-        };
+        let session = mock_matrix_session();
 
         let client1 = Client::builder()
             .homeserver_url("http://localhost:1234")
@@ -2014,13 +2008,7 @@ mod tests {
         // Create two clients using the same sqlite database.
         let sqlite_path =
             std::env::temp_dir().join("generation_counter_no_spurious_invalidations.db");
-        let session = MatrixSession {
-            meta: SessionMeta {
-                user_id: user_id!("@example:localhost").to_owned(),
-                device_id: device_id!("DEVICEID").to_owned(),
-            },
-            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-        };
+        let session = mock_matrix_session();
 
         let client = Client::builder()
             .homeserver_url("http://localhost:1234")

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3720,12 +3720,12 @@ pub struct TryFromReportedContentScoreError(());
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use assert_matches2::assert_matches;
-    use matrix_sdk_base::{store::ComposerDraftType, ComposerDraft, SessionMeta};
+    use matrix_sdk_base::{store::ComposerDraftType, ComposerDraft};
     use matrix_sdk_test::{
         async_test, event_factory::EventFactory, test_json, JoinedRoomBuilder, StateTestEvent,
         SyncResponseBuilder,
     };
-    use ruma::{device_id, event_id, events::room::member::MembershipState, int, room_id, user_id};
+    use ruma::{event_id, events::room::member::MembershipState, int, room_id, user_id};
     use wiremock::{
         matchers::{header, method, path_regex},
         Mock, MockServer, ResponseTemplate,
@@ -3733,9 +3733,8 @@ mod tests {
 
     use super::ReportedContentScore;
     use crate::{
-        authentication::matrix::{MatrixSession, MatrixSessionTokens},
         config::RequestConfig,
-        test_utils::{logged_in_client, mocks::MatrixMockServer},
+        test_utils::{client::mock_matrix_session, logged_in_client, mocks::MatrixMockServer},
         Client,
     };
 
@@ -3745,13 +3744,7 @@ mod tests {
         use matrix_sdk_test::{message_like_event_content, DEFAULT_TEST_ROOM_ID};
 
         let sqlite_path = std::env::temp_dir().join("cache_invalidation_while_encrypt.db");
-        let session = MatrixSession {
-            meta: SessionMeta {
-                user_id: user_id!("@example:localhost").to_owned(),
-                device_id: device_id!("DEVICEID").to_owned(),
-            },
-            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-        };
+        let session = mock_matrix_session();
 
         let client = Client::builder()
             .homeserver_url("http://localhost:1234")

--- a/crates/matrix-sdk/src/test_utils/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mod.rs
@@ -3,12 +3,10 @@
 #![allow(dead_code)]
 
 use assert_matches2::assert_let;
-use matrix_sdk_base::{deserialized_responses::TimelineEvent, SessionMeta};
+use matrix_sdk_base::deserialized_responses::TimelineEvent;
 use ruma::{
     api::MatrixVersion,
-    device_id,
     events::{room::message::MessageType, AnySyncMessageLikeEvent, AnySyncTimelineEvent},
-    user_id,
 };
 use url::Url;
 
@@ -16,11 +14,8 @@ pub mod client;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod mocks;
 
-use crate::{
-    authentication::matrix::{MatrixSession, MatrixSessionTokens},
-    config::RequestConfig,
-    Client, ClientBuilder,
-};
+use self::client::mock_matrix_session;
+use crate::{config::RequestConfig, Client, ClientBuilder};
 
 /// Checks that an event is a message-like text event with the given text.
 #[track_caller]
@@ -56,17 +51,7 @@ pub async fn no_retry_test_client(homeserver_url: Option<String>) -> Client {
 
 /// Restore the common (Matrix-auth) user session for a client.
 pub async fn set_client_session(client: &Client) {
-    client
-        .matrix_auth()
-        .restore_session(MatrixSession {
-            meta: SessionMeta {
-                user_id: user_id!("@example:localhost").to_owned(),
-                device_id: device_id!("DEVICEID").to_owned(),
-            },
-            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-        })
-        .await
-        .unwrap();
+    client.matrix_auth().restore_session(mock_matrix_session()).await.unwrap();
 }
 
 /// A [`Client`] using the given `homeserver_url` (or localhost:1234), that will

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -4,11 +4,10 @@ use assert_matches2::{assert_let, assert_matches};
 use eyeball_im::VectorDiff;
 use futures_util::FutureExt;
 use matrix_sdk::{
-    authentication::matrix::{MatrixSession, MatrixSessionTokens},
     config::{RequestConfig, StoreConfig, SyncSettings},
     sync::RoomUpdate,
-    test_utils::no_retry_test_client_with_server,
-    Client, MemoryStore, SessionMeta, StateChanges, StateStore,
+    test_utils::{client::mock_matrix_session, no_retry_test_client_with_server},
+    Client, MemoryStore, StateChanges, StateStore,
 };
 use matrix_sdk_base::{sync::RoomUpdates, RoomState};
 use matrix_sdk_test::{
@@ -1380,17 +1379,7 @@ async fn test_restore_room() {
         .build()
         .await
         .unwrap();
-    client
-        .matrix_auth()
-        .restore_session(MatrixSession {
-            meta: SessionMeta {
-                user_id: user_id!("@example:localhost").to_owned(),
-                device_id: device_id!("DEVICEID").to_owned(),
-            },
-            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-        })
-        .await
-        .unwrap();
+    client.matrix_auth().restore_session(mock_matrix_session()).await.unwrap();
 
     let room = client.get_room(room_id).unwrap();
     assert!(room.is_favourite());

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -18,7 +18,7 @@ use anyhow::Result;
 use assert_matches::assert_matches;
 use futures_util::{pin_mut, FutureExt, StreamExt};
 use matrix_sdk::{
-    authentication::matrix::{MatrixSession, MatrixSessionTokens},
+    authentication::matrix::MatrixSession,
     config::RequestConfig,
     crypto::{
         olm::{InboundGroupSession, SenderData, SessionCreationError},
@@ -30,17 +30,20 @@ use matrix_sdk::{
         secret_storage::SecretStore,
         BackupDownloadStrategy, EncryptionSettings,
     },
-    test_utils::{no_retry_test_client_with_server, test_client_builder_with_server},
-    Client,
+    test_utils::{
+        client::mock_session_tokens, no_retry_test_client_with_server,
+        test_client_builder_with_server,
+    },
+    Client, SessionMeta,
 };
-use matrix_sdk_base::{crypto::olm::OutboundGroupSession, SessionMeta};
+use matrix_sdk_base::crypto::olm::OutboundGroupSession;
 use matrix_sdk_common::timeout::timeout;
 use matrix_sdk_test::{async_test, JoinedRoomBuilder, SyncResponseBuilder};
 use ruma::{
     api::client::room::create_room::v3::Request as CreateRoomRequest,
     assign, device_id, event_id,
     events::room::message::{RoomMessageEvent, RoomMessageEventContent},
-    room_id, user_id, EventId, RoomId, TransactionId,
+    owned_device_id, owned_user_id, room_id, user_id, EventId, RoomId, TransactionId,
 };
 use serde_json::{json, Value};
 use tempfile::tempdir;
@@ -72,6 +75,26 @@ const ROOM_KEY: &[u8] = b"\
         HztoSJUr/2Y\n\
         -----END MEGOLM SESSION DATA-----";
 
+fn matrix_session_example() -> MatrixSession {
+    MatrixSession {
+        meta: SessionMeta {
+            user_id: owned_user_id!("@example:morpheus.localhost"),
+            device_id: owned_device_id!("DEVICEID"),
+        },
+        tokens: mock_session_tokens(),
+    }
+}
+
+fn matrix_session_example2() -> MatrixSession {
+    MatrixSession {
+        meta: SessionMeta {
+            user_id: owned_user_id!("@example2:morpheus.localhost"),
+            device_id: owned_device_id!("DEVICEID"),
+        },
+        tokens: mock_session_tokens(),
+    }
+}
+
 async fn mount_and_assert_called_once(
     server: &wiremock::MockServer,
     method_argument: &str,
@@ -89,12 +112,7 @@ async fn mount_and_assert_called_once(
 
 #[async_test]
 async fn test_create() {
-    let user_id = user_id!("@example:morpheus.localhost");
-
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example();
 
     let (client, server) = no_retry_test_client_with_server().await;
 
@@ -165,12 +183,7 @@ async fn test_create() {
 
 #[async_test]
 async fn test_creation_failure() {
-    let user_id = user_id!("@example:morpheus.localhost");
-
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example();
     let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
@@ -246,12 +259,7 @@ async fn test_creation_failure() {
 
 #[async_test]
 async fn test_disabling() {
-    let user_id = user_id!("@example:morpheus.localhost");
-
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example();
     let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
@@ -333,12 +341,7 @@ async fn test_disabling() {
 
 #[async_test]
 async fn test_disable_if_only_enabled_remotely() {
-    let user_id = user_id!("@example:morpheus.localhost");
-
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example();
     let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
@@ -369,8 +372,6 @@ async fn test_backup_resumption() {
 
     let dir = tempdir().unwrap();
 
-    let user_id = user_id!("@example:morpheus.localhost");
-
     let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
@@ -379,10 +380,7 @@ async fn test_backup_resumption() {
         .await
         .unwrap();
 
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example();
 
     Mock::given(method("POST"))
         .and(path("_matrix/client/unstable/room_keys/version"))
@@ -459,12 +457,7 @@ async fn setup_backups(client: &Client, server: &wiremock::MockServer) {
 
 #[async_test]
 async fn test_steady_state_waiting() {
-    let user_id = user_id!("@example:morpheus.localhost");
-
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example();
     let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
@@ -643,12 +636,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
 /// device event as well.
 #[async_test]
 async fn test_incremental_upload_of_keys() -> Result<()> {
-    let user_id = user_id!("@example:morpheus.localhost");
-
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example();
     let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
@@ -717,12 +705,7 @@ async fn test_incremental_upload_of_keys() -> Result<()> {
 async fn test_incremental_upload_of_keys_sliding_sync() -> Result<()> {
     use tokio::task::spawn_blocking;
 
-    let user_id = user_id!("@example:morpheus.localhost");
-
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example();
     let server = wiremock::MockServer::start().await;
     let builder = Client::builder()
         .homeserver_url(server.uri())
@@ -837,12 +820,7 @@ async fn test_incremental_upload_of_keys_sliding_sync() -> Result<()> {
 
 #[async_test]
 async fn test_steady_state_waiting_errors() {
-    let user_id = user_id!("@example:morpheus.localhost");
-
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example();
     let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
@@ -926,10 +904,7 @@ async fn test_enable_from_secret_storage() {
     let room_id = room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost");
     let event_id = event_id!("$JbFHtZpEJiH8uaajZjPLz0QUZc1xtBR9rPGBOjF6WFM");
 
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example2();
     let (builder, server) = test_client_builder_with_server().await;
     let encryption_settings = EncryptionSettings {
         backup_download_strategy: BackupDownloadStrategy::OneShot,
@@ -1062,12 +1037,7 @@ async fn test_enable_from_secret_storage() {
 
 #[async_test]
 async fn test_enable_from_secret_storage_no_existing_backup() {
-    let user_id = user_id!("@example2:morpheus.localhost");
-
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example2();
     let (builder, server) = test_client_builder_with_server().await;
     let encryption_settings = EncryptionSettings {
         backup_download_strategy: BackupDownloadStrategy::OneShot,
@@ -1105,12 +1075,7 @@ async fn test_enable_from_secret_storage_no_existing_backup() {
 
 #[async_test]
 async fn test_enable_from_secret_storage_mismatched_key() {
-    let user_id = user_id!("@example2:morpheus.localhost");
-
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example2();
     let (builder, server) = test_client_builder_with_server().await;
     let encryption_settings = EncryptionSettings {
         backup_download_strategy: BackupDownloadStrategy::OneShot,
@@ -1157,12 +1122,7 @@ async fn test_enable_from_secret_storage_mismatched_key() {
 
 #[async_test]
 async fn test_enable_from_secret_storage_manual_download() {
-    let user_id = user_id!("@example2:morpheus.localhost");
-
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example2();
     let (builder, server) = test_client_builder_with_server().await;
     let client =
         builder.request_config(RequestConfig::new().disable_retry()).build().await.unwrap();
@@ -1188,13 +1148,9 @@ async fn test_enable_from_secret_storage_manual_download() {
 
 #[async_test]
 async fn test_enable_from_secret_storage_and_manual_download() {
-    let user_id = user_id!("@example2:morpheus.localhost");
     let room_id = room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost");
 
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example2();
     let (builder, server) = test_client_builder_with_server().await;
     let encryption_settings = EncryptionSettings {
         backup_download_strategy: BackupDownloadStrategy::Manual,
@@ -1309,14 +1265,10 @@ async fn test_enable_from_secret_storage_and_manual_download() {
 
 #[async_test]
 async fn test_enable_from_secret_storage_and_download_after_utd() {
-    let user_id = user_id!("@example2:morpheus.localhost");
     let room_id = room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost");
     let event_id = event_id!("$JbFHtZpEJiH8uaajZjPLz0QUZc1xtBR9rPGBOjF6WFM");
 
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example2();
     let (builder, server) = test_client_builder_with_server().await;
     let encryption_settings = EncryptionSettings {
         backup_download_strategy: BackupDownloadStrategy::AfterDecryptionFailure,
@@ -1424,14 +1376,10 @@ async fn test_enable_from_secret_storage_and_download_after_utd() {
 /// download if the UTD message has a lower megolm ratchet index than we have.
 #[async_test]
 async fn test_enable_from_secret_storage_and_download_after_utd_from_old_message_index() {
-    let user_id = user_id!("@example2:morpheus.localhost");
     let room_id = room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost");
     let event_id = event_id!("$JbFHtZpEJiH8uaajZjPLz0QUZc1xtBR9rPGBOjF6WFM");
 
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = matrix_session_example2();
     let (builder, server) = test_client_builder_with_server().await;
     let encryption_settings = EncryptionSettings {
         backup_download_strategy: BackupDownloadStrategy::AfterDecryptionFailure,

--- a/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
@@ -14,13 +14,11 @@
 
 use assert_matches2::assert_let;
 use matrix_sdk::{
-    authentication::matrix::{MatrixSession, MatrixSessionTokens},
     encryption::CrossSigningResetAuthType,
-    test_utils::no_retry_test_client_with_server,
-    SessionMeta,
+    test_utils::{client::mock_matrix_session, no_retry_test_client_with_server},
 };
 use matrix_sdk_test::async_test;
-use ruma::{api::client::uiaa, device_id, user_id};
+use ruma::{api::client::uiaa, user_id};
 use serde_json::json;
 use wiremock::{
     matchers::{method, path},
@@ -31,10 +29,7 @@ use wiremock::{
 async fn test_reset_legacy_auth() {
     let user_id = user_id!("@example:morpheus.localhost");
 
-    let session = MatrixSession {
-        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+    let session = mock_matrix_session();
 
     let (client, server) = no_retry_test_client_with_server().await;
 

--- a/crates/matrix-sdk/tests/integration/encryption/recovery.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/recovery.rs
@@ -17,14 +17,17 @@ use std::sync::{Arc, Mutex};
 use assert_matches2::assert_let;
 use futures_util::StreamExt;
 use matrix_sdk::{
-    authentication::matrix::{MatrixSession, MatrixSessionTokens},
+    authentication::matrix::MatrixSession,
     config::RequestConfig,
     encryption::{
         backups::BackupState,
         recovery::{EnableProgress, RecoveryState},
         BackupDownloadStrategy, CrossSigningResetAuthType,
     },
-    test_utils::{no_retry_test_client_with_server, test_client_builder_with_server},
+    test_utils::{
+        client::mock_session_tokens, no_retry_test_client_with_server,
+        test_client_builder_with_server,
+    },
     Client,
 };
 use matrix_sdk_base::SessionMeta;
@@ -43,7 +46,7 @@ use crate::{encryption::mock_secret_store_with_backup_key, logged_in_client_with
 async fn test_client(user_id: &UserId) -> (Client, wiremock::MockServer) {
     let session = MatrixSession {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+        tokens: mock_session_tokens(),
     };
 
     let (builder, server) = test_client_builder_with_server().await;
@@ -168,7 +171,7 @@ async fn test_recovery_status_secret_storage_set_up() {
 
     let session = MatrixSession {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+        tokens: mock_session_tokens(),
     };
 
     let (client, server) = no_retry_test_client_with_server().await;
@@ -189,7 +192,7 @@ async fn test_recovery_status_secret_storage_not_set_up() {
 
     let session = MatrixSession {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+        tokens: mock_session_tokens(),
     };
 
     let (client, server) = no_retry_test_client_with_server().await;
@@ -717,7 +720,7 @@ async fn test_recover_and_reset() {
 
     let session = MatrixSession {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+        tokens: mock_session_tokens(),
     };
 
     let (client, server) = no_retry_test_client_with_server().await;

--- a/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
@@ -2,9 +2,9 @@ use std::sync::{Arc, Mutex};
 
 use assert_matches::assert_matches;
 use matrix_sdk::{
-    authentication::matrix::{MatrixSession, MatrixSessionTokens},
+    authentication::matrix::MatrixSession,
     encryption::secret_storage::SecretStorageError,
-    test_utils::no_retry_test_client_with_server,
+    test_utils::{client::mock_session_tokens, no_retry_test_client_with_server},
 };
 use matrix_sdk_base::SessionMeta;
 use matrix_sdk_test::async_test;
@@ -374,7 +374,7 @@ async fn test_restore_cross_signing_from_secret_store() {
             user_id: user_id!("@example:morpheus.localhost").to_owned(),
             device_id: device_id!("DEVICEID").to_owned(),
         },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+        tokens: mock_session_tokens(),
     };
     let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
@@ -575,7 +575,7 @@ async fn test_is_secret_storage_enabled() {
             user_id: user_id!("@example:morpheus.localhost").to_owned(),
             device_id: device_id!("DEVICEID").to_owned(),
         },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+        tokens: mock_session_tokens(),
     };
     let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();

--- a/crates/matrix-sdk/tests/integration/encryption/verification.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/verification.rs
@@ -7,10 +7,10 @@ use assert_matches2::assert_matches;
 use futures_util::FutureExt;
 use imbl::HashSet;
 use matrix_sdk::{
-    authentication::matrix::{MatrixSession, MatrixSessionTokens},
+    authentication::matrix::MatrixSession,
     config::RequestConfig,
     encryption::VerificationState,
-    test_utils::logged_in_client_with_server,
+    test_utils::{client::mock_session_tokens, logged_in_client_with_server},
     Client,
 };
 use matrix_sdk_base::SessionMeta;
@@ -333,7 +333,7 @@ async fn test_own_verification() {
     alice
         .restore_session(MatrixSession {
             meta: SessionMeta { user_id: user_id.clone(), device_id: device_id.clone() },
-            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+            tokens: mock_session_tokens(),
         })
         .await
         .unwrap();
@@ -417,7 +417,7 @@ async fn test_reset_cross_signing_resets_verification() {
     alice
         .restore_session(MatrixSession {
             meta: SessionMeta { user_id: user_id.clone(), device_id: device_id.clone() },
-            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+            tokens: mock_session_tokens(),
         })
         .await
         .unwrap();
@@ -470,7 +470,7 @@ async fn test_reset_cross_signing_resets_verification() {
     alice2
         .restore_session(MatrixSession {
             meta: SessionMeta { user_id: user_id.clone(), device_id: device_id.clone() },
-            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+            tokens: mock_session_tokens(),
         })
         .await
         .unwrap();
@@ -517,7 +517,7 @@ async fn test_unchecked_mutual_verification() {
                 user_id: alice_user_id.clone(),
                 device_id: alice_device_id.clone(),
             },
-            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+            tokens: mock_session_tokens(),
         })
         .await
         .unwrap();
@@ -534,7 +534,7 @@ async fn test_unchecked_mutual_verification() {
     let bob_device_id = owned_device_id!("B0B0B0B0B");
     bob.restore_session(MatrixSession {
         meta: SessionMeta { user_id: bob_user_id.clone(), device_id: bob_device_id.clone() },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+        tokens: mock_session_tokens(),
     })
     .await
     .unwrap();

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -2,10 +2,10 @@ use std::{collections::BTreeMap, sync::Mutex};
 
 use assert_matches::assert_matches;
 use matrix_sdk::{
-    authentication::matrix::{MatrixSession, MatrixSessionTokens},
+    authentication::matrix::MatrixSession,
     config::RequestConfig,
     test_utils::{logged_in_client_with_server, no_retry_test_client_with_server},
-    AuthApi, AuthSession, Client, RumaApiError,
+    AuthApi, AuthSession, Client, RumaApiError, SessionTokens,
 };
 use matrix_sdk_base::SessionMeta;
 use matrix_sdk_test::{async_test, test_json};
@@ -335,7 +335,7 @@ fn test_serialize_session() {
             user_id: user_id!("@user:localhost").to_owned(),
             device_id: device_id!("EFGHIJ").to_owned(),
         },
-        tokens: MatrixSessionTokens { access_token: "abcd".to_owned(), refresh_token: None },
+        tokens: SessionTokens { access_token: "abcd".to_owned(), refresh_token: None },
     };
     assert_eq!(
         to_json_value(session.clone()).unwrap(),

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -1,16 +1,15 @@
 use matrix_sdk::{
-    authentication::matrix::{MatrixSession, MatrixSessionTokens},
     config::RequestConfig,
     media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings},
-    test_utils::logged_in_client_with_server,
-    Client, SessionMeta,
+    test_utils::{client::mock_matrix_session, logged_in_client_with_server},
+    Client,
 };
 use matrix_sdk_test::async_test;
 use ruma::{
     api::client::media::get_content_thumbnail::v3::Method,
-    assign, device_id,
+    assign,
     events::room::{message::ImageMessageEventContent, ImageInfo, MediaSource},
-    mxc_uri, owned_mxc_uri, uint, user_id,
+    mxc_uri, owned_mxc_uri, uint,
 };
 use serde_json::json;
 use wiremock::{
@@ -216,17 +215,7 @@ async fn test_get_media_file_with_auth_matrix_1_11() {
         .unwrap();
 
     // Restore session.
-    client
-        .matrix_auth()
-        .restore_session(MatrixSession {
-            meta: SessionMeta {
-                user_id: user_id!("@example:localhost").to_owned(),
-                device_id: device_id!("DEVICEID").to_owned(),
-            },
-            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-        })
-        .await
-        .unwrap();
+    client.matrix_auth().restore_session(mock_matrix_session()).await.unwrap();
 
     // Build event content.
     let event_content = ImageMessageEventContent::plain(
@@ -331,17 +320,7 @@ async fn test_get_media_file_with_auth_matrix_stable_feature() {
         .unwrap();
 
     // Restore session.
-    client
-        .matrix_auth()
-        .restore_session(MatrixSession {
-            meta: SessionMeta {
-                user_id: user_id!("@example:localhost").to_owned(),
-                device_id: device_id!("DEVICEID").to_owned(),
-            },
-            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-        })
-        .await
-        .unwrap();
+    client.matrix_auth().restore_session(mock_matrix_session()).await.unwrap();
 
     // Build event content.
     let event_content = ImageMessageEventContent::plain(

--- a/examples/secret_storage/src/main.rs
+++ b/examples/secret_storage/src/main.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use matrix_sdk::{
-    authentication::matrix::{MatrixSession, MatrixSessionTokens},
+    authentication::matrix::MatrixSession,
     encryption::secret_storage::SecretStore,
     ruma::{events::secret::request::SecretName, OwnedDeviceId, OwnedUserId},
-    AuthSession, Client, SessionMeta,
+    AuthSession, Client, SessionMeta, SessionTokens,
 };
 use url::Url;
 
@@ -115,10 +115,7 @@ async fn restore_client(cli: &Cli) -> Result<Client> {
     // TODO: We should be able to get the device id from `/whoami`.
     let session = AuthSession::Matrix(MatrixSession {
         meta: SessionMeta { user_id: cli.user_id.to_owned(), device_id: cli.device_id.to_owned() },
-        tokens: MatrixSessionTokens {
-            access_token: cli.access_token.to_owned(),
-            refresh_token: None,
-        },
+        tokens: SessionTokens { access_token: cli.access_token.to_owned(), refresh_token: None },
     });
 
     client.restore_session(session).await?;


### PR DESCRIPTION
Since both authentication APIs now have identical session tokens type, we can merge them an put the data in `AuthCtx`.

I decided to not reuse a `SharedObservable` because the `session_tokens_stream` behavior can be done by subscribing to `Client::subscribe_to_session_changes()` and then calling `Client::session_tokens()`.
