### PR TITLE
multiverse: reduce redraw rate

### DIFF
--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -368,7 +368,7 @@ impl App {
         loop {
             terminal.draw(|f| f.render_widget(&mut *self, f.area()))?;
 
-            if event::poll(Duration::from_millis(16))? {
+            if event::poll(Duration::from_millis(100))? {
                 if let Event::Key(key) = event::read()? {
                     if key.kind == KeyEventKind::Press {
                         match &mut self.state.global_mode {


### PR DESCRIPTION
This reduces the framerate from ~62fps to 10fps.

This is a workaround for a problem in my terminal, so apologies for inflicting
it on everyone else, but here we are, and 10fps seems like it should be enough
for anyone.

The problem in question is specifically when I try to select some text by
dragging the mouse (eg, to copy a generated recovery key). If I start a drag,
but a redraw happens before the mouse has moved [a certain distance?], then the
drag doesn't work, and nothing gets selected. By reducing the framerate, I have
a much better chance of successfully starting a drag.
