### PR TITLE
Reduce the sizes of various types and mostly `matrix_sdk::Error`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -224,7 +224,7 @@ impl From<SdkOAuthError> for OidcError {
 impl From<Error> for OidcError {
     fn from(e: Error) -> OidcError {
         match e {
-            Error::OAuth(e) => e.into(),
+            Error::OAuth(e) => (*e).into(),
             _ => OidcError::Generic { message: e.to_string() },
         }
     }

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -277,8 +277,10 @@ impl RawAnySyncOrStrippedState {
     /// Try to deserialize the inner JSON as the expected type.
     pub fn deserialize(&self) -> serde_json::Result<AnySyncOrStrippedState> {
         match self {
-            Self::Sync(raw) => Ok(AnySyncOrStrippedState::Sync(raw.deserialize()?)),
-            Self::Stripped(raw) => Ok(AnySyncOrStrippedState::Stripped(raw.deserialize()?)),
+            Self::Sync(raw) => Ok(AnySyncOrStrippedState::Sync(Box::new(raw.deserialize()?))),
+            Self::Stripped(raw) => {
+                Ok(AnySyncOrStrippedState::Stripped(Box::new(raw.deserialize()?)))
+            }
         }
     }
 
@@ -300,9 +302,15 @@ impl RawAnySyncOrStrippedState {
 #[derive(Clone, Debug)]
 pub enum AnySyncOrStrippedState {
     /// An event from a room in joined or left state.
-    Sync(AnySyncStateEvent),
+    ///
+    /// The value is `Box`ed because it is quite large. Let's keep the size of
+    /// `Self` as small as possible.
+    Sync(Box<AnySyncStateEvent>),
     /// An event from a room in invited state.
-    Stripped(AnyStrippedStateEvent),
+    ///
+    /// The value is `Box`ed because it is quite large. Let's keep the size of
+    /// `Self` as small as possible.
+    Stripped(Box<AnyStrippedStateEvent>),
 }
 
 impl AnySyncOrStrippedState {

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -248,7 +248,7 @@ impl EventCacheStore for MemoryStore {
 
                 // Must not be filtered out.
                 if let Some(filters) = &filters {
-                    filters.iter().any(|f| *f == rel_type).then_some(event.clone())
+                    filters.contains(&rel_type).then_some(event.clone())
                 } else {
                     Some(event.clone())
                 }

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -236,7 +236,9 @@ pub enum DependentQueuedRequestKind {
     /// the final media event with the remote MXC URIs.
     FinishUpload {
         /// Local echo for the event (containing the local MXC URIs).
-        local_echo: RoomMessageEventContent,
+        ///
+        /// `Box` the local echo so that it reduces the size of the whole enum.
+        local_echo: Box<RoomMessageEventContent>,
 
         /// Transaction id for the file upload.
         file_upload: OwnedTransactionId,

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1217,7 +1217,9 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                     self.update_event_send_state(
                         &echo.transaction_id,
                         EventSendState::SendingFailed {
-                            error: Arc::new(matrix_sdk::Error::SendQueueWedgeError(send_error)),
+                            error: Arc::new(matrix_sdk::Error::SendQueueWedgeError(Box::new(
+                                send_error,
+                            ))),
                             is_recoverable: false,
                         },
                     )

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -64,10 +64,9 @@ async fn test_remote_echo_full_trip() {
     // Scenario 2: The local event has not been sent to the server successfully, it
     // has failed. In this case, there is no event ID.
     {
-        let error =
-            Arc::new(matrix_sdk::Error::SendQueueWedgeError(QueueWedgeError::GenericApiError {
-                msg: "this is a test".to_owned(),
-            }));
+        let error = Arc::new(matrix_sdk::Error::SendQueueWedgeError(Box::new(
+            QueueWedgeError::GenericApiError { msg: "this is a test".to_owned() },
+        )));
         timeline
             .controller
             .update_event_send_state(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -300,7 +300,9 @@ async fn test_reloaded_failed_local_echoes_are_marked_as_failed() {
     // It was persisted and it can be matched as a string now.
     let msg = assert_matches!(
         &**error,
-        Error::SendQueueWedgeError(QueueWedgeError::GenericApiError { msg }) => msg
+        Error::SendQueueWedgeError(error) => {
+            assert_matches!(&**error, QueueWedgeError::GenericApiError { msg } => { msg })
+        }
     );
     assert_eq!(
         msg,

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -792,7 +792,7 @@ impl OAuth {
             let mut guard = cross_process_lock
                 .spin_lock()
                 .await
-                .map_err(|err| crate::Error::OAuth(err.into()))?;
+                .map_err(|err| crate::Error::OAuth(Box::new(err.into())))?;
 
             // After we got the lock, it's possible that our session doesn't match the one
             // read from the database, because of a race: another process has
@@ -804,12 +804,12 @@ impl OAuth {
             if guard.hash_mismatch {
                 Box::pin(self.handle_session_hash_mismatch(&mut guard))
                     .await
-                    .map_err(|err| crate::Error::OAuth(err.into()))?;
+                    .map_err(|err| crate::Error::OAuth(Box::new(err.into())))?;
             } else {
                 guard
                     .save_in_memory_and_db(&tokens)
                     .await
-                    .map_err(|err| crate::Error::OAuth(err.into()))?;
+                    .map_err(|err| crate::Error::OAuth(Box::new(err.into())))?;
                 // No need to call the save_session_callback here; it was the
                 // source of the session, so it's already in
                 // sync with what we had.

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -193,7 +193,9 @@ async fn test_high_level_login_cancellation() -> anyhow::Result<()> {
     // Then a cancellation error should be thrown.
     assert_matches!(
         error,
-        Error::OAuth(OAuthError::AuthorizationCode(OAuthAuthorizationCodeError::Cancelled))
+        Error::OAuth(error) => {
+            assert_matches!(*error, OAuthError::AuthorizationCode(OAuthAuthorizationCodeError::Cancelled));
+        }
     );
 
     Ok(())
@@ -220,7 +222,9 @@ async fn test_high_level_login_invalid_state() -> anyhow::Result<()> {
     // Then the login should fail by flagging the invalid state.
     assert_matches!(
         error,
-        Error::OAuth(OAuthError::AuthorizationCode(OAuthAuthorizationCodeError::InvalidState))
+        Error::OAuth(error) => {
+            assert_matches!(*error, OAuthError::AuthorizationCode(OAuthAuthorizationCodeError::InvalidState));
+        }
     );
 
     Ok(())
@@ -327,7 +331,9 @@ async fn test_finish_login() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(Error::OAuth(OAuthError::AuthorizationCode(OAuthAuthorizationCodeError::InvalidState)))
+        Err(Error::OAuth(error)) => {
+            assert_matches!(*error, OAuthError::AuthorizationCode(OAuthAuthorizationCodeError::InvalidState));
+        }
     );
     assert!(client.session_tokens().is_none());
     assert!(client.session_meta().is_none());
@@ -355,7 +361,9 @@ async fn test_finish_login() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(Error::OAuth(OAuthError::AuthorizationCode(OAuthAuthorizationCodeError::InvalidState)))
+        Err(Error::OAuth(error)) => {
+            assert_matches!(*error, OAuthError::AuthorizationCode(OAuthAuthorizationCodeError::InvalidState));
+        }
     );
     assert!(client.session_tokens().is_none());
     assert!(oauth.data().unwrap().authorization_data.lock().await.get(&state1).is_some());
@@ -467,7 +475,12 @@ async fn test_finish_login() -> anyhow::Result<()> {
     let res =
         oauth.finish_login(UrlOrQuery::Query(format!("code=42&state={}", state3.secret()))).await;
 
-    assert_matches!(res, Err(Error::OAuth(OAuthError::SessionMismatch)));
+    assert_matches!(
+        res,
+        Err(Error::OAuth(error)) => {
+            assert_matches!(*error, OAuthError::SessionMismatch);
+        }
+    );
     assert!(oauth.data().unwrap().authorization_data.lock().await.get(&state3).is_none());
 
     Ok(())

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -14,7 +14,7 @@
 
 //! Error conditions.
 
-use std::{io::Error as IoError, sync::Arc, time::Duration};
+use std::{io::Error as IoError, ops::Deref, sync::Arc, time::Duration};
 
 use as_variant::as_variant;
 use http::StatusCode;
@@ -261,7 +261,7 @@ impl RetryKind {
 pub enum Error {
     /// Error doing an HTTP request.
     #[error(transparent)]
-    Http(#[from] HttpError),
+    Http(Box<HttpError>),
 
     /// Queried endpoint requires authentication but was called on an anonymous
     /// client.
@@ -431,6 +431,12 @@ impl Error {
     }
 }
 
+impl From<HttpError> for Error {
+    fn from(error: HttpError) -> Self {
+        Error::Http(Box::new(error))
+    }
+}
+
 /// Error for the room key importing functionality.
 #[cfg(feature = "e2e-encryption")]
 #[derive(Error, Debug)]
@@ -505,7 +511,7 @@ impl From<SdkBaseError> for Error {
 
 impl From<ReqwestError> for Error {
     fn from(e: ReqwestError) -> Self {
-        Error::Http(HttpError::Reqwest(e))
+        Error::Http(Box::new(HttpError::Reqwest(e)))
     }
 }
 

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -371,7 +371,7 @@ pub enum Error {
 
     /// An error coming from the event cache subsystem.
     #[error(transparent)]
-    EventCache(#[from] EventCacheError),
+    EventCache(Box<EventCacheError>),
 
     /// An item has been wedged in the send queue.
     #[error(transparent)]
@@ -486,6 +486,12 @@ impl From<SlidingSyncError> for Error {
 impl From<OAuthError> for Error {
     fn from(error: OAuthError) -> Self {
         Error::OAuth(Box::new(error))
+    }
+}
+
+impl From<EventCacheError> for Error {
+    fn from(error: EventCacheError) -> Self {
+        Error::EventCache(Box::new(error))
     }
 }
 

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -348,7 +348,7 @@ pub enum Error {
     /// specific membership state in the room, but the membership state is
     /// different.
     #[error("wrong room state: {0}")]
-    WrongRoomState(WrongRoomState),
+    WrongRoomState(Box<WrongRoomState>),
 
     /// Session callbacks have been set multiple times.
     #[error("session callbacks have been set multiple times")]

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -375,7 +375,7 @@ pub enum Error {
 
     /// An item has been wedged in the send queue.
     #[error(transparent)]
-    SendQueueWedgeError(#[from] QueueWedgeError),
+    SendQueueWedgeError(Box<QueueWedgeError>),
 
     /// Backups are not enabled
     #[error("backups are not enabled")]
@@ -492,6 +492,12 @@ impl From<OAuthError> for Error {
 impl From<EventCacheError> for Error {
     fn from(error: EventCacheError) -> Self {
         Error::EventCache(Box::new(error))
+    }
+}
+
+impl From<QueueWedgeError> for Error {
+    fn from(error: QueueWedgeError) -> Self {
+        Error::SendQueueWedgeError(Box::new(error))
     }
 }
 

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -303,7 +303,7 @@ pub enum Error {
     /// An error occurred during a E2EE operation.
     #[cfg(feature = "e2e-encryption")]
     #[error(transparent)]
-    OlmError(#[from] OlmError),
+    OlmError(Box<OlmError>),
 
     /// An error occurred during a E2EE group operation.
     #[cfg(feature = "e2e-encryption")]
@@ -444,6 +444,13 @@ impl From<CryptoStoreError> for Error {
     }
 }
 
+#[cfg(feature = "e2e-encryption")]
+impl From<OlmError> for Error {
+    fn from(error: OlmError) -> Self {
+        Error::OlmError(Box::new(error))
+    }
+}
+
 /// Error for the room key importing functionality.
 #[cfg(feature = "e2e-encryption")]
 #[derive(Error, Debug)]
@@ -502,7 +509,7 @@ impl From<SdkBaseError> for Error {
             #[cfg(feature = "e2e-encryption")]
             SdkBaseError::BadCryptoStoreState => Self::BadCryptoStoreState,
             #[cfg(feature = "e2e-encryption")]
-            SdkBaseError::OlmError(e) => Self::OlmError(e),
+            SdkBaseError::OlmError(e) => Self::OlmError(Box::new(e)),
             #[cfg(feature = "eyre")]
             _ => Self::UnknownError(eyre::eyre!(e).into()),
             #[cfg(all(not(feature = "eyre"), feature = "anyhow"))]

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -317,7 +317,7 @@ pub enum Error {
 
     /// An error occurred in the state store.
     #[error(transparent)]
-    StateStore(#[from] StoreError),
+    StateStore(Box<StoreError>),
 
     /// An error occurred in the event cache store.
     #[error(transparent)]
@@ -458,6 +458,12 @@ impl From<MegolmError> for Error {
     }
 }
 
+impl From<StoreError> for Error {
+    fn from(error: StoreError) -> Self {
+        Error::StateStore(Box::new(error))
+    }
+}
+
 /// Error for the room key importing functionality.
 #[cfg(feature = "e2e-encryption")]
 #[derive(Error, Debug)]
@@ -510,7 +516,7 @@ impl From<FromHttpResponseError<ruma::api::error::MatrixError>> for HttpError {
 impl From<SdkBaseError> for Error {
     fn from(e: SdkBaseError) -> Self {
         match e {
-            SdkBaseError::StateStore(e) => Self::StateStore(e),
+            SdkBaseError::StateStore(e) => Self::StateStore(Box::new(e)),
             #[cfg(feature = "e2e-encryption")]
             SdkBaseError::CryptoStore(e) => Self::CryptoStoreError(Box::new(e)),
             #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -334,7 +334,7 @@ pub enum Error {
     /// An error while scanning a QR code.
     #[cfg(feature = "qrcode")]
     #[error(transparent)]
-    QrCodeScanError(#[from] ScanError),
+    QrCodeScanError(Box<ScanError>),
 
     /// An error encountered when trying to parse a user tag name.
     #[error(transparent)]
@@ -467,6 +467,13 @@ impl From<StoreError> for Error {
 impl From<EventCacheStoreError> for Error {
     fn from(error: EventCacheStoreError) -> Self {
         Error::EventCacheStore(Box::new(error))
+    }
+}
+
+#[cfg(feature = "qrcode")]
+impl From<ScanError> for Error {
+    fn from(error: ScanError) -> Self {
+        Error::QrCodeScanError(Box::new(error))
     }
 }
 

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -46,8 +46,8 @@ use thiserror::Error;
 use url::ParseError as UrlParseError;
 
 use crate::{
-    event_cache::EventCacheError, media::MediaError, room::reply::ReplyError,
-    sliding_sync::Error as SlidingSyncError, store_locks::LockStoreError,
+    authentication::oauth::OAuthError, event_cache::EventCacheError, media::MediaError,
+    room::reply::ReplyError, sliding_sync::Error as SlidingSyncError, store_locks::LockStoreError,
 };
 
 /// Result type of the matrix-sdk.
@@ -356,7 +356,7 @@ pub enum Error {
 
     /// An error occurred interacting with the OAuth 2.0 API.
     #[error(transparent)]
-    OAuth(#[from] crate::authentication::oauth::OAuthError),
+    OAuth(Box<OAuthError>),
 
     /// A concurrent request to a deduplicated request has failed.
     #[error("a concurrent request failed; see logs for details")]
@@ -480,6 +480,12 @@ impl From<ScanError> for Error {
 impl From<SlidingSyncError> for Error {
     fn from(error: SlidingSyncError) -> Self {
         Error::SlidingSync(Box::new(error))
+    }
+}
+
+impl From<OAuthError> for Error {
+    fn from(error: OAuthError) -> Self {
+        Error::OAuth(Box::new(error))
     }
 }
 
@@ -618,7 +624,7 @@ pub enum RefreshTokenError {
 
     /// An error occurred interacting with the OAuth 2.0 API.
     #[error(transparent)]
-    OAuth(#[from] Arc<crate::authentication::oauth::OAuthError>),
+    OAuth(#[from] Arc<OAuthError>),
 }
 
 /// Errors that can occur when manipulating push notification settings.

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -321,7 +321,7 @@ pub enum Error {
 
     /// An error occurred in the event cache store.
     #[error(transparent)]
-    EventCacheStore(#[from] EventCacheStoreError),
+    EventCacheStore(Box<EventCacheStoreError>),
 
     /// An error encountered when trying to parse an identifier.
     #[error(transparent)]
@@ -461,6 +461,12 @@ impl From<MegolmError> for Error {
 impl From<StoreError> for Error {
     fn from(error: StoreError) -> Self {
         Error::StateStore(Box::new(error))
+    }
+}
+
+impl From<EventCacheStoreError> for Error {
+    fn from(error: EventCacheStoreError) -> Self {
+        Error::EventCacheStore(Box::new(error))
     }
 }
 

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -308,7 +308,7 @@ pub enum Error {
     /// An error occurred during a E2EE group operation.
     #[cfg(feature = "e2e-encryption")]
     #[error(transparent)]
-    MegolmError(#[from] MegolmError),
+    MegolmError(Box<MegolmError>),
 
     /// An error occurred during decryption.
     #[cfg(feature = "e2e-encryption")]
@@ -448,6 +448,13 @@ impl From<CryptoStoreError> for Error {
 impl From<OlmError> for Error {
     fn from(error: OlmError) -> Self {
         Error::OlmError(Box::new(error))
+    }
+}
+
+#[cfg(feature = "e2e-encryption")]
+impl From<MegolmError> for Error {
+    fn from(error: MegolmError) -> Self {
+        Error::MegolmError(Box::new(error))
     }
 }
 

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -14,7 +14,7 @@
 
 //! Error conditions.
 
-use std::{io::Error as IoError, ops::Deref, sync::Arc, time::Duration};
+use std::{io::Error as IoError, sync::Arc, time::Duration};
 
 use as_variant::as_variant;
 use http::StatusCode;
@@ -294,7 +294,7 @@ pub enum Error {
     /// An error occurred in the crypto store.
     #[cfg(feature = "e2e-encryption")]
     #[error(transparent)]
-    CryptoStoreError(#[from] CryptoStoreError),
+    CryptoStoreError(Box<CryptoStoreError>),
 
     /// An error occurred with a cross-process store lock.
     #[error(transparent)]
@@ -437,6 +437,13 @@ impl From<HttpError> for Error {
     }
 }
 
+#[cfg(feature = "e2e-encryption")]
+impl From<CryptoStoreError> for Error {
+    fn from(error: CryptoStoreError) -> Self {
+        Error::CryptoStoreError(Box::new(error))
+    }
+}
+
 /// Error for the room key importing functionality.
 #[cfg(feature = "e2e-encryption")]
 #[derive(Error, Debug)]
@@ -491,7 +498,7 @@ impl From<SdkBaseError> for Error {
         match e {
             SdkBaseError::StateStore(e) => Self::StateStore(e),
             #[cfg(feature = "e2e-encryption")]
-            SdkBaseError::CryptoStore(e) => Self::CryptoStoreError(e),
+            SdkBaseError::CryptoStore(e) => Self::CryptoStoreError(Box::new(e)),
             #[cfg(feature = "e2e-encryption")]
             SdkBaseError::BadCryptoStoreState => Self::BadCryptoStoreState,
             #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -47,7 +47,7 @@ use url::ParseError as UrlParseError;
 
 use crate::{
     event_cache::EventCacheError, media::MediaError, room::reply::ReplyError,
-    store_locks::LockStoreError,
+    sliding_sync::Error as SlidingSyncError, store_locks::LockStoreError,
 };
 
 /// Result type of the matrix-sdk.
@@ -342,7 +342,7 @@ pub enum Error {
 
     /// An error occurred within sliding-sync
     #[error(transparent)]
-    SlidingSync(#[from] crate::sliding_sync::Error),
+    SlidingSync(Box<SlidingSyncError>),
 
     /// Attempted to call a method on a room that requires the user to have a
     /// specific membership state in the room, but the membership state is
@@ -474,6 +474,12 @@ impl From<EventCacheStoreError> for Error {
 impl From<ScanError> for Error {
     fn from(error: ScanError) -> Self {
         Error::QrCodeScanError(Box::new(error))
+    }
+}
+
+impl From<SlidingSyncError> for Error {
+    fn from(error: SlidingSyncError) -> Self {
+        Error::SlidingSync(Box::new(error))
     }
 }
 

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -298,7 +298,7 @@ pub enum Error {
 
     /// An error occurred with a cross-process store lock.
     #[error(transparent)]
-    CrossProcessLockError(#[from] LockStoreError),
+    CrossProcessLockError(Box<LockStoreError>),
 
     /// An error occurred during a E2EE operation.
     #[cfg(feature = "e2e-encryption")]
@@ -441,6 +441,12 @@ impl From<HttpError> for Error {
 impl From<CryptoStoreError> for Error {
     fn from(error: CryptoStoreError) -> Self {
         Error::CryptoStoreError(Box::new(error))
+    }
+}
+
+impl From<LockStoreError> for Error {
+    fn from(error: LockStoreError) -> Self {
+        Error::CrossProcessLockError(Box::new(error))
     }
 }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -210,7 +210,10 @@ impl Room {
     pub async fn leave(&self) -> Result<()> {
         let state = self.state();
         if state == RoomState::Left {
-            return Err(Error::WrongRoomState(WrongRoomState::new("Joined or Invited", state)));
+            return Err(Error::WrongRoomState(Box::new(WrongRoomState::new(
+                "Joined or Invited",
+                state,
+            ))));
         }
 
         let request = leave_room::v3::Request::new(self.inner.room_id().to_owned());
@@ -226,7 +229,10 @@ impl Room {
     pub async fn join(&self) -> Result<()> {
         let state = self.state();
         if state == RoomState::Joined {
-            return Err(Error::WrongRoomState(WrongRoomState::new("Invited or Left", state)));
+            return Err(Error::WrongRoomState(Box::new(WrongRoomState::new(
+                "Invited or Left",
+                state,
+            ))));
         }
 
         let prev_room_state = self.inner.state();
@@ -2938,7 +2944,7 @@ impl Room {
     pub async fn invite_details(&self) -> Result<Invite> {
         let state = self.state();
         if state != RoomState::Invited {
-            return Err(Error::WrongRoomState(WrongRoomState::new("Invited", state)));
+            return Err(Error::WrongRoomState(Box::new(WrongRoomState::new("Invited", state))));
         }
 
         let invitee = self
@@ -2989,7 +2995,10 @@ impl Room {
         let state = self.state();
         match state {
             RoomState::Joined | RoomState::Invited | RoomState::Knocked => {
-                return Err(Error::WrongRoomState(WrongRoomState::new("Left / Banned", state)));
+                return Err(Error::WrongRoomState(Box::new(WrongRoomState::new(
+                    "Left / Banned",
+                    state,
+                ))));
             }
             RoomState::Left | RoomState::Banned => {}
         }
@@ -3016,7 +3025,7 @@ impl Room {
         if state == RoomState::Joined {
             Ok(())
         } else {
-            Err(Error::WrongRoomState(WrongRoomState::new("Joined", state)))
+            Err(Error::WrongRoomState(Box::new(WrongRoomState::new("Joined", state))))
         }
     }
 
@@ -3099,7 +3108,7 @@ impl Room {
     ) -> Result<report_content::v3::Response> {
         let state = self.state();
         if state != RoomState::Joined {
-            return Err(Error::WrongRoomState(WrongRoomState::new("Joined", state)));
+            return Err(Error::WrongRoomState(Box::new(WrongRoomState::new("Joined", state))));
         }
 
         let request = report_content::v3::Request::new(

--- a/crates/matrix-sdk/src/room/reply.rs
+++ b/crates/matrix-sdk/src/room/reply.rs
@@ -292,7 +292,7 @@ mod tests {
             self.events
                 .get(event_id)
                 .cloned()
-                .ok_or(Error::EventCache(EventCacheError::ClientDropped))
+                .ok_or(Error::EventCache(Box::new(EventCacheError::ClientDropped)))
         }
     }
 

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -1262,7 +1262,7 @@ impl QueueStorage {
                 send_event_txn.into(),
                 created_at,
                 DependentQueuedRequestKind::FinishUpload {
-                    local_echo: event,
+                    local_echo: Box::new(event),
                     file_upload: upload_file_txn.clone(),
                     thumbnail_info,
                 },
@@ -1388,7 +1388,7 @@ impl QueueStorage {
                     Some(LocalEcho {
                         transaction_id: dep.own_transaction_id.clone().into(),
                         content: LocalEchoContent::Event {
-                            serialized_event: SerializableEventContent::new(&local_echo.into())
+                            serialized_event: SerializableEventContent::new(&(*local_echo).into())
                                 .ok()?,
                             send_handle: SendHandle {
                                 room: room.clone(),
@@ -1620,7 +1620,7 @@ impl QueueStorage {
                     client,
                     dependent_request.own_transaction_id.into(),
                     parent_key,
-                    local_echo,
+                    *local_echo,
                     file_upload,
                     thumbnail_info,
                     new_updates,

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -580,7 +580,7 @@ impl QueueStorage {
                     .await?;
 
                 trace!("caption successfully updated");
-                return Ok(Some(local_echo.into()));
+                return Ok(Some((*local_echo).into()));
             }
         }
 

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -232,7 +232,7 @@ impl SlidingSyncBuilder {
         let version = self.version.unwrap_or_else(|| client.sliding_sync_version());
 
         if matches!(version, Version::None) {
-            return Err(crate::error::Error::SlidingSync(Error::VersionIsMissing));
+            return Err(crate::error::Error::SlidingSync(Box::new(Error::VersionIsMissing)));
         }
 
         let (internal_channel_sender, _internal_channel_receiver) = channel(8);

--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -71,7 +71,7 @@ impl FromWidgetErrorResponse {
     /// Create a error response to send to the widget from a matrix sdk error.
     pub(crate) fn from_error(error: Error) -> Self {
         match error {
-            Error::Http(e) => FromWidgetErrorResponse::from_http_error(e),
+            Error::Http(e) => FromWidgetErrorResponse::from_http_error(*e),
             // For UnknownError's we do not want to have the `unknown error` bit in the message.
             // Hence we only convert the inner error to a string.
             Error::UnknownError(e) => FromWidgetErrorResponse::from_string(e.to_string()),

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -55,7 +55,11 @@ impl MatrixDriver {
     /// Requests an OpenID token for the current user.
     pub(crate) async fn get_open_id(&self) -> Result<OpenIdResponse> {
         let user_id = self.room.own_user_id().to_owned();
-        self.room.client.send(OpenIdRequest::new(user_id)).await.map_err(Error::Http)
+        self.room
+            .client
+            .send(OpenIdRequest::new(user_id))
+            .await
+            .map_err(|error| Error::Http(Box::new(error)))
     }
 
     /// Reads the latest `limit` events of a given `event_type` from the room.
@@ -172,7 +176,7 @@ impl MatrixDriver {
         action: UpdateAction,
     ) -> Result<delayed_events::update_delayed_event::unstable::Response> {
         let r = delayed_events::update_delayed_event::unstable::Request::new(delay_id, action);
-        self.room.client.send(r).await.map_err(Error::Http)
+        self.room.client.send(r).await.map_err(|error| Error::Http(Box::new(error)))
     }
 
     /// Starts forwarding new room events. Once the returned `EventReceiver`

--- a/crates/matrix-sdk/tests/integration/room/beacon_info/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon_info/mod.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use js_int::uint;
 use matrix_sdk::config::SyncSettings;
-use matrix_sdk_base::deserialized_responses::AnySyncOrStrippedState;
 use matrix_sdk_test::{async_test, test_json, DEFAULT_TEST_ROOM_ID};
 use ruma::{
     event_id,
@@ -95,8 +94,9 @@ async fn test_start_live_location_share_for_room() {
 
     let raw_event = state_events.first().expect("There should be a beacon_info state event");
 
-    let ev = match raw_event.deserialize().expect("Failed to deserialize event") {
-        AnySyncOrStrippedState::Sync(AnySyncStateEvent::BeaconInfo(ev)) => ev,
+    let ev = raw_event.deserialize().expect("Failed to deserialize event");
+    let ev = match ev.as_sync() {
+        Some(AnySyncStateEvent::BeaconInfo(ev)) => ev,
         _ => panic!("Expected a BeaconInfo event"),
     };
 
@@ -228,8 +228,9 @@ async fn test_stop_sharing_live_location() {
 
     let raw_event = state_events.first().expect("There should be a beacon_info state event");
 
-    let ev = match raw_event.deserialize().expect("Failed to deserialize event") {
-        AnySyncOrStrippedState::Sync(AnySyncStateEvent::BeaconInfo(ev)) => ev,
+    let ev = raw_event.deserialize().expect("Failed to deserialize event");
+    let ev = match ev.as_sync() {
+        Some(AnySyncStateEvent::BeaconInfo(ev)) => ev,
         _ => panic!("Expected a BeaconInfo event"),
     };
 


### PR DESCRIPTION
This PR is a collection of small patches that reduce the sizes of various types. A particular focus has been made on `matrix_sdk::Error` where its size has been reduced by 6.5x (from 160 bytes to 24 bytes). This is important as it impacts all the methods and functions that return a `Result`.