### PR TITLE
refactor(oauth): Simplify behavior to finish login

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -422,7 +422,7 @@ impl Client {
     /// Aborts an existing OIDC login operation that might have been cancelled,
     /// failed etc.
     pub async fn abort_oidc_auth(&self, authorization_data: Arc<OAuthAuthorizationData>) {
-        self.inner.oauth().abort_authorization(&authorization_data.state).await;
+        self.inner.oauth().abort_login(&authorization_data.state).await;
     }
 
     /// Completes the OIDC login process.

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -181,6 +181,12 @@ simpler methods:
   - `OidcError` was renamed to `OAuthError` and the `RefreshTokenError::Oidc`
     variant was renamed to `RefreshTokenError::OAuth`.
   - `Oidc::provider_metadata()` was renamed to `OAuth::server_metadata()`.
+- [**breaking**]: `OAuth::finish_login()` must always be called, instead of `OAuth::finish_authorization()`
+  ([#4817](https://github.com/matrix-org/matrix-rust-sdk/pull/4817))
+  - `OAuth::abort_authorization()` was renamed to `OAuth::abort_login()`.
+  - `OAuth::finish_login()` can be called several times for the same session,
+    but it will return an error if it is called with a new session.
+  - `OAuthError::MissingDeviceId` was removed, it cannot occur anymore.
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/src/authentication/oauth/auth_code_builder.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/auth_code_builder.rs
@@ -67,8 +67,8 @@ impl OAuthAuthCodeUrlBuilder {
     /// flow.
     ///
     /// This URL should be presented to the user and once they are redirected to
-    /// the `redirect_uri`, the authorization can be completed by calling
-    /// [`OAuth::finish_authorization()`].
+    /// the `redirect_uri`, the login can be completed by calling
+    /// [`OAuth::finish_login()`].
     ///
     /// Returns an error if the client registration was not restored, or if a
     /// request fails.

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -336,8 +336,8 @@ mod tests {
         let session_tokens = mock_session_tokens_with_refresh();
         client.auth_ctx().set_session_tokens(session_tokens.clone());
 
-        // Now, finishing logging will get the user and device ids.
-        oauth.load_session().await?;
+        // Now, finishing logging will get the user ID.
+        oauth.load_session(owned_device_id!("D3V1C31D")).await?;
 
         let session_meta = client.session_meta().context("should have session meta now")?;
         assert_eq!(

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -337,7 +337,7 @@ mod tests {
         client.auth_ctx().set_session_tokens(session_tokens.clone());
 
         // Now, finishing logging will get the user and device ids.
-        oauth.finish_login().await?;
+        oauth.load_session().await?;
 
         let session_meta = client.session_meta().context("should have session meta now")?;
         assert_eq!(

--- a/crates/matrix-sdk/src/authentication/oauth/error.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/error.rs
@@ -65,10 +65,6 @@ pub enum OAuthError {
     #[error("client not registered")]
     NotRegistered,
 
-    /// The device ID was not returned by the homeserver after login.
-    #[error("missing device ID in response")]
-    MissingDeviceId,
-
     /// The client is not authenticated while the request requires it.
     #[error("client not authenticated")]
     NotAuthenticated,

--- a/crates/matrix-sdk/src/authentication/oauth/error.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/error.rs
@@ -94,6 +94,14 @@ pub enum OAuthError {
     #[error(transparent)]
     LockError(#[from] CrossProcessRefreshLockError),
 
+    /// The user logged into a session that is different than the one the client
+    /// is already using.
+    ///
+    /// This only happens if the session was already restored, and the user logs
+    /// into a new session that is different than the old one.
+    #[error("new logged-in session is different than current client session")]
+    SessionMismatch,
+
     /// An unknown error occurred.
     #[error("unknown error")]
     UnknownError(#[source] Box<dyn std::error::Error + Send + Sync>),

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -352,6 +352,7 @@ async fn test_finish_login() -> anyhow::Result<()> {
     let redirect_uri = REDIRECT_URI_STRING;
     let (_pkce_code_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
     let auth_validation_data = AuthorizationValidationData {
+        device_id: owned_device_id!("D3V1C31D"),
         redirect_uri: RedirectUrl::new(redirect_uri.to_owned())?,
         pkce_verifier,
     };
@@ -410,6 +411,7 @@ async fn test_finish_login() -> anyhow::Result<()> {
     let redirect_uri = REDIRECT_URI_STRING;
     let (_pkce_code_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
     let auth_validation_data = AuthorizationValidationData {
+        device_id: owned_device_id!("D3V1C31D"),
         redirect_uri: RedirectUrl::new(redirect_uri.to_owned())?,
         pkce_verifier,
     };
@@ -449,10 +451,12 @@ async fn test_finish_login() -> anyhow::Result<()> {
     assert!(oauth.data().unwrap().authorization_data.lock().await.get(&state2).is_none());
 
     // Try to log in again, with a different session
+    let wrong_device_id = device_id!("WR0NG");
     let state3 = CsrfToken::new("state3".to_owned());
     let redirect_uri = REDIRECT_URI_STRING;
     let (_pkce_code_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
     let auth_validation_data = AuthorizationValidationData {
+        device_id: wrong_device_id.to_owned(),
         redirect_uri: RedirectUrl::new(redirect_uri.to_owned())?,
         pkce_verifier,
     };
@@ -475,7 +479,7 @@ async fn test_finish_login() -> anyhow::Result<()> {
     server
         .mock_who_am_i()
         .expect_access_token("AT3")
-        .ok_with_device_id(device_id!("WR0NG"))
+        .ok_with_device_id(wrong_device_id)
         .mock_once()
         .named("whoami_3")
         .mount()

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -30,6 +30,7 @@ use matrix_sdk_test::{
 use percent_encoding::{AsciiSet, CONTROLS};
 use ruma::{
     api::client::room::Visibility,
+    device_id,
     directory::PublicRoomsChunk,
     events::{
         room::member::RoomMemberEvent, AnyStateEvent, AnyTimelineEvent, MessageLikeEventType,
@@ -37,7 +38,7 @@ use ruma::{
     },
     serde::Raw,
     time::Duration,
-    MxcUri, OwnedEventId, OwnedRoomId, RoomId, ServerName,
+    DeviceId, MxcUri, OwnedEventId, OwnedRoomId, RoomId, ServerName,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -2410,11 +2411,16 @@ impl<'a> MockEndpoint<'a, SetRoomPinnedEventsEndpoint> {
 pub struct WhoAmIEndpoint;
 
 impl<'a> MockEndpoint<'a, WhoAmIEndpoint> {
-    /// Returns a successful response with a user ID and device ID.
+    /// Returns a successful response with the default device ID.
     pub fn ok(self) -> MatrixMock<'a> {
+        self.ok_with_device_id(device_id!("D3V1C31D"))
+    }
+
+    /// Returns a successful response with the given device ID.
+    pub fn ok_with_device_id(self, device_id: &DeviceId) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "user_id": "@joe:example.org",
-            "device_id": "D3V1C31D",
+            "device_id": device_id,
         })))
     }
 

--- a/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
@@ -295,12 +295,17 @@ impl<'a> MockEndpoint<'a, DeviceAuthorizationEndpoint> {
 pub struct TokenEndpoint;
 
 impl<'a> MockEndpoint<'a, TokenEndpoint> {
-    /// Returns a successful token response.
+    /// Returns a successful token response with the default tokens.
     pub fn ok(self) -> MatrixMock<'a> {
+        self.ok_with_tokens("1234", "ZYXWV")
+    }
+
+    /// Returns a successful token response with custom tokens.
+    pub fn ok_with_tokens(self, access_token: &str, refresh_token: &str) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "access_token": "1234",
+            "access_token": access_token,
             "expires_in": 300,
-            "refresh_token": "ZYXWV",
+            "refresh_token":  refresh_token,
             "token_type": "Bearer"
         })))
     }


### PR DESCRIPTION
This can be reviewed commit by commit:

1. Merge `finish_authorization()` and `finish_login()`: now the user only needs to call `finish_login()`, since currently the only way to use the authorization code flow is for logging in it makes more sense.
2. Allow to log into the same session several times: useful for soft logouts, we just check that we are indeed logged into the same session.
3. Get rid of `OAuthError::MissingDeviceId`: since we are the ones providing the device ID to the server, there is clearly a way to work around the ID missing in the response.