### PR TITLE
test(sdk): Allow any MockEndpoint to override the expected access token

### DIFF
--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -288,13 +288,12 @@ impl MatrixMockServer {
     /// # anyhow::Ok(()) });
     /// ```
     pub fn mock_sync(&self) -> MockEndpoint<'_, SyncEndpoint> {
-        let mock = Mock::given(method("GET"))
-            .and(path("/_matrix/client/v3/sync"))
-            .and(header("authorization", "Bearer 1234"));
+        let mock = Mock::given(method("GET")).and(path("/_matrix/client/v3/sync"));
         self.mock_endpoint(
             mock,
             SyncEndpoint { sync_response_builder: self.sync_response_builder.clone() },
         )
+        .expect_default_access_token()
     }
 
     /// Creates a prebuilt mock for sending an event in a room.
@@ -336,9 +335,8 @@ impl MatrixMockServer {
     /// ```
     pub fn mock_room_send(&self) -> MockEndpoint<'_, RoomSendEndpoint> {
         let mock = Mock::given(method("PUT"))
-            .and(header("authorization", "Bearer 1234"))
             .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*".to_owned()));
-        self.mock_endpoint(mock, RoomSendEndpoint)
+        self.mock_endpoint(mock, RoomSendEndpoint).expect_default_access_token()
     }
 
     /// Creates a prebuilt mock for sending a state event in a room.
@@ -385,10 +383,9 @@ impl MatrixMockServer {
     /// # anyhow::Ok(()) });
     /// ```
     pub fn mock_room_send_state(&self) -> MockEndpoint<'_, RoomSendStateEndpoint> {
-        let mock = Mock::given(method("PUT"))
-            .and(header("authorization", "Bearer 1234"))
-            .and(path_regex(r"^/_matrix/client/v3/rooms/.*/state/.*/.*"));
-        self.mock_endpoint(mock, RoomSendStateEndpoint::default())
+        let mock =
+            Mock::given(method("PUT")).and(path_regex(r"^/_matrix/client/v3/rooms/.*/state/.*/.*"));
+        self.mock_endpoint(mock, RoomSendStateEndpoint::default()).expect_default_access_token()
     }
 
     /// Creates a prebuilt mock for asking whether *a* room is encrypted or not.
@@ -418,9 +415,8 @@ impl MatrixMockServer {
     /// ```
     pub fn mock_room_state_encryption(&self) -> MockEndpoint<'_, EncryptionStateEndpoint> {
         let mock = Mock::given(method("GET"))
-            .and(header("authorization", "Bearer 1234"))
             .and(path_regex(r"^/_matrix/client/v3/rooms/.*/state/m.*room.*encryption.?"));
-        self.mock_endpoint(mock, EncryptionStateEndpoint)
+        self.mock_endpoint(mock, EncryptionStateEndpoint).expect_default_access_token()
     }
 
     /// Creates a prebuilt mock for setting the room encryption state.
@@ -458,9 +454,8 @@ impl MatrixMockServer {
     /// ```
     pub fn mock_set_room_state_encryption(&self) -> MockEndpoint<'_, SetEncryptionStateEndpoint> {
         let mock = Mock::given(method("PUT"))
-            .and(header("authorization", "Bearer 1234"))
             .and(path_regex(r"^/_matrix/client/v3/rooms/.*/state/m.*room.*encryption.?"));
-        self.mock_endpoint(mock, SetEncryptionStateEndpoint)
+        self.mock_endpoint(mock, SetEncryptionStateEndpoint).expect_default_access_token()
     }
 
     /// Creates a prebuilt mock for the room redact endpoint.
@@ -491,32 +486,29 @@ impl MatrixMockServer {
     /// ```
     pub fn mock_room_redact(&self) -> MockEndpoint<'_, RoomRedactEndpoint> {
         let mock = Mock::given(method("PUT"))
-            .and(path_regex(r"^/_matrix/client/v3/rooms/.*/redact/.*?/.*?"))
-            .and(header("authorization", "Bearer 1234"));
-        self.mock_endpoint(mock, RoomRedactEndpoint)
+            .and(path_regex(r"^/_matrix/client/v3/rooms/.*/redact/.*?/.*?"));
+        self.mock_endpoint(mock, RoomRedactEndpoint).expect_default_access_token()
     }
 
     /// Creates a prebuilt mock for retrieving an event with /room/.../event.
     pub fn mock_room_event(&self) -> MockEndpoint<'_, RoomEventEndpoint> {
-        let mock = Mock::given(method("GET")).and(header("authorization", "Bearer 1234"));
+        let mock = Mock::given(method("GET"));
         self.mock_endpoint(mock, RoomEventEndpoint { room: None, match_event_id: false })
