### PR TITLE
crypto: `get_most_recent_session`: return `None` for unknown device

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -31,14 +31,14 @@ use ruma::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::{instrument, trace, warn};
+use tracing::{instrument, trace};
 use vodozemac::{olm::SessionConfig, Curve25519PublicKey, Ed25519PublicKey};
 
 use super::{atomic_bool_deserializer, atomic_bool_serializer};
 #[cfg(any(test, feature = "testing", doc))]
 use crate::OlmMachine;
 use crate::{
-    error::{EventError, MismatchedIdentityKeysError, OlmError, OlmResult, SignatureError},
+    error::{MismatchedIdentityKeysError, OlmError, OlmResult, SignatureError},
     identities::{OwnUserIdentityData, UserIdentityData},
     olm::{
         InboundGroupSession, OutboundGroupSession, Session, ShareInfo, SignedJsonObject, VerifyJson,
@@ -695,12 +695,7 @@ impl DeviceData {
                 Ok(None)
             }
         } else {
-            warn!(
-                "Trying to find an Olm session of a device, but the device doesn't have a \
-                Curve25519 key",
-            );
-
-            Err(EventError::MissingSenderKey.into())
+            Ok(None)
         }
     }
 
@@ -846,7 +841,7 @@ impl DeviceData {
                 message: encrypted.cast(),
             }),
 
-            Err(OlmError::MissingSession | OlmError::EventError(EventError::MissingSenderKey)) => {
+            Err(OlmError::MissingSession) => {
                 Ok(MaybeEncryptedRoomKey::Withheld { code: WithheldCode::NoOlm })
             }
             Err(e) => Err(e),

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -21,7 +21,7 @@ mod account;
 mod group_sessions;
 mod session;
 mod signing;
-mod utility;
+pub(crate) mod utility;
 
 pub use account::{Account, OlmMessageHash, PickledAccount, StaticAccountData};
 pub(crate) use account::{OlmDecryptionInfo, SessionType};


### PR DESCRIPTION
If we have a device whose Curve25519 key we don't know, then self-evidently we can't have any active Olm sessions with that device. Currently, we return an `EventError::MissingSenderKey` in this case, but (a) the definition of that error doesn't match this situation, and (b) it complicates handling in methods that call `DeviceData::encrypt` (currently only `DeviceData::maybe_encrypt_room_key`, but I want to add a second).

Other than `DeviceData::encrypt`, the only place where `get_most_recent_session` is called is `mark_device_as_wedged`. In that case, we have just looked up the device by its Curve25519 key, so we know it must have one.

We can therefore be reasonably certain that this change is a no-op.