### PR TITLE
WidgetDriver: add to_device support

### DIFF
--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -509,9 +509,9 @@ impl From<WidgetEventFilter> for matrix_sdk::widget::EventFilter {
     }
 }
 
-impl From<matrix_sdk::widget::EventFilter> for WidgetEventFilter {
-    fn from(value: matrix_sdk::widget::EventFilter) -> Self {
-        use matrix_sdk::widget::EventFilter as F;
+impl From<matrix_sdk::widget::Filter> for WidgetEventFilter {
+    fn from(value: matrix_sdk::widget::Filter) -> Self {
+        use matrix_sdk::widget::Filter as F;
 
         match value {
             F::MessageLike(MessageLikeEventFilter::WithType(event_type)) => {

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -321,7 +321,11 @@ pub fn get_element_call_required_permissions(
             event_type: "org.matrix.rageshake_request".to_owned(),
         },
         // To read and send encryption keys
+        WidgetEventFilter::ToDeviceWithType {
+            event_type: "io.element.call.encryption_keys".to_owned(),
+        },
         // TODO change this to the appropriate to-device version once ready
+        // remove this once all calling supports to-device encryption
         WidgetEventFilter::MessageLikeWithType {
             event_type: "io.element.call.encryption_keys".to_owned(),
         },

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -40,6 +40,9 @@ All notable changes to this project will be documented in this file.
   This allows for example to make the difference between an event sent in clear and an event successfully decrypted.
   For quick compatibility a helper `ProcessedToDeviceEvent::to_raw` allows to map back to the previous behaviour.
 
+- Add WidgetDriver support for to-device messages. This allows widgets to send and receive encrypted/unencrypted to-device
+  messages via the parent client as defined in [MSC3819](https://github.com/matrix-org/matrix-spec-proposals/pull/3819).
+
 - [**breaking**] Add support for the shared history flag defined in
   [MSC3061](https://github.com/matrix-org/matrix-spec-proposals/pull/3061).
   The shared history flag is now respected when room keys are received as an

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -778,6 +778,56 @@ impl MatrixMockServer {
         self.mock_endpoint(mock, DeleteRoomKeysVersionEndpoint).expect_default_access_token()
     }
 
+    /// Creates a prebuilt mock for the `/sendToDevice` endpoint.
+    ///
+    /// This mock can be used to simulate sending to-device messages in tests.
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(feature = "e2e-encryption")]
+    /// # {
+    /// # tokio_test::block_on(async {
+    /// use std::collections::BTreeMap;
+    /// use matrix_sdk::{
+    ///     ruma::{
+    ///         serde::Raw,
+    ///         api::client::to_device::send_event_to_device::v3::Request as ToDeviceRequest,
+    ///         to_device::DeviceIdOrAllDevices,
+    ///         user_id,owned_device_id
+    ///     },
+    ///     test_utils::mocks::MatrixMockServer,
+    /// };
+    /// use serde_json::json;
+    ///
+    /// let mock_server = MatrixMockServer::new().await;
+    /// let client = mock_server.client_builder().build().await;
+    ///
+    /// mock_server.mock_send_to_device().ok().mock_once().mount().await;
+    ///
+    /// let request = ToDeviceRequest::new_raw(
+    ///     "m.custom.event".into(),
+    ///     "txn_id".into(),
+    /// BTreeMap::from([
+    /// (user_id!("@alice:localhost").to_owned(), BTreeMap::from([(
+    ///     DeviceIdOrAllDevices::AllDevices,
+    ///     Raw::new(&ruma::events::AnyToDeviceEventContent::Dummy(ruma::events::dummy::ToDeviceDummyEventContent {})).unwrap(),
+    /// )])),
+    /// ])
+    /// );
+    ///
+    /// client
+    ///     .send(request)
+    ///     .await
+    ///     .expect("We should be able to send a to-device message");
+    /// # anyhow::Ok(()) });
+    /// # }
+    /// ```
+    pub fn mock_send_to_device(&self) -> MockEndpoint<'_, SendToDeviceEndpoint> {
+        let mock =
+            Mock::given(method("PUT")).and(path_regex(r"^/_matrix/client/v3/sendToDevice/.*/.*"));
+        self.mock_endpoint(mock, SendToDeviceEndpoint).expect_default_access_token()
+    }
+
     /// Create a prebuilt mock for getting the room members in a room.
     ///
     /// # Examples
@@ -2297,6 +2347,17 @@ impl<'a> MockEndpoint<'a, DeleteRoomKeysVersionEndpoint> {
     pub fn ok(self) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
             .named("DELETE for the backup deletion")
+    }
+}
+
+/// A prebuilt mock for the `/sendToDevice` endpoint.
+///
+/// This mock can be used to simulate sending to-device messages in tests.
+pub struct SendToDeviceEndpoint;
+impl<'a> MockEndpoint<'a, SendToDeviceEndpoint> {
+    /// Returns a successful response with default data.
+    pub fn ok(self) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }
 

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -14,12 +14,20 @@
 
 //! A high-level API for requests that we send to the matrix driver.
 
-use std::marker::PhantomData;
+use std::{collections::BTreeMap, marker::PhantomData};
 
 use ruma::{
-    api::client::{account::request_openid_token, delayed_events::update_delayed_event},
-    events::{AnyTimelineEvent, MessageLikeEventType, StateEventType, TimelineEventType},
+    api::client::{
+        account::request_openid_token, delayed_events::update_delayed_event,
+        to_device::send_event_to_device,
+    },
+    events::{
+        AnyTimelineEvent, AnyToDeviceEventContent, MessageLikeEventType, StateEventType,
+        TimelineEventType, ToDeviceEventType,
+    },
     serde::Raw,
+    to_device::DeviceIdOrAllDevices,
+    OwnedUserId,
 };
 use serde::Deserialize;
 use serde_json::value::RawValue as RawJsonValue;
@@ -51,6 +59,9 @@ pub(crate) enum MatrixDriverRequestData {
 
     /// Send matrix event that corresponds to the given description.
     SendMatrixEvent(SendEventRequest),
+
+    /// Send matrix event that corresponds to the given description.
+    SendToDeviceEvent(SendToDeviceRequest),
 
     /// Data for sending a UpdateDelayedEvent client server api request.
     UpdateDelayedEvent(UpdateDelayedEventRequest),
@@ -239,6 +250,45 @@ impl FromMatrixDriverResponse for SendEventResponse {
     fn from_response(ev: MatrixDriverResponse) -> Option<Self> {
         match ev {
             MatrixDriverResponse::MatrixEventSent(response) => Some(response),
+            _ => {
+                error!("bug in MatrixDriver, received wrong event response");
+                None
+            }
+        }
+    }
+}
+
+/// Ask the client to send matrix event that corresponds to the given
+/// description and returns an event ID (or a delay ID,
+/// see [MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140)) as a response.
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct SendToDeviceRequest {
+    /// The type of the event.
+    #[serde(rename = "type")]
+    pub(crate) event_type: ToDeviceEventType,
+    // If the to_device message should be encrypted or not.
+    pub(crate) encrypted: bool,
+    /// The messages that will be encrypted (per device) and sent.
+    /// They are organized in a map of user_id -> device_id -> content like the
+    /// cs api request.
+    pub(crate) messages:
+        BTreeMap<OwnedUserId, BTreeMap<DeviceIdOrAllDevices, Raw<AnyToDeviceEventContent>>>,
+}
+
+impl From<SendToDeviceRequest> for MatrixDriverRequestData {
+    fn from(value: SendToDeviceRequest) -> Self {
+        MatrixDriverRequestData::SendToDeviceEvent(value)
+    }
+}
+
+impl MatrixDriverRequest for SendToDeviceRequest {
+    type Response = send_event_to_device::v3::Response;
+}
+
+impl FromMatrixDriverResponse for send_event_to_device::v3::Response {
+    fn from_response(ev: MatrixDriverResponse) -> Option<Self> {
+        match ev {
+            MatrixDriverResponse::MatrixToDeviceSent(response) => Some(response),
             _ => {
                 error!("bug in MatrixDriver, received wrong event response");
                 None

--- a/crates/matrix-sdk/src/widget/machine/incoming.rs
+++ b/crates/matrix-sdk/src/widget/machine/incoming.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use ruma::{
-    api::client::{account::request_openid_token, delayed_events},
-    events::AnyTimelineEvent,
+    api::client::{account::request_openid_token, delayed_events, to_device::send_event_to_device},
+    events::{AnyTimelineEvent, AnyToDeviceEvent},
     serde::Raw,
 };
 use serde::{de, Deserialize, Deserializer};
@@ -47,8 +47,13 @@ pub(crate) enum IncomingMessage {
     /// The `MatrixDriver` notified the `WidgetMachine` of a new matrix event.
     ///
     /// This means that the machine previously subscribed to some events
-    /// ([`crate::widget::Action::Subscribe`] request).
+    /// ([`crate::widget::Action::SubscribeTimeline`] or
+    /// [`crate::widget::Action::SubscribeToDevice`] request).
     MatrixEventReceived(Raw<AnyTimelineEvent>),
+
+    /// The `MatrixDriver` notified the `WidgetMachine` of a new to_device
+    /// event.
+    ToDeviceReceived(Raw<AnyToDeviceEvent>),
 }
 
 pub(crate) enum MatrixDriverResponse {
@@ -65,6 +70,7 @@ pub(crate) enum MatrixDriverResponse {
     /// Client sent some matrix event. The response contains the event ID.
     /// A response to an `Action::SendMatrixEvent` command.
     MatrixEventSent(SendEventResponse),
+    MatrixToDeviceSent(send_event_to_device::v3::Response),
     MatrixDelayedEventUpdate(delayed_events::update_delayed_event::unstable::Response),
 }
 

--- a/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
@@ -18,8 +18,12 @@ use ruma::owned_room_id;
 use serde_json::{from_value, json};
 
 use super::{parse_msg, WIDGET_ID};
-use crate::widget::machine::{
-    incoming::MatrixDriverResponse, Action, IncomingMessage, MatrixDriverRequestData, WidgetMachine,
+use crate::widget::{
+    capabilities::{READ_EVENT, READ_STATE, READ_TODEVICE},
+    machine::{
+        incoming::MatrixDriverResponse, Action, IncomingMessage, MatrixDriverRequestData,
+        WidgetMachine,
+    },
 };
 
 #[test]
@@ -191,10 +195,7 @@ pub(super) fn assert_capabilities_dance(
     };
 
     // We get the `Subscribe` command if we requested some reading capabilities.
-    if ["org.matrix.msc2762.receive.state_event", "org.matrix.msc2762.receive.event"]
-        .into_iter()
-        .any(|c| capability.starts_with(c))
-    {
+    if [READ_EVENT, READ_STATE, READ_TODEVICE].into_iter().any(|c| capability.starts_with(c)) {
         let action = actions.remove(0);
         assert_matches!(action, Action::Subscribe);
     }

--- a/crates/matrix-sdk/src/widget/machine/to_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/to_widget.rs
@@ -14,7 +14,10 @@
 
 use std::marker::PhantomData;
 
-use ruma::{events::AnyTimelineEvent, serde::Raw};
+use ruma::{
+    events::{AnyTimelineEvent, AnyToDeviceEvent},
+    serde::Raw,
+};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 use tracing::error;
@@ -124,3 +127,14 @@ impl ToWidgetRequest for NotifyNewMatrixEvent {
 
 #[derive(Deserialize)]
 pub(crate) struct Empty {}
+
+/// Notify the widget that we received a new matrix event.
+/// This is a "response" to the widget subscribing to the events in the room.
+#[derive(Serialize)]
+#[serde(transparent)]
+pub(crate) struct NotifyNewToDeviceEvent(pub(crate) Raw<AnyToDeviceEvent>);
+
+impl ToWidgetRequest for NotifyNewToDeviceEvent {
+    const ACTION: &'static str = "send_to_device";
+    type ResponseData = Empty;
+}

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -17,28 +17,36 @@
 
 use std::collections::BTreeMap;
 
-use matrix_sdk_base::deserialized_responses::RawAnySyncOrStrippedState;
+use futures_util::future::join_all;
+use matrix_sdk_base::deserialized_responses::{EncryptionInfo, RawAnySyncOrStrippedState};
+use matrix_sdk_common::executor::spawn;
 use ruma::{
     api::client::{
         account::request_openid_token::v3::{Request as OpenIdRequest, Response as OpenIdResponse},
         delayed_events::{self, update_delayed_event::unstable::UpdateAction},
         filter::RoomEventFilter,
+        to_device::send_event_to_device::{self, v3::Request as RumaToDeviceRequest},
     },
     assign,
     events::{
         AnyMessageLikeEventContent, AnyStateEventContent, AnySyncMessageLikeEvent,
-        AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent, MessageLikeEventType,
-        StateEventType, TimelineEventType,
+        AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent, AnyToDeviceEvent,
+        AnyToDeviceEventContent, MessageLikeEventType, StateEventType, TimelineEventType,
+        ToDeviceEventType,
     },
     serde::{from_raw_json_value, Raw},
-    EventId, RoomId, TransactionId,
+    to_device::DeviceIdOrAllDevices,
+    EventId, OwnedUserId, RoomId, TransactionId, UserId,
 };
 use serde_json::{value::RawValue as RawJsonValue, Value};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
-use tracing::error;
+use tracing::{error, info, warn};
 
 use super::{machine::SendEventResponse, StateKeySelector};
-use crate::{event_handler::EventHandlerDropGuard, room::MessagesOptions, Error, Result, Room};
+use crate::{
+    encryption::identities::Device, event_handler::EventHandlerDropGuard, room::MessagesOptions,
+    Client, Error, Result, Room,
+};
 
 /// Thin wrapper around a [`Room`] that provides functionality relevant for
 /// widgets.
@@ -86,7 +94,11 @@ impl MatrixDriver {
     ) -> Result<Vec<Raw<AnyTimelineEvent>>> {
         let room_id = self.room.room_id();
         let convert = |sync_or_stripped_state| match sync_or_stripped_state {
-            RawAnySyncOrStrippedState::Sync(ev) => Some(attach_room_id(ev.cast_ref(), room_id)),
+            RawAnySyncOrStrippedState::Sync(ev) => with_attached_room_id(ev.cast_ref(), room_id)
+                .map_err(|e| {
+                    error!("failed to convert event from `get_state_event` response:{}", e)
+                })
+                .ok(),
             RawAnySyncOrStrippedState::Stripped(_) => {
                 error!("MatrixDriver can't operate in invited rooms");
                 None
@@ -181,7 +193,7 @@ impl MatrixDriver {
 
     /// Starts forwarding new room events. Once the returned `EventReceiver`
     /// is dropped, forwarding will be stopped.
-    pub(crate) fn events(&self) -> EventReceiver {
+    pub(crate) fn events(&self) -> EventReceiver<Raw<AnyTimelineEvent>> {
         let (tx, rx) = unbounded_channel();
         let room_id = self.room.room_id().to_owned();
 
@@ -190,14 +202,29 @@ impl MatrixDriver {
         let _room_id = room_id.clone();
         let handle_msg_like =
             self.room.add_event_handler(move |raw: Raw<AnySyncMessageLikeEvent>| {
-                let _ = _tx.send(attach_room_id(raw.cast_ref(), &_room_id));
+                match with_attached_room_id(raw.cast_ref(), &_room_id) {
+                    Ok(event_with_room_id) => {
+                        let _ = _tx.send(event_with_room_id);
+                    }
+                    Err(e) => {
+                        error!("Failed to attach room id to message like event: {}", e);
+                    }
+                }
                 async {}
             });
         let drop_guard_msg_like = self.room.client().event_handler_drop_guard(handle_msg_like);
-
+        let _room_id = room_id;
+        let _tx = tx;
         // Get only all state events from the state section of the sync.
         let handle_state = self.room.add_event_handler(move |raw: Raw<AnySyncStateEvent>| {
-            let _ = tx.send(attach_room_id(raw.cast_ref(), &room_id));
+            match with_attached_room_id(raw.cast_ref(), &_room_id) {
+                Ok(event_with_room_id) => {
+                    let _ = _tx.send(event_with_room_id);
+                }
+                Err(e) => {
+                    error!("Failed to attach room id to state event: {}", e);
+                }
+            }
             async {}
         });
         let drop_guard_state = self.room.client().event_handler_drop_guard(handle_state);
@@ -208,25 +235,214 @@ impl MatrixDriver {
         // section of the sync will not be forwarded to the widget.
         // TODO annotate the events and send both timeline and state section state
         // events.
-        EventReceiver { rx, _drop_guards: [drop_guard_msg_like, drop_guard_state] }
+        EventReceiver { rx, _drop_guards: vec![drop_guard_msg_like, drop_guard_state] }
+    }
+
+    /// Starts forwarding new room events. Once the returned `EventReceiver`
+    /// is dropped, forwarding will be stopped.
+    pub(crate) fn to_device_events(&self) -> EventReceiver<Raw<AnyToDeviceEvent>> {
+        let (tx, rx) = unbounded_channel();
+
+        let to_device_handle = self.room.client().add_event_handler(
+            move |raw: Raw<AnyToDeviceEvent>, encryption_info: Option<EncryptionInfo>| {
+                match with_attached_encryption_flag(raw, &encryption_info) {
+                    Ok(ev) => {
+                        let _ = tx.send(ev);
+                    }
+                    Err(e) => {
+                        error!("Failed to attach encryption flag to to_device event: {}", e);
+                    }
+                }
+                async {}
+            },
+        );
+
+        let drop_guard = self.room.client().event_handler_drop_guard(to_device_handle);
+        EventReceiver { rx, _drop_guards: vec![drop_guard] }
+    }
+
+    /// It will ignore all devices where errors occurred or where the device is
+    /// not verified or where th user has a has_verification_violation.
+    pub(crate) async fn send_to_device(
+        &self,
+        event_type: ToDeviceEventType,
+        encrypted: bool,
+        messages: BTreeMap<
+            OwnedUserId,
+            BTreeMap<DeviceIdOrAllDevices, Raw<AnyToDeviceEventContent>>,
+        >,
+    ) -> Result<send_event_to_device::v3::Response> {
+        let client = self.room.client();
+        /// This encrypts to device content for a collection of devices.
+        /// It will ignore all devices where errors occurred or where the device
+        /// is not verified or where th user has a has_verification_violation.
+        async fn encrypted_content_for_devices(
+            unencrypted_content: &Raw<AnyToDeviceEventContent>,
+            devices: Vec<Device>,
+            event_type: &ToDeviceEventType,
+        ) -> Result<impl Iterator<Item = (DeviceIdOrAllDevices, Raw<AnyToDeviceEventContent>)>>
+        {
+            let content: Value =
+                unencrypted_content.deserialize_as().map_err(Into::<Error>::into)?;
+            let event_type = event_type.clone();
+            let device_content_tasks = devices.into_iter().map(|device| spawn({
+                let event_type = event_type.clone();
+                let content = content.clone();
+
+                async move {
+                    if !device.is_cross_signed_by_owner() {
+                        info!("Device {} is not verified, skipping encryption", device.device_id());
+                        return None;
+                    }
+                    match device
+                        .inner
+                        .encrypt_event_raw(&event_type.to_string(), &content)
+                        .await {
+                            Ok(encrypted) => Some((device.device_id().to_owned().into(), encrypted.cast())),
+                            Err(e) =>{ info!("Failed to encrypt to_device event from widget for device: {} because, {}", device.device_id(), e); None},
+                        }
+                }
+            }));
+            let device_encrypted_content_map =
+                join_all(device_content_tasks).await.into_iter().flatten().flatten();
+            Ok(device_encrypted_content_map)
+        }
+
+        /// Convert the device content map for one user into the same content
+        /// map with encrypted content This needs to flatten the vectors
+        /// we get from `encrypted_content_for_devices`
+        /// since one `DeviceIdOrAllDevices` id can be multiple devices.
+        async fn encrypted_device_content_map(
+            client: &Client,
+            user_id: &UserId,
+            event_type: &ToDeviceEventType,
+            device_content_map: BTreeMap<DeviceIdOrAllDevices, Raw<AnyToDeviceEventContent>>,
+        ) -> BTreeMap<DeviceIdOrAllDevices, Raw<AnyToDeviceEventContent>> {
+            let device_map_futures =
+                device_content_map.into_iter().map(|(device_or_all_id, content)| spawn({
+                    let client = client.clone();
+                    let user_id = user_id.to_owned();
+                    let event_type = event_type.clone();
+                    async move {
+                        let Ok(user_devices) = client.encryption().get_user_devices(&user_id).await else {
+                            warn!("Failed to get user devices for user: {}", user_id);
+                            return None;
+                        };
+                        let Ok(user_identity) = client.encryption().get_user_identity(&user_id).await else{
+                            warn!("Failed to get user identity for user: {}", user_id);
+                            return None;
+                        };
+                        if user_identity.map(|i|i.has_verification_violation()).unwrap_or(false) {
+                            info!("User {} has a verification violation, skipping encryption", user_id);
+                            return None;
+                        }
+                        let devices: Vec<Device> = match device_or_all_id {
+                            DeviceIdOrAllDevices::DeviceId(device_id) => {
+                                vec![user_devices.get(&device_id)].into_iter().flatten().collect()
+                            }
+                            DeviceIdOrAllDevices::AllDevices => user_devices.devices().collect(),
+                        };
+                        encrypted_content_for_devices(
+                            &content,
+                            devices,
+                            &event_type,
+                        )
+                        .await
+                        .map_err(|e| info!("WidgetDriver: could not encrypt content for to device widget event content: {}. because, {}", content.json(), e))
+                        .ok()
+                }}));
+            let content_map_iterator = join_all(device_map_futures).await.into_iter();
+
+            // The first flatten takes the iterator over Result<Option<impl Iterator<Item =
+            // (DeviceIdOrAllDevices, Raw<AnyToDeviceEventContent>)>>, JoinError>>
+            // and flattens the Result (drops Err() items)
+            // The second takes the iterator over: Option<impl Iterator<Item =
+            // (DeviceIdOrAllDevices, Raw<AnyToDeviceEventContent>)>>
+            // and flattens the Option (drops None items)
+            // The third takes the iterator over iterators: impl Iterator<Item =
+            // (DeviceIdOrAllDevices, Raw<AnyToDeviceEventContent>)>
+            // and flattens it to just an iterator over (DeviceIdOrAllDevices,
+            // Raw<AnyToDeviceEventContent>)
+            content_map_iterator.flatten().flatten().flatten().collect()
+        }
+
+        let request = if encrypted {
+            // We first want to get all missing session before we start any to device
+            // sending!
+            client.claim_one_time_keys(messages.keys().map(|u| u.as_ref())).await?;
+            let encrypted_content: BTreeMap<
+                OwnedUserId,
+                BTreeMap<DeviceIdOrAllDevices, Raw<AnyToDeviceEventContent>>,
+            > = join_all(messages.into_iter().map(|(user_id, device_content_map)| {
+                let event_type = event_type.clone();
+                async move {
+                    (
+                        user_id.clone(),
+                        encrypted_device_content_map(
+                            &self.room.client(),
+                            &user_id,
+                            &event_type,
+                            device_content_map,
+                        )
+                        .await,
+                    )
+                }
+            }))
+            .await
+            .into_iter()
+            .collect();
+
+            RumaToDeviceRequest::new_raw(
+                ToDeviceEventType::RoomEncrypted,
+                TransactionId::new(),
+                encrypted_content,
+            )
+        } else {
+            RumaToDeviceRequest::new_raw(event_type, TransactionId::new(), messages)
+        };
+
+        let response = client.send(request).await;
+
+        response.map_err(Into::into)
     }
 }
 
 /// A simple entity that wraps an `UnboundedReceiver`
 /// along with the drop guard for the room event handler.
-pub(crate) struct EventReceiver {
-    rx: UnboundedReceiver<Raw<AnyTimelineEvent>>,
-    _drop_guards: [EventHandlerDropGuard; 2],
+pub(crate) struct EventReceiver<E> {
+    rx: UnboundedReceiver<E>,
+    _drop_guards: Vec<EventHandlerDropGuard>,
 }
 
-impl EventReceiver {
-    pub(crate) async fn recv(&mut self) -> Option<Raw<AnyTimelineEvent>> {
+impl<T> EventReceiver<T> {
+    pub(crate) async fn recv(&mut self) -> Option<T> {
         self.rx.recv().await
     }
 }
 
-fn attach_room_id(raw_ev: &Raw<AnySyncTimelineEvent>, room_id: &RoomId) -> Raw<AnyTimelineEvent> {
-    let mut ev_obj = raw_ev.deserialize_as::<BTreeMap<String, Box<RawJsonValue>>>().unwrap();
-    ev_obj.insert("room_id".to_owned(), serde_json::value::to_raw_value(room_id).unwrap());
-    Raw::new(&ev_obj).unwrap().cast()
+fn with_attached_room_id(
+    raw: &Raw<AnySyncTimelineEvent>,
+    room_id: &RoomId,
+) -> Result<Raw<AnyTimelineEvent>> {
+    match raw.deserialize_as::<BTreeMap<String, Box<RawJsonValue>>>() {
+        Ok(mut ev_mut) => {
+            ev_mut.insert("room_id".to_owned(), serde_json::value::to_raw_value(room_id)?);
+            Ok(Raw::new(&ev_mut)?.cast())
+        }
+        Err(e) => Err(Error::from(e)),
+    }
+}
+
+fn with_attached_encryption_flag(
+    raw: Raw<AnyToDeviceEvent>,
+    encryption_info: &Option<EncryptionInfo>,
+) -> Result<Raw<AnyToDeviceEvent>> {
+    match raw.deserialize_as::<BTreeMap<String, Box<RawJsonValue>>>() {
+        Ok(mut ev_mut) => {
+            let encrypted = encryption_info.is_some();
+            ev_mut.insert("encrypted".to_owned(), serde_json::value::to_raw_value(&encrypted)?);
+            Ok(Raw::new(&ev_mut)?.cast())
+        }
+        Err(e) => Err(Error::from(e)),
+    }
 }

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -236,6 +236,8 @@ impl WidgetDriver {
                         .update_delayed_event(req.delay_id, req.action)
                         .await
                         .map(MatrixDriverResponse::MatrixDelayedEventUpdate),
+
+                    MatrixDriverRequestData::SendToDeviceEvent(req) => todo!(),
                 };
 
                 // Forward the matrix driver response to the incoming message stream.

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -85,7 +85,7 @@ async fn run_test_driver(
 
 async fn recv_message(driver_handle: &WidgetDriverHandle) -> JsonObject {
     let fut = pin!(driver_handle.recv());
-    let msg = timeout(fut, Duration::from_secs(1)).await.unwrap();
+    let msg = timeout(fut, Duration::from_secs(10)).await.unwrap();
     serde_json::from_str(&msg.unwrap()).unwrap()
 }
 
@@ -95,15 +95,15 @@ async fn send_request(
     action: &str,
     data: impl Serialize,
 ) {
-    let sent = driver_handle
-        .send(json_string!({
-            "api": "fromWidget",
-            "widgetId": WIDGET_ID,
-            "requestId": request_id,
-            "action": action,
-            "data": data,
-        }))
-        .await;
+    let json_string = json_string!({
+        "api": "fromWidget",
+        "widgetId": WIDGET_ID,
+        "requestId": request_id,
+        "action": action,
+        "data": data,
+    });
+    println!("Json string sent from the widget {}", json_string);
+    let sent = driver_handle.send(json_string).await;
     assert!(sent);
 }
 
@@ -381,6 +381,8 @@ async fn test_receive_live_events() {
             "org.matrix.msc2762.receive.event:m.room.message#m.text",
             "org.matrix.msc2762.receive.state_event:m.room.name#",
             "org.matrix.msc2762.receive.state_event:m.room.member#@example:localhost",
+            "org.matrix.msc2762.receive.state_event:m.room.member#@example:localhost",
+            "org.matrix.msc3819.receive.to_device:my.custom.to.device"
         ]),
     )
     .await;
@@ -417,32 +419,63 @@ async fn test_receive_live_events() {
                     // set room name - matches filter #3
                     .add_timeline_event(f.room_name("New Room Name").sender(&BOB)),
             );
+            // to device message - doesn't match
+            sync_builder.add_to_device_event(json!({
+              "sender": "@alice:example.com",
+              "type": "m.not_matching.to.device",
+              "content": {
+                "a": "test",
+              }
+            }));
+            // to device message - matches filter #6
+            sync_builder.add_to_device_event(json!({
+                    "sender": "@alice:example.com",
+                    "type": "my.custom.to.device",
+                    "content": {
+                      "a": "test",
+                    }
+                  }
+            ));
         })
         .await;
 
-    let msg = recv_message(&driver_handle).await;
-    assert_eq!(msg["api"], "toWidget");
-    assert_eq!(msg["action"], "send_event");
-    assert_eq!(msg["data"]["type"], "m.room.message");
-    assert_eq!(msg["data"]["room_id"], ROOM_ID.as_str());
-    assert_eq!(msg["data"]["content"]["msgtype"], "m.text");
-    assert_eq!(msg["data"]["content"]["body"], "simple text message");
+    // The to device and room events are racing -> we dont know the order and just
+    // need to store them separately.
+    let mut to_device: JsonObject = JsonObject::new();
+    let mut events = vec![];
+    for _ in 0..4 {
+        let msg = recv_message(&driver_handle).await;
+        if msg["action"] == "send_to_device" {
+            to_device = msg;
+        } else {
+            events.push(msg);
+        }
+    }
 
-    let msg = recv_message(&driver_handle).await;
-    assert_eq!(msg["api"], "toWidget");
-    assert_eq!(msg["action"], "send_event");
-    assert_eq!(msg["data"]["type"], "m.room.member");
-    assert_eq!(msg["data"]["room_id"], ROOM_ID.as_str());
-    assert_eq!(msg["data"]["state_key"], "@example:localhost");
-    assert_eq!(msg["data"]["content"]["membership"], "join");
-    assert_eq!(msg["data"]["unsigned"]["prev_content"]["membership"], "join");
+    assert_eq!(events[0]["api"], "toWidget");
+    assert_eq!(events[0]["action"], "send_event");
+    assert_eq!(events[0]["data"]["type"], "m.room.message");
+    assert_eq!(events[0]["data"]["room_id"], ROOM_ID.as_str());
+    assert_eq!(events[0]["data"]["content"]["msgtype"], "m.text");
+    assert_eq!(events[0]["data"]["content"]["body"], "simple text message");
 
-    let msg = recv_message(&driver_handle).await;
-    assert_eq!(msg["api"], "toWidget");
-    assert_eq!(msg["action"], "send_event");
-    assert_eq!(msg["data"]["type"], "m.room.name");
-    assert_eq!(msg["data"]["sender"], BOB.as_str());
-    assert_eq!(msg["data"]["content"]["name"], "New Room Name");
+    assert_eq!(events[1]["api"], "toWidget");
+    assert_eq!(events[1]["action"], "send_event");
+    assert_eq!(events[1]["data"]["type"], "m.room.member");
+    assert_eq!(events[1]["data"]["room_id"], ROOM_ID.as_str());
+    assert_eq!(events[1]["data"]["state_key"], "@example:localhost");
+    assert_eq!(events[1]["data"]["content"]["membership"], "join");
+    assert_eq!(events[1]["data"]["unsigned"]["prev_content"]["membership"], "join");
+
+    assert_eq!(events[2]["api"], "toWidget");
+    assert_eq!(events[2]["action"], "send_event");
+    assert_eq!(events[2]["data"]["type"], "m.room.name");
+    assert_eq!(events[2]["data"]["sender"], BOB.as_str());
+    assert_eq!(events[2]["data"]["content"]["name"], "New Room Name");
+
+    assert_eq!(to_device["api"], "toWidget");
+    assert_eq!(to_device["action"], "send_to_device");
+    assert_eq!(to_device["data"]["type"], "my.custom.to.device");
 
     // No more messages from the driver
     assert_matches!(recv_message(&driver_handle).now_or_never(), None);
@@ -816,7 +849,6 @@ async fn test_send_redaction() {
         ]),
     )
     .await;
-
     mock_server.mock_room_redact().ok(event_id!("$redact_event_id")).mock_once().mount().await;
 
     send_request(
@@ -841,6 +873,104 @@ async fn test_send_redaction() {
 
     assert_eq!(redact_event_id, "$redact_event_id");
     assert_eq!(redact_room_id, "!a98sd12bjh:example.org");
+}
+
+async fn send_to_device_test_helper(
+    request_id: &str,
+    data: JsonValue,
+    expected_response: JsonValue,
+    calls: u64,
+) -> JsonValue {
+    let (_, mock_server, driver_handle) = run_test_driver(false).await;
+
+    negotiate_capabilities(
+        &driver_handle,
+        json!([
+            "org.matrix.msc3819.send.to_device:my.custom.to_device_type",
+            "org.matrix.msc3819.send.to_device:my.other_type"
+        ]),
+    )
+    .await;
+
+    mock_server.mock_send_to_device().ok().expect(calls).mount().await;
+
+    send_request(&driver_handle, request_id, "send_to_device", data).await;
+
+    // Receive the response
+    let msg = recv_message(&driver_handle).await;
+    assert_eq!(msg["api"], "fromWidget");
+    assert_eq!(msg["action"], "send_to_device");
+    let response = msg["response"].clone();
+    assert_eq!(
+        serde_json::to_string(&response).unwrap(),
+        serde_json::to_string(&expected_response).unwrap()
+    );
+
+    response
+}
+
+#[async_test]
+async fn test_send_to_device_event() {
+    send_to_device_test_helper(
+        "id_my.custom.to_device_type",
+        json!({
+            "type":"my.custom.to_device_type",
+            "encrypted": false,
+            "messages":{
+                "@username:test.org": {
+                    "DEVICEID": {
+                        "param1":"test",
+                    },
+                },
+            }
+        }),
+        json! {{}},
+        1,
+    )
+    .await;
+}
+
+#[async_test]
+async fn test_error_to_device_event_no_permission() {
+    send_to_device_test_helper(
+        "id_my.unallowed_type",
+        json!({
+            "type": "my.unallowed_type",
+            "encrypted": false,
+            "messages": {
+                "@username:test.org": {
+                    "DEVICEID": {
+                        "param1":"test",
+                    },
+                },
+            }
+        }),
+        // this means the server did not get the correct event type
+        json! {{"error": {"message": "Not allowed to send to-device message of type: my.unallowed_type"}}},
+        0
+    )
+    .await;
+}
+
+#[async_test]
+async fn test_send_encrypted_to_device_event() {
+    send_to_device_test_helper(
+        "my.custom.to_device_type",
+        json!({
+            "type": "my.custom.to_device_type",
+            "encrypted": true,
+            "messages":{
+                "@username:test.org": {
+                    "DEVICEID": {
+                        "param1":"test",
+                    },
+                },
+            }
+        }),
+        json! {{}},
+        1,
+    )
+    .await;
 }
 
 async fn negotiate_capabilities(driver_handle: &WidgetDriverHandle, caps: JsonValue) {

--- a/testing/matrix-sdk-test/src/sync_builder/mod.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/mod.rs
@@ -8,7 +8,7 @@ use ruma::{
         },
         IncomingResponse,
     },
-    events::{presence::PresenceEvent, AnyGlobalAccountDataEvent},
+    events::{presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyToDeviceEvent},
     serde::Raw,
     OwnedRoomId, OwnedUserId, UserId,
 };
@@ -58,6 +58,7 @@ pub struct SyncResponseBuilder {
     batch_counter: i64,
     /// The device lists of the user.
     changed_device_lists: Vec<OwnedUserId>,
+    to_device_events: Vec<Raw<AnyToDeviceEvent>>,
 }
 
 impl SyncResponseBuilder {
@@ -162,6 +163,12 @@ impl SyncResponseBuilder {
         self
     }
 
+    /// Add a to device event.
+    pub fn add_to_device_event(&mut self, event: JsonValue) -> &mut Self {
+        self.to_device_events.push(from_json_value(event).unwrap());
+        self
+    }
+
     /// Builds a sync response as a JSON Value containing the events we queued
     /// so far.
     ///
@@ -191,7 +198,7 @@ impl SyncResponseBuilder {
                     "knock": self.knocked_rooms,
                 },
                 "to_device": {
-                    "events": []
+                    "events": self.to_device_events,
                 },
                 "presence": {
                     "events": self.presence,


### PR DESCRIPTION
Updated version of: https://github.com/matrix-org/matrix-rust-sdk/pull/4155

This introduces widget driver support for sending to devices messages: "A widget (element call) can request send an action via postmessage to the client (element X). This PRs job is to do everything from parsing the json to sending the to_device cs api request to sending back the response."


<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