+            .expect_default_access_token()
     }
 
     /// Create a prebuild mock for paginating room message with the `/messages`
     /// endpoint.
     pub fn mock_room_messages(&self) -> MockEndpoint<'_, RoomMessagesEndpoint> {
-        let mock = Mock::given(method("GET"))
-            .and(path_regex(r"^/_matrix/client/v3/rooms/.*/messages$"))
-            .and(header("authorization", "Bearer 1234"));
-        self.mock_endpoint(mock, RoomMessagesEndpoint)
+        let mock =
+            Mock::given(method("GET")).and(path_regex(r"^/_matrix/client/v3/rooms/.*/messages$"));
+        self.mock_endpoint(mock, RoomMessagesEndpoint).expect_default_access_token()
     }
 
     /// Create a prebuilt mock for uploading media.
     pub fn mock_upload(&self) -> MockEndpoint<'_, UploadEndpoint> {
-        let mock = Mock::given(method("POST"))
-            .and(path("/_matrix/media/v3/upload"))
-            .and(header("authorization", "Bearer 1234"));
-        self.mock_endpoint(mock, UploadEndpoint)
+        let mock = Mock::given(method("POST")).and(path("/_matrix/media/v3/upload"));
+        self.mock_endpoint(mock, UploadEndpoint).expect_default_access_token()
     }
 
     /// Create a prebuilt mock for resolving room aliases.
@@ -768,26 +760,23 @@ impl MatrixMockServer {
     /// # }
     /// ```
     pub fn mock_room_keys_version(&self) -> MockEndpoint<'_, RoomKeysVersionEndpoint> {
-        let mock = Mock::given(method("GET"))
-            .and(path_regex(r"_matrix/client/v3/room_keys/version"))
-            .and(header("authorization", "Bearer 1234"));
-        self.mock_endpoint(mock, RoomKeysVersionEndpoint)
+        let mock =
+            Mock::given(method("GET")).and(path_regex(r"_matrix/client/v3/room_keys/version"));
+        self.mock_endpoint(mock, RoomKeysVersionEndpoint).expect_default_access_token()
     }
 
     /// Create a prebuilt mock for adding key storage backups via POST
     pub fn mock_add_room_keys_version(&self) -> MockEndpoint<'_, AddRoomKeysVersionEndpoint> {
-        let mock = Mock::given(method("POST"))
-            .and(path_regex(r"_matrix/client/v3/room_keys/version"))
-            .and(header("authorization", "Bearer 1234"));
-        self.mock_endpoint(mock, AddRoomKeysVersionEndpoint)
+        let mock =
+            Mock::given(method("POST")).and(path_regex(r"_matrix/client/v3/room_keys/version"));
+        self.mock_endpoint(mock, AddRoomKeysVersionEndpoint).expect_default_access_token()
     }
 
     /// Create a prebuilt mock for adding key storage backups via POST
     pub fn mock_delete_room_keys_version(&self) -> MockEndpoint<'_, DeleteRoomKeysVersionEndpoint> {
         let mock = Mock::given(method("DELETE"))
-            .and(path_regex(r"_matrix/client/v3/room_keys/version/[^/]*"))
-            .and(header("authorization", "Bearer 1234"));
-        self.mock_endpoint(mock, DeleteRoomKeysVersionEndpoint)
+            .and(path_regex(r"_matrix/client/v3/room_keys/version/[^/]*"));
+        self.mock_endpoint(mock, DeleteRoomKeysVersionEndpoint).expect_default_access_token()
     }
 
     /// Create a prebuilt mock for getting the room members in a room.
@@ -945,9 +934,8 @@ impl MatrixMockServer {
     /// events.
     pub fn mock_set_room_pinned_events(&self) -> MockEndpoint<'_, SetRoomPinnedEventsEndpoint> {
         let mock = Mock::given(method("PUT"))
-            .and(path_regex(r"^/_matrix/client/v3/rooms/.*/state/m.room.pinned_events/.*?"))
-            .and(header("authorization", "Bearer 1234"));
-        self.mock_endpoint(mock, SetRoomPinnedEventsEndpoint)
+            .and(path_regex(r"^/_matrix/client/v3/rooms/.*/state/m.room.pinned_events/.*?"));
+        self.mock_endpoint(mock, SetRoomPinnedEventsEndpoint).expect_default_access_token()
     }
 
     /// Creates a prebuilt mock for the endpoint used to get information about
