### PR TITLE
refactor(oauth): Allow to use any registration method with any login function

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -410,11 +410,13 @@ impl Client {
         let registrations = oidc_configuration.registrations().await?;
         let redirect_uri = oidc_configuration.redirect_uri()?;
 
-        let data = self
-            .inner
-            .oauth()
-            .url_for_oidc(registrations, redirect_uri, prompt.map(Into::into))
-            .await?;
+        let mut url_builder = self.inner.oauth().login(registrations.into(), redirect_uri, None);
+
+        if let Some(prompt) = prompt {
+            url_builder = url_builder.prompt(vec![prompt.into()]);
+        }
+
+        let data = url_builder.build().await?;
 
         Ok(Arc::new(data))
     }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -428,14 +428,10 @@ impl Client {
     }
 
     /// Completes the OIDC login process.
-    pub async fn login_with_oidc_callback(
-        &self,
-        authorization_data: Arc<OAuthAuthorizationData>,
-        callback_url: String,
-    ) -> Result<(), OidcError> {
+    pub async fn login_with_oidc_callback(&self, callback_url: String) -> Result<(), OidcError> {
         let url = Url::parse(&callback_url).or(Err(OidcError::CallbackUrlInvalid))?;
 
-        self.inner.oauth().login_with_oidc_callback(&authorization_data, url).await?;
+        self.inner.oauth().finish_login(url.into()).await?;
 
         Ok(())
     }

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -688,12 +688,13 @@ impl ClientBuilder {
             }
         })?;
 
-        let client_metadata = oidc_configuration
-            .client_metadata()
+        let registrations = oidc_configuration
+            .registrations()
+            .await
             .map_err(|_| HumanQrLoginError::OidcMetadataInvalid)?;
 
         let oauth = client.inner.oauth();
-        let login = oauth.login_with_qr_code(&qr_code_data.inner, client_metadata);
+        let login = oauth.login_with_qr_code(&qr_code_data.inner, registrations.into());
 
         let mut progress = login.subscribe_to_progress();
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -200,6 +200,22 @@ simpler methods:
   - `OAuthRegistrationStore::new()` no longer takes a `static_registrations`
     parameter. It should be provided if needed with
     `OAuthRegistrationStore::with_static_registrations()`.
