### PR TITLE
feat(sdk): Add `Client::logout()` to log out regardless of the auth API

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -808,24 +808,7 @@ impl Client {
 
     /// Log the current user out.
     pub async fn logout(&self) -> Result<(), ClientError> {
-        let Some(auth_api) = self.inner.auth_api() else {
-            return Err(anyhow!("Missing authentication API").into());
-        };
-
-        match auth_api {
-            AuthApi::Matrix(a) => {
-                tracing::info!("Logging out via the homeserver.");
-                a.logout().await?;
-                Ok(())
-            }
-
-            AuthApi::OAuth(api) => {
-                tracing::info!("Logging out via OAuth 2.0.");
-                api.logout().await?;
-                Ok(())
-            }
-            _ => Err(anyhow!("Unknown authentication API").into()),
-        }
+        Ok(self.inner.logout().await?)
     }
 
     /// Registers a pusher with given parameters

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -74,6 +74,9 @@ simpler methods:
   `ClientBuilder::sqlite_store_with_config_and_cache_path` to configure the
   SQLite store with the new `SqliteStoreConfig` structure
   ([#4870](https://github.com/matrix-org/matrix-rust-sdk/pull/4870))
+- Add `Client::logout()` that allows to log out regardless of the `AuthApi` that
+  is used for the session.
+  ([#4886](https://github.com/matrix-org/matrix-rust-sdk/pull/4886))
 
 ### Bug Fixes
 
@@ -201,7 +204,7 @@ simpler methods:
   - `OAuthError::MissingDeviceId` was removed, it cannot occur anymore.
 - [**breaking**] `OidcRegistrations` was renamed to `OAuthRegistrationStore`.
   ([#4814](https://github.com/matrix-org/matrix-rust-sdk/pull/4814))
-  - `OidcRegistrationsError` was renamed to `OAuthRegistrationStoreError`. 
+  - `OidcRegistrationsError` was renamed to `OAuthRegistrationStoreError`.
   - The `registrations` module was renamed and is now private.
     `OAuthRegistrationStore` and `ClientId` are exported from `oauth`, and
     `OAuthRegistrationStoreError` is exported from `oauth::error`.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1323,6 +1323,23 @@ impl Client {
         Ok(())
     }
 
+    /// Log out the current session using the proper authentication API.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session is not authenticated or if an error
+    /// occurred while making the request to the server.
+    pub async fn logout(&self) -> Result<(), Error> {
+        let auth_api = self.auth_api().ok_or(Error::AuthenticationRequired)?;
+        match auth_api {
+            AuthApi::Matrix(matrix_auth) => {
+                matrix_auth.logout().await?;
+                Ok(())
+            }
+            AuthApi::OAuth(oauth) => Ok(oauth.logout().await?),
+        }
+    }
+
     /// Get or upload a sync filter.
     ///
     /// This method will either get a filter ID from the store or upload the

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -995,6 +995,12 @@ impl MatrixMockServer {
             Mock::given(method("POST")).and(path_regex(r"^/_matrix/client/v3/rooms/.*/leave"));
         self.mock_endpoint(mock, RoomLeaveEndpoint).expect_default_access_token()
     }
+
+    /// Create a prebuilt mock for the endpoint use to log out a session.
+    pub fn mock_logout(&self) -> MockEndpoint<'_, LogoutEndpoint> {
+        let mock = Mock::given(method("POST")).and(path("/_matrix/client/v3/logout"));
+        self.mock_endpoint(mock, LogoutEndpoint).expect_default_access_token()
+    }
 }
 
 /// Parameter to [`MatrixMockServer::sync_room`].
@@ -2552,5 +2558,15 @@ impl<'a> MockEndpoint<'a, RoomLeaveEndpoint> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "room_id": room_id,
         })))
+    }
+}
+
+/// A prebuilt mock for `POST /logout` request.
+pub struct LogoutEndpoint;
+
+impl<'a> MockEndpoint<'a, LogoutEndpoint> {
+    /// Returns a successful empty response.
+    pub fn ok(self) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -4,11 +4,14 @@ use assert_matches2::{assert_let, assert_matches};
 use eyeball_im::VectorDiff;
 use futures_util::FutureExt;
 use matrix_sdk::{
+    authentication::oauth::{error::OAuthTokenRevocationError, OAuthError},
     config::{RequestConfig, StoreConfig, SyncSettings},
     store::RoomLoadSettings,
     sync::RoomUpdate,
-    test_utils::{client::mock_matrix_session, no_retry_test_client_with_server},
-    Client, MemoryStore, StateChanges, StateStore,
+    test_utils::{
+        client::mock_matrix_session, mocks::MatrixMockServer, no_retry_test_client_with_server,
+    },
+    Client, Error, MemoryStore, StateChanges, StateStore,
 };
 use matrix_sdk_base::{sync::RoomUpdates, RoomState};
 use matrix_sdk_test::{
@@ -567,7 +570,7 @@ async fn test_marking_room_as_dm_fails_if_undeserializable() {
 
     let result = client.account().mark_as_dm(&DEFAULT_TEST_ROOM_ID, &users).await;
 
-    assert_matches!(result, Err(matrix_sdk::Error::SerdeJson(_)));
+    assert_matches!(result, Err(Error::SerdeJson(_)));
 
     server.verify().await;
 }
@@ -1394,4 +1397,38 @@ async fn test_restore_room() {
     let room = client.get_room(room_id).unwrap();
     assert!(room.is_favourite());
     assert!(!room.pinned_event_ids().unwrap().is_empty());
+}
+
+#[async_test]
+async fn test_logout() {
+    let server = MatrixMockServer::new().await;
+
+    // Test unauthenticated client.
+    let unlogged_client = server.client_builder().unlogged().build().await;
+    let res = unlogged_client.logout().await;
+    assert_matches!(res, Err(Error::AuthenticationRequired));
+
+    // Test MatrixAuth.
+    server.mock_logout().ok().mock_once().named("matrix_logout").mount().await;
+
+    let matrix_auth_client = server.client_builder().build().await;
+    matrix_auth_client.logout().await.unwrap();
+
+    // Test OAuth.
+    server
+        .oauth()
+        .mock_server_metadata()
+        .ok()
+        .mock_once()
+        .named("oauth_server_metadata")
+        .mount()
+        .await;
+
+    let oauth_client = server.client_builder().logged_in_with_oauth().build().await;
+    let res = oauth_client.logout().await;
+
+    // This returns an error because it requires a HTTPS server URI, or to be able
+    // to call `OAuth::insecure_rewrite_https_to_http()`, but at least we are
+    // testing the OAuth branch inside `Client::logout()`.
+    assert_matches!(res, Err(Error::OAuth(OAuthError::Logout(OAuthTokenRevocationError::Url(_)))));
 }

--- a/examples/oauth_cli/src/main.rs
+++ b/examples/oauth_cli/src/main.rs
@@ -559,7 +559,7 @@ impl OAuthCli {
     /// Log out from this session.
     async fn logout(&self) -> anyhow::Result<()> {
         // Log out via OAuth 2.0.
-        self.client.oauth().logout().await?;
+        self.client.logout().await?;
 
         // Delete the stored session and database.
         let data_dir = self.session_file.parent().expect("The file has a parent directory");


### PR DESCRIPTION
It simplifies code for users, and avoids to have to match on `AuthApi`, which is a non-exhaustive enum.
