### PR TITLE
refactor(sdk): `RoomEventCacheState::remove_events` checks if events to remove aren't empty

### DIFF
--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1091,6 +1091,7 @@ mod private {
         /// This method is purposely isolated because it must ensure that
         /// positions are sorted appropriately or it can be disastrous.
         #[must_use = "Updates as `VectorDiff` must probably be propagated via `RoomEventCacheUpdate`"]
+        #[instrument(skip_all)]
         pub(crate) async fn remove_events(
             &mut self,
             in_memory_events: Vec<(OwnedEventId, Position)>,

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1097,7 +1097,7 @@ mod private {
             in_store_events: Vec<(OwnedEventId, Position)>,
         ) -> Result<Vec<VectorDiff<TimelineEvent>>, EventCacheError> {
             // In-store events.
-            {
+            if !in_store_events.is_empty() {
                 let mut positions = in_store_events
                     .into_iter()
                     .map(|(_event_id, position)| position)
@@ -1115,8 +1115,8 @@ mod private {
             }
 
             // In-memory events.
-            let timeline_event_diffs = self
-                .with_events_mut(|room_events| {
+            let timeline_event_diffs = if !in_memory_events.is_empty() {
+                self.with_events_mut(|room_events| {
                     // `remove_events_by_position` sorts the positions by itself.
                     room_events
                         .remove_events_by_position(
@@ -1129,7 +1129,10 @@ mod private {
 
                     vec![]
                 })
-                .await?;
+                .await?
+            } else {
+                Vec::new()
+            };
 
             Ok(timeline_event_diffs)
         }


### PR DESCRIPTION
This patch updates `RoomEventCacheState::remove_events` to check whether
the set of events are not empty before removing them. When removing
`in_memory_events`, it avoids taking a write lock on the `RoomEvents`
for nothing for example.