### PR TITLE
chore: move `RedactedMessage` and `UnableToDecrypt` to `MsgLike`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -57,7 +57,7 @@ impl From<matrix_sdk_ui::timeline::TimelineItemContent> for TimelineItemContent 
                 }
             }
 
-            Content::MsgLike(MsgLikeContent { kind: MsgLikeKind::RedactedMessage, .. }) => {
+            Content::MsgLike(MsgLikeContent { kind: MsgLikeKind::Redacted, .. }) => {
                 TimelineItemContent::RedactedMessage
             }
 

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -57,7 +57,9 @@ impl From<matrix_sdk_ui::timeline::TimelineItemContent> for TimelineItemContent 
                 }
             }
 
-            Content::RedactedMessage => TimelineItemContent::RedactedMessage,
+            Content::MsgLike(MsgLikeContent { kind: MsgLikeKind::RedactedMessage, .. }) => {
+                TimelineItemContent::RedactedMessage
+            }
 
             Content::MsgLike(MsgLikeContent { kind: MsgLikeKind::Sticker(sticker), .. }) => {
                 let content = sticker.content();

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -94,9 +94,9 @@ impl From<matrix_sdk_ui::timeline::TimelineItemContent> for TimelineItemContent 
 
             Content::CallNotify => TimelineItemContent::CallNotify,
 
-            Content::UnableToDecrypt(msg) => {
-                TimelineItemContent::UnableToDecrypt { msg: EncryptedMessage::new(&msg) }
-            }
+            Content::MsgLike(MsgLikeContent {
+                kind: MsgLikeKind::UnableToDecrypt(msg), ..
+            }) => TimelineItemContent::UnableToDecrypt { msg: EncryptedMessage::new(&msg) },
 
             Content::MembershipChange(membership) => {
                 let reason = match membership.content() {

--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -29,7 +29,7 @@ use crate::timeline::{
     controller::{TimelineSettings, TimelineState},
     event_item::EventTimelineItemKind,
     traits::{Decryptor, RoomDataProvider},
-    EncryptedMessage, EventTimelineItem, TimelineItem, TimelineItemContent, TimelineItemKind,
+    EncryptedMessage, EventTimelineItem, TimelineItem, TimelineItemKind,
 };
 
 /// Holds a long-running task that is used to retry decryption of items in the
@@ -168,18 +168,17 @@ fn compute_event_indices_to_retry_decryption(
 
     // We retry an event if its session ID should be retried
     let should_retry_event = |event: &EventTimelineItem| {
-        let session_id =
-            if let TimelineItemContent::UnableToDecrypt(encrypted_message) = event.content() {
-                // UTDs carry their session ID inside the content
-                encrypted_message.session_id()
-            } else {
-                // Non-UTDs only have a session ID if they are remote and have it in the
-                // EncryptionInfo
-                event
-                    .as_remote()
-                    .and_then(|remote| remote.encryption_info.as_ref()?.session_id.as_ref())
-                    .map(String::as_str)
-            };
+        let session_id = if let Some(encrypted_message) = event.content().as_unable_to_decrypt() {
+            // UTDs carry their session ID inside the content
+            encrypted_message.session_id()
+        } else {
+            // Non-UTDs only have a session ID if they are remote and have it in the
+            // EncryptionInfo
+            event
+                .as_remote()
+                .and_then(|remote| remote.encryption_info.as_ref()?.session_id.as_ref())
+                .map(String::as_str)
+        };
 
         if let Some(session_id) = session_id {
             // Should we retry this session ID?
@@ -359,8 +358,9 @@ mod tests {
             EventTimelineItemKind, LocalEventTimelineItem, RemoteEventOrigin,
             RemoteEventTimelineItem,
         },
-        EventSendState, EventTimelineItem, MsgLikeContent, ReactionsByKeyBySender, TimelineDetails,
-        TimelineItem, TimelineItemContent, TimelineItemKind, TimelineUniqueId, VirtualTimelineItem,
+        EncryptedMessage, EventSendState, EventTimelineItem, MsgLikeContent,
+        ReactionsByKeyBySender, TimelineDetails, TimelineItem, TimelineItemContent,
+        TimelineItemKind, TimelineUniqueId, VirtualTimelineItem,
     };
 
     #[test]
@@ -486,20 +486,22 @@ mod tests {
                 owned_user_id!("@u:s.to"),
                 TimelineDetails::Pending,
                 timestamp(),
-                TimelineItemContent::unable_to_decrypt(
-                    RoomEncryptedEventContent::new(
-                        EncryptedEventScheme::MegolmV1AesSha2(MegolmV1AesSha2Content::from(
-                            MegolmV1AesSha2ContentInit {
-                                ciphertext: "cyf".to_owned(),
-                                sender_key: "sendk".to_owned(),
-                                device_id: owned_device_id!("DEV"),
-                                session_id: session_id.to_owned(),
-                            },
-                        )),
-                        None,
+                TimelineItemContent::MsgLike(MsgLikeContent::unable_to_decrypt(
+                    EncryptedMessage::from_content(
+                        RoomEncryptedEventContent::new(
+                            EncryptedEventScheme::MegolmV1AesSha2(MegolmV1AesSha2Content::from(
+                                MegolmV1AesSha2ContentInit {
+                                    ciphertext: "cyf".to_owned(),
+                                    sender_key: "sendk".to_owned(),
+                                    device_id: owned_device_id!("DEV"),
+                                    session_id: session_id.to_owned(),
+                                },
+                            )),
+                            None,
+                        ),
+                        UtdCause::Unknown,
                     ),
-                    UtdCause::Unknown,
-                ),
+                )),
                 event_kind,
                 true,
             )),

--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -460,7 +460,7 @@ mod tests {
                 owned_user_id!("@u:s.to"),
                 TimelineDetails::Pending,
                 timestamp(),
-                TimelineItemContent::MsgLike(MsgLikeContent::redacted_message()),
+                TimelineItemContent::MsgLike(MsgLikeContent::redacted()),
                 event_kind,
                 true,
             )),

--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -359,8 +359,8 @@ mod tests {
             EventTimelineItemKind, LocalEventTimelineItem, RemoteEventOrigin,
             RemoteEventTimelineItem,
         },
-        EventSendState, EventTimelineItem, ReactionsByKeyBySender, TimelineDetails, TimelineItem,
-        TimelineItemContent, TimelineItemKind, TimelineUniqueId, VirtualTimelineItem,
+        EventSendState, EventTimelineItem, MsgLikeContent, ReactionsByKeyBySender, TimelineDetails,
+        TimelineItem, TimelineItemContent, TimelineItemKind, TimelineUniqueId, VirtualTimelineItem,
     };
 
     #[test]
@@ -460,7 +460,7 @@ mod tests {
                 owned_user_id!("@u:s.to"),
                 TimelineDetails::Pending,
                 timestamp(),
-                TimelineItemContent::RedactedMessage,
+                TimelineItemContent::MsgLike(MsgLikeContent::redacted_message()),
                 event_kind,
                 true,
             )),

--- a/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
@@ -674,7 +674,7 @@ mod tests {
             owned_user_id!("@alice:example.org"),
             crate::timeline::TimelineDetails::Pending,
             timestamp,
-            TimelineItemContent::MsgLike(MsgLikeContent::redacted_message()),
+            TimelineItemContent::MsgLike(MsgLikeContent::redacted()),
             event_kind,
             false,
         )

--- a/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
@@ -654,7 +654,8 @@ mod tests {
         controller::TimelineMetadata,
         date_dividers::timestamp_to_date,
         event_item::{EventTimelineItemKind, RemoteEventTimelineItem},
-        DateDividerMode, EventTimelineItem, TimelineItemContent, VirtualTimelineItem,
+        DateDividerMode, EventTimelineItem, MsgLikeContent, TimelineItemContent,
+        VirtualTimelineItem,
     };
 
     fn event_with_ts(timestamp: MilliSecondsSinceUnixEpoch) -> EventTimelineItem {
@@ -673,7 +674,7 @@ mod tests {
             owned_user_id!("@alice:example.org"),
             crate::timeline::TimelineDetails::Pending,
             timestamp,
-            TimelineItemContent::RedactedMessage,
+            TimelineItemContent::MsgLike(MsgLikeContent::redacted_message()),
             event_kind,
             false,
         )

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -479,7 +479,10 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
             TimelineEventKind::RedactedMessage { event_type } => {
                 if event_type != MessageLikeEventType::Reaction && should_add {
-                    self.add_item(TimelineItemContent::RedactedMessage, None);
+                    self.add_item(
+                        TimelineItemContent::MsgLike(MsgLikeContent::redacted_message()),
+                        None,
+                    );
                 }
             }
 
@@ -969,7 +972,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         // General path: redact another kind of (non-reaction) event.
         if let Some((idx, item)) = rfind_event_by_id(self.items, &redacted) {
             if item.as_remote().is_some() {
-                if let TimelineItemContent::RedactedMessage = &item.content {
+                if item.content.is_redacted() {
                     debug!("event item is already redacted");
                 } else {
                     let new_item = item.redact(&self.meta.room_version);

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -480,7 +480,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             TimelineEventKind::RedactedMessage { event_type } => {
                 if event_type != MessageLikeEventType::Reaction && should_add {
                     self.add_item(
-                        TimelineItemContent::MsgLike(MsgLikeContent::redacted_message()),
+                        TimelineItemContent::MsgLike(MsgLikeContent::redacted()),
                         None,
                     );
                 }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -65,8 +65,8 @@ use super::{
         TimelineEventItemId,
     },
     traits::RoomDataProvider,
-    EventTimelineItem, InReplyToDetails, MsgLikeContent, MsgLikeKind, OtherState, ReactionStatus,
-    RepliedToEvent, Sticker, TimelineDetails, TimelineItem, TimelineItemContent,
+    EncryptedMessage, EventTimelineItem, InReplyToDetails, MsgLikeContent, MsgLikeKind, OtherState,
+    ReactionStatus, RepliedToEvent, Sticker, TimelineDetails, TimelineItem, TimelineItemContent,
 };
 use crate::events::SyncTimelineEventWithoutContent;
 
@@ -464,7 +464,12 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             TimelineEventKind::UnableToDecrypt { content, utd_cause } => {
                 // TODO: Handle replacements if the replaced event is also UTD
                 if should_add {
-                    self.add_item(TimelineItemContent::unable_to_decrypt(content, utd_cause), None);
+                    self.add_item(
+                        TimelineItemContent::MsgLike(MsgLikeContent::unable_to_decrypt(
+                            EncryptedMessage::from_content(content, utd_cause),
+                        )),
+                        None,
+                    );
                 }
 
                 // Let the hook know that we ran into an unable-to-decrypt that is added to the
@@ -479,10 +484,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
             TimelineEventKind::RedactedMessage { event_type } => {
                 if event_type != MessageLikeEventType::Reaction && should_add {
-                    self.add_item(
-                        TimelineItemContent::MsgLike(MsgLikeContent::redacted()),
-                        None,
-                    );
+                    self.add_item(TimelineItemContent::MsgLike(MsgLikeContent::redacted()), None);
                 }
             }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -337,6 +337,12 @@ impl TimelineItemContent {
         }) => message)
     }
 
+    /// Check whether this item's content is a
+    /// [`Message`][MsgLikeKind::Message].
+    pub fn is_message(&self) -> bool {
+        matches!(self, Self::MsgLike(MsgLikeContent { kind: MsgLikeKind::Message(_), .. }))
+    }
+
     /// If `self` is of the [`MsgLike`][Self::MsgLike] variant, return the
     /// inner [`PollState`].
     pub fn as_poll(&self) -> Option<&PollState> {
@@ -344,6 +350,12 @@ impl TimelineItemContent {
             kind: MsgLikeKind::Poll(poll_state),
             ..
         }) => poll_state)
+    }
+
+    /// Check whether this item's content is a
+    /// [`Poll`][MsgLikeKind::Poll].
+    pub fn is_poll(&self) -> bool {
+        matches!(self, Self::MsgLike(MsgLikeContent { kind: MsgLikeKind::Poll(_), .. }))
     }
 
     pub fn as_sticker(&self) -> Option<&Sticker> {
@@ -356,6 +368,12 @@ impl TimelineItemContent {
         )
     }
 
+    /// Check whether this item's content is a
+    /// [`Sticker`][MsgLikeKind::Sticker].
+    pub fn is_sticker(&self) -> bool {
+        matches!(self, Self::MsgLike(MsgLikeContent { kind: MsgLikeKind::Sticker(_), .. }))
+    }
+
     /// If `self` is of the [`UnableToDecrypt`][Self::UnableToDecrypt] variant,
     /// return the inner [`EncryptedMessage`].
     pub fn as_unable_to_decrypt(&self) -> Option<&EncryptedMessage> {
@@ -366,24 +384,6 @@ impl TimelineItemContent {
     /// [`UnableToDecrypt`][Self::UnableToDecrypt].
     pub fn is_unable_to_decrypt(&self) -> bool {
         matches!(self, Self::UnableToDecrypt(_))
-    }
-
-    /// Check whether this item's content is a
-    /// [`Message`][MsgLikeKind::Message].
-    pub fn is_message(&self) -> bool {
-        matches!(self, Self::MsgLike(MsgLikeContent { kind: MsgLikeKind::Message(_), .. }))
-    }
-
-    /// Check whether this item's content is a
-    /// [`Poll`][MsgLikeKind::Poll].
-    pub fn is_poll(&self) -> bool {
-        matches!(self, Self::MsgLike(MsgLikeContent { kind: MsgLikeKind::Poll(_), .. }))
-    }
-
-    /// Check whether this item's content is a
-    /// [`Sticker`][MsgLikeKind::Sticker].
-    pub fn is_sticker(&self) -> bool {
-        matches!(self, Self::MsgLike(MsgLikeContent { kind: MsgLikeKind::Sticker(_), .. }))
     }
 
     // These constructors could also be `From` implementations, but that would

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -217,7 +217,7 @@ impl TimelineItemContent {
             }
 
             SyncRoomMessageEvent::Redacted(_) => {
-                TimelineItemContent::MsgLike(MsgLikeContent::redacted_message())
+                TimelineItemContent::MsgLike(MsgLikeContent::redacted())
             }
         }
     }
@@ -236,7 +236,7 @@ impl TimelineItemContent {
                 )
             }
             SyncRoomMemberEvent::Redacted(_) => {
-                TimelineItemContent::MsgLike(MsgLikeContent::redacted_message())
+                TimelineItemContent::MsgLike(MsgLikeContent::redacted())
             }
         }
     }
