### PR TITLE
fix(encryption): Return the uiaa error if we have one in the identity reset loop

### DIFF
--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -286,8 +286,13 @@ impl CrossSigningResetHandle {
                 return Ok(());
             }
 
-            if e.as_uiaa_response().is_none() {
-                return Err(e.into());
+            match e.as_uiaa_response() {
+                Some(uiaa_info) => {
+                    if uiaa_info.auth_error.is_some() {
+                        return Err(e.into());
+                    }
+                }
+                None => return Err(e.into()),
             }
         }
 

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -2481,6 +2481,21 @@ impl<'a> MockEndpoint<'a, UploadCrossSigningKeysEndpoint> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 
+    /// Returns an error response with a UIAA stage.
+    pub fn uiaa(self) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "flows": [
+                {
+                    "stages": [
+                        "m.login.password"
+                    ]
+                }
+            ],
+            "params": {},
+            "session": "oFIJVvtEOCKmRUTYKTYIIPHL"
+        })))
+    }
+
     /// Returns an error response with an OAuth 2.0 UIAA stage.
     pub fn uiaa_oauth(self) -> MatrixMock<'a> {
         let server_uri = self.server.uri();

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -2481,6 +2481,24 @@ impl<'a> MockEndpoint<'a, UploadCrossSigningKeysEndpoint> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 
+    /// Returns an error response with a UIAA stage that failed to authenticate
+    /// because of an invalid password.
+    pub fn uiaa_invalid_password(self) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "errcode": "M_FORBIDDEN",
+            "error": "Invalid password",
+            "flows": [
+                {
+                    "stages": [
+                        "m.login.password"
+                    ]
+                }
+            ],
+            "params": {},
+            "session": "oFIJVvtEOCKmRUTYKTYIIPHL"
+        })))
+    }
+
     /// Returns an error response with a UIAA stage.
     pub fn uiaa(self) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(401).set_body_json(json!({


### PR DESCRIPTION
Seems that we don't handle an error here correctly which ends up creating an infinite loop.

Opening as a draft since we need a test.
