### PR TITLE
refactor(base): `Store` is renamed `BaseStateStore`, and `store()` methods are renamed `state_store()`.

### DIFF
--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -28,6 +28,13 @@ All notable changes to this project will be documented in this file.
   which returns a value of the new `EncryptionState` enum
   ([#4777](https://github.com/matrix-org/matrix-rust-sdk/pull/4777))
 
+### Refactor
+
+- [**breaking**] `BaseClient::with_store_config` is renamed `new`
+  ([#4847](https://github.com/matrix-org/matrix-rust-sdk/pull/4847))
+- [**breaking**] `BaseClient::store` is renamed `state_store`
+  ([#4851](https://github.com/matrix-org/matrix-rust-sdk/pull/4851))
+
 ## [0.10.0] - 2025-02-04
 
 ### Features

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -77,8 +77,9 @@ use crate::{
         Room, RoomInfo, RoomState,
     },
     store::{
-        ambiguity_map::AmbiguityCache, DynStateStore, MemoryStore, Result as StoreResult,
-        StateChanges, StateStoreDataKey, StateStoreDataValue, StateStoreExt, Store, StoreConfig,
+        ambiguity_map::AmbiguityCache, BaseStateStore, DynStateStore, MemoryStore,
+        Result as StoreResult, StateChanges, StateStoreDataKey, StateStoreDataValue, StateStoreExt,
+        StoreConfig,
     },
     sync::{JoinedRoomUpdate, LeftRoomUpdate, Notification, RoomUpdates, SyncResponse, Timeline},
     RoomStateFilter, SessionMeta,
@@ -100,7 +101,7 @@ use crate::{
 #[derive(Clone)]
 pub struct BaseClient {
     /// Database
-    pub(crate) store: Store,
+    pub(crate) store: BaseStateStore,
 
     /// The store used by the event cache.
     event_cache_store: EventCacheStoreLock,
@@ -157,7 +158,7 @@ impl BaseClient {
     /// * `config` - the configuration for the stores (state store, event cache
     ///   store and crypto store).
     pub fn new(config: StoreConfig) -> Self {
-        let store = Store::new(config.state_store);
+        let store = BaseStateStore::new(config.state_store);
 
         // Create the channel to receive `RoomInfoNotableUpdate`.
         //
@@ -202,7 +203,7 @@ impl BaseClient {
         let config = config.crypto_store(self.crypto_store.clone());
 
         let copy = Self {
-            store: Store::new(config.state_store),
+            store: BaseStateStore::new(config.state_store),
             event_cache_store: config.event_cache_store,
             // We copy the crypto store as well as the `OlmMachine` for two reasons:
             // 1. The `self.crypto_store` is the same as the one used inside the `OlmMachine`.

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -278,8 +278,8 @@ impl BaseClient {
         )
     }
 
-    /// Get a reference to the store.
-    pub fn store(&self) -> &DynStateStore {
+    /// Get a reference to the state store.
+    pub fn state_store(&self) -> &DynStateStore {
         self.state_store.deref()
     }
 
@@ -1334,7 +1334,7 @@ impl BaseClient {
     pub(crate) async fn load_previous_ignored_user_list(
         &self,
     ) -> Option<Raw<IgnoredUserListEvent>> {
-        self.store().get_account_data_event_static().await.ok().flatten()
+        self.state_store().get_account_data_event_static().await.ok().flatten()
     }
 
     pub(crate) fn apply_changes(
@@ -2297,7 +2297,7 @@ mod tests {
 
         client.receive_sync_response(response).await.unwrap();
         client
-            .store()
+            .state_store()
             .get_state_event_static::<ruma::events::room::name::RoomNameEventContent>(room_id)
             .await
             .expect("Failed to fetch state event")

--- a/crates/matrix-sdk-base/src/response_processors.rs
+++ b/crates/matrix-sdk-base/src/response_processors.rs
@@ -26,14 +26,14 @@ use ruma::{
 };
 use tracing::{debug, instrument, trace, warn};
 
-use crate::{store::Store, RoomInfo, StateChanges};
+use crate::{store::BaseStateStore, RoomInfo, StateChanges};
 
 /// Applies a function to an existing `RoomInfo` if present in changes, or one
 /// loaded from the database.
 fn map_info<F: FnOnce(&mut RoomInfo)>(
     room_id: &RoomId,
     changes: &mut StateChanges,
-    store: &Store,
+    store: &BaseStateStore,
     f: F,
 ) {
     if let Some(info) = changes.room_infos.get_mut(room_id) {
@@ -90,7 +90,7 @@ impl AccountDataProcessor {
     pub(crate) fn process_direct_rooms(
         &self,
         events: &[AnyGlobalAccountDataEvent],
-        store: &Store,
+        store: &BaseStateStore,
         changes: &mut StateChanges,
     ) {
         for event in events {
@@ -136,7 +136,7 @@ impl AccountDataProcessor {
     }
 
     /// Applies the processed data to the state changes.
-    pub async fn apply(mut self, changes: &mut StateChanges, store: &Store) {
+    pub async fn apply(mut self, changes: &mut StateChanges, store: &BaseStateStore) {
         // Fill in the content of `changes.account_data`.
         mem::swap(&mut changes.account_data, &mut self.raw_by_type);
 

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -46,7 +46,7 @@ use crate::{
         RoomState,
     },
     ruma::assign,
-    store::{ambiguity_map::AmbiguityCache, StateChanges, Store},
+    store::{ambiguity_map::AmbiguityCache, BaseStateStore, StateChanges},
     sync::{JoinedRoomUpdate, LeftRoomUpdate, Notification, RoomUpdates, SyncResponse},
     RequestedRequiredStates, Room, RoomInfo,
 };
@@ -356,7 +356,7 @@ impl BaseClient {
         requested_required_states: &[(StateEventType, String)],
         room_data: &http::response::Room,
         rooms_account_data: &mut BTreeMap<OwnedRoomId, Vec<Raw<AnyRoomAccountDataEvent>>>,
-        store: &Store,
+        store: &BaseStateStore,
         user_id: &UserId,
         account_data_processor: &AccountDataProcessor,
         changes: &mut StateChanges,
@@ -536,7 +536,7 @@ impl BaseClient {
         &self,
         state_events: &[AnySyncStateEvent],
         stripped_state: Option<&Vec<(Raw<AnyStrippedStateEvent>, AnyStrippedStateEvent)>>,
-        store: &Store,
+        store: &BaseStateStore,
         user_id: &UserId,
         room_id: &RoomId,
         room_info_notable_updates: &mut BTreeMap<OwnedRoomId, RoomInfoNotableUpdateReasons>,
@@ -655,7 +655,7 @@ async fn cache_latest_events(
     room_info: &mut RoomInfo,
     events: &[TimelineEvent],
     changes: Option<&StateChanges>,
-    store: Option<&Store>,
+    store: Option<&BaseStateStore>,
 ) {
     use crate::{
         deserialized_responses::DisplayName, store::ambiguity_map::is_display_name_ambiguous,

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -110,7 +110,7 @@ impl BaseClient {
 
         trace!("ready to submit e2ee changes to store");
         let prev_ignored_user_list = self.load_previous_ignored_user_list().await;
-        self.store.save_changes(&changes).await?;
+        self.state_store.save_changes(&changes).await?;
         self.apply_changes(&changes, room_info_notable_updates, prev_ignored_user_list);
         trace!("applied e2ee changes");
 
@@ -161,7 +161,7 @@ impl BaseClient {
         let mut room_info_notable_updates =
             BTreeMap::<OwnedRoomId, RoomInfoNotableUpdateReasons>::new();
 
-        let store = self.store.clone();
+        let store = self.state_store.clone();
         let mut ambiguity_cache = AmbiguityCache::new(store.inner.clone());
 
         let account_data_processor = AccountDataProcessor::process(&extensions.account_data.global);
@@ -260,7 +260,7 @@ impl BaseClient {
             )
             .await;
 
-            if let Some(room) = self.store.room(room_id) {
+            if let Some(room) = self.state_store.room(room_id) {
                 match room.state() {
                     RoomState::Joined => new_rooms
                         .join
@@ -337,7 +337,7 @@ impl BaseClient {
         // live in memory, until the next sync which will saves the room info to
         // disk; we do this to avoid saving that would be redundant with the
         // above. Oh well.
-        new_rooms.update_in_memory_caches(&self.store).await;
+        new_rooms.update_in_memory_caches(&self.state_store).await;
 
         Ok(SyncResponse {
             rooms: new_rooms,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -146,7 +146,7 @@ pub type Result<T, E = StoreError> = std::result::Result<T, E>;
 /// This adds additional higher level store functionality on top of a
 /// `StateStore` implementation.
 #[derive(Clone)]
-pub(crate) struct Store {
+pub(crate) struct BaseStateStore {
     pub(super) inner: Arc<DynStateStore>,
     session_meta: Arc<OnceCell<SessionMeta>>,
     /// The current sync token that should be used for the next sync call.
@@ -158,7 +158,7 @@ pub(crate) struct Store {
     sync_lock: Arc<Mutex<()>>,
 }
 
-impl Store {
+impl BaseStateStore {
     /// Create a new store, wrapping the given `StateStore`
     pub fn new(inner: Arc<DynStateStore>) -> Self {
         Self {
@@ -319,7 +319,7 @@ impl Store {
 }
 
 #[cfg(not(tarpaulin_include))]
-impl fmt::Debug for Store {
+impl fmt::Debug for BaseStateStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Store")
             .field("inner", &self.inner)
@@ -330,7 +330,7 @@ impl fmt::Debug for Store {
     }
 }
 
-impl Deref for Store {
+impl Deref for BaseStateStore {
     type Target = DynStateStore;
 
     fn deref(&self) -> &Self::Target {

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -35,7 +35,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     debug::{DebugInvitedRoom, DebugKnockedRoom, DebugListOfRawEvents, DebugListOfRawEventsNoId},
     deserialized_responses::{AmbiguityChange, RawAnySyncOrStrippedTimelineEvent},
-    store::Store,
+    store::BaseStateStore,
 };
 
 /// Generalized representation of a `/sync` response.
@@ -85,7 +85,7 @@ impl RoomUpdates {
     /// Update the caches for the rooms that received updates.
     ///
     /// This will only fill the in-memory caches, not save the info on disk.
-    pub(crate) async fn update_in_memory_caches(&self, store: &Store) {
+    pub(crate) async fn update_in_memory_caches(&self, store: &BaseStateStore) {
         for room in self
             .leave
             .keys()

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -204,7 +204,7 @@ impl UtdHookManager {
     /// Otherwise, there is no effect.
     pub async fn reload_from_store(&mut self) -> Result<(), StoreError> {
         let existing_data =
-            self.client.store().get_kv_data(StateStoreDataKey::UtdHookManagerData).await?;
+            self.client.state_store().get_kv_data(StateStoreDataKey::UtdHookManagerData).await?;
 
         if let Some(existing_data) = existing_data {
             let bloom_filter = existing_data
@@ -367,7 +367,7 @@ impl UtdHookManager {
         parent_hook.on_utd(info);
         reported_utds_lock.insert(event_id);
         if let Err(e) = client
-            .store()
+            .state_store()
             .set_kv_data(
                 StateStoreDataKey::UtdHookManagerData,
                 StateStoreDataValue::UtdHookManagerData(reported_utds_lock.clone()),

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -229,6 +229,8 @@ simpler methods:
   return an `AccountManagementUrlBuilder`. The final URL can be obtained with
   `AccountManagementUrlBuilder::build()`.
   ([#4831](https://github.com/matrix-org/matrix-rust-sdk/pull/4831))
+- [**breaking**] `Client::store` is renamed `state_store`
+  ([#4851](https://github.com/matrix-org/matrix-rust-sdk/pull/4851))
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -152,7 +152,7 @@ impl Account {
             // If an avatar is found cache it.
             let _ = self
                 .client
-                .store()
+                .state_store()
                 .set_kv_data(
                     StateStoreDataKey::UserAvatarUrl(user_id),
                     StateStoreDataValue::UserAvatarUrl(url),
@@ -160,8 +160,11 @@ impl Account {
                 .await;
         } else {
             // If there is no avatar the user has removed it and we uncache it.
-            let _ =
-                self.client.store().remove_kv_data(StateStoreDataKey::UserAvatarUrl(user_id)).await;
+            let _ = self
+                .client
+                .state_store()
+                .remove_kv_data(StateStoreDataKey::UserAvatarUrl(user_id))
+                .await;
         }
         Ok(response.avatar_url)
     }
@@ -169,8 +172,11 @@ impl Account {
     /// Get the URL of the account's avatar, if is stored in cache.
     pub async fn get_cached_avatar_url(&self) -> Result<Option<OwnedMxcUri>> {
         let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
-        let data =
-            self.client.store().get_kv_data(StateStoreDataKey::UserAvatarUrl(user_id)).await?;
+        let data = self
+            .client
+            .state_store()
+            .get_kv_data(StateStoreDataKey::UserAvatarUrl(user_id))
+            .await?;
         Ok(data.map(|v| v.into_user_avatar_url().expect("Session data is not a user avatar url")))
     }
 
@@ -711,7 +717,7 @@ impl Account {
     where
         C: GlobalAccountDataEventContent + StaticEventContent,
     {
-        get_raw_content(self.client.store().get_account_data_event_static::<C>().await?)
+        get_raw_content(self.client.state_store().get_account_data_event_static::<C>().await?)
     }
 
     /// Get the content of an account data event of a given type.
@@ -719,7 +725,7 @@ impl Account {
         &self,
         event_type: GlobalAccountDataEventType,
     ) -> Result<Option<Raw<AnyGlobalAccountDataEventContent>>> {
-        get_raw_content(self.client.store().get_account_data_event(event_type).await?)
+        get_raw_content(self.client.state_store().get_account_data_event(event_type).await?)
     }
 
     /// Fetch a global account data event from the server.
@@ -939,7 +945,7 @@ impl Account {
         let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
         let data = self
             .client
-            .store()
+            .state_store()
             .get_kv_data(StateStoreDataKey::RecentlyVisitedRooms(user_id))
             .await?;
 
@@ -969,7 +975,7 @@ impl Account {
 
         let data = StateStoreDataValue::RecentlyVisitedRooms(recently_visited_rooms);
         self.client
-            .store()
+            .state_store()
             .set_kv_data(StateStoreDataKey::RecentlyVisitedRooms(user_id), data)
             .await?;
         Ok(())

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -621,8 +621,8 @@ impl Client {
     }
 
     /// Get a reference to the state store.
-    pub fn store(&self) -> &DynStateStore {
-        self.base_client().store()
+    pub fn state_store(&self) -> &DynStateStore {
+        self.base_client().state_store()
     }
 
     /// Get a reference to the event cache store.
@@ -1695,7 +1695,7 @@ impl Client {
     async fn load_or_fetch_server_capabilities(
         &self,
     ) -> HttpResult<(Box<[MatrixVersion]>, BTreeMap<String, bool>)> {
-        match self.store().get_kv_data(StateStoreDataKey::ServerCapabilities).await {
+        match self.state_store().get_kv_data(StateStoreDataKey::ServerCapabilities).await {
             Ok(Some(stored)) => {
                 if let Some((versions, unstable_features)) =
                     stored.into_server_capabilities().and_then(|cap| cap.maybe_decode())
@@ -1718,7 +1718,7 @@ impl Client {
         {
             let encoded = ServerCapabilities::new(&versions, unstable_features.clone());
             if let Err(err) = self
-                .store()
+                .state_store()
                 .set_kv_data(
                     StateStoreDataKey::ServerCapabilities,
                     StateStoreDataValue::ServerCapabilities(encoded),
@@ -1813,7 +1813,7 @@ impl Client {
         guard.unstable_features = None;
 
         // Empty the store cache.
-        Ok(self.store().remove_kv_data(StateStoreDataKey::ServerCapabilities).await?)
+        Ok(self.state_store().remove_kv_data(StateStoreDataKey::ServerCapabilities).await?)
     }
 
     /// Check whether MSC 4028 is enabled on the homeserver.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -805,7 +805,11 @@ impl Room {
         &self,
         event_type: StateEventType,
     ) -> Result<Vec<RawAnySyncOrStrippedState>> {
-        self.client.state_store().get_state_events(self.room_id(), event_type).await.map_err(Into::into)
+        self.client
+            .state_store()
+            .get_state_events(self.room_id(), event_type)
+            .await
+            .map_err(Into::into)
     }
 
     /// Get all state events of a given statically-known type in this room.
@@ -877,7 +881,11 @@ impl Room {
         I: IntoIterator<Item = &'a K> + Send,
         I::IntoIter: Send,
     {
-        Ok(self.client.state_store().get_state_events_for_keys_static(self.room_id(), state_keys).await?)
+        Ok(self
+            .client
+            .state_store()
+            .get_state_events_for_keys_static(self.room_id(), state_keys)
+            .await?)
     }
 
     /// Get a specific state event in this room.
@@ -948,7 +956,11 @@ impl Room {
         C::Redacted: RedactedStateEventContent,
         K: AsRef<str> + ?Sized + Sync,
     {
-        Ok(self.client.state_store().get_state_event_static_for_key(self.room_id(), state_key).await?)
+        Ok(self
+            .client
+            .state_store()
+            .get_state_event_static_for_key(self.room_id(), state_key)
+            .await?)
     }
 
     /// Returns the parents this room advertises as its parents.
@@ -1069,8 +1081,11 @@ impl Room {
     /// Returns true if all devices in the room are verified, otherwise false.
     #[cfg(feature = "e2e-encryption")]
     pub async fn contains_only_verified_devices(&self) -> Result<bool> {
-        let user_ids =
-            self.client.state_store().get_user_ids(self.room_id(), RoomMemberships::empty()).await?;
+        let user_ids = self
+            .client
+            .state_store()
+            .get_user_ids(self.room_id(), RoomMemberships::empty())
+            .await?;
 
         for user_id in user_ids {
             let devices = self.client.encryption().get_user_devices(&user_id).await?;

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -204,10 +204,12 @@ impl SendQueue {
         }
 
         let room_ids =
-            self.client.store().load_rooms_with_unsent_requests().await.unwrap_or_else(|err| {
-                warn!("error when loading rooms with unsent requests: {err}");
-                Vec::new()
-            });
+            self.client.state_store().load_rooms_with_unsent_requests().await.unwrap_or_else(
+                |err| {
+                    warn!("error when loading rooms with unsent requests: {err}");
+                    Vec::new()
+                },
+            );
 
         // Getting the [`RoomSendQueue`] is sufficient to spawn the task if needs be.
         for room_id in room_ids {
@@ -959,7 +961,7 @@ impl QueueStorage {
             .lock()
             .await
             .client()?
-            .store()
+            .state_store()
             .save_send_queue_request(
                 &self.room_id,
                 transaction_id.clone(),
@@ -982,7 +984,7 @@ impl QueueStorage {
     {
         let mut guard = self.store.lock().await;
         let queued_requests =
-            guard.client()?.store().load_send_queue_requests(&self.room_id).await?;
+            guard.client()?.state_store().load_send_queue_requests(&self.room_id).await?;
 
         if let Some(request) = queued_requests.iter().find(|queued| !queued.is_wedged()) {
             let (cancel_upload_tx, cancel_upload_rx) =
@@ -1042,7 +1044,7 @@ impl QueueStorage {
 
         Ok(guard
             .client()?
-            .store()
+            .state_store()
             .update_send_queue_request_status(&self.room_id, transaction_id, Some(reason))
             .await?)
     }
@@ -1058,7 +1060,7 @@ impl QueueStorage {
             .lock()
             .await
             .client()?
-            .store()
+            .state_store()
             .update_send_queue_request_status(&self.room_id, transaction_id, None)
             .await?)
     }
@@ -1080,7 +1082,7 @@ impl QueueStorage {
         }
 
         let client = guard.client()?;
-        let store = client.store();
+        let store = client.state_store();
 
         // Update all dependent requests.
         store
@@ -1114,7 +1116,7 @@ impl QueueStorage {
             // Save the intent to redact the event.
             guard
                 .client()?
-                .store()
+                .state_store()
                 .save_dependent_queued_request(
                     &self.room_id,
                     transaction_id,
@@ -1129,7 +1131,7 @@ impl QueueStorage {
 
         let removed = guard
             .client()?
-            .store()
+            .state_store()
             .remove_send_queue_request(&self.room_id, transaction_id)
             .await?;
 
@@ -1155,7 +1157,7 @@ impl QueueStorage {
             // Save the intent to edit the associated event.
             guard
                 .client()?
-                .store()
+                .state_store()
                 .save_dependent_queued_request(
                     &self.room_id,
                     transaction_id,
@@ -1170,7 +1172,7 @@ impl QueueStorage {
 
         let edited = guard
             .client()?
-            .store()
+            .state_store()
             .update_send_queue_request(&self.room_id, transaction_id, serializable.into())
             .await?;
 
@@ -1193,7 +1195,7 @@ impl QueueStorage {
     ) -> Result<(), RoomSendQueueStorageError> {
         let guard = self.store.lock().await;
         let client = guard.client()?;
-        let store = client.store();
+        let store = client.state_store();
         let thumbnail_info =
             if let Some((thumbnail_info, thumbnail_media_request, thumbnail_content_type)) =
                 thumbnail
@@ -1280,7 +1282,7 @@ impl QueueStorage {
     ) -> Result<Option<ChildTransactionId>, RoomSendQueueStorageError> {
         let guard = self.store.lock().await;
         let client = guard.client()?;
-        let store = client.store();
+        let store = client.state_store();
 
         let requests = store.load_send_queue_requests(&self.room_id).await?;
 
@@ -1322,7 +1324,7 @@ impl QueueStorage {
     ) -> Result<Vec<LocalEcho>, RoomSendQueueStorageError> {
         let guard = self.store.lock().await;
         let client = guard.client()?;
-        let store = client.store();
+        let store = client.state_store();
 
         let local_requests =
             store.load_send_queue_requests(&self.room_id).await?.into_iter().filter_map(|queued| {
@@ -1420,7 +1422,7 @@ impl QueueStorage {
         dependent_request: DependentQueuedRequest,
         new_updates: &mut Vec<RoomSendQueueUpdate>,
     ) -> Result<bool, RoomSendQueueError> {
-        let store = client.store();
+        let store = client.state_store();
 
         let parent_key = dependent_request.parent_key;
 
@@ -1638,7 +1640,7 @@ impl QueueStorage {
         let guard = self.store.lock().await;
 
         let client = guard.client()?;
-        let store = client.store();
+        let store = client.state_store();
 
         let dependent_requests = store
             .load_dependent_queued_requests(&self.room_id)
@@ -1713,7 +1715,7 @@ impl QueueStorage {
             .lock()
             .await
             .client()?
-            .store()
+            .state_store()
             .remove_dependent_queued_request(&self.room_id, dependent_event_id)
             .await?)
     }

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -329,7 +329,7 @@ impl QueueStorage {
         trace!(%event_txn, "queueing media event after successfully uploading media(s)");
 
         client
-            .store()
+            .state_store()
             .save_send_queue_request(
                 &self.room_id,
                 event_txn,
@@ -377,7 +377,7 @@ impl QueueStorage {
         };
 
         client
-            .store()
+            .state_store()
             .save_send_queue_request(
                 &self.room_id,
                 next_upload_txn,
@@ -409,7 +409,7 @@ impl QueueStorage {
         // Keep the lock until we're done touching the storage.
         debug!("trying to abort an upload");
 
-        let store = client.store();
+        let store = client.state_store();
 
         let upload_file_as_dependent = ChildTransactionId::from(handles.upload_file_txn.clone());
         let event_as_dependent = ChildTransactionId::from(event_txn.to_owned());
@@ -530,7 +530,7 @@ impl QueueStorage {
 
         let guard = self.store.lock().await;
         let client = guard.client()?;
-        let store = client.store();
+        let store = client.state_store();
 
         // The media event can be in one of three states:
         // - still stored as a dependent request,

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -145,7 +145,7 @@ impl SlidingSyncListBuilder {
         self.cache_policy = SlidingSyncListCachePolicy::Enabled;
 
         if let Some(frozen_list) =
-            restore_sliding_sync_list(client.store(), storage_key, &self.name).await?
+            restore_sliding_sync_list(client.state_store(), storage_key, &self.name).await?
         {
             assert!(
                 self.reloaded_cached_data.is_none(),

--- a/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
@@ -97,15 +97,15 @@ async fn test_repeated_join_leave() -> Result<()> {
 
     // Now check the underlying state store that it also has the correct information
     // (for when the client restarts).
-    let invited = karl.store().get_user_ids(room_id, RoomMemberships::INVITE).await?;
+    let invited = karl.state_store().get_user_ids(room_id, RoomMemberships::INVITE).await?;
     assert_eq!(invited.len(), 1);
     assert_eq!(invited[0], karl_id);
 
-    let joined = karl.store().get_user_ids(room_id, RoomMemberships::JOIN).await?;
+    let joined = karl.state_store().get_user_ids(room_id, RoomMemberships::JOIN).await?;
     assert!(!joined.contains(&karl_id));
 
     let event = karl
-        .store()
+        .state_store()
         .get_member_event(room_id, &karl_id)
         .await?
         .expect("member event should exist")


### PR DESCRIPTION
This set of patches rename the `Store` struture to `BaseStateStore` (`StateStore` was already taken by `traits::StateStore`, let's avoid confusions). It also renames `BaseClient::store()` and `Client::store()` to `state_store()` for the sake of consistency.

---

* Part of the https://github.com/matrix-org/matrix-rust-sdk/issues/4801 journey