### PR TITLE
fix: Adjust the event origins in the `Timeline` and the `EventCache`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -244,15 +244,12 @@ impl TimelineBuilder {
                             // The updates might have lagged, but the room event cache might have
                             // events, so retrieve them and add them back again to the timeline,
                             // after clearing it.
-                            //
-                            // If we can't get a handle on the room cache's events, just clear the
-                            // current timeline.
                             let (initial_events, _stream) = room_event_cache.subscribe().await;
 
                             inner
                                 .replace_with_initial_remote_events(
                                     initial_events.into_iter(),
-                                    RemoteEventOrigin::Sync,
+                                    RemoteEventOrigin::Cache,
                                 )
                                 .await;
 

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -1028,7 +1028,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         .as_event()
                         .and_then(|ev| Some(ev.as_remote()?.origin))
                         .unwrap_or_else(|| {
-                            error!("Decryption retried on a local event");
+                            error!("Tried to update a local event");
                             RemoteEventOrigin::Unknown
                         }),
                 };

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -467,7 +467,8 @@ impl EventTimelineItem {
             EventTimelineItemKind::Remote(remote_event) => match remote_event.origin {
                 RemoteEventOrigin::Sync => Some(EventItemOrigin::Sync),
                 RemoteEventOrigin::Pagination => Some(EventItemOrigin::Pagination),
-                _ => None,
+                RemoteEventOrigin::Cache => Some(EventItemOrigin::Cache),
+                RemoteEventOrigin::Unknown => None,
             },
         }
     }
@@ -722,6 +723,8 @@ pub enum EventItemOrigin {
     Sync,
     /// The event came from pagination.
     Pagination,
+    /// The event came from a cache.
+    Cache,
 }
 
 /// What's the status of a reaction?

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -426,7 +426,13 @@ impl EventCache {
 
         room_cache
             .inner
-            .replace_all_events_by(events, prev_batch, Default::default(), Default::default())
+            .replace_all_events_by(
+                events,
+                prev_batch,
+                Default::default(),
+                Default::default(),
+                EventsOrigin::Cache,
+            )
             .await?;
 
         Ok(())

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -226,7 +226,7 @@ impl RoomPagination {
                         let _ =
                             self.inner.sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
                                 diffs: timeline_event_diffs,
-                                origin: EventsOrigin::Pagination,
+                                origin: EventsOrigin::Cache,
                             });
                     }
 

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1210,8 +1210,8 @@ mod private {
             let diff_updates = self.events.updates_as_vector_diffs();
 
             // Ensure the contract defined in the doc comment is true:
-            assert_eq!(diff_updates.len(), 1);
-            assert!(matches!(diff_updates[0], VectorDiff::Clear));
+            debug_assert_eq!(diff_updates.len(), 1);
+            debug_assert!(matches!(diff_updates[0], VectorDiff::Clear));
 
             Ok(diff_updates)
         }

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -239,7 +239,7 @@ impl RoomEventCache {
         // Notify observers about the update.
         let _ = self.inner.sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
             diffs: updates_as_vector_diffs,
-            origin: EventsOrigin::Sync,
+            origin: EventsOrigin::Cache,
         });
 
         Ok(())

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -418,6 +418,7 @@ impl RoomEventCacheInner {
                 timeline.prev_batch,
                 ephemeral_events,
                 ambiguity_changes,
+                EventsOrigin::Sync,
             )
             .await?;
         } else {
@@ -467,6 +468,7 @@ impl RoomEventCacheInner {
         prev_batch: Option<String>,
         ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
         ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
+        events_origin: EventsOrigin,
     ) -> Result<()> {
         // Acquire the lock.
         let mut state = self.state.write().await;
@@ -477,7 +479,7 @@ impl RoomEventCacheInner {
         // Propagate to observers.
         let _ = self.sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
             diffs: updates_as_vector_diffs,
-            origin: EventsOrigin::Sync,
+            origin: events_origin,
         });
 
         // Push the new events.


### PR DESCRIPTION
Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/4794/.

These patches update the `EventsOrigin` and `RemoteEventOrigin` to `Cache` when necessary. Better to review patch by patch.