### PR TITLE
fix(ffi): Remove `Room::is_encrypted`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -250,10 +250,6 @@ impl Room {
         Ok(self.inner.latest_encryption_state().await?)
     }
 
-    pub async fn is_encrypted(&self) -> Result<bool, ClientError> {
-        Ok(self.latest_encryption_state().await?.is_encrypted())
-    }
-
     pub async fn members(&self) -> Result<Arc<RoomMembersIterator>, ClientError> {
         Ok(Arc::new(RoomMembersIterator::new(self.inner.members(RoomMemberships::empty()).await?)))
     }


### PR DESCRIPTION
This API is now deprecated.

---

* Follow up of https://github.com/matrix-org/matrix-rust-sdk/pull/4777
* Complement Crypto PR: https://github.com/matrix-org/complement-crypto/pull/167