### PR TITLE
feat(event cache): rework the SQL schema

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -172,7 +172,8 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
             assert_eq!(pinned_event_ids.len(), PINNED_EVENTS_COUNT);
 
             // Reset cache so it always loads the events from the mocked endpoint
-            client.event_cache().empty_immutable_cache().await;
+            // TODO: allow clearing the events table?
+            //client.event_cache().empty_immutable_cache().await;
 
             let timeline = Timeline::builder(&room)
                 .with_focus(TimelineFocus::PinnedEvents {

--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -172,8 +172,14 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
             assert_eq!(pinned_event_ids.len(), PINNED_EVENTS_COUNT);
 
             // Reset cache so it always loads the events from the mocked endpoint
-            // TODO: allow clearing the events table?
-            //client.event_cache().empty_immutable_cache().await;
+            client
+                .event_cache_store()
+                .lock()
+                .await
+                .unwrap()
+                .clear_all_rooms_chunks()
+                .await
+                .unwrap();
 
             let timeline = Timeline::builder(&room)
                 .with_focus(TimelineFocus::PinnedEvents {

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -862,14 +862,12 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         .unwrap();
 
         // Now let's find the event.
-        let (position, event) = self
+        let event = self
             .find_event(room_id, event_comte.event_id().unwrap().as_ref())
             .await
             .expect("failed to query for finding an event")
             .expect("failed to find an event");
 
-        assert_eq!(position.chunk_identifier(), 0);
-        assert_eq!(position.index(), 0);
         assert_eq!(event.event_id(), event_comte.event_id());
 
         // Now let's try to find an event that exists, but not in the expected room.

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -32,6 +32,7 @@ use ruma::{
     time::{Instant, SystemTime},
     EventId, MxcUri, OwnedEventId, OwnedMxcUri, RoomId,
 };
+use tracing::error;
 
 use super::{
     compute_filters_string, extract_event_relation,
@@ -258,6 +259,10 @@ impl EventCacheStore for MemoryStore {
     }
 
     async fn save_event(&self, room_id: &RoomId, event: Event) -> Result<(), Self::Error> {
+        if event.event_id().is_none() {
+            error!(%room_id, "Trying to save an event with no ID");
+            return Ok(());
+        }
         self.inner.write().unwrap().events.save_item(room_id.to_owned(), event);
         Ok(())
     }

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -34,7 +34,7 @@ use ruma::{
 };
 
 use super::{
-    extract_event_relation,
+    compute_filters_string, extract_event_relation,
     media::{EventCacheStoreMedia, IgnoreMediaRetentionPolicy, MediaRetentionPolicy, MediaService},
     EventCacheStore, EventCacheStoreError, Result,
 };
@@ -222,23 +222,11 @@ impl EventCacheStore for MemoryStore {
         &self,
         room_id: &RoomId,
         event_id: &EventId,
-        filters: Option<Vec<RelationType>>,
+        filters: Option<&[RelationType]>,
     ) -> Result<Vec<Event>, Self::Error> {
         let inner = self.inner.read().unwrap();
 
-        let filters = filters.map(|filter| {
-            filter
-                .into_iter()
-                .map(|f| {
-                    // TODO: get Ruma fix from https://github.com/ruma/ruma/pull/2052
-                    if f == RelationType::Replacement {
-                        "m.replace".to_owned()
-                    } else {
-                        f.to_string()
-                    }
-                })
-                .collect::<Vec<_>>()
-        });
+        let filters = compute_filters_string(filters);
 
         let related_events = inner
             .events

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -218,22 +218,13 @@ impl EventCacheStore for MemoryStore {
         Ok(event)
     }
 
-    async fn find_event_with_relations(
+    async fn find_event_relations(
         &self,
         room_id: &RoomId,
         event_id: &EventId,
         filters: Option<Vec<RelationType>>,
-    ) -> Result<Option<(Event, Vec<Event>)>, Self::Error> {
+    ) -> Result<Vec<Event>, Self::Error> {
         let inner = self.inner.read().unwrap();
-
-        let event = inner.events.items().find_map(|(event, this_room_id)| {
-            (room_id == this_room_id && event.event_id()? == event_id).then_some(event.clone())
-        });
-
-        let Some(event) = event else {
-            // Not found.
-            return Ok(None);
-        };
 
         let filters = filters.map(|filter| {
             filter
@@ -275,7 +266,7 @@ impl EventCacheStore for MemoryStore {
             })
             .collect();
 
-        Ok(Some((event, related_events)))
+        Ok(related_events)
     }
 
     async fn save_event(&self, room_id: &RoomId, event: Event) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -206,16 +206,14 @@ impl EventCacheStore for MemoryStore {
         &self,
         room_id: &RoomId,
         event_id: &EventId,
-    ) -> Result<Option<(Position, Event)>, Self::Error> {
+    ) -> Result<Option<Event>, Self::Error> {
         let inner = self.inner.read().unwrap();
 
-        let pos_and_event =
-            inner.events.items_with_positions().find_map(|(position, event, this_room_id)| {
-                (room_id == this_room_id && event.event_id()? == event_id)
-                    .then_some((position, event.clone()))
-            });
+        let event = inner.events.items().find_map(|(event, this_room_id)| {
+            (room_id == this_room_id && event.event_id()? == event_id).then_some(event.clone())
+        });
 
-        Ok(pos_and_event)
+        Ok(event)
     }
 
     async fn save_event(&self, room_id: &RoomId, event: Event) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -218,6 +218,11 @@ impl EventCacheStore for MemoryStore {
         Ok(pos_and_event)
     }
 
+    async fn save_event(&self, room_id: &RoomId, event: Event) -> Result<(), Self::Error> {
+        self.inner.write().unwrap().events.save_item(room_id.to_owned(), event);
+        Ok(())
+    }
+
     async fn add_media_content(
         &self,
         request: &MediaRequestParameters,

--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -32,6 +32,8 @@ use matrix_sdk_common::store_locks::{
     BackingStore, CrossProcessStoreLock, CrossProcessStoreLockGuard, LockStoreError,
 };
 pub use matrix_sdk_store_encryption::Error as StoreEncryptionError;
+use ruma::{events::AnySyncTimelineEvent, serde::Raw, OwnedEventId};
+use tracing::trace;
 
 #[cfg(any(test, feature = "testing"))]
 pub use self::integration_tests::EventCacheStoreIntegrationTests;
@@ -191,5 +193,34 @@ impl BackingStore for LockableEventCacheStore {
         holder: &str,
     ) -> std::result::Result<bool, Self::LockError> {
         self.0.try_take_leased_lock(lease_duration_ms, key, holder).await
+    }
+}
+
+/// Helper to extract the relation information from an event.
+///
+/// If the event isn't in relation to another event, then this will return
+/// `None`. Otherwise, returns both the event id this event relates to, and the
+/// kind of relation as a string (e.g. `m.replace`).
+pub fn extract_event_relation(event: &Raw<AnySyncTimelineEvent>) -> Option<(OwnedEventId, String)> {
+    #[derive(serde::Deserialize)]
+    struct RelatesTo {
+        event_id: OwnedEventId,
+        rel_type: String,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct EventContent {
+        #[serde(rename = "m.relates_to")]
+        rel: Option<RelatesTo>,
+    }
+
+    match event.get_field::<EventContent>("content") {
+        Ok(event_content) => {
+            event_content.and_then(|c| c.rel).map(|rel| (rel.event_id, rel.rel_type))
+        }
+        Err(err) => {
+            trace!("when extracting relation data from an event: {err}");
+            None
+        }
     }
 }

--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -32,7 +32,11 @@ use matrix_sdk_common::store_locks::{
     BackingStore, CrossProcessStoreLock, CrossProcessStoreLockGuard, LockStoreError,
 };
 pub use matrix_sdk_store_encryption::Error as StoreEncryptionError;
-use ruma::{events::AnySyncTimelineEvent, serde::Raw, OwnedEventId};
+use ruma::{
+    events::{relation::RelationType, AnySyncTimelineEvent},
+    serde::Raw,
+    OwnedEventId,
+};
 use tracing::trace;
 
 #[cfg(any(test, feature = "testing"))]
@@ -223,4 +227,23 @@ pub fn extract_event_relation(event: &Raw<AnySyncTimelineEvent>) -> Option<(Owne
             None
         }
     }
+}
+
+/// Compute the list of string filters to be applied when looking for an event's
+/// relations.
+// TODO: get Ruma fix from https://github.com/ruma/ruma/pull/2052, and get rid of this function
+// then.
+pub fn compute_filters_string(filters: Option<&[RelationType]>) -> Option<Vec<String>> {
+    filters.map(|filter| {
+        filter
+            .iter()
+            .map(|f| {
+                if *f == RelationType::Replacement {
+                    "m.replace".to_owned()
+                } else {
+                    f.to_string()
+                }
+            })
+            .collect()
+    })
 }

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -132,7 +132,8 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// Save an event, that might or might not be part of an existing linked
     /// chunk.
     ///
-    /// If the event has no event id, it may not be saved.
+    /// If the event has no event id, it will not be saved, and the function
+    /// must return an Ok result early.
     ///
     /// If the event was already stored with the same id, it must be replaced,
     /// without causing an error.

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -116,17 +116,16 @@ pub trait EventCacheStore: AsyncTraitDeps {
         event_id: &EventId,
     ) -> Result<Option<Event>, Self::Error>;
 
-    /// Get an event from a given room, along with all the events which relate
-    /// to it.
+    /// Find all the events that relate to a given event.
     ///
     /// An additional filter can be provided to only retrieve related events for
     /// a certain relationship.
-    async fn find_event_with_relations(
+    async fn find_event_relations(
         &self,
         room_id: &RoomId,
         event_id: &EventId,
         filter: Option<Vec<RelationType>>,
-    ) -> Result<Option<(Event, Vec<Event>)>, Self::Error>;
+    ) -> Result<Vec<Event>, Self::Error>;
 
     /// Save an event, that might or might not be part of an existing linked
     /// chunk.
@@ -335,13 +334,13 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
         self.0.find_event(room_id, event_id).await.map_err(Into::into)
     }
 
-    async fn find_event_with_relations(
+    async fn find_event_relations(
         &self,
         room_id: &RoomId,
         event_id: &EventId,
         filter: Option<Vec<RelationType>>,
-    ) -> Result<Option<(Event, Vec<Event>)>, Self::Error> {
-        self.0.find_event_with_relations(room_id, event_id, filter).await.map_err(Into::into)
+    ) -> Result<Vec<Event>, Self::Error> {
+        self.0.find_event_relations(room_id, event_id, filter).await.map_err(Into::into)
     }
 
     async fn save_event(&self, room_id: &RoomId, event: Event) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -114,7 +114,7 @@ pub trait EventCacheStore: AsyncTraitDeps {
         &self,
         room_id: &RoomId,
         event_id: &EventId,
-    ) -> Result<Option<(Position, Event)>, Self::Error>;
+    ) -> Result<Option<Event>, Self::Error>;
 
     /// Save an event, that might or might not be part of an existing linked
     /// chunk.
@@ -319,7 +319,7 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
         &self,
         room_id: &RoomId,
         event_id: &EventId,
-    ) -> Result<Option<(Position, Event)>, Self::Error> {
+    ) -> Result<Option<Event>, Self::Error> {
         self.0.find_event(room_id, event_id).await.map_err(Into::into)
     }
 

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -124,7 +124,7 @@ pub trait EventCacheStore: AsyncTraitDeps {
         &self,
         room_id: &RoomId,
         event_id: &EventId,
-        filter: Option<Vec<RelationType>>,
+        filter: Option<&[RelationType]>,
     ) -> Result<Vec<Event>, Self::Error>;
 
     /// Save an event, that might or might not be part of an existing linked
@@ -338,7 +338,7 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
         &self,
         room_id: &RoomId,
         event_id: &EventId,
-        filter: Option<Vec<RelationType>>,
+        filter: Option<&[RelationType]>,
     ) -> Result<Vec<Event>, Self::Error> {
         self.0.find_event_relations(room_id, event_id, filter).await.map_err(Into::into)
     }

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -98,7 +98,9 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// Clear persisted events for all the rooms.
     ///
     /// This will empty and remove all the linked chunks stored previously,
-    /// using the above [`Self::handle_linked_chunk_updates`] methods.
+    /// using the above [`Self::handle_linked_chunk_updates`] methods. It
+    /// must *also* delete all the events' content, if they were stored in a
+    /// separate table.
     async fn clear_all_rooms_chunks(&self) -> Result<(), Self::Error>;
 
     /// Given a set of event IDs, return the duplicated events along with their

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -379,6 +379,12 @@ where
             }
         })
     }
