### PR TITLE
fix(ffi+event cache): properly clear all rooms

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -101,6 +101,10 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// using the above [`Self::handle_linked_chunk_updates`] methods. It
     /// must *also* delete all the events' content, if they were stored in a
     /// separate table.
+    ///
+    /// ⚠ This is meant only for super specific use cases, where there shouldn't
+    /// be any live in-memory linked chunks. In general, prefer using
+    /// `EventCache::clear_all_rooms()` from the common SDK crate.
     async fn clear_all_rooms_chunks(&self) -> Result<(), Self::Error>;
 
     /// Given a set of event IDs, return the duplicated events along with their

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -361,6 +361,13 @@ impl EventCache {
         Ok((room, drop_handles))
     }
 
+    /// Cleanly clear all the rooms' event caches.
+    ///
+    /// This will notify any live observers that the room has been cleared.
+    pub async fn clear_all_rooms(&self) -> Result<()> {
+        self.inner.clear_all_rooms().await
+    }
+
     /// Add an initial set of events to the event cache, reloaded from a cache.
     ///
     /// TODO: temporary for API compat, as the event cache should take care of


### PR DESCRIPTION
- First commit makes it so that we use the `EventCache::clear_all_rooms()` methods when clearing the rooms, from the FFI. Doing otherwise would be incorrect, because if there's a live room in the background, then its in-memory linked chunk would have been desynchronized from the store, leading to confusion all over the place (and potentially some weird constraint violations in the sqlite backend).
- Second commit fixes `clear_all_rooms()` so that it also removes rooms from the store, that haven't ever been loaded in the app. This wasn't the case before, where we'd only clear rooms that have been loaded at least once (either because their room event cache was explicitly requested, or because a sync caused changes to the room). Clearing sleeping rooms causes complications, but hopefully the doc comment explains how they're solved.