### PR TITLE
fix(xtask): Add `--limit 100` to `gh pr list`

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -142,7 +142,7 @@ fn weekly_report() -> Result<()> {
 
     cmd!(
         sh,
-        "gh pr list --search merged:>{one_week_ago} --json {JSON_FIELDS} --template {template}"
+        "gh pr list --search merged:>{one_week_ago} --limit 100 --json {JSON_FIELDS} --template {template}"
     )
     .quiet()
     .run()?;


### PR DESCRIPTION
Because yes, some weeks, we are very productive!

This patch adds `--limit 100` to `gh pr list` so that we are sure to not miss pull requests if there are many.