### PR TITLE
Introduce MsgLike on the FFI layer

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -15,12 +15,10 @@
 use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::{crypto::types::events::UtdCause, room::power_levels::power_level_user_changes};
-use matrix_sdk_ui::timeline::{
-    MsgLikeContent, MsgLikeKind, PollResult, RoomPinnedEventsChange, TimelineDetails,
-};
+use matrix_sdk_ui::timeline::{MsgLikeContent, MsgLikeKind, PollResult, RoomPinnedEventsChange};
 use ruma::events::{room::MediaSource as RumaMediaSource, EventContent, FullStateEventContent};
 
-use super::ProfileDetails;
+use super::reply::InReplyToDetails;
 use crate::{
     ruma::{ImageInfo, MediaSource, MediaSourceExt, Mentions, MessageType, PollKind},
     utils::Timestamp,
@@ -225,57 +223,6 @@ pub enum TimelineItemContent {
         state_key: String,
         error: String,
     },
-}
-
-#[derive(Clone, uniffi::Object)]
-pub struct InReplyToDetails {
-    event_id: String,
-    event: RepliedToEventDetails,
-}
-
-impl InReplyToDetails {
-    pub(crate) fn new(event_id: String, event: RepliedToEventDetails) -> Self {
-        Self { event_id, event }
-    }
-}
-
-#[matrix_sdk_ffi_macros::export]
-impl InReplyToDetails {
-    pub fn event_id(&self) -> String {
-        self.event_id.clone()
-    }
-
-    pub fn event(&self) -> RepliedToEventDetails {
-        self.event.clone()
-    }
-}
-
-impl From<matrix_sdk_ui::timeline::InReplyToDetails> for InReplyToDetails {
-    fn from(inner: matrix_sdk_ui::timeline::InReplyToDetails) -> Self {
-        let event_id = inner.event_id.to_string();
-        let event = match &inner.event {
-            TimelineDetails::Unavailable => RepliedToEventDetails::Unavailable,
-            TimelineDetails::Pending => RepliedToEventDetails::Pending,
-            TimelineDetails::Ready(event) => RepliedToEventDetails::Ready {
-                content: event.content().clone().into(),
-                sender: event.sender().to_string(),
-                sender_profile: event.sender_profile().into(),
-            },
-            TimelineDetails::Error(err) => {
-                RepliedToEventDetails::Error { message: err.to_string() }
-            }
-        };
-
-        Self { event_id, event }
-    }
-}
-
-#[derive(Clone, uniffi::Enum)]
-pub enum RepliedToEventDetails {
-    Unavailable,
-    Pending,
-    Ready { content: TimelineItemContent, sender: String, sender_profile: ProfileDetails },
-    Error { message: String },
 }
 
 #[derive(Clone, uniffi::Enum)]

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -17,7 +17,6 @@ use std::{collections::HashMap, fmt::Write as _, fs, panic, sync::Arc};
 use anyhow::{Context, Result};
 use as_variant::as_variant;
 use async_compat::get_runtime_handle;
