### PR TITLE
refactor(encryption): Simplify the parsing of OAuthCrossSigningResetInfo

### DIFF
--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -319,15 +319,10 @@ pub enum CrossSigningResetAuthType {
 }
 
 impl CrossSigningResetAuthType {
-    #[allow(clippy::unused_async)]
-    async fn new(
-        #[allow(unused_variables)] client: &Client,
-        error: &HttpError,
-    ) -> Result<Option<Self>> {
+    fn new(error: &HttpError) -> Result<Option<Self>> {
         if let Some(auth_info) = error.as_uiaa_response() {
-            if client.oauth().issuer().is_some() {
-                OAuthCrossSigningResetInfo::from_auth_info(client, auth_info)
-                    .map(|t| Some(CrossSigningResetAuthType::OAuth(t)))
+            if let Ok(auth_info) = OAuthCrossSigningResetInfo::from_auth_info(auth_info) {
+                Ok(Some(CrossSigningResetAuthType::OAuth(auth_info)))
             } else {
                 Ok(Some(CrossSigningResetAuthType::Uiaa(auth_info.clone())))
             }
@@ -346,11 +341,7 @@ pub struct OAuthCrossSigningResetInfo {
 }
 
 impl OAuthCrossSigningResetInfo {
-    fn from_auth_info(
-        // This is used if the OAuth 2.0 feature is enabled.
-        #[allow(unused_variables)] client: &Client,
-        auth_info: &UiaaInfo,
-    ) -> Result<Self> {
+    fn from_auth_info(auth_info: &UiaaInfo) -> Result<Self> {
         let parameters =
             serde_json::from_str::<OAuthCrossSigningResetUiaaParameters>(auth_info.params.get())?;
 
@@ -1208,7 +1199,7 @@ impl Encryption {
         }
 
         if let Err(error) = self.client.send(upload_signing_keys_req.clone()).await {
-            if let Some(auth_type) = CrossSigningResetAuthType::new(&self.client, &error).await? {
+            if let Ok(Some(auth_type)) = CrossSigningResetAuthType::new(&error) {
                 let client = self.client.clone();
 
                 Ok(Some(CrossSigningResetHandle::new(
@@ -1776,7 +1767,7 @@ mod tests {
     use crate::{
         assert_next_matches_with_timeout,
         config::RequestConfig,
-        encryption::VerificationState,
+        encryption::{OAuthCrossSigningResetInfo, VerificationState},
         test_utils::{
             client::mock_matrix_session, logged_in_client, no_retry_test_client, set_client_session,
         },
@@ -2106,5 +2097,30 @@ mod tests {
         // Then we can get an updated value without waiting for any network requests
         assert!(keys_requested.load(Ordering::SeqCst).not());
         assert_next_matches_with_timeout!(verification_state, VerificationState::Unverified);
+    }
+
+    #[test]
+    fn test_oauth_reset_info_from_uiaa_info() {
+        let auth_info = json!({
+            "session": "dummy",
+            "flows": [
+                {
+                    "stages": [
+                        "org.matrix.cross_signing_reset"
+                    ]
+                }
+            ],
+            "params": {
+                "org.matrix.cross_signing_reset": {
+                    "url": "https://example.org/account/account?action=org.matrix.cross_signing_reset"
+                }
+            },
+            "msg": "To reset..."
+        });
+
+        let auth_info = serde_json::from_value(auth_info)
+            .expect("We should be able to deserialize the UiaaInfo");
+        OAuthCrossSigningResetInfo::from_auth_info(&auth_info)
+            .expect("We should be able to fetch the cross-signing reset info from the auth info");
     }
 }


### PR DESCRIPTION
Now that OAuth isn't behind a feature flag a bunch of things can be simplified.

This was also tested with a  real server.