### PR TITLE
test(common): Ensure inserting a new first chunk is as expected

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -459,6 +459,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             // A unique chunk.
             assert_matches!(rchunks.next(), Some(chunk) => {
                 assert_eq!(chunk.identifier(), 2);
+                assert_eq!(chunk.lazy_previous(), Some(CId::new(1)));
 
                 assert_matches!(chunk.content(), ChunkContent::Items(events) => {
                     assert_eq!(events.len(), 3);
@@ -476,11 +477,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         // Load the previous chunk: this is a gap.
         {
             let first_chunk = linked_chunk.chunks().next().unwrap().identifier();
-            let mut previous_chunk =
+            let previous_chunk =
                 self.load_previous_chunk(room_id, first_chunk).await.unwrap().unwrap();
-
-            // Pretend it's the first chunk.
-            previous_chunk.previous = None;
 
             let _ = lazy_loader::insert_new_first_chunk(&mut linked_chunk, previous_chunk).unwrap();
 
@@ -489,6 +487,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             // The last chunk.
             assert_matches!(rchunks.next(), Some(chunk) => {
                 assert_eq!(chunk.identifier(), 2);
+                assert!(chunk.lazy_previous().is_none());
 
                 // Already asserted, but let's be sure nothing breaks.
                 assert_matches!(chunk.content(), ChunkContent::Items(events) => {
@@ -502,6 +501,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             // The new chunk.
             assert_matches!(rchunks.next(), Some(chunk) => {
                 assert_eq!(chunk.identifier(), 1);
+                assert_eq!(chunk.lazy_previous(), Some(CId::new(0)));
 
                 assert_matches!(chunk.content(), ChunkContent::Gap(gap) => {
                     assert_eq!(gap.prev_token, "morbier");
@@ -524,6 +524,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             // The last chunk.
             assert_matches!(rchunks.next(), Some(chunk) => {
                 assert_eq!(chunk.identifier(), 2);
+                assert!(chunk.lazy_previous().is_none());
 
                 // Already asserted, but let's be sure nothing breaks.
                 assert_matches!(chunk.content(), ChunkContent::Items(events) => {
@@ -537,6 +538,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             // Its previous chunk.
             assert_matches!(rchunks.next(), Some(chunk) => {
                 assert_eq!(chunk.identifier(), 1);
+                assert!(chunk.lazy_previous().is_none());
 
                 // Already asserted, but let's be sure nothing breaks.
                 assert_matches!(chunk.content(), ChunkContent::Gap(gap) => {
@@ -547,6 +549,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             // The new chunk.
             assert_matches!(rchunks.next(), Some(chunk) => {
                 assert_eq!(chunk.identifier(), 0);
+                assert!(chunk.lazy_previous().is_none());
 
                 assert_matches!(chunk.content(), ChunkContent::Items(events) => {
                     assert_eq!(events.len(), 2);
@@ -574,6 +577,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             // The first chunk.
             assert_matches!(chunks.next(), Some(chunk) => {
                 assert_eq!(chunk.identifier(), 0);
+                assert!(chunk.lazy_previous().is_none());
 
                 assert_matches!(chunk.content(), ChunkContent::Items(events) => {
                     assert_eq!(events.len(), 2);
@@ -585,6 +589,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             // The second chunk.
             assert_matches!(chunks.next(), Some(chunk) => {
                 assert_eq!(chunk.identifier(), 1);
+                assert!(chunk.lazy_previous().is_none());
 
                 assert_matches!(chunk.content(), ChunkContent::Gap(gap) => {
                     assert_eq!(gap.prev_token, "morbier");
@@ -594,6 +599,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             // The third and last chunk.
             assert_matches!(chunks.next(), Some(chunk) => {
                 assert_eq!(chunk.identifier(), 2);
+                assert!(chunk.lazy_previous().is_none());
 
                 assert_matches!(chunk.content(), ChunkContent::Items(events) => {
                     assert_eq!(events.len(), 3);

--- a/crates/matrix-sdk-common/src/linked_chunk/lazy_loader.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/lazy_loader.rs
@@ -96,7 +96,8 @@ where
             }
         }
 
-        let expected_next_chunk = linked_chunk.links.first_chunk().identifier();
+        let first_chunk = linked_chunk.links.first_chunk();
+        let expected_next_chunk = first_chunk.identifier();
 
         // New chunk has a next chunk.
         let Some(next_chunk) = new_first_chunk.next else {
@@ -108,6 +109,15 @@ where
             return Err(LazyLoaderError::CannotConnectTwoChunks {
                 new_chunk: new_first_chunk.identifier,
                 with_chunk: expected_next_chunk,
+            });
+        }
+
+        // Same check as before, but in reverse: the first chunk has a `lazy_previous`
+        // to the new first chunk.
+        if first_chunk.lazy_previous() != Some(new_first_chunk.identifier) {
+            return Err(LazyLoaderError::CannotConnectTwoChunks {
+                new_chunk: first_chunk.identifier,
+                with_chunk: new_first_chunk.identifier,
             });
         }
 
@@ -525,6 +535,26 @@ mod tests {
     }
 
     #[test]
+    fn test_insert_new_first_chunk_err_cannot_connect_two_chunks_before_no_lazy_previous() {
+        let new_first_chunk = RawChunk {
+            previous: None,
+            identifier: ChunkIdentifier::new(1),
+            next: Some(ChunkIdentifier::new(0)),
+            content: ChunkContent::Gap(()),
+        };
+
+        let mut linked_chunk = LinkedChunk::<2, char, ()>::new();
+        linked_chunk.push_gap_back(());
+
+        let result = insert_new_first_chunk(&mut linked_chunk, new_first_chunk);
+
+        assert_matches!(result, Err(LazyLoaderError::CannotConnectTwoChunks { new_chunk, with_chunk }) => {
+            assert_eq!(new_chunk, 0);
+            assert_eq!(with_chunk, 1);
+        });
+    }
+
+    #[test]
     fn test_insert_new_first_chunk_gap() {
         let new_first_chunk = RawChunk {
             previous: None,
@@ -535,6 +565,7 @@ mod tests {
 
         let mut linked_chunk = LinkedChunk::<5, char, ()>::new_with_update_history();
         linked_chunk.push_items_back(vec!['a', 'b']);
+        linked_chunk.links.first_chunk_mut().lazy_previous = Some(ChunkIdentifier::new(1));
 
         // Drain initial updates.
         let _ = linked_chunk.updates().unwrap().take();
@@ -593,6 +624,7 @@ mod tests {
 
         let mut linked_chunk = LinkedChunk::<5, char, ()>::new_with_update_history();
         linked_chunk.push_items_back(vec!['a', 'b']);
+        linked_chunk.links.first_chunk_mut().lazy_previous = Some(ChunkIdentifier::new(1));
 
         // Drain initial updates.
         let _ = linked_chunk.updates().unwrap().take();


### PR DESCRIPTION
This patch adds a `debug_assert_eq` to ensure the new first chunk is the one that matches the `lazy_previous` of the current first chunk.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280