### PR TITLE
feat(bindings): expose `is_public` and `join_rule` in notifications

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -5,7 +5,11 @@ use matrix_sdk_ui::notification_client::{
 };
 use ruma::{EventId, RoomId};
 
-use crate::{client::Client, error::ClientError, event::TimelineEvent};
+use crate::{
+    client::{Client, JoinRule},
+    error::ClientError,
+    event::TimelineEvent,
+};
 
 #[derive(uniffi::Enum)]
 pub enum NotificationEvent {
@@ -25,6 +29,7 @@ pub struct NotificationRoomInfo {
     pub display_name: String,
     pub avatar_url: Option<String>,
     pub canonical_alias: Option<String>,
+    pub join_rule: Option<JoinRule>,
     pub joined_members_count: u64,
     pub is_encrypted: Option<bool>,
     pub is_direct: bool,
@@ -67,6 +72,7 @@ impl NotificationItem {
                 display_name: item.room_computed_display_name,
                 avatar_url: item.room_avatar_url,
                 canonical_alias: item.room_canonical_alias,
+                join_rule: item.room_join_rule.try_into().ok(),
                 joined_members_count: item.joined_members_count,
                 is_encrypted: item.is_room_encrypted,
                 is_direct: item.is_direct_message_room,

--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -28,6 +28,7 @@ pub struct NotificationRoomInfo {
     pub joined_members_count: u64,
     pub is_encrypted: Option<bool>,
     pub is_direct: bool,
+    pub is_public: bool,
 }
 
 #[derive(uniffi::Record)]
@@ -69,6 +70,7 @@ impl NotificationItem {
                 joined_members_count: item.joined_members_count,
                 is_encrypted: item.is_room_encrypted,
                 is_direct: item.is_direct_message_room,
+                is_public: item.is_room_public,
             },
             is_noisy: item.is_noisy,
             has_mention: item.has_mention,

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -674,6 +674,8 @@ pub struct NotificationItem {
     pub room_canonical_alias: Option<String>,
     /// Is this room encrypted?
     pub is_room_encrypted: Option<bool>,
+    /// Is this a public room?
+    pub is_room_public: bool,
     /// Is this room considered a direct message?
     pub is_direct_message_room: bool,
     /// Numbers of members who joined the room.
@@ -764,6 +766,7 @@ impl NotificationItem {
             room_avatar_url: room.avatar_url().map(|s| s.to_string()),
             room_canonical_alias: room.canonical_alias().map(|c| c.to_string()),
             is_direct_message_room: room.is_direct().await?,
+            is_room_public: room.is_public(),
             is_room_encrypted: room
                 .latest_encryption_state()
                 .await

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -28,6 +28,7 @@ use ruma::{
     directory::RoomTypeFilter,
     events::{
         room::{
+            join_rules::JoinRule,
             member::{MembershipState, StrippedRoomMemberEvent},
             message::{Relation, SyncRoomMessageEvent},
         },
@@ -672,6 +673,8 @@ pub struct NotificationItem {
     pub room_avatar_url: Option<String>,
     /// Room canonical alias.
     pub room_canonical_alias: Option<String>,
+    /// Room join rule.
+    pub room_join_rule: JoinRule,
     /// Is this room encrypted?
     pub is_room_encrypted: Option<bool>,
     /// Is this a public room?
@@ -765,6 +768,7 @@ impl NotificationItem {
             room_computed_display_name: room.display_name().await?.to_string(),
             room_avatar_url: room.avatar_url().map(|s| s.to_string()),
             room_canonical_alias: room.canonical_alias().map(|c| c.to_string()),
+            room_join_rule: room.join_rule(),
             is_direct_message_room: room.is_direct().await?,
             is_room_public: room.is_public(),
             is_room_encrypted: room


### PR DESCRIPTION
Would be useful to tell from a notification if the room that generated it, is public or not, or if has some specific join rule, since a client may want to hide or show the media based on the join rule of the room for safety reasons