### PR TITLE
Include the matrix-sdk-ffi crate in the release process

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -1,4 +1,10 @@
-# unreleased
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+<!-- next-header -->
+
+## [Unreleased] - ReleaseDate
 
 Breaking changes:
 

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 readme = "README.md"
 rust-version = { workspace = true }
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "staticlib"]
@@ -23,7 +24,7 @@ vergen = { version = "8.1.3", features = ["build", "git", "gitcl"] }
 [dependencies]
 anyhow = { workspace = true }
 as_variant = { workspace = true }
-async-compat = "0.2.5"
+async-compat = "0.2.4"
 eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-util = { workspace = true }
@@ -80,4 +81,4 @@ features = [
 workspace = true
 
 [package.metadata.release]
-release = false
+release = true


### PR DESCRIPTION
The crate won't be published but it's useful to maintain a changelog for this crate as well. Additionally the tag is useful as well.