### PR TITLE
feat(base): Expose `RoomLoadSettings` when loading rooms in `BaseStateStore`

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use matrix_sdk::test_utils::mocks::MatrixMockServer;
+use matrix_sdk::{store::RoomLoadSettings, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_base::{
     store::StoreConfig, BaseClient, RoomInfo, RoomState, SessionMeta, StateChanges, StateStore,
 };
@@ -66,6 +66,7 @@ pub fn receive_all_members_benchmark(c: &mut Criterion) {
                 user_id: user_id!("@somebody:example.com").to_owned(),
                 device_id: device_id!("DEVICE_ID").to_owned(),
             },
+            RoomLoadSettings::default(),
             None,
         ))
         .expect("Could not set session meta");

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -2247,7 +2247,9 @@ mod tests {
     use crate::{
         latest_event::LatestEvent,
         rooms::RoomNotableTags,
-        store::{IntoStateStore, MemoryStore, StateChanges, StateStore, StoreConfig},
+        store::{
+            IntoStateStore, MemoryStore, RoomLoadSettings, StateChanges, StateStore, StoreConfig,
+        },
         test_utils::logged_in_base_client,
         BaseClient, MinimalStateEvent, OriginalMinimalStateEvent, RoomDisplayName,
         RoomInfoNotableUpdateReasons, RoomStateFilter, SessionMeta,
@@ -2543,6 +2545,7 @@ mod tests {
                     user_id: user_id!("@alice:example.org").into(),
                     device_id: ruma::device_id!("AYEAYEAYE").into(),
                 },
+                RoomLoadSettings::default(),
                 #[cfg(feature = "e2e-encryption")]
                 None,
             )
@@ -2622,6 +2625,7 @@ mod tests {
                     user_id: user_id!("@alice:example.org").into(),
                     device_id: ruma::device_id!("AYEAYEAYE").into(),
                 },
+                RoomLoadSettings::default(),
                 #[cfg(feature = "e2e-encryption")]
                 None,
             )
@@ -3206,6 +3210,7 @@ mod tests {
                     user_id: user_id!("@alice:example.org").into(),
                     device_id: ruma::device_id!("AYEAYEAYE").into(),
                 },
