### PR TITLE
feat(timeline): add a virtual start of timeline item

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -974,6 +974,7 @@ impl TimelineItem {
         match self.0.as_virtual()? {
             VItem::DateDivider(ts) => Some(VirtualTimelineItem::DateDivider { ts: (*ts).into() }),
             VItem::ReadMarker => Some(VirtualTimelineItem::ReadMarker),
+            VItem::TimelineStart => Some(VirtualTimelineItem::TimelineStart),
         }
     }
 
@@ -1254,6 +1255,9 @@ pub enum VirtualTimelineItem {
 
     /// The user's own read marker.
     ReadMarker,
+
+    /// The timeline start, that is, the *oldest* event in time for that room.
+    TimelineStart,
 }
 
 /// A [`TimelineItem`](super::TimelineItem) that doesn't correspond to an event.

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -178,7 +178,7 @@ impl TimelineBuilder {
             .unwrap_or_default();
 
         let controller = TimelineController::new(
-            room,
+            room.clone(),
             focus.clone(),
             internal_id_prefix.clone(),
             unable_to_decrypt_hook,
@@ -187,9 +187,6 @@ impl TimelineBuilder {
         .with_settings(settings);
 
         let has_events = controller.init_focus(&room_event_cache).await?;
-
-        let room = controller.room();
-        let client = room.client();
 
         let pinned_events_join_handle = if is_pinned_events {
             Some(spawn(pinned_events_task(room.pinned_event_ids_stream(), controller.clone())))
@@ -256,7 +253,7 @@ impl TimelineBuilder {
             room.room_id().to_owned(),
         ));
 
-        let handles = vec![room_key_handle, forwarded_room_key_handle];
+        let event_handlers = vec![room_key_handle, forwarded_room_key_handle];
 
         // Not using room.add_event_handler here because RoomKey events are
         // to-device events that are not received in the context of a room.
@@ -291,7 +288,7 @@ impl TimelineBuilder {
             event_cache: room_event_cache,
             drop_handle: Arc::new(TimelineDropHandle {
                 client,
-                event_handler_handles: handles,
+                event_handler_handles: event_handlers,
                 room_update_join_handle,
                 pinned_events_join_handle,
                 room_key_from_backups_join_handle,

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -41,7 +41,7 @@ pub(in crate::timeline) struct TimelineMetadata {
     /// This value is constant over the lifetime of the metadata.
     internal_id_prefix: Option<String>,
 
-    /// The `count` value for the `Skip higher-order stream used by the
+    /// The `count` value for the `Skip` higher-order stream used by the
     /// `TimelineSubscriber`. See its documentation to learn more.
     pub(super) subscriber_skip_count: SkipCount,
 

--- a/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
@@ -153,7 +153,8 @@ impl DateDividerAdjuster {
                     latest_event_ts = Some(ts);
                 }
 
-                TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker) => {
+                TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker)
+                | TimelineItemKind::Virtual(VirtualTimelineItem::TimelineStart) => {
                     // Nothing to do.
                 }
             }
@@ -242,8 +243,9 @@ impl DateDividerAdjuster {
                 return true;
             }
 
-            TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker) => {
-                // Nothing to do for read markers.
+            TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker)
+            | TimelineItemKind::Virtual(VirtualTimelineItem::TimelineStart) => {
+                // Nothing to do.
             }
         }
 
@@ -304,7 +306,8 @@ impl DateDividerAdjuster {
                 }
             }
 
-            TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker) => {
+            TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker)
+            | TimelineItemKind::Virtual(VirtualTimelineItem::TimelineStart) => {
                 // Nothing to do.
             }
         }

--- a/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
@@ -402,16 +402,21 @@ impl DateDividerAdjuster {
         };
 
         // Assert invariants.
