### PR TITLE
integration-test: Remove postgres container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,27 +342,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # run several docker containers with the same networking stack so the hostname 'postgres'
-    # maps to the postgres container, etc.
+    # run several docker containers with the same networking stack so the hostname 'synapse'
+    # maps to the synapse container, etc.
     services:
-      # synapse needs a postgres container
-      postgres:
-        # Docker Hub image
-        image: postgres
-        # Provide the password for postgres
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: syncv3
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
       # tests need a synapse: this is a service and not michaelkaye/setup-matrix-synapse@main as the
       # latter does not provide networking for services to communicate with it.
       synapse:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,26 +26,9 @@ jobs:
     name: Code Coverage
     runs-on: "ubuntu-latest"
 
-    # run several docker containers with the same networking stack so the hostname 'postgres'
-    # maps to the postgres container, etc.
+    # run several docker containers with the same networking stack so the hostname 'synapse'
+    # maps to the synapse container, etc.
     services:
-      postgres:
-        # Docker Hub image
-        image: postgres
-        # Provide the password for postgres
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: syncv3
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
       # tests need a synapse: this is a service and not michaelkaye/setup-matrix-synapse@main as the
       # latter does not provide networking for services to communicate with it.
       synapse:

--- a/testing/matrix-sdk-integration-testing/README.md
+++ b/testing/matrix-sdk-integration-testing/README.md
@@ -36,7 +36,7 @@ template; if you haven't touched it, you don't need to manually set those enviro
 To stop the services and drop the database of your docker-compose cluster, run:
 
 ```bash
-docker compose -f assets/docker-compose.yml down --volumes --remove-orphan -t 0
+docker compose -f assets/docker-compose.yml down --volumes --remove-orphans -t 0
 ```
 
 ### Rebuild the synapse image

--- a/testing/matrix-sdk-integration-testing/assets/docker-compose.yml
+++ b/testing/matrix-sdk-integration-testing/assets/docker-compose.yml
@@ -10,20 +10,5 @@ services:
     ports:
       - 8228:8008/tcp
 
-  postgres:
-    image: docker.io/postgres
-    environment:
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_USER: postgres
-      POSTGRES_DB: syncv3
-    healthcheck:
-      test: ["CMD", "pg_isready"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    volumes:
-      - db:/var/lib/postgresql/data
-
 volumes:
   synapse:
-  db:


### PR DESCRIPTION
Followup on https://github.com/matrix-org/matrix-rust-sdk/pull/3983: now that we don't have a sliding sync proxy, we don't need a postgres container.