-use content::{InReplyToDetails, RepliedToEventDetails};
 use eyeball_im::VectorDiff;
 use futures_util::{pin_mut, StreamExt as _};
 use matrix_sdk::{
@@ -37,6 +36,7 @@ use matrix_sdk_ui::timeline::{
     TimelineUniqueId as SdkTimelineUniqueId,
 };
 use mime::Mime;
+use reply::{InReplyToDetails, RepliedToEventDetails};
 use ruma::{
     events::{
         location::{AssetType as RumaAssetType, LocationContent, ZoomLevel},
@@ -80,6 +80,7 @@ use crate::{
 
 pub mod configuration;
 mod content;
+mod reply;
 
 pub use content::MessageContent;
 use matrix_sdk::utils::formatted_body_from;

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -65,6 +65,8 @@ use tracing::{error, warn};
 use uuid::Uuid;
 
 use self::content::{Reaction, ReactionSenderData, TimelineItemContent};
+pub use self::msg_like::MessageContent;
+
 use crate::{
     client::ProgressWatcher,
     error::{ClientError, RoomError},
@@ -80,9 +82,9 @@ use crate::{
 
 pub mod configuration;
 mod content;
+mod msg_like;
 mod reply;
 
-pub use content::MessageContent;
 use matrix_sdk::utils::formatted_body_from;
 
 use crate::error::QueueWedgeError;

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -64,7 +64,7 @@ use tokio::{
 use tracing::{error, warn};
 use uuid::Uuid;
 
-use self::content::{Reaction, ReactionSenderData, TimelineItemContent};
+use self::content::TimelineItemContent;
 pub use self::msg_like::MessageContent;
 use crate::{
     client::ProgressWatcher,
@@ -1061,7 +1061,6 @@ pub struct EventTimelineItem {
     is_editable: bool,
     content: TimelineItemContent,
     timestamp: Timestamp,
-    reactions: Vec<Reaction>,
     local_send_state: Option<EventSendState>,
     local_created_at: Option<u64>,
     read_receipts: HashMap<String, Receipt>,
@@ -1072,21 +1071,6 @@ pub struct EventTimelineItem {
 
 impl From<matrix_sdk_ui::timeline::EventTimelineItem> for EventTimelineItem {
     fn from(item: matrix_sdk_ui::timeline::EventTimelineItem) -> Self {
-        let reactions = item
-            .content()
-            .reactions()
-            .iter()
-            .map(|(k, v)| Reaction {
-                key: k.to_owned(),
-                senders: v
-                    .into_iter()
-                    .map(|(sender_id, info)| ReactionSenderData {
-                        sender_id: sender_id.to_string(),
-                        timestamp: info.timestamp.into(),
-                    })
-                    .collect(),
-            })
-            .collect();
         let item = Arc::new(item);
         let lazy_provider = Arc::new(LazyTimelineItemProvider(item.clone()));
         let read_receipts =
@@ -1100,7 +1084,6 @@ impl From<matrix_sdk_ui::timeline::EventTimelineItem> for EventTimelineItem {
             is_editable: item.is_editable(),
             content: item.content().clone().into(),
             timestamp: item.timestamp().into(),
-            reactions,
             local_send_state: item.send_state().map(|s| s.into()),
             local_created_at: item.local_created_at().map(|t| t.0.into()),
             read_receipts,

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -66,7 +66,6 @@ use uuid::Uuid;
 
 use self::content::{Reaction, ReactionSenderData, TimelineItemContent};
 pub use self::msg_like::MessageContent;
-
 use crate::{
     client::ProgressWatcher,
     error::{ClientError, RoomError},

--- a/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
@@ -1,0 +1,101 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use matrix_sdk::crypto::types::events::UtdCause;
+use matrix_sdk_ui::timeline::PollResult;
+
+use super::{content::TimelineItemContent, reply::InReplyToDetails};
+use crate::ruma::{Mentions, MessageType, PollKind};
+
+#[derive(Clone, uniffi::Record)]
+pub struct MessageContent {
+    pub msg_type: MessageType,
+    pub body: String,
+    pub in_reply_to: Option<Arc<InReplyToDetails>>,
+    pub thread_root: Option<String>,
+    pub is_edited: bool,
+    pub mentions: Option<Mentions>,
+}
+
+impl From<ruma::events::Mentions> for Mentions {
+    fn from(value: ruma::events::Mentions) -> Self {
+        Self {
+            user_ids: value.user_ids.iter().map(|id| id.to_string()).collect(),
+            room: value.room,
+        }
+    }
+}
+
+#[derive(Clone, uniffi::Enum)]
+pub enum EncryptedMessage {
+    OlmV1Curve25519AesSha2 {
+        /// The Curve25519 key of the sender.
+        sender_key: String,
+    },
+    // Other fields not included because UniFFI doesn't have the concept of
+    // deprecated fields right now.
+    MegolmV1AesSha2 {
+        /// The ID of the session used to encrypt the message.
+        session_id: String,
+
+        /// What we know about what caused this UTD. E.g. was this event sent
+        /// when we were not a member of this room?
+        cause: UtdCause,
+    },
+    Unknown,
+}
+
+impl EncryptedMessage {
+    pub(crate) fn new(msg: &matrix_sdk_ui::timeline::EncryptedMessage) -> Self {
+        use matrix_sdk_ui::timeline::EncryptedMessage as Message;
+
+        match msg {
+            Message::OlmV1Curve25519AesSha2 { sender_key } => {
+                let sender_key = sender_key.clone();
+                Self::OlmV1Curve25519AesSha2 { sender_key }
+            }
+            Message::MegolmV1AesSha2 { session_id, cause, .. } => {
+                let session_id = session_id.clone();
+                Self::MegolmV1AesSha2 { session_id, cause: *cause }
+            }
+            Message::Unknown => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Clone, uniffi::Record)]
+pub struct PollAnswer {
+    pub id: String,
+    pub text: String,
+}
+
+impl From<PollResult> for TimelineItemContent {
+    fn from(value: PollResult) -> Self {
+        TimelineItemContent::Poll {
+            question: value.question,
+            kind: PollKind::from(value.kind),
+            max_selections: value.max_selections,
+            answers: value
+                .answers
+                .into_iter()
+                .map(|i| PollAnswer { id: i.id, text: i.text })
+                .collect(),
+            votes: value.votes,
+            end_time: value.end_time.map(|t| t.into()),
+            has_been_edited: value.has_been_edited,
+        }
+    }
+}

--- a/bindings/matrix-sdk-ffi/src/timeline/reply.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/reply.rs
@@ -1,0 +1,68 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk_ui::timeline::TimelineDetails;
+
+use super::{content::TimelineItemContent, ProfileDetails};
+
+#[derive(Clone, uniffi::Object)]
+pub struct InReplyToDetails {
+    event_id: String,
+    event: RepliedToEventDetails,
+}
+
+impl InReplyToDetails {
+    pub(crate) fn new(event_id: String, event: RepliedToEventDetails) -> Self {
+        Self { event_id, event }
+    }
+}
+
+#[matrix_sdk_ffi_macros::export]
+impl InReplyToDetails {
+    pub fn event_id(&self) -> String {
+        self.event_id.clone()
+    }
+
+    pub fn event(&self) -> RepliedToEventDetails {
+        self.event.clone()
+    }
+}
+
+impl From<matrix_sdk_ui::timeline::InReplyToDetails> for InReplyToDetails {
+    fn from(inner: matrix_sdk_ui::timeline::InReplyToDetails) -> Self {
+        let event_id = inner.event_id.to_string();
+        let event = match &inner.event {
+            TimelineDetails::Unavailable => RepliedToEventDetails::Unavailable,
+            TimelineDetails::Pending => RepliedToEventDetails::Pending,
+            TimelineDetails::Ready(event) => RepliedToEventDetails::Ready {
+                content: event.content().clone().into(),
+                sender: event.sender().to_string(),
+                sender_profile: event.sender_profile().into(),
+            },
+            TimelineDetails::Error(err) => {
+                RepliedToEventDetails::Error { message: err.to_string() }
+            }
+        };
+
+        Self { event_id, event }
+    }
+}
+
+#[derive(Clone, uniffi::Enum)]
+pub enum RepliedToEventDetails {
+    Unavailable,
+    Pending,
+    Ready { content: TimelineItemContent, sender: String, sender_profile: ProfileDetails },
+    Error { message: String },
+}


### PR DESCRIPTION
This patch introduces an intermediary MsgLike Content and Type on the FFI layer and brings the timeline items in line with the ones from the UI crate.

This is the last step in the timeline item structure factoring, following https://github.com/matrix-org/matrix-rust-sdk/pull/4839, https://github.com/matrix-org/matrix-rust-sdk/pull/4853 and https://github.com/matrix-org/matrix-rust-sdk/pull/4860

Best reviewed commit by commit.