### PR TITLE
feat(sqlite): Add `StoreOpenConfig` and `open_with_config` for all stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3203,6 +3203,7 @@ dependencies = [
  "matrix-sdk-crypto",
  "matrix-sdk-store-encryption",
  "matrix-sdk-test",
+ "num_cpus",
  "once_cell",
  "rmp-serde",
  "ruma",

--- a/crates/matrix-sdk-sqlite/CHANGELOG.md
+++ b/crates/matrix-sdk-sqlite/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
   ([#4603](https://github.com/matrix-org/matrix-rust-sdk/pull/4603))
 - Defragment an sqlite state store after removing a room.
   ([#4651](https://github.com/matrix-org/matrix-rust-sdk/pull/4651))
+- Add `SqliteStoreConfig` and the `open_with_config` constructor on all the
+  stores, it allows to control the maximum size of the pool of connections to
+  SQLite for example.
+  ([#4826](https://github.com/matrix-org/matrix-rust-sdk/pull/4826))
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -23,6 +23,7 @@ itertools = { workspace = true }
 matrix-sdk-base = { workspace = true, optional = true }
 matrix-sdk-crypto = { workspace = true, optional = true }
 matrix-sdk-store-encryption = { workspace = true }
+num_cpus = "1.16.0"
 rmp-serde = { workspace = true }
 ruma = { workspace = true }
 rusqlite = { version = "0.32.1", features = ["limits"] }

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -51,8 +51,11 @@ use crate::{
         repeat_vars, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
         SqliteKeyValueStoreConnExt,
     },
-    OpenStoreError,
+    OpenStoreError, SqliteStoreConfig,
 };
+
+/// The database name.
+const DATABASE_NAME: &str = "matrix-sdk-crypto.sqlite3";
 
 /// A sqlite based cryptostore.
 #[derive(Clone)]
@@ -79,12 +82,21 @@ impl SqliteCryptoStore {
         path: impl AsRef<Path>,
         passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {
-        let path = path.as_ref();
-        fs::create_dir_all(path).await.map_err(OpenStoreError::CreateDir)?;
-        let cfg = deadpool_sqlite::Config::new(path.join("matrix-sdk-crypto.sqlite3"));
-        let pool = cfg.create_pool(Runtime::Tokio1)?;
+        Self::open_with_config(SqliteStoreConfig::new(path).passphrase(passphrase)).await
+    }
 
-        Self::open_with_pool(pool, passphrase).await
+    /// Open the sqlite-based crypto store with the config open config.
+    pub async fn open_with_config(config: SqliteStoreConfig) -> Result<Self, OpenStoreError> {
+        let SqliteStoreConfig { path, passphrase, pool_config } = config;
+
+        fs::create_dir_all(&path).await.map_err(OpenStoreError::CreateDir)?;
+
+        let mut config = deadpool_sqlite::Config::new(path.join(DATABASE_NAME));
+        config.pool = Some(pool_config);
+
+        let pool = config.create_pool(Runtime::Tokio1)?;
+
+        Self::open_with_pool(pool, passphrase.as_deref()).await
     }
 
     /// Create a sqlite-based crypto store using the given sqlite database pool.
@@ -1421,6 +1433,7 @@ mod tests {
     use tokio::fs;
 
     use super::SqliteCryptoStore;
+    use crate::SqliteStoreConfig;
 
     static TMP_DIR: Lazy<TempDir> = Lazy::new(|| tempdir().unwrap());
 
@@ -1431,8 +1444,8 @@ mod tests {
         database: SqliteCryptoStore,
     }
 
-    async fn get_test_db(data_path: &str, passphrase: Option<&str>) -> TestDb {
-        let db_name = "matrix-sdk-crypto.sqlite3";
+    fn copy_db(data_path: &str) -> TempDir {
+        let db_name = super::DATABASE_NAME;
 
         let manifest_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
         let database_path = manifest_path.join(data_path).join(db_name);
@@ -1443,11 +1456,27 @@ mod tests {
         // Copy the test database to the tempdir so our test runs are idempotent.
         std::fs::copy(&database_path, destination).unwrap();
 
+        tmpdir
+    }
+
+    async fn get_test_db(data_path: &str, passphrase: Option<&str>) -> TestDb {
+        let tmpdir = copy_db(data_path);
+
         let database = SqliteCryptoStore::open(tmpdir.path(), passphrase)
             .await
             .expect("Can't open the test store");
 
         TestDb { _dir: tmpdir, database }
+    }
+
+    #[async_test]
+    async fn test_pool_size() {
+        let store_open_config =
+            SqliteStoreConfig::new(TMP_DIR.path().join("test_pool_size")).pool_max_size(42);
+
+        let store = SqliteCryptoStore::open_with_config(store_open_config).await.unwrap();
+
+        assert_eq!(store.pool.status().max_size, 42);
     }
 
     /// Test that we didn't regress in our storage layer by loading data from a
@@ -1787,6 +1816,7 @@ mod tests {
         assert_eq!(backup_keys.backup_version.unwrap(), "6");
         assert!(backup_keys.decryption_key.is_some());
     }
+
     async fn get_store(
         name: &str,
         passphrase: Option<&str>,

--- a/crates/matrix-sdk-sqlite/src/lib.rs
+++ b/crates/matrix-sdk-sqlite/src/lib.rs
@@ -24,6 +24,9 @@ mod event_cache_store;
 #[cfg(feature = "state-store")]
 mod state_store;
 mod utils;
+use std::path::{Path, PathBuf};
+
+use deadpool_sqlite::PoolConfig;
 
 #[cfg(feature = "crypto-store")]
 pub use self::crypto_store::SqliteCryptoStore;
@@ -35,3 +38,59 @@ pub use self::state_store::SqliteStateStore;
 
 #[cfg(test)]
 matrix_sdk_test::init_tracing_for_tests!();
+
+/// A configuration structure used for opening a store.
+pub struct SqliteStoreConfig {
+    /// Path to the database, without the file name.
+    path: PathBuf,
+    /// Passphrase to open the store, if any.
+    passphrase: Option<String>,
+    /// The pool configuration for [`deadpool_sqlite`].
+    pool_config: PoolConfig,
+}
+
+impl SqliteStoreConfig {
+    /// Create a new [`SqliteStoreConfig`] with a path representing the
+    /// directory containing the store database.
+    pub fn new<P>(path: P) -> Self
+    where
+        P: AsRef<Path>,
+    {
+        Self {
+            path: path.as_ref().to_path_buf(),
+            passphrase: None,
+            pool_config: PoolConfig::new(num_cpus::get_physical() * 4),
+        }
+    }
+
+    /// Define the passphrase if the store is encoded.
+    pub fn passphrase(mut self, passphrase: Option<&str>) -> Self {
+        self.passphrase = passphrase.map(|passphrase| passphrase.to_owned());
+        self
+    }
+
+    /// Define the maximum pool size for [`deadpool_sqlite`].
+    ///
+    /// See [`deadpool_sqlite::PoolConfig::max_size`] to learn more.
+    pub fn pool_max_size(mut self, max_size: usize) -> Self {
+        self.pool_config.max_size = max_size;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::SqliteStoreConfig;
+
+    #[test]
+    fn test_store_open_config() {
+        let store_open_config =
+            SqliteStoreConfig::new(Path::new("foo")).passphrase(Some("bar")).pool_max_size(42);
+
+        assert_eq!(store_open_config.path, PathBuf::from("foo"));
+        assert_eq!(store_open_config.passphrase, Some("bar".to_owned()));
+        assert_eq!(store_open_config.pool_config.max_size, 42);
+    }
+}


### PR DESCRIPTION
This patch adds a new `StoreOpenConfig` type to configure the store when opening it and when creating the pool of connections to SQLite via `deadpool_sqlite`.

This patch also adds a new `open_with_config` constructor on all stores, namely `SqliteCryptoStore`, `SqliteEventCacheStore` and `SqliteStateStore`.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4801