+- [**breaking**] Allow to use any registration method with `OAuth::login()` and
+  `OAuth::login_with_qr_code()`.
+  ([#4827](https://github.com/matrix-org/matrix-rust-sdk/pull/4827))
+  - `OAuth::login` takes an `ClientRegistrationMethod` to be able to register
+    and login with a single function call.
+  - `OAuth::url_for_oidc()` was removed, it can be replaced by a call to
+    `OAuth::login()`.
+  - `OAuth::login_with_qr_code()` takes a `ClientRegistrationMethod` instead of
+    the client metadata.
+  - `OAuth::finish_login` takes a `UrlOrQuery` instead of an
+    `AuthorizationCode`. The deserialization of the query string will occur
+    inside the method and eventual errors will be handled.
+  - `OAuth::login_with_oidc_callback()` was removed, it can be replaced by a
+    call to `OAuth::finish_login()`.
+  - `AuthorizationResponse`, `AuthorizationCode` and `AuthorizationError` are
+    now private.
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -448,7 +448,7 @@ impl OAuth {
 
         self.configure(server_metadata.issuer, registrations).await?;
 
-        let mut data_builder = self.login(redirect_uri, None)?;
+        let mut data_builder = self.login(redirect_uri, None);
 
         if let Some(prompt) = prompt {
             data_builder = data_builder.prompt(vec![prompt]);
@@ -1003,10 +1003,6 @@ impl OAuth {
     ///   device ID from a previous login call. Note that this should be done
     ///   only if the client also holds the corresponding encryption keys.
     ///
-    /// # Errors
-    ///
-    /// Returns an error if the device ID is not valid.
-    ///
     /// # Example
     ///
     /// ```no_run
@@ -1029,7 +1025,7 @@ impl OAuth {
     ///     client_id,
     /// );
     ///
-    /// let auth_data = oauth.login(redirect_uri, None)?.build().await?;
+    /// let auth_data = oauth.login(redirect_uri, None).build().await?;
     ///
     /// // Open auth_data.url and wait for response at the redirect URI.
     /// let redirected_to_uri = open_uri_and_wait_for_redirect(auth_data.url).await;
@@ -1057,10 +1053,10 @@ impl OAuth {
         &self,
         redirect_uri: Url,
         device_id: Option<OwnedDeviceId>,
-    ) -> Result<OAuthAuthCodeUrlBuilder, OAuthError> {
+    ) -> OAuthAuthCodeUrlBuilder {
         let (scopes, device_id) = Self::login_scopes(device_id);
 
-        Ok(OAuthAuthCodeUrlBuilder::new(self.clone(), scopes.to_vec(), device_id, redirect_uri))
+        OAuthAuthCodeUrlBuilder::new(self.clone(), scopes.to_vec(), device_id, redirect_uri)
     }
 
     /// Finish the login process.

--- a/crates/matrix-sdk/src/authentication/oauth/registration.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/registration.rs
@@ -160,12 +160,10 @@ impl ClientMetadata {
 pub enum OAuthGrantType {
     /// The authorization code grant type, defined in [RFC 6749].
     ///
-    /// This grant type is necessary to use the [`OAuth::login()`] and
-    /// [`OAuth::url_for_oidc()`] methods.
+    /// This grant type is necessary to use [`OAuth::login()`].
     ///
     /// [RFC 6749]: https://datatracker.ietf.org/doc/html/rfc6749
     /// [`OAuth::login()`]: super::OAuth::login
-    /// [`OAuth::url_for_oidc()`]: super::OAuth::url_for_oidc
     AuthorizationCode {
         /// Redirection URIs for the authorization endpoint.
         redirect_uris: Vec<Url>,

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -285,13 +285,13 @@ async fn test_login_url() -> anyhow::Result<()> {
 
     // No extra parameters.
     let authorization_data =
-        oauth.login(redirect_uri.clone(), Some(device_id.clone()))?.build().await?;
+        oauth.login(redirect_uri.clone(), Some(device_id.clone())).build().await?;
     check_authorization_url(&authorization_data, &oauth, &issuer, Some(&device_id), None, None)
         .await;
 
     // With prompt parameter.
     let authorization_data = oauth
-        .login(redirect_uri.clone(), Some(device_id.clone()))?
+        .login(redirect_uri.clone(), Some(device_id.clone()))
         .prompt(vec![Prompt::Create])
         .build()
         .await?;
@@ -307,7 +307,7 @@ async fn test_login_url() -> anyhow::Result<()> {
 
     // With user_id_hint parameter.
     let authorization_data = oauth
-        .login(redirect_uri.clone(), Some(device_id.clone()))?
+        .login(redirect_uri.clone(), Some(device_id.clone()))
         .user_id_hint(user_id!("@joe:example.org"))
         .build()
         .await?;

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -46,7 +46,7 @@ async fn mock_environment() -> anyhow::Result<(OAuth, MatrixMockServer, Url, OAu
     server.mock_who_am_i().ok().named("whoami").mount().await;
 
     let oauth_server = server.oauth();
-    oauth_server.mock_server_metadata().ok().expect(1..).named("server_metadata").mount().await;
+    oauth_server.mock_server_metadata().ok().expect(1).named("server_metadata").mount().await;
     oauth_server.mock_registration().ok().expect(1).named("registration").mount().await;
     oauth_server.mock_token().ok().mount().await;
 
@@ -275,7 +275,7 @@ async fn test_login_url() -> anyhow::Result<()> {
     let issuer = Url::parse(&server.server().uri())?;
 
     let oauth_server = server.oauth();
-    oauth_server.mock_server_metadata().ok().expect(1..).mount().await;
+    oauth_server.mock_server_metadata().ok().expect(3).mount().await;
 
     let client = server.client_builder().registered_with_oauth(server.server().uri()).build().await;
     let oauth = client.oauth();
@@ -361,9 +361,8 @@ fn test_authorization_response() -> anyhow::Result<()> {
 #[async_test]
 async fn test_finish_login() -> anyhow::Result<()> {
     let server = MatrixMockServer::new().await;
-
     let oauth_server = server.oauth();
-    oauth_server.mock_server_metadata().ok().expect(1..).named("server_metadata").mount().await;
+    let server_metadata = oauth_server.server_metadata();
 
     let client = server.client_builder().registered_with_oauth(server.server().uri()).build().await;
     let oauth = client.oauth();
@@ -383,6 +382,7 @@ async fn test_finish_login() -> anyhow::Result<()> {
     let redirect_uri = REDIRECT_URI_STRING;
     let (_pkce_code_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
     let auth_validation_data = AuthorizationValidationData {
+        server_metadata: server_metadata.clone(),
         device_id: owned_device_id!("D3V1C31D"),
         redirect_uri: RedirectUrl::new(redirect_uri.to_owned())?,
         pkce_verifier,
@@ -435,6 +435,7 @@ async fn test_finish_login() -> anyhow::Result<()> {
     let redirect_uri = REDIRECT_URI_STRING;
     let (_pkce_code_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
     let auth_validation_data = AuthorizationValidationData {
+        server_metadata: server_metadata.clone(),
         device_id: owned_device_id!("D3V1C31D"),
         redirect_uri: RedirectUrl::new(redirect_uri.to_owned())?,
         pkce_verifier,
@@ -478,6 +479,7 @@ async fn test_finish_login() -> anyhow::Result<()> {
     let redirect_uri = REDIRECT_URI_STRING;
     let (_pkce_code_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
     let auth_validation_data = AuthorizationValidationData {
+        server_metadata,
         device_id: wrong_device_id.to_owned(),
         redirect_uri: RedirectUrl::new(redirect_uri.to_owned())?,
         pkce_verifier,

--- a/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
@@ -66,6 +66,14 @@ impl<'a> OAuthMockServer<'a> {
     fn mock_endpoint<T>(&self, mock: MockBuilder, endpoint: T) -> MockEndpoint<'a, T> {
         self.server.mock_endpoint(mock, endpoint)
     }
+
+    /// Get the mock OAuth 2.0 server metadata.
+    pub fn server_metadata(&self) -> AuthorizationServerMetadata {
+        MockServerMetadataBuilder::new(&self.server.server().uri())
+            .build()
+            .deserialize()
+            .expect("mock OAuth 2.0 server metadata should deserialize successfully")
+    }
 }
 
 // Specific mount endpoints.

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -24,8 +24,8 @@ use futures_util::StreamExt;
 use matrix_sdk::{
     authentication::oauth::{
         registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
-        AccountManagementActionFull, AuthorizationCode, AuthorizationResponse, ClientId, CsrfToken,
-        OAuthAuthorizationData, OAuthSession, UserSession,
+        AccountManagementActionFull, AuthorizationCode, AuthorizationResponse, ClientId,
+        ClientRegistrationMethod, CsrfToken, OAuthAuthorizationData, OAuthSession, UserSession,
     },
     config::SyncSettings,
     encryption::{recovery::RecoveryState, CrossSigningResetAuthType},
@@ -219,7 +219,7 @@ impl OidcCli {
             let (redirect_uri, server_handle) = LocalServerBuilder::new().spawn().await?;
 
             let OAuthAuthorizationData { url, state } =
-                oauth.login(redirect_uri, None).build().await?;
+                oauth.login(ClientRegistrationMethod::None, redirect_uri, None).build().await?;
 
             let authorization_code = match use_auth_url(&url, &state, server_handle).await {
                 Ok(code) => code,

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -219,7 +219,7 @@ impl OidcCli {
             let (redirect_uri, server_handle) = LocalServerBuilder::new().spawn().await?;
 
             let OAuthAuthorizationData { url, state } =
-                oauth.login(redirect_uri, None)?.build().await?;
+                oauth.login(redirect_uri, None).build().await?;
 
             let authorization_code = match use_auth_url(&url, &state, server_handle).await {
                 Ok(code) => code,

--- a/examples/qr-login/src/main.rs
+++ b/examples/qr-login/src/main.rs
@@ -120,7 +120,7 @@ async fn login(proxy: Option<Url>) -> Result<()> {
     let metadata = client_metadata();
     let oauth = client.oauth();
 
-    let login_client = oauth.login_with_qr_code(&data, metadata);
+    let login_client = oauth.login_with_qr_code(&data, metadata.into());
     let mut subscriber = login_client.subscribe_to_progress();
 
     let task = tokio::spawn(async move {


### PR DESCRIPTION
This creates a `ClientRegistrationMethod` enum and use it for `OAuth::login` and `OAuth::login_with_qr_code`, allowing notable to use the `OAuthRegistrationStore` every time.

We can get rid of `url_for_oidc` since everything can be done with `OAuth::login` now, and we also merge `OAuth::finish_login` and `OAuth::login_with_oidc_callback()` to use the simplest API.

Finally there are some optimizations to reduce the number of requests by reusing the `AuthorizationServerMetadata`.

This can be reviewed commit by commit.