### PR TITLE
chore(sqlite): log underlying errors in many `OpenStoreError` variants

### DIFF
--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -27,7 +27,7 @@ use tokio::io;
 #[non_exhaustive]
 pub enum OpenStoreError {
     /// Failed to create the DB's parent directory.
-    #[error("Failed to create the database's parent directory")]
+    #[error("Failed to create the database's parent directory: {0}")]
     CreateDir(#[source] io::Error),
 
     /// Failed to create the DB pool.
@@ -35,7 +35,7 @@ pub enum OpenStoreError {
     CreatePool(#[from] CreatePoolError),
 
     /// Failed to load the database's version.
-    #[error("Failed to load database version")]
+    #[error("Failed to load database version: {0}")]
     LoadVersion(#[source] rusqlite::Error),
 
     /// The version of the database is missing.
@@ -47,7 +47,7 @@ pub enum OpenStoreError {
     InvalidVersion,
 
     /// Failed to apply migrations.
-    #[error("Failed to run migrations")]
+    #[error("Failed to run migrations: {0}")]
     Migration(#[from] Error),
 
     /// Failed to get a DB connection from the pool.
@@ -55,15 +55,15 @@ pub enum OpenStoreError {
     Pool(#[from] PoolError),
 
     /// Failed to initialize the store cipher.
-    #[error("Failed to initialize the store cipher")]
+    #[error("Failed to initialize the store cipher: {0}")]
     InitCipher(#[from] matrix_sdk_store_encryption::Error),
 
     /// Failed to load the store cipher from the DB.
-    #[error("Failed to load the store cipher from the DB")]
+    #[error("Failed to load the store cipher from the DB: {0}")]
     LoadCipher(#[source] rusqlite::Error),
 
     /// Failed to save the store cipher to the DB.
-    #[error("Failed to save the store cipher to the DB")]
+    #[error("Failed to save the store cipher to the DB: {0}")]
     SaveCipher(#[source] rusqlite::Error),
 }
 


### PR DESCRIPTION
This would help understanding what's the underlying error each time.