### PR TITLE
fix(ffi): propagate initial values before the future is picked by a runtime

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_directory_search.rs
+++ b/bindings/matrix-sdk-ffi/src/room_directory_search.rs
@@ -137,11 +137,11 @@ impl RoomDirectorySearch {
     ) -> Arc<TaskHandle> {
         let (initial_values, mut stream) = self.inner.read().await.results();
 
-        Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
-            listener.on_update(vec![RoomDirectorySearchEntryUpdate::Reset {
-                values: initial_values.into_iter().map(Into::into).collect(),
-            }]);
+        listener.on_update(vec![RoomDirectorySearchEntryUpdate::Reset {
+            values: initial_values.into_iter().map(Into::into).collect(),
+        }]);
 
+        Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
             while let Some(diffs) = stream.next().await {
                 listener.on_update(diffs.into_iter().map(|diff| diff.into()).collect());
             }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -215,18 +215,18 @@ impl Timeline {
     pub async fn add_listener(&self, listener: Box<dyn TimelineListener>) -> Arc<TaskHandle> {
         let (timeline_items, timeline_stream) = self.inner.subscribe().await;
 
+        // It's important that the initial items are passed *before* we forward the
+        // stream updates, with a guaranteed ordering. Otherwise, it could
+        // be that the listener be called before the initial items have been
+        // handled by the caller. See #3535 for details.
+
+        // First, pass all the items as a reset update.
+        listener.on_update(vec![Arc::new(TimelineDiff::new(VectorDiff::Reset {
+            values: timeline_items,
+        }))]);
+
         Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
             pin_mut!(timeline_stream);
-
-            // It's important that the initial items are passed *before* we forward the
-            // stream updates, with a guaranteed ordering. Otherwise, it could
-            // be that the listener be called before the initial items have been
-            // handled by the caller. See #3535 for details.
-
-            // First, pass all the items as a reset update.
-            listener.on_update(vec![Arc::new(TimelineDiff::new(VectorDiff::Reset {
-                values: timeline_items,
-            }))]);
 
             // Then forward new items.
             while let Some(diffs) = timeline_stream.next().await {
@@ -446,7 +446,7 @@ impl Timeline {
         Ok(())
     }
 
-    pub fn end_poll(
+    pub async fn end_poll(
         self: Arc<Self>,
         poll_start_event_id: String,
         text: String,
@@ -456,11 +456,9 @@ impl Timeline {
         let poll_end_event_content = UnstablePollEndEventContent::new(text, poll_start_event_id);
         let event_content = AnyMessageLikeEventContent::UnstablePollEnd(poll_end_event_content);
 
-        get_runtime_handle().spawn(async move {
-            if let Err(err) = self.inner.send(event_content).await {
-                error!("unable to end poll: {err}");
-            }
-        });
+        if let Err(err) = self.inner.send(event_content).await {
+            error!("unable to end poll: {err}");
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Same spirit as #4818; doing work after the `async move` "moves" the code inside the future, and it will be executed only when a tokio runtime is available, instead of doing it right away. We can improve and do it right away in a few cases:

- when getting the initial timeline items
- when looking at the room directory search results

I've audited all the `spawn`s at the FFI layer, so we should be in a good shape now.