+
+    /// Save a single item "out-of-band" in the relational linked chunk.
+    pub fn save_item(&mut self, room_id: OwnedRoomId, item: Item) {
+        let id = item.id();
+        self.items.entry(room_id).or_default().insert(id, item);
+    }
 }
 
 impl<ItemId, Item, Gap> RelationalLinkedChunk<ItemId, Item, Gap>

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -363,23 +363,6 @@ where
             .flat_map(|(room_id, items)| items.values().map(|item| (item, room_id.as_ref())))
     }
 
-    /// Return an iterator over all items of all rooms, with their actual
-    /// positions, in no particular order.
-    ///
-    /// This will *not* include out of band items.
-    // TODO(bnjbvr): see if I can delete this one — reviewier, if this comment is
-    // still here during review, please let me know.
-    pub fn items_with_positions(&self) -> impl Iterator<Item = (Position, &Item, &RoomId)> {
-        self.items_chunks.iter().filter_map(|item_row| {
-            if let Either::Item(item_id) = &item_row.item {
-                let item = self.items.get(&item_row.room_id)?.get(item_id)?;
-                Some((item_row.position, item, item_row.room_id.as_ref()))
-            } else {
-                None
-            }
-        })
-    }
-
     /// Save a single item "out-of-band" in the relational linked chunk.
     pub fn save_item(&mut self, room_id: OwnedRoomId, item: Item) {
         let id = item.id();

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/007_event_chunks.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/007_event_chunks.sql
@@ -1,4 +1,4 @@
--- We're going to split the `events` table into two tables: `events` and `events_chunks`.
+-- We're going to split the `events` table into two tables: `events` and `event_chunks`.
 -- The former table will include the events' content, while the latter will include the location of
 -- each event in the linked chunk.
 
@@ -14,7 +14,7 @@ CREATE TABLE "events" (
     -- The room in which the event is located.
     "room_id" BLOB NOT NULL,
 
-    -- `OwnedEventId` for events.
+    -- The `OwnedEventId` of this event.
     "event_id" BLOB NOT NULL,
 
     -- JSON serialized `TimelineEvent` (encrypted value).
@@ -35,7 +35,7 @@ CREATE TABLE "events" (
 WITHOUT ROWID;
 
 -- Entries inside an event chunk.
-CREATE TABLE "events_chunks" (
+CREATE TABLE "event_chunks" (
     -- Which room does this event belong to? (hashed key shared with linked_chunks)
     "room_id" BLOB NOT NULL,
     -- Which chunk does this event refer to? Corresponds to a `ChunkIdentifier`.
@@ -58,3 +58,6 @@ CREATE TABLE "events_chunks" (
     FOREIGN KEY (room_id, chunk_id) REFERENCES linked_chunks(room_id, id) ON DELETE CASCADE
 )
 WITHOUT ROWID;
+
+-- For consistency, rename gaps to gap_chunks.
+ALTER TABLE gaps RENAME TO gap_chunks;

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/007_events_chunks.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/007_events_chunks.sql
@@ -11,6 +11,9 @@ DROP TABLE "events";
 
 -- Events and their content.
 CREATE TABLE "events" (
+    -- The room in which the event is located.
+    "room_id" BLOB NOT NULL,
+
     -- `OwnedEventId` for events.
     "event_id" BLOB NOT NULL,
 

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/007_events_chunks.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/007_events_chunks.sql
@@ -1,0 +1,57 @@
+-- We're going to split the `events` table into two tables: `events` and `events_chunks`.
+-- The former table will include the events' content, while the latter will include the location of
+-- each event in the linked chunk.
+
+-- Since we're going to get rid of the event chunks, we have to empty all the linked chunks.
+DELETE FROM "linked_chunks";
+
+-- Delete the events table that contains entries into an event chunk, along with the content of
+-- those events.
+DROP TABLE "events";
+
+-- Events and their content.
+CREATE TABLE "events" (
+    -- `OwnedEventId` for events.
+    "event_id" BLOB NOT NULL,
+
+    -- JSON serialized `TimelineEvent` (encrypted value).
+    "content" BLOB NOT NULL,
+
+    -- If this event is an aggregation (related event), the event id of the event it relates to.
+    -- Can be null if this event isn't an aggregation.
+    "relates_to" BLOB,
+
+    -- If this event is an aggregation (related event), the kind of relation it has to the event it
+    -- relates to.
+    -- Can be null if this event isn't an aggregation.
+    "rel_type" BLOB,
+
+    -- Primary key is the event ID.
+    PRIMARY KEY (event_id)
+)
+WITHOUT ROWID;
+
+-- Entries inside an event chunk.
+CREATE TABLE "events_chunks" (
+    -- Which room does this event belong to? (hashed key shared with linked_chunks)
+    "room_id" BLOB NOT NULL,
+    -- Which chunk does this event refer to? Corresponds to a `ChunkIdentifier`.
+    "chunk_id" INTEGER NOT NULL,
+
+    -- `OwnedEventId` for events.
+    "event_id" BLOB NOT NULL,
+    -- Position (index) in the chunk.
+    "position" INTEGER NOT NULL,
+
+    -- Primary key is the event ID.
+    PRIMARY KEY (event_id),
+
+    -- We need a uniqueness constraint over the `room_id`, `chunk_id` and
+    -- `position` tuple because (i) they must be unique, (ii) it dramatically
+    -- improves the performance.
+    UNIQUE (room_id, chunk_id, position),
+
+    -- If the owning chunk gets deleted, delete the entry too.
+    FOREIGN KEY (room_id, chunk_id) REFERENCES linked_chunks(room_id, id) ON DELETE CASCADE
+)
+WITHOUT ROWID;

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -862,7 +862,9 @@ impl EventCacheStore for SqliteEventCacheStore {
             .await?
             .with_transaction(move |txn| {
                 // Remove all the chunks, and let cascading do its job.
-                txn.execute("DELETE FROM linked_chunks", ())
+                txn.execute("DELETE FROM linked_chunks", ())?;
+                // Also clear all the events' contents.
+                txn.execute("DELETE FROM events", ())
             })
             .await?;
         Ok(())

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -335,7 +335,7 @@ impl TransactionExtForLinkedChunks for Transaction<'_> {
                 r#"
                     SELECT content
                     FROM events_chunks ec
-                    INNER JOIN events USING (event_id)
+                    INNER JOIN events USING (event_id, room_id)
                     WHERE ec.chunk_id = ? AND ec.room_id = ?
                     ORDER BY ec.position ASC
                 "#,
@@ -583,7 +583,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                         // already inserted in the database. This is the case when an event is
                         // deduplicated and moved to another position.
                         let mut content_statement = txn.prepare(
-                            "INSERT OR REPLACE INTO events(event_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?)"
+                            "INSERT OR REPLACE INTO events(room_id, event_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?)"
                         )?;
 
                         let invalid_event = |event: TimelineEvent| {
@@ -602,7 +602,7 @@ impl EventCacheStore for SqliteEventCacheStore {
 
                             // Now, insert the event content into the database.
                             let encoded_event = this.encode_event(&event)?;
-                            content_statement.execute((event_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
+                            content_statement.execute((&hashed_room_id, event_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
                         }
                     }
 
@@ -624,8 +624,8 @@ impl EventCacheStore for SqliteEventCacheStore {
                         // of the new event.
                         let encoded_event = this.encode_event(&event)?;
                         txn.execute(
-                            "INSERT OR REPLACE INTO events(event_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?)"
-                        , (&event_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
+                            "INSERT OR REPLACE INTO events(room_id, event_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?)"
+                        , (&hashed_room_id, &event_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
 
                         // Replace the event id in the linked chunk, in case it changed.
                         txn.execute(
@@ -965,7 +965,7 @@ impl EventCacheStore for SqliteEventCacheStore {
         &self,
         room_id: &RoomId,
         event_id: &EventId,
-    ) -> Result<Option<(Position, Event)>, Self::Error> {
+    ) -> Result<Option<Event>, Self::Error> {
         let hashed_room_id = self.encode_key(keys::LINKED_CHUNKS, room_id);
         let event_id = event_id.to_owned();
         let this = self.clone();
@@ -973,22 +973,9 @@ impl EventCacheStore for SqliteEventCacheStore {
         self.acquire()
             .await?
             .with_transaction(move |txn| -> Result<_> {
-                let Some((chunk_identifier, index, event)) = txn
-                    .prepare(
-                        r#"
-                            SELECT chunk_id, position, content
-                            FROM events_chunks ec
-                            INNER JOIN events USING (event_id)
-                            WHERE ec.room_id = ? AND ec.event_id = ?
-                        "#,
-                    )?
-                    .query_row((hashed_room_id, event_id.as_str()), |row| {
-                        Ok((
-                            row.get::<_, u64>(0)?,
-                            row.get::<_, usize>(1)?,
-                            row.get::<_, Vec<u8>>(2)?,
-                        ))
-                    })
+                let Some(event) = txn
+                    .prepare("SELECT content FROM events WHERE event_id = ? AND room_id = ?")?
+                    .query_row((event_id.as_str(), hashed_room_id), |row| row.get::<_, Vec<u8>>(0))
                     .optional()?
                 else {
                     // Event is not found.
@@ -997,7 +984,7 @@ impl EventCacheStore for SqliteEventCacheStore {
 
                 let event = serde_json::from_slice(&this.decode_value(&event)?)?;
 
-                Ok(Some((Position::new(ChunkIdentifier::new(chunk_identifier), index), event)))
+                Ok(Some(event))
             })
             .await
     }
@@ -1008,6 +995,7 @@ impl EventCacheStore for SqliteEventCacheStore {
             return Ok(());
         };
 
+        let hashed_room_id = self.encode_key(keys::LINKED_CHUNKS, room_id);
         let event_id = event_id.to_string();
         let encoded_event = self.encode_event(&event)?;
 
@@ -1015,8 +1003,8 @@ impl EventCacheStore for SqliteEventCacheStore {
             .await?
             .with_transaction(move |txn| -> Result<_> {
                 txn.execute(
-                    "INSERT OR REPLACE INTO events(event_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?)"
-                    , (&event_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
+                    "INSERT OR REPLACE INTO events(room_id, event_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?)"
+                    , (&hashed_room_id, &event_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
 
                 Ok(())
             })

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -37,7 +37,10 @@ use matrix_sdk_base::{
     media::{MediaRequestParameters, UniqueKey},
 };
 use matrix_sdk_store_encryption::StoreCipher;
-use ruma::{time::SystemTime, EventId, MilliSecondsSinceUnixEpoch, MxcUri, OwnedEventId, RoomId};
+use ruma::{
+    events::relation::RelationType, time::SystemTime, EventId, MilliSecondsSinceUnixEpoch, MxcUri,
+    OwnedEventId, RoomId,
+};
 use rusqlite::{params_from_iter, OptionalExtension, ToSql, Transaction, TransactionBehavior};
 use tokio::fs;
 use tracing::{debug, error, trace};
@@ -967,6 +970,70 @@ impl EventCacheStore for SqliteEventCacheStore {
                 let event = serde_json::from_slice(&this.decode_value(&event)?)?;
 
                 Ok(Some(event))
+            })
+            .await
+    }
+
+    async fn find_event_with_relations(
+        &self,
+        room_id: &RoomId,
+        event_id: &EventId,
+        filters: Option<Vec<RelationType>>,
+    ) -> Result<Option<(Event, Vec<Event>)>, Self::Error> {
+        let hashed_room_id = self.encode_key(keys::LINKED_CHUNKS, room_id);
+        let event_id = event_id.to_owned();
+        let this = self.clone();
+
+        self.acquire()
+            .await?
+            .with_transaction(move |txn| -> Result<_> {
+                let Some(target) = txn
+                    .prepare("SELECT content FROM events WHERE event_id = ? AND room_id = ?")?
+                    .query_row((event_id.as_str(), &hashed_room_id), |row| row.get::<_, Vec<u8>>(0))
+                    .optional()?
+                else {
+                    // Event is not found.
+                    return Ok(None);
+                };
+
+                let filter_query = if let Some(filters) = filters {
+                    let filters = filters
+                        .into_iter()
+                        .map(|f| {
+                            // TODO: get Ruma fix from https://github.com/ruma/ruma/pull/2052
+                            if f == RelationType::Replacement {
+                                "m.replace".to_owned()
+                            } else {
+                                f.to_string()
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    format!(" AND rel_type IN ({})", filters.join(" AND "))
+                } else {
+                    "".to_owned()
+                };
+
+                let query = format!(
+                    "SELECT content FROM events WHERE relates_to = ? AND room_id = ? {}",
+                    filter_query
+                );
+
+                // Collect related events.
+                let mut rel = Vec::new();
+                for ev in
+                    txn.prepare(&query)?.query_map((event_id.as_str(), hashed_room_id), |row| {
+                        row.get::<_, Vec<u8>>(0)
+                    })?
+                {
+                    let ev = ev?;
+                    let ev = serde_json::from_slice(&this.decode_value(&ev)?)?;
+                    rel.push(ev);
+                }
+
+                let target = serde_json::from_slice(&this.decode_value(&target)?)?;
+
+                Ok(Some((target, rel)))
             })
             .await
     }

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -68,7 +68,7 @@ const DATABASE_NAME: &str = "matrix-sdk-event-cache.sqlite3";
 /// This is used to figure whether the SQLite database requires a migration.
 /// Every new SQL migration should imply a bump of this number, and changes in
 /// the [`run_migrations`] function.
-const DATABASE_VERSION: u8 = 6;
+const DATABASE_VERSION: u8 = 7;
 
 /// The string used to identify a chunk of type events, in the `type` field in
 /// the database.
@@ -291,9 +291,11 @@ impl TransactionExtForLinkedChunks for Transaction<'_> {
         for event_data in self
             .prepare(
                 r#"
-                    SELECT content FROM events
-                    WHERE chunk_id = ? AND room_id = ?
-                    ORDER BY position ASC
+                    SELECT content
+                    FROM events_chunks ec
+                    INNER JOIN events USING (event_id)
+                    WHERE ec.chunk_id = ? AND ec.room_id = ?
+                    ORDER BY ec.position ASC
                 "#,
             )?
             .query_map((chunk_id.index(), &room_id), |row| row.get::<_, Vec<u8>>(0))?
@@ -373,6 +375,16 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/event_cache_store/006_events.sql"))?;
             txn.set_db_version(6)
+        })
+        .await?;
+    }
+
+    if version < 7 {
+        conn.with_transaction(|txn| {
+            txn.execute_batch(include_str!(
+                "../migrations/event_cache_store/007_events_chunks.sql"
+            ))?;
+            txn.set_db_version(7)
         })
         .await?;
     }
@@ -521,8 +533,15 @@ impl EventCacheStore for SqliteEventCacheStore {
 
                         trace!(%room_id, "pushing {} items @ {chunk_id}", items.len());
 
-                        let mut statement = txn.prepare(
-                            "INSERT INTO events(chunk_id, room_id, event_id, content, position) VALUES (?, ?, ?, ?, ?)"
+                        let mut chunk_statement = txn.prepare(
+                            "INSERT INTO events_chunks(chunk_id, room_id, event_id, position) VALUES (?, ?, ?, ?)"
+                        )?;
+
+                        // Note: we use `OR REPLACE` here, because the event might have been
+                        // already inserted in the database. This is the case when an event is
+                        // deduplicated and moved to another position.
+                        let mut content_statement = txn.prepare(
+                            "INSERT OR REPLACE INTO events(event_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?)"
                         )?;
 
                         let invalid_event = |event: TimelineEvent| {
@@ -535,23 +554,27 @@ impl EventCacheStore for SqliteEventCacheStore {
                         };
 
                         for (i, (event_id, event)) in items.into_iter().filter_map(invalid_event).enumerate() {
+                            // Insert the location information into the database.
+                            let index = at.index() + i;
+                            chunk_statement.execute((chunk_id, &hashed_room_id, &event_id, index))?;
+
+                            // Now, insert the event content into the database.
                             let serialized = serde_json::to_vec(&event)?;
                             let content = this.encode_value(serialized)?;
-
-                            let index = at.index() + i;
-
-                            statement.execute((chunk_id, &hashed_room_id, event_id, content, index))?;
+                            // Extract the relationship information, if any.
+                            // TODO
+                            let relates_to = None::<usize>;
+                            let rel_type = None::<usize>;
+                            content_statement.execute((event_id, content, relates_to, rel_type))?;
                         }
                     }
 
                     Update::ReplaceItem { at, item: event } => {
                         let chunk_id = at.chunk_identifier().index();
+
                         let index = at.index();
 
                         trace!(%room_id, "replacing item @ {chunk_id}:{index}");
-
-                        let serialized = serde_json::to_vec(&event)?;
-                        let content = this.encode_value(serialized)?;
 
                         // The event id should be the same, but just in case it changed…
                         let Some(event_id) = event.event_id().map(|event_id| event_id.to_string()) else {
@@ -559,13 +582,23 @@ impl EventCacheStore for SqliteEventCacheStore {
                             continue;
                         };
 
+                        let serialized = serde_json::to_vec(&event)?;
+                        let content = this.encode_value(serialized)?;
+                        // TODO extract the relationship information here too!
+
+                        // Replace the event's content. Really we'd like to update, but in case the
+                        // event id changed, we are a bit lenient here and will allow an insertion
+                        // of the new event.
+                        let relates_to = None::<usize>;
+                        let rel_type = None::<usize>;
                         txn.execute(
-                            r#"
-                            UPDATE events
-                            SET content = ?, event_id = ?
-                            WHERE room_id = ? AND chunk_id = ? AND position = ?
-                        "#,
-                            (content, event_id, &hashed_room_id, chunk_id, index,)
+                            "INSERT OR REPLACE INTO events(event_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?)"
+                        , (&event_id, content, relates_to, rel_type))?;
+
+                        // Replace the event id in the linked chunk, in case it changed.
+                        txn.execute(
+                            r#"UPDATE events_chunks SET event_id = ? WHERE room_id = ? AND chunk_id = ? AND position = ?"#,
+                            (event_id, &hashed_room_id, chunk_id, index)
                         )?;
                     }
 
@@ -575,13 +608,13 @@ impl EventCacheStore for SqliteEventCacheStore {
 
                         trace!(%room_id, "removing item @ {chunk_id}:{index}");
 
-                        // Remove the entry.
-                        txn.execute("DELETE FROM events WHERE room_id = ? AND chunk_id = ? AND position = ?", (&hashed_room_id, chunk_id, index))?;
+                        // Remove the entry in the chunk table.
+                        txn.execute("DELETE FROM events_chunks WHERE room_id = ? AND chunk_id = ? AND position = ?", (&hashed_room_id, chunk_id, index))?;
 
                         // Decrement the index of each item after the one we're going to remove.
                         txn.execute(
                             r#"
-                                UPDATE events
+                                UPDATE events_chunks
                                 SET position = position - 1
                                 WHERE room_id = ? AND chunk_id = ? AND position > ?
                             "#,
@@ -597,7 +630,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                         trace!(%room_id, "truncating items >= {chunk_id}:{index}");
 
                         // Remove these entries.
-                        txn.execute("DELETE FROM events WHERE room_id = ? AND chunk_id = ? AND position >= ?", (&hashed_room_id, chunk_id, index))?;
+                        txn.execute("DELETE FROM events_chunks WHERE room_id = ? AND chunk_id = ? AND position >= ?", (&hashed_room_id, chunk_id, index))?;
                     }
 
                     Update::Clear => {
@@ -839,9 +872,15 @@ impl EventCacheStore for SqliteEventCacheStore {
             .with_transaction(move |txn| -> Result<_> {
                 txn.chunk_large_query_over(events, None, move |txn, events| {
                     let query = format!(
-                        "SELECT event_id, chunk_id, position FROM events WHERE room_id = ? AND event_id IN ({}) ORDER BY chunk_id ASC, position ASC",
+                        r#"
+                            SELECT event_id, chunk_id, position
+                            FROM events_chunks
+                            WHERE room_id = ? AND event_id IN ({})
+                            ORDER BY chunk_id ASC, position ASC
+                        "#,
                         repeat_vars(events.len()),
                     );
+
                     let parameters = params_from_iter(
                         // parameter for `room_id = ?`
                         once(
@@ -862,16 +901,13 @@ impl EventCacheStore for SqliteEventCacheStore {
 
                     let mut duplicated_events = Vec::new();
 
-                    for duplicated_event in txn
-                        .prepare(&query)?
-                        .query_map(parameters, |row| {
-                            Ok((
-                                row.get::<_, String>(0)?,
-                                row.get::<_, u64>(1)?,
-                                row.get::<_, usize>(2)?
-                            ))
-                        })?
-                    {
+                    for duplicated_event in txn.prepare(&query)?.query_map(parameters, |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, u64>(1)?,
+                            row.get::<_, usize>(2)?,
+                        ))
+                    })? {
                         let (duplicated_event, chunk_identifier, index) = duplicated_event?;
 
                         let Ok(duplicated_event) = EventId::parse(duplicated_event.clone()) else {
@@ -881,7 +917,10 @@ impl EventCacheStore for SqliteEventCacheStore {
                             continue;
                         };
 
-                        duplicated_events.push((duplicated_event, Position::new(ChunkIdentifier::new(chunk_identifier), index)));
+                        duplicated_events.push((
+                            duplicated_event,
+                            Position::new(ChunkIdentifier::new(chunk_identifier), index),
+                        ));
                     }
 
                     Ok(duplicated_events)
@@ -904,9 +943,14 @@ impl EventCacheStore for SqliteEventCacheStore {
             .with_transaction(move |txn| -> Result<_> {
                 let Some((chunk_identifier, index, event)) = txn
                     .prepare(
-                        "SELECT chunk_id, position, content FROM events WHERE room_id = ? AND event_id = ?",
+                        r#"
+                            SELECT chunk_id, position, content
+                            FROM events_chunks ec
+                            INNER JOIN events USING (event_id)
+                            WHERE ec.room_id = ? AND ec.event_id = ?
+                        "#,
                     )?
-                    .query_row((hashed_room_id, event_id.as_str(),), |row| {
+                    .query_row((hashed_room_id, event_id.as_str()), |row| {
                         Ok((
                             row.get::<_, u64>(0)?,
                             row.get::<_, usize>(1)?,
@@ -1366,7 +1410,9 @@ mod tests {
     use matrix_sdk_base::{
         event_cache::{
             store::{
-                integration_tests::{check_test_event, make_test_event},
+                integration_tests::{
+                    check_test_event, make_test_event, make_test_event_with_event_id,
+                },
                 media::IgnoreMediaRetentionPolicy,
                 EventCacheStore, EventCacheStoreError,
             },
@@ -1379,7 +1425,7 @@ mod tests {
     };
     use matrix_sdk_test::{async_test, DEFAULT_TEST_ROOM_ID};
     use once_cell::sync::Lazy;
-    use ruma::{events::room::MediaSource, media::Method, mxc_uri, room_id, uint};
+    use ruma::{event_id, events::room::MediaSource, media::Method, mxc_uri, room_id, uint};
     use tempfile::{tempdir, TempDir};
 
     use super::SqliteEventCacheStore;
@@ -1595,6 +1641,7 @@ mod tests {
         let store = get_event_cache_store().await.expect("creating cache store failed");
 
         let room_id = &DEFAULT_TEST_ROOM_ID;
+        let event_id = event_id!("$world");
 
         store
             .handle_linked_chunk_updates(
@@ -1609,12 +1656,12 @@ mod tests {
                         at: Position::new(ChunkIdentifier::new(42), 0),
                         items: vec![
                             make_test_event(room_id, "hello"),
-                            make_test_event(room_id, "world"),
+                            make_test_event_with_event_id(room_id, "world", Some(event_id)),
                         ],
                     },
                     Update::ReplaceItem {
                         at: Position::new(ChunkIdentifier::new(42), 1),
-                        item: make_test_event(room_id, "yolo"),
+                        item: make_test_event_with_event_id(room_id, "yolo", Some(event_id)),
                     },
                 ],
             )
@@ -1808,7 +1855,7 @@ mod tests {
             .unwrap()
             .with_transaction(move |txn| {
                 txn.query_row(
-                    "SELECT COUNT(*) FROM events WHERE chunk_id = 42 AND room_id = ? AND position = 0",
+                    "SELECT COUNT(*) FROM events_chunks WHERE chunk_id = 42 AND room_id = ? AND position = 0",
                     (room_id.as_bytes(),),
                     |row| row.get(0),
                 )
@@ -1959,7 +2006,7 @@ mod tests {
                 assert_eq!(num_gaps, 0);
 
                 let num_events = txn
-                    .prepare("SELECT COUNT(event_id) FROM events ORDER BY chunk_id")?
+                    .prepare("SELECT COUNT(event_id) FROM events_chunks ORDER BY chunk_id")?
                     .query_row((), |row| row.get::<_, u64>(0))?;
                 assert_eq!(num_events, 0);
 

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -992,7 +992,14 @@ impl EventCacheStore for SqliteEventCacheStore {
             .with_transaction(move |txn| -> Result<_> {
                 let filter_query = if let Some(filters) = compute_filters_string(filters.as_deref())
                 {
-                    format!(" AND rel_type IN ({})", filters.join(" AND "))
+                    format!(
+                        " AND rel_type IN ({})",
+                        filters
+                            .into_iter()
+                            .map(|f| format!(r#""{f}""#))
+                            .collect::<Vec<_>>()
+                            .join(r#", "#)
+                    )
                 } else {
                     "".to_owned()
                 };

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -297,7 +297,7 @@ impl TransactionExtForLinkedChunks for Transaction<'_> {
         // There's at most one row for it in the database, so a call to `query_row` is
         // sufficient.
         let encoded_prev_token: Vec<u8> = self.query_row(
-            "SELECT prev_token FROM gaps WHERE chunk_id = ? AND room_id = ?",
+            "SELECT prev_token FROM gap_chunks WHERE chunk_id = ? AND room_id = ?",
             (chunk_id.index(), &room_id),
             |row| row.get(0),
         )?;
@@ -318,8 +318,8 @@ impl TransactionExtForLinkedChunks for Transaction<'_> {
         for event_data in self
             .prepare(
                 r#"
-                    SELECT content
-                    FROM events_chunks ec
+                    SELECT events.content
+                    FROM event_chunks ec
                     INNER JOIN events USING (event_id, room_id)
                     WHERE ec.chunk_id = ? AND ec.room_id = ?
                     ORDER BY ec.position ASC
@@ -409,7 +409,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     if version < 7 {
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
-                "../migrations/event_cache_store/007_events_chunks.sql"
+                "../migrations/event_cache_store/007_event_chunks.sql"
             ))?;
             txn.set_db_version(7)
         })
@@ -516,7 +516,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                         // Insert the gap's value.
                         txn.execute(
                             r#"
-                            INSERT INTO gaps(chunk_id, room_id, prev_token)
+                            INSERT INTO gap_chunks(chunk_id, room_id, prev_token)
                             VALUES (?, ?, ?)
                         "#,
                             (new, &hashed_room_id, prev_token),
@@ -561,12 +561,13 @@ impl EventCacheStore for SqliteEventCacheStore {
                         trace!(%room_id, "pushing {} items @ {chunk_id}", items.len());
 
                         let mut chunk_statement = txn.prepare(
-                            "INSERT INTO events_chunks(chunk_id, room_id, event_id, position) VALUES (?, ?, ?, ?)"
+                            "INSERT INTO event_chunks(chunk_id, room_id, event_id, position) VALUES (?, ?, ?, ?)"
                         )?;
 
                         // Note: we use `OR REPLACE` here, because the event might have been
                         // already inserted in the database. This is the case when an event is
-                        // deduplicated and moved to another position.
+                        // deduplicated and moved to another position; or because it was inserted
+                        // outside the context of a linked chunk (e.g. pinned event).
                         let mut content_statement = txn.prepare(
                             "INSERT OR REPLACE INTO events(room_id, event_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?)"
                         )?;
@@ -614,7 +615,7 @@ impl EventCacheStore for SqliteEventCacheStore {
 
                         // Replace the event id in the linked chunk, in case it changed.
                         txn.execute(
-                            r#"UPDATE events_chunks SET event_id = ? WHERE room_id = ? AND chunk_id = ? AND position = ?"#,
+                            r#"UPDATE event_chunks SET event_id = ? WHERE room_id = ? AND chunk_id = ? AND position = ?"#,
                             (event_id, &hashed_room_id, chunk_id, index)
                         )?;
                     }
@@ -626,12 +627,12 @@ impl EventCacheStore for SqliteEventCacheStore {
                         trace!(%room_id, "removing item @ {chunk_id}:{index}");
 
                         // Remove the entry in the chunk table.
-                        txn.execute("DELETE FROM events_chunks WHERE room_id = ? AND chunk_id = ? AND position = ?", (&hashed_room_id, chunk_id, index))?;
+                        txn.execute("DELETE FROM event_chunks WHERE room_id = ? AND chunk_id = ? AND position = ?", (&hashed_room_id, chunk_id, index))?;
 
                         // Decrement the index of each item after the one we're going to remove.
                         txn.execute(
                             r#"
-                                UPDATE events_chunks
+                                UPDATE event_chunks
                                 SET position = position - 1
                                 WHERE room_id = ? AND chunk_id = ? AND position > ?
                             "#,
@@ -647,7 +648,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                         trace!(%room_id, "truncating items >= {chunk_id}:{index}");
 
                         // Remove these entries.
-                        txn.execute("DELETE FROM events_chunks WHERE room_id = ? AND chunk_id = ? AND position >= ?", (&hashed_room_id, chunk_id, index))?;
+                        txn.execute("DELETE FROM event_chunks WHERE room_id = ? AND chunk_id = ? AND position >= ?", (&hashed_room_id, chunk_id, index))?;
                     }
 
                     Update::Clear => {
@@ -893,7 +894,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                     let query = format!(
                         r#"
                             SELECT event_id, chunk_id, position
-                            FROM events_chunks
+                            FROM event_chunks
                             WHERE room_id = ? AND event_id IN ({})
                             ORDER BY chunk_id ASC, position ASC
                         "#,
@@ -998,7 +999,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                             .into_iter()
                             .map(|f| format!(r#""{f}""#))
                             .collect::<Vec<_>>()
-                            .join(r#", "#)
+                            .join(", ")
                     )
                 } else {
                     "".to_owned()
@@ -1824,7 +1825,7 @@ mod tests {
             .with_transaction(|txn| -> rusqlite::Result<_> {
                 let mut gaps = Vec::new();
                 for data in txn
-                    .prepare("SELECT chunk_id FROM gaps ORDER BY chunk_id")?
+                    .prepare("SELECT chunk_id FROM gap_chunks ORDER BY chunk_id")?
                     .query_map((), |row| row.get::<_, u64>(0))?
                 {
                     gaps.push(data?);
@@ -1933,7 +1934,7 @@ mod tests {
             .unwrap()
             .with_transaction(move |txn| {
                 txn.query_row(
-                    "SELECT COUNT(*) FROM events_chunks WHERE chunk_id = 42 AND room_id = ? AND position = 0",
+                    "SELECT COUNT(*) FROM event_chunks WHERE chunk_id = 42 AND room_id = ? AND position = 0",
                     (room_id.as_bytes(),),
                     |row| row.get(0),
                 )
@@ -2079,12 +2080,12 @@ mod tests {
             .unwrap()
             .with_transaction(|txn| -> rusqlite::Result<_> {
                 let num_gaps = txn
-                    .prepare("SELECT COUNT(chunk_id) FROM gaps ORDER BY chunk_id")?
+                    .prepare("SELECT COUNT(chunk_id) FROM gap_chunks ORDER BY chunk_id")?
                     .query_row((), |row| row.get::<_, u64>(0))?;
                 assert_eq!(num_gaps, 0);
 
                 let num_events = txn
-                    .prepare("SELECT COUNT(event_id) FROM events_chunks ORDER BY chunk_id")?
+                    .prepare("SELECT COUNT(event_id) FROM event_chunks ORDER BY chunk_id")?
                     .query_row((), |row| row.get::<_, u64>(0))?;
                 assert_eq!(num_events, 0);
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -630,7 +630,6 @@ async fn test_send_edit_when_timeline_is_clear() {
     // expectations).
 
     server.sync_room(&client, JoinedRoomBuilder::new(room_id).set_timeline_limited()).await;
-    client.event_cache().empty_immutable_cache().await;
 
     yield_now().await;
     assert_next_matches!(timeline_stream, VectorDiff::Clear);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -303,21 +303,6 @@ async fn test_cached_events_are_kept_for_different_room_instances() {
     server.server().reset().await;
     drop(timeline);
     drop(room);
-
-    // Now remove the pinned events from the cache and try again
-    client.event_cache().empty_immutable_cache().await;
-    let room = PinnedEventsSync::new(room_id)
-        .with_pinned_event_ids(vec!["$1", "$2"])
-        .mock_and_sync(&client, &server)
-        .await
-        .expect("Sync failed");
-
-    // And a new timeline one
-    let ret = Timeline::builder(&room).with_focus(pinned_events_focus(2)).build().await;
-
-    // Since the events are no longer in the cache the timeline couldn't load them
-    // and can't be initialised.
-    assert!(ret.is_err());
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -240,7 +240,9 @@ async fn test_cached_events_are_kept_for_different_room_instances() {
     let room_id = room_id!("!test:localhost");
 
     // Subscribe to the event cache.
-    client.event_cache().subscribe().unwrap();
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+    event_cache.enable_storage().unwrap();
 
     let f = EventFactory::new().room(room_id).sender(*BOB);
     let pinned_event = f

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -972,12 +972,13 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_save_event_and_clear() {
+    async fn test_save_event() {
         let client = logged_in_client(None).await;
         let room_id = room_id!("!galette:saucisse.bzh");
 
         let event_cache = client.event_cache();
         event_cache.subscribe().unwrap();
+        event_cache.enable_storage().unwrap();
 
         let f = EventFactory::new().room(room_id).sender(user_id!("@ben:saucisse.bzh"));
         let event_id = event_id!("$1");

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -987,7 +987,7 @@ mod tests {
         let room = client.get_room(room_id).unwrap();
 
         let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
-        room_event_cache.save_event(f.text_msg("hey there").event_id(event_id).into()).await;
+        room_event_cache.save_events([f.text_msg("hey there").event_id(event_id).into()]).await;
 
         // Retrieving the event at the room-wide cache works.
         assert!(room_event_cache.event(event_id).await.is_some());

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -46,14 +46,7 @@ use matrix_sdk_common::executor::{spawn, JoinHandle};
 use once_cell::sync::OnceCell;
 use room::RoomEventCacheState;
 use ruma::{
-    events::{
-        relation::RelationType,
-        room::{message::Relation, redaction::SyncRoomRedactionEvent},
-        AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
-        AnySyncTimelineEvent,
-    },
-    serde::Raw,
-    EventId, OwnedEventId, OwnedRoomId, RoomId, RoomVersionId,
+    events::AnySyncEphemeralRoomEvent, serde::Raw, OwnedEventId, OwnedRoomId, RoomId, RoomVersionId,
 };
 use tokio::sync::{
     broadcast::{error::RecvError, Receiver},
@@ -169,7 +162,6 @@ impl EventCache {
                 multiple_room_updates_lock: Default::default(),
                 by_room: Default::default(),
                 drop_handles: Default::default(),
-                all_events: Default::default(),
                 auto_shrink_sender: Default::default(),
             }),
         }
@@ -228,33 +220,6 @@ impl EventCache {
         });
 
         Ok(())
-    }
-
-    /// Try to find an event by its ID in all the rooms.
-    // Note: replace this with a select-by-id query when this is implemented in a
-    // store.
-    pub async fn event(&self, event_id: &EventId) -> Option<TimelineEvent> {
-        self.inner
-            .all_events
-            .read()
-            .await
-            .events
-            .get(event_id)
-            .map(|(_room_id, event)| event.clone())
-    }
-
-    /// Clear all the events from the immutable event cache.
-    ///
-    /// This keeps all the rooms along with their internal events linked chunks,
-    /// but it clears the side immutable cache for events.
-    ///
-    /// As such, it doesn't emit any [`RoomEventCacheUpdate`], and it's expected
-    /// to be only useful in testing contexts.
-    // Note: replace this with a remove query when this is implemented in a
-    // store.
-    #[cfg(any(test, feature = "testing"))]
-    pub async fn empty_immutable_cache(&self) {
-        self.inner.all_events.write().await.events.clear();
     }
 
     #[instrument(skip_all)]
@@ -439,146 +404,6 @@ impl EventCache {
     }
 }
 
-type AllEventsMap = BTreeMap<OwnedEventId, (OwnedRoomId, TimelineEvent)>;
-type RelationsMap = BTreeMap<OwnedEventId, BTreeMap<OwnedEventId, RelationType>>;
-
-/// Cache wrapper containing both copies of received events and lists of event
-/// ids related to them.
-#[derive(Default, Clone)]
-struct AllEventsCache {
-    /// A cache of received events mapped by their event id.
-    events: AllEventsMap,
-    /// A cache of related event ids for an event id. The key is the original
-    /// event id and the value a list of event ids related to it.
-    relations: RelationsMap,
-}
-
-impl AllEventsCache {
-    fn clear(&mut self) {
-        self.events.clear();
-        self.relations.clear();
-    }
-
-    /// If the event is related to another one, its id is added to the relations
-    /// map.
-    fn append_related_event(&mut self, event: &TimelineEvent) {
-        // Handle and cache events and relations.
-        let Ok(AnySyncTimelineEvent::MessageLike(ev)) = event.raw().deserialize() else {
-            return;
-        };
-
-        // Handle redactions separately, as their logic is slightly different.
-        if let AnySyncMessageLikeEvent::RoomRedaction(room_redaction) = &ev {
-            let redacted_event_id = match room_redaction {
-                SyncRoomRedactionEvent::Original(ev) => {
-                    ev.content.redacts.as_ref().or(ev.redacts.as_ref())
-                }
-                SyncRoomRedactionEvent::Redacted(redacted_redaction) => {
-                    redacted_redaction.content.redacts.as_ref()
-                }
-            };
-
-            if let Some(redacted_event_id) = redacted_event_id {
-                self.relations
-                    .entry(redacted_event_id.to_owned())
-                    .or_default()
-                    .insert(ev.event_id().to_owned(), RelationType::Replacement);
-            }
-
-            return;
-        }
-
-        let relationship = match ev.original_content() {
-            Some(AnyMessageLikeEventContent::RoomMessage(c)) => {
-                if let Some(relation) = c.relates_to {
-                    match relation {
-                        Relation::Replacement(replacement) => {
-                            Some((replacement.event_id, RelationType::Replacement))
-                        }
-                        Relation::Reply { in_reply_to } => {
-                            Some((in_reply_to.event_id, RelationType::Reference))
-                        }
-                        Relation::Thread(thread) => Some((thread.event_id, RelationType::Thread)),
-                        // Do nothing for custom
-                        _ => None,
-                    }
-                } else {
-                    None
-                }
-            }
-            Some(AnyMessageLikeEventContent::PollResponse(c)) => {
-                Some((c.relates_to.event_id, RelationType::Reference))
-            }
-            Some(AnyMessageLikeEventContent::PollEnd(c)) => {
-                Some((c.relates_to.event_id, RelationType::Reference))
-            }
-            Some(AnyMessageLikeEventContent::UnstablePollResponse(c)) => {
-                Some((c.relates_to.event_id, RelationType::Reference))
-            }
-            Some(AnyMessageLikeEventContent::UnstablePollEnd(c)) => {
-                Some((c.relates_to.event_id, RelationType::Reference))
-            }
-            Some(AnyMessageLikeEventContent::Reaction(c)) => {
-                Some((c.relates_to.event_id, RelationType::Annotation))
-            }
-            _ => None,
-        };
-
-        if let Some(relationship) = relationship {
-            self.relations
-                .entry(relationship.0)
-                .or_default()
-                .insert(ev.event_id().to_owned(), relationship.1);
-        }
-    }
-
-    /// Looks for related event ids for the passed event id, and appends them to
-    /// the `results` parameter. Then it'll recursively get the related
-    /// event ids for those too.
-    fn collect_related_events(
-        &self,
-        event_id: &EventId,
-        filter: Option<&[RelationType]>,
-    ) -> Vec<TimelineEvent> {
-        let mut results = Vec::new();
-        self.collect_related_events_rec(event_id, filter, &mut results);
-        results
-    }
-
-    fn collect_related_events_rec(
-        &self,
-        event_id: &EventId,
-        filter: Option<&[RelationType]>,
-        results: &mut Vec<TimelineEvent>,
-    ) {
-        let Some(related_event_ids) = self.relations.get(event_id) else {
-            return;
-        };
-
-        for (related_event_id, relation_type) in related_event_ids {
-            if let Some(filter) = filter {
-                if !filter.contains(relation_type) {
-                    continue;
-                }
-            }
-
-            // If the event was already added to the related ones, skip it.
-            if results.iter().any(|event| {
-                event.event_id().is_some_and(|added_related_event_id| {
-                    added_related_event_id == *related_event_id
-                })
-            }) {
-                continue;
-            }
-
-            if let Some((_, ev)) = self.events.get(related_event_id) {
-                results.push(ev.clone());
-                self.collect_related_events_rec(related_event_id, filter, results);
-            }
-        }
-    }
-}
-
 struct EventCacheInner {
     /// A weak reference to the inner client, useful when trying to get a handle
     /// on the owning client.
@@ -600,16 +425,6 @@ struct EventCacheInner {
 
     /// Lazily-filled cache of live [`RoomEventCache`], once per room.
     by_room: RwLock<BTreeMap<OwnedRoomId, RoomEventCache>>,
-
-    /// All events, keyed by event id.
-    ///
-    /// Since events are immutable in Matrix, this is append-only — events can
-    /// be updated, though (e.g. if it was encrypted before, and
-    /// successfully decrypted later).
-    ///
-    /// This is shared between the [`EventCacheInner`] singleton and all
-    /// [`RoomEventCacheInner`] instances.
-    all_events: Arc<RwLock<AllEventsCache>>,
 
     /// Handles to keep alive the task listening to updates.
     drop_handles: OnceLock<Arc<EventCacheDropHandles>>,
@@ -746,7 +561,6 @@ impl EventCacheInner {
                     room_state,
                     pagination_status,
                     room_id.to_owned(),
-                    self.all_events.clone(),
                     auto_shrink_sender,
                 );
 
@@ -939,20 +753,7 @@ mod tests {
         // Have the event cache handle them.
         event_cache.inner.handle_room_updates(updates).await.unwrap();
 
-        // Now retrieve all the events one by one.
-        let found1 = event_cache.event(eid1).await.unwrap();
-        assert_event_matches_msg(&found1, "hey");
-
-        let found2 = event_cache.event(eid2).await.unwrap();
-        assert_event_matches_msg(&found2, "you");
-
-        let found3 = event_cache.event(eid3).await.unwrap();
-        assert_event_matches_msg(&found3, "bjr");
-
-        // An unknown event won't be found.
-        assert!(event_cache.event(event_id!("$unknown")).await.is_none());
-
-        // Can also find events in a single room.
+        // We can find the events in a single room.
         client.base_client().get_or_create_room(room_id1, matrix_sdk_base::RoomState::Joined);
         let room1 = client.get_room(room_id1).unwrap();
 
@@ -967,8 +768,6 @@ mod tests {
         // Retrieving the event with id3 from the room which doesn't contain it will
         // fail…
         assert!(room_event_cache.event(eid3).await.is_none());
-        // …but it doesn't fail at the client-wide level.
-        assert!(event_cache.event(eid3).await.is_some());
     }
 
     #[async_test]
@@ -991,14 +790,6 @@ mod tests {
 
         // Retrieving the event at the room-wide cache works.
         assert!(room_event_cache.event(event_id).await.is_some());
-        // Also at the client level.
-        assert!(event_cache.event(event_id).await.is_some());
-
-        event_cache.empty_immutable_cache().await;
-
-        // After clearing, both fail to find the event.
-        assert!(room_event_cache.event(event_id).await.is_none());
-        assert!(event_cache.event(event_id).await.is_none());
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1390,6 +1390,11 @@ mod private {
         }
 
         /// Save a single event into the database, without notifying observers.
+        ///
+        /// Note: if the event was already saved as part of a linked chunk, and
+        /// its event id may have changed, it's not safe to use this
+        /// method because it may break the link between the chunk and
+        /// the event. Instead, an update to the linked chunk must be used.
         pub async fn save_event(
             &self,
             events: impl IntoIterator<Item = TimelineEvent>,

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1497,22 +1497,6 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_event_with_reply_relation() {
-        let original_id = event_id!("$original");
-        let related_id = event_id!("$related");
-        let room_id = room_id!("!galette:saucisse.bzh");
-        let f = EventFactory::new().room(room_id).sender(user_id!("@ben:saucisse.bzh"));
-
-        assert_relations(
-            room_id,
-            f.text_msg("Original event").event_id(original_id).into(),
-            f.text_msg("A reply").reply_to(original_id).event_id(related_id).into(),
-            f,
-        )
-        .await;
-    }
-
-    #[async_test]
     async fn test_event_with_thread_reply_relation() {
         let original_id = event_id!("$original");
         let related_id = event_id!("$related");

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1236,7 +1236,7 @@ mod private {
             // Then, initialize the stack with all the related events, to find the
             // transitive closure of all the related events.
             let mut related =
-                store.find_event_relations(&self.room, event_id, filters.clone()).await?;
+                store.find_event_relations(&self.room, event_id, filters.as_deref()).await?;
             let mut stack = related.iter().filter_map(|event| event.event_id()).collect::<Vec<_>>();
 
             // Also keep track of already seen events, in case there's a loop in the
@@ -1254,7 +1254,7 @@ mod private {
                 }
 
                 let other_related =
-                    store.find_event_relations(&self.room, &event_id, filters.clone()).await?;
+                    store.find_event_relations(&self.room, &event_id, filters.as_deref()).await?;
 
                 stack.extend(other_related.iter().filter_map(|event| event.event_id()));
                 related.extend(other_related);

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1459,22 +1459,6 @@ mod tests {
     use crate::test_utils::{client::MockClientBuilder, logged_in_client};
 
     #[async_test]
-    async fn test_event_with_redaction_relation() {
-        let original_id = event_id!("$original");
-        let related_id = event_id!("$related");
-        let room_id = room_id!("!galette:saucisse.bzh");
-        let f = EventFactory::new().room(room_id).sender(user_id!("@ben:saucisse.bzh"));
-
-        assert_relations(
-            room_id,
-            f.text_msg("Original event").event_id(original_id).into(),
-            f.redaction(original_id).event_id(related_id).into(),
-            f,
-        )
-        .await;
-    }
-
-    #[async_test]
     async fn test_event_with_edit_relation() {
         let original_id = event_id!("$original");
         let related_id = event_id!("$related");

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -489,7 +489,7 @@ impl Room {
 
         // Save the event into the event cache, if it's set up.
         if let Ok((cache, _handles)) = self.event_cache().await {
-            cache.save_event(event.clone()).await;
+            cache.save_events([event.clone()]).await;
         }
 
         Ok(event)

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -688,6 +688,7 @@ async fn test_event_with_context() {
     let (client, server) = logged_in_client_with_server().await;
     let cache = client.event_cache();
     let _ = cache.subscribe();
+    cache.enable_storage().unwrap();
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -626,6 +626,7 @@ async fn test_event() {
 
     let cache = client.event_cache();
     let _ = cache.subscribe();
+    cache.enable_storage().unwrap();
 
     let room = server
         .sync_room(
@@ -668,7 +669,8 @@ async fn test_event() {
     assert!(push_actions.iter().any(|a| a.should_notify()));
 
     // Requested event was saved to the cache
-    assert!(cache.event(event_id).await.is_some());
+    let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
+    assert!(room_event_cache.event(event_id).await.is_some());
 
     // So we can reload it without hitting the network.
     let timeline_event = room.load_or_fetch_event(event_id, None).await.unwrap();
@@ -742,9 +744,10 @@ async fn test_event_with_context() {
     assert_eq!(event.event_id(), next_event_id);
 
     // Requested event and their context ones were saved to the cache
-    assert!(cache.event(event_id).await.is_some());
-    assert!(cache.event(prev_event_id).await.is_some());
-    assert!(cache.event(next_event_id).await.is_some());
+    let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
+    assert!(room_event_cache.event(event_id).await.is_some());
+    assert!(room_event_cache.event(prev_event_id).await.is_some());
+    assert!(room_event_cache.event(next_event_id).await.is_some());
 }
 
 #[async_test]


### PR DESCRIPTION
This rejiggers the event cache's store schema so that events can be saved independently of their position in a linked chunk. Also, it makes it possible to extract an event's relation metadata, so we can get rid of the `AllEventsCache` along the way.

Fixes #4841.
Fixes #3886.

Part of #3280.

Remaining steps:

- [x] benchmark performance hit of extracting the relationship + join request
- [x] add save_event to the event cache store trait + impl
- [x] add event_with_relations to the event cache store trait + impl
- [x] remove `AllEventsCache`
- [x] 94626aea3e3c2b8d7e9a9262cc21aaeded7ba339 is the wrong abstraction: instead there should be a way to retrieve only related events with the given filters; then, the transitive closure of relationships can be achieved in the caller, instead of the store impl
- [x] rejigger find_event_with_relations event cache API so it doesn't return redacted events (there's no reason to do that) 
- [x] add test for the store `save_event()` method
- [x] add test for the store `find_event_relations()` method
- [x] add method to clear all events

Kind of depending on https://github.com/ruma/ruma/pull/2052, although we don't really have to.