### PR TITLE
refactor(ffi): export `NotificationItem::thread_id` in the FFI layer

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -42,6 +42,7 @@ pub struct NotificationItem {
     /// information to create a push context.
     pub is_noisy: Option<bool>,
     pub has_mention: Option<bool>,
+    pub thread_id: Option<String>,
 }
 
 impl NotificationItem {
@@ -54,7 +55,6 @@ impl NotificationItem {
                 NotificationEvent::Invite { sender: event.sender.to_string() }
             }
         };
-
         Self {
             event,
             sender_info: NotificationSenderInfo {
@@ -72,6 +72,7 @@ impl NotificationItem {
             },
             is_noisy: item.is_noisy,
             has_mention: item.has_mention,
+            thread_id: item.thread_id.map(|t| t.to_string()),
         }
     }
 }


### PR DESCRIPTION
It seems like I mixed up the FFI and UI layer structs. Also, use the preferred `OwnedEventId` in the UI layer one.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
