### PR TITLE
refactor(examples): Update OAuth examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "example-oidc-cli"
+name = "example-oauth-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -120,14 +120,14 @@
 //! # Examples
 //!
 //! Most methods have examples, there is also an example CLI application that
-//! supports all the actions described here, in [`examples/oidc_cli`].
+//! supports all the actions described here, in [`examples/oauth_cli`].
 //!
 //! [MSC3861]: https://github.com/matrix-org/matrix-spec-proposals/pull/3861
 //! [areweoidcyet.com]: https://areweoidcyet.com/
 //! [`ClientBuilder::handle_refresh_tokens()`]: crate::ClientBuilder::handle_refresh_tokens()
 //! [`Error`]: ruma::api::client::error::Error
 //! [`ErrorKind::UnknownToken`]: ruma::api::client::error::ErrorKind::UnknownToken
-//! [`examples/oidc_cli`]: https://github.com/matrix-org/matrix-rust-sdk/tree/main/examples/oidc_cli
+//! [`examples/oauth_cli`]: https://github.com/matrix-org/matrix-rust-sdk/tree/main/examples/oauth_cli
 
 use std::{
     borrow::Cow,

--- a/examples/oauth_cli/Cargo.toml
+++ b/examples/oauth_cli/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "example-oidc-cli"
+name = "example-oauth-cli"
 version = "0.1.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"
 
 [[bin]]
-name = "example-oidc-cli"
+name = "example-oauth-cli"
 test = false
 
 [dependencies]

--- a/examples/qr-login/src/main.rs
+++ b/examples/qr-login/src/main.rs
@@ -28,12 +28,7 @@ struct Cli {
     verbose: bool,
 }
 
-/// Generate the OIDC client metadata.
-///
-/// For simplicity, we use most of the default values here, but usually this
-/// should be adapted to the provider metadata to make interactions as secure as
-/// possible, for example by using the most secure signing algorithms supported
-/// by the provider.
+/// Generate the OAuth 2.0 client metadata.
 fn client_metadata() -> Raw<ClientMetadata> {
     let client_uri = Localized::new(
         Url::parse("https://github.com/matrix-org/matrix-rust-sdk")
@@ -42,10 +37,10 @@ fn client_metadata() -> Raw<ClientMetadata> {
     );
 
     let metadata = ClientMetadata {
-        // The following fields should be displayed in the OIDC provider interface as part of the
-        // process to get the user's consent. It means that these should contain real data so the
-        // user can make sure that they allow the proper application.
-        // We are cheating here because this is an example.
+        // The following fields should be displayed in the OAuth 2.0 authorization server's web UI
+        // as part of the process to get the user's consent. It means that these should
+        // contain real data so the user can make sure that they allow the proper
+        // application. We are cheating here because this is an example.
         client_name: Some(Localized::new("matrix-rust-sdk-qrlogin".to_owned(), [])),
         policy_uri: Some(client_uri.clone()),
         tos_uri: Some(client_uri.clone()),


### PR DESCRIPTION
To mention OAuth 2.0 instead of OpenID Connect.

Also use `OAuthRegistrationStore` in the oauth_cli example, since it's probably the recommended way to manage registrations.