### PR TITLE
multiverse: allow recovery keys with `h` or `l` in them

### DIFF
--- a/labs/multiverse/src/widgets/settings/mod.rs
+++ b/labs/multiverse/src/widgets/settings/mod.rs
@@ -95,7 +95,7 @@ impl SettingsView {
         use KeyCode::*;
 
         match event.code {
-            Char('l') | Right => {
+            Right => {
                 self.next_tab();
                 false
             }
@@ -110,7 +110,7 @@ impl SettingsView {
                 false
             }
 
-            Char('h') | Left => {
+            Left => {
                 self.previous_tab();
                 false
             }


### PR DESCRIPTION
Currently, `h` and `l` are intercepted by the parent view to change tab,
meaning it's impossible to enter a recovery key which contains those
characters.

The fix here is very blunt: it just disables `h` and `l` for tab-changing. I
considered making it dependent on which tab is open, or what's going on in the
'Encryption' tab, but given you need to know about the alternatives (tab/cursor
keys) to switch away from the Encryption tab, I don't think that makes sense.