### PR TITLE
fix(ffi): Restore some needed OIDC prompts in the FFI layer

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -39,6 +39,8 @@ Breaking changes:
 
 - The `get_element_call_required_permissions` function now requires the device_id.
 
+- Some `OidcPrompt` cases have been removed (`None`, `SelectAccount`).
+
 - `Room::is_encrypted` is replaced by `Room::latest_encryption_state`
   which returns a value of the new `EncryptionState` enum; another
   `Room::encryption_state` non-async and infallible method is added to get the

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1817,6 +1817,14 @@ pub enum OidcPrompt {
     /// Defined in [Initiating User Registration via OpenID Connect](https://openid.net/specs/openid-connect-prompt-create-1_0.html).
     Create,
 
+    /// The Authorization Server should prompt the End-User for
+    /// reauthentication.
+    Login,
+
+    /// The Authorization Server should prompt the End-User for consent before
+    /// returning information to the Client.
+    Consent,
+
     /// An unknown value.
     Unknown { value: String },
 }
@@ -1825,6 +1833,8 @@ impl From<&SdkOidcPrompt> for OidcPrompt {
     fn from(value: &SdkOidcPrompt) -> Self {
         match value {
             SdkOidcPrompt::Create => Self::Create,
+            SdkOidcPrompt::Login => Self::Login,
+            SdkOidcPrompt::Consent => Self::Consent,
             _ => Self::Unknown { value: value.to_string() },
         }
     }
@@ -1834,6 +1844,8 @@ impl From<OidcPrompt> for RumaOidcPrompt {
     fn from(value: OidcPrompt) -> Self {
         match value {
             OidcPrompt::Create => Self::Create,
+            OidcPrompt::Consent => Self::from(SdkOidcPrompt::Consent.to_string()),
+            OidcPrompt::Login => Self::from(SdkOidcPrompt::Login.to_string()),
             OidcPrompt::Unknown { value } => value.into(),
         }
     }


### PR DESCRIPTION
Restores recently removed but needed OIDC prompts.

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
