### PR TITLE
fix(base): Do not define the `RoomInfoNotableUpdate`'s channel based on number of rooms

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -152,17 +152,15 @@ impl BaseClient {
 
         // Create the channel to receive `RoomInfoNotableUpdate`.
         //
-        // Configure the size of the channel based on the number of rooms. Let's
-        // consider a room can receive 5 updates at the same time. This is unrealistic
-        // in practise, as the sync mechanism is pretty unlikely to trigger such amount
-        // of updates. It's a trade-off here. The size of the channel should be
-        // as small as possible avoiding to allocate too much memory.
+        // Let's consider the channel will receive 5 updates for 100 rooms maximum. This
+        // is unrealistic in practise, as the sync mechanism is pretty unlikely to
+        // trigger such amount of updates, it's a safe value.
         //
-        // The size cannot be below 500, which corresponds to 100 rooms. It must not be
-        // zero, because (i) it will panic, (ii) a new user has no room, we have to
-        // handle this case.
+        // Also, note that it must not be
+        // zero, because (i) it will panic, (ii) a new user has no room, but can create
+        // rooms; remember that the channel's capacity is immutable.
         let (room_info_notable_update_sender, _room_info_notable_update_receiver) =
-            broadcast::channel(usize::max(500, store.number_of_rooms().saturating_mul(5)));
+            broadcast::channel(500);
 
         BaseClient {
             store,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -280,11 +280,6 @@ impl Store {
         self.rooms.read().unwrap().get(room_id).is_some()
     }
 
-    /// Get the number of rooms.
-    pub(crate) fn number_of_rooms(&self) -> usize {
-        self.rooms.read().unwrap().len()
-    }
-
     /// Lookup the `Room` for the given `RoomId`, or create one, if it didn't
     /// exist yet in the store
     pub fn get_or_create_room(

--- a/crates/matrix-sdk-base/src/store/observable_map.rs
+++ b/crates/matrix-sdk-base/src/store/observable_map.rs
@@ -147,11 +147,6 @@ where
 
         Some(self.values.remove(position))
     }
-
-    /// Get the number of values.
-    pub(crate) fn len(&self) -> usize {
-        self.mapping.len()
-    }
 }
 
 #[cfg(test)]
@@ -299,22 +294,5 @@ mod tests {
 
         drop(map);
         assert_closed!(stream);
-    }
-
-    #[test]
-    fn test_len() {
-        let mut map = ObservableMap::<char, char>::new();
-
-        assert_eq!(map.len(), 0);
-
-        map.insert('a', 'e');
-        map.insert('b', 'f');
-        map.insert('c', 'g');
-
-        assert_eq!(map.len(), 3);
-
-        map.remove(&'b');
-
-        assert_eq!(map.len(), 2);
     }
 }


### PR DESCRIPTION
When `BaseClient` is created, the rooms aren't loaded yet. Then, calculating the size of the channel for `RoomInfoNotableUpdate` is useless, as it will always be zero, and we will fallback to 500 every time. By the way, 500 is a nice default. This patch uses this value as the only channel's size.
