### PR TITLE
crypto: support for building key bundles

### DIFF
--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -64,9 +64,11 @@ pub enum SessionExportError {
     MissingEd25519Key,
 }
 
-/// An exported version of an `InboundGroupSession`
+/// An exported version of an [`InboundGroupSession`].
 ///
 /// This can be used to share the `InboundGroupSession` in an exported file.
+///
+/// See <https://spec.matrix.org/v1.13/client-server-api/#key-export-format>.
 #[derive(Deserialize, Serialize)]
 #[allow(missing_debug_implementations)]
 pub struct ExportedRoomKey {
@@ -144,7 +146,9 @@ impl ExportedRoomKey {
 /// This can be used to back up the [`InboundGroupSession`] to the server using
 /// [server-side key backups].
 ///
-/// [server-side key backups]: https://spec.matrix.org/unstable/client-server-api/#server-side-key-backups
+/// See <https://spec.matrix.org/v1.13/client-server-api/#definition-backedupsessiondata>.
+///
+/// [server-side key backups]: https://spec.matrix.org/v1.13/client-server-api/#server-side-key-backups
 #[derive(Deserialize, Serialize)]
 #[allow(missing_debug_implementations)]
 pub struct BackedUpRoomKey {

--- a/crates/matrix-sdk-crypto/src/store/snapshots/matrix_sdk_crypto__store__tests__build_room_key_bundle.snap
+++ b/crates/matrix-sdk-crypto/src/store/snapshots/matrix_sdk_crypto__store__tests__build_room_key_bundle.snap
@@ -1,0 +1,39 @@
+---
+source: crates/matrix-sdk-crypto/src/store/mod.rs
+expression: bundle
+---
+{
+  "room_keys": [
+    {
+      "algorithm": "m.megolm.v1.aes-sha2",
+      "room_id": "!room1:localhost",
+      "sender_key": "[alice curve key]",
+      "session_id": "AWcCd1w7VlIPYaZeB53LqfgHbQxYjWMY/bCJ7E5ZsVI",
+      "session_key": "AQAAAAC2XHVzsMBKs4QCRElJ92CJKyGtknCSC8HY7cQ7UYwndMKLQAejXLh5UA0l6s736mgctcUMNvELScUWrObdflrHo+vth/gWreXOaCnaSxmyjjKErQwyIYTkUfqbHy40RJfEesLwnN23on9XAkch/iy8R2+Jz7B8zfG01f2Ow2SxPQFnAndcO1ZSD2GmXgedy6n4B20MWI1jGP2wiexOWbFS",
+      "sender_claimed_keys": {
+        "ed25519": "[alice ed25519 key]"
+      }
+    },
+    {
+      "algorithm": "m.megolm.v1.aes-sha2",
+      "room_id": "!room1:localhost",
+      "sender_key": "[alice curve key]",
+      "session_id": "y1i8rPyf5MMnB0tenJPrMqWO6oAMCKi536z+KrH0tic",
+      "session_key": "AQAAAAC1BXreFTUQQSBGekTEuYxhdytRKyv4JgDGcG+VOBYdPNGgs807SdibCGJky4lJ3I+7ZDGHoUzZPZP/4ogGu4kxni0PWdtWuN7+5zsuamgoFF/BkaGeUUGv6kgIkx8pyPpM5SASTUEP9bN2loDSpUPYwfiIqz74DgC4WQ4435sTBctYvKz8n+TDJwdLXpyT6zKljuqADAioud+s/iqx9LYn",
+      "sender_claimed_keys": {
+        "ed25519": "[alice ed25519 key]"
+      }
+    }
+  ],
+  "withheld": [
+    {
+      "algorithm": "m.megolm.v1.aes-sha2",
+      "code": "m.unauthorised",
+      "from_device": "BOB",
+      "reason": "You are not authorised to read the message.",
+      "room_id": "!room1:localhost",
+      "sender_key": "[alice curve key]",
+      "session_id": "lpRzTgD3Nook/Wk62Fm9ECWGnKYZgeCwO1Y+uuPJz/I"
+    }
+  ]
+}

--- a/crates/matrix-sdk-crypto/src/types/events/forwarded_room_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/forwarded_room_key.rs
@@ -22,6 +22,8 @@ use serde_json::Value;
 use vodozemac::{megolm::ExportedSessionKey, Curve25519PublicKey, Ed25519PublicKey};
 
 use super::{EventType, ToDeviceEvent};
+#[cfg(doc)]
+use crate::olm::InboundGroupSession;
 use crate::types::{
     deserialize_curve_key, deserialize_curve_key_vec, deserialize_ed25519_key, serialize_curve_key,
     serialize_curve_key_vec, serialize_ed25519_key, EventEncryptionAlgorithm, SigningKeys,
@@ -39,11 +41,15 @@ impl ForwardedRoomKeyEvent {
 
 /// The `m.forwarded_room_key` event content.
 ///
-/// This is an enum over the different room key algorithms we support.
+/// This is an enum over the different room key algorithms we support. The
+/// currently-supported implementations are used to share
+/// [`InboundGroupSession`]s.
 ///
 /// This event type is used to forward keys for end-to-end encryption.
-/// Typically it is encrypted as an m.room.encrypted event, then sent as a
+/// Typically, it is encrypted as an m.room.encrypted event, then sent as a
 /// to-device event.
+///
+/// See <https://spec.matrix.org/v1.13/client-server-api/#mforwarded_room_key>.
 #[derive(Debug, Deserialize)]
 #[serde(try_from = "RoomKeyHelper")]
 pub enum ForwardedRoomKeyContent {

--- a/crates/matrix-sdk-crypto/src/types/events/room_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key.rs
@@ -22,6 +22,8 @@ use serde_json::{value::to_raw_value, Value};
 use vodozemac::megolm::SessionKey;
 
 use super::{EventType, ToDeviceEvent};
+#[cfg(doc)]
+use crate::olm::InboundGroupSession;
 use crate::types::EventEncryptionAlgorithm;
 
 /// The `m.room_key` to-device event.
@@ -40,11 +42,15 @@ impl EventType for RoomKeyContent {
 
 /// The `m.room_key` event content.
 ///
-/// This is an enum over the different room key algorithms we support.
+/// This is an enum over the different room key algorithms we support.  The
+/// currently-supported implementations are used to share
+/// [`InboundGroupSession`]s.
 ///
 /// This event type is used to exchange keys for end-to-end encryption.
-/// Typically it is encrypted as an m.room.encrypted event, then sent as a
+/// Typically, it is encrypted as an m.room.encrypted event, then sent as a
 /// to-device event.
+///
+/// See <https://spec.matrix.org/v1.13/client-server-api/#mroom_key>.
 #[derive(Debug, Deserialize)]
 #[serde(try_from = "RoomKeyHelper")]
 pub enum RoomKeyContent {

--- a/crates/matrix-sdk-crypto/src/types/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/mod.rs
@@ -49,6 +49,7 @@ pub mod events;
 mod one_time_keys;
 pub mod qr_login;
 pub mod requests;
+pub mod room_history;
 
 pub use self::{backup::*, cross_signing::*, device_keys::*, one_time_keys::*};
 use crate::store::BackupDecryptionKey;

--- a/crates/matrix-sdk-crypto/src/types/room_history.rs
+++ b/crates/matrix-sdk-crypto/src/types/room_history.rs
@@ -112,3 +112,28 @@ impl From<ExportedRoomKey> for HistoricRoomKey {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_debug_snapshot;
+    use ruma::{owned_room_id, DeviceKeyAlgorithm};
+    use vodozemac::{
+        megolm::ExportedSessionKey, Curve25519PublicKey, Curve25519SecretKey, Ed25519SecretKey,
+    };
+
+    use crate::types::{room_history::HistoricRoomKey, EventEncryptionAlgorithm};
+
+    #[test]
+    fn test_historic_room_key_debug() {
+        let key = HistoricRoomKey {
+            algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+            room_id: owned_room_id!("!room:id"),
+            sender_key: Curve25519PublicKey::from(&Curve25519SecretKey::from_slice(b"abcdabcdabcdabcdabcdabcdabcdabcd")),
+            session_id: "id1234".to_owned(),
+            session_key: ExportedSessionKey::from_base64("AQAAAAC2XHVzsMBKs4QCRElJ92CJKyGtknCSC8HY7cQ7UYwndMKLQAejXLh5UA0l6s736mgctcUMNvELScUWrObdflrHo+vth/gWreXOaCnaSxmyjjKErQwyIYTkUfqbHy40RJfEesLwnN23on9XAkch/iy8R2+Jz7B8zfG01f2Ow2SxPQFnAndcO1ZSD2GmXgedy6n4B20MWI1jGP2wiexOWbFS").unwrap(),
+            sender_claimed_keys: vec![(DeviceKeyAlgorithm::Ed25519, Ed25519SecretKey::from_slice(b"abcdabcdabcdabcdabcdabcdabcdabcd").public_key().into())].into_iter().collect(),
+        };
+
+        assert_debug_snapshot!(key);
+    }
+}

--- a/crates/matrix-sdk-crypto/src/types/snapshots/matrix_sdk_crypto__types__room_history__tests__historic_room_key_debug.snap
+++ b/crates/matrix-sdk-crypto/src/types/snapshots/matrix_sdk_crypto__types__room_history__tests__historic_room_key_debug.snap
@@ -1,0 +1,18 @@
+---
+source: crates/matrix-sdk-crypto/src/types/room_history.rs
+expression: key
+---
+SharedRoomKey {
+    algorithm: "m.megolm.v1.aes-sha2",
+    room_id: "!room:id",
+    sender_key: "curve25519:2n4iKRAGOTwcw54MuivfjtU/KZl1Fslme/b1FZMMRQM",
+    session_id: "id1234",
+    sender_claimed_keys: SigningKeys(
+        {
+            "ed25519": Ed25519(
+                "ed25519:kbNLK/pAgXV57gwDRd/0TjMp4BsqwtWXgPmSxgHVnpk",
+            ),
+        },
+    ),
+    ..
+}


### PR DESCRIPTION
Add a method to CryptoStore which will construct a key bundle, ready for encrypting and sharing with invited users.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/4504.