### PR TITLE
refactor(oidc): Remove dependency on mas-oidc-client 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,18 +516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,18 +1109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,12 +1200,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "date_header"
@@ -1328,7 +1298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1339,7 +1308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -1355,7 +1323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1414,26 +1381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,27 +1411,6 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
- "rand_core",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "emojis"
@@ -1831,16 +1757,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
-name = "ff"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
-dependencies = [
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,7 +1945,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -2106,17 +2021,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "growable-bloom-filter"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,7 +2044,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.7.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2156,12 +2060,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2189,30 +2087,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "headers"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,12 +2097,6 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
@@ -2295,12 +2163,6 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
 
 [[package]]
 name = "httparse"
@@ -2634,17 +2496,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
@@ -2667,7 +2518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c77a3ae7d4761b9c64d2c030f70746ceb8cfba32dce0325a56792e0a4816c31"
 dependencies = [
  "ahash",
- "indexmap 2.7.1",
+ "indexmap",
  "is-terminal",
  "itoa",
  "log",
@@ -2827,20 +2678,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "k256"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "sha2",
- "signature",
-]
-
-[[package]]
 name = "konst"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2865,30 +2702,18 @@ name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "libm"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"
@@ -3038,105 +2863,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mas-http"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0f43adb7c4c4dc44517b3167d0b25111273c088eaaf79bf326c5bfb6006e52"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "headers",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "opentelemetry",
- "opentelemetry-semantic-conventions",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "thiserror 1.0.63",
- "tower 0.4.13",
- "tower-http",
- "tracing",
- "tracing-opentelemetry",
-]
-
-[[package]]
-name = "mas-iana"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d41af7e8eb3584b648c563a1b97b8f60c7f3dcd7ea0ded525050418d90c5200"
-dependencies = [
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "mas-jose"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6a1c99221601a1e9ef284efaa6db5985389c839c299d71d5a4c2933ba88eda"
-dependencies = [
- "base64ct",
- "chrono",
- "digest",
- "ecdsa",
- "elliptic-curve",
- "generic-array",
- "hmac",
- "k256",
- "mas-iana",
- "p256",
- "p384",
- "rand",
- "rsa",
- "schemars",
- "sec1",
- "serde",
- "serde_json",
- "serde_with",
- "sha2",
- "signature",
- "thiserror 1.0.63",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "mas-oidc-client"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b4aea512a69c0441c349668da2f5b0bdaeba45163b9616cb9373177de1834ec"
-dependencies = [
- "base64ct",
- "bytes",
- "chrono",
- "form_urlencoded",
- "futures-util",
- "headers",
- "http",
- "language-tags",
- "mas-http",
- "mas-iana",
- "mas-jose",
- "mime",
- "oauth2-types",
- "rand",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "serde_with",
- "thiserror 1.0.63",
- "tower 0.4.13",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3210,10 +2936,9 @@ dependencies = [
  "growable-bloom-filter",
  "http",
  "imbl",
- "indexmap 2.7.1",
+ "indexmap",
  "js_int",
  "language-tags",
- "mas-oidc-client",
  "matrix-sdk-base",
  "matrix-sdk-common",
  "matrix-sdk-ffi-macros",
@@ -3455,7 +3180,7 @@ dependencies = [
  "assert_matches",
  "assert_matches2",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "getrandom 0.2.15",
  "gloo-utils",
  "growable-bloom-filter",
@@ -3560,7 +3285,7 @@ name = "matrix-sdk-store-encryption"
 version = "0.10.0"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "blake3",
  "chacha20poly1305",
  "getrandom 0.2.15",
@@ -3628,7 +3353,7 @@ dependencies = [
  "fuzzy-matcher",
  "growable-bloom-filter",
  "imbl",
- "indexmap 2.7.1",
+ "indexmap",
  "itertools 0.14.0",
  "matrix-sdk",
  "matrix-sdk-base",
@@ -3801,23 +3526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3834,33 +3542,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3888,7 +3575,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "getrandom 0.2.15",
  "http",
@@ -3897,26 +3584,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
- "thiserror 1.0.63",
- "url",
-]
-
-[[package]]
-name = "oauth2-types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9baa46cfc1969e04a7f8c31ee6718a8b4cb52ef31d7d91772f878052d872e1"
-dependencies = [
- "chrono",
- "data-encoding",
- "http",
- "language-tags",
- "mas-iana",
- "mas-jose",
- "serde",
- "serde_json",
- "serde_with",
  "sha2",
  "thiserror 1.0.63",
  "url",
@@ -3994,43 +3661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.63",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cefe0543875379e47eb5f1e68ff83f45cc41366a92dfd0d073d513bf68e9a05"
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry",
- "percent-encoding",
- "rand",
- "thiserror 1.0.63",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4047,30 +3677,6 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
 
 [[package]]
 name = "paranoid-android"
@@ -4128,15 +3734,6 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -4294,17 +3891,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4405,15 +3991,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -4770,7 +4347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "async-compression",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4812,16 +4389,6 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "windows-registry",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -4881,26 +4448,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rtoolbox"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4955,12 +4502,12 @@ version = "0.15.1"
 source = "git+https://github.com/ruma/ruma?rev=b1cb83544faafaef92be56c53cd98af4c51da858#b1cb83544faafaef92be56c53cd98af4c51da858"
 dependencies = [
  "as_variant",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "form_urlencoded",
  "getrandom 0.2.15",
  "http",
- "indexmap 2.7.1",
+ "indexmap",
  "js-sys",
  "js_int",
  "konst",
@@ -4987,7 +4534,7 @@ version = "0.30.1"
 source = "git+https://github.com/ruma/ruma?rev=b1cb83544faafaef92be56c53cd98af4c51da858#b1cb83544faafaef92be56c53cd98af4c51da858"
 dependencies = [
  "as_variant",
- "indexmap 2.7.1",
+ "indexmap",
  "js_int",
  "js_option",
  "percent-encoding",
@@ -5130,7 +4677,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "rustls-pki-types",
 ]
 
@@ -5182,33 +4729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
-dependencies = [
- "chrono",
- "dyn-clone",
- "indexmap 1.9.3",
- "schemars_derive",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5238,20 +4758,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -5327,24 +4833,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "serde_html_form"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d2de91cf02bbc07cde38891769ccd5d4f073d22a40683aa4bc7a95781aaa2c4"
 dependencies = [
  "form_urlencoded",
- "indexmap 2.7.1",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -5356,7 +4851,6 @@ version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
- "indexmap 2.7.1",
  "itoa",
  "memchr",
  "ryu",
@@ -5392,47 +4886,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.7.1",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -5497,7 +4950,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
  "rand_core",
 ]
 
@@ -5557,12 +5009,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -6001,7 +5447,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6034,31 +5480,6 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.8.0",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "http-range-header",
- "httpdate",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6135,22 +5556,6 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9784ed4da7d921bc8df6963f8c80a0e4ce34ba6ba76668acadd3edbd985ff3b"
-dependencies = [
- "js-sys",
- "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
- "web-time",
 ]
 
 [[package]]
@@ -6518,7 +5923,7 @@ checksum = "c022a277687e4e8685d72b95a7ca3ccfec907daa946678e715f8badaa650883d"
 dependencies = [
  "aes",
  "arrayvec",
- "base64 0.22.1",
+ "base64",
  "base64ct",
  "cbc",
  "chacha20poly1305",
@@ -6957,7 +6362,7 @@ checksum = "7fff469918e7ca034884c7fd8f93fe27bacb7fcb599fd879df6c7b429a29b646"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "deadpool 0.10.0",
  "futures",
  "http",

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1681,14 +1681,14 @@ impl TryFrom<Session> for AuthSession {
 #[serde(try_from = "OidcSessionDataDeHelper")]
 pub(crate) struct OidcSessionData {
     client_id: ClientId,
-    issuer: String,
+    issuer: Url,
 }
 
 #[derive(Deserialize)]
 struct OidcSessionDataDeHelper {
     client_id: ClientId,
     issuer_info: Option<AuthenticationServerInfo>,
-    issuer: Option<String>,
+    issuer: Option<Url>,
 }
 
 impl TryFrom<OidcSessionDataDeHelper> for OidcSessionData {
@@ -1698,7 +1698,7 @@ impl TryFrom<OidcSessionDataDeHelper> for OidcSessionData {
         let OidcSessionDataDeHelper { client_id, issuer_info, issuer } = value;
 
         let issuer = issuer
-            .or(issuer_info.map(|info| info.issuer))
+            .or(issuer_info.and_then(|info| Url::parse(&info.issuer).ok()))
             .ok_or_else(|| "missing field `issuer`".to_owned())?;
 
         Ok(Self { client_id, issuer })

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -8,8 +8,8 @@ use anyhow::{anyhow, Context as _};
 use async_compat::get_runtime_handle;
 use matrix_sdk::{
     authentication::oidc::{
-        registrations::ClientId, requests::account_management::AccountManagementActionFull,
-        types::requests::Prompt as SdkOidcPrompt, OidcAuthorizationData, OidcSession,
+        registrations::ClientId, types::requests::Prompt as SdkOidcPrompt,
+        AccountManagementActionFull, OidcAuthorizationData, OidcSession,
     },
     event_cache::EventCacheError,
     media::{
@@ -1723,8 +1723,12 @@ impl From<AccountManagementAction> for AccountManagementActionFull {
         match value {
             AccountManagementAction::Profile => Self::Profile,
             AccountManagementAction::SessionsList => Self::SessionsList,
-            AccountManagementAction::SessionView { device_id } => Self::SessionView { device_id },
-            AccountManagementAction::SessionEnd { device_id } => Self::SessionEnd { device_id },
+            AccountManagementAction::SessionView { device_id } => {
+                Self::SessionView { device_id: device_id.into() }
+            }
+            AccountManagementAction::SessionEnd { device_id } => {
+                Self::SessionEnd { device_id: device_id.into() }
+            }
             AccountManagementAction::AccountDeactivate => Self::AccountDeactivate,
             AccountManagementAction::CrossSigningReset => Self::CrossSigningReset,
         }

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -115,9 +115,10 @@ simpler methods:
   - `Oidc::restore_registered_client()` doesn't take a `VerifiedClientMetadata`
     anymore.
   - `Oidc::latest_id_token()` and `Oidc::client_metadata()` were removed.
-- [**breaking**]: The `Oidc` API makes use of the oauth2 crate rather than
-  mas-oidc-client.
+- [**breaking**]: The `Oidc` API makes use of the oauth2 and ruma crates rather
+  than mas-oidc-client.
   ([#4761](https://github.com/matrix-org/matrix-rust-sdk/pull/4761))
+  ([#4789](https://github.com/matrix-org/matrix-rust-sdk/pull/4789))
   - `ClientId` is a different type reexported from the oauth2 crate.
   - The error types that were in the `oidc` module have been moved to the
     `oidc::error` module.
@@ -130,6 +131,14 @@ simpler methods:
     `CsrfToken`.
   - The `error` field of `AuthorizationError` uses an error type from the oauth2
     crate rather than one from mas-oidc-client.
+  - The `types` and `requests` modules are gone and the necessary types are
+    exported from the `oidc` module or available from `ruma`.
+  - `AccountManagementUrlFull` now takes an `OwnedDeviceId` when a device ID is
+    required.
+  - `(Verified)ProviderMetadata` was replaced by `AuthorizationServerMetadata`.
+  - The `issuer` is now a `Url`.
+  - `Oidc::register()` doesn't accept a software statement anymore.
+  - `(Verified)ClientMetadata` was replaced by the opinionated `ClientMetadata`.
 - [**breaking**]: `OidcSessionTokens` and `MatrixSessionTokens` have been merged
   into `SessionTokens`. Methods to get and watch session tokens are now
   available directly on `Client`.

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -48,9 +48,7 @@ experimental-oidc = [
     "ruma/unstable-msc2967",
     "ruma/unstable-msc4108",
     "dep:language-tags",
-    "dep:mas-oidc-client",
     "dep:sha2",
-    "dep:tower",
     "dep:oauth2",
 ]
 experimental-widgets = ["dep:language-tags", "dep:uuid"]
@@ -81,7 +79,6 @@ imbl = { workspace = true, features = ["serde"] }
 indexmap = { workspace = true }
 js_int = "0.2.2"
 language-tags = { version = "0.3.2", optional = true }
-mas-oidc-client = { version = "0.11.0", default-features = false, optional = true }
 matrix-sdk-base = { workspace = true }
 matrix-sdk-common = { workspace = true }
 matrix-sdk-ffi-macros = { workspace = true, optional = true }

--- a/crates/matrix-sdk/src/authentication/oidc/account_management_url.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/account_management_url.rs
@@ -1,0 +1,191 @@
+// Copyright 2025 Kévin Commaille
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types and functions related to the account management URL.
+//!
+//! This is a Matrix extension introduced in [MSC4191](https://github.com/matrix-org/matrix-spec-proposals/pull/4191).
+
+use ruma::OwnedDeviceId;
+use serde::Serialize;
+use url::Url;
+
+/// An account management action that a user can take, including a device ID for
+/// the actions that support it.
+///
+/// The actions are defined in [MSC4191].
+///
+/// [MSC4191]: https://github.com/matrix-org/matrix-spec-proposals/pull/4191
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "action")]
+#[non_exhaustive]
+pub enum AccountManagementActionFull {
+    /// `org.matrix.profile`
+    ///
+    /// The user wishes to view their profile (name, avatar, contact details).
+    #[serde(rename = "org.matrix.profile")]
+    Profile,
+
+    /// `org.matrix.sessions_list`
+    ///
+    /// The user wishes to view a list of their sessions.
+    #[serde(rename = "org.matrix.sessions_list")]
+    SessionsList,
+
+    /// `org.matrix.session_view`
+    ///
+    /// The user wishes to view the details of a specific session.
+    #[serde(rename = "org.matrix.session_view")]
+    SessionView {
+        /// The ID of the session to view the details of.
+        device_id: OwnedDeviceId,
+    },
+
+    /// `org.matrix.session_end`
+    ///
+    /// The user wishes to end/log out of a specific session.
+    #[serde(rename = "org.matrix.session_end")]
+    SessionEnd {
+        /// The ID of the session to end.
+        device_id: OwnedDeviceId,
+    },
+
+    /// `org.matrix.account_deactivate`
+    ///
+    /// The user wishes to deactivate their account.
+    #[serde(rename = "org.matrix.account_deactivate")]
+    AccountDeactivate,
+
+    /// `org.matrix.cross_signing_reset`
+    ///
+    /// The user wishes to reset their cross-signing keys.
+    #[serde(rename = "org.matrix.cross_signing_reset")]
+    CrossSigningReset,
+}
+
+/// Build the URL for accessing the account management capabilities, as defined
+/// in [MSC].
+///
+/// # Arguments
+///
+/// * `account_management_uri` - The URL to access the issuer's account
+///   management capabilities.
+///
+/// * `action` - The action that the user wishes to take.
+///
+/// # Returns
+///
+/// A URL to be opened in a web browser where the end-user will be able to
+/// access the account management capabilities of the issuer.
+///
+/// # Errors
+///
+/// Returns an error if serializing the action fails.
+///
+/// [MSC4191]: https://github.com/matrix-org/matrix-spec-proposals/pull/4191
+pub(crate) fn build_account_management_url(
+    mut account_management_uri: Url,
+    action: AccountManagementActionFull,
+) -> Result<Url, serde_html_form::ser::Error> {
+    let extra_query = serde_html_form::to_string(action)?;
+
+    // Add our parameters to the query, because the URL might already have one.
+    let mut full_query = account_management_uri.query().map(ToOwned::to_owned).unwrap_or_default();
+
+    if !full_query.is_empty() {
+        full_query.push('&');
+    }
+    full_query.push_str(&extra_query);
+
+    account_management_uri.set_query(Some(&full_query));
+
+    Ok(account_management_uri)
+}
+
+#[cfg(test)]
+mod tests {
+    use ruma::owned_device_id;
+    use url::Url;
+
+    use super::{build_account_management_url, AccountManagementActionFull};
+
+    #[test]
+    fn test_build_account_management_url_actions() {
+        let base_url = Url::parse("https://example.org").unwrap();
+        let device_id = owned_device_id!("ABCDEFG");
+
+        let url =
+            build_account_management_url(base_url.clone(), AccountManagementActionFull::Profile)
+                .unwrap();
+        assert_eq!(url.as_str(), "https://example.org/?action=org.matrix.profile");
+
+        let url = build_account_management_url(
+            base_url.clone(),
+            AccountManagementActionFull::SessionsList,
+        )
+        .unwrap();
+        assert_eq!(url.as_str(), "https://example.org/?action=org.matrix.sessions_list");
+
+        let url = build_account_management_url(
+            base_url.clone(),
+            AccountManagementActionFull::SessionView { device_id: device_id.clone() },
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://example.org/?action=org.matrix.session_view&device_id=ABCDEFG"
+        );
+
+        let url = build_account_management_url(
+            base_url.clone(),
+            AccountManagementActionFull::SessionEnd { device_id },
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://example.org/?action=org.matrix.session_end&device_id=ABCDEFG"
+        );
+
+        let url = build_account_management_url(
+            base_url.clone(),
+            AccountManagementActionFull::AccountDeactivate,
+        )
+        .unwrap();
+        assert_eq!(url.as_str(), "https://example.org/?action=org.matrix.account_deactivate");
+
+        let url =
+            build_account_management_url(base_url, AccountManagementActionFull::CrossSigningReset)
+                .unwrap();
+        assert_eq!(url.as_str(), "https://example.org/?action=org.matrix.cross_signing_reset");
+    }
+
+    #[test]
+    fn test_build_account_management_url_with_query() {
+        let base_url = Url::parse("https://example.org/?sid=123456").unwrap();
+
+        let url =
+            build_account_management_url(base_url.clone(), AccountManagementActionFull::Profile)
+                .unwrap();
+        assert_eq!(url.as_str(), "https://example.org/?sid=123456&action=org.matrix.profile");
+
+        let url = build_account_management_url(
+            base_url,
+            AccountManagementActionFull::SessionView { device_id: owned_device_id!("ABCDEFG") },
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://example.org/?sid=123456&action=org.matrix.session_view&device_id=ABCDEFG"
+        );
+    }
+}

--- a/crates/matrix-sdk/src/authentication/oidc/auth_code_builder.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/auth_code_builder.rs
@@ -78,7 +78,7 @@ impl OidcAuthCodeUrlBuilder {
 
         let data = oidc.data().ok_or(OidcError::NotAuthenticated)?;
         info!(
-            issuer = data.issuer,
+            issuer = data.issuer.as_str(),
             ?scopes,
             "Authorizing scope via the OpenID Connect Authorization Code flow"
         );

--- a/crates/matrix-sdk/src/authentication/oidc/auth_code_builder.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/auth_code_builder.rs
@@ -84,7 +84,7 @@ impl OidcAuthCodeUrlBuilder {
         );
 
         let provider_metadata = oidc.provider_metadata().await?;
-        let auth_url = AuthUrl::from_url(provider_metadata.authorization_endpoint().clone());
+        let auth_url = AuthUrl::from_url(provider_metadata.authorization_endpoint);
 
         let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
         let redirect_uri = RedirectUrl::from_url(redirect_uri);

--- a/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/cross_process.rs
@@ -293,10 +293,7 @@ mod tests {
         let session_hash = compute_session_hash(&tokens);
         client
             .oidc()
-            .restore_session(mock_session(
-                tokens.clone(),
-                "https://oidc.example.com/issuer".to_owned(),
-            ))
+            .restore_session(mock_session(tokens.clone(), "https://oidc.example.com/issuer"))
             .await?;
 
         assert_eq!(client.session_tokens().unwrap(), tokens);
@@ -558,7 +555,7 @@ mod tests {
         let tokens = mock_session_tokens_with_refresh();
         oidc.restore_session(mock_session(tokens.clone(), server.server().uri())).await?;
 
-        oidc.logout().await?;
+        oidc.logout().await.unwrap();
 
         {
             // The cross process lock has been correctly updated, and all the hashes are

--- a/crates/matrix-sdk/src/authentication/oidc/error.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/error.rs
@@ -15,6 +15,7 @@
 //! Error types used in the [`Oidc`](super::Oidc) API.
 
 pub use mas_oidc_client::error::*;
+use mas_oidc_client::types::oidc::ProviderMetadataVerificationError;
 use matrix_sdk_base::deserialized_responses::PrivOwnedStr;
 use oauth2::ErrorResponseType;
 pub use oauth2::{
@@ -131,9 +132,18 @@ pub enum OauthDiscoveryError {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
 
+    /// The server metadata is incomplete or insecure.
+    #[error(transparent)]
+    Validation(#[from] ProviderMetadataVerificationError),
+
+    /// An error occurred when building the OpenID Connect provider
+    /// configuration URL.
+    #[error(transparent)]
+    Url(#[from] url::ParseError),
+
     /// An error occurred when making a request to the OpenID Connect provider.
     #[error(transparent)]
-    Oidc(#[from] DiscoveryError),
+    Oidc(#[from] OauthRequestError<BasicErrorResponseType>),
 }
 
 impl OauthDiscoveryError {

--- a/crates/matrix-sdk/src/authentication/oidc/error.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/error.rs
@@ -96,10 +96,6 @@ pub enum OidcError {
     #[error("failed to build account management URL: {0}")]
     AccountManagementUrl(serde_html_form::ser::Error),
 
-    /// An error occurred parsing a URL.
-    #[error(transparent)]
-    Url(url::ParseError),
-
     /// An error occurred caused by the cross-process locks.
     #[error(transparent)]
     LockError(#[from] CrossProcessRefreshLockError),

--- a/crates/matrix-sdk/src/authentication/oidc/error.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/error.rs
@@ -14,7 +14,6 @@
 
 //! Error types used in the [`Oidc`](super::Oidc) API.
 
-pub use mas_oidc_client::error::*;
 use matrix_sdk_base::deserialized_responses::PrivOwnedStr;
 use oauth2::ErrorResponseType;
 pub use oauth2::{
@@ -53,10 +52,6 @@ pub enum RedirectUriQueryParseError {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum OidcError {
-    /// An error occurred when interacting with the provider.
-    #[error(transparent)]
-    Oidc(Error),
-
     /// An error occurred when discovering the authorization server's issuer.
     #[error("authorization server discovery failed: {0}")]
     Discovery(#[from] OauthDiscoveryError),
@@ -102,15 +97,6 @@ pub enum OidcError {
     /// An unknown error occurred.
     #[error("unknown error")]
     UnknownError(#[source] Box<dyn std::error::Error + Send + Sync>),
-}
-
-impl<E> From<E> for OidcError
-where
-    E: Into<Error>,
-{
-    fn from(value: E) -> Self {
-        Self::Oidc(value.into())
-    }
 }
 
 /// All errors that can occur when discovering the OAuth 2.0 server metadata.

--- a/crates/matrix-sdk/src/authentication/oidc/error.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/error.rs
@@ -15,7 +15,6 @@
 //! Error types used in the [`Oidc`](super::Oidc) API.
 
 pub use mas_oidc_client::error::*;
-use mas_oidc_client::types::oidc::ProviderMetadataVerificationError;
 use matrix_sdk_base::deserialized_responses::PrivOwnedStr;
 use oauth2::ErrorResponseType;
 pub use oauth2::{
@@ -26,7 +25,10 @@ pub use oauth2::{
     ConfigurationError, HttpClientError, RequestTokenError, RevocationErrorResponseType,
     StandardErrorResponse,
 };
-use ruma::serde::{PartialEqAsRefStr, StringEnum};
+use ruma::{
+    api::client::discovery::get_authorization_server_metadata::msc2965::AuthorizationServerMetadataUrlError,
+    serde::{PartialEqAsRefStr, StringEnum},
+};
 
 pub use super::cross_process::CrossProcessRefreshLockError;
 
@@ -132,9 +134,9 @@ pub enum OauthDiscoveryError {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
 
-    /// The server metadata is incomplete or insecure.
+    /// The server metadata URLs are insecure.
     #[error(transparent)]
-    Validation(#[from] ProviderMetadataVerificationError),
+    Validation(#[from] AuthorizationServerMetadataUrlError),
 
     /// An error occurred when building the OpenID Connect provider
     /// configuration URL.
@@ -242,10 +244,6 @@ impl ErrorResponseType for AuthorizationCodeErrorResponseType {}
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum OauthTokenRevocationError {
-    /// Revocation is not supported by the OAuth 2.0 authorization server.
-    #[error("token revocation is not supported")]
-    NotSupported,
-
     /// The revocation endpoint URL is insecure.
     #[error(transparent)]
     Url(ConfigurationError),

--- a/crates/matrix-sdk/src/authentication/oidc/error.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/error.rs
@@ -29,6 +29,10 @@ use ruma::serde::{PartialEqAsRefStr, StringEnum};
 
 pub use super::cross_process::CrossProcessRefreshLockError;
 
+/// An error when interacting with the OAuth 2.0 authorization server.
+pub type OauthRequestError<T> =
+    RequestTokenError<HttpClientError<reqwest::Error>, StandardErrorResponse<T>>;
+
 /// An error when trying to parse the query of a redirect URI.
 #[derive(Debug, Clone, thiserror::Error)]
 #[non_exhaustive]
@@ -79,7 +83,7 @@ pub enum OidcError {
     /// An error occurred interacting with the OAuth 2.0 authorization server
     /// while refreshing the access token.
     #[error("failed to refresh token: {0}")]
-    RefreshToken(BasicRequestTokenError<HttpClientError<reqwest::Error>>),
+    RefreshToken(OauthRequestError<BasicErrorResponseType>),
 
     /// An error occurred revoking an OAuth 2.0 access token.
     #[error("failed to log out: {0}")]
@@ -162,7 +166,7 @@ pub enum OauthAuthorizationCodeError {
     /// An error occurred interacting with the OAuth 2.0 authorization server
     /// while exchanging the authorization code for an access token.
     #[error("failed to request token: {0}")]
-    RequestToken(BasicRequestTokenError<HttpClientError<reqwest::Error>>),
+    RequestToken(OauthRequestError<BasicErrorResponseType>),
 }
 
 impl From<StandardErrorResponse<AuthorizationCodeErrorResponseType>>
@@ -235,5 +239,5 @@ pub enum OauthTokenRevocationError {
     /// An error occurred interacting with the OAuth 2.0 authorization server
     /// while revoking the token.
     #[error("failed to revoke token: {0}")]
-    Revoke(RequestTokenError<HttpClientError<reqwest::Error>, BasicRevocationErrorResponse>),
+    Revoke(OauthRequestError<RevocationErrorResponseType>),
 }

--- a/crates/matrix-sdk/src/authentication/oidc/error.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/error.rs
@@ -89,6 +89,10 @@ pub enum OidcError {
     #[error("failed to log out: {0}")]
     Logout(#[from] OauthTokenRevocationError),
 
+    /// An error occurred building the account management URL.
+    #[error("failed to build account management URL: {0}")]
+    AccountManagementUrl(serde_html_form::ser::Error),
+
     /// An error occurred parsing a URL.
     #[error(transparent)]
     Url(url::ParseError),

--- a/crates/matrix-sdk/src/authentication/oidc/http_client.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/http_client.rs
@@ -1,0 +1,191 @@
+// Copyright 2025 Kévin Commaille
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! HTTP client and helpers for making OAuth 2.0 requests.
+
+use std::{future::Future, pin::Pin};
+
+use oauth2::{
+    AsyncHttpClient, ErrorResponse, HttpClientError, HttpRequest, HttpResponse, RequestTokenError,
+};
+
+/// An HTTP client for making OAuth 2.0 requests.
+#[derive(Debug, Clone)]
+pub(super) struct OauthHttpClient {
+    pub(super) inner: reqwest::Client,
+    /// Rewrite HTTPS requests to use HTTP instead.
+    ///
+    /// This is a workaround to bypass some checks that require an HTTPS URL,
+    /// but we can only mock HTTP URLs.
+    #[cfg(test)]
+    pub(super) insecure_rewrite_https_to_http: bool,
+}
+
+impl<'c> AsyncHttpClient<'c> for OauthHttpClient {
+    type Error = HttpClientError<reqwest::Error>;
+
+    type Future =
+        Pin<Box<dyn Future<Output = Result<HttpResponse, Self::Error>> + Send + Sync + 'c>>;
+
+    fn call(&'c self, request: HttpRequest) -> Self::Future {
+        Box::pin(async move {
+            #[cfg(test)]
+            let request = if self.insecure_rewrite_https_to_http
+                && request.uri().scheme().is_some_and(|scheme| *scheme == http::uri::Scheme::HTTPS)
+            {
+                let mut request = request;
+
+                let mut uri_parts = request.uri().clone().into_parts();
+                uri_parts.scheme = Some(http::uri::Scheme::HTTP);
+                *request.uri_mut() = http::uri::Uri::from_parts(uri_parts)
+                    .expect("reconstructing URI from parts should work");
+
+                request
+            } else {
+                request
+            };
+
+            let response = self.inner.call(request).await?;
+
+            Ok(response)
+        })
+    }
+}
+
+/// Check the status code of the given HTTP response to identify errors.
+pub(super) fn check_http_response_status_code<T: ErrorResponse + 'static>(
+    http_response: &HttpResponse,
+) -> Result<(), RequestTokenError<HttpClientError<reqwest::Error>, T>> {
+    if http_response.status().as_u16() < 400 {
+        return Ok(());
+    }
+
+    let reason = http_response.body().as_slice();
+    let error = if reason.is_empty() {
+        RequestTokenError::Other("server returned an empty error response".to_owned())
+    } else {
+        match serde_json::from_slice(reason) {
+            Ok(error) => RequestTokenError::ServerResponse(error),
+            Err(error) => RequestTokenError::Other(error.to_string()),
+        }
+    };
+
+    Err(error)
+}
+
+/// Check that the server returned a response with a JSON `Content-Type`.
+pub(super) fn check_http_response_json_content_type<T: ErrorResponse + 'static>(
+    http_response: &HttpResponse,
+) -> Result<(), RequestTokenError<HttpClientError<reqwest::Error>, T>> {
+    let Some(content_type) = http_response.headers().get(http::header::CONTENT_TYPE) else {
+        return Ok(());
+    };
+
+    if content_type
+        .to_str()
+        // Check only the beginning of the content type, because there might be extra
+        // parameters, like a charset.
+        .is_ok_and(|ct| ct.to_lowercase().starts_with(mime::APPLICATION_JSON.essence_str()))
+    {
+        Ok(())
+    } else {
+        Err(RequestTokenError::Other(format!(
+            "unexpected response Content-Type: {content_type:?}, should be `{}`",
+            mime::APPLICATION_JSON
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches2::assert_matches;
+    use oauth2::{basic::BasicErrorResponse, RequestTokenError};
+
+    use super::{check_http_response_json_content_type, check_http_response_status_code};
+
+    #[test]
+    fn test_check_http_response_status_code() {
+        // OK
+        let response = http::Response::builder().status(200).body(Vec::<u8>::new()).unwrap();
+        assert_matches!(check_http_response_status_code::<BasicErrorResponse>(&response), Ok(()));
+
+        // Error without body.
+        let response = http::Response::builder().status(404).body(Vec::<u8>::new()).unwrap();
+        assert_matches!(
+            check_http_response_status_code::<BasicErrorResponse>(&response),
+            Err(RequestTokenError::Other(_))
+        );
+
+        // Error with invalid body.
+        let response =
+            http::Response::builder().status(404).body(b"invalid error format".to_vec()).unwrap();
+        assert_matches!(
+            check_http_response_status_code::<BasicErrorResponse>(&response),
+            Err(RequestTokenError::Other(_))
+        );
+
+        // Error with valid body.
+        let response = http::Response::builder()
+            .status(404)
+            .body(br#"{"error": "invalid_request"}"#.to_vec())
+            .unwrap();
+        assert_matches!(
+            check_http_response_status_code::<BasicErrorResponse>(&response),
+            Err(RequestTokenError::ServerResponse(_))
+        );
+    }
+
+    #[test]
+    fn test_check_http_response_json_content_type() {
+        // Valid content type.
+        let response = http::Response::builder()
+            .status(200)
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .body(b"{}".to_vec())
+            .unwrap();
+        assert_matches!(
+            check_http_response_json_content_type::<BasicErrorResponse>(&response),
+            Ok(())
+        );
+
+        // Valid content type with charset.
+        let response = http::Response::builder()
+            .status(200)
+            .header(http::header::CONTENT_TYPE, "application/json; charset=utf-8")
+            .body(b"{}".to_vec())
+            .unwrap();
+        assert_matches!(
+            check_http_response_json_content_type::<BasicErrorResponse>(&response),
+            Ok(())
+        );
+
+        // Without content type.
+        let response = http::Response::builder().status(200).body(b"{}".to_vec()).unwrap();
+        assert_matches!(
+            check_http_response_json_content_type::<BasicErrorResponse>(&response),
+            Ok(())
+        );
+
+        // Wrong content type.
+        let response = http::Response::builder()
+            .status(200)
+            .header(http::header::CONTENT_TYPE, "text/html")
+            .body(b"<html><body><h1>HTML!</h1></body></html>".to_vec())
+            .unwrap();
+        assert_matches!(
+            check_http_response_json_content_type::<BasicErrorResponse>(&response),
+            Err(RequestTokenError::Other(_))
+        );
+    }
+}

--- a/crates/matrix-sdk/src/authentication/oidc/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/mod.rs
@@ -158,7 +158,6 @@ use error::{
     CrossProcessRefreshLockError, OauthAuthorizationCodeError, OauthClientRegistrationError,
     OauthDiscoveryError, OauthTokenRevocationError, RedirectUriQueryParseError,
 };
-pub use mas_oidc_client::{requests, types};
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::types::qr_login::QrCodeData;
 use matrix_sdk_base::{once_cell::sync::OnceCell, SessionMeta};

--- a/crates/matrix-sdk/src/authentication/oidc/oidc_discovery.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/oidc_discovery.rs
@@ -1,0 +1,64 @@
+// Copyright 2025 Kévin Commaille
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Requests for [OpenID Connect Provider Discovery].
+//!
+//! [OpenID Connect Provider Discovery]: https://openid.net/specs/openid-connect-discovery-1_0.html
+
+use oauth2::{AsyncHttpClient, HttpClientError, RequestTokenError};
+use ruma::{
+    api::client::discovery::get_authorization_server_metadata::msc2965::AuthorizationServerMetadata,
+    serde::Raw,
+};
+use url::Url;
+
+use super::{
+    error::OauthDiscoveryError,
+    http_client::{check_http_response_json_content_type, check_http_response_status_code},
+    OauthHttpClient,
+};
+
+/// Fetch the OpenID Connect provider metadata.
+pub(super) async fn discover(
+    http_client: &OauthHttpClient,
+    issuer: &str,
+) -> Result<Raw<AuthorizationServerMetadata>, OauthDiscoveryError> {
+    tracing::debug!("Fetching provider metadata...");
+
+    let mut url = Url::parse(issuer)?;
+
+    // If the path doesn't end with a slash, the last segment is removed when
+    // using `join`.
+    if !url.path().ends_with('/') {
+        let mut path = url.path().to_owned();
+        path.push('/');
+        url.set_path(&path);
+    }
+
+    let config_url = url.join(".well-known/openid-configuration")?;
+
+    let request = http::Request::get(config_url.as_str())
+        .body(Vec::new())
+        .map_err(|err| RequestTokenError::Request(HttpClientError::Http(err)))?;
+    let response = http_client.call(request).await.map_err(RequestTokenError::Request)?;
+
+    check_http_response_status_code(&response)?;
+    check_http_response_json_content_type(&response)?;
+
+    let metadata = serde_json::from_slice(&response.into_body())?;
+
+    tracing::debug!(?metadata);
+
+    Ok(metadata)
+}

--- a/crates/matrix-sdk/src/authentication/oidc/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/qrcode/login.rs
@@ -285,7 +285,7 @@ impl<'a> LoginWithQrCode<'a> {
     /// Register the client with the OAuth 2.0 authorization server.
     async fn register_client(&self) -> Result<(), DeviceAuthorizationOauthError> {
         let oidc = self.client.oidc();
-        oidc.register_client(self.client_metadata.clone()).await?;
+        oidc.register_client(&self.client_metadata).await?;
         Ok(())
     }
 

--- a/crates/matrix-sdk/src/authentication/oidc/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/qrcode/login.rs
@@ -285,7 +285,7 @@ impl<'a> LoginWithQrCode<'a> {
     /// Register the client with the OAuth 2.0 authorization server.
     async fn register_client(&self) -> Result<(), DeviceAuthorizationOauthError> {
         let oidc = self.client.oidc();
-        oidc.register_client(self.client_metadata.clone(), None).await?;
+        oidc.register_client(self.client_metadata.clone()).await?;
         Ok(())
     }
 

--- a/crates/matrix-sdk/src/authentication/oidc/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/qrcode/login.rs
@@ -16,14 +16,13 @@ use std::future::IntoFuture;
 
 use eyeball::SharedObservable;
 use futures_core::Stream;
-use mas_oidc_client::types::registration::VerifiedClientMetadata;
 use matrix_sdk_base::{
     boxed_into_future,
     crypto::types::qr_login::{QrCodeData, QrCodeMode},
     SessionMeta,
 };
 use oauth2::{DeviceCodeErrorResponseType, StandardDeviceAuthorizationResponse};
-use ruma::OwnedDeviceId;
+use ruma::{serde::Raw, OwnedDeviceId};
 use tracing::trace;
 use vodozemac::{ecies::CheckCode, Curve25519PublicKey};
 
@@ -34,7 +33,7 @@ use super::{
 };
 #[cfg(doc)]
 use crate::authentication::oidc::Oidc;
-use crate::Client;
+use crate::{authentication::oidc::ClientMetadata, Client};
 
 async fn send_unexpected_message_error(
     channel: &mut EstablishedSecureChannel,
@@ -77,7 +76,7 @@ pub enum LoginProgress {
 #[derive(Debug)]
 pub struct LoginWithQrCode<'a> {
     client: &'a Client,
-    client_metadata: VerifiedClientMetadata,
+    client_metadata: Raw<ClientMetadata>,
     qr_code_data: &'a QrCodeData,
     state: SharedObservable<LoginProgress>,
 }
@@ -261,7 +260,7 @@ impl<'a> IntoFuture for LoginWithQrCode<'a> {
 impl<'a> LoginWithQrCode<'a> {
     pub(crate) fn new(
         client: &'a Client,
-        client_metadata: VerifiedClientMetadata,
+        client_metadata: Raw<ClientMetadata>,
         qr_code_data: &'a QrCodeData,
     ) -> LoginWithQrCode<'a> {
         LoginWithQrCode { client, client_metadata, qr_code_data, state: Default::default() }

--- a/crates/matrix-sdk/src/authentication/oidc/registration.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/registration.rs
@@ -1,0 +1,82 @@
+// Copyright 2025 Kévin Commaille
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types and functions for OAuth 2.0 Dynamic Client Registration ([RFC 7591]).
+//!
+//! [RFC 7591]: http://tools.ietf.org/html/rfc7591
+
+use mas_oidc_client::types::registration::VerifiedClientMetadata;
+use oauth2::{AsyncHttpClient, ClientId, HttpClientError, RequestTokenError};
+use ruma::SecondsSinceUnixEpoch;
+use serde::Deserialize;
+use url::Url;
+
+use super::{
+    error::OauthClientRegistrationError,
+    http_client::{check_http_response_json_content_type, check_http_response_status_code},
+    OauthHttpClient,
+};
+
+/// Register a client with an OAuth 2.0 authorization server.
+///
+/// # Arguments
+///
+/// * `http_service` - The service to use for making HTTP requests.
+///
+/// * `registration_endpoint` - The URL of the issuer's Registration endpoint.
+///
+/// * `client_metadata` - The metadata to register with the issuer.
+///
+/// * `software_statement` - A JWT that asserts metadata values about the client
+///   software that should be signed.
+///
+/// # Errors
+///
+/// Returns an error if the request fails or the response is invalid.
+#[tracing::instrument(skip_all, fields(registration_endpoint))]
+pub(super) async fn register_client(
+    http_client: &OauthHttpClient,
+    registration_endpoint: &Url,
+    client_metadata: &VerifiedClientMetadata,
+) -> Result<ClientRegistrationResponse, OauthClientRegistrationError> {
+    tracing::debug!("Registering client...");
+
+    let body =
+        serde_json::to_vec(client_metadata).map_err(OauthClientRegistrationError::IntoJson)?;
+    let request = http::Request::post(registration_endpoint.as_str())
+        .body(body)
+        .map_err(|err| RequestTokenError::Request(HttpClientError::Http(err)))?;
+
+    let response = http_client.call(request).await.map_err(RequestTokenError::Request)?;
+
+    check_http_response_status_code(&response)?;
+    check_http_response_json_content_type(&response)?;
+
+    let response = serde_json::from_slice(&response.into_body())
+        .map_err(OauthClientRegistrationError::FromJson)?;
+
+    Ok(response)
+}
+
+/// A successful response to OAuth 2.0 Dynamic Client Registration ([RFC 7591]).
+///
+/// [RFC 7591]: http://tools.ietf.org/html/rfc7591
+#[derive(Debug, Clone, Deserialize)]
+pub struct ClientRegistrationResponse {
+    /// The ID issued for the client by the authorization server.
+    pub client_id: ClientId,
+
+    /// The timestamp at which the client identifier was issued.
+    pub client_id_issued_at: Option<SecondsSinceUnixEpoch>,
+}

--- a/crates/matrix-sdk/src/authentication/oidc/registration.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/registration.rs
@@ -16,10 +16,18 @@
 //!
 //! [RFC 7591]: http://tools.ietf.org/html/rfc7591
 
-use mas_oidc_client::types::registration::VerifiedClientMetadata;
+use std::collections::{BTreeSet, HashMap};
+
+pub use language_tags;
+use language_tags::LanguageTag;
+use matrix_sdk_base::deserialized_responses::PrivOwnedStr;
 use oauth2::{AsyncHttpClient, ClientId, HttpClientError, RequestTokenError};
-use ruma::SecondsSinceUnixEpoch;
-use serde::Deserialize;
+use ruma::{
+    api::client::discovery::get_authorization_server_metadata::msc2965::{GrantType, ResponseType},
+    serde::{PartialEqAsRefStr, Raw, StringEnum},
+    SecondsSinceUnixEpoch,
+};
+use serde::{ser::SerializeMap, Deserialize, Serialize};
 use url::Url;
 
 use super::{
@@ -48,13 +56,14 @@ use super::{
 pub(super) async fn register_client(
     http_client: &OauthHttpClient,
     registration_endpoint: &Url,
-    client_metadata: &VerifiedClientMetadata,
+    client_metadata: &Raw<ClientMetadata>,
 ) -> Result<ClientRegistrationResponse, OauthClientRegistrationError> {
     tracing::debug!("Registering client...");
 
     let body =
         serde_json::to_vec(client_metadata).map_err(OauthClientRegistrationError::IntoJson)?;
     let request = http::Request::post(registration_endpoint.as_str())
+        .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.to_string())
         .body(body)
         .map_err(|err| RequestTokenError::Request(HttpClientError::Http(err)))?;
 
@@ -79,4 +88,380 @@ pub struct ClientRegistrationResponse {
 
     /// The timestamp at which the client identifier was issued.
     pub client_id_issued_at: Option<SecondsSinceUnixEpoch>,
+}
+
+/// The metadata necessary to register a client with an OAuth 2.0 authorization
+/// server.
+///
+/// This is a simplified type, designed to avoid inconsistencies between fields.
+/// Only the fields defined in [MSC2966] can be set with this type, and only if
+/// different values are supported by this API. To set other fields, use your
+/// own type or construct directly the JSON representation.
+///
+/// The original format is defined in [RFC 7591].
+///
+/// [MSC2966]: https://github.com/matrix-org/matrix-spec-proposals/pull/2966
+/// [RFC 7591]: https://datatracker.ietf.org/doc/html/rfc7591
+#[derive(Debug, Clone, Serialize)]
+#[serde(into = "ClientMetadataSerializeHelper")]
+pub struct ClientMetadata {
+    /// The type of the application.
+    pub application_type: ApplicationType,
+
+    /// The grant types that the client will use at the token endpoint.
+    ///
+    /// This should match the login methods that the client can use.
+    pub grant_types: Vec<OauthGrantType>,
+
+    /// URL of the home page of the client.
+    pub client_uri: Localized<Url>,
+
+    /// Name of the client to be presented to the end-user during authorization.
+    pub client_name: Option<Localized<String>>,
+
+    /// URL that references a logo for the client application.
+    pub logo_uri: Option<Localized<Url>>,
+
+    /// URL that the client provides to the end-user to read about the how the
+    /// profile data will be used.
+    pub policy_uri: Option<Localized<Url>>,
+
+    /// URL that the client provides to the end-user to read about the client's
+    /// terms of service.
+    pub tos_uri: Option<Localized<Url>>,
+}
+
+impl ClientMetadata {
+    /// Construct a `ClientMetadata` with only the required fields.
+    pub fn new(
+        application_type: ApplicationType,
+        grant_types: Vec<OauthGrantType>,
+        client_uri: Localized<Url>,
+    ) -> Self {
+        Self {
+            application_type,
+            grant_types,
+            client_uri,
+            client_name: None,
+            logo_uri: None,
+            policy_uri: None,
+            tos_uri: None,
+        }
+    }
+}
+
+/// The grant types that the user will use at the token endpoint.
+///
+/// The available variants match the methods supported by the [`Oidc`] API.
+///
+/// [`Oidc`]: super::Oidc
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum OauthGrantType {
+    /// The authorization code grant type, defined in [RFC 6749].
+    ///
+    /// This grant type is necessary to use the [`Oidc::login()`] and
+    /// [`Oidc::url_for_oidc()`] methods.
+    ///
+    /// [RFC 6749]: https://datatracker.ietf.org/doc/html/rfc6749
+    /// [`Oidc::login()`]: super::Oidc::login
+    /// [`Oidc::url_for_oidc()`]: super::Oidc::url_for_oidc
+    AuthorizationCode {
+        /// Redirection URIs for the authorization endpoint.
+        redirect_uris: Vec<Url>,
+    },
+
+    /// The device authorization grant, defined in [RFC 8628].
+    ///
+    /// This grant type is necessary to use [`Oidc::login_with_qr_code()`].
+    ///
+    /// [RFC 8628]: https://datatracker.ietf.org/doc/html/rfc8628
+    /// [`Oidc::login_with_qr_code()`]: super::Oidc::login_with_qr_code
+    DeviceCode,
+}
+
+/// The possible types of an application.
+#[derive(Clone, StringEnum, PartialEqAsRefStr, Eq)]
+#[ruma_enum(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum ApplicationType {
+    /// The application is a web client.
+    ///
+    /// This is a client executed within a user-agent on the device used by the
+    /// user.
+    Web,
+
+    /// The application is a native client.
+    ///
+    /// This is a client installed and executed on the device used by the user.
+    Native,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+/// A collection of localized variants.
+///
+/// Always includes one non-localized variant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Localized<T> {
+    non_localized: T,
+    localized: HashMap<LanguageTag, T>,
+}
+
+impl<T> Localized<T> {
+    /// Constructs a new `Localized` with the given non-localized and localized
+    /// variants.
+    pub fn new(non_localized: T, localized: impl IntoIterator<Item = (LanguageTag, T)>) -> Self {
+        Self { non_localized, localized: localized.into_iter().collect() }
+    }
+
+    /// Get the non-localized variant.
+    pub fn non_localized(&self) -> &T {
+        &self.non_localized
+    }
+
+    /// Get the variant corresponding to the given language, if it exists.
+    pub fn get(&self, language: Option<&LanguageTag>) -> Option<&T> {
+        match language {
+            Some(lang) => self.localized.get(lang),
+            None => Some(&self.non_localized),
+        }
+    }
+}
+
+impl<T> From<(T, HashMap<LanguageTag, T>)> for Localized<T> {
+    fn from(t: (T, HashMap<LanguageTag, T>)) -> Self {
+        Localized { non_localized: t.0, localized: t.1 }
+    }
+}
+
+#[derive(Serialize)]
+struct ClientMetadataSerializeHelper {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    redirect_uris: Vec<Url>,
+    token_endpoint_auth_method: &'static str,
+    grant_types: BTreeSet<GrantType>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    response_types: Vec<ResponseType>,
+    application_type: ApplicationType,
+    #[serde(flatten)]
+    localized: ClientMetadataLocalizedFields,
+}
+
+impl From<ClientMetadata> for ClientMetadataSerializeHelper {
+    fn from(value: ClientMetadata) -> Self {
+        let ClientMetadata {
+            application_type,
+            grant_types: oauth_grant_types,
+            client_uri,
+            client_name,
+            logo_uri,
+            policy_uri,
+            tos_uri,
+        } = value;
+
+        let mut redirect_uris = None;
+        let mut response_types = None;
+        let mut grant_types = BTreeSet::new();
+
+        // Support for refresh tokens is mandatory.
+        grant_types.insert(GrantType::RefreshToken);
+
+        for oauth_grant_type in oauth_grant_types {
+            match oauth_grant_type {
+                OauthGrantType::AuthorizationCode { redirect_uris: uris } => {
+                    redirect_uris = Some(uris);
+                    response_types = Some(vec![ResponseType::Code]);
+                    grant_types.insert(GrantType::AuthorizationCode);
+                }
+                OauthGrantType::DeviceCode => {
+                    grant_types.insert(GrantType::DeviceCode);
+                }
+            }
+        }
+
+        ClientMetadataSerializeHelper {
+            redirect_uris: redirect_uris.unwrap_or_default(),
+            // We only support public clients.
+            token_endpoint_auth_method: "none",
+            grant_types,
+            response_types: response_types.unwrap_or_default(),
+            application_type,
+            localized: ClientMetadataLocalizedFields {
+                client_uri,
+                client_name,
+                logo_uri,
+                policy_uri,
+                tos_uri,
+            },
+        }
+    }
+}
+
+/// Helper type for serialization of `Localized` fields.
+///
+/// Those fields require to be serialized as one field per language so we need
+/// to use a custom `Serialize` implementation.
+struct ClientMetadataLocalizedFields {
+    client_uri: Localized<Url>,
+    client_name: Option<Localized<String>>,
+    logo_uri: Option<Localized<Url>>,
+    policy_uri: Option<Localized<Url>>,
+    tos_uri: Option<Localized<Url>>,
+}
+
+impl Serialize for ClientMetadataLocalizedFields {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        fn serialize_localized_into_map<M: SerializeMap, T: Serialize>(
+            map: &mut M,
+            field_name: &str,
+            value: &Localized<T>,
+        ) -> Result<(), M::Error> {
+            map.serialize_entry(field_name, &value.non_localized)?;
+
+            for (lang, localized) in &value.localized {
+                map.serialize_entry(&format!("{field_name}#{lang}"), localized)?;
+            }
+
+            Ok(())
+        }
+
+        let mut map = serializer.serialize_map(None)?;
+
+        serialize_localized_into_map(&mut map, "client_uri", &self.client_uri)?;
+
+        if let Some(client_name) = &self.client_name {
+            serialize_localized_into_map(&mut map, "client_name", client_name)?;
+        }
+
+        if let Some(logo_uri) = &self.logo_uri {
+            serialize_localized_into_map(&mut map, "logo_uri", logo_uri)?;
+        }
+
+        if let Some(policy_uri) = &self.policy_uri {
+            serialize_localized_into_map(&mut map, "policy_uri", policy_uri)?;
+        }
+
+        if let Some(tos_uri) = &self.tos_uri {
+            serialize_localized_into_map(&mut map, "tos_uri", tos_uri)?;
+        }
+
+        map.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use language_tags::LanguageTag;
+    use serde_json::json;
+    use url::Url;
+
+    use super::{ApplicationType, ClientMetadata, Localized, OauthGrantType};
+
+    #[test]
+    fn test_serialize_minimal_client_metadata() {
+        let metadata = ClientMetadata::new(
+            ApplicationType::Native,
+            vec![OauthGrantType::AuthorizationCode {
+                redirect_uris: vec![Url::parse("http://127.0.0.1/").unwrap()],
+            }],
+            Localized::new(
+                Url::parse("https://github.com/matrix-org/matrix-rust-sdk").unwrap(),
+                [],
+            ),
+        );
+
+        assert_eq!(
+            serde_json::to_value(metadata).unwrap(),
+            json!({
+                "application_type": "native",
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "none",
+                "redirect_uris": ["http://127.0.0.1/"],
+                "client_uri": "https://github.com/matrix-org/matrix-rust-sdk",
+            }),
+        );
+    }
+
+    #[test]
+    fn test_serialize_full_client_metadata() {
+        let lang_fr = LanguageTag::parse("fr").unwrap();
+        let lang_mas = LanguageTag::parse("mas").unwrap();
+
+        let mut metadata = ClientMetadata::new(
+            ApplicationType::Web,
+            vec![
+                OauthGrantType::AuthorizationCode {
+                    redirect_uris: vec![
+                        Url::parse("http://127.0.0.1/").unwrap(),
+                        Url::parse("http://[::1]/").unwrap(),
+                    ],
+                },
+                OauthGrantType::DeviceCode,
+            ],
+            Localized::new(
+                Url::parse("https://example.org/matrix-client").unwrap(),
+                [
+                    (lang_fr.clone(), Url::parse("https://example.org/fr/matrix-client").unwrap()),
+                    (
+                        lang_mas.clone(),
+                        Url::parse("https://example.org/mas/matrix-client").unwrap(),
+                    ),
+                ],
+            ),
+        );
+
+        metadata.client_name = Some(Localized::new(
+            "My Matrix client".to_owned(),
+            [(lang_fr.clone(), "Mon client Matrix".to_owned())],
+        ));
+        metadata.logo_uri =
+            Some(Localized::new(Url::parse("https://example.org/logo.svg").unwrap(), []));
+        metadata.policy_uri = Some(Localized::new(
+            Url::parse("https://example.org/policy").unwrap(),
+            [
+                (lang_fr.clone(), Url::parse("https://example.org/fr/policy").unwrap()),
+                (lang_mas.clone(), Url::parse("https://example.org/mas/policy").unwrap()),
+            ],
+        ));
+        metadata.tos_uri = Some(Localized::new(
+            Url::parse("https://example.org/tos").unwrap(),
+            [
+                (lang_fr, Url::parse("https://example.org/fr/tos").unwrap()),
+                (lang_mas, Url::parse("https://example.org/mas/tos").unwrap()),
+            ],
+        ));
+
+        assert_eq!(
+            serde_json::to_value(metadata).unwrap(),
+            json!({
+                "application_type": "web",
+                "grant_types": [
+                    "authorization_code",
+                    "refresh_token",
+                    "urn:ietf:params:oauth:grant-type:device_code",
+                ],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "none",
+                "redirect_uris": ["http://127.0.0.1/", "http://[::1]/"],
+                "client_uri": "https://example.org/matrix-client",
+                "client_uri#fr": "https://example.org/fr/matrix-client",
+                "client_uri#mas": "https://example.org/mas/matrix-client",
+                "client_name": "My Matrix client",
+                "client_name#fr": "Mon client Matrix",
+                "logo_uri": "https://example.org/logo.svg",
+                "policy_uri": "https://example.org/policy",
+                "policy_uri#fr": "https://example.org/fr/policy",
+                "policy_uri#mas": "https://example.org/mas/policy",
+                "tos_uri": "https://example.org/tos",
+                "tos_uri#fr": "https://example.org/fr/tos",
+                "tos_uri#mas": "https://example.org/mas/tos",
+            }),
+        );
+    }
 }

--- a/crates/matrix-sdk/src/authentication/oidc/registrations.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/registrations.rs
@@ -28,12 +28,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use mas_oidc_client::types::registration::{
-    ClientMetadata, ClientMetadataVerificationError, VerifiedClientMetadata,
-};
 pub use oauth2::ClientId;
+use ruma::serde::Raw;
 use serde::{Deserialize, Serialize};
 use url::Url;
+
+use super::ClientMetadata;
 
 /// Errors related to persisting OIDC registrations.
 #[derive(Debug, thiserror::Error)]
@@ -51,51 +51,22 @@ pub enum OidcRegistrationsError {
 pub struct OidcRegistrations {
     /// The path of the file where the registrations are stored.
     file_path: PathBuf,
-    /// The hash for the metadata used to register the client.
+    /// The metadata used to register the client.
     /// This is used to check if the client needs to be re-registered.
-    pub(super) verified_metadata: VerifiedClientMetadata,
+    pub(super) metadata: Raw<ClientMetadata>,
     /// Pre-configured registrations for use with issuers that don't support
     /// dynamic client registration.
     static_registrations: HashMap<Url, ClientId>,
 }
 
 /// The underlying data serialized into the registration file.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct FrozenRegistrationData {
-    /// The hash for the metadata used to register the client.
-    metadata: VerifiedClientMetadata,
+    /// The metadata used to register the client.
+    metadata: Raw<ClientMetadata>,
     /// All of the registrations this client has made as a HashMap of issuer URL
     /// (as a string) to client ID (as a string).
     dynamic_registrations: HashMap<Url, ClientId>,
-}
-
-/// The deserialize data from the registration file. This data needs to be
-/// validated before it can be used.
-#[derive(Debug, Deserialize)]
-struct UnvalidatedRegistrationData {
-    /// The hash for the metadata used to register the client.
-    metadata: ClientMetadata,
-    /// All of the registrations this client has made as a HashMap of issuer URL
-    /// (as a string) to client ID (as a string).
-    dynamic_registrations: HashMap<Url, ClientId>,
-}
-
-impl UnvalidatedRegistrationData {
-    /// Validates the registration data, returning a `FrozenRegistrationData`.
-    fn validate(&self) -> Result<FrozenRegistrationData, ClientMetadataVerificationError> {
-        let verified_metadata = match self.metadata.clone().validate() {
-            Ok(metadata) => metadata,
-            Err(e) => {
-                tracing::warn!("Failed to validate stored metadata.");
-                return Err(e);
-            }
-        };
-
-        Ok(FrozenRegistrationData {
-            metadata: verified_metadata,
-            dynamic_registrations: self.dynamic_registrations.clone(),
-        })
-    }
 }
 
 /// Manages the storage of OIDC registrations.
@@ -116,7 +87,7 @@ impl OidcRegistrations {
     ///   issuers that don't support dynamic client registration.
     pub fn new(
         registrations_file: &Path,
-        metadata: VerifiedClientMetadata,
+        metadata: Raw<ClientMetadata>,
         static_registrations: HashMap<Url, ClientId>,
     ) -> Result<Self, OidcRegistrationsError> {
         let parent = registrations_file.parent().ok_or(OidcRegistrationsError::InvalidFilePath)?;
@@ -124,7 +95,7 @@ impl OidcRegistrations {
 
         Ok(OidcRegistrations {
             file_path: registrations_file.to_owned(),
-            verified_metadata: metadata,
+            metadata,
             static_registrations,
         })
     }
@@ -166,20 +137,13 @@ impl OidcRegistrations {
                     .ok()?,
             );
 
-            let registration_data: UnvalidatedRegistrationData = serde_json::from_reader(reader)
+            let registration_data: FrozenRegistrationData = serde_json::from_reader(reader)
                 .map_err(|error| {
                     tracing::warn!("Failed to deserialize registrations file: {error}");
                 })
                 .ok()?;
 
-            let registration_data = registration_data
-                .validate()
-                .map_err(|error| {
-                    tracing::warn!("Failed to validate registration data: {error}");
-                })
-                .ok()?;
-
-            if registration_data.metadata != self.verified_metadata {
+            if registration_data.metadata.json().get() != self.metadata.json().get() {
                 tracing::warn!("Metadata mismatch, ignoring any stored registrations.");
                 return None;
             }
@@ -190,7 +154,7 @@ impl OidcRegistrations {
         try_read_previous().unwrap_or_else(|| {
             tracing::warn!("Generating new registration data");
             FrozenRegistrationData {
-                metadata: self.verified_metadata.clone(),
+                metadata: self.metadata.clone(),
                 dynamic_registrations: Default::default(),
             }
         })
@@ -199,10 +163,10 @@ impl OidcRegistrations {
 
 #[cfg(test)]
 mod tests {
-    use mas_oidc_client::types::registration::Localized;
     use tempfile::tempdir;
 
     use super::*;
+    use crate::authentication::oidc::registration::{ApplicationType, Localized, OauthGrantType};
 
     #[test]
     fn test_oidc_registrations() {
@@ -275,16 +239,17 @@ mod tests {
         assert_eq!(registrations.client_id(&static_url), Some(static_id));
     }
 
-    fn mock_metadata(client_name: String) -> VerifiedClientMetadata {
+    fn mock_metadata(client_name: String) -> Raw<ClientMetadata> {
         let callback_url = Url::parse("https://example.org/login/callback").unwrap();
-        let client_name = Some(Localized::new(client_name, None));
+        let client_uri = Url::parse("https://example.org/").unwrap();
 
-        ClientMetadata {
-            redirect_uris: Some(vec![callback_url]),
-            client_name,
-            ..Default::default()
-        }
-        .validate()
-        .unwrap()
+        let mut metadata = ClientMetadata::new(
+            ApplicationType::Web,
+            vec![OauthGrantType::AuthorizationCode { redirect_uris: vec![callback_url] }],
+            Localized::new(client_uri, None),
+        );
+        metadata.client_name = Some(Localized::new(client_name, None));
+
+        Raw::new(&metadata).unwrap()
     }
 }

--- a/crates/matrix-sdk/src/authentication/oidc/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/tests.rs
@@ -481,7 +481,7 @@ async fn test_register_client() {
         .mount()
         .await;
 
-    let result = oidc.register_client(client_metadata.clone(), None).await;
+    let result = oidc.register_client(client_metadata.clone()).await;
     assert_matches!(result, Err(OidcError::NoRegistrationSupport));
 
     server.verify_and_reset().await;
@@ -496,7 +496,7 @@ async fn test_register_client() {
         .await;
     oauth_server.mock_registration().ok().expect(1).named("registration").mount().await;
 
-    let response = oidc.register_client(client_metadata, None).await.unwrap();
+    let response = oidc.register_client(client_metadata).await.unwrap();
     assert_eq!(response.client_id, "test_client_id");
 
     let auth_data = oidc.data().unwrap();

--- a/crates/matrix-sdk/src/authentication/oidc/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oidc/tests.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use anyhow::Context as _;
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
-use mas_oidc_client::requests::account_management::AccountManagementActionFull;
 use matrix_sdk_test::async_test;
 use oauth2::{CsrfToken, PkceCodeChallenge, RedirectUrl};
 use ruma::{
@@ -25,8 +24,8 @@ use super::{
 };
 use crate::{
     authentication::oidc::{
-        error::AuthorizationCodeErrorResponseType, AuthorizationValidationData,
-        OauthAuthorizationCodeError,
+        error::AuthorizationCodeErrorResponseType, AccountManagementActionFull,
+        AuthorizationValidationData, OauthAuthorizationCodeError,
     },
     test_utils::{
         client::{

--- a/crates/matrix-sdk/src/client/caches.rs
+++ b/crates/matrix-sdk/src/client/caches.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #[cfg(feature = "experimental-oidc")]
-use mas_oidc_client::types::oidc::VerifiedProviderMetadata;
-#[cfg(feature = "experimental-oidc")]
 use matrix_sdk_base::ttl_cache::TtlCache;
+#[cfg(feature = "experimental-oidc")]
+use ruma::api::client::discovery::get_authorization_server_metadata::msc2965::AuthorizationServerMetadata;
 use tokio::sync::RwLock;
 
 use super::ClientServerCapabilities;
@@ -27,5 +27,5 @@ pub(crate) struct ClientCaches {
     /// the server.
     pub(super) server_capabilities: RwLock<ClientServerCapabilities>,
     #[cfg(feature = "experimental-oidc")]
-    pub(crate) provider_metadata: tokio::sync::Mutex<TtlCache<String, VerifiedProviderMetadata>>,
+    pub(crate) provider_metadata: tokio::sync::Mutex<TtlCache<String, AuthorizationServerMetadata>>,
 }

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -256,31 +256,6 @@ async fn response_to_http_response(
     Ok(http_builder.body(body).expect("Can't construct a response using the given body"))
 }
 
-#[cfg(feature = "experimental-oidc")]
-impl tower::Service<http::Request<Bytes>> for HttpClient {
-    type Response = http::Response<Bytes>;
-    type Error = tower::BoxError;
-    type Future = matrix_sdk_base::BoxFuture<'static, Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(
-        &mut self,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        std::task::Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, req: http::Request<Bytes>) -> Self::Future {
-        let inner = self.inner.clone();
-
-        let fut = async move {
-            native::send_request(&inner, &req, DEFAULT_REQUEST_TIMEOUT, Default::default())
-                .await
-                .map_err(Into::into)
-        };
-        Box::pin(fut)
-    }
-}
-
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use std::{

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -119,6 +119,7 @@ impl AuthState {
             }
             #[cfg(feature = "experimental-oidc")]
             AuthState::RegisteredWithOauth { issuer } => {
+                let issuer = url::Url::parse(&issuer).unwrap();
                 client.oidc().restore_registered_client(issuer, oauth::mock_client_id());
             }
             #[cfg(feature = "experimental-oidc")]
@@ -220,7 +221,9 @@ pub mod oauth {
     }
 
     /// An [`OidcSession`] to restore, for unit or integration tests.
-    pub fn mock_session(tokens: SessionTokens, issuer: String) -> OidcSession {
+    pub fn mock_session(tokens: SessionTokens, issuer: impl AsRef<str>) -> OidcSession {
+        let issuer = Url::parse(issuer.as_ref()).unwrap();
+
         OidcSession {
             client_id: mock_client_id(),
             user: UserSession { meta: super::mock_session_meta(), tokens, issuer },

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -210,7 +210,7 @@ impl OidcCli {
         // to update the metadata later without changing the client ID, but requires to
         // have a way to serve public keys online to validate the signature of
         // the JWT.
-        let res = oidc.register_client(metadata.clone(), None).await?;
+        let res = oidc.register_client(metadata.clone()).await?;
 
         println!("\nRegistered successfully");
 

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -31,15 +31,14 @@ use futures_util::StreamExt;
 use matrix_sdk::{
     authentication::oidc::{
         registrations::ClientId,
-        requests::account_management::AccountManagementActionFull,
         types::{
             iana::oauth::OAuthClientAuthenticationMethod,
             oidc::ApplicationType,
             registration::{ClientMetadata, Localized, VerifiedClientMetadata},
             requests::GrantType,
         },
-        AuthorizationCode, AuthorizationResponse, CsrfToken, OidcAuthorizationData, OidcSession,
-        UserSession,
+        AccountManagementActionFull, AuthorizationCode, AuthorizationResponse, CsrfToken,
+        OidcAuthorizationData, OidcSession, UserSession,
     },
     config::SyncSettings,
     encryption::{recovery::RecoveryState, CrossSigningResetAuthType},

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -661,7 +661,7 @@ async fn build_client(data_dir: &Path) -> anyhow::Result<(Client, ClientSession)
                     Ok(server_metadata) => {
                         println!(
                             "Found OAuth 2.0 server metadata with issuer: {}",
-                            server_metadata.issuer()
+                            server_metadata.issuer
                         );
 
                         let homeserver = client.homeserver().to_string();

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -210,11 +210,11 @@ impl OidcCli {
         // to update the metadata later without changing the client ID, but requires to
         // have a way to serve public keys online to validate the signature of
         // the JWT.
-        let res = oidc.register_client(metadata.clone()).await?;
+        let res = oidc.register_client(&metadata).await?;
 
         println!("\nRegistered successfully");
 
-        Ok(ClientId::new(res.client_id))
+        Ok(res.client_id)
     }
 
     /// Login via the OIDC Authorization Code flow.

--- a/examples/qr-login/src/main.rs
+++ b/examples/qr-login/src/main.rs
@@ -6,13 +6,9 @@ use futures_util::StreamExt;
 use matrix_sdk::{
     authentication::oidc::{
         qrcode::{LoginProgress, QrCodeData, QrCodeModeData},
-        types::{
-            iana::oauth::OAuthClientAuthenticationMethod,
-            oidc::ApplicationType,
-            registration::{ClientMetadata, Localized, VerifiedClientMetadata},
-            requests::GrantType,
-        },
+        registration::{ApplicationType, ClientMetadata, Localized, OauthGrantType},
     },
+    ruma::serde::Raw,
     Client,
 };
 use url::Url;
@@ -38,36 +34,32 @@ struct Cli {
 /// should be adapted to the provider metadata to make interactions as secure as
 /// possible, for example by using the most secure signing algorithms supported
 /// by the provider.
-fn client_metadata() -> VerifiedClientMetadata {
-    let client_uri = Url::parse("https://github.com/matrix-org/matrix-rust-sdk")
-        .expect("Couldn't parse client URI");
+fn client_metadata() -> Raw<ClientMetadata> {
+    let client_uri = Localized::new(
+        Url::parse("https://github.com/matrix-org/matrix-rust-sdk")
+            .expect("Couldn't parse client URI"),
+        None,
+    );
 
-    ClientMetadata {
-        // This is a native application (in contrast to a web application, that runs in a browser).
-        application_type: Some(ApplicationType::Native),
-        // Native clients should be able to register the loopback interface and then point to any
-        // port when needing a redirect URI. An alternative is to use a custom URI scheme registered
-        // with the OS.
-        redirect_uris: None,
-        // We are going to use the Authorization Code flow, and of course we want to be able to
-        // refresh our access token.
-        grant_types: Some(vec![GrantType::RefreshToken, GrantType::DeviceCode]),
-        // A native client shouldn't use authentication as the credentials could be intercepted.
-        // Other protections are in place for the different requests.
-        token_endpoint_auth_method: Some(OAuthClientAuthenticationMethod::None),
+    let metadata = ClientMetadata {
         // The following fields should be displayed in the OIDC provider interface as part of the
         // process to get the user's consent. It means that these should contain real data so the
         // user can make sure that they allow the proper application.
         // We are cheating here because this is an example.
         client_name: Some(Localized::new("matrix-rust-sdk-qrlogin".to_owned(), [])),
-        contacts: Some(vec!["root@127.0.0.1".to_owned()]),
-        client_uri: Some(Localized::new(client_uri.clone(), [])),
-        policy_uri: Some(Localized::new(client_uri.clone(), [])),
-        tos_uri: Some(Localized::new(client_uri, [])),
-        ..Default::default()
-    }
-    .validate()
-    .unwrap()
+        policy_uri: Some(client_uri.clone()),
+        tos_uri: Some(client_uri.clone()),
+        ..ClientMetadata::new(
+            // This is a native application (in contrast to a web application, that runs in a
+            // browser).
+            ApplicationType::Native,
+            // We are going to use the Device Authorization flow.
+            vec![OauthGrantType::DeviceCode],
+            client_uri,
+        )
+    };
+
+    Raw::new(&metadata).expect("Couldn't serialize client metadata")
 }
 
 async fn print_devices(client: &Client) -> Result<()> {


### PR DESCRIPTION
To get rid of mas-oidc-client, we need to import a few methods and types, but nothing very complex.

I decided to create a more opinionated `ClientMetadata` type so that it is easy to construct and we don't need to validate it.

This can be reviewed commit by commit.