@@ -958,25 +946,21 @@ impl MatrixMockServer {
     pub fn mock_who_am_i(&self) -> MockEndpoint<'_, WhoAmIEndpoint> {
         let mock =
             Mock::given(method("GET")).and(path_regex(r"^/_matrix/client/v3/account/whoami"));
-        self.mock_endpoint(mock, WhoAmIEndpoint { expected_access_token: "1234" })
+        self.mock_endpoint(mock, WhoAmIEndpoint).expect_default_access_token()
     }
 
     /// Creates a prebuilt mock for the endpoint used to publish end-to-end
     /// encryption keys.
     pub fn mock_upload_keys(&self) -> MockEndpoint<'_, UploadKeysEndpoint> {
-        let mock = Mock::given(method("POST"))
-            .and(path_regex(r"^/_matrix/client/v3/keys/upload"))
-            .and(header("authorization", "Bearer 1234"));
-        self.mock_endpoint(mock, UploadKeysEndpoint)
+        let mock = Mock::given(method("POST")).and(path_regex(r"^/_matrix/client/v3/keys/upload"));
+        self.mock_endpoint(mock, UploadKeysEndpoint).expect_default_access_token()
     }
 
     /// Creates a prebuilt mock for the endpoint used to query end-to-end
     /// encryption keys.
     pub fn mock_query_keys(&self) -> MockEndpoint<'_, QueryKeysEndpoint> {
-        let mock = Mock::given(method("POST"))
-            .and(path_regex(r"^/_matrix/client/v3/keys/query"))
-            .and(header("authorization", "Bearer 1234"));
-        self.mock_endpoint(mock, QueryKeysEndpoint)
+        let mock = Mock::given(method("POST")).and(path_regex(r"^/_matrix/client/v3/keys/query"));
+        self.mock_endpoint(mock, QueryKeysEndpoint).expect_default_access_token()
     }
 
     /// Creates a prebuilt mock for the endpoint used to discover the URL of a
@@ -992,9 +976,8 @@ impl MatrixMockServer {
         &self,
     ) -> MockEndpoint<'_, UploadCrossSigningKeysEndpoint> {
         let mock = Mock::given(method("POST"))
-            .and(path_regex(r"^/_matrix/client/v3/keys/device_signing/upload"))
-            .and(header("authorization", "Bearer 1234"));
-        self.mock_endpoint(mock, UploadCrossSigningKeysEndpoint)
+            .and(path_regex(r"^/_matrix/client/v3/keys/device_signing/upload"));
+        self.mock_endpoint(mock, UploadCrossSigningKeysEndpoint).expect_default_access_token()
     }
 
     /// Creates a prebuilt mock for the endpoint used to publish cross-signing
@@ -1003,9 +986,8 @@ impl MatrixMockServer {
         &self,
     ) -> MockEndpoint<'_, UploadCrossSigningSignaturesEndpoint> {
         let mock = Mock::given(method("POST"))
-            .and(path_regex(r"^/_matrix/client/v3/keys/signatures/upload"))
-            .and(header("authorization", "Bearer 1234"));
-        self.mock_endpoint(mock, UploadCrossSigningSignaturesEndpoint)
+            .and(path_regex(r"^/_matrix/client/v3/keys/signatures/upload"));
+        self.mock_endpoint(mock, UploadCrossSigningSignaturesEndpoint).expect_default_access_token()
     }
 }
 
@@ -1162,11 +1144,24 @@ pub struct MockEndpoint<'a, T> {
     server: &'a MockServer,
     mock: MockBuilder,
     endpoint: T,
+    expected_access_token: ExpectedAccessToken,
 }
 
 impl<'a, T> MockEndpoint<'a, T> {
     fn new(server: &'a MockServer, mock: MockBuilder, endpoint: T) -> Self {
-        Self { server, mock, endpoint }
+        Self { server, mock, endpoint, expected_access_token: ExpectedAccessToken::None }
+    }
+
+    /// Expect authentication with the default access token on this endpoint.
+    pub fn expect_default_access_token(mut self) -> Self {
+        self.expected_access_token = ExpectedAccessToken::Default;
+        self
+    }
+
+    /// Expect authentication with the given access token on this endpoint.
+    pub fn expect_access_token(mut self, access_token: &'static str) -> Self {
+        self.expected_access_token = ExpectedAccessToken::Custom(access_token);
+        self
     }
 
     /// Specify how to respond to a query (viz., like
@@ -1211,7 +1206,11 @@ impl<'a, T> MockEndpoint<'a, T> {
     /// # anyhow::Ok(()) });
     /// ```
     pub fn respond_with<R: Respond + 'static>(self, func: R) -> MatrixMock<'a> {
-        MatrixMock { mock: self.mock.respond_with(func), server: self.server }
+        let mock = self
+            .expected_access_token
+            .maybe_match_authorization_header(self.mock)
+            .respond_with(func);
+        MatrixMock { mock, server: self.server }
     }
 
     /// Returns a send endpoint that emulates a transient failure, i.e responds
@@ -1289,6 +1288,30 @@ impl<'a, T> MockEndpoint<'a, T> {
             // From https://spec.matrix.org/v1.10/client-server-api/#standard-error-response
             "errcode": "M_TOO_LARGE",
         })))