@@ -265,7 +265,7 @@ impl TimelineItemContent {
                 TimelineItemContent::MsgLike(msglike)
             }
             SyncStickerEvent::Redacted(_) => {
-                TimelineItemContent::MsgLike(MsgLikeContent::redacted_message())
+                TimelineItemContent::MsgLike(MsgLikeContent::redacted())
             }
         }
     }
@@ -276,7 +276,7 @@ impl TimelineItemContent {
         event: &SyncUnstablePollStartEvent,
     ) -> TimelineItemContent {
         let SyncUnstablePollStartEvent::Original(event) = event else {
-            return TimelineItemContent::MsgLike(MsgLikeContent::redacted_message());
+            return TimelineItemContent::MsgLike(MsgLikeContent::redacted());
         };
 
         // Feed the bundled edit, if present, or we might miss showing edited content.
@@ -315,7 +315,7 @@ impl TimelineItemContent {
         match event {
             SyncCallInviteEvent::Original(_) => TimelineItemContent::CallInvite,
             SyncCallInviteEvent::Redacted(_) => {
-                TimelineItemContent::MsgLike(MsgLikeContent::redacted_message())
+                TimelineItemContent::MsgLike(MsgLikeContent::redacted())
             }
         }
     }
@@ -326,7 +326,7 @@ impl TimelineItemContent {
         match event {
             SyncCallNotifyEvent::Original(_) => TimelineItemContent::CallNotify,
             SyncCallNotifyEvent::Redacted(_) => {
-                TimelineItemContent::MsgLike(MsgLikeContent::redacted_message())
+                TimelineItemContent::MsgLike(MsgLikeContent::redacted())
             }
         }
     }
@@ -394,7 +394,7 @@ impl TimelineItemContent {
     }
 
     pub fn is_redacted(&self) -> bool {
-        matches!(self, Self::MsgLike(MsgLikeContent { kind: MsgLikeKind::RedactedMessage, .. }))
+        matches!(self, Self::MsgLike(MsgLikeContent { kind: MsgLikeKind::Redacted, .. }))
     }
 
     // These constructors could also be `From` implementations, but that would
@@ -504,7 +504,7 @@ impl TimelineItemContent {
     pub(in crate::timeline) fn redact(&self, room_version: &RoomVersionId) -> Self {
         match self {
             Self::MsgLike(_) | Self::CallInvite | Self::CallNotify | Self::UnableToDecrypt(_) => {
-                TimelineItemContent::MsgLike(MsgLikeContent::redacted_message())
+                TimelineItemContent::MsgLike(MsgLikeContent::redacted())
             }
             Self::MembershipChange(ev) => Self::MembershipChange(ev.redact(room_version)),
             Self::ProfileChange(ev) => Self::ProfileChange(ev.redact()),

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/msg_like.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/msg_like.rs
@@ -28,6 +28,9 @@ pub enum MsgLikeKind {
 
     /// An `m.poll.start` event.
     Poll(PollState),
+
+    /// A redacted message.
+    RedactedMessage,
 }
 
 /// A special kind of [`super::TimelineItemContent`] that groups together
@@ -50,6 +53,16 @@ impl MsgLikeContent {
             MsgLikeKind::Message(_) => "a message",
             MsgLikeKind::Sticker(_) => "a sticker",
             MsgLikeKind::Poll(_) => "a poll",
+            MsgLikeKind::RedactedMessage => "a redacted message",
+        }
+    }
+
+    pub fn redacted_message() -> Self {
+        Self {
+            kind: MsgLikeKind::RedactedMessage,
+            reactions: Default::default(),
+            thread_root: None,
+            in_reply_to: None,
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/msg_like.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/msg_like.rs
@@ -15,7 +15,7 @@
 use as_variant::as_variant;
 use ruma::OwnedEventId;
 
-use super::{InReplyToDetails, Message, PollState, Sticker};
+use super::{EncryptedMessage, InReplyToDetails, Message, PollState, Sticker};
 use crate::timeline::ReactionsByKeyBySender;
 
 #[derive(Clone, Debug)]
@@ -31,6 +31,9 @@ pub enum MsgLikeKind {
 
     /// A redacted message.
     Redacted,
+
+    /// An `m.room.encrypted` event that could not be decrypted.
+    UnableToDecrypt(EncryptedMessage),
 }
 
 /// A special kind of [`super::TimelineItemContent`] that groups together
@@ -54,12 +57,22 @@ impl MsgLikeContent {
             MsgLikeKind::Sticker(_) => "a sticker",
             MsgLikeKind::Poll(_) => "a poll",
             MsgLikeKind::Redacted => "a redacted message",
+            MsgLikeKind::UnableToDecrypt(_) => "an encrypted message we couldn't decrypt",
         }
     }
 
     pub fn redacted() -> Self {
         Self {
             kind: MsgLikeKind::Redacted,
+            reactions: Default::default(),
+            thread_root: None,
+            in_reply_to: None,
+        }
+    }
+
+    pub fn unable_to_decrypt(encrypted_message: EncryptedMessage) -> Self {
+        Self {
+            kind: MsgLikeKind::UnableToDecrypt(encrypted_message),
             reactions: Default::default(),
             thread_root: None,
             in_reply_to: None,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/msg_like.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/msg_like.rs
@@ -30,7 +30,7 @@ pub enum MsgLikeKind {
     Poll(PollState),
 
     /// A redacted message.
-    RedactedMessage,
+    Redacted,
 }
 
 /// A special kind of [`super::TimelineItemContent`] that groups together
@@ -53,13 +53,13 @@ impl MsgLikeContent {
             MsgLikeKind::Message(_) => "a message",
             MsgLikeKind::Sticker(_) => "a sticker",
             MsgLikeKind::Poll(_) => "a poll",
-            MsgLikeKind::RedactedMessage => "a redacted message",
+            MsgLikeKind::Redacted => "a redacted message",
         }
     }
 
-    pub fn redacted_message() -> Self {
+    pub fn redacted() -> Self {
         Self {
-            kind: MsgLikeKind::RedactedMessage,
+            kind: MsgLikeKind::Redacted,
             reactions: Default::default(),
             thread_root: None,
             in_reply_to: None,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -206,10 +206,7 @@ impl RepliedToEvent {
                 }
             },
 
-            None => {
-                // Redacted message.
-                TimelineItemContent::RedactedMessage
-            }
+            None => TimelineItemContent::MsgLike(MsgLikeContent::redacted_message()),
         };
 
         let sender = event.sender().to_owned();

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -206,7 +206,7 @@ impl RepliedToEvent {
                 }
             },
 
-            None => TimelineItemContent::MsgLike(MsgLikeContent::redacted_message()),
+            None => TimelineItemContent::MsgLike(MsgLikeContent::redacted()),
         };
 
         let sender = event.sender().to_owned();

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -177,8 +177,8 @@ impl RepliedToEvent {
                         _ => UtdCause::Unknown,
                     };
 
-                    TimelineItemContent::UnableToDecrypt(EncryptedMessage::from_content(
-                        content, utd_cause,
+                    TimelineItemContent::MsgLike(MsgLikeContent::unable_to_decrypt(
+                        EncryptedMessage::from_content(content, utd_cause),
                     ))
                 }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -595,7 +595,7 @@ impl EventTimelineItem {
                     MessageType::Video(video) => video.caption(),
                     _ => None,
                 },
-                MsgLikeKind::Sticker(_) | MsgLikeKind::Poll(_) | MsgLikeKind::RedactedMessage => {
+                MsgLikeKind::Sticker(_) | MsgLikeKind::Poll(_) | MsgLikeKind::Redacted => {
                     None
                 }
             },

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -404,7 +404,7 @@ impl EventTimelineItem {
         }
 
         // An unable-to-decrypt message has no authenticity shield.
-        if let TimelineItemContent::UnableToDecrypt(_) = self.content() {
+        if self.content().is_unable_to_decrypt() {
             return None;
         }
 
@@ -595,12 +595,12 @@ impl EventTimelineItem {
                     MessageType::Video(video) => video.caption(),
                     _ => None,
                 },
-                MsgLikeKind::Sticker(_) | MsgLikeKind::Poll(_) | MsgLikeKind::Redacted => {
-                    None
-                }
+                MsgLikeKind::Sticker(_)
+                | MsgLikeKind::Poll(_)
+                | MsgLikeKind::Redacted
+                | MsgLikeKind::UnableToDecrypt(_) => None,
             },
-            TimelineItemContent::UnableToDecrypt(_)
-            | TimelineItemContent::MembershipChange(_)
+            TimelineItemContent::MembershipChange(_)
             | TimelineItemContent::ProfileChange(_)
             | TimelineItemContent::OtherState(_)
             | TimelineItemContent::FailedToParseMessageLike { .. }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -595,10 +595,11 @@ impl EventTimelineItem {
                     MessageType::Video(video) => video.caption(),
                     _ => None,
                 },
-                MsgLikeKind::Sticker(_) | MsgLikeKind::Poll(_) => None,
+                MsgLikeKind::Sticker(_) | MsgLikeKind::Poll(_) | MsgLikeKind::RedactedMessage => {
+                    None
+                }
             },
-            TimelineItemContent::RedactedMessage
-            | TimelineItemContent::UnableToDecrypt(_)
+            TimelineItemContent::UnableToDecrypt(_)
             | TimelineItemContent::MembershipChange(_)
             | TimelineItemContent::ProfileChange(_)
             | TimelineItemContent::OtherState(_)

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -53,7 +53,7 @@ use super::TestTimeline;
 use crate::{
     timeline::{
         tests::{TestRoomDataProvider, TestTimelineBuilder},
-        EncryptedMessage, TimelineDetails, TimelineItemContent,
+        EncryptedMessage, MsgLikeContent, MsgLikeKind, TimelineDetails, TimelineItemContent,
     },
     unable_to_decrypt_hook::{UnableToDecryptHook, UnableToDecryptInfo, UtdHookManager},
 };
@@ -125,8 +125,11 @@ async fn test_retry_message_decryption() {
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let event = item.as_event().unwrap();
     assert_let!(
-        TimelineItemContent::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 {
-            session_id,
+        TimelineItemContent::MsgLike(MsgLikeContent {
+            kind: MsgLikeKind::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 {
+                session_id,
+                ..
+            }),
             ..
         }) = event.content()
     );
@@ -561,8 +564,11 @@ async fn test_retry_message_decryption_highlighted() {
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let event = item.as_event().unwrap();
     assert_let!(
-        TimelineItemContent::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 {
-            session_id,
+        TimelineItemContent::MsgLike(MsgLikeContent {
+            kind: MsgLikeKind::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 {
+                session_id,
+                ..
+            }),
             ..
         }) = event.content()
     );
@@ -704,8 +710,10 @@ async fn test_utd_cause_for_nonmember_event_is_found() {
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let event = item.as_event().unwrap();
     assert_let!(
-        TimelineItemContent::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 { cause, .. }) =
-            event.content()
+        TimelineItemContent::MsgLike(MsgLikeContent {
+            kind: MsgLikeKind::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 { cause, .. }),
+            ..
+        }) = event.content()
     );
     assert_eq!(*cause, UtdCause::SentBeforeWeJoined);
 }
@@ -727,8 +735,10 @@ async fn test_utd_cause_for_nonmember_event_is_found_unstable_prefix() {
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let event = item.as_event().unwrap();
     assert_let!(
-        TimelineItemContent::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 { cause, .. }) =
-            event.content()
+        TimelineItemContent::MsgLike(MsgLikeContent {
+            kind: MsgLikeKind::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 { cause, .. }),
+            ..
+        }) = event.content()
     );
     assert_eq!(*cause, UtdCause::SentBeforeWeJoined);
 }
@@ -746,8 +756,10 @@ async fn test_utd_cause_for_member_event_is_unknown() {
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let event = item.as_event().unwrap();
     assert_let!(
-        TimelineItemContent::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 { cause, .. }) =
-            event.content()
+        TimelineItemContent::MsgLike(MsgLikeContent {
+            kind: MsgLikeKind::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 { cause, .. }),
+            ..
+        }) = event.content()
     );
     assert_eq!(*cause, UtdCause::Unknown);
 }
