### PR TITLE
refactor(oauth): Rename `OidcRegistrations` to `OAuthRegistrationStore` and other improvements

### DIFF
--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -9,8 +9,8 @@ use matrix_sdk::{
     authentication::oauth::{
         error::OAuthAuthorizationCodeError,
         registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
-        registrations::{ClientId, OidcRegistrations, OidcRegistrationsError},
-        OAuthError as SdkOAuthError,
+        registrations::{OidcRegistrations, OidcRegistrationsError},
+        ClientId, OAuthError as SdkOAuthError,
     },
     Error,
 };

--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     fmt::{self, Debug},
-    path::Path,
+    path::PathBuf,
     sync::Arc,
 };
 
@@ -165,10 +165,10 @@ impl OidcConfiguration {
         Raw::new(&metadata).map_err(|_| OidcError::MetadataInvalid)
     }
 
-    pub fn registrations(&self) -> Result<OAuthRegistrationStore, OidcError> {
+    pub async fn registrations(&self) -> Result<OAuthRegistrationStore, OidcError> {
         let client_metadata = self.client_metadata()?;
 
-        let registrations_file = Path::new(&self.dynamic_registrations_file);
+        let registrations_file = PathBuf::from(&self.dynamic_registrations_file);
         let static_registrations = self
             .static_registrations
             .iter()
@@ -181,7 +181,8 @@ impl OidcConfiguration {
             })
             .collect();
 
-        Ok(OAuthRegistrationStore::new(registrations_file, client_metadata, static_registrations)?)
+        Ok(OAuthRegistrationStore::new(registrations_file, client_metadata, static_registrations)
+            .await?)
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -7,9 +7,9 @@ use std::{
 
 use matrix_sdk::{
     authentication::oauth::{
-        error::{OAuthAuthorizationCodeError, OidcRegistrationsError},
+        error::{OAuthAuthorizationCodeError, OAuthRegistrationStoreError},
         registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
-        ClientId, OAuthError as SdkOAuthError, OidcRegistrations,
+        ClientId, OAuthError as SdkOAuthError, OAuthRegistrationStore,
     },
     Error,
 };
@@ -165,7 +165,7 @@ impl OidcConfiguration {
         Raw::new(&metadata).map_err(|_| OidcError::MetadataInvalid)
     }
 
-    pub fn registrations(&self) -> Result<OidcRegistrations, OidcError> {
+    pub fn registrations(&self) -> Result<OAuthRegistrationStore, OidcError> {
         let client_metadata = self.client_metadata()?;
 
         let registrations_file = Path::new(&self.dynamic_registrations_file);
@@ -181,7 +181,7 @@ impl OidcConfiguration {
             })
             .collect();
 
-        Ok(OidcRegistrations::new(registrations_file, client_metadata, static_registrations)?)
+        Ok(OAuthRegistrationStore::new(registrations_file, client_metadata, static_registrations)?)
     }
 }
 
@@ -221,10 +221,10 @@ impl From<SdkOAuthError> for OidcError {
     }
 }
 