+    }
+}
+
+/// The access token to expect on an endpoint.
+enum ExpectedAccessToken {
+    /// We don't expect an access token.
+    None,
+
+    /// We expect the default access token.
+    Default,
+
+    /// We expect the given access token.
+    Custom(&'static str),
+}
+
+impl ExpectedAccessToken {
+    /// Match an `Authorization` header on the given mock if one is expected.
+    fn maybe_match_authorization_header(&self, mock: MockBuilder) -> MockBuilder {
+        let token = match self {
+            Self::None => return mock,
+            Self::Default => "1234",
+            Self::Custom(token) => token,
+        };
+        mock.and(header(http::header::AUTHORIZATION, format!("Bearer {token}")))
     }
 }
 
@@ -2377,26 +2400,11 @@ impl<'a> MockEndpoint<'a, SetRoomPinnedEventsEndpoint> {
 }
 
 /// A prebuilt mock for `GET /account/whoami` request.
-pub struct WhoAmIEndpoint {
-    expected_access_token: &'static str,
-}
-
-impl WhoAmIEndpoint {
-    fn add_access_token_matcher(&self, mock: MockBuilder) -> MockBuilder {
-        mock.and(header("authorization", format!("Bearer {}", self.expected_access_token)))
-    }
-}
+pub struct WhoAmIEndpoint;
 
 impl<'a> MockEndpoint<'a, WhoAmIEndpoint> {
-    /// Override the access token to expect for this endpoint.
-    pub fn expected_access_token(mut self, access_token: &'static str) -> Self {
-        self.endpoint.expected_access_token = access_token;
-        self
-    }
-
     /// Returns a successful response with a user ID and device ID.
-    pub fn ok(mut self) -> MatrixMock<'a> {
-        self.mock = self.endpoint.add_access_token_matcher(self.mock);
+    pub fn ok(self) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "user_id": "@joe:example.org",
             "device_id": "D3V1C31D",
@@ -2404,8 +2412,7 @@ impl<'a> MockEndpoint<'a, WhoAmIEndpoint> {
     }
 
     /// Returns an error response with an `M_UNKNOWN_TOKEN`.
-    pub fn err_unknown_token(mut self) -> MatrixMock<'a> {
-        self.mock = self.endpoint.add_access_token_matcher(self.mock);
+    pub fn err_unknown_token(self) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(401).set_body_json(json!({
             "errcode": "M_UNKNOWN_TOKEN",
             "error": "Invalid token"

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1245,16 +1245,13 @@ impl<'a, T> MockEndpoint<'a, T> {
     /// # anyhow::Ok(()) });
     /// ```
     pub fn error500(self) -> MatrixMock<'a> {
-        MatrixMock { mock: self.mock.respond_with(ResponseTemplate::new(500)), server: self.server }
+        self.respond_with(ResponseTemplate::new(500))
     }
 
     /// Internal helper to return an `{ event_id }` JSON struct along with a 200
     /// ok response.
     fn ok_with_event_id(self, event_id: OwnedEventId) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({ "event_id": event_id })),
-        );
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({ "event_id": event_id })))
     }
 
     /// Returns an endpoint that emulates a permanent failure error (e.g. event
@@ -1288,13 +1285,10 @@ impl<'a, T> MockEndpoint<'a, T> {
     /// # anyhow::Ok(()) });
     /// ```
     pub fn error_too_large(self) -> MatrixMock<'a> {
-        MatrixMock {
-            mock: self.mock.respond_with(ResponseTemplate::new(413).set_body_json(json!({
-                // From https://spec.matrix.org/v1.10/client-server-api/#standard-error-response
-                "errcode": "M_TOO_LARGE",
-            }))),
-            server: self.server,
-        }
+        self.respond_with(ResponseTemplate::new(413).set_body_json(json!({
+            // From https://spec.matrix.org/v1.10/client-server-api/#standard-error-response
+            "errcode": "M_TOO_LARGE",
+        })))
     }
 }
 
