### PR TITLE
feat(ffi): trace log bundles + log the log levels

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Breaking changes:
 
+- `TracingConfiguration` now includes a new field `trace_log_packs`, which gives a convenient way
+  to set the TRACE log level for multiple targets related to a given feature.
+  ([#4824](https://github.com/matrix-org/matrix-rust-sdk/pull/4824))
+
 - `setup_tracing` has been renamed `init_platform`; in addition to the `TracingConfiguration`
   parameter it also now takes a boolean indicating whether to spawn a minimal tokio runtime for the
   application; in general for main app processes this can be set to `false`, and memory-constrained

--- a/bindings/matrix-sdk-ffi/src/platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform.rs
@@ -410,10 +410,15 @@ fn build_tracing_filter(config: &TracingConfiguration) -> String {
 pub fn init_platform(config: TracingConfiguration, use_lightweight_tokio_runtime: bool) {
     log_panics();
 
+    let env_filter = build_tracing_filter(&config);
+
     tracing_subscriber::registry()
-        .with(EnvFilter::new(build_tracing_filter(&config)))
+        .with(EnvFilter::new(&env_filter))
         .with(text_layers(config))
         .init();
+
+    // Log the log levels 🧠.
+    tracing::info!(env_filter, "Logging has been set up");
 
     if use_lightweight_tokio_runtime {
         setup_lightweight_tokio_runtime();

--- a/bindings/matrix-sdk-ffi/src/tracing.rs
+++ b/bindings/matrix-sdk-ffi/src/tracing.rs
@@ -166,7 +166,7 @@ impl Span {
     }
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, uniffi::Enum)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, uniffi::Enum)]
 pub enum LogLevel {
     Error,
     Warn,
@@ -176,7 +176,7 @@ pub enum LogLevel {
 }
 
 impl LogLevel {
-    fn to_tracing_level(&self) -> tracing::Level {
+    fn to_tracing_level(self) -> tracing::Level {
         match self {
             LogLevel::Error => tracing::Level::ERROR,
             LogLevel::Warn => tracing::Level::WARN,


### PR DESCRIPTION
This is a new convenient way to enable the TRACE log levels for multiple targets at the same time, when they relate to the same feature. For instance, there's a log pack for the event cache, that will enable the trace level for `matrix_sdk::event_cache`, `matrix_sdk_base::event_cache` and `matrix_sdk_sqlite::event_cache_store` at the same time.

I haven't made it possible to configure the log *level* (instead of TRACE) for those targets, because I think we won't need it; the only interesting case is debugging purposes, which usually requires trace logs.

Also, log the env filter string, so we know when looking at rageshakes what logs are enabled.