### PR TITLE
feat(ffi): Add `RoomInfo::encryption_state`

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -58,3 +58,5 @@ Additions:
 - Add `Room::send_raw`
 - Expose `withdraw_verification` to `UserIdentity`
 - Expose `report_room` to `Room`
+- Add `RoomInfo::encryption_state`
+  ([#4788](https://github.com/matrix-org/matrix-rust-sdk/pull/4788))

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use matrix_sdk::RoomState;
+use matrix_sdk::{EncryptionState, RoomState};
 use tracing::warn;
 
 use crate::{
@@ -14,6 +14,7 @@ use crate::{
 #[derive(uniffi::Record)]
 pub struct RoomInfo {
     id: String,
+    encryption_state: EncryptionState,
     creator: Option<String>,
     /// The room's name from the room state event if received from sync, or one
     /// that's been computed otherwise.
@@ -84,6 +85,7 @@ impl RoomInfo {
 
         Ok(Self {
             id: room.room_id().to_string(),
+            encryption_state: room.encryption_state(),
             creator: room.creator().as_ref().map(ToString::to_string),
             display_name: room.cached_display_name().map(|name| name.to_string()),
             raw_name: room.name(),


### PR DESCRIPTION
This patch adds the `EncryptionState` onto the new `RoomInfo::encryption_state` field.