### PR TITLE
feat!(ffi): rename `setup_tracing` into `init_platform`

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Breaking changes:
 
+- `setup_tracing` has been renamed `init_platform`; in addition to the `TracingConfiguration`
+  parameter it also now takes a boolean indicating whether to spawn a minimal tokio runtime for the
+  application; in general for main app processes this can be set to `false`, and memory-constrained
+  programs can set it to `true`.
+
 - Matrix client API errors coming from API responses will now be mapped to `ClientError::MatrixApi`, containing both the
   original message and the associated error code and kind. 
 

--- a/bindings/matrix-sdk-ffi/src/platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform.rs
@@ -350,9 +350,10 @@ fn build_tracing_filter(config: &TracingConfiguration) -> String {
 
 /// Sets up logs and the tokio runtime for the current application.
 ///
-/// If `use_lightweight_tokio_runtime` is set to true, this will set up a lightweight tokio
-/// runtime, for processes that have memory limitations (like the NSE process on iOS). Otherwise,
-/// this can remain false, in which case a multithreaded tokio runtime will be set up.
+/// If `use_lightweight_tokio_runtime` is set to true, this will set up a
+/// lightweight tokio runtime, for processes that have memory limitations (like
+/// the NSE process on iOS). Otherwise, this can remain false, in which case a
+/// multithreaded tokio runtime will be set up.
 #[matrix_sdk_ffi_macros::export]
 pub fn init_platform(config: TracingConfiguration, use_lightweight_tokio_runtime: bool) {
     log_panics();


### PR DESCRIPTION
And make it take a boolean indicating whether we want to set up a lightweight tokio runtime or not, instead of having `setup_lightweight_tokio_runtime` as a public function + another function, both of which would have to be called anyways.

cc @stefanceriu @jmartinesp 