### PR TITLE
feat(timeline): add functions for sending messages in threads

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -67,3 +67,6 @@ Additions:
 - Expose `report_room` to `Room`
 - Add `RoomInfo::encryption_state`
   ([#4788](https://github.com/matrix-org/matrix-rust-sdk/pull/4788))
+- Add `Timeline::send_thread_reply` for clients that need to start threads
+  themselves.
+  ([4819](https://github.com/matrix-org/matrix-rust-sdk/pull/4819))

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -48,7 +48,7 @@ use ruma::{
         },
         receipt::ReceiptThread,
         room::message::{
-            ForwardThread, LocationMessageEventContent, MessageType,
+            ForwardThread, LocationMessageEventContent, MessageType, ReplyWithinThread,
             RoomMessageEventContentWithoutRelation,
         },
         AnyMessageLikeEventContent,
@@ -461,6 +461,10 @@ impl Timeline {
         Ok(())
     }
 
+    /// Send a reply.
+    ///
+    /// If the replied to event has a thread relation, it is forwarded on the reply
+    /// so that clients that support threads can render the reply inside the thread.
     pub async fn send_reply(
         &self,
         msg: Arc<RoomMessageEventContentWithoutRelation>,
@@ -475,6 +479,29 @@ impl Timeline {
 
         self.inner
             .send_reply((*msg).clone(), replied_to_info, ForwardThread::Yes)
+            .await
+            .map_err(|err| anyhow::anyhow!(err))?;
+        Ok(())
+    }
+
+    /// Send a message on a thread.
+    ///
+    /// If the replied to event does not have a thread relation, it becomes the root
+    /// of a new thread.
+    pub async fn send_thread_reply(
+        &self,
+        msg: Arc<RoomMessageEventContentWithoutRelation>,
+        event_id: String,
+    ) -> Result<(), ClientError> {
+        let event_id = EventId::parse(event_id)?;
+        let replied_to_info = self
+            .inner
+            .replied_to_info_from_event_id(&event_id)
+            .await
+            .map_err(|err| anyhow::anyhow!(err))?;
+
+        self.inner
+            .send_thread_reply((*msg).clone(), replied_to_info, ReplyWithinThread::No)
             .await
             .map_err(|err| anyhow::anyhow!(err))?;
         Ok(())

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -479,7 +479,11 @@ impl Timeline {
             .map_err(|err| anyhow::anyhow!(err))?;
 
         self.inner
-            .send_reply((*msg).clone(), replied_to_info, ForwardThread::Yes)
+            .send_reply(
+                (*msg).clone(),
+                replied_to_info,
+                timeline::EnforceThread::No(ForwardThread::Yes),
+            )
             .await
             .map_err(|err| anyhow::anyhow!(err))?;
         Ok(())
@@ -502,7 +506,11 @@ impl Timeline {
             .map_err(|err| anyhow::anyhow!(err))?;
 
         self.inner
-            .send_thread_reply((*msg).clone(), replied_to_info, ReplyWithinThread::No)
+            .send_reply(
+                (*msg).clone(),
+                replied_to_info,
+                timeline::EnforceThread::Yes(ReplyWithinThread::No),
+            )
             .await
             .map_err(|err| anyhow::anyhow!(err))?;
         Ok(())

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -493,10 +493,19 @@ impl Timeline {
     ///
     /// If the replied to event does not have a thread relation, it becomes the
     /// root of a new thread.
+    ///
+    /// # Arguments
+    ///
+    /// * `msg` - Message content to send
+    ///
+    /// * `event_id` - ID of the event to reply to
+    ///
+    /// * `is_reply` - Whether the message is a reply on a thread
     pub async fn send_thread_reply(
         &self,
         msg: Arc<RoomMessageEventContentWithoutRelation>,
         event_id: String,
+        is_reply: bool,
     ) -> Result<(), ClientError> {
         let event_id = EventId::parse(event_id)?;
         let replied_to_info = self
@@ -509,7 +518,11 @@ impl Timeline {
             .send_reply(
                 (*msg).clone(),
                 replied_to_info,
-                timeline::EnforceThread::Yes(ReplyWithinThread::No),
+                timeline::EnforceThread::Yes(if is_reply {
+                    ReplyWithinThread::Yes
+                } else {
+                    ReplyWithinThread::No
+                }),
             )
             .await
             .map_err(|err| anyhow::anyhow!(err))?;

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -463,8 +463,9 @@ impl Timeline {
 
     /// Send a reply.
     ///
-    /// If the replied to event has a thread relation, it is forwarded on the reply
-    /// so that clients that support threads can render the reply inside the thread.
+    /// If the replied to event has a thread relation, it is forwarded on the
+    /// reply so that clients that support threads can render the reply
+    /// inside the thread.
     pub async fn send_reply(
         &self,
         msg: Arc<RoomMessageEventContentWithoutRelation>,
@@ -486,8 +487,8 @@ impl Timeline {
 
     /// Send a message on a thread.
     ///
-    /// If the replied to event does not have a thread relation, it becomes the root
-    /// of a new thread.
+    /// If the replied to event does not have a thread relation, it becomes the
+    /// root of a new thread.
     pub async fn send_thread_reply(
         &self,
         msg: Arc<RoomMessageEventContentWithoutRelation>,

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -48,7 +48,7 @@ use ruma::{
         },
         receipt::ReceiptThread,
         room::message::{
-            ForwardThread, LocationMessageEventContent, MessageType, ReplyWithinThread,
+            LocationMessageEventContent, MessageType, ReplyWithinThread,
             RoomMessageEventContentWithoutRelation,
         },
         AnyMessageLikeEventContent,
@@ -479,11 +479,7 @@ impl Timeline {
             .map_err(|err| anyhow::anyhow!(err))?;
 
         self.inner
-            .send_reply(
-                (*msg).clone(),
-                replied_to_info,
-                timeline::EnforceThread::No(ForwardThread::Yes),
-            )
+            .send_reply((*msg).clone(), replied_to_info, timeline::EnforceThread::MaybeThreaded)
             .await
             .map_err(|err| anyhow::anyhow!(err))?;
         Ok(())
@@ -518,7 +514,7 @@ impl Timeline {
             .send_reply(
                 (*msg).clone(),
                 replied_to_info,
-                timeline::EnforceThread::Yes(if is_reply {
+                timeline::EnforceThread::Threaded(if is_reply {
                     ReplyWithinThread::Yes
                 } else {
                     ReplyWithinThread::No

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add `Timeline::send_thread_reply` for clients that need to start threads
+  themselves.
+  ([4819](https://github.com/matrix-org/matrix-rust-sdk/pull/4819))
+
 ### Refactor
 
 - [**breaking**] Reactions on a given timeline item have been moved from

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -10,8 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Add `Timeline::send_thread_reply` for clients that need to start threads
-  themselves.
+- Optionally allow starting threads with `Timeline::send_reply`.
   ([4819](https://github.com/matrix-org/matrix-rust-sdk/pull/4819))
 
 ### Refactor

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Optionally allow starting threads with `Timeline::send_reply`.
+- [**breaking**] Optionally allow starting threads with `Timeline::send_reply`.
   ([4819](https://github.com/matrix-org/matrix-rust-sdk/pull/4819))
 
 ### Refactor

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -41,6 +41,7 @@ use ruma::{
         receipt::{Receipt, ReceiptThread},
         relation::Thread,
         room::{
+            encrypted::Relation as EncryptedRelation,
             message::{
                 AddMentions, ForwardThread, OriginalRoomMessageEvent, Relation, ReplyWithinThread,
                 RoomMessageEventContentWithoutRelation,
@@ -391,7 +392,7 @@ impl Timeline {
                         #[derive(Deserialize)]
                         struct ContentDeHelper {
                             #[serde(rename = "m.relates_to")]
-                            relates_to: Option<ruma::events::room::encrypted::Relation>,
+                            relates_to: Option<EncryptedRelation>,
                         }
 
                         let previous_content =
@@ -409,14 +410,13 @@ impl Timeline {
                             content.into()
                         };
 
-                        let thread_root =
-                            if let Some(ruma::events::room::encrypted::Relation::Thread(thread)) =
-                                previous_content.as_ref().and_then(|c| c.relates_to.as_ref())
-                            {
-                                thread.event_id.to_owned()
-                            } else {
-                                replied_to_info.event_id.to_owned()
-                            };
+                        let thread_root = if let Some(EncryptedRelation::Thread(thread)) =
+                            previous_content.as_ref().and_then(|c| c.relates_to.as_ref())
+                        {
+                            thread.event_id.to_owned()
+                        } else {
+                            replied_to_info.event_id.to_owned()
+                        };
 
                         let thread = if is_reply == ReplyWithinThread::Yes {
                             Thread::reply(thread_root, replied_to_info.event_id)

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -373,8 +373,9 @@ impl Timeline {
 
     /// Send a message on a thread.
     ///
-    /// If the message is also a reply, the sender will be added to the mentions of the reply if
-    /// and only if the event has not been written by the sender.
+    /// If the message is also a reply, the sender will be added to the mentions
+    /// of the reply if and only if the event has not been written by the
+    /// sender.
     ///
     /// # Arguments
     ///

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -147,11 +147,11 @@ pub enum EnforceThread {
     Threaded(ReplyWithinThread),
 
     /// A thread relation is not enforced. If the original message has a thread
-    /// relation, it is forwarded, however.
+    /// relation, it is forwarded.
     MaybeThreaded,
 
     /// A thread relation is not enforced. If the original message has a thread
-    /// relation, it is *not* forwarded, however.
+    /// relation, it is *not* forwarded.
     Unthreaded,
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -21,7 +21,9 @@ use ruma::{
             encrypted::{
                 EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
             },
-            message::{ForwardThread, Relation, ReplyWithinThread, RoomMessageEventContentWithoutRelation},
+            message::{
+                ForwardThread, Relation, ReplyWithinThread, RoomMessageEventContentWithoutRelation,
+            },
             ImageInfo,
         },
         sticker::{StickerEventContent, StickerMediaSource},
@@ -949,7 +951,6 @@ async fn test_send_thread_reply() {
                 .body_json::<RoomMessageEventContent>()
                 .expect("Failed to deserialize the event");
 
-                
             assert_matches!(reply_event.relates_to, Some(Relation::Thread(thread)) => {
                 assert_eq!(thread.event_id, event_id_from_bob);
                 assert_eq!(thread.in_reply_to.unwrap().event_id, event_id_from_bob);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -10,7 +10,8 @@ use matrix_sdk_test::{
     async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE, BOB, CAROL,
 };
 use matrix_sdk_ui::timeline::{
-    EnforceThread, Error as TimelineError, EventSendState, RoomExt, TimelineDetails, TimelineItemContent
+    EnforceThread, Error as TimelineError, EventSendState, RoomExt, TimelineDetails,
+    TimelineItemContent,
 };
 use ruma::{
     event_id,
@@ -939,7 +940,8 @@ async fn test_send_reply_enforce_thread() {
     assert_next_matches!(timeline_stream, VectorDiff::Clear);
 
     // Now, let's reply to a message sent by `BOB`.
-    server.mock_room_send()
+    server
+        .mock_room_send()
         .respond_with(move |req: &Request| {
             use ruma::events::room::message::RoomMessageEventContent;
 
@@ -1026,7 +1028,8 @@ async fn test_send_reply_enforce_thread_is_reply() {
     assert_next_matches!(timeline_stream, VectorDiff::Clear);
 
     // Now, let's reply to a message sent by `BOB`.
-    server.mock_room_send()
+    server
+        .mock_room_send()
         .respond_with(move |req: &Request| {
             use ruma::events::room::message::RoomMessageEventContent;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -21,7 +21,7 @@ use ruma::{
             encrypted::{
                 EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
             },
-            message::{ForwardThread, Relation, RoomMessageEventContentWithoutRelation},
+            message::{ForwardThread, Relation, ReplyWithinThread, RoomMessageEventContentWithoutRelation},
             ImageInfo,
         },
         sticker::{StickerEventContent, StickerMediaSource},
@@ -904,6 +904,107 @@ async fn test_send_reply_with_event_id() {
     assert_eq!(reply_message.body(), "Replying to Bob");
     let in_reply_to = reply_message.in_reply_to().unwrap();
     assert_eq!(in_reply_to.event_id, event_id_from_bob);
+}
+
+#[async_test]
+async fn test_send_thread_reply() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let timeline = room.timeline().await.unwrap();
+    let (_, mut timeline_stream) =
+        timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
+
+    let event_id_from_bob = event_id!("$event_from_bob");
+    let f = EventFactory::new();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(
+                f.text_msg("Hello from Bob").sender(&BOB).event_id(event_id_from_bob),
+            ),
+        )
+        .await;
+
+    let event_from_bob =
+        assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);
+
+    // Clear the timeline to make sure the old item does not need to be
+    // available in it for the reply to work.
+    timeline.clear().await;
+    assert_next_matches!(timeline_stream, VectorDiff::Clear);
+
+    // Now, let's reply to a message sent by `BOB`.
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
+        .respond_with(move |req: &Request| {
+            use ruma::events::room::message::RoomMessageEventContent;
+
+            let reply_event = req
+                .body_json::<RoomMessageEventContent>()
+                .expect("Failed to deserialize the event");
+
+                
+            assert_matches!(reply_event.relates_to, Some(Relation::Thread(thread)) => {
+                assert_eq!(thread.event_id, event_id_from_bob);
+                assert_eq!(thread.in_reply_to.unwrap().event_id, event_id_from_bob);
+            });
+            assert_matches!(reply_event.mentions, None);
+
+            ResponseTemplate::new(200).set_body_json(json!({ "event_id": "$reply_event" }))
+        })
+        .expect(1)
+        .mount(server.server())
+        .await;
+
+    let replied_to_info = event_from_bob.replied_to_info().unwrap();
+    timeline
+        .send_thread_reply(
+            RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),
+            replied_to_info,
+            ReplyWithinThread::No,
+        )
+        .await
+        .unwrap();
+
+    // Let the send queue handle the event.
+    yield_now().await;
+
+    let reply_item = assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);
+
+    assert_matches!(reply_item.send_state(), Some(EventSendState::NotSentYet));
+    let reply_message = reply_item.content().as_message().unwrap();
+    assert_eq!(reply_message.body(), "Replying to Bob");
+    let in_reply_to = reply_message.in_reply_to().unwrap();
+    assert_eq!(in_reply_to.event_id, event_id_from_bob);
+
+    // Right now, we don't pass along the replied-to event to the event handler,
+    // so it's not available if the timeline got cleared. Not critical, but
+    // there's notable room for improvement here.
+    //
+    // let replied_to_event =
+    // assert_matches!(&in_reply_to.event, TimelineDetails::Ready(ev) => ev);
+    // assert_eq!(replied_to_event.sender(), *BOB);
+
+    let diff = timeout(timeline_stream.next(), Duration::from_secs(1)).await.unwrap().unwrap();
+    assert_let!(VectorDiff::Set { index: 0, value: reply_item_remote_echo } = diff);
+
+    assert_matches!(reply_item_remote_echo.send_state(), Some(EventSendState::Sent { .. }));
+    let reply_message = reply_item_remote_echo.content().as_message().unwrap();
+    assert_eq!(reply_message.body(), "Replying to Bob");
+    let in_reply_to = reply_message.in_reply_to().unwrap();
+    assert_eq!(in_reply_to.event_id, event_id_from_bob);
+
+    // Same as above.
+    //
+    // let replied_to_event =
+    // assert_matches!(&in_reply_to.event, TimelineDetails::Ready(ev) =>
+    // ev); assert_eq!(replied_to_event.sender(), *BOB);
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -10,7 +10,7 @@ use matrix_sdk_test::{
     async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE, BOB, CAROL,
 };
 use matrix_sdk_ui::timeline::{
-    Error as TimelineError, EventSendState, RoomExt, TimelineDetails, TimelineItemContent,
+    EnforceThread, Error as TimelineError, EventSendState, RoomExt, TimelineDetails, TimelineItemContent
 };
 use ruma::{
     event_id,
@@ -605,7 +605,7 @@ async fn test_send_reply() {
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),
             replied_to_info,
-            ForwardThread::Yes,
+            EnforceThread::No(ForwardThread::Yes),
         )
         .await
         .unwrap();
@@ -705,7 +705,7 @@ async fn test_send_reply_to_self() {
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to self"),
             replied_to_info,
-            ForwardThread::Yes,
+            EnforceThread::No(ForwardThread::Yes),
         )
         .await
         .unwrap();
@@ -771,7 +771,7 @@ async fn test_send_reply_to_threaded() {
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Hello, Bob!"),
             replied_to_info,
-            ForwardThread::Yes,
+            EnforceThread::No(ForwardThread::Yes),
         )
         .await
         .unwrap();
@@ -879,7 +879,7 @@ async fn test_send_reply_with_event_id() {
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),
             replied_to_info,
-            ForwardThread::Yes,
+            EnforceThread::No(ForwardThread::Yes),
         )
         .await
         .unwrap();
@@ -906,7 +906,7 @@ async fn test_send_reply_with_event_id() {
 }
 
 #[async_test]
-async fn test_send_thread_reply() {
+async fn test_send_reply_enforce_thread() {
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
 
@@ -961,10 +961,10 @@ async fn test_send_thread_reply() {
 
     let replied_to_info = event_from_bob.replied_to_info().unwrap();
     timeline
-        .send_thread_reply(
+        .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),
             replied_to_info,
-            ReplyWithinThread::No,
+            EnforceThread::Yes(ReplyWithinThread::No),
         )
         .await
         .unwrap();
@@ -1074,7 +1074,7 @@ async fn test_send_reply_with_event_id_that_is_redacted() {
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),
             replied_to_info,
-            ForwardThread::Yes,
+            EnforceThread::No(ForwardThread::Yes),
         )
         .await
         .unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -22,9 +22,7 @@ use ruma::{
             encrypted::{
                 EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
             },
-            message::{
-                ForwardThread, Relation, ReplyWithinThread, RoomMessageEventContentWithoutRelation,
-            },
+            message::{Relation, ReplyWithinThread, RoomMessageEventContentWithoutRelation},
             ImageInfo,
         },
         sticker::{StickerEventContent, StickerMediaSource},
@@ -606,7 +604,7 @@ async fn test_send_reply() {
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),
             replied_to_info,
-            EnforceThread::No(ForwardThread::Yes),
+            EnforceThread::MaybeThreaded,
         )
         .await
         .unwrap();
@@ -706,7 +704,7 @@ async fn test_send_reply_to_self() {
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to self"),
             replied_to_info,
-            EnforceThread::No(ForwardThread::Yes),
+            EnforceThread::MaybeThreaded,
         )
         .await
         .unwrap();
@@ -772,7 +770,7 @@ async fn test_send_reply_to_threaded() {
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Hello, Bob!"),
             replied_to_info,
-            EnforceThread::No(ForwardThread::Yes),
+            EnforceThread::MaybeThreaded,
         )
         .await
         .unwrap();
@@ -880,7 +878,7 @@ async fn test_send_reply_with_event_id() {
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),
             replied_to_info,
-            EnforceThread::No(ForwardThread::Yes),
+            EnforceThread::MaybeThreaded,
         )
         .await
         .unwrap();
@@ -966,7 +964,7 @@ async fn test_send_reply_enforce_thread() {
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),
             replied_to_info,
-            EnforceThread::Yes(ReplyWithinThread::No),
+            EnforceThread::Threaded(ReplyWithinThread::No),
         )
         .await
         .unwrap();
@@ -1063,7 +1061,7 @@ async fn test_send_reply_enforce_thread_is_reply() {
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),
             replied_to_info,
-            EnforceThread::Yes(ReplyWithinThread::Yes),
+            EnforceThread::Threaded(ReplyWithinThread::Yes),
         )
         .await
         .unwrap();
@@ -1161,7 +1159,7 @@ async fn test_send_reply_with_event_id_that_is_redacted() {
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),
             replied_to_info,
-            EnforceThread::No(ForwardThread::Yes),
+            EnforceThread::MaybeThreaded,
         )
         .await
         .unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -578,8 +578,7 @@ async fn test_send_reply() {
     assert_next_matches!(timeline_stream, VectorDiff::Clear);
 
     // Now, let's reply to a message sent by `BOB`.
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
+    server.mock_room_send()
         .respond_with(move |req: &Request| {
             use ruma::events::room::message::RoomMessageEventContent;
 
@@ -598,7 +597,7 @@ async fn test_send_reply() {
             ResponseTemplate::new(200).set_body_json(json!({ "event_id": "$reply_event" }))
         })
         .expect(1)
-        .mount(server.server())
+        .mount()
         .await;
 
     let replied_to_info = event_from_bob.replied_to_info().unwrap();
@@ -682,8 +681,7 @@ async fn test_send_reply_to_self() {
     assert_next_matches!(timeline_stream, VectorDiff::Clear);
 
     // Now, let's reply to a message sent by the current user.
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
+    server.mock_room_send()
         .respond_with(move |req: &Request| {
             use ruma::events::room::message::RoomMessageEventContent;
 
@@ -699,7 +697,7 @@ async fn test_send_reply_to_self() {
             ResponseTemplate::new(200).set_body_json(json!({ "event_id": "$reply_event" }))
         })
         .expect(1)
-        .mount(server.server())
+        .mount()
         .await;
 
     let replied_to_info = event_from_self.replied_to_info().unwrap();
@@ -849,8 +847,7 @@ async fn test_send_reply_with_event_id() {
     assert_next_matches!(timeline_stream, VectorDiff::Clear);
 
     // Now, let's reply to a message sent by `BOB`.
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
+    server.mock_room_send()
         .respond_with(move |req: &Request| {
             use ruma::events::room::message::RoomMessageEventContent;
 
@@ -869,7 +866,7 @@ async fn test_send_reply_with_event_id() {
             ResponseTemplate::new(200).set_body_json(json!({ "event_id": "$reply_event" }))
         })
         .expect(1)
-        .mount(server.server())
+        .mount()
         .await;
 
     // Since we assume we can't use the timeline item directly in this use case, the
@@ -942,8 +939,7 @@ async fn test_send_thread_reply() {
     assert_next_matches!(timeline_stream, VectorDiff::Clear);
 
     // Now, let's reply to a message sent by `BOB`.
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
+    server.mock_room_send()
         .respond_with(move |req: &Request| {
             use ruma::events::room::message::RoomMessageEventContent;
 
@@ -960,7 +956,7 @@ async fn test_send_thread_reply() {
             ResponseTemplate::new(200).set_body_json(json!({ "event_id": "$reply_event" }))
         })
         .expect(1)
-        .mount(server.server())
+        .mount()
         .await;
 
     let replied_to_info = event_from_bob.replied_to_info().unwrap();
@@ -1045,8 +1041,7 @@ async fn test_send_reply_with_event_id_that_is_redacted() {
     assert_next_matches!(timeline_stream, VectorDiff::Clear);
 
     // Now, let's reply to a message sent by `BOB`.
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
+    server.mock_room_send()
         .respond_with(move |req: &Request| {
             use ruma::events::room::message::RoomMessageEventContent;
 
@@ -1065,7 +1060,7 @@ async fn test_send_reply_with_event_id_that_is_redacted() {
             ResponseTemplate::new(200).set_body_json(json!({ "event_id": "$reply_event" }))
         })
         .expect(1)
-        .mount(server.server())
+        .mount()
         .await;
 
     // Since we assume we can't use the timeline item directly in this use case, the

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -980,14 +980,6 @@ async fn test_send_reply_enforce_thread() {
     let in_reply_to = reply_message.in_reply_to().unwrap();
     assert_eq!(in_reply_to.event_id, event_id_from_bob);
 
-    // Right now, we don't pass along the replied-to event to the event handler,
-    // so it's not available if the timeline got cleared. Not critical, but
-    // there's notable room for improvement here.
-    //
-    // let replied_to_event =
-    // assert_matches!(&in_reply_to.event, TimelineDetails::Ready(ev) => ev);
-    // assert_eq!(replied_to_event.sender(), *BOB);
-
     let diff = timeout(timeline_stream.next(), Duration::from_secs(1)).await.unwrap().unwrap();
     assert_let!(VectorDiff::Set { index: 0, value: reply_item_remote_echo } = diff);
 
@@ -997,11 +989,6 @@ async fn test_send_reply_enforce_thread() {
     let in_reply_to = reply_message.in_reply_to().unwrap();
     assert_eq!(in_reply_to.event_id, event_id_from_bob);
 
-    // Same as above.
-    //
-    // let replied_to_event =
-    // assert_matches!(&in_reply_to.event, TimelineDetails::Ready(ev) =>
-    // ev); assert_eq!(replied_to_event.sender(), *BOB);
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -979,6 +979,7 @@ async fn test_send_reply_enforce_thread() {
     assert_eq!(reply_message.body(), "Replying to Bob");
     let in_reply_to = reply_message.in_reply_to().unwrap();
     assert_eq!(in_reply_to.event_id, event_id_from_bob);
+    assert_eq!(reply_message.thread_root().unwrap(), event_id_from_bob);
 
     let diff = timeout(timeline_stream.next(), Duration::from_secs(1)).await.unwrap().unwrap();
     assert_let!(VectorDiff::Set { index: 0, value: reply_item_remote_echo } = diff);
@@ -988,6 +989,7 @@ async fn test_send_reply_enforce_thread() {
     assert_eq!(reply_message.body(), "Replying to Bob");
     let in_reply_to = reply_message.in_reply_to().unwrap();
     assert_eq!(in_reply_to.event_id, event_id_from_bob);
+    assert_eq!(reply_message.thread_root().unwrap(), event_id_from_bob);
 
 }
 


### PR DESCRIPTION
`send_reply` is geared towards clients that don't render threads themselves. It sends a reply and optionally forwards it onto any existing thread.

This PR adds `send_thread_reply` for clients that do render threads themselves. This sends a message onto a thread, regardless of whether a thread existed before, and includes the fallback for non-threaded clients only if the message is not itself a reply on the thread.

- [ ] Public API changes documented in changelogs (optional)