@@ -1880,10 +1874,9 @@ impl<'a> MockEndpoint<'a, EncryptionStateEndpoint> {
     /// # anyhow::Ok(()) });
     /// ```
     pub fn encrypted(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(
+        self.respond_with(
             ResponseTemplate::new(200).set_body_json(&*test_json::sync_events::ENCRYPTION_CONTENT),
-        );
-        MatrixMock { mock, server: self.server }
+        )
     }
 
     /// Marks the room as not encrypted.
@@ -1910,10 +1903,7 @@ impl<'a> MockEndpoint<'a, EncryptionStateEndpoint> {
     /// # anyhow::Ok(()) });
     /// ```
     pub fn plain(self) -> MatrixMock<'a> {
-        let mock = self
-            .mock
-            .respond_with(ResponseTemplate::new(404).set_body_json(&*test_json::NOT_FOUND));
-        MatrixMock { mock, server: self.server }
+        self.respond_with(ResponseTemplate::new(404).set_body_json(&*test_json::NOT_FOUND))
     }
 }
 
@@ -2012,8 +2002,7 @@ impl<'a> MockEndpoint<'a, RoomMessagesEndpoint> {
             template = template.set_delay(delay);
         }
 
-        let mock = self.mock.respond_with(template);
-        MatrixMock { server: self.server, mock }
+        self.respond_with(template)
     }
 }
 
@@ -2076,10 +2065,9 @@ impl<'a> MockEndpoint<'a, UploadEndpoint> {
     /// Returns a redact endpoint that emulates success, i.e. the redaction
     /// event has been sent with the given event id.
     pub fn ok(self, mxc_id: &MxcUri) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "content_uri": mxc_id
-        })));
-        MatrixMock { server: self.server, mock }
+        })))
     }
 }
 
@@ -2102,20 +2090,18 @@ impl<'a> MockEndpoint<'a, ResolveRoomAliasEndpoint> {
 
     /// Returns a data endpoint with a resolved room alias.
     pub fn ok(self, room_id: &str, servers: Vec<String>) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "room_id": room_id,
             "servers": servers,
-        })));
-        MatrixMock { server: self.server, mock }
+        })))
     }
 
     /// Returns a data endpoint for a room alias that does not exit.
     pub fn not_found(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(404).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(404).set_body_json(json!({
           "errcode": "M_NOT_FOUND",
           "error": "Room alias not found."
-        })));
-        MatrixMock { server: self.server, mock }
+        })))
     }
 }
 
@@ -2125,8 +2111,7 @@ pub struct CreateRoomAliasEndpoint;
 impl<'a> MockEndpoint<'a, CreateRoomAliasEndpoint> {
     /// Returns a data endpoint for creating a room alias.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }
 
@@ -2136,8 +2121,7 @@ pub struct RemoveRoomAliasEndpoint;
 impl<'a> MockEndpoint<'a, RemoveRoomAliasEndpoint> {
     /// Returns a data endpoint for removing a room alias.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }
 
@@ -2153,13 +2137,12 @@ impl<'a> MockEndpoint<'a, PublicRoomsEndpoint> {
         prev_batch: Option<String>,
         total_room_count_estimate: Option<u64>,
     ) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "chunk": chunk,
             "next_batch": next_batch,
             "prev_batch": prev_batch,
             "total_room_count_estimate": total_room_count_estimate,
-        })));
-        MatrixMock { server: self.server, mock }
+        })))
     }
 
     /// Returns a data endpoint for paginating the public room list with several
@@ -2171,7 +2154,7 @@ impl<'a> MockEndpoint<'a, PublicRoomsEndpoint> {
         self,
         server_map: BTreeMap<OwnedServerName, Vec<PublicRoomsChunk>>,
     ) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(move |req: &Request| {
+        self.respond_with(move |req: &Request| {
             #[derive(Deserialize)]
             struct PartialRequest {
                 server: Option<OwnedServerName>,
@@ -2189,8 +2172,7 @@ impl<'a> MockEndpoint<'a, PublicRoomsEndpoint> {
                 "chunk": chunk,
                 "total_room_count_estimate": chunk.len(),
             }))
-        });
-        MatrixMock { server: self.server, mock }
+        })
     }
 }
 
@@ -2200,10 +2182,9 @@ pub struct GetRoomVisibilityEndpoint;
 impl<'a> MockEndpoint<'a, GetRoomVisibilityEndpoint> {
     /// Returns an endpoint that get the room's public visibility.
     pub fn ok(self, visibility: Visibility) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "visibility": visibility,
-        })));
-        MatrixMock { server: self.server, mock }
+        })))
     }
 }
 