-impl From<OidcRegistrationsError> for OidcError {
-    fn from(e: OidcRegistrationsError) -> OidcError {
+impl From<OAuthRegistrationStoreError> for OidcError {
+    fn from(e: OAuthRegistrationStoreError) -> OidcError {
         match e {
-            OidcRegistrationsError::InvalidFilePath => OidcError::RegistrationsPathInvalid,
+            OAuthRegistrationStoreError::InvalidFilePath => OidcError::RegistrationsPathInvalid,
             _ => OidcError::Generic { message: e.to_string() },
         }
     }

--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -224,7 +224,9 @@ impl From<SdkOAuthError> for OidcError {
 impl From<OAuthRegistrationStoreError> for OidcError {
     fn from(e: OAuthRegistrationStoreError) -> OidcError {
         match e {
-            OAuthRegistrationStoreError::InvalidFilePath => OidcError::RegistrationsPathInvalid,
+            OAuthRegistrationStoreError::NotAFilePath | OAuthRegistrationStoreError::File(_) => {
+                OidcError::RegistrationsPathInvalid
+            }
             _ => OidcError::Generic { message: e.to_string() },
         }
     }

--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -7,10 +7,9 @@ use std::{
 
 use matrix_sdk::{
     authentication::oauth::{
-        error::OAuthAuthorizationCodeError,
+        error::{OAuthAuthorizationCodeError, OidcRegistrationsError},
         registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
-        registrations::{OidcRegistrations, OidcRegistrationsError},
-        ClientId, OAuthError as SdkOAuthError,
+        ClientId, OAuthError as SdkOAuthError, OidcRegistrations,
     },
     Error,
 };

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -407,7 +407,7 @@ impl Client {
         oidc_configuration: &OidcConfiguration,
         prompt: Option<OidcPrompt>,
     ) -> Result<Arc<OAuthAuthorizationData>, OidcError> {
-        let registrations = oidc_configuration.registrations()?;
+        let registrations = oidc_configuration.registrations().await?;
         let redirect_uri = oidc_configuration.redirect_uri()?;
 
         let data = self

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Context as _};
 use async_compat::get_runtime_handle;
 use matrix_sdk::{
     authentication::oauth::{
-        registrations::ClientId, AccountManagementActionFull, OAuthAuthorizationData, OAuthSession,
+        AccountManagementActionFull, ClientId, OAuthAuthorizationData, OAuthSession,
     },
     event_cache::EventCacheError,
     media::{

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -187,6 +187,19 @@ simpler methods:
   - `OAuth::finish_login()` can be called several times for the same session,
     but it will return an error if it is called with a new session.
   - `OAuthError::MissingDeviceId` was removed, it cannot occur anymore.
+- [**breaking**] `OidcRegistrations` was renamed to `OAuthRegistrationStore`.
+  ([#4814](https://github.com/matrix-org/matrix-rust-sdk/pull/4814))
+  - `OidcRegistrationsError` was renamed to `OAuthRegistrationStoreError`. 
+  - The `registrations` module was renamed and is now private.
+    `OAuthRegistrationStore` and `ClientId` are exported from `oauth`, and
+    `OAuthRegistrationStoreError` is exported from `oauth::error`.
+  - All the methods of `OAuthRegistrationStore` are now `async` and return a
+    `Result`: errors when reading the file are no longer ignored, and blocking
+    I/O is performed in a separate thread.
+  - `OAuthRegistrationStore::new()` takes a `PathBuf` instead of a `Path`.
+  - `OAuthRegistrationStore::new()` no longer takes a `static_registrations`
+    parameter. It should be provided if needed with
+    `OAuthRegistrationStore::with_static_registrations()`.
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/src/authentication/oauth/error.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/error.rs
@@ -30,7 +30,7 @@ use ruma::{
 };
 
 pub use super::{
-    cross_process::CrossProcessRefreshLockError, registrations::OidcRegistrationsError,
+    cross_process::CrossProcessRefreshLockError, registration_store::OAuthRegistrationStoreError,
 };
 
 /// An error when interacting with the OAuth 2.0 authorization server.

--- a/crates/matrix-sdk/src/authentication/oauth/error.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/error.rs
@@ -29,7 +29,9 @@ use ruma::{
     serde::{PartialEqAsRefStr, StringEnum},
 };
 
-pub use super::cross_process::CrossProcessRefreshLockError;
+pub use super::{
+    cross_process::CrossProcessRefreshLockError, registrations::OidcRegistrationsError,
+};
 
 /// An error when interacting with the OAuth 2.0 authorization server.
 pub type OAuthRequestError<T> =

--- a/crates/matrix-sdk/src/authentication/oauth/error.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/error.rs
@@ -99,10 +99,6 @@ pub enum OAuthError {
     /// into a new session that is different than the old one.
     #[error("new logged-in session is different than current client session")]
     SessionMismatch,
-
-    /// An unknown error occurred.
-    #[error("unknown error")]
-    UnknownError(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// All errors that can occur when discovering the OAuth 2.0 server metadata.
@@ -264,6 +260,10 @@ pub enum OAuthClientRegistrationError {
     /// Deserialization of the registration response failed.
     #[error("failed to deserialize registration response: {0}")]
     FromJson(serde_json::Error),
+
+    /// Failed to access or store the registration in the store.
+    #[error("failed to use registration store: {0}")]
+    Store(#[from] OAuthRegistrationStoreError),
 }
 
 /// Error response returned by server after requesting an authorization code.

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -502,7 +502,10 @@ impl OAuth {
             return Ok(());
         };
 
-        if self.load_client_registration(issuer, &registrations) {
+        if self
+            .load_client_registration(issuer, &registrations)
+            .map_err(OAuthClientRegistrationError::from)?
+        {
             tracing::info!("OAuth 2.0 configuration loaded from disk.");
             return Ok(());
         }
@@ -539,14 +542,14 @@ impl OAuth {
         &self,
         issuer: Url,
         registrations: &OAuthRegistrationStore,
-    ) -> bool {
-        let Some(client_id) = registrations.client_id(&issuer) else {
-            return false;
+    ) -> Result<bool, OAuthRegistrationStoreError> {
+        let Some(client_id) = registrations.client_id(&issuer)? else {
+            return Ok(false);
         };
 
         self.restore_registered_client(issuer, client_id);
 
-        true
+        Ok(true)
     }
 
     /// The OAuth 2.0 authorization server used for authorization.

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -507,10 +507,10 @@ impl OAuth {
         }
 
         tracing::info!("Registering this client for OAuth 2.0.");
-        self.register_client(&registrations.metadata).await?;
+        let response = self.register_client(&registrations.metadata).await?;
 
         tracing::info!("Persisting OAuth 2.0 registration data.");
-        self.store_client_registration(&registrations)
+        self.store_client_registration(response.client_id, &registrations)
             .map_err(|e| OAuthError::UnknownError(Box::new(e)))?;
 
         Ok(())
@@ -520,10 +520,10 @@ impl OAuth {
     /// re-used if we ever log in via the same issuer again.
     fn store_client_registration(
         &self,
+        client_id: ClientId,
         registrations: &OAuthRegistrationStore,
     ) -> std::result::Result<(), OAuthError> {
         let issuer = self.issuer().expect("issuer should be set after registration").to_owned();
-        let client_id = self.client_id().ok_or(OAuthError::NotRegistered)?.to_owned();
 
         registrations
             .set_and_write_client_id(client_id, issuer)

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -144,11 +144,11 @@ use error::{
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::types::qr_login::QrCodeData;
 use matrix_sdk_base::{once_cell::sync::OnceCell, SessionMeta};
-pub use oauth2::CsrfToken;
 use oauth2::{
     basic::BasicClient as OAuthClient, AccessToken, PkceCodeVerifier, RedirectUrl, RefreshToken,
     RevocationUrl, Scope, StandardErrorResponse, StandardRevocableToken, TokenResponse, TokenUrl,
 };
+pub use oauth2::{ClientId, CsrfToken};
 use ruma::{
     api::client::discovery::{
         get_authentication_issuer,
@@ -186,7 +186,7 @@ use self::{
     oidc_discovery::discover,
     qrcode::LoginWithQrCode,
     registration::{register_client, ClientMetadata, ClientRegistrationResponse},
-    registrations::{ClientId, OidcRegistrations},
+    registrations::OidcRegistrations,
 };
 pub use self::{
     account_management_url::AccountManagementActionFull,
@@ -764,7 +764,7 @@ impl OAuth {
     ///
     /// ```no_run
     /// use matrix_sdk::{Client, ServerName};
-    /// use matrix_sdk::authentication::oauth::registrations::ClientId;
+    /// # use matrix_sdk::authentication::oauth::ClientId;
     /// # use matrix_sdk::authentication::oauth::registration::ClientMetadata;
     /// # use ruma::serde::Raw;
     /// # let client_metadata = unimplemented!();

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -139,7 +139,8 @@ use std::{
 use as_variant::as_variant;
 use error::{
     CrossProcessRefreshLockError, OAuthAuthorizationCodeError, OAuthClientRegistrationError,
-    OAuthDiscoveryError, OAuthTokenRevocationError, RedirectUriQueryParseError,
+    OAuthDiscoveryError, OAuthRegistrationStoreError, OAuthTokenRevocationError,
+    RedirectUriQueryParseError,
 };
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::types::qr_login::QrCodeData;
@@ -511,7 +512,7 @@ impl OAuth {
 
         tracing::info!("Persisting OAuth 2.0 registration data.");
         self.store_client_registration(response.client_id, &registrations)
-            .map_err(|e| OAuthError::UnknownError(Box::new(e)))?;
+            .map_err(OAuthClientRegistrationError::from)?;
 
         Ok(())
     }
@@ -522,12 +523,10 @@ impl OAuth {
         &self,
         client_id: ClientId,
         registrations: &OAuthRegistrationStore,
-    ) -> std::result::Result<(), OAuthError> {
+    ) -> std::result::Result<(), OAuthRegistrationStoreError> {
         let issuer = self.issuer().expect("issuer should be set after registration").to_owned();
 
-        registrations
-            .set_and_write_client_id(client_id, issuer)
-            .map_err(|e| OAuthError::UnknownError(Box::new(e)))?;
+        registrations.set_and_write_client_id(client_id, issuer)?;
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -175,7 +175,7 @@ mod oidc_discovery;
 #[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
 pub mod qrcode;
 pub mod registration;
-pub mod registrations;
+mod registrations;
 #[cfg(test)]
 mod tests;
 
@@ -186,12 +186,12 @@ use self::{
     oidc_discovery::discover,
     qrcode::LoginWithQrCode,
     registration::{register_client, ClientMetadata, ClientRegistrationResponse},
-    registrations::OidcRegistrations,
 };
 pub use self::{
     account_management_url::AccountManagementActionFull,
     auth_code_builder::{OAuthAuthCodeUrlBuilder, OAuthAuthorizationData},
     error::OAuthError,
+    registrations::OidcRegistrations,
 };
 use super::{AuthData, SessionTokens};
 use crate::{client::SessionChange, Client, HttpError, RefreshTokenError, Result};

--- a/crates/matrix-sdk/src/authentication/oauth/registration_store.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/registration_store.rs
@@ -70,7 +70,7 @@ pub enum OAuthRegistrationStoreError {
 #[derive(Debug)]
 pub struct OAuthRegistrationStore {
     /// The path of the file where the registrations are stored.
-    file_path: PathBuf,
+    pub(super) file_path: PathBuf,
     /// The metadata used to register the client.
     /// This is used to check if the client needs to be re-registered.
     pub(super) metadata: Raw<ClientMetadata>,

--- a/crates/matrix-sdk/src/authentication/oauth/registrations.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/registrations.rs
@@ -28,7 +28,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub use oauth2::ClientId;
+use oauth2::ClientId;
 use ruma::serde::Raw;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use anyhow::Context as _;
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
@@ -56,9 +54,7 @@ async fn mock_environment() -> anyhow::Result<(OAuth, MatrixMockServer, Url, OAu
     let registrations_path =
         tempdir().unwrap().path().join("matrix-sdk-oauth").join("registrations.json");
     let registrations =
-        OAuthRegistrationStore::new(registrations_path, client_metadata, HashMap::new())
-            .await
-            .unwrap();
+        OAuthRegistrationStore::new(registrations_path, client_metadata).await.unwrap();
 
     Ok((client.oauth(), server, mock_redirect_uri(), registrations))
 }

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -56,7 +56,9 @@ async fn mock_environment() -> anyhow::Result<(OAuth, MatrixMockServer, Url, OAu
     let registrations_path =
         tempdir().unwrap().path().join("matrix-sdk-oauth").join("registrations.json");
     let registrations =
-        OAuthRegistrationStore::new(&registrations_path, client_metadata, HashMap::new()).unwrap();
+        OAuthRegistrationStore::new(registrations_path, client_metadata, HashMap::new())
+            .await
+            .unwrap();
 
     Ok((client.oauth(), server, mock_redirect_uri(), registrations))
 }

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -19,8 +19,8 @@ use wiremock::{
 };
 
 use super::{
-    registrations::OidcRegistrations, AuthorizationCode, AuthorizationError, AuthorizationResponse,
-    OAuth, OAuthAuthorizationData, OAuthError, RedirectUriQueryParseError,
+    registration_store::OAuthRegistrationStore, AuthorizationCode, AuthorizationError,
+    AuthorizationResponse, OAuth, OAuthAuthorizationData, OAuthError, RedirectUriQueryParseError,
 };
 use crate::{
     authentication::oauth::{
@@ -40,7 +40,8 @@ use crate::{
 
 const REDIRECT_URI_STRING: &str = "http://127.0.0.1:6778/oauth/callback";
 
-async fn mock_environment() -> anyhow::Result<(OAuth, MatrixMockServer, Url, OidcRegistrations)> {
+async fn mock_environment() -> anyhow::Result<(OAuth, MatrixMockServer, Url, OAuthRegistrationStore)>
+{
     let server = MatrixMockServer::new().await;
     server.mock_who_am_i().ok().named("whoami").mount().await;
 
@@ -55,7 +56,7 @@ async fn mock_environment() -> anyhow::Result<(OAuth, MatrixMockServer, Url, Oid
     let registrations_path =
         tempdir().unwrap().path().join("matrix-sdk-oauth").join("registrations.json");
     let registrations =
-        OidcRegistrations::new(&registrations_path, client_metadata, HashMap::new()).unwrap();
+        OAuthRegistrationStore::new(&registrations_path, client_metadata, HashMap::new()).unwrap();
 
     Ok((client.oauth(), server, mock_redirect_uri(), registrations))
 }

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -153,6 +153,9 @@ async fn check_authorization_url(
 async fn test_high_level_login() -> anyhow::Result<()> {
     // Given a fresh environment.
     let (oauth, _server, mut redirect_uri, registrations) = mock_environment().await.unwrap();
+    let registrations_path = registrations.file_path.clone();
+    let client_metadata = registrations.metadata.clone();
+
     assert!(oauth.issuer().is_none());
     assert!(oauth.client_id().is_none());
 
@@ -164,7 +167,15 @@ async fn test_high_level_login() -> anyhow::Result<()> {
 
     // Then the client should be configured correctly.
     assert_let!(Some(issuer) = oauth.issuer());
-    assert!(oauth.client_id().is_some());
+    assert_eq!(oauth.client_id().map(|id| id.as_str()), Some("test_client_id"));
+
+    // The client ID should have been saved in the registration file.
+    let registrations =
+        OAuthRegistrationStore::new(registrations_path, client_metadata).await.unwrap();
+    assert_eq!(
+        registrations.client_id(issuer).await.unwrap().as_ref().map(|id| id.as_str()),
+        Some("test_client_id")
+    );
 
     check_authorization_url(&authorization_data, &oauth, issuer, None, Some("create"), None).await;
 
@@ -181,11 +192,22 @@ async fn test_high_level_login() -> anyhow::Result<()> {
 async fn test_high_level_login_cancellation() -> anyhow::Result<()> {
     // Given a client ready to complete login.
     let (oauth, _server, mut redirect_uri, registrations) = mock_environment().await.unwrap();
+    let registrations_path = registrations.file_path.clone();
+    let client_metadata = registrations.metadata.clone();
+
     let authorization_data =
         oauth.url_for_oidc(registrations, redirect_uri.clone(), None).await.unwrap();
 
     assert_let!(Some(issuer) = oauth.issuer());
-    assert!(oauth.client_id().is_some());
+    assert_eq!(oauth.client_id().map(|id| id.as_str()), Some("test_client_id"));
+
+    // The client ID should have been saved in the registration file.
+    let registrations =
+        OAuthRegistrationStore::new(registrations_path, client_metadata).await.unwrap();
+    assert_eq!(
+        registrations.client_id(issuer).await.unwrap().as_ref().map(|id| id.as_str()),
+        Some("test_client_id")
+    );
 
     check_authorization_url(&authorization_data, &oauth, issuer, None, None, None).await;
 
@@ -211,11 +233,22 @@ async fn test_high_level_login_cancellation() -> anyhow::Result<()> {
 async fn test_high_level_login_invalid_state() -> anyhow::Result<()> {
     // Given a client ready to complete login.
     let (oauth, _server, mut redirect_uri, registrations) = mock_environment().await.unwrap();
+    let registrations_path = registrations.file_path.clone();
+    let client_metadata = registrations.metadata.clone();
+
     let authorization_data =
         oauth.url_for_oidc(registrations, redirect_uri.clone(), None).await.unwrap();
 
     assert_let!(Some(issuer) = oauth.issuer());
-    assert!(oauth.client_id().is_some());
+    assert_eq!(oauth.client_id().map(|id| id.as_str()), Some("test_client_id"));
+
+    // The client ID should have been saved in the registration file.
+    let registrations =
+        OAuthRegistrationStore::new(registrations_path, client_metadata).await.unwrap();
+    assert_eq!(
+        registrations.client_id(issuer).await.unwrap().as_ref().map(|id| id.as_str()),
+        Some("test_client_id")
+    );
 
     check_authorization_url(&authorization_data, &oauth, issuer, None, None, None).await;
 

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -180,8 +180,7 @@ pub mod oauth {
     use crate::{
         authentication::oauth::{
             registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
-            registrations::ClientId,
-            OAuthSession, UserSession,
+            ClientId, OAuthSession, UserSession,
         },
         SessionTokens,
     };

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -24,8 +24,7 @@ use futures_util::StreamExt;
 use matrix_sdk::{
     authentication::oauth::{
         registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
-        registrations::ClientId,
-        AccountManagementActionFull, AuthorizationCode, AuthorizationResponse, CsrfToken,
+        AccountManagementActionFull, AuthorizationCode, AuthorizationResponse, ClientId, CsrfToken,
         OAuthAuthorizationData, OAuthSession, UserSession,
     },
     config::SyncSettings,


### PR DESCRIPTION
We rename the types to use the same prefix as the other types in the OAuth 2.0 API, and we use the
same suffix as other data-persisting APIs for consistency. It also avoids to have two modules with very similar names, the only difference being a trailing `s`.

We also refactor the error types to have more precise variants, we don't ignore errors when reading from the file, and we make the methods async because they perform blocking I/O.

This can be reviewed commit by commit.