### PR TITLE
refactor!(timeline): simplify getting the `RepliedToInfo` + introduce `Room::load_or_fetch_event()`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1503,12 +1503,7 @@ async fn fetch_replied_to_event(
     room: &Room,
 ) -> Result<TimelineDetails<Box<RepliedToEvent>>, Error> {
     if let Some((_, item)) = rfind_event_by_id(&state.items, in_reply_to) {
-        let details = TimelineDetails::Ready(Box::new(RepliedToEvent {
-            content: item.content.clone(),
-            sender: item.sender().to_owned(),
-            sender_profile: item.sender_profile().clone(),
-        }));
-
+        let details = TimelineDetails::Ready(Box::new(RepliedToEvent::from_timeline_item(&item)));
         trace!("Found replied-to event locally");
         return Ok(details);
     };

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1529,9 +1529,7 @@ async fn fetch_replied_to_event(
     drop(state);
 
     trace!("Fetching replied-to event");
-
-    // TODO: read from the event cache, if available, or fetch from the server.
-    let res = match room.event(in_reply_to, None).await {
+    let res = match room.load_or_fetch_event(in_reply_to, None).await {
         Ok(timeline_event) => TimelineDetails::Ready(Box::new(
             RepliedToEvent::try_from_timeline_event(timeline_event, room).await?,
         )),

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1529,6 +1529,8 @@ async fn fetch_replied_to_event(
     drop(state);
 
     trace!("Fetching replied-to event");
+
+    // TODO: read from the event cache, if available, or fetch from the server.
     let res = match room.event(in_reply_to, None).await {
         Ok(timeline_event) => TimelineDetails::Ready(Box::new(
             RepliedToEvent::try_from_timeline_event(timeline_event, room).await?,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -311,9 +311,9 @@ impl InReplyToDetails {
 /// An event that is replied to.
 #[derive(Clone, Debug)]
 pub struct RepliedToEvent {
-    pub(in crate::timeline) content: TimelineItemContent,
-    pub(in crate::timeline) sender: OwnedUserId,
-    pub(in crate::timeline) sender_profile: TimelineDetails<Profile>,
+    content: TimelineItemContent,
+    sender: OwnedUserId,
+    sender_profile: TimelineDetails<Profile>,
 }
 
 impl RepliedToEvent {
@@ -332,6 +332,7 @@ impl RepliedToEvent {
         &self.sender_profile
     }
 
+    /// Create a [`RepliedToEvent`] from a loaded event timeline item.
     pub fn from_timeline_item(timeline_item: &EventTimelineItem) -> Self {
         Self {
             content: timeline_item.content.clone(),

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -158,16 +158,6 @@ impl Message {
         self.mentions.as_ref()
     }
 
-    pub(in crate::timeline) fn to_content(&self) -> RoomMessageEventContent {
-        // Like the `impl From<Message> for RoomMessageEventContent` below, but
-        // takes &self and only copies what's needed.
-        let relates_to = make_relates_to(
-            self.thread_root.clone(),
-            self.in_reply_to.as_ref().map(|details| details.event_id.clone()),
-        );
-        assign!(RoomMessageEventContent::new(self.msgtype.clone()), { relates_to })
-    }
-
     pub(in crate::timeline) fn with_in_reply_to(&self, in_reply_to: InReplyToDetails) -> Self {
         Self { in_reply_to: Some(in_reply_to), ..self.clone() }
     }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -541,7 +541,7 @@ impl EventTimelineItem {
     /// Gives the information needed to reply to the event of the item.
     pub fn replied_to_info(&self) -> Result<RepliedToInfo, UnsupportedReplyItem> {
         let reply_content = match self.content() {
-            TimelineItemContent::Message(msg) => ReplyContent::Message(msg.to_owned()),
+            TimelineItemContent::Message(msg) => ReplyContent::Message(msg.to_content()),
             _ => {
                 let Some(raw_event) = self.latest_json() else {
                     return Err(UnsupportedReplyItem::MissingJson);

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -57,7 +57,6 @@ pub use self::{
     },
     local::EventSendState,
 };
-use super::{RepliedToInfo, ReplyContent, UnsupportedReplyItem};
 
 /// An item in the timeline that represents at least one event.
 ///
@@ -536,31 +535,6 @@ impl EventTimelineItem {
             kind,
             is_room_encrypted: self.is_room_encrypted,
         }
-    }
-
-    /// Gives the information needed to reply to the event of the item.
-    pub fn replied_to_info(&self) -> Result<RepliedToInfo, UnsupportedReplyItem> {
-        let reply_content = match self.content() {
-            TimelineItemContent::Message(msg) => ReplyContent::Message(msg.to_content()),
-            _ => {
-                let Some(raw_event) = self.latest_json() else {
-                    return Err(UnsupportedReplyItem::MissingJson);
-                };
-
-                ReplyContent::Raw(raw_event.clone())
-            }
-        };
-
-        let Some(event_id) = self.event_id() else {
-            return Err(UnsupportedReplyItem::MissingEventId);
-        };
-
-        Ok(RepliedToInfo {
-            event_id: event_id.to_owned(),
-            sender: self.sender().to_owned(),
-            timestamp: self.timestamp(),
-            content: reply_content,
-        })
     }
 
     pub(super) fn handle(&self) -> TimelineItemHandle<'_> {

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -457,8 +457,7 @@ impl Timeline {
             return timeline_item.replied_to_info();
         }
 
-        // TODO: read from the event cache, if available, or fetch from the server.
-        let event = self.room().event(event_id, None).await.map_err(|error| {
+        let event = self.room().load_or_fetch_event(event_id, None).await.map_err(|error| {
             error!("Failed to fetch event with ID {event_id} with error: {error}");
             UnsupportedReplyItem::MissingEvent
         })?;

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -453,10 +453,6 @@ impl Timeline {
         &self,
         event_id: &EventId,
     ) -> Result<RepliedToInfo, UnsupportedReplyItem> {
-        if let Some(timeline_item) = self.item_by_event_id(event_id).await {
-            return timeline_item.replied_to_info();
-        }
-
         let event = self.room().load_or_fetch_event(event_id, None).await.map_err(|error| {
             error!("Failed to fetch event with ID {event_id} with error: {error}");
             UnsupportedReplyItem::MissingEvent

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -846,7 +846,7 @@ async fn test_retry_decryption_updates_response() {
         assert_eq!(reply_details.event_id, original_event_id);
 
         let replied_to = as_variant!(&reply_details.event, TimelineDetails::Ready).unwrap();
-        assert!(replied_to.content.is_unable_to_decrypt());
+        assert!(replied_to.content().is_unable_to_decrypt());
     }
 
     // Import a room key backup.
@@ -880,7 +880,7 @@ async fn test_retry_decryption_updates_response() {
         assert_eq!(reply_details.event_id, original_event_id);
 
         let replied_to = as_variant!(&reply_details.event, TimelineDetails::Ready).unwrap();
-        assert_eq!(replied_to.content.as_message().unwrap().body(), "It's a secret to everybody");
+        assert_eq!(replied_to.content().as_message().unwrap().body(), "It's a secret to everybody");
     }
 
     // The event itself is decrypted.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -868,11 +868,6 @@ async fn test_send_reply_with_event_id() {
         .mount()
         .await;
 
-    // Since we assume we can't use the timeline item directly in this use case, the
-    // API will fetch the event from the server directly so we need to mock the
-    // response.
-    server.mock_room_event().ok(bob_event).named("event_1").mock_once().mount().await;
-
     let replied_to_info = timeline.replied_to_info_from_event_id(event_id_from_bob).await.unwrap();
     timeline
         .send_reply(
@@ -1147,11 +1142,6 @@ async fn test_send_reply_with_event_id_that_is_redacted() {
         .expect(1)
         .mount()
         .await;
-
-    // Since we assume we can't use the timeline item directly in this use case, the
-    // API will fetch the event from the server directly so we need to mock the
-    // response.
-    server.mock_room_event().ok(event_from_bob).mock_once().named("event_1").mount().await;
 
     let replied_to_info =
         timeline.replied_to_info_from_event_id(redacted_event_id_from_bob).await.unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -568,8 +568,7 @@ async fn test_send_reply() {
         )
         .await;
 
-    let event_from_bob =
-        assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { .. });
 
     // Clear the timeline to make sure the old item does not need to be
     // available in it for the reply to work.
@@ -599,7 +598,7 @@ async fn test_send_reply() {
         .mount()
         .await;
 
-    let replied_to_info = event_from_bob.replied_to_info().unwrap();
+    let replied_to_info = timeline.replied_to_info_from_event_id(event_id_from_bob).await.unwrap();
     timeline
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),
@@ -671,8 +670,7 @@ async fn test_send_reply_to_self() {
         )
         .await;
 
-    let event_from_self =
-        assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { .. });
 
     // Clear the timeline to make sure the old item does not need to be
     // available in it for the reply to work.
@@ -699,7 +697,7 @@ async fn test_send_reply_to_self() {
         .mount()
         .await;
 
-    let replied_to_info = event_from_self.replied_to_info().unwrap();
+    let replied_to_info = timeline.replied_to_info_from_event_id(event_id_from_self).await.unwrap();
     timeline
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to self"),
@@ -760,12 +758,11 @@ async fn test_send_reply_to_threaded() {
         )
         .await;
 
-    let hello_world_item =
-        assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { .. });
 
     server.mock_room_send().ok(event_id!("$reply_event")).mock_once().mount().await;
 
-    let replied_to_info = hello_world_item.replied_to_info().unwrap();
+    let replied_to_info = timeline.replied_to_info_from_event_id(event_id_1).await.unwrap();
     timeline
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Hello, Bob!"),
@@ -924,8 +921,7 @@ async fn test_send_reply_enforce_thread() {
         )
         .await;
 
-    let event_from_bob =
-        assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { .. });
 
     // Clear the timeline to make sure the old item does not need to be
     // available in it for the reply to work.
@@ -954,7 +950,7 @@ async fn test_send_reply_enforce_thread() {
         .mount()
         .await;
 
-    let replied_to_info = event_from_bob.replied_to_info().unwrap();
+    let replied_to_info = timeline.replied_to_info_from_event_id(event_id_from_bob).await.unwrap();
     timeline
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),
@@ -1017,8 +1013,7 @@ async fn test_send_reply_enforce_thread_is_reply() {
         )
         .await;
 
-    let event_from_bob =
-        assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { .. });
 
     // Clear the timeline to make sure the old item does not need to be
     // available in it for the reply to work.
@@ -1051,7 +1046,7 @@ async fn test_send_reply_enforce_thread_is_reply() {
         .mount()
         .await;
 
-    let replied_to_info = event_from_bob.replied_to_info().unwrap();
+    let replied_to_info = timeline.replied_to_info_from_event_id(event_id_from_bob).await.unwrap();
     timeline
         .send_reply(
             RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- `Room::load_or_fetch_event()` is a new method that will find an event in the event cache (if
+  enabled), or using network like `Room::event()` does.
+  ([#4837](https://github.com/matrix-org/matrix-rust-sdk/pull/4837))
 - [**breaking**]: The element call widget URL configuration struct (`VirtualElementCallWidgetOptions`) and URL generation
   have changed.
   - It supports the new fields: `hide_screensharing`, `posthog_api_host`, `posthog_api_key`,


### PR DESCRIPTION
Small refactoring which should help with https://github.com/matrix-org/matrix-rust-sdk/issues/4835.

Also introduces a new way to retrieve an event from the event cache, or if it's missing, from the network.