### PR TITLE
refactor(base): Continue to extract response processors, take 3

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -858,7 +858,7 @@ impl BaseClient {
             let processors::e2ee::to_device::Output {
                 decrypted_to_device_events: to_device,
                 room_key_updates,
-            } = processors::e2ee::to_device::from_sync_v3(
+            } = processors::e2ee::to_device::from_sync_v2(
                 &mut context,
                 &response,
                 olm_machine.as_ref(),

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -783,7 +783,6 @@ impl BaseClient {
         #[cfg(feature = "e2e-encryption")]
         let olm_machine = self.olm_machine().await;
 
-        #[allow(unused_mut)]
         let mut context =
             Context::new(StateChanges::new(response.next_batch.clone()), Default::default());
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -614,7 +614,7 @@ impl BaseClient {
             room_info.handle_encryption_state(requested_required_states.for_room(&room_id));
 
             let (raw_state_events, state_events) =
-                processors::state_events::collect_sync(&mut context, &new_info.state.events);
+                processors::state_events::sync::collect(&mut context, &new_info.state.events);
 
             let mut new_user_ids = processors::state_events::dispatch_and_get_new_users(
                 &mut context,
@@ -646,7 +646,7 @@ impl BaseClient {
             }
 
             let (raw_state_events_from_timeline, state_events_from_timeline) =
-                processors::state_events::collect_sync_from_timeline(
+                processors::state_events::sync::collect_from_timeline(
                     &mut context,
                     &new_info.timeline.events,
                 );
@@ -743,7 +743,7 @@ impl BaseClient {
             room_info.handle_encryption_state(requested_required_states.for_room(&room_id));
 
             let (raw_state_events, state_events) =
-                processors::state_events::collect_sync(&mut context, &new_info.state.events);
+                processors::state_events::sync::collect(&mut context, &new_info.state.events);
 
             let mut new_user_ids = processors::state_events::dispatch_and_get_new_users(
                 &mut context,
@@ -754,7 +754,7 @@ impl BaseClient {
             .await?;
 
             let (raw_state_events_from_timeline, state_events_from_timeline) =
-                processors::state_events::collect_sync_from_timeline(
+                processors::state_events::sync::collect_from_timeline(
                     &mut context,
                     &new_info.timeline.events,
                 );
@@ -818,7 +818,7 @@ impl BaseClient {
                 self.room_info_notable_update_sender.clone(),
             );
 
-            let invite_state = processors::state_events::collect_stripped(
+            let invite_state = processors::state_events::stripped::collect(
                 &mut context,
                 &new_info.invite_state.events,
             );
@@ -849,7 +849,7 @@ impl BaseClient {
                 self.room_info_notable_update_sender.clone(),
             );
 
-            let knock_state = processors::state_events::collect_stripped(
+            let knock_state = processors::state_events::stripped::collect(
                 &mut context,
                 &new_info.knock_state.events,
             );

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -575,7 +575,7 @@ impl BaseClient {
     ) -> Result<()> {
         let mut state_events = BTreeMap::new();
 
-        for (raw_event, event) in events.0.into_iter().zip(events.1.into_iter()) {
+        for (raw_event, event) in iter::zip(events.0, events.1) {
             room_info.handle_stripped_state_event(&event);
             state_events
                 .entry(event.event_type())

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -30,7 +30,10 @@ use matrix_sdk_crypto::{
     OlmError, OlmMachine, TrustRequirement,
 };
 #[cfg(feature = "e2e-encryption")]
-use ruma::events::{room::history_visibility::HistoryVisibility, SyncMessageLikeEvent};
+use ruma::events::{
+    room::{history_visibility::HistoryVisibility, member::MembershipState},
+    SyncMessageLikeEvent,
+};
 #[cfg(doc)]
 use ruma::DeviceId;
 use ruma::{
@@ -38,7 +41,7 @@ use ruma::{
     events::{
         push_rules::{PushRulesEvent, PushRulesEventContent},
         room::{
-            member::{MembershipState, SyncRoomMemberEvent},
+            member::SyncRoomMemberEvent,
             power_levels::{
                 RoomPowerLevelsEvent, RoomPowerLevelsEventContent, StrippedRoomPowerLevelsEvent,
             },

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -307,6 +307,8 @@ impl BaseClient {
     /// # Panics
     ///
     /// This method panics if it is called twice.
+    ///
+    /// [`UserId`]: ruma::UserId
     pub async fn activate(
         &self,
         session_meta: SessionMeta,

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
@@ -1,0 +1,88 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk_common::deserialized_responses::TimelineEvent;
+use matrix_sdk_crypto::{
+    DecryptionSettings, OlmMachine, RoomEventDecryptionResult, TrustRequirement,
+};
+use ruma::{
+    events::{
+        room::message::MessageType, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+        SyncMessageLikeEvent,
+    },
+    serde::Raw,
+    RoomId,
+};
+
+use super::super::{verification, Context};
+use crate::Result;
+
+/// Attempt to decrypt the given raw event into a [`TimelineEvent`].
+///
+/// In the case of a decryption error, returns a [`TimelineEvent`]
+/// representing the decryption error; in the case of problems with our
+/// application, returns `Err`.
+///
+/// Returns `Ok(None)` if encryption is not configured.
+pub async fn sync_timeline_event(
+    context: &mut Context,
+    olm_machine: Option<&OlmMachine>,
+    event: &Raw<AnySyncTimelineEvent>,
+    room_id: &RoomId,
+    decryption_trust_requirement: TrustRequirement,
+    verification_is_allowed: bool,
+) -> Result<Option<TimelineEvent>> {
+    let Some(olm) = olm_machine else { return Ok(None) };
+
+    let decryption_settings =
+        DecryptionSettings { sender_device_trust_requirement: decryption_trust_requirement };
+
+    Ok(Some(
+        match olm.try_decrypt_room_event(event.cast_ref(), room_id, &decryption_settings).await? {
+            RoomEventDecryptionResult::Decrypted(decrypted) => {
+                let event: TimelineEvent = decrypted.into();
+
+                if let Ok(AnySyncTimelineEvent::MessageLike(e)) = event.raw().deserialize() {
+                    match &e {
+                        AnySyncMessageLikeEvent::RoomMessage(SyncMessageLikeEvent::Original(
+                            original_event,
+                        )) => {
+                            if let MessageType::VerificationRequest(_) =
+                                &original_event.content.msgtype
+                            {
+                                verification(
+                                    context,
+                                    verification_is_allowed,
+                                    Some(olm),
+                                    &e,
+                                    room_id,
+                                )
+                                .await?;
+                            }
+                        }
+                        _ if e.event_type().to_string().starts_with("m.key.verification") => {
+                            verification(context, verification_is_allowed, Some(olm), &e, room_id)
+                                .await?;
+                        }
+                        _ => (),
+                    }
+                }
+                event
+            }
+            RoomEventDecryptionResult::UnableToDecrypt(utd_info) => {
+                TimelineEvent::new_utd_event(event.clone(), utd_info)
+            }
+        },
+    ))
+}

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
@@ -47,7 +47,7 @@ pub async fn sync_timeline_event(
                 let timeline_event = TimelineEvent::from(decrypted);
 
                 if let Ok(sync_timeline_event) = timeline_event.raw().deserialize() {
-                    verification::process_if_candidate(
+                    verification::process_if_relevant(
                         context,
                         &sync_timeline_event,
                         verification_is_allowed,

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/mod.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod decrypt;
 pub mod to_device;
 pub mod tracked_users;

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
@@ -53,7 +53,7 @@ pub async fn from_msc4186(
 ///
 /// This returns a list of all the to-device events that were passed in but
 /// encrypted ones were replaced with their decrypted version.
-pub async fn from_sync_v3(
+pub async fn from_sync_v2(
     context: &mut Context,
     response: &v3::Response,
     olm_machine: Option<&OlmMachine>,

--- a/crates/matrix-sdk-base/src/response_processors/latest_event.rs
+++ b/crates/matrix-sdk-base/src/response_processors/latest_event.rs
@@ -139,7 +139,7 @@ async fn decrypt_sync_room_event(
             let event: TimelineEvent = decrypted.into();
 
             if let Ok(sync_timeline_event) = event.raw().deserialize() {
-                verification::process_if_candidate(
+                verification::process_if_relevant(
                     context,
                     &sync_timeline_event,
                     verification_is_allowed,

--- a/crates/matrix-sdk-base/src/response_processors/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/mod.rs
@@ -20,6 +20,7 @@ pub mod e2ee;
 pub mod latest_event;
 pub mod profiles;
 pub mod state_events;
+pub mod timeline;
 #[cfg(feature = "e2e-encryption")]
 pub mod verification;
 

--- a/crates/matrix-sdk-base/src/response_processors/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/mod.rs
@@ -26,8 +26,6 @@ pub mod verification;
 use std::collections::BTreeMap;
 
 use ruma::OwnedRoomId;
-#[cfg(feature = "e2e-encryption")]
-pub use verification::verification;
 
 use crate::{RoomInfoNotableUpdateReasons, StateChanges};
 

--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -56,7 +56,7 @@ pub fn collect_sync_from_timeline(
     _context: &mut Context,
     raw_events: &[Raw<AnySyncTimelineEvent>],
 ) -> (Vec<Raw<AnySyncStateEvent>>, Vec<AnySyncStateEvent>) {
-    collect(raw_events.into_iter().filter_map(|raw_event| {
+    collect(raw_events.iter().filter_map(|raw_event| {
         // State events have a `state_key` field.
         match raw_event.get_field::<&str>("state_key") {
             Ok(Some(_)) => Some(raw_event.cast_ref()),

--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -12,14 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    iter,
+};
+
 use ruma::{
-    events::{AnyStrippedStateEvent, AnySyncStateEvent},
+    events::{room::member::MembershipState, AnyStrippedStateEvent, AnySyncStateEvent},
     serde::Raw,
+    OwnedUserId,
 };
 use serde::Deserialize;
-use tracing::warn;
+use tracing::{instrument, warn};
 
-use super::Context;
+use super::{profiles, Context};
+use crate::{
+    store::{ambiguity_map::AmbiguityCache, Result as StoreResult},
+    RoomInfo,
+};
 
 pub fn collect_sync(
     _context: &mut Context,
@@ -49,4 +59,53 @@ where
             }
         })
         .unzip()
+}
+
+/// Dispatch the state events and return the new users for this room.
+///
+/// `raw_events` and `events` must be generated from [`collect_sync`]. Events
+/// must be exactly the same list of events that are in raw_events, but
+/// deserialised. We demand them here to avoid deserialising multiple times.
+#[instrument(skip_all, fields(room_id = ?room_info.room_id))]
+pub async fn dispatch_and_get_new_users(
+    context: &mut Context,
+    (raw_events, events): (&[Raw<AnySyncStateEvent>], &[AnySyncStateEvent]),
+    room_info: &mut RoomInfo,
+    ambiguity_cache: &mut AmbiguityCache,
+) -> StoreResult<BTreeSet<OwnedUserId>> {
+    let mut user_ids = BTreeSet::new();
+
+    if raw_events.is_empty() {
+        return Ok(user_ids);
+    }
+
+    let mut state_events = BTreeMap::new();
+
+    for (raw_event, event) in iter::zip(raw_events, events) {
+        room_info.handle_state_event(event);
+
+        if let AnySyncStateEvent::RoomMember(member) = event {
+            ambiguity_cache
+                .handle_event(&context.state_changes, &room_info.room_id, member)
+                .await?;
+
+            match member.membership() {
+                MembershipState::Join | MembershipState::Invite => {
+                    user_ids.insert(member.state_key().to_owned());
+                }
+                _ => (),
+            }
+
+            profiles::upsert_or_delete(context, &room_info.room_id, member);
+        }
+
+        state_events
+            .entry(event.event_type())
+            .or_insert_with(BTreeMap::new)
+            .insert(event.state_key().to_owned(), raw_event.clone());
+    }
+
+    context.state_changes.state.insert(room_info.room_id.clone(), state_events);
+
+    Ok(user_ids)
 }

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -1,0 +1,361 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk_common::deserialized_responses::TimelineEvent;
+#[cfg(feature = "e2e-encryption")]
+use ruma::events::SyncMessageLikeEvent;
+use ruma::{
+    events::{
+        room::power_levels::{
+            RoomPowerLevelsEvent, RoomPowerLevelsEventContent, StrippedRoomPowerLevelsEvent,
+        },
+        AnyStrippedStateEvent, AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent,
+        StateEventType,
+    },
+    push::{Action, PushConditionRoomCtx},
+    RoomVersionId, UInt, UserId,
+};
+use tracing::{instrument, trace, warn};
+
+use super::Context;
+#[cfg(feature = "e2e-encryption")]
+use super::{e2ee, verification};
+use crate::{
+    deserialized_responses::RawAnySyncOrStrippedTimelineEvent,
+    store::{BaseStateStore, StateStoreExt as _},
+    sync::{Notification, Timeline},
+    Result, Room, RoomInfo,
+};
+
+/// Process a set of sync timeline event, and create a [`Timeline`].
+///
+/// For each event:
+/// - will try to decrypt it,
+/// - will process verification,
+/// - will process redaction,
+/// - will process notification.
+#[instrument(skip_all, fields(room_id = ?room_info.room_id))]
+pub async fn build<'notification, 'e2ee>(
+    context: &mut Context,
+    room: &Room,
+    room_info: &mut RoomInfo,
+    timeline_inputs: builder::Timeline,
+    notification_inputs: builder::Notification<'notification>,
+    #[cfg(feature = "e2e-encryption")] e2ee: builder::E2EE<'e2ee>,
+) -> Result<Timeline> {
+    let mut timeline = Timeline::new(timeline_inputs.limited, timeline_inputs.prev_batch);
+    let mut push_context =
+        get_push_room_context(context, room, room_info, notification_inputs.state_store).await?;
+    let room_id = room.room_id();
+
+    for raw_event in timeline_inputs.raw_events {
+        // Start by assuming we have a plaintext event. We'll replace it with a
+        // decrypted or UTD event below if necessary.
+        let mut timeline_event = TimelineEvent::new(raw_event);
+
+        // Do some special stuff on the `timeline_event` before collecting it.
+        match timeline_event.raw().deserialize() {
+            Ok(sync_timeline_event) => {
+                #[allow(clippy::single_match)]
+                match &sync_timeline_event {
+                    // State events are ignored. They must be processed separately.
+                    AnySyncTimelineEvent::State(_) => {
+                        // do nothing
+                    }
+
+                    // A room redaction.
+                    AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomRedaction(
+                        redaction_event,
+                    )) => {
+                        let room_version = room_info.room_version().unwrap_or(&RoomVersionId::V1);
+
+                        if let Some(redacts) = redaction_event.redacts(room_version) {
+                            room_info
+                                .handle_redaction(redaction_event, timeline_event.raw().cast_ref());
+
+                            context.state_changes.add_redaction(
+                                room_id,
+                                redacts,
+                                timeline_event.raw().clone().cast(),
+                            );
+                        }
+                    }
+
+                    // Decrypt encrypted event, or process verification event.
+                    #[cfg(feature = "e2e-encryption")]
+                    AnySyncTimelineEvent::MessageLike(sync_message_like_event) => {
+                        match sync_message_like_event {
+                            AnySyncMessageLikeEvent::RoomEncrypted(
+                                SyncMessageLikeEvent::Original(_),
+                            ) => {
+                                if let Some(decrypted_timeline_event) =
+                                    Box::pin(e2ee::decrypt::sync_timeline_event(
+                                        context,
+                                        e2ee.olm_machine,
+                                        timeline_event.raw(),
+                                        room_id,
+                                        e2ee.decryption_trust_requirement,
+                                        e2ee.verification_is_allowed,
+                                    ))
+                                    .await?
+                                {
+                                    timeline_event = decrypted_timeline_event;
+                                }
+                            }
+
+                            _ => {
+                                Box::pin(verification::process_if_candidate(
+                                    context,
+                                    &sync_timeline_event,
+                                    e2ee.verification_is_allowed,
+                                    e2ee.olm_machine,
+                                    room_id,
+                                ))
+                                .await?;
+                            }
+                        }
+                    }
+
+                    // Nothing particular to do.
+                    #[cfg(not(feature = "e2e-encryption"))]
+                    AnySyncTimelineEvent::MessageLike(_) => (),
+                }
+
+                if let Some(push_context) = &mut push_context {
+                    update_push_room_context(context, push_context, room.own_user_id(), room_info)
+                } else {
+                    push_context = get_push_room_context(
+                        context,
+                        room,
+                        room_info,
+                        notification_inputs.state_store,
+                    )
+                    .await?;
+                }
+
+                if let Some(context) = &push_context {
+                    let actions =
+                        notification_inputs.push_rules.get_actions(timeline_event.raw(), context);
+
+                    if actions.iter().any(Action::should_notify) {
+                        notification_inputs
+                            .notifications
+                            .entry(room_id.to_owned())
+                            .or_default()
+                            .push(Notification {
+                                actions: actions.to_owned(),
+                                event: RawAnySyncOrStrippedTimelineEvent::Sync(
+                                    timeline_event.raw().clone(),
+                                ),
+                            });
+                    }
+
+                    timeline_event.push_actions = Some(actions.to_owned());
+                }
+            }
+            Err(error) => {
+                warn!("Error deserializing event: {error}");
+            }
+        }
+
+        // Finally, we have process the timeline event. We can collect it.
+        timeline.events.push(timeline_event);
+    }
+
+    Ok(timeline)
+}
+
+/// Set of types used by [`build`] to reduce the number of arguments by grouping
+/// them by thematics.
+pub mod builder {
+    use std::collections::BTreeMap;
+
+    #[cfg(feature = "e2e-encryption")]
+    use matrix_sdk_crypto::{OlmMachine, TrustRequirement};
+    use ruma::{
+        api::client::sync::sync_events::{v3, v5},
+        events::AnySyncTimelineEvent,
+        push::Ruleset,
+        serde::Raw,
+        OwnedRoomId,
+    };
+
+    use crate::{store::BaseStateStore, sync};
+
+    pub struct Timeline {
+        pub limited: bool,
+        pub raw_events: Vec<Raw<AnySyncTimelineEvent>>,
+        pub prev_batch: Option<String>,
+    }
+
+    impl From<v3::Timeline> for Timeline {
+        fn from(value: v3::Timeline) -> Self {
+            Self { limited: value.limited, raw_events: value.events, prev_batch: value.prev_batch }
+        }
+    }
+
+    impl From<&v5::response::Room> for Timeline {
+        fn from(value: &v5::response::Room) -> Self {
+            Self {
+                limited: value.limited,
+                raw_events: value.timeline.clone(),
+                prev_batch: value.prev_batch.clone(),
+            }
+        }
+    }
+
+    pub struct Notification<'a> {
+        pub push_rules: &'a Ruleset,
+        pub notifications: &'a mut BTreeMap<OwnedRoomId, Vec<sync::Notification>>,
+        pub state_store: &'a BaseStateStore,
+    }
+
+    impl<'a> Notification<'a> {
+        pub fn new(
+            push_rules: &'a Ruleset,
+            notifications: &'a mut BTreeMap<OwnedRoomId, Vec<sync::Notification>>,
+            state_store: &'a BaseStateStore,
+        ) -> Self {
+            Self { push_rules, notifications, state_store }
+        }
+    }
+
+    #[cfg(feature = "e2e-encryption")]
+    pub struct E2EE<'a> {
+        pub olm_machine: Option<&'a OlmMachine>,
+        pub decryption_trust_requirement: TrustRequirement,
+        pub verification_is_allowed: bool,
+    }
+
+    #[cfg(feature = "e2e-encryption")]
+    impl<'a> E2EE<'a> {
+        pub fn new(
+            olm_machine: Option<&'a OlmMachine>,
+            decryption_trust_requirement: TrustRequirement,
+            verification_is_allowed: bool,
+        ) -> Self {
+            Self { olm_machine, decryption_trust_requirement, verification_is_allowed }
+        }
+    }
+}
+
+/// Update the push context for the given room.
+///
+/// Updates the context data from `context.state_changes` or `room_info`.
+fn update_push_room_context(
+    context: &mut Context,
+    push_rules: &mut PushConditionRoomCtx,
+    user_id: &UserId,
+    room_info: &RoomInfo,
+) {
+    let room_id = &*room_info.room_id;
+
+    push_rules.member_count = UInt::new(room_info.active_members_count()).unwrap_or(UInt::MAX);
+
+    // TODO: Use if let chain once stable
+    if let Some(AnySyncStateEvent::RoomMember(member)) =
+        context.state_changes.state.get(room_id).and_then(|events| {
+            events.get(&StateEventType::RoomMember)?.get(user_id.as_str())?.deserialize().ok()
+        })
+    {
+        push_rules.user_display_name = member
+            .as_original()
+            .and_then(|ev| ev.content.displayname.clone())
+            .unwrap_or_else(|| user_id.localpart().to_owned())
+    }
+
+    if let Some(AnySyncStateEvent::RoomPowerLevels(event)) =
+        context.state_changes.state.get(room_id).and_then(|types| {
+            types.get(&StateEventType::RoomPowerLevels)?.get("")?.deserialize().ok()
+        })
+    {
+        push_rules.power_levels = Some(event.power_levels().into());
+    }
+}
+
+/// Get the push context for the given room.
+///
+/// Tries to get the data from `changes` or the up to date `room_info`.
+/// Loads the data from the store otherwise.
+///
+/// Returns `None` if some data couldn't be found. This should only happen
+/// in brand new rooms, while we process its state.
+pub async fn get_push_room_context(
+    context: &mut Context,
+    room: &Room,
+    room_info: &RoomInfo,
+    state_store: &BaseStateStore,
+) -> Result<Option<PushConditionRoomCtx>> {
+    let room_id = room.room_id();
+    let user_id = room.own_user_id();
+
+    let member_count = room_info.active_members_count();
+
+    // TODO: Use if let chain once stable
+    let user_display_name = if let Some(AnySyncStateEvent::RoomMember(member)) =
+        context.state_changes.state.get(room_id).and_then(|events| {
+            events.get(&StateEventType::RoomMember)?.get(user_id.as_str())?.deserialize().ok()
+        }) {
+        member
+            .as_original()
+            .and_then(|ev| ev.content.displayname.clone())
+            .unwrap_or_else(|| user_id.localpart().to_owned())
+    } else if let Some(AnyStrippedStateEvent::RoomMember(member)) =
+        context.state_changes.stripped_state.get(room_id).and_then(|events| {
+            events.get(&StateEventType::RoomMember)?.get(user_id.as_str())?.deserialize().ok()
+        })
+    {
+        member.content.displayname.unwrap_or_else(|| user_id.localpart().to_owned())
+    } else if let Some(member) = Box::pin(room.get_member(user_id)).await? {
+        member.name().to_owned()
+    } else {
+        trace!("Couldn't get push context because of missing own member information");
+        return Ok(None);
+    };
+
+    let power_levels = if let Some(event) =
+        context.state_changes.state.get(room_id).and_then(|types| {
+            types
+                .get(&StateEventType::RoomPowerLevels)?
+                .get("")?
+                .deserialize_as::<RoomPowerLevelsEvent>()
+                .ok()
+        }) {
+        Some(event.power_levels().into())
+    } else if let Some(event) =
+        context.state_changes.stripped_state.get(room_id).and_then(|types| {
+            types
+                .get(&StateEventType::RoomPowerLevels)?
+                .get("")?
+                .deserialize_as::<StrippedRoomPowerLevelsEvent>()
+                .ok()
+        })
+    {
+        Some(event.power_levels().into())
+    } else {
+        state_store
+            .get_state_event_static::<RoomPowerLevelsEventContent>(room_id)
+            .await?
+            .and_then(|e| e.deserialize().ok())
+            .map(|event| event.power_levels().into())
+    };
+
+    Ok(Some(PushConditionRoomCtx {
+        user_id: user_id.to_owned(),
+        room_id: room_id.to_owned(),
+        member_count: UInt::new(member_count).unwrap_or(UInt::MAX),
+        user_display_name,
+        power_levels,
+    }))
+}

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -114,7 +114,7 @@ pub async fn build<'notification, 'e2ee>(
                             }
 
                             _ => {
-                                Box::pin(verification::process_if_candidate(
+                                Box::pin(verification::process_if_relevant(
                                     context,
                                     &sync_timeline_event,
                                     e2ee.verification_is_allowed,

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -67,7 +67,6 @@ pub async fn build<'notification, 'e2ee>(
         // Do some special stuff on the `timeline_event` before collecting it.
         match timeline_event.raw().deserialize() {
             Ok(sync_timeline_event) => {
-                #[allow(clippy::single_match)]
                 match &sync_timeline_event {
                     // State events are ignored. They must be processed separately.
                     AnySyncTimelineEvent::State(_) => {

--- a/crates/matrix-sdk-base/src/response_processors/verification.rs
+++ b/crates/matrix-sdk-base/src/response_processors/verification.rs
@@ -26,7 +26,7 @@ use crate::Result;
 
 /// Process the given event as a verification event if it is a candidate. The
 /// event must be decrypted.
-pub async fn process_if_candidate(
+pub async fn process_if_relevant(
     context: &mut Context,
     event: &AnySyncTimelineEvent,
     verification_is_allowed: bool,

--- a/crates/matrix-sdk-base/src/response_processors/verification.rs
+++ b/crates/matrix-sdk-base/src/response_processors/verification.rs
@@ -58,7 +58,7 @@ pub async fn process_if_candidate(
 
             _ => false,
         } {
-            verification(context, verification_is_allowed, olm_machine, &event, room_id).await?;
+            verification(context, verification_is_allowed, olm_machine, event, room_id).await?;
         }
     }
 

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -393,7 +393,8 @@ impl BaseClient {
         room_info.mark_state_partially_synced();
         room_info.handle_encryption_state(requested_required_states);
 
-        let _new_user_ids = processors::state_events::dispatch_and_get_new_users(
+        #[cfg_attr(not(feature = "e2e-encryption"), allow(unused))]
+        let new_user_ids = processors::state_events::dispatch_and_get_new_users(
             context,
             (&raw_state_events, &state_events),
             &mut room_info,
@@ -453,7 +454,7 @@ impl BaseClient {
         processors::e2ee::tracked_users::update_or_set_if_room_is_newly_encrypted(
             context,
             self.olm_machine().await.as_ref(),
-            &_new_user_ids,
+            &new_user_ids,
             room_info.encryption_state(),
             room.encryption_state(),
             room_id,

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -393,18 +393,13 @@ impl BaseClient {
         room_info.mark_state_partially_synced();
         room_info.handle_encryption_state(requested_required_states);
 
-        let mut new_user_ids = if !state_events.is_empty() {
-            self.handle_state(
-                context,
-                &raw_state_events,
-                &state_events,
-                &mut room_info,
-                ambiguity_cache,
-            )
-            .await?
-        } else {
-            Default::default()
-        };
+        let mut new_user_ids = processors::state_events::dispatch_and_get_new_users(
+            context,
+            (&raw_state_events, &state_events),
+            &mut room_info,
+            ambiguity_cache,
+        )
+        .await?;
 
         let push_rules = self.get_push_rules(global_account_data_processor).await?;
 

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -393,7 +393,7 @@ impl BaseClient {
         room_info.mark_state_partially_synced();
         room_info.handle_encryption_state(requested_required_states);
 
-        let new_user_ids = processors::state_events::dispatch_and_get_new_users(
+        let _new_user_ids = processors::state_events::dispatch_and_get_new_users(
             context,
             (&raw_state_events, &state_events),
             &mut room_info,
@@ -447,7 +447,7 @@ impl BaseClient {
         processors::e2ee::tracked_users::update_or_set_if_room_is_newly_encrypted(
             context,
             self.olm_machine().await.as_ref(),
-            &new_user_ids,
+            &_new_user_ids,
             room_info.encryption_state(),
             room.encryption_state(),
             room_id,

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -369,7 +369,7 @@ impl BaseClient {
         // incomplete or staled already. We must only read state events from
         // `required_state`.
         let (raw_state_events, state_events) =
-            processors::state_events::collect_sync(context, &room_data.required_state);
+            processors::state_events::sync::collect(context, &room_data.required_state);
 
         // Find or create the room in the store
         let is_new_room = !state_store.room_exists(room_id);
@@ -377,7 +377,7 @@ impl BaseClient {
         let invite_state_events = room_data
             .invite_state
             .as_ref()
-            .map(|events| processors::state_events::collect_stripped(context, events));
+            .map(|events| processors::state_events::stripped::collect(context, events));
 
         #[allow(unused_mut)] // Required for some feature flag combinations
         let (mut room, mut room_info, invited_room, knocked_room) = self

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -393,7 +393,7 @@ impl BaseClient {
         room_info.mark_state_partially_synced();
         room_info.handle_encryption_state(requested_required_states);
 
-        let mut new_user_ids = processors::state_events::dispatch_and_get_new_users(
+        let new_user_ids = processors::state_events::dispatch_and_get_new_users(
             context,
             (&raw_state_events, &state_events),
             &mut room_info,
@@ -424,13 +424,10 @@ impl BaseClient {
                 &room,
                 room_data.limited,
                 room_data.timeline.clone(),
-                true,
                 room_data.prev_batch.clone(),
                 &push_rules,
-                &mut new_user_ids,
                 &mut room_info,
                 notifications,
-                ambiguity_cache,
             )
             .await?;
 


### PR DESCRIPTION
Sequel of https://github.com/matrix-org/matrix-rust-sdk/pull/4901.

This PR continues to refactor and clean up the response workflow as so-called response processors.

Each patch should be reviewed individually. There is nothing fancy, it's mostly code moves.

This time, it's a bit more interesting as we are clearly reusing existing processors. Even some processors are re-using other processors.

I've cleaned up the `BaseClient::handle_timeline` quite a lot, to finally be able to move it as the new `timeline::build` processor. It is still a bit too broad from my point of view as the commit description says, but at least `BaseClient` is cleaner.

The detection and processing of the verification events is also now unified: previously it was more or less copy-pasted in three different locations.