### PR TITLE
refactor(timeline): move `is_utd()` to `TimelineItemContent`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -325,6 +325,12 @@ impl TimelineItemContent {
         as_variant!(self, Self::UnableToDecrypt)
     }
 
+    /// Check whether this item's content is a
+    /// [`UnableToDecrypt`][Self::UnableToDecrypt].
+    pub fn is_unable_to_decrypt(&self) -> bool {
+        matches!(self, Self::UnableToDecrypt(_))
+    }
+
     // These constructors could also be `From` implementations, but that would
     // allow users to call them directly, which should not be supported
     pub(crate) fn message(

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -233,11 +233,6 @@ impl EventTimelineItem {
         matches!(self.kind, EventTimelineItemKind::Remote(_))
     }
 
-    /// Check whether this item's content is UTD (unable to decrypt).
-    pub fn is_utd(&self) -> bool {
-        matches!(self.content(), TimelineItemContent::UnableToDecrypt(_))
-    }
-
     /// Get the `LocalEventTimelineItem` if `self` is `Local`.
     pub(super) fn as_local(&self) -> Option<&LocalEventTimelineItem> {
         as_variant!(&self.kind, EventTimelineItemKind::Local(local_event_item) => local_event_item)

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -748,7 +748,7 @@ async fn test_retry_decryption_updates_response() {
         assert_eq!(reply_details.event_id, original_event_id);
 
         let replied_to = as_variant!(&reply_details.event, TimelineDetails::Ready).unwrap();
-        assert!(replied_to.content.as_unable_to_decrypt().is_some());
+        assert!(replied_to.content.is_unable_to_decrypt());
     }
 
     // Import a room key backup.

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -920,7 +920,7 @@ async fn test_delayed_invite_response_and_sent_message_decryption() {
                         continue;
                     };
 
-                    if event.is_utd() {
+                    if event.content().is_unable_to_decrypt() {
                         info!("Observed UTD for {}", event.event_id().unwrap());
                     }
 


### PR DESCRIPTION
It's unusual to have the method on the parent type when the field type could also hold the method. In fact, this was the only bool getter inspecting the timeline's content, so let's move the method next to as its siblings, for consistency, and let's spell it out fully for clarity.