### PR TITLE
chore(ui): Extract `TimelineBuilder` tasks into their own functions

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -246,9 +246,6 @@ impl TimelineBuilder {
             })
         };
 
-        // Not using room.add_event_handler here because RoomKey events are
-        // to-device events that are not received in the context of a room.
-
         let room_key_handle = client.add_event_handler(handle_room_key_event(
             controller.clone(),
             room.room_id().to_owned(),
@@ -260,6 +257,9 @@ impl TimelineBuilder {
         ));
 
         let handles = vec![room_key_handle, forwarded_room_key_handle];
+
+        // Not using room.add_event_handler here because RoomKey events are
+        // to-device events that are not received in the context of a room.
 
         let room_key_from_backups_join_handle = spawn(room_keys_from_backups_task(
             client.encryption().backups().room_keys_for_room_stream(controller.room().room_id()),

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -70,7 +70,7 @@ mod room;
 
 pub mod paginator;
 pub use pagination::{PaginationToken, RoomPagination, RoomPaginationStatus};
-pub use room::RoomEventCache;
+pub use room::{RoomEventCache, RoomEventCacheListener};
 
 /// An error observed in the [`EventCache`].
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/4794.

This patch rewrites the `TimelineBuilder::build()` method by extracting all the spawned task code block into their own function. The resulting code is simpler to read, and we can reference each task by its function name. Moreover, each task is isolated, it's a bit easier to reason about.