-        // 1. The timeline starts with a date divider.
-        if let Some(item) = items.get(0) {
-            if item.is_read_marker() {
-                if let Some(next_item) = items.get(1) {
-                    if !next_item.is_date_divider() {
-                        report.errors.push(DateDividerInsertError::FirstItemNotDateDivider);
+        // 1. The timeline starts with a date divider, if it's not only virtual items.
+        {
+            let mut i = 0;
+            while let Some(item) = items.get(i) {
+                if let Some(virt) = item.as_virtual() {
+                    if matches!(virt, VirtualTimelineItem::DateDivider(_)) {
+                        // We found a date divider among the first virtual items: stop here.
+                        break;
                     }
+                } else {
+                    // We found an event, but we didn't have a date divider: report an error.
+                    report.errors.push(DateDividerInsertError::FirstItemNotDateDivider);
+                    break;
                 }
-            } else if !item.is_date_divider() {
-                report.errors.push(DateDividerInsertError::FirstItemNotDateDivider);
+                i += 1;
             }
         }
 

--- a/crates/matrix-sdk-ui/src/timeline/item.rs
+++ b/crates/matrix-sdk-ui/src/timeline/item.rs
@@ -106,14 +106,18 @@ impl TimelineItem {
         matches!(&self.kind, TimelineItemKind::Event(_))
     }
 
-    /// Check whether this item is a date divider.
-    #[must_use]
+    /// Check whether this item is a (virtual) date divider.
     pub fn is_date_divider(&self) -> bool {
         matches!(self.kind, TimelineItemKind::Virtual(VirtualTimelineItem::DateDivider(_)))
     }
 
     pub(crate) fn is_read_marker(&self) -> bool {
         matches!(self.kind, TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker))
+    }
+
+    /// Check whether this item is a (virtual) timeline start item.
+    pub fn is_timeline_start(&self) -> bool {
+        matches!(self.kind, TimelineItemKind::Virtual(VirtualTimelineItem::TimelineStart))
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/virtual_item.rs
+++ b/crates/matrix-sdk-ui/src/timeline/virtual_item.rs
@@ -26,4 +26,8 @@ pub enum VirtualTimelineItem {
 
     /// The user's own read marker.
     ReadMarker,
+
+    /// The timeline start, that is, an indication that we've seen all the
+    /// events for that timeline.
+    TimelineStart,
 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/decryption.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/decryption.rs
@@ -318,13 +318,21 @@ async fn test_an_utd_from_the_event_cache_as_a_paginated_item_is_decrypted() {
     // let's test everything :-).
     assert!(reached_start);
 
+    assert_next_matches_with_timeout!(updates_stream, 250, updates => {
+        assert_eq!(updates.len(), 1, "We get the start of timeline item");
+
+        assert_matches!(&updates[0], VectorDiff::PushFront { value } => {
+            assert!(value.is_timeline_start());
+        });
+    });
+
     // Now, let's look at the updates. We must observe an update reflecting the UTD
     // has entered the `Timeline`.
     assert_next_matches_with_timeout!(updates_stream, 250, updates => {
         assert_eq!(updates.len(), 2, "Expecting 2 updates from the `Timeline`");
 
         // UTD! UTD!
-        assert_matches!(&updates[0], VectorDiff::Insert { index: 1, value: event } => {
+        assert_matches!(&updates[0], VectorDiff::Insert { index: 2, value: event } => {
             assert_matches!(event.as_event(), Some(event) => {
                 assert_eq!(event.event_id().unwrap().as_str(), "$ev0");
                 assert!(event.content().is_unable_to_decrypt());
@@ -332,7 +340,7 @@ async fn test_an_utd_from_the_event_cache_as_a_paginated_item_is_decrypted() {
         });
 
         // UTD is decrypted now!
-        assert_matches!(&updates[1], VectorDiff::Set { index: 1, value: event } => {
+        assert_matches!(&updates[1], VectorDiff::Set { index: 2, value: event } => {
             assert_matches!(event.as_event(), Some(event) => {
                 assert_eq!(event.event_id().unwrap().as_str(), "$ev0");
                 assert_matches!(event.content().as_message(), Some(message) => {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -1198,18 +1198,20 @@ async fn test_no_duplicate_receipt_after_backpagination() {
         .mount()
         .await;
 
-    timeline.paginate_backwards(42).await.unwrap();
+    let reached_start = timeline.paginate_backwards(42).await.unwrap();
+    assert!(reached_start);
 
     yield_now().await;
 
     // Check that the receipts are at the correct place.
     let timeline_items = timeline.items().await;
-    assert_eq!(timeline_items.len(), 3);
+    assert_eq!(timeline_items.len(), 4);
 
-    assert!(timeline_items[0].is_date_divider());
+    assert!(timeline_items[0].is_timeline_start());
+    assert!(timeline_items[1].is_date_divider());
 
     {
-        let event1 = timeline_items[1].as_event().unwrap();
+        let event1 = timeline_items[2].as_event().unwrap();
         // Sanity check: this is the edited event from Alice.
         assert_eq!(event1.event_id().unwrap(), eid1);
 
@@ -1232,7 +1234,7 @@ async fn test_no_duplicate_receipt_after_backpagination() {
     }
 
     {
-        let event2 = timeline_items[2].as_event().unwrap();
+        let event2 = timeline_items[3].as_event().unwrap();
 
         // Sanity check: this is Bob's event.
         assert_eq!(event2.event_id().unwrap(), eid2);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -145,6 +145,32 @@ macro_rules! assert_timeline_stream {
         )
     };
 
+
+    // `prepend --- timeline start ---`
+    ( @_ [ $iterator:ident ] [ prepend --- timeline start --- ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
+        assert_timeline_stream!(
+            @_
+            [ $iterator ]
+            [ $( $rest )* ]
+            [
+                $( $accumulator )*
+                {
+                    assert_matches!(
+                        $iterator .next(),
+                        Some(eyeball_im::VectorDiff::PushFront { value }) => {
+                            assert_matches!(
+                                &**value,
+                                matrix_sdk_ui::timeline::TimelineItemKind::Virtual(
+                                    matrix_sdk_ui::timeline::VirtualTimelineItem::TimelineStart
+                                ) => {}
+                            );
+                        }
+                    );
+                }
+            ]
+        )
+    };
+
     // `prepend "$event_id"`
     ( @_ [ $iterator:ident ] [ prepend $event_id:literal ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
         assert_timeline_stream!(

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -836,6 +836,9 @@ impl App {
                     VirtualTimelineItem::ReadMarker => {
                         content.push("Read marker".to_owned());
                     }
+                    VirtualTimelineItem::TimelineStart => {
+                        content.push("🥳 Timeline start! 🥳".to_owned());
+                    }
                 },
             }
         }


### PR DESCRIPTION
Might be better than letting the apps figure out whether they need to put one or not.

The next step would be to add a virtuel item for gaps as well, `Gap { loading: bool }`:

1. this would pave the way for inserting gaps at random positions in the timeline,
2. when the timeline is back-paginating, we'd have a gap with `loading: true`
3. when the timeline is idle and we suspect there *might* be an history we haven't loaded, we'd have a gap with `loading: false`. The next call to `Timeline::paginate_backwards()` would resolve it into a `TimelineStart` or another `Gap { loading: false }`.

Part of #4821.