### PR TITLE
Invites room summary fallback

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -886,6 +886,24 @@ impl Client {
         self.inner.rooms().into_iter().map(|room| Arc::new(Room::new(room))).collect()
     }
 
+    /// Get a room by its ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The ID of the room to get.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing an optional room, or a `ClientError`.
+    /// This method will not initialize the room's timeline or populate it with
+    /// events.
+    pub fn get_room(&self, room_id: String) -> Result<Option<Arc<Room>>, ClientError> {
+        let room_id = RoomId::parse(room_id)?;
+        let sdk_room = self.inner.get_room(&room_id);
+        let room = sdk_room.map(|room| Arc::new(Room::new(room)));
+        Ok(room)
+    }
+
     pub fn get_dm_room(&self, user_id: String) -> Result<Option<Arc<Room>>, ClientError> {
         let user_id = UserId::parse(user_id)?;
         let sdk_room = self.inner.get_dm_room(&user_id);

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -161,21 +161,6 @@ impl Room {
         self.inner.active_room_call_participants().iter().map(|u| u.to_string()).collect()
     }
 
-    /// For rooms one is invited to, retrieves the room member information for
-    /// the user who invited the logged-in user to a room.
-    pub async fn inviter(&self) -> Option<RoomMember> {
-        if self.inner.state() == RoomState::Invited {
-            self.inner
-                .invite_details()
-                .await
-                .ok()
-                .and_then(|a| a.inviter)
-                .and_then(|m| m.try_into().ok())
-        } else {
-            None
-        }
-    }
-
     /// Forces the currently active room key, which is used to encrypt messages,
     /// to be rotated.
     ///

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -573,24 +573,6 @@ impl RoomListItem {
         self.inner.inner_room().state().into()
     }
 
-    /// Builds a `Room` FFI from an invited room without initializing its
-    /// internal timeline.
-    ///
-    /// An error will be returned if the room is a state different than invited.
-    ///
-    /// ⚠️ Holding on to this room instance after it has been joined is not
-    /// safe. Use `full_room` instead.
-    #[deprecated(note = "Please use `preview_room` instead.")]
-    fn invited_room(&self) -> Result<Arc<Room>, RoomListError> {
-        if !matches!(self.membership(), Membership::Invited) {
-            return Err(RoomListError::IncorrectRoomMembership {
-                expected: vec![Membership::Invited],
-                actual: self.membership(),
-            });
-        }
-        Ok(Arc::new(Room::new(self.inner.inner_room().clone())))
-    }
-
     /// Builds a `RoomPreview` from a room list item. This is intended for
     /// invited, knocked or banned rooms.
     async fn preview_room(&self, via: Vec<String>) -> Result<Arc<RoomPreview>, ClientError> {

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -989,6 +989,13 @@ impl MatrixMockServer {
             .and(path_regex(r"^/_matrix/client/v3/keys/signatures/upload"));
         self.mock_endpoint(mock, UploadCrossSigningSignaturesEndpoint).expect_default_access_token()
     }
+
+    /// Creates a prebuilt mock for the endpoint used to leave a room.
+    pub fn mock_room_leave(&self) -> MockEndpoint<'_, RoomLeaveEndpoint> {
+        let mock =
+            Mock::given(method("POST")).and(path_regex(r"^/_matrix/client/v3/rooms/.*/leave"));
+        self.mock_endpoint(mock, RoomLeaveEndpoint).expect_default_access_token()
+    }
 }
 
 /// Parameter to [`MatrixMockServer::sync_room`].
@@ -2496,5 +2503,18 @@ impl<'a> MockEndpoint<'a, UploadCrossSigningSignaturesEndpoint> {
     /// Returns a successful empty response.
     pub fn ok(self) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+    }
+}
+
+/// A prebuilt mock for the room leave endpoint.
+pub struct RoomLeaveEndpoint;
+
+impl<'a> MockEndpoint<'a, RoomLeaveEndpoint> {
+    /// Returns a successful response with some default data for the given room
+    /// id.
+    pub fn ok(self, room_id: &RoomId) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "room_id": room_id,
+        })))
     }
 }


### PR DESCRIPTION
This PR introduces a fallback mechanism for dealing with invites when the room summary API [MSC3266](https://github.com/matrix-org/matrix-spec-proposals/pull/3266) isn't enabled on the homeserver. 
It does so by trying to use whatever data the client has cached about the room, and even though it won't contain a lot of information, it will still provide an usable instance which can be used to accept/decline the invite and partially populate the join room screen (in EX).

It also deals away with the now unnecessary `invited_room` and `inviter` and expose a new client one for fetching arbitrary rooms based on their identifier.