@@ -2213,8 +2194,7 @@ pub struct SetRoomVisibilityEndpoint;
 impl<'a> MockEndpoint<'a, SetRoomVisibilityEndpoint> {
     /// Returns an endpoint that updates the room's visibility.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }
 
@@ -2225,7 +2205,7 @@ pub struct RoomKeysVersionEndpoint;
 impl<'a> MockEndpoint<'a, RoomKeysVersionEndpoint> {
     /// Returns an endpoint that says there is a single room keys backup
     pub fn exists(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "algorithm": "m.megolm_backup.v1.curve25519-aes-sha2",
             "auth_data": {
                 "public_key": "abcdefg",
@@ -2234,33 +2214,29 @@ impl<'a> MockEndpoint<'a, RoomKeysVersionEndpoint> {
             "count": 42,
             "etag": "anopaquestring",
             "version": "1",
-        })));
-        MatrixMock { server: self.server, mock }
+        })))
     }
 
     /// Returns an endpoint that says there is no room keys backup
     pub fn none(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(404).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(404).set_body_json(json!({
             "errcode": "M_NOT_FOUND",
             "error": "No current backup version"
-        })));
-        MatrixMock { server: self.server, mock }
+        })))
     }
 
     /// Returns an endpoint that 429 errors when we get it
     pub fn error429(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(429).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(429).set_body_json(json!({
             "errcode": "M_LIMIT_EXCEEDED",
             "error": "Too many requests",
             "retry_after_ms": 2000
-        })));
-        MatrixMock { server: self.server, mock }
+        })))
     }
 
     /// Returns an endpoint that 404 errors when we get it
     pub fn error404(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(404));
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(404))
     }
 }
 
@@ -2270,13 +2246,10 @@ pub struct AddRoomKeysVersionEndpoint;
 impl<'a> MockEndpoint<'a, AddRoomKeysVersionEndpoint> {
     /// Returns an endpoint that may be used to add room key backups
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self
-            .mock
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-              "version": "1"
-            })))
-            .named("POST for the backup creation");
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+          "version": "1"
+        })))
+        .named("POST for the backup creation")
     }
 }
 
@@ -2287,11 +2260,8 @@ pub struct DeleteRoomKeysVersionEndpoint;
 impl<'a> MockEndpoint<'a, DeleteRoomKeysVersionEndpoint> {
     /// Returns an endpoint that allows deleting room key backups
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self
-            .mock
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
-            .named("DELETE for the backup deletion");
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .named("DELETE for the backup deletion")
     }
 }
 
@@ -2301,10 +2271,9 @@ pub struct GetRoomMembersEndpoint;
 impl<'a> MockEndpoint<'a, GetRoomMembersEndpoint> {
     /// Returns a successful get members request with a list of members.
     pub fn ok(self, members: Vec<Raw<RoomMemberEvent>>) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "chunk": members,
-        })));
-        MatrixMock { server: self.server, mock }
+        })))
     }
 }
 
@@ -2314,8 +2283,7 @@ pub struct InviteUserByIdEndpoint;
 impl<'a> MockEndpoint<'a, InviteUserByIdEndpoint> {
     /// Returns a successful invite user by id request.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }
 
@@ -2325,8 +2293,7 @@ pub struct KickUserEndpoint;
 impl<'a> MockEndpoint<'a, KickUserEndpoint> {
     /// Returns a successful kick user request.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }
 
@@ -2336,8 +2303,7 @@ pub struct BanUserEndpoint;
 impl<'a> MockEndpoint<'a, BanUserEndpoint> {
     /// Returns a successful ban user request.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }
 
@@ -2349,7 +2315,7 @@ impl<'a> MockEndpoint<'a, VersionsEndpoint> {
     ///
     /// The response will return some commonly supported versions.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "unstable_features": {
             },
             "versions": [
@@ -2372,9 +2338,7 @@ impl<'a> MockEndpoint<'a, VersionsEndpoint> {
                 "v1.10",
                 "v1.11"
             ]
-        })));
-
-        MatrixMock { server: self.server, mock }
+        })))
     }
 }
 
@@ -2385,14 +2349,13 @@ impl<'a> MockEndpoint<'a, RoomSummaryEndpoint> {
     /// Returns a successful response with some default data for the given room
     /// id.
     pub fn ok(self, room_id: &RoomId) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "room_id": room_id,
             "guest_can_join": true,
             "num_joined_members": 1,
             "world_readable": true,
             "join_rule": "public",
-        })));
-        MatrixMock { server: self.server, mock }
+        })))
     }
 }
 
