### PR TITLE
refactor(client): Improve documentation and rename `BaseClient::with_store_config` to `new`

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -55,7 +55,7 @@ pub fn receive_all_members_benchmark(c: &mut Criterion) {
         .block_on(sqlite_store.save_changes(&changes))
         .expect("initial filling of sqlite failed");
 
-    let base_client = BaseClient::with_store_config(
+    let base_client = BaseClient::new(
         StoreConfig::new("cross-process-store-locks-holder-name".to_owned())
             .state_store(sqlite_store),
     );

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -90,15 +90,12 @@ use crate::{
 /// accordingly updates its state. It is not designed to be used directly, but
 /// rather through `matrix_sdk::Client`.
 ///
-/// To create a client, one preferably uses the
-/// [`BaseClient::with_store_config`] method:
-///
 /// ```rust
 /// use matrix_sdk_base::{store::StoreConfig, BaseClient};
 ///
-/// let client = BaseClient::with_store_config(
-///     StoreConfig::new("cross-process-holder-name".to_owned())
-/// );
+/// let client = BaseClient::new(StoreConfig::new(
+///     "cross-process-holder-name".to_owned(),
+/// ));
 /// ```
 #[derive(Clone)]
 pub struct BaseClient {
@@ -159,7 +156,7 @@ impl BaseClient {
     ///
     /// * `config` - the configuration for the stores (state store, event cache
     ///   store and crypto store).
-    pub fn with_store_config(config: StoreConfig) -> Self {
+    pub fn new(config: StoreConfig) -> Self {
         let store = Store::new(config.state_store);
 
         // Create the channel to receive `RoomInfoNotableUpdate`.
@@ -242,7 +239,7 @@ impl BaseClient {
     ) -> Result<Self> {
         let config = StoreConfig::new(cross_process_store_locks_holder.to_owned())
             .state_store(MemoryStore::new());
-        Ok(Self::with_store_config(config))
+        Ok(Self::new(config))
     }
 
     /// Get the session meta information.
@@ -2253,9 +2250,8 @@ mod tests {
         let user_id = user_id!("@alice:example.org");
         let room_id = room_id!("!ithpyNKDtmhneaTQja:example.org");
 
-        let client = BaseClient::with_store_config(StoreConfig::new(
-            "cross-process-store-locks-holder-name".to_owned(),
-        ));
+        let client =
+            BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
         client
             .set_session_meta(
                 SessionMeta { user_id: user_id.to_owned(), device_id: "FOOBAR".into() },
@@ -2313,9 +2309,8 @@ mod tests {
         let inviter_user_id = user_id!("@bob:example.org");
         let room_id = room_id!("!ithpyNKDtmhneaTQja:example.org");
 
-        let client = BaseClient::with_store_config(StoreConfig::new(
-            "cross-process-store-locks-holder-name".to_owned(),
-        ));
+        let client =
+            BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
         client
             .set_session_meta(
                 SessionMeta { user_id: user_id.to_owned(), device_id: "FOOBAR".into() },
@@ -2375,9 +2370,8 @@ mod tests {
         let inviter_user_id = user_id!("@bob:example.org");
         let room_id = room_id!("!ithpyNKDtmhneaTQja:example.org");
 
-        let client = BaseClient::with_store_config(StoreConfig::new(
-            "cross-process-store-locks-holder-name".to_owned(),
-        ));
+        let client =
+            BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
         client
             .set_session_meta(
                 SessionMeta { user_id: user_id.to_owned(), device_id: "FOOBAR".into() },
@@ -2447,9 +2441,8 @@ mod tests {
     #[async_test]
     async fn test_ignored_user_list_changes() {
         let user_id = user_id!("@alice:example.org");
-        let client = BaseClient::with_store_config(StoreConfig::new(
-            "cross-process-store-locks-holder-name".to_owned(),
-        ));
+        let client =
+            BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
         client
             .set_session_meta(
                 SessionMeta { user_id: user_id.to_owned(), device_id: "FOOBAR".into() },

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -157,8 +157,8 @@ impl BaseClient {
     ///
     /// # Arguments
     ///
-    /// * `config` - An optional session if the user already has one from a
-    ///   previous login call.
+    /// * `config` - the configuration for the stores (state store, event cache
+    ///   store and crypto store).
     pub fn with_store_config(config: StoreConfig) -> Self {
         let store = Store::new(config.state_store);
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -84,10 +84,22 @@ use crate::{
     RoomStateFilter, SessionMeta,
 };
 
-/// A no IO Client implementation.
+/// A no (network) IO client implementation.
 ///
-/// This Client is a state machine that receives responses and events and
-/// accordingly updates its state.
+/// This client is a state machine that receives responses and events and
+/// accordingly updates its state. It is not designed to be used directly, but
+/// rather through `matrix_sdk::Client`.
+///
+/// To create a client, one preferably uses the
+/// [`BaseClient::with_store_config`] method:
+///
+/// ```rust
+/// use matrix_sdk_base::{store::StoreConfig, BaseClient};
+///
+/// let client = BaseClient::with_store_config(
+///     StoreConfig::new("cross-process-holder-name".to_owned())
+/// );
+/// ```
 #[derive(Clone)]
 pub struct BaseClient {
     /// Database

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -2534,9 +2534,8 @@ mod tests {
     #[async_test]
     async fn test_is_favourite() {
         // Given a room,
-        let client = BaseClient::with_store_config(StoreConfig::new(
-            "cross-process-store-locks-holder-name".to_owned(),
-        ));
+        let client =
+            BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
 
         client
             .set_session_meta(
@@ -2614,9 +2613,8 @@ mod tests {
     #[async_test]
     async fn test_is_low_priority() {
         // Given a room,
-        let client = BaseClient::with_store_config(StoreConfig::new(
-            "cross-process-store-locks-holder-name".to_owned(),
-        ));
+        let client =
+            BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
 
         client
             .set_session_meta(
@@ -3199,9 +3197,8 @@ mod tests {
         use crate::{RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons};
 
         // Given a room,
-        let client = BaseClient::with_store_config(StoreConfig::new(
-            "cross-process-store-locks-holder-name".to_owned(),
-        ));
+        let client =
+            BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
 
         client
             .set_session_meta(

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -479,7 +479,7 @@ impl StateChanges {
 ///
 /// ```
 /// # use matrix_sdk_base::store::StoreConfig;
-///
+/// #
 /// let store_config =
 ///     StoreConfig::new("cross-process-store-locks-holder-name".to_owned());
 /// ```

--- a/crates/matrix-sdk-base/src/test_utils.rs
+++ b/crates/matrix-sdk-base/src/test_utils.rs
@@ -23,9 +23,8 @@ use crate::{store::StoreConfig, BaseClient, SessionMeta};
 /// Create a [`BaseClient`] with the given user id, if provided, or an hardcoded
 /// one otherwise.
 pub(crate) async fn logged_in_base_client(user_id: Option<&UserId>) -> BaseClient {
-    let client = BaseClient::with_store_config(StoreConfig::new(
-        "cross-process-store-locks-holder-name".to_owned(),
-    ));
+    let client =
+        BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
     let user_id =
         user_id.map(|user_id| user_id.to_owned()).unwrap_or_else(|| owned_user_id!("@u:e.uk"));
     client

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -475,7 +475,7 @@ impl ClientBuilder {
             base_client
         } else {
             #[allow(unused_mut)]
-            let mut client = BaseClient::with_store_config(
+            let mut client = BaseClient::new(
                 build_store_config(self.store_config, &self.cross_process_store_locks_holder_name)
                     .await?,
             );


### PR DESCRIPTION
This is a small set of patches that improve the documentation of `BaseClient` but also renames the `with_store_config` constructor to `new`:

1. there is no alternative constructor, it's the only one,
2. the `with_` prefix is usually reserved to (i) builders or (ii) alternative constructors,
3. I believe it clarifies the code.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4801