### PR TITLE
Enable QRCode login feature for wasm32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,6 +2913,8 @@ dependencies = [
  "urlencoding",
  "uuid",
  "vodozemac",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "wiremock",
  "zeroize",

--- a/crates/matrix-sdk-ui/src/timeline/futures.rs
+++ b/crates/matrix-sdk-ui/src/timeline/futures.rs
@@ -49,7 +49,6 @@ impl<'a> SendAttachment<'a> {
     }
 
     /// Get a subscriber to observe the progress of sending the request body.
-    #[cfg(not(target_arch = "wasm32"))]
     pub fn subscribe_to_send_progress(&self) -> eyeball::Subscriber<TransmissionProgress> {
         self.send_progress.subscribe()
     }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -104,6 +104,7 @@ sha2 = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio-stream = { workspace = true, features = ["sync"] }
+tokio-util = "0.7.13"
 tower = { version = "0.5.2", features = ["util"], optional = true }
 tracing = { workspace = true, features = ["attributes"] }
 uniffi = { workspace = true, optional = true }
@@ -117,6 +118,8 @@ zeroize = { workspace = true }
 gloo-timers = { workspace = true, features = ["futures"] }
 reqwest = { workspace = true, features = ["gzip", "http2"] }
 tokio = { workspace = true, features = ["macros"] }
+wasm-bindgen-futures = { version = "0.4.33", optional = true }
+wasm-bindgen = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }
@@ -124,7 +127,6 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 # support *sending* streams, which makes it useless for us.
 reqwest = { workspace = true, features = ["stream", "gzip", "http2"] }
 tokio = { workspace = true, features = ["fs", "rt", "macros"] }
-tokio-util = "0.7.13"
 wiremock = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -139,7 +139,7 @@ use error::{
     OAuthAuthorizationCodeError, OAuthClientRegistrationError, OAuthDiscoveryError,
     OAuthTokenRevocationError, RedirectUriQueryParseError,
 };
-#[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+#[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::types::qr_login::QrCodeData;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::once_cell::sync::OnceCell;
@@ -173,7 +173,7 @@ mod cross_process;
 pub mod error;
 mod http_client;
 mod oidc_discovery;
-#[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+#[cfg(feature = "e2e-encryption")]
 pub mod qrcode;
 pub mod registration;
 #[cfg(not(target_arch = "wasm32"))]
@@ -183,7 +183,7 @@ mod tests;
 
 #[cfg(feature = "e2e-encryption")]
 use self::cross_process::{CrossProcessRefreshLockGuard, CrossProcessRefreshManager};
-#[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+#[cfg(feature = "e2e-encryption")]
 use self::qrcode::LoginWithQrCode;
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::registration_store::OAuthRegistrationStore;
@@ -418,7 +418,7 @@ impl OAuth {
     /// println!("Successfully logged in: {:?} {:?}", client.user_id(), client.device_id());
     /// # anyhow::Ok(()) };
     /// ```
-    #[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+    #[cfg(feature = "e2e-encryption")]
     pub fn login_with_qr_code<'a>(
         &'a self,
         data: &'a QrCodeData,
@@ -1176,7 +1176,7 @@ impl OAuth {
 
     /// Request codes from the authorization server for logging in with another
     /// device.
-    #[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+    #[cfg(feature = "e2e-encryption")]
     async fn request_device_authorization(
         &self,
         server_metadata: &AuthorizationServerMetadata,
@@ -1204,7 +1204,7 @@ impl OAuth {
     }
 
     /// Exchange the device code against an access token.
-    #[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+    #[cfg(feature = "e2e-encryption")]
     async fn exchange_device_code(
         &self,
         server_metadata: &AuthorizationServerMetadata,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2537,6 +2537,7 @@ pub(crate) mod tests {
         store::{MemoryStore, StoreConfig},
         RoomState,
     };
+    use matrix_sdk_common::executor::spawn;
     use matrix_sdk_test::{
         async_test, test_json, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder,
         DEFAULT_TEST_ROOM_ID,
@@ -2551,10 +2552,7 @@ pub(crate) mod tests {
         owned_room_id, room_alias_id, room_id, RoomId, ServerName, UserId,
     };
     use serde_json::json;
-    use tokio::{
-        spawn,
-        time::{sleep, timeout},
-    };
+    use tokio::time::{sleep, timeout};
     use url::Url;
     use wiremock::{
         matchers::{body_json, header, method, path, query_param_is_missing},

--- a/crates/matrix-sdk/src/encryption/futures.rs
+++ b/crates/matrix-sdk/src/encryption/futures.rs
@@ -20,7 +20,6 @@
 use std::{future::IntoFuture, io::Read};
 
 use eyeball::SharedObservable;
-#[cfg(not(target_arch = "wasm32"))]
 use eyeball::Subscriber;
 use matrix_sdk_common::boxed_into_future;
 use ruma::events::room::{EncryptedFile, EncryptedFileInit};
@@ -73,7 +72,6 @@ impl<'a, R: ?Sized> UploadEncryptedFile<'a, R> {
 
     /// Get a subscriber to observe the progress of sending the request
     /// body.
-    #[cfg(not(target_arch = "wasm32"))]
     pub fn subscribe_to_send_progress(&self) -> Subscriber<TransmissionProgress> {
         self.send_progress.subscribe()
     }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -722,7 +722,6 @@ impl Encryption {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) async fn import_secrets_bundle(
         &self,
         bundle: &matrix_sdk_base::crypto::types::SecretsBundle,
@@ -1690,7 +1689,6 @@ impl Encryption {
     /// **Warning**: Do not use this method if we're already calling
     /// [`Client::send_outgoing_request()`]. This method is intended for
     /// explicitly uploading the device keys before starting a sync.
-    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) async fn ensure_device_keys_upload(&self) -> Result<()> {
         let olm = self.client.olm_machine().await;
         let olm = olm.as_ref().ok_or(Error::NoOlmMachine)?;

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -17,6 +17,7 @@
 use std::{fmt, time::Duration};
 
 use async_channel::{Receiver, Sender};
+use matrix_sdk_common::executor::spawn;
 use ruma::api::client::delayed_events::DelayParameters;
 use serde::de::{self, Deserialize, Deserializer, Visitor};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
@@ -139,7 +140,7 @@ impl WidgetDriver {
         let (incoming_msg_tx, mut incoming_msg_rx) = unbounded_channel();
 
         // Forward all of the incoming messages from the widget.
-        tokio::spawn({
+        spawn({
             let incoming_msg_tx = incoming_msg_tx.clone();
             let from_widget_rx = self.from_widget_rx.clone();
             async move {
@@ -259,7 +260,7 @@ impl WidgetDriver {
                 let mut matrix = matrix_driver.events();
                 let incoming_msg_tx = incoming_msg_tx.clone();
 
-                tokio::spawn(async move {
+                spawn(async move {
                     loop {
                         tokio::select! {
                             _ = stop_forwarding.cancelled() => {

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -36,7 +36,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 wiremock = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2.6", default-features = false, features = ["js"] }
+getrandom = { version = "0.2.15", default-features = false, features = ["js"] }
 wasm-bindgen-test = "0.3.33"
 
 [lints]


### PR DESCRIPTION
With recent changes to OAuth/OIDC, the wasm32 removal flags are no longer needed.

Signed-off-by: Daniel Salinas
