### PR TITLE
fix(event cache): don't remove a gap when it's the only chunk in memory

### DIFF
--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] The `Client::subscribe_to_ignore_user_list_changes()` method will now only trigger
+  whenever the ignored user list has changed from what was previously known, instead of triggering
+  every time an ignore-user-list event has been received from sync.
+  ([#4779](https://github.com/matrix-org/matrix-rust-sdk/pull/4779))
 - [**breaking**] The `MediaRetentionPolicy` can now trigger regular cleanups
   with its new `cleanup_frequency` setting.
   ([#4603](https://github.com/matrix-org/matrix-rust-sdk/pull/4603))

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -2534,7 +2534,7 @@ mod tests {
         client
             .handle_room_account_data(room_id, &[tag_raw], &mut changes, &mut Default::default())
             .await;
-        client.apply_changes(&changes, Default::default());
+        client.apply_changes(&changes, Default::default(), None);
 
         // The `RoomInfo` is getting notified.
         assert_ready!(room_info_subscriber);
@@ -2555,7 +2555,7 @@ mod tests {
         client
             .handle_room_account_data(room_id, &[tag_raw], &mut changes, &mut Default::default())
             .await;
-        client.apply_changes(&changes, Default::default());
+        client.apply_changes(&changes, Default::default(), None);
 
         // The `RoomInfo` is getting notified.
         assert_ready!(room_info_subscriber);
@@ -2614,7 +2614,7 @@ mod tests {
         client
             .handle_room_account_data(room_id, &[tag_raw], &mut changes, &mut Default::default())
             .await;
-        client.apply_changes(&changes, Default::default());
+        client.apply_changes(&changes, Default::default(), None);
 
         // The `RoomInfo` is getting notified.
         assert_ready!(room_info_subscriber);
@@ -2635,7 +2635,7 @@ mod tests {
         client
             .handle_room_account_data(room_id, &[tag_raw], &mut changes, &mut Default::default())
             .await;
-        client.apply_changes(&changes, Default::default());
+        client.apply_changes(&changes, Default::default(), None);
 
         // The `RoomInfo` is getting notified.
         assert_ready!(room_info_subscriber);
@@ -3197,7 +3197,7 @@ mod tests {
         assert!(room_info_notable_update.try_recv().is_err());
 
         // Then updating the room info will store the event,
-        client.apply_changes(&changes, room_info_notable_updates);
+        client.apply_changes(&changes, room_info_notable_updates, None);
         assert_eq!(room.latest_event().unwrap().event_id(), event.event_id());
 
         // And wake up the subscriber.

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -109,8 +109,9 @@ impl BaseClient {
             .await?;
 
         trace!("ready to submit e2ee changes to store");
+        let prev_ignored_user_list = self.load_previous_ignored_user_list().await;
         self.store.save_changes(&changes).await?;
-        self.apply_changes(&changes, room_info_notable_updates);
+        self.apply_changes(&changes, room_info_notable_updates, prev_ignored_user_list);
         trace!("applied e2ee changes");
 
         Ok(Some(to_device))
@@ -324,8 +325,9 @@ impl BaseClient {
         changes.ambiguity_maps = ambiguity_cache.cache;
 
         trace!("ready to submit changes to store");
+        let prev_ignored_user_list = self.load_previous_ignored_user_list().await;
         store.save_changes(&changes).await?;
-        self.apply_changes(&changes, room_info_notable_updates);
+        self.apply_changes(&changes, room_info_notable_updates, prev_ignored_user_list);
         trace!("applied changes");
 
         // Now that all the rooms information have been saved, update the display name

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -99,7 +99,6 @@ mod updates;
 use std::{
     fmt,
     marker::PhantomData,
-    ops::Not,
     ptr::NonNull,
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -354,7 +353,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
         // We need to update `self.links.last` if and only if `last_chunk` _is not_ the
         // first chunk, and _is_ the last chunk (ensured by the `debug_assert!`
         // above).
-        if last_chunk.is_first_chunk().not() {
+        if !last_chunk.is_first_chunk() {
             // Maybe `last_chunk` is the same as the previous `self.links.last` chunk, but
             // it's OK.
             self.links.last = Some(last_chunk.as_ptr());
@@ -455,7 +454,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
         // We need to update `self.links.last` if and only if `chunk` _is not_ the first
         // chunk, and _is_ the last chunk.
-        if chunk.is_first_chunk().not() && chunk.is_last_chunk() {
+        if !chunk.is_first_chunk() && chunk.is_last_chunk() {
             // Maybe `chunk` is the same as the previous `self.links.last` chunk, but it's
             // OK.
             self.links.last = Some(chunk.as_ptr());
@@ -509,7 +508,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
             // If removing empty chunk is desired, and if the `chunk` can be unlinked, and
             // if the `chunk` is not the first one, we can remove it.
-            if can_unlink_chunk && chunk.is_first_chunk().not() {
+            if can_unlink_chunk && !chunk.is_first_chunk() {
                 // Unlink `chunk`.
                 chunk.unlink(self.updates.as_mut());
 
@@ -682,7 +681,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
         // We need to update `self.links.last` if and only if `chunk` _is not_ the first
         // chunk, and _is_ the last chunk.
-        if chunk.is_first_chunk().not() && chunk.is_last_chunk() {
+        if !chunk.is_first_chunk() && chunk.is_last_chunk() {
             // Maybe `chunk` is the same as the previous `self.links.last` chunk, but it's
             // OK.
             self.links.last = Some(chunk.as_ptr());

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -640,15 +640,7 @@ impl EventCacheInner {
 
         let rooms = self.by_room.write().await;
         for room in rooms.values() {
-            // Clear all the room state.
-            let updates_as_vector_diffs = room.inner.state.write().await.reset().await?;
-
-            // Notify all the observers that we've lost track of state. (We ignore the
-            // error if there aren't any.)
-            let _ = room.inner.sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
-                diffs: updates_as_vector_diffs,
-                origin: EventsOrigin::Sync,
-            });
+            room.clear().await?;
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -681,7 +681,7 @@ impl EventCacheInner {
                 room.inner.handle_joined_room_update(self.has_storage(), joined_room_update).await
             {
                 // Non-fatal error, try to continue to the next room.
-                error!("handling joined room update: {err}");
+                error!(%room_id, "handling joined room update: {err}");
             }
         }
 

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -367,17 +367,15 @@ impl RoomPagination {
             let insert_new_gap_pos = if let Some(gap_id) = prev_gap_id {
                 // There is a prior gap, let's replace it by new events!
                 if all_duplicates {
-                    // All the events were duplicated; don't act upon them, and only remove the
-                    // prior gap that we just filled.
-                    trace!("removing previous gap, as all events have been deduplicated");
-                    room_events.remove_empty_chunk_at(gap_id).expect("gap identifier is a valid gap chunk id we read previously")
-                } else {
-                    trace!("replacing previous gap with the back-paginated events");
-
-                    // Replace the gap with the events we just deduplicated.
-                    room_events.replace_gap_at(reversed_events.clone(), gap_id)
-                        .expect("gap_identifier is a valid chunk id we read previously")
+                    assert!(reversed_events.is_empty());
                 }
+
+                trace!("replacing previous gap with the back-paginated events");
+
+                // Replace the gap with the events we just deduplicated. This might get rid of the
+                // underlying gap, if the conditions are favorable to us.
+                room_events.replace_gap_at(reversed_events.clone(), gap_id)
+                    .expect("gap_identifier is a valid chunk id we read previously")
             } else if let Some(pos) = first_event_pos {
                 // No prior gap, but we had some events: assume we need to prepend events
                 // before those.

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -143,7 +143,7 @@ impl RoomEvents {
     /// returns a `Result`.
     ///
     /// This method returns the position of the (first if many) newly created
-    /// `Chunk` that   contains the `items`.
+    /// `Chunk` that contains the `items`.
     pub fn replace_gap_at(
         &mut self,
         events: Vec<Event>,

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -40,7 +40,7 @@ use tokio::sync::{
     broadcast::{Receiver, Sender},
     mpsc, Notify, RwLock,
 };
-use tracing::{error, trace, warn};
+use tracing::{error, instrument, trace, warn};
 
 use super::{
     deduplicator::DeduplicationOutcome, AllEventsCache, AutoShrinkChannelPayload, EventsOrigin,
@@ -381,6 +381,7 @@ impl RoomEventCacheInner {
         }
     }
 
+    #[instrument(skip_all, fields(room_id = %self.room_id))]
     pub(super) async fn handle_joined_room_update(
         &self,
         has_storage: bool,
@@ -447,6 +448,7 @@ impl RoomEventCacheInner {
         Ok(())
     }
 
+    #[instrument(skip_all, fields(room_id = %self.room_id))]
     pub(super) async fn handle_left_room_update(
         &self,
         has_storage: bool,


### PR DESCRIPTION
See the commit messages for more explanations. This makes the event cache much more stable for `multiverse`, by addressing three issues:

- if a gap was the only chunk loaded in a linked chunk, don't try to remove it after resolving it to an empty set of events
- #4785: enable the foreign keys pragma for each sqlite connection, to make sure cascading works
- #4784 (perf): now we'll only wake the subscribers if the ignored user list has changed, when compared to the previous version we knew about

Bugs found with `multiverse`.

Fixes #4785.
Fixes #4784.

Part of #3280.