### PR TITLE
feat(sqlite): Add `SqliteStoreConfig::with_low_memory_config`

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -88,3 +88,6 @@ Additions:
   ([4819](https://github.com/matrix-org/matrix-rust-sdk/pull/4819))
 - Add `ClientBuilder::session_pool_max_size`, `::session_cache_size` and `::session_journal_size_limit` to control the stores configuration, especially their memory consumption
   ([#4870](https://github.com/matrix-org/matrix-rust-sdk/pull/4870/))
+- Add `ClientBuilder::system_is_memory_constrained` to indicate that the system
+  has less memory available than the current standard
+  ([#4894](https://github.com/matrix-org/matrix-rust-sdk/pull/4894))

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -259,6 +259,7 @@ pub struct ClientBuilder {
     session_pool_max_size: Option<usize>,
     session_cache_size: Option<u32>,
     session_journal_size_limit: Option<u32>,
+    system_is_memory_constrained: bool,
     username: Option<String>,
     homeserver_cfg: Option<HomeserverConfig>,
     user_agent: Option<String>,
@@ -291,6 +292,7 @@ impl ClientBuilder {
             session_pool_max_size: None,
             session_cache_size: None,
             session_journal_size_limit: None,
+            system_is_memory_constrained: false,
             username: None,
             homeserver_cfg: None,
             user_agent: None,
@@ -421,6 +423,19 @@ impl ClientBuilder {
     pub fn session_journal_size_limit(self: Arc<Self>, limit: Option<u32>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.session_journal_size_limit = limit;
+        Arc::new(builder)
+    }
+
+    /// Tell the client that the system is memory constrained, like in a push
+    /// notification process for example.
+    ///
+    /// So far, at the time of writing (2025-04-07), it changes the defaults of
+    /// [`SqliteStoreConfig`], so one might not need to call
+    /// [`ClientBuilder::session_cache_size`] and siblings for example. Please
+    /// check [`SqliteStoreConfig::with_low_memory_config`].
+    pub fn system_is_memory_constrained(self: Arc<Self>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.system_is_memory_constrained = true;
         Arc::new(builder)
     }
 
@@ -576,8 +591,14 @@ impl ClientBuilder {
             fs::create_dir_all(data_path)?;
             fs::create_dir_all(cache_path)?;
 
-            let mut sqlite_store_config =
-                SqliteStoreConfig::new(data_path).passphrase(builder.session_passphrase.as_deref());
+            let mut sqlite_store_config = if builder.system_is_memory_constrained {
+                SqliteStoreConfig::with_low_memory_config(data_path)
+            } else {
+                SqliteStoreConfig::new(data_path)
+            };
+
+            sqlite_store_config =
+                sqlite_store_config.passphrase(builder.session_passphrase.as_deref());
 
             if let Some(size) = builder.session_pool_max_size {
                 sqlite_store_config = sqlite_store_config.pool_max_size(size);

--- a/crates/matrix-sdk-sqlite/CHANGELOG.md
+++ b/crates/matrix-sdk-sqlite/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
   ([#4870](https://github.com/matrix-org/matrix-rust-sdk/pull/4870/))
 - Implement `Clone` and `Debug` on `SqliteStoreConfig`
   ([#4870](https://github.com/matrix-org/matrix-rust-sdk/pull/4870/))
+- Add `SqliteStoreConfig::with_low_memory_config` constructor
+  ([#4894](https://github.com/matrix-org/matrix-rust-sdk/pull/4894))
 
 ## [0.10.0] - 2025-02-04
 


### PR DESCRIPTION
This PR is twofold:

1. One patch adds a new constructor for `SqliteStoreConfig`, namely `with_low_memory_config`, which sets some defaults tailored for low memory usage,
2. Another patch adds `ClientBuilder::system_is_memory_constrained` so that the client can be built with that in mind. Behind the scene, for the moment, it only calls `SqliteStoreConfig::with_low_memory_config` instead of `SqliteStoreConfig::new`, but this flag can be used for other use cases.