+                RoomLoadSettings::default(),
                 None,
             )
             .await

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -35,7 +35,7 @@ use serde_json::{json, value::Value as JsonValue};
 
 use super::{
     send_queue::SentRequestKey, DependentQueuedRequestKind, DisplayName, DynStateStore,
-    ServerCapabilities,
+    RoomLoadSettings, ServerCapabilities,
 };
 use crate::{
     deserialized_responses::MemberEvent,
@@ -265,7 +265,11 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         assert!(self.get_kv_data(StateStoreDataKey::SyncToken).await?.is_some());
         assert!(self.get_presence_event(user_id).await?.is_some());
-        assert_eq!(self.get_room_infos().await?.len(), 2, "Expected to find 2 room infos");
+        assert_eq!(
+            self.get_room_infos(&RoomLoadSettings::default()).await?.len(),
+            2,
+            "Expected to find 2 room infos"
+        );
         assert!(self
             .get_account_data_event(GlobalAccountDataEventType::PushRules)
             .await?
@@ -927,7 +931,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         let user_id = user_id();
 
         assert!(self.get_member_event(room_id, user_id).await.unwrap().is_none());
-        assert_eq!(self.get_room_infos().await.unwrap().len(), 0);
+        assert_eq!(self.get_room_infos(&RoomLoadSettings::default()).await.unwrap().len(), 0);
 
         let mut changes = StateChanges::default();
         changes
@@ -943,7 +947,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         let member_event =
             self.get_member_event(room_id, user_id).await.unwrap().unwrap().deserialize().unwrap();
         assert!(matches!(member_event, MemberEvent::Sync(_)));
-        assert_eq!(self.get_room_infos().await.unwrap().len(), 1);
+        assert_eq!(self.get_room_infos(&RoomLoadSettings::default()).await.unwrap().len(), 1);
 
         let members = self.get_user_ids(room_id, RoomMemberships::empty()).await.unwrap();
         assert_eq!(members, vec![user_id.to_owned()]);
@@ -956,7 +960,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         let member_event =
             self.get_member_event(room_id, user_id).await.unwrap().unwrap().deserialize().unwrap();
         assert!(matches!(member_event, MemberEvent::Stripped(_)));
-        assert_eq!(self.get_room_infos().await.unwrap().len(), 1);
+        assert_eq!(self.get_room_infos(&RoomLoadSettings::default()).await.unwrap().len(), 1);
 
         let members = self.get_user_ids(room_id, RoomMemberships::empty()).await.unwrap();
         assert_eq!(members, vec![user_id.to_owned()]);
@@ -1000,7 +1004,11 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         self.remove_room(room_id).await?;
 
-        assert_eq!(self.get_room_infos().await?.len(), 1, "room is still there");
+        assert_eq!(
+            self.get_room_infos(&RoomLoadSettings::default()).await?.len(),
+            1,
+            "room is still there"
+        );
 
         assert!(self.get_state_event(room_id, StateEventType::RoomName, "").await?.is_none());
         assert!(
@@ -1054,7 +1062,10 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         self.remove_room(stripped_room_id).await?;
 
-        assert!(self.get_room_infos().await?.is_empty(), "still room info found");
+        assert!(
+            self.get_room_infos(&RoomLoadSettings::default()).await?.is_empty(),
+            "still room info found"
+        );
         Ok(())
     }
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -42,8 +42,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     send_queue::SentRequestKey, ChildTransactionId, DependentQueuedRequest,
-    DependentQueuedRequestKind, QueueWedgeError, QueuedRequest, QueuedRequestKind, StateChanges,
-    StoreError,
+    DependentQueuedRequestKind, QueueWedgeError, QueuedRequest, QueuedRequestKind,
+    RoomLoadSettings, StateChanges, StoreError,
 };
 use crate::{
     deserialized_responses::{
@@ -194,8 +194,11 @@ pub trait StateStore: AsyncTraitDeps {
         memberships: RoomMemberships,
     ) -> Result<Vec<OwnedUserId>, Self::Error>;
 
-    /// Get all the pure `RoomInfo`s the store knows about.
-    async fn get_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error>;
+    /// Get a set of pure `RoomInfo`s the store knows about.
+    async fn get_room_infos(
+        &self,
+        room_load_settings: &RoomLoadSettings,
+    ) -> Result<Vec<RoomInfo>, Self::Error>;
 
     /// Get all the users that use the given display name in the given room.
     ///
@@ -574,8 +577,11 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         self.0.get_user_ids(room_id, memberships).await.map_err(Into::into)
     }
 
-    async fn get_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error> {
-        self.0.get_room_infos().await.map_err(Into::into)
+    async fn get_room_infos(
+        &self,
+        room_load_settings: &RoomLoadSettings,
+    ) -> Result<Vec<RoomInfo>, Self::Error> {
+        self.0.get_room_infos(room_load_settings).await.map_err(Into::into)
     }
 
     async fn get_users_with_display_name(

--- a/crates/matrix-sdk-base/src/test_utils.rs
+++ b/crates/matrix-sdk-base/src/test_utils.rs
@@ -18,7 +18,10 @@
 
 use ruma::{owned_user_id, UserId};
 
-use crate::{store::StoreConfig, BaseClient, SessionMeta};
+use crate::{
+    store::{RoomLoadSettings, StoreConfig},
+    BaseClient, SessionMeta,
+};
 
 /// Create a [`BaseClient`] with the given user id, if provided, or an hardcoded
 /// one otherwise.
@@ -30,6 +33,7 @@ pub(crate) async fn logged_in_base_client(user_id: Option<&UserId>) -> BaseClien
     client
         .activate(
             SessionMeta { user_id: user_id.to_owned(), device_id: "FOOBAR".into() },
+            RoomLoadSettings::default(),
             #[cfg(feature = "e2e-encryption")]
             None,
         )

--- a/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
@@ -801,9 +801,10 @@ mod tests {
     use assert_matches2::assert_let;
     use indexed_db_futures::prelude::*;
     use matrix_sdk_base::{
-        deserialized_responses::RawMemberEvent, store::StateStoreExt,
-        sync::UnreadNotificationsCount, RoomMemberships, RoomState, StateStore, StateStoreDataKey,
-        StoreError,
+        deserialized_responses::RawMemberEvent,
+        store::{RoomLoadSettings, StateStoreExt},
+        sync::UnreadNotificationsCount,
+        RoomMemberships, RoomState, StateStore, StateStoreDataKey, StoreError,
     };
     use matrix_sdk_test::{async_test, test_json};
     use ruma::{
@@ -1480,7 +1481,7 @@ mod tests {
         // this transparently migrates to the latest version
         let store = IndexeddbStateStore::builder().name(name).build().await?;
 
-        assert_eq!(store.get_room_infos().await.unwrap().len(), 2);
+        assert_eq!(store.get_room_infos(&RoomLoadSettings::default()).await.unwrap().len(), 2);
 
         Ok(())
     }
@@ -1586,7 +1587,7 @@ mod tests {
         let store = IndexeddbStateStore::builder().name(name).build().await?;
 
         // Check all room infos are there.
-        let room_infos = store.get_room_infos().await?;
+        let room_infos = store.get_room_infos(&RoomLoadSettings::default()).await?;
         assert_eq!(room_infos.len(), 3);
 
         let room_a = room_infos.iter().find(|r| r.room_id() == room_a_id).unwrap();

--- a/crates/matrix-sdk/src/authentication/matrix/mod.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/mod.rs
@@ -20,7 +20,7 @@ use std::fmt;
 #[cfg(feature = "sso-login")]
 use std::future::Future;
 
-use matrix_sdk_base::SessionMeta;
+use matrix_sdk_base::{store::RoomLoadSettings, SessionMeta};
 use ruma::{
     api::{
         client::{
@@ -611,6 +611,7 @@ impl MatrixAuth {
             let _ = self
                 .set_session(
                     session,
+                    RoomLoadSettings::default(),
                     #[cfg(feature = "e2e-encryption")]
                     login_info,
                 )
@@ -647,8 +648,11 @@ impl MatrixAuth {
     ///
     /// # Arguments
     ///
-    /// * `session` - A session that the user already has from a
-    /// previous login call.
+    /// * `session` - A session that the user already has from a previous login
+    ///   call.
+    ///
+    /// * `room_load_settings` — Specify how many rooms must be restored; use
+    ///   `::default()` if you don't know which value to pick.
     ///
     /// # Panics
     ///
@@ -687,7 +691,7 @@ impl MatrixAuth {
     /// [`LoginBuilder::send()`] method returns:
     ///
     /// ```no_run
-    /// use matrix_sdk::Client;
+    /// use matrix_sdk::{store::RoomLoadSettings, Client};
     /// use url::Url;
     /// # async {
     ///
@@ -699,17 +703,23 @@ impl MatrixAuth {
     ///
     /// // Persist the `MatrixSession` so it can later be used to restore the login.
     ///
-    /// auth.restore_session((&response).into()).await?;
+    /// auth.restore_session((&response).into(), RoomLoadSettings::default())
+    ///     .await?;
     /// # anyhow::Ok(()) };
     /// ```
     ///
     /// [`login`]: #method.login
     /// [`LoginBuilder::send()`]: crate::authentication::matrix::LoginBuilder::send
     #[instrument(skip_all)]
-    pub async fn restore_session(&self, session: MatrixSession) -> Result<()> {
+    pub async fn restore_session(
+        &self,
+        session: MatrixSession,
+        room_load_settings: RoomLoadSettings,
+    ) -> Result<()> {
         debug!("Restoring Matrix auth session");
         self.set_session(
             session,
+            room_load_settings,
             #[cfg(feature = "e2e-encryption")]
             None,
         )
@@ -733,6 +743,7 @@ impl MatrixAuth {
 
         self.set_session(
             response.into(),
+            RoomLoadSettings::default(),
             #[cfg(feature = "e2e-encryption")]
             login_info,
         )
@@ -743,12 +754,20 @@ impl MatrixAuth {
 
     /// Set the Matrix authentication session.
     ///
+    /// # Arguments
+    ///
+    /// * `session` — The session being opened.
+    ///
+    /// * `room_load_settings` — Specify how much rooms must be restored; use
+    ///   `::default()` if you don't know which value to pick.
+    ///
     /// # Panic
     ///
     /// Panics if authentication data was already set.
     async fn set_session(
         &self,
         session: MatrixSession,
+        room_load_settings: RoomLoadSettings,
         #[cfg(feature = "e2e-encryption")] login_info: Option<login::v3::LoginInfo>,
     ) -> Result<()> {
         // This API doesn't have any data but by setting this variant we protect the
@@ -763,6 +782,7 @@ impl MatrixAuth {
             .base_client()
             .activate(
                 session.meta,
+                room_load_settings,
                 #[cfg(feature = "e2e-encryption")]
                 None,
             )

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -249,7 +249,7 @@ mod tests {
 
     use anyhow::Context as _;
     use futures_util::future::join_all;
-    use matrix_sdk_base::SessionMeta;
+    use matrix_sdk_base::{store::RoomLoadSettings, SessionMeta};
     use matrix_sdk_test::async_test;
     use ruma::{owned_device_id, owned_user_id};
 
@@ -293,7 +293,10 @@ mod tests {
         let session_hash = compute_session_hash(&tokens);
         client
             .oauth()
-            .restore_session(mock_session(tokens.clone(), "https://oauth.example.com/issuer"))
+            .restore_session(
+                mock_session(tokens.clone(), "https://oauth.example.com/issuer"),
+                RoomLoadSettings::default(),
+            )
             .await?;
 
         assert_eq!(client.session_tokens().unwrap(), tokens);
@@ -385,10 +388,10 @@ mod tests {
 
         // Restore the session.
         oauth
-            .restore_session(mock_session(
-                mock_prev_session_tokens_with_refresh(),
-                server.server().uri(),
-            ))
+            .restore_session(
+                mock_session(mock_prev_session_tokens_with_refresh(), server.server().uri()),
+                RoomLoadSettings::default(),
+            )
             .await?;
 
         // Immediately try to refresh the access token twice in parallel.
@@ -430,7 +433,12 @@ mod tests {
         let oauth = client.oauth();
         oauth.enable_cross_process_refresh_lock("client1".to_owned()).await?;
 
-        oauth.restore_session(mock_session(prev_tokens.clone(), issuer.clone())).await?;
+        oauth
+            .restore_session(
+                mock_session(prev_tokens.clone(), issuer.clone()),
+                RoomLoadSettings::default(),
+            )
+            .await?;
 
         // Create a second client, without restoring it, to test that a token update
         // before restoration doesn't cause new issues.
@@ -446,7 +454,12 @@ mod tests {
 
             let oauth3 = client3.oauth();
             oauth3.enable_cross_process_refresh_lock("client3".to_owned()).await?;
-            oauth3.restore_session(mock_session(prev_tokens.clone(), issuer.clone())).await?;
+            oauth3
+                .restore_session(
+                    mock_session(prev_tokens.clone(), issuer.clone()),
+                    RoomLoadSettings::default(),
+                )
+                .await?;
 
             // Run a refresh in the second client; this will invalidate the tokens from the
             // first token.
@@ -478,7 +491,12 @@ mod tests {
                 Box::new(|_| panic!("save_session_callback shouldn't be called here")),
             )?;
 
-            oauth.restore_session(mock_session(prev_tokens.clone(), issuer)).await?;
+            oauth
+                .restore_session(
+                    mock_session(prev_tokens.clone(), issuer),
+                    RoomLoadSettings::default(),
+                )
+                .await?;
 
             // And this client is now aware of the latest tokens.
             let xp_manager =
@@ -554,7 +572,12 @@ mod tests {
 
         // Restore the session.
         let tokens = mock_session_tokens_with_refresh();
-        oauth.restore_session(mock_session(tokens.clone(), server.server().uri())).await?;
+        oauth
+            .restore_session(
+                mock_session(tokens.clone(), server.server().uri()),
+                RoomLoadSettings::default(),
+            )
+            .await?;
 
         oauth.logout().await.unwrap();
 

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -143,7 +143,7 @@ use error::{
 use matrix_sdk_base::crypto::types::qr_login::QrCodeData;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::once_cell::sync::OnceCell;
-use matrix_sdk_base::SessionMeta;
+use matrix_sdk_base::{store::RoomLoadSettings, SessionMeta};
 use oauth2::{
     basic::BasicClient as OAuthClient, AccessToken, PkceCodeVerifier, RedirectUrl, RefreshToken,
     RevocationUrl, Scope, StandardErrorResponse, StandardRevocableToken, TokenResponse, TokenUrl,
@@ -795,11 +795,17 @@ impl OAuth {
     /// # Arguments
     ///
     /// * `session` - The session to restore.
+    /// * `room_load_settings` — Specify how many rooms must be restored; use
+    ///   `::default()` if you don't know which value to pick.
     ///
     /// # Panic
     ///
     /// Panics if authentication data was already set.
-    pub async fn restore_session(&self, session: OAuthSession) -> Result<()> {
+    pub async fn restore_session(
+        &self,
+        session: OAuthSession,
+        room_load_settings: RoomLoadSettings,
+    ) -> Result<()> {
         let OAuthSession { client_id, user: UserSession { meta, tokens, issuer } } = session;
 
         let data = OAuthAuthData { issuer, client_id, authorization_data: Default::default() };
@@ -809,6 +815,7 @@ impl OAuth {
             .base_client()
             .activate(
                 meta,
+                room_load_settings,
                 #[cfg(feature = "e2e-encryption")]
                 None,
             )
@@ -1048,6 +1055,7 @@ impl OAuth {
                 .base_client()
                 .activate(
                     new_session,
+                    RoomLoadSettings::default(),
                     #[cfg(feature = "e2e-encryption")]
                     None,
                 )

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
@@ -19,6 +19,7 @@ use futures_core::Stream;
 use matrix_sdk_base::{
     boxed_into_future,
     crypto::types::qr_login::{QrCodeData, QrCodeMode},
+    store::RoomLoadSettings,
     SessionMeta,
 };
 use oauth2::{DeviceCodeErrorResponseType, StandardDeviceAuthorizationResponse};
@@ -205,6 +206,7 @@ impl<'a> IntoFuture for LoginWithQrCode<'a> {
                         user_id: whoami_response.user_id,
                         device_id: OwnedDeviceId::from(device_id.to_base64()),
                     },
+                    RoomLoadSettings::default(),
                     Some(account),
                 )
                 .await

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -1,6 +1,7 @@
 use anyhow::Context as _;
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
+use matrix_sdk_base::store::RoomLoadSettings;
 use matrix_sdk_test::async_test;
 use oauth2::{ClientId, CsrfToken, PkceCodeChallenge, RedirectUrl};
 use ruma::{
@@ -525,7 +526,7 @@ async fn test_oauth_session() -> anyhow::Result<()> {
     let tokens = mock_session_tokens_with_refresh();
     let issuer = "https://oauth.example.com/issuer";
     let session = mock_session(tokens.clone(), issuer);
-    oauth.restore_session(session.clone()).await?;
+    oauth.restore_session(session.clone(), RoomLoadSettings::default()).await?;
 
     // Test a few extra getters.
     assert_eq!(client.session_tokens().unwrap(), tokens);
@@ -574,7 +575,12 @@ async fn test_insecure_clients() -> anyhow::Result<()> {
         let oauth = client.oauth();
 
         // Restore the previous session so we have an existing set of refresh tokens.
-        oauth.restore_session(mock_session(prev_tokens.clone(), &server_url)).await?;
+        oauth
+            .restore_session(
+                mock_session(prev_tokens.clone(), &server_url),
+                RoomLoadSettings::default(),
+            )
+            .await?;
 
         let mut session_changes = client.subscribe_to_session_changes();
 

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1907,6 +1907,8 @@ mod tests {
     #[async_test]
     async fn test_generation_counter_invalidates_olm_machine() {
         // Create two clients using the same sqlite database.
+
+        use matrix_sdk_base::store::RoomLoadSettings;
         let sqlite_path = std::env::temp_dir().join("generation_counter_sqlite.db");
         let session = mock_matrix_session();
 
@@ -1917,7 +1919,11 @@ mod tests {
             .build()
             .await
             .unwrap();
-        client1.matrix_auth().restore_session(session.clone()).await.unwrap();
+        client1
+            .matrix_auth()
+            .restore_session(session.clone(), RoomLoadSettings::default())
+            .await
+            .unwrap();
 
         let client2 = Client::builder()
             .homeserver_url("http://localhost:1234")
@@ -1926,7 +1932,7 @@ mod tests {
             .build()
             .await
             .unwrap();
-        client2.matrix_auth().restore_session(session).await.unwrap();
+        client2.matrix_auth().restore_session(session, RoomLoadSettings::default()).await.unwrap();
 
         // When the lock isn't enabled, any attempt at locking won't return a guard.
         let guard = client1.encryption().try_lock_store_once().await.unwrap();
@@ -2008,6 +2014,8 @@ mod tests {
     #[async_test]
     async fn test_generation_counter_no_spurious_invalidation() {
         // Create two clients using the same sqlite database.
+
+        use matrix_sdk_base::store::RoomLoadSettings;
         let sqlite_path =
             std::env::temp_dir().join("generation_counter_no_spurious_invalidations.db");
         let session = mock_matrix_session();
@@ -2019,7 +2027,11 @@ mod tests {
             .build()
             .await
             .unwrap();
-        client.matrix_auth().restore_session(session.clone()).await.unwrap();
+        client
+            .matrix_auth()
+            .restore_session(session.clone(), RoomLoadSettings::default())
+            .await
+            .unwrap();
 
         let initial_olm_machine = client.olm_machine().await.as_ref().unwrap().clone();
 
@@ -2038,7 +2050,11 @@ mod tests {
                 .build()
                 .await
                 .unwrap();
-            client2.matrix_auth().restore_session(session).await.unwrap();
+            client2
+                .matrix_auth()
+                .restore_session(session, RoomLoadSettings::default())
+                .await
+                .unwrap();
 
             client2
                 .encryption()

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3833,6 +3833,7 @@ mod tests {
     #[cfg(all(feature = "sqlite", feature = "e2e-encryption"))]
     #[async_test]
     async fn test_cache_invalidation_while_encrypt() {
+        use matrix_sdk_base::store::RoomLoadSettings;
         use matrix_sdk_test::{message_like_event_content, DEFAULT_TEST_ROOM_ID};
 
         let sqlite_path = std::env::temp_dir().join("cache_invalidation_while_encrypt.db");
@@ -3845,7 +3846,11 @@ mod tests {
             .build()
             .await
             .unwrap();
-        client.matrix_auth().restore_session(session.clone()).await.unwrap();
+        client
+            .matrix_auth()
+            .restore_session(session.clone(), RoomLoadSettings::default())
+            .await
+            .unwrap();
 
         client.encryption().enable_cross_process_store_lock("client1".to_owned()).await.unwrap();
 
@@ -3887,7 +3892,11 @@ mod tests {
                 .build()
                 .await
                 .unwrap();
-            client.matrix_auth().restore_session(session.clone()).await.unwrap();
+            client
+                .matrix_auth()
+                .restore_session(session.clone(), RoomLoadSettings::default())
+                .await
+                .unwrap();
             client
                 .encryption()
                 .enable_cross_process_store_lock("client2".to_owned())

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -14,7 +14,10 @@
 
 //! Augmented [`ClientBuilder`] that can set up an already logged-in user.
 
-use matrix_sdk_base::{store::StoreConfig, SessionMeta};
+use matrix_sdk_base::{
+    store::{RoomLoadSettings, StoreConfig},
+    SessionMeta,
+};
 use ruma::{api::MatrixVersion, owned_device_id, owned_user_id};
 
 use crate::{
@@ -111,7 +114,11 @@ impl AuthState {
         match self {
             AuthState::None => {}
             AuthState::LoggedInWithMatrixAuth => {
-                client.matrix_auth().restore_session(mock_matrix_session()).await.unwrap();
+                client
+                    .matrix_auth()
+                    .restore_session(mock_matrix_session(), RoomLoadSettings::default())
+                    .await
+                    .unwrap();
             }
             AuthState::RegisteredWithOAuth { issuer } => {
                 let issuer = url::Url::parse(&issuer).unwrap();
@@ -120,10 +127,10 @@ impl AuthState {
             AuthState::LoggedInWithOAuth { issuer } => {
                 client
                     .oauth()
-                    .restore_session(oauth::mock_session(
-                        mock_session_tokens_with_refresh(),
-                        issuer,
-                    ))
+                    .restore_session(
+                        oauth::mock_session(mock_session_tokens_with_refresh(), issuer),
+                        RoomLoadSettings::default(),
+                    )
                     .await
                     .unwrap();
             }

--- a/crates/matrix-sdk/src/test_utils/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mod.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use assert_matches2::assert_let;
-use matrix_sdk_base::deserialized_responses::TimelineEvent;
+use matrix_sdk_base::{deserialized_responses::TimelineEvent, store::RoomLoadSettings};
 use ruma::{
     api::MatrixVersion,
     events::{room::message::MessageType, AnySyncMessageLikeEvent, AnySyncTimelineEvent},
@@ -51,7 +51,11 @@ pub async fn no_retry_test_client(homeserver_url: Option<String>) -> Client {
 
 /// Restore the common (Matrix-auth) user session for a client.
 pub async fn set_client_session(client: &Client) {
-    client.matrix_auth().restore_session(mock_matrix_session()).await.unwrap();
+    client
+        .matrix_auth()
+        .restore_session(mock_matrix_session(), RoomLoadSettings::default())
+        .await
+        .unwrap();
 }
 
 /// A [`Client`] using the given `homeserver_url` (or localhost:1234), that will

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -5,6 +5,7 @@ use eyeball_im::VectorDiff;
 use futures_util::FutureExt;
 use matrix_sdk::{
     config::{RequestConfig, StoreConfig, SyncSettings},
+    store::RoomLoadSettings,
     sync::RoomUpdate,
     test_utils::{client::mock_matrix_session, no_retry_test_client_with_server},
     Client, MemoryStore, StateChanges, StateStore,
@@ -1384,7 +1385,11 @@ async fn test_restore_room() {
         .build()
         .await
         .unwrap();
-    client.matrix_auth().restore_session(mock_matrix_session()).await.unwrap();
+    client
+        .matrix_auth()
+        .restore_session(mock_matrix_session(), RoomLoadSettings::default())
+        .await
+        .unwrap();
 
     let room = client.get_room(room_id).unwrap();
     assert!(room.is_favourite());

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -1,6 +1,7 @@
 use matrix_sdk::{
     config::RequestConfig,
     media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings},
+    store::RoomLoadSettings,
     test_utils::{client::mock_matrix_session, logged_in_client_with_server},
     Client,
 };
@@ -215,7 +216,11 @@ async fn test_get_media_file_with_auth_matrix_1_11() {
         .unwrap();
 
     // Restore session.
-    client.matrix_auth().restore_session(mock_matrix_session()).await.unwrap();
+    client
+        .matrix_auth()
+        .restore_session(mock_matrix_session(), RoomLoadSettings::default())
+        .await
+        .unwrap();
 
     // Build event content.
     let event_content = ImageMessageEventContent::plain(
@@ -320,7 +325,11 @@ async fn test_get_media_file_with_auth_matrix_stable_feature() {
         .unwrap();
 
     // Restore session.
-    client.matrix_auth().restore_session(mock_matrix_session()).await.unwrap();
+    client
+        .matrix_auth()
+        .restore_session(mock_matrix_session(), RoomLoadSettings::default())
+        .await
+        .unwrap();
 
     // Build event content.
     let event_content = ImageMessageEventContent::plain(

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -9,6 +9,7 @@ use matrix_sdk::{
     authentication::matrix::MatrixSession,
     config::RequestConfig,
     executor::spawn,
+    store::RoomLoadSettings,
     test_utils::{
         client::mock_session_meta, logged_in_client_with_server, no_retry_test_client_with_server,
         test_client_builder_with_server,
@@ -181,7 +182,7 @@ async fn test_refresh_token() {
     let mut session_changes = client.subscribe_to_session_changes();
 
     let session = session();
-    auth.restore_session(session).await.unwrap();
+    auth.restore_session(session, RoomLoadSettings::default()).await.unwrap();
 
     assert_eq!(*num_save_session_callback_calls.lock().unwrap(), 0);
     assert_eq!(session_changes.try_recv(), Err(TryRecvError::Empty));
@@ -242,7 +243,7 @@ async fn test_refresh_token_not_handled() {
     let auth = client.matrix_auth();
 
     let session = session();
-    auth.restore_session(session).await.unwrap();
+    auth.restore_session(session, RoomLoadSettings::default()).await.unwrap();
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/v3/refresh"))
@@ -277,7 +278,7 @@ async fn test_refresh_token_handled_success() {
     let auth = client.matrix_auth();
 
     let session = session();
-    auth.restore_session(session).await.unwrap();
+    auth.restore_session(session, RoomLoadSettings::default()).await.unwrap();
 
     let mut session_changes = client.subscribe_to_session_changes();
 
@@ -328,7 +329,7 @@ async fn test_refresh_token_handled_failure() {
     let auth = client.matrix_auth();
 
     let session = session();
-    auth.restore_session(session).await.unwrap();
+    auth.restore_session(session, RoomLoadSettings::default()).await.unwrap();
 
     let mut session_changes = client.subscribe_to_session_changes();
 
@@ -386,7 +387,7 @@ async fn test_refresh_token_handled_multi_success() {
     let auth = client.matrix_auth();
 
     let session = session();
-    auth.restore_session(session).await.unwrap();
+    auth.restore_session(session, RoomLoadSettings::default()).await.unwrap();
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/v3/refresh"))
@@ -459,7 +460,7 @@ async fn test_refresh_token_handled_multi_failure() {
     let auth = client.matrix_auth();
 
     let session = session();
-    auth.restore_session(session).await.unwrap();
+    auth.restore_session(session, RoomLoadSettings::default()).await.unwrap();
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/v3/refresh"))
@@ -532,7 +533,7 @@ async fn test_refresh_token_handled_other_error() {
     let auth = client.matrix_auth();
 
     let session = session();
-    auth.restore_session(session).await.unwrap();
+    auth.restore_session(session, RoomLoadSettings::default()).await.unwrap();
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/v3/refresh"))
@@ -581,7 +582,10 @@ async fn test_oauth_refresh_token_handled_success() {
     let oauth = client.oauth();
 
     oauth
-        .restore_session(mock_session(mock_prev_session_tokens_with_refresh(), issuer))
+        .restore_session(
+            mock_session(mock_prev_session_tokens_with_refresh(), issuer),
+            RoomLoadSettings::default(),
+        )
         .await
         .unwrap();
 
@@ -633,7 +637,10 @@ async fn test_oauth_refresh_token_handled_failure() {
     let oauth = client.oauth();
 
     oauth
-        .restore_session(mock_session(mock_prev_session_tokens_with_refresh(), issuer))
+        .restore_session(
+            mock_session(mock_prev_session_tokens_with_refresh(), issuer),
+            RoomLoadSettings::default(),
+        )
         .await
         .unwrap();
 
@@ -684,7 +691,10 @@ async fn test_oauth_handle_refresh_tokens() {
 
     let oauth = client.oauth();
     oauth
-        .restore_session(mock_session(mock_prev_session_tokens_with_refresh(), issuer))
+        .restore_session(
+            mock_session(mock_prev_session_tokens_with_refresh(), issuer),
+            RoomLoadSettings::default(),
+        )
         .await
         .unwrap();
 


### PR DESCRIPTION
This set of patches introduces the `RoomLoadSettings` enum. It is helpful to load either all rooms or one room when activating a `BaseClient`, i.e. when a session is initialized or restored.

It addresses a broader problem where, for large accounts with large caches, creating a `BaseClient` takes many resources. In a resource constrained context, like a push notification process, it can eat all resources up to the point the process is killed (then notifications can be missed).

The idea is then to force the `BaseClient` to load a single room.

It's better to review this PR patch by patch. Don't be fooled by the number of new lines: they are mostly tests.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4801
* Address https://github.com/element-hq/customer-success/issues/457