### PR TITLE
feat(sqlite): Introduce `RuntimeConfig` which includes `cache_size`

### DIFF
--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -104,7 +104,7 @@ impl SqliteEventCacheStore {
 
     /// Open the sqlite-based event cache store with the config open config.
     pub async fn open_with_config(config: SqliteStoreConfig) -> Result<Self, OpenStoreError> {
-        let SqliteStoreConfig { path, passphrase, pool_config } = config;
+        let SqliteStoreConfig { path, passphrase, pool_config, runtime_config } = config;
 
         fs::create_dir_all(&path).await.map_err(OpenStoreError::CreateDir)?;
 
@@ -113,21 +113,22 @@ impl SqliteEventCacheStore {
 
         let pool = config.create_pool(Runtime::Tokio1)?;
 
-        Self::open_with_pool(pool, passphrase.as_deref()).await
+        let this = Self::open_with_pool(pool, passphrase.as_deref()).await?;
+        this.pool.get().await?.apply_runtime_config(runtime_config).await?;
+
+        Ok(this)
     }
 
     /// Open an SQLite-based event cache store using the given SQLite database
     /// pool. The given passphrase will be used to encrypt private data.
-    pub async fn open_with_pool(
+    async fn open_with_pool(
         pool: SqlitePool,
         passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {
         let conn = pool.get().await?;
-        conn.set_journal_size_limit().await?;
 
         let version = conn.db_version().await?;
         run_migrations(&conn, version).await?;
-        conn.optimize().await?;
 
         let store_cipher = match passphrase {
             Some(p) => Some(Arc::new(conn.get_or_create_store_cipher(p).await?)),

--- a/crates/matrix-sdk-sqlite/src/lib.rs
+++ b/crates/matrix-sdk-sqlite/src/lib.rs
@@ -47,6 +47,8 @@ pub struct SqliteStoreConfig {
     passphrase: Option<String>,
     /// The pool configuration for [`deadpool_sqlite`].
     pool_config: PoolConfig,
+    /// The runtime configuration to apply when opening an SQLite connection.
+    runtime_config: RuntimeConfig,
 }
 
 impl SqliteStoreConfig {
@@ -60,6 +62,7 @@ impl SqliteStoreConfig {
             path: path.as_ref().to_path_buf(),
             passphrase: None,
             pool_config: PoolConfig::new(num_cpus::get_physical() * 4),
+            runtime_config: RuntimeConfig::default(),
         }
     }
 
@@ -75,6 +78,89 @@ impl SqliteStoreConfig {
     pub fn pool_max_size(mut self, max_size: usize) -> Self {
         self.pool_config.max_size = max_size;
         self
+    }
+
+    /// Optimize the database.
+    ///
+    /// The SQLite documentation recommends to run this regularly and after any
+    /// schema change. The easiest is to do it consistently when the store is
+    /// constructed, after eventual migrations.
+    ///
+    /// See [`PRAGMA optimize`] to learn more.
+    ///
+    /// The default value is `true`.
+    ///
+    /// [`PRAGMA cache_size`]: https://www.sqlite.org/pragma.html#pragma_optimize
+    pub fn optimize(mut self, optimize: bool) -> Self {
+        self.runtime_config.optimize = optimize;
+        self
+    }
+
+    /// Define the maximum size in **bytes** the SQLite cache can use.
+    ///
+    /// See [`PRAGMA cache_size`] to learn more.
+    ///
+    /// The default value is 2Mib.
+    ///
+    /// [`PRAGMA cache_size`]: https://www.sqlite.org/pragma.html#pragma_cache_size
+    pub fn cache_size(mut self, cache_size: u32) -> Self {
+        self.runtime_config.cache_size = cache_size;
+        self
+    }
+
+    /// Limit the size of the WAL file, in **bytes**.
+    ///
+    /// By default, while the DB connections of the databases are open, [the
+    /// size of the WAL file can keep increasing][size_wal_file] depending on
+    /// the size needed for the transactions. A critical case is `VACUUM`
+    /// which basically writes the content of the DB file to the WAL file
+    /// before writing it back to the DB file, so we end up taking twice the
+    /// size of the database.
+    ///
+    /// By setting this limit, the WAL file is truncated after its content is
+    /// written to the database, if it is bigger than the limit.
+    ///
+    /// See [`PRAGMA journal_size_limit`] to learn more. The value `limit`
+    /// corresponds to `N` in `PRAGMA journal_size_limit = N`.
+    ///
+    /// The default value is 10Mib.
+    ///
+    /// [size_wal_file]: https://www.sqlite.org/wal.html#avoiding_excessively_large_wal_files
+    /// [`PRAGMA journal_size_limit`]: https://www.sqlite.org/pragma.html#pragma_journal_size_limit
+    pub fn journal_size_limit(mut self, limit: u32) -> Self {
+        self.runtime_config.journal_size_limit = limit;
+        self
+    }
+}
+
+/// This type represents values to set at runtime when a database is opened.
+///
+/// This configuration is applied by
+/// [`utils::SqliteAsyncConnExt::apply_runtime_config`].
+struct RuntimeConfig {
+    /// If `true`, [`utils::SqliteAsyncConnExt::optimize`] will be called.
+    optimize: bool,
+
+    /// Regardless of the value, [`utils::SqliteAsyncConnExt::cache_size`] will
+    /// always be called with this value.
+    cache_size: u32,
+
+    /// Regardless of the value,
+    /// [`utils::SqliteAsyncConnExt::journal_size_limit`] will always be called
+    /// with this value.
+    journal_size_limit: u32,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            // Optimize is always applied.
+            optimize: true,
+            // A cache of 2Mib.
+            cache_size: 2_000_000,
+            // A limit of 10Mib.
+            journal_size_limit: 10_000_000,
+        }
     }
 }
 

--- a/crates/matrix-sdk-sqlite/src/lib.rs
+++ b/crates/matrix-sdk-sqlite/src/lib.rs
@@ -166,17 +166,27 @@ impl Default for RuntimeConfig {
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
+    use std::{
+        ops::Not,
+        path::{Path, PathBuf},
+    };
 
     use super::SqliteStoreConfig;
 
     #[test]
     fn test_store_open_config() {
-        let store_open_config =
-            SqliteStoreConfig::new(Path::new("foo")).passphrase(Some("bar")).pool_max_size(42);
+        let store_open_config = SqliteStoreConfig::new(Path::new("foo"))
+            .passphrase(Some("bar"))
+            .pool_max_size(42)
+            .optimize(false)
+            .cache_size(43)
+            .journal_size_limit(44);
 
         assert_eq!(store_open_config.path, PathBuf::from("foo"));
         assert_eq!(store_open_config.passphrase, Some("bar".to_owned()));
         assert_eq!(store_open_config.pool_config.max_size, 42);
+        assert!(store_open_config.runtime_config.optimize.not());
+        assert_eq!(store_open_config.runtime_config.cache_size, 43);
+        assert_eq!(store_open_config.runtime_config.journal_size_limit, 44);
     }
 }

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -99,7 +99,7 @@ impl SqliteStateStore {
 
     /// Open the sqlite-based state store with the config open config.
     pub async fn open_with_config(config: SqliteStoreConfig) -> Result<Self, OpenStoreError> {
-        let SqliteStoreConfig { path, passphrase, pool_config } = config;
+        let SqliteStoreConfig { path, passphrase, pool_config, runtime_config } = config;
 
         fs::create_dir_all(&path).await.map_err(OpenStoreError::CreateDir)?;
 
@@ -108,17 +108,19 @@ impl SqliteStateStore {
 
         let pool = config.create_pool(Runtime::Tokio1)?;
 
-        Self::open_with_pool(pool, passphrase.as_deref()).await
+        let this = Self::open_with_pool(pool, passphrase.as_deref()).await?;
+        this.pool.get().await?.apply_runtime_config(runtime_config).await?;
+
+        Ok(this)
     }
 
     /// Create a sqlite-based state store using the given sqlite database pool.
     /// The given passphrase will be used to encrypt private data.
-    pub async fn open_with_pool(
+    async fn open_with_pool(
         pool: SqlitePool,
         passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {
         let conn = pool.get().await?;
-        conn.set_journal_size_limit().await?;
 
         let mut version = conn.db_version().await?;
 
@@ -133,7 +135,6 @@ impl SqliteStateStore {
         };
         let this = Self { store_cipher, pool };
         this.run_migrations(&conn, version, None).await?;
-        conn.optimize().await?;
 
         Ok(this)
     }


### PR DESCRIPTION
This patch updates `StoreOpenConfig` to hold a new type: `RuntimeConfig`.

This `RuntimeConfig` type is passed to a new `SqliteAsyncConnExt`
method, named `apply_runtime_config`. Depending on the values passed
here, the `optimize`, `cache_size` (new!) and `journal_size_limit`
methods will be called automatically.

The goal of this type is to automate a flow we keep repeating in
all the stores. This is error-prone. This type brings uniformity and
consistency.

This patch also makes all `open_with_pool` methods on the stores private
(they were public before):

1. they were never used as far as I know because getting a `SqlitePool`
   isn't possible since the `pool` attribute is private…
2. it's better to keep control of this flow.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4801 by introducing `cache_size`
* Built on top of https://github.com/matrix-org/matrix-rust-sdk/pull/4826. The latter must be merged before this one.