@@ -2409,8 +2372,7 @@ impl<'a> MockEndpoint<'a, SetRoomPinnedEventsEndpoint> {
     /// Returns an error response with a generic error code indicating the
     /// client is not authorized to set pinned events.
     pub fn unauthorized(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(400));
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(400))
     }
 }
 
@@ -2433,27 +2395,21 @@ impl<'a> MockEndpoint<'a, WhoAmIEndpoint> {
     }
 
     /// Returns a successful response with a user ID and device ID.
-    pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.endpoint.add_access_token_matcher(self.mock).respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({
-                "user_id": "@joe:example.org",
-                "device_id": "D3V1C31D",
-            })),
-        );
-
-        MatrixMock { server: self.server, mock }
+    pub fn ok(mut self) -> MatrixMock<'a> {
+        self.mock = self.endpoint.add_access_token_matcher(self.mock);
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "user_id": "@joe:example.org",
+            "device_id": "D3V1C31D",
+        })))
     }
 
     /// Returns an error response with an `M_UNKNOWN_TOKEN`.
-    pub fn err_unknown_token(self) -> MatrixMock<'a> {
-        let mock = self.endpoint.add_access_token_matcher(self.mock).respond_with(
-            ResponseTemplate::new(401).set_body_json(json!({
-                "errcode": "M_UNKNOWN_TOKEN",
-                "error": "Invalid token"
-            })),
-        );
-
-        MatrixMock { server: self.server, mock }
+    pub fn err_unknown_token(mut self) -> MatrixMock<'a> {
+        self.mock = self.endpoint.add_access_token_matcher(self.mock);
+        self.respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "errcode": "M_UNKNOWN_TOKEN",
+            "error": "Invalid token"
+        })))
     }
 }
 
@@ -2464,14 +2420,12 @@ impl<'a> MockEndpoint<'a, UploadKeysEndpoint> {
     /// Returns a successful response with counts of 10 curve25519 keys and 20
     /// signed curve25519 keys.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "one_time_key_counts": {
                 "curve25519": 10,
                 "signed_curve25519": 20,
             },
-        })));
-
-        MatrixMock { server: self.server, mock }
+        })))
     }
 }
 
@@ -2481,9 +2435,7 @@ pub struct QueryKeysEndpoint;
 impl<'a> MockEndpoint<'a, QueryKeysEndpoint> {
     /// Returns a successful empty response.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
-
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }
 
@@ -2493,13 +2445,12 @@ pub struct WellKnownEndpoint;
 impl<'a> MockEndpoint<'a, WellKnownEndpoint> {
     /// Returns a successful response.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        let server_uri = self.server.uri();
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "m.homeserver": {
-                "base_url": self.server.uri(),
+                "base_url": server_uri,
             },
-        })));
-
-        MatrixMock { server: self.server, mock }
+        })))
     }
 }
 
@@ -2509,28 +2460,25 @@ pub struct UploadCrossSigningKeysEndpoint;
 impl<'a> MockEndpoint<'a, UploadCrossSigningKeysEndpoint> {
     /// Returns a successful empty response.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
-
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 
     /// Returns an error response with an OAuth 2.0 UIAA stage.
     #[cfg(feature = "experimental-oidc")]
     pub fn uiaa_oauth(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(401).set_body_json(json!({
+        let server_uri = self.server.uri();
+        self.respond_with(ResponseTemplate::new(401).set_body_json(json!({
             "session": "dummy",
             "flows": [{
                 "stages": [ "org.matrix.cross_signing_reset" ]
             }],
             "params": {
                 "org.matrix.cross_signing_reset": {
-                    "url": format!("{}/account/?action=org.matrix.cross_signing_reset", self.server.uri())
+                    "url": format!("{server_uri}/account/?action=org.matrix.cross_signing_reset"),
                 }
             },
             "msg": "To reset your end-to-end encryption cross-signing identity, you first need to approve it and then try again."
-        })));
-
-        MatrixMock { server: self.server, mock }
+        })))
     }
 }
 
@@ -2540,8 +2488,6 @@ pub struct UploadCrossSigningSignaturesEndpoint;
 impl<'a> MockEndpoint<'a, UploadCrossSigningSignaturesEndpoint> {
     /// Returns a successful empty response.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
-
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }

--- a/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
@@ -114,9 +114,7 @@ impl<'a> MockEndpoint<'a, ServerMetadataEndpoint> {
     /// Returns a successful metadata response with all the supported endpoints.
     pub fn ok(self) -> MatrixMock<'a> {
         let metadata = MockServerMetadataBuilder::new(&self.server.uri()).build();
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(metadata));
-
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(metadata))
     }
 
     /// Returns a successful metadata response with all the supported endpoints
