### PR TITLE
feat(base): Reduce memory usage of `BaseClient::room_info_notable_update_sender` by 65'536 times for a regular user

### DIFF
--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -280,6 +280,11 @@ impl Store {
         self.rooms.read().unwrap().get(room_id).is_some()
     }
 
+    /// Get the number of rooms.
+    pub(crate) fn number_of_rooms(&self) -> usize {
+        self.rooms.read().unwrap().len()
+    }
+
     /// Lookup the `Room` for the given `RoomId`, or create one, if it didn't
     /// exist yet in the store
     pub fn get_or_create_room(

--- a/crates/matrix-sdk-base/src/store/observable_map.rs
+++ b/crates/matrix-sdk-base/src/store/observable_map.rs
@@ -147,6 +147,11 @@ where
 
         Some(self.values.remove(position))
     }
+
+    /// Get the number of values.
+    pub(crate) fn len(&self) -> usize {
+        self.mapping.len()
+    }
 }
 
 #[cfg(test)]
@@ -294,5 +299,22 @@ mod tests {
 
         drop(map);
         assert_closed!(stream);
+    }
+
+    #[test]
+    fn test_len() {
+        let mut map = ObservableMap::<char, char>::new();
+
+        assert_eq!(map.len(), 0);
+
+        map.insert('a', 'e');
+        map.insert('b', 'f');
+        map.insert('c', 'g');
+
+        assert_eq!(map.len(), 3);
+
+        map.remove(&'b');
+
+        assert_eq!(map.len(), 2);
     }
 }


### PR DESCRIPTION
This patch reduces the memory usage of the broadcast channel used by
`BaseClient::room_info_notable_update_sender`. So far, its size was
`u16::MAX`. Considering `RoomInfoNotableUpdate` is 24 bytes, the channel
was allocating 1.5Mb of memory, which is way too much. It is creating
problems on systems where the process has limited resources, like the
[Notification Service Extension][NSE] on iOS.

For a regular users with 200 rooms, the memory usage becomes 24Kb, which
is 65'536 times less.

[NSE]: https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension

---

* Follow up of https://github.com/matrix-org/matrix-rust-sdk/pull/4013