### PR TITLE
feat: Always know when a room is encrypted or not (with sliding sync)

### DIFF
--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 pub use crate::error::{Error, Result};
 
 mod client;
+pub use client::RequestedRequiredStates;
 pub mod debug;
 pub mod deserialized_responses;
 mod error;

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -801,7 +801,7 @@ mod tests {
     use matrix_sdk::test_utils::logged_in_client;
     use matrix_sdk_base::{
         deserialized_responses::TimelineEvent, latest_event::LatestEvent, MinimalStateEvent,
-        OriginalMinimalStateEvent,
+        OriginalMinimalStateEvent, RequestedRequiredStates,
     };
     use matrix_sdk_test::{
         async_test, event_factory::EventFactory, sync_state_event, sync_timeline_event,
@@ -888,7 +888,10 @@ mod tests {
 
         // And the room is stored in the client so it can be extracted when needed
         let response = response_with_room(room_id, room);
-        client.process_sliding_sync_test_helper(&response).await.unwrap();
+        client
+            .process_sliding_sync_test_helper(&response, &RequestedRequiredStates::default())
+            .await
+            .unwrap();
 
         // When we construct a timeline event from it
         let event = TimelineEvent::new(raw_event.cast());
@@ -1037,7 +1040,10 @@ mod tests {
 
         // And the room is stored in the client so it can be extracted when needed
         let response = response_with_room(room_id, room);
-        client.process_sliding_sync_test_helper(&response).await.unwrap();
+        client
+            .process_sliding_sync_test_helper(&response, &RequestedRequiredStates::default())
+            .await
+            .unwrap();
 
         // When we construct a timeline event from it
         let timeline_item =
@@ -1081,7 +1087,10 @@ mod tests {
 
         // And the room is stored in the client so it can be extracted when needed
         let response = response_with_room(room_id, room);
-        client.process_sliding_sync_test_helper(&response).await.unwrap();
+        client
+            .process_sliding_sync_test_helper(&response, &RequestedRequiredStates::default())
+            .await
+            .unwrap();
 
         // When we construct a timeline event from it
         let timeline_item = EventTimelineItem::from_latest_event(

--- a/crates/matrix-sdk/tests/integration/room_preview.rs
+++ b/crates/matrix-sdk/tests/integration/room_preview.rs
@@ -4,7 +4,7 @@ use matrix_sdk::{
     config::SyncSettings,
     test_utils::{logged_in_client_with_server, mocks::MatrixMockServer},
 };
-use matrix_sdk_base::RoomState;
+use matrix_sdk_base::{RequestedRequiredStates, RoomState};
 use matrix_sdk_test::{
     async_test, InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, SyncResponseBuilder,
 };
@@ -167,7 +167,10 @@ async fn test_room_preview_computes_name_if_room_is_known() {
     let mut response = sliding_sync_http::Response::new("0".to_owned());
     response.rooms.insert(room_id.to_owned(), room);
 
-    client.process_sliding_sync_test_helper(&response).await.expect("Failed to process sync");
+    client
+        .process_sliding_sync_test_helper(&response, &RequestedRequiredStates::default())
+        .await
+        .expect("Failed to process sync");
 
     // When we get its preview
     let room_preview = client.get_room_preview(room_id.into(), Vec::new()).await.unwrap();

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -100,7 +100,7 @@ async fn test_notification() -> Result<()> {
         assert_matches!(notification.event, NotificationEvent::Invite(_));
         assert_eq!(notification.event.sender(), alice.user_id().unwrap());
         assert_eq!(notification.joined_members_count, 0);
-        assert_eq!(notification.is_room_encrypted, None);
+        assert_eq!(notification.is_room_encrypted, Some(false));
         assert!(notification.is_direct_message_room);
 
         assert_matches!(notification.event, NotificationEvent::Invite(observed_invite) => {


### PR DESCRIPTION
<figure role="presentation">
<p align="center"><img src="https://github.com/user-attachments/assets/dbd5bffc-181b-4a7d-8e22-8bffc591056a" width="60%" /></p>
<figcaption><p align="center"><a href="https://commons.wikimedia.org/wiki/File:John_Collier_-_Priestess_of_Delphi_-_Google_Art_Project.jpg">Priestess of Delphi (John Collier)</a></p></figcaption>
</figure>

---

So, we have a problem with encryption state.

First off, a patch has clarified the different states for encryption, see https://github.com/matrix-org/matrix-rust-sdk/pull/4777.

Second, the problem is pretty basic to understand:

- the _presence_ of a `m.room.encryption` state event for a room in a sync response means the encryption state for this room is `Encrypted`,
- the _absence_ of a `m.room.encryption` state event means two things:

  1. if the `m.room.encryption` state event was requested (via `required_state` in MSC4186, aka (simplified) sliding sync), it means the encryption state is `NotEncrypted`,
  2. if the`m.room.encryption` state event was **not** requested, it means the encryption state is `Unknown`; indeed, there is no way to interpret the meaning of the absence of this event.

So far, the presence of `m.room.encryption` was always interpreted as `Encrypted`, which is fine. However, the absence was always interpreted as `Unknown`, which is _not incorrect_, but it means a request to [`/…/state/m.room.encryption/`](https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidstateeventtypestatekey) (with `matrix_sdk::Room::request_encryption_state`) was necessary to resolve that. This implies a network call, and it creates slowness, or worst, in offline mode, it can block some clients if not used appropriately (note: this method is async, but it can be misused)!

With this patch, when sliding sync is used, the `Unknown` is impossible to get if `m.room.encryption` is present in `required_state`. Thus, the encryption state for a room is always `Encrypted` or `NotEncrypted` with `matrix_sdk_ui::RoomListService` or `matrix_sdk_ui::NotificationClient` for example.

---

* Fix https://github.com/element-hq/element-x-ios/issues/3857