@@ -765,8 +777,10 @@ async fn test_utd_cause_for_missing_membership_is_unknown() {
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let event = item.as_event().unwrap();
     assert_let!(
-        TimelineItemContent::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 { cause, .. }) =
-            event.content()
+        TimelineItemContent::MsgLike(MsgLikeContent {
+            kind: MsgLikeKind::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 { cause, .. }),
+            ..
+        }) = event.content()
     );
     assert_eq!(*cause, UtdCause::Unknown);
 }
@@ -828,8 +842,11 @@ async fn test_retry_decryption_updates_response() {
     {
         let event = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
         assert_let!(
-            TimelineItemContent::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 {
-                session_id,
+            TimelineItemContent::MsgLike(MsgLikeContent {
+                kind: MsgLikeKind::UnableToDecrypt(EncryptedMessage::MegolmV1AesSha2 {
+                    session_id,
+                    ..
+                }),
                 ..
             }) = event.content()
         );

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use matrix_sdk::deserialized_responses::TimelineEvent;
@@ -72,7 +71,7 @@ async fn test_default_filter() {
 
     timeline.handle_live_event(f.redaction(second_event_id).sender(&BOB)).await;
     let item = assert_next_matches!(stream, VectorDiff::Set { index: 2, value } => value);
-    assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::RedactedMessage);
+    assert!(item.as_event().unwrap().content().is_redacted());
 
     // TODO: After adding raw timeline items, check for one here.
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -86,11 +86,11 @@ async fn test_redact_replied_to_event() {
     let msglike = second_item_again.content().as_msglike().unwrap();
     let in_reply_to = msglike.in_reply_to.clone().unwrap();
     assert_let!(TimelineDetails::Ready(replied_to_event) = &in_reply_to.event);
-    assert_matches!(replied_to_event.content(), TimelineItemContent::RedactedMessage);
+    assert!(replied_to_event.content().is_redacted());
 
     let first_item_again =
         assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
-    assert_matches!(first_item_again.content(), TimelineItemContent::RedactedMessage);
+    assert!(first_item_again.content().is_redacted());
     assert_matches!(first_item_again.original_json(), None);
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -179,7 +179,7 @@ async fn test_redacted_message() {
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::PushBack { value: first } = &timeline_updates[0]);
-    assert_matches!(first.as_event().unwrap().content(), TimelineItemContent::RedactedMessage);
+    assert!(first.as_event().unwrap().content().is_redacted());
 
     assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[1]);
     assert!(date_divider.is_date_divider());

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -347,7 +347,7 @@ async fn test_fetch_details_utd() {
         let in_reply_to = in_reply_to.clone().unwrap();
         assert_let!(TimelineDetails::Ready(replied_to) = &in_reply_to.event);
         assert_eq!(replied_to.sender(), *ALICE);
-        assert_matches!(replied_to.content(), TimelineItemContent::UnableToDecrypt(_));
+        assert!(replied_to.content().is_unable_to_decrypt());
     }
 }
 

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -816,7 +816,7 @@ impl App {
                         }
 
                         TimelineItemContent::MsgLike(MsgLikeContent {
-                            kind: MsgLikeKind::RedactedMessage,
+                            kind: MsgLikeKind::Redacted,
                             ..
                         }) => content.push(format!("{}: -- redacted --", sender)),
                         TimelineItemContent::UnableToDecrypt(_) => {

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -815,9 +815,10 @@ impl App {
                             }
                         }
 
-                        TimelineItemContent::RedactedMessage => {
-                            content.push(format!("{}: -- redacted --", sender))
-                        }
+                        TimelineItemContent::MsgLike(MsgLikeContent {
+                            kind: MsgLikeKind::RedactedMessage,
+                            ..
+                        }) => content.push(format!("{}: -- redacted --", sender)),
                         TimelineItemContent::UnableToDecrypt(_) => {
                             content.push(format!("{}: (UTD)", sender))
                         }

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -819,9 +819,12 @@ impl App {
                             kind: MsgLikeKind::Redacted,
                             ..
                         }) => content.push(format!("{}: -- redacted --", sender)),
-                        TimelineItemContent::UnableToDecrypt(_) => {
-                            content.push(format!("{}: (UTD)", sender))
-                        }
+
+                        TimelineItemContent::MsgLike(MsgLikeContent {
+                            kind: MsgLikeKind::UnableToDecrypt(_),
+                            ..
+                        }) => content.push(format!("{}: (UTD)", sender)),
+
                         TimelineItemContent::MsgLike(MsgLikeContent {
                             kind: MsgLikeKind::Sticker(_),
                             ..

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -41,10 +41,7 @@ use matrix_sdk_ui::{
     notification_client::NotificationClient,
     room_list_service::RoomListLoadingState,
     sync_service::SyncService,
-    timeline::{
-        EventSendState, EventTimelineItem, ReactionStatus, RoomExt, TimelineItem,
-        TimelineItemContent,
-    },
+    timeline::{EventSendState, EventTimelineItem, ReactionStatus, RoomExt, TimelineItem},
     Timeline,
 };
 use similar_asserts::assert_eq;
@@ -474,7 +471,7 @@ async fn test_enabling_backups_retries_decryption() {
         timeline.item_by_event_id(&event_id).await.expect("The event should be in the timeline");
 
     // The event is not decrypted yet.
-    assert_matches!(item.content(), TimelineItemContent::UnableToDecrypt(_));
+    assert!(item.content().is_unable_to_decrypt());
 
     // We now connect to the backup which will not give us the room key right away,
     // we first need to encounter a UTD to attempt the download.
@@ -667,7 +664,7 @@ async fn test_room_keys_received_on_notification_client_trigger_redecryption() {
     let item = item.expect("The event should be in the timeline by now");
 
     // The event is not decrypted yet.
-    assert_matches!(item.content(), TimelineItemContent::UnableToDecrypt(_));
+    assert!(item.content().is_unable_to_decrypt());
 
     // Let's subscribe to our timeline so we don't miss the transition from UTD to
     // decrypted event.


### PR DESCRIPTION
This patch moves `RedactedMessage` and `UnableToDecrypt` to the newly introduced `TimelineItemContent::MsgLike` variant to bring consistency with Ruma and have them provide aggregations if necessary (e.g. UTD on a thread).