### PR TITLE
refactor(base): Introduce `BaseClient::activate` and split `BaseStateStore::set_session_meta` to 3 methods

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -61,7 +61,7 @@ pub fn receive_all_members_benchmark(c: &mut Criterion) {
     );
 
     runtime
-        .block_on(base_client.set_or_reload_session(
+        .block_on(base_client.activate(
             SessionMeta {
                 user_id: user_id!("@somebody:example.com").to_owned(),
                 device_id: device_id!("DEVICE_ID").to_owned(),

--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -61,7 +61,7 @@ pub fn receive_all_members_benchmark(c: &mut Criterion) {
     );
 
     runtime
-        .block_on(base_client.set_session_meta(
+        .block_on(base_client.set_or_reload_session(
             SessionMeta {
                 user_id: user_id!("@somebody:example.com").to_owned(),
                 device_id: device_id!("DEVICE_ID").to_owned(),

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -34,7 +34,8 @@ All notable changes to this project will be documented in this file.
   ([#4851](https://github.com/matrix-org/matrix-rust-sdk/pull/4851))
 - [**breaking**] `BaseClient::with_store_config` is renamed `new`
   ([#4847](https://github.com/matrix-org/matrix-rust-sdk/pull/4847))
-- [**breaking**] `BaseClient::set_session_metadata` is renamed `set_or_reload_session`
+- [**breaking**] `BaseClient::set_session_metadata` is renamed
+  `activate`, and `BaseClient::logged_in` is renamed `is_activated`
   ([#4850](https://github.com/matrix-org/matrix-rust-sdk/pull/4850))
 
 ## [0.10.0] - 2025-02-04

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -30,10 +30,12 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
-- [**breaking**] `BaseClient::with_store_config` is renamed `new`
-  ([#4847](https://github.com/matrix-org/matrix-rust-sdk/pull/4847))
 - [**breaking**] `BaseClient::store` is renamed `state_store`
   ([#4851](https://github.com/matrix-org/matrix-rust-sdk/pull/4851))
+- [**breaking**] `BaseClient::with_store_config` is renamed `new`
+  ([#4847](https://github.com/matrix-org/matrix-rust-sdk/pull/4847))
+- [**breaking**] `BaseClient::set_session_metadata` is renamed `set_or_reload_session`
+  ([#4850](https://github.com/matrix-org/matrix-rust-sdk/pull/4850))
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -220,14 +220,12 @@ impl BaseClient {
             handle_verification_events,
         };
 
-        if let Some(session_meta) = self.session_meta().cloned() {
-            copy.state_store
-                .set_session_meta_and_reload_state(
-                    session_meta,
-                    &copy.room_info_notable_update_sender,
-                )
-                .await?;
-        }
+        copy.state_store
+            .set_or_reload_session_from_other(
+                &self.state_store,
+                &copy.room_info_notable_update_sender,
+            )
+            .await?;
 
         Ok(copy)
     }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -2538,7 +2538,7 @@ mod tests {
             BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
 
         client
-            .set_or_reload_session(
+            .activate(
                 SessionMeta {
                     user_id: user_id!("@alice:example.org").into(),
                     device_id: ruma::device_id!("AYEAYEAYE").into(),
@@ -2617,7 +2617,7 @@ mod tests {
             BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
 
         client
-            .set_or_reload_session(
+            .activate(
                 SessionMeta {
                     user_id: user_id!("@alice:example.org").into(),
                     device_id: ruma::device_id!("AYEAYEAYE").into(),
@@ -3201,7 +3201,7 @@ mod tests {
             BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
 
         client
-            .set_or_reload_session(
+            .activate(
                 SessionMeta {
                     user_id: user_id!("@alice:example.org").into(),
                     device_id: ruma::device_id!("AYEAYEAYE").into(),

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -2538,7 +2538,7 @@ mod tests {
             BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
 
         client
-            .set_session_meta(
+            .set_or_reload_session(
                 SessionMeta {
                     user_id: user_id!("@alice:example.org").into(),
                     device_id: ruma::device_id!("AYEAYEAYE").into(),
@@ -2617,7 +2617,7 @@ mod tests {
             BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
 
         client
-            .set_session_meta(
+            .set_or_reload_session(
                 SessionMeta {
                     user_id: user_id!("@alice:example.org").into(),
                     device_id: ruma::device_id!("AYEAYEAYE").into(),
@@ -3201,7 +3201,7 @@ mod tests {
             BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
 
         client
-            .set_session_meta(
+            .set_or_reload_session(
                 SessionMeta {
                     user_id: user_id!("@alice:example.org").into(),
                     device_id: ruma::device_id!("AYEAYEAYE").into(),

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -205,13 +205,15 @@ impl BaseStateStore {
         Ok(room_infos)
     }
 
-    /// Set the meta of the session.
+    /// Set a [`SessionMeta`] and, if a previous state exists, reload the
+    /// session.
     ///
-    /// Restores the state of this `Store` from the given `SessionMeta` and the
-    /// inner `StateStore`.
+    /// Reloading a session means: reload all rooms from the state store.
+    ///
+    /// # Panics
     ///
     /// This method panics if it is called twice.
-    pub async fn set_session_meta(
+    pub async fn set_or_reload_session(
         &self,
         session_meta: SessionMeta,
         room_info_notable_update_sender: &broadcast::Sender<RoomInfoNotableUpdate>,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -245,6 +245,21 @@ impl BaseStateStore {
         Ok(())
     }
 
+    /// Similar to [`Store::set_or_reload_session`] but takes values from
+    /// another existing [`Store`].
+    #[cfg(any(feature = "e2e-encryption", test))]
+    pub(crate) async fn set_or_reload_session_from_other(
+        &self,
+        other: &Self,
+        room_info_notable_update_sender: &broadcast::Sender<RoomInfoNotableUpdate>,
+    ) -> Result<()> {
+        let Some(session_meta) = other.session_meta.get() else {
+            return Ok(());
+        };
+
+        self.set_or_reload_session(session_meta.clone(), room_info_notable_update_sender).await
+    }
+
     /// The current [`SessionMeta`] containing our user ID and device ID.
     pub fn session_meta(&self) -> Option<&SessionMeta> {
         self.session_meta.get()

--- a/crates/matrix-sdk-base/src/test_utils.rs
+++ b/crates/matrix-sdk-base/src/test_utils.rs
@@ -28,12 +28,12 @@ pub(crate) async fn logged_in_base_client(user_id: Option<&UserId>) -> BaseClien
     let user_id =
         user_id.map(|user_id| user_id.to_owned()).unwrap_or_else(|| owned_user_id!("@u:e.uk"));
     client
-        .set_or_reload_session(
+        .activate(
             SessionMeta { user_id: user_id.to_owned(), device_id: "FOOBAR".into() },
             #[cfg(feature = "e2e-encryption")]
             None,
         )
         .await
-        .expect("`set_or_reload_session` failed!");
+        .expect("`activate` failed!");
     client
 }

--- a/crates/matrix-sdk-base/src/test_utils.rs
+++ b/crates/matrix-sdk-base/src/test_utils.rs
@@ -28,12 +28,12 @@ pub(crate) async fn logged_in_base_client(user_id: Option<&UserId>) -> BaseClien
     let user_id =
         user_id.map(|user_id| user_id.to_owned()).unwrap_or_else(|| owned_user_id!("@u:e.uk"));
     client
-        .set_session_meta(
+        .set_or_reload_session(
             SessionMeta { user_id: user_id.to_owned(), device_id: "FOOBAR".into() },
             #[cfg(feature = "e2e-encryption")]
             None,
         )
         .await
-        .expect("set_session_meta failed!");
+        .expect("`set_or_reload_session` failed!");
     client
 }

--- a/crates/matrix-sdk/src/authentication/matrix/mod.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/mod.rs
@@ -760,7 +760,8 @@ impl MatrixAuth {
             .expect("Client authentication data was already set");
         self.client.auth_ctx().set_session_tokens(session.tokens);
         self.client
-            .set_session_meta(
+            .base_client()
+            .set_or_reload_session(
                 session.meta,
                 #[cfg(feature = "e2e-encryption")]
                 None,

--- a/crates/matrix-sdk/src/authentication/matrix/mod.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/mod.rs
@@ -761,7 +761,7 @@ impl MatrixAuth {
         self.client.auth_ctx().set_session_tokens(session.tokens);
         self.client
             .base_client()
-            .set_or_reload_session(
+            .activate(
                 session.meta,
                 #[cfg(feature = "e2e-encryption")]
                 None,

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -807,7 +807,7 @@ impl OAuth {
         self.client.auth_ctx().set_session_tokens(tokens.clone());
         self.client
             .base_client()
-            .set_or_reload_session(
+            .activate(
                 meta,
                 #[cfg(feature = "e2e-encryption")]
                 None,
@@ -1046,7 +1046,7 @@ impl OAuth {
         } else {
             self.client
                 .base_client()
-                .set_or_reload_session(
+                .activate(
                     new_session,
                     #[cfg(feature = "e2e-encryption")]
                     None,

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
@@ -199,7 +199,8 @@ impl<'a> IntoFuture for LoginWithQrCode<'a> {
             let whoami_response =
                 self.client.whoami().await.map_err(QRCodeLoginError::UserIdDiscovery)?;
             self.client
-                .set_session_meta(
+                .base_client()
+                .set_or_reload_session(
                     SessionMeta {
                         user_id: whoami_response.user_id,
                         device_id: OwnedDeviceId::from(device_id.to_base64()),
@@ -207,7 +208,7 @@ impl<'a> IntoFuture for LoginWithQrCode<'a> {
                     Some(account),
                 )
                 .await
-                .map_err(QRCodeLoginError::SessionTokens)?;
+                .map_err(|error| QRCodeLoginError::SessionTokens(error.into()))?;
 
             self.client.oauth().enable_cross_process_lock().await?;
 

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
@@ -200,7 +200,7 @@ impl<'a> IntoFuture for LoginWithQrCode<'a> {
                 self.client.whoami().await.map_err(QRCodeLoginError::UserIdDiscovery)?;
             self.client
                 .base_client()
-                .set_or_reload_session(
+                .activate(
                     SessionMeta {
                         user_id: whoami_response.user_id,
                         device_id: OwnedDeviceId::from(device_id.to_base64()),

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -511,8 +511,8 @@ impl Client {
     /// 2. Has loaded cached data from storage,
     /// 3. If encryption is enabled, it also initialized or restored its
     ///    `OlmMachine`.
-    pub fn is_activated(&self) -> bool {
-        self.inner.base_client.is_activated()
+    pub fn is_active(&self) -> bool {
+        self.inner.base_client.is_active()
     }
 
     /// The server used by the client.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1271,22 +1271,6 @@ impl Client {
         }
     }
 
-    pub(crate) async fn set_session_meta(
-        &self,
-        session_meta: SessionMeta,
-        #[cfg(feature = "e2e-encryption")] custom_account: Option<vodozemac::olm::Account>,
-    ) -> Result<()> {
-        self.base_client()
-            .set_session_meta(
-                session_meta,
-                #[cfg(feature = "e2e-encryption")]
-                custom_account,
-            )
-            .await?;
-
-        Ok(())
-    }
-
     /// Refresh the access token using the authentication API used to log into
     /// this session.
     ///

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -502,9 +502,17 @@ impl Client {
         self.inner.http_client.request_config
     }
 
-    /// Is the client logged in.
-    pub fn logged_in(&self) -> bool {
-        self.inner.base_client.logged_in()
+    /// Check whether the client has been activated.
+    ///
+    /// A client is considered active when:
+    ///
+    /// 1. It has a `SessionMeta` (user ID, device ID and access token), i.e. it
+    ///    is logged in,
+    /// 2. Has loaded cached data from storage,
+    /// 3. If encryption is enabled, it also initialized or restored its
+    ///    `OlmMachine`.
+    pub fn is_activated(&self) -> bool {
+        self.inner.base_client.is_activated()
     }
 
     /// The server used by the client.

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -73,7 +73,7 @@ async fn test_login() {
     let auth = client.matrix_auth();
     auth.login_username("example", "wordpass").send().await.unwrap();
 
-    assert!(client.is_activated(), "Client should be activated");
+    assert!(client.is_active(), "Client should be active");
     assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");
 
     assert_matches!(client.auth_api(), Some(AuthApi::Matrix(_)));
@@ -94,7 +94,7 @@ async fn test_login_with_discovery() {
 
     client.matrix_auth().login_username("example", "wordpass").send().await.unwrap();
 
-    assert!(client.is_activated(), "Client should be activated");
+    assert!(client.is_active(), "Client should be active");
     assert_eq!(client.homeserver().as_str(), "https://example.org/");
 }
 
@@ -110,7 +110,7 @@ async fn test_login_no_discovery() {
 
     client.matrix_auth().login_username("example", "wordpass").send().await.unwrap();
 
-    assert!(client.is_activated(), "Client should be activated");
+    assert!(client.is_active(), "Client should be active");
     assert_eq!(client.homeserver(), Url::parse(&server.uri()).unwrap());
 }
 
@@ -148,7 +148,7 @@ async fn test_login_with_sso() {
         .await
         .unwrap();
 
-    assert!(client.is_activated(), "Client should be activated");
+    assert!(client.is_active(), "Client should be active");
 }
 
 #[async_test]
@@ -182,7 +182,7 @@ async fn test_login_with_sso_token() {
 
     auth.login_token("averysmalltoken").send().await.unwrap();
 
-    assert!(client.is_activated(), "Client should be activated");
+    assert!(client.is_active(), "Client should be active");
 }
 
 #[async_test]
@@ -217,7 +217,7 @@ async fn test_login_with_sso_callback() {
     let callback_url = Url::parse("http://127.0.0.1:3030?loginToken=averysmalltoken").unwrap();
     auth.login_with_sso_callback(callback_url).unwrap().await.unwrap();
 
-    assert!(client.is_activated(), "Client should be activated");
+    assert!(client.is_active(), "Client should be active");
 }
 
 #[async_test]
@@ -477,7 +477,7 @@ async fn test_login_with_cross_signing_bootstrapping() {
         let auth = client.matrix_auth();
         auth.login_username("example", "hunter2").send().await.unwrap();
 
-        assert!(client.is_activated(), "Client should be activated");
+        assert!(client.is_active(), "Client should be active");
         assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");
 
         client.encryption().wait_for_e2ee_initialization_tasks().await;
@@ -530,7 +530,7 @@ async fn test_login_with_cross_signing_bootstrapping() {
         let auth = client.matrix_auth();
         auth.login_token("HUNTER2").send().await.unwrap();
 
-        assert!(client.is_activated(), "Client should be activated");
+        assert!(client.is_active(), "Client should be active");
         assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");
 
         client.encryption().wait_for_e2ee_initialization_tasks().await;
@@ -606,7 +606,7 @@ async fn test_login_doesnt_fail_if_cross_signing_bootstrapping_failed() {
     let auth = client.matrix_auth();
     auth.login_username("example", "hunter2").send().await.unwrap();
 
-    assert!(client.is_activated(), "Client should be activated");
+    assert!(client.is_active(), "Client should be active");
     assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");
 
     let me = client.user_id().expect("we are now logged in");
@@ -727,6 +727,6 @@ async fn test_login_with_cross_signing_bootstrapping_already_bootstrapped() {
     let auth = client.matrix_auth();
     auth.login_username("example", "hunter2").send().await.unwrap();
 
-    assert!(client.is_activated(), "Client should be activated");
+    assert!(client.is_active(), "Client should be active");
     assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");
 }

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -73,7 +73,7 @@ async fn test_login() {
     let auth = client.matrix_auth();
     auth.login_username("example", "wordpass").send().await.unwrap();
 
-    assert!(client.logged_in(), "Client should be logged in");
+    assert!(client.is_activated(), "Client should be activated");
     assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");
 
     assert_matches!(client.auth_api(), Some(AuthApi::Matrix(_)));
@@ -94,9 +94,7 @@ async fn test_login_with_discovery() {
 
     client.matrix_auth().login_username("example", "wordpass").send().await.unwrap();
 
-    let logged_in = client.logged_in();
-    assert!(logged_in, "Client should be logged in");
-
+    assert!(client.is_activated(), "Client should be activated");
     assert_eq!(client.homeserver().as_str(), "https://example.org/");
 }
 
@@ -112,9 +110,7 @@ async fn test_login_no_discovery() {
 
     client.matrix_auth().login_username("example", "wordpass").send().await.unwrap();
 
-    let logged_in = client.logged_in();
-    assert!(logged_in, "Client should be logged in");
-
+    assert!(client.is_activated(), "Client should be activated");
     assert_eq!(client.homeserver(), Url::parse(&server.uri()).unwrap());
 }
 
@@ -152,8 +148,7 @@ async fn test_login_with_sso() {
         .await
         .unwrap();
 
-    let logged_in = client.logged_in();
-    assert!(logged_in, "Client should be logged in");
+    assert!(client.is_activated(), "Client should be activated");
 }
 
 #[async_test]
@@ -187,8 +182,7 @@ async fn test_login_with_sso_token() {
 
     auth.login_token("averysmalltoken").send().await.unwrap();
 
-    let logged_in = client.logged_in();
-    assert!(logged_in, "Client should be logged in");
+    assert!(client.is_activated(), "Client should be activated");
 }
 
 #[async_test]
@@ -223,8 +217,7 @@ async fn test_login_with_sso_callback() {
     let callback_url = Url::parse("http://127.0.0.1:3030?loginToken=averysmalltoken").unwrap();
     auth.login_with_sso_callback(callback_url).unwrap().await.unwrap();
 
-    let logged_in = client.logged_in();
-    assert!(logged_in, "Client should be logged in");
+    assert!(client.is_activated(), "Client should be activated");
 }
 
 #[async_test]
@@ -484,7 +477,7 @@ async fn test_login_with_cross_signing_bootstrapping() {
         let auth = client.matrix_auth();
         auth.login_username("example", "hunter2").send().await.unwrap();
 
-        assert!(client.logged_in(), "Client should be logged in");
+        assert!(client.is_activated(), "Client should be activated");
         assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");
 
         client.encryption().wait_for_e2ee_initialization_tasks().await;
@@ -537,7 +530,7 @@ async fn test_login_with_cross_signing_bootstrapping() {
         let auth = client.matrix_auth();
         auth.login_token("HUNTER2").send().await.unwrap();
 
-        assert!(client.logged_in(), "Client should be logged in");
+        assert!(client.is_activated(), "Client should be activated");
         assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");
 
         client.encryption().wait_for_e2ee_initialization_tasks().await;
@@ -613,7 +606,7 @@ async fn test_login_doesnt_fail_if_cross_signing_bootstrapping_failed() {
     let auth = client.matrix_auth();
     auth.login_username("example", "hunter2").send().await.unwrap();
 
-    assert!(client.logged_in(), "Client should be logged in");
+    assert!(client.is_activated(), "Client should be activated");
     assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");
 
     let me = client.user_id().expect("we are now logged in");
@@ -734,6 +727,6 @@ async fn test_login_with_cross_signing_bootstrapping_already_bootstrapped() {
     let auth = client.matrix_auth();
     auth.login_username("example", "hunter2").send().await.unwrap();
 
-    assert!(client.logged_in(), "Client should be logged in");
+    assert!(client.is_activated(), "Client should be activated");
     assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");
 }

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -63,8 +63,7 @@ async fn test_login_username_refresh_token() {
         .await
         .unwrap();
 
-    let logged_in = client.logged_in();
-    assert!(logged_in, "Client should be logged in");
+    assert!(client.is_activated(), "Client should be activated");
     res.refresh_token.unwrap();
 }
 
@@ -108,8 +107,7 @@ async fn test_login_sso_refresh_token() {
         .await
         .unwrap();
 
-    let logged_in = client.logged_in();
-    assert!(logged_in, "Client should be logged in");
+    assert!(client.is_activated(), "Client should be activated");
     res.refresh_token.unwrap();
 }
 

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -63,7 +63,7 @@ async fn test_login_username_refresh_token() {
         .await
         .unwrap();
 
-    assert!(client.is_activated(), "Client should be activated");
+    assert!(client.is_active(), "Client should be active");
     res.refresh_token.unwrap();
 }
 
@@ -107,7 +107,7 @@ async fn test_login_sso_refresh_token() {
         .await
         .unwrap();
 
-    assert!(client.is_activated(), "Client should be activated");
+    assert!(client.is_active(), "Client should be active");
     res.refresh_token.unwrap();
 }
 


### PR DESCRIPTION
This set of patches is twofold:

1. it renames `set_session_meta` to `set_or_reload_session` to clarify that the state _can be reloaded_, which is not obvious for a setter,
2. a new `Store::set_or_reload_session_from_other` method is added, to derive a state store from another one.

Finally, this patch adds missing unit tests and adds one for the `…from_other` method.

See https://github.com/matrix-org/matrix-rust-sdk/pull/4850#issuecomment-2761547063 to see the next step we went for: `BaseClient::activate` and `BaseStateStore::set_session_meta` + `::load_rooms` + `::load_sync_token` + `::derive_from_other`.

This refactoring is necessary regarding https://github.com/matrix-org/matrix-rust-sdk/issues/4801 because I'm about to add another data in `Store`. Having this `set_or_reload_session_from_other` is a nice abstraction for now, but also in a short future.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4801