@@ -129,9 +127,7 @@ impl<'a> MockEndpoint<'a, ServerMetadataEndpoint> {
         let issuer = self.server.uri().replace("http://", "https://");
 
         let metadata = MockServerMetadataBuilder::new(&issuer).build();
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(metadata));
-
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(metadata))
     }
 
     /// Returns a successful metadata response without the device authorization
@@ -140,9 +136,7 @@ impl<'a> MockEndpoint<'a, ServerMetadataEndpoint> {
         let metadata = MockServerMetadataBuilder::new(&self.server.uri())
             .without_device_authorization()
             .build();
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(metadata));
-
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(metadata))
     }
 
     /// Returns a successful metadata response without the registration
@@ -150,9 +144,7 @@ impl<'a> MockEndpoint<'a, ServerMetadataEndpoint> {
     pub fn ok_without_registration(self) -> MatrixMock<'a> {
         let metadata =
             MockServerMetadataBuilder::new(&self.server.uri()).without_registration().build();
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(metadata));
-
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(metadata))
     }
 }
 
@@ -251,12 +243,10 @@ pub struct RegistrationEndpoint;
 impl<'a> MockEndpoint<'a, RegistrationEndpoint> {
     /// Returns a successful registration response.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "client_id": "test_client_id",
             "client_id_issued_at": 1716375696,
-        })));
-
-        MatrixMock { server: self.server, mock }
+        })))
     }
 }
 
@@ -272,16 +262,14 @@ impl<'a> MockEndpoint<'a, DeviceAuthorizationEndpoint> {
         let mut verification_uri_complete = issuer_url.join("link").unwrap();
         verification_uri_complete.set_query(Some("code=N32YVC"));
 
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "device_code": "N8NAYD9fOhMulpm37mSthx0xSw2p7vdR",
             "expires_in": 1200,
             "interval": 5,
             "user_code": "N32YVC",
             "verification_uri": verification_uri,
             "verification_uri_complete": verification_uri_complete,
-        })));
-
-        MatrixMock { server: self.server, mock }
+        })))
     }
 }
 
@@ -291,41 +279,33 @@ pub struct TokenEndpoint;
 impl<'a> MockEndpoint<'a, TokenEndpoint> {
     /// Returns a successful token response.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "access_token": "1234",
             "expires_in": 300,
             "refresh_token": "ZYXWV",
             "token_type": "Bearer"
-        })));
-
-        MatrixMock { server: self.server, mock }
+        })))
     }
 
     /// Returns an error response when the request was invalid.
     pub fn access_denied(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(400).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(400).set_body_json(json!({
             "error": "access_denied",
-        })));
-
-        MatrixMock { server: self.server, mock }
+        })))
     }
 
     /// Returns an error response when the token in the request has expired.
     pub fn expired_token(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(400).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(400).set_body_json(json!({
             "error": "expired_token",
-        })));
-
-        MatrixMock { server: self.server, mock }
+        })))
     }
 
     /// Returns an error response when the token in the request is invalid.
     pub fn invalid_grant(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(400).set_body_json(json!({
+        self.respond_with(ResponseTemplate::new(400).set_body_json(json!({
             "error": "invalid_grant",
-        })));
-
-        MatrixMock { server: self.server, mock }
+        })))
     }
 }
 
@@ -335,8 +315,6 @@ pub struct RevocationEndpoint;
 impl<'a> MockEndpoint<'a, RevocationEndpoint> {
     /// Returns a successful revocation response.
     pub fn ok(self) -> MatrixMock<'a> {
-        let mock = self.mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({})));
-
-        MatrixMock { server: self.server, mock }
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -589,7 +589,7 @@ async fn test_oauth_refresh_token_handled_success() {
     // Return an error first so the token is refreshed.
     server
         .mock_who_am_i()
-        .expected_access_token("prev-access-token")
+        .expect_access_token("prev-access-token")
         .err_unknown_token()
         .expect(1)
         .named("whoami_unknown_token")
@@ -647,7 +647,7 @@ async fn test_oauth_refresh_token_handled_failure() {
     // Return an error first so the token is refreshed.
     server
         .mock_who_am_i()
-        .expected_access_token("prev-access-token")
+        .expect_access_token("prev-access-token")
         .err_unknown_token()
         .expect(1)
         .named("whoami_unknown_token")


### PR DESCRIPTION
Generalizes the behavior introduced in #4767 for the `/whoami` mock endpoint.

It requires creators of `MockEndpoint`s to use the built-in methods instead of custom methods on `MockBuilder` and sadly there is no way to enforce this programmatically.