### PR TITLE
chore: Remove the RSA security advisory from our deny config

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -9,7 +9,6 @@ exclude = [
 [advisories]
 version = 2
 ignore = [
-    { id = "RUSTSEC-2023-0071", reason = "We are not using RSA directly, nor do we depend on the RSA crate directly" },
     { id = "RUSTSEC-2024-0436", reason = "Unmaintained paste crate, not critical." },
     { id = "RUSTSEC-2024-0384", reason = "Unmaintained backoff crate, not critical. We'll migrate soon." },
     { id = "RUSTSEC-2025-0012", reason = "Unmaintained backoff crate, not critical. We'll migrate soon." },


### PR DESCRIPTION
Since we don't depend on mas anymore, we don't depend on RSA either.

Let's remove the exception, lest we reintroduce the dependency and security issue.