### PR TITLE
refactor(sdk): Migrate away from the backoff crate to the backon crate

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -10,8 +10,6 @@ exclude = [
 version = 2
 ignore = [
     { id = "RUSTSEC-2024-0436", reason = "Unmaintained paste crate, not critical." },
-    { id = "RUSTSEC-2024-0384", reason = "Unmaintained backoff crate, not critical. We'll migrate soon." },
-    { id = "RUSTSEC-2025-0012", reason = "Unmaintained backoff crate, not critical. We'll migrate soon." },
 ]
 
 [licenses]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,16 +438,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
 dependencies = [
- "futures-core",
- "getrandom 0.2.15",
- "instant",
- "pin-project-lite",
- "rand",
+ "fastrand",
+ "gloo-timers",
  "tokio",
 ]
 
@@ -2531,15 +2528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,7 +2865,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "backoff",
+ "backon",
  "bytes",
  "bytesize",
  "dirs 6.0.0",

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -705,7 +705,8 @@ impl ClientBuilder {
         if let Some(config) = builder.request_config {
             let mut updated_config = matrix_sdk::config::RequestConfig::default();
             if let Some(retry_limit) = config.retry_limit {
-                updated_config = updated_config.retry_limit(retry_limit);
+                updated_config =
+                    updated_config.retry_limit(retry_limit.try_into().unwrap_or(usize::MAX));
             }
             if let Some(timeout) = config.timeout {
                 updated_config = updated_config.timeout(Duration::from_millis(timeout));
@@ -717,8 +718,9 @@ impl ClientBuilder {
                     ));
                 }
             }
-            if let Some(retry_timeout) = config.retry_timeout {
-                updated_config = updated_config.retry_timeout(Duration::from_millis(retry_timeout));
+            if let Some(max_retry_time) = config.max_retry_time {
+                updated_config =
+                    updated_config.max_retry_time(Duration::from_millis(max_retry_time));
             }
             inner_builder = inner_builder.request_config(updated_config);
         }
@@ -819,7 +821,7 @@ pub struct RequestConfig {
     /// Max number of concurrent requests. No value means no limits.
     max_concurrent_requests: Option<u64>,
     /// Base delay between retries.
-    retry_timeout: Option<u64>,
+    max_retry_time: Option<u64>,
 }
 
 #[derive(Clone, uniffi::Enum)]

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -91,9 +91,15 @@ simpler methods:
 
 ### Refactor
 
+
+- [**breaking**] Switched from the unmaintained backoff crate to the [backon](https://docs.rs/backon/1.5.0/backon/)
+  crate. As part of this change, the `RequestConfig::retry_limit` method was
+  renamed to `RequestConfig::max_retry_time` and the parameter for the method was
+  updated from a `u64` to a `usize`.
+  ([#4916](https://github.com/matrix-org/matrix-rust-sdk/pull/4916))
 - [**breaking**] We now require Rust 1.85 as the minimum supported Rust version to compile.
   Yay for async closures!
-  ([#4745](https://github.com/matrix-org/matrix-rust-sdk/pull/4745)
+  ([#4745](https://github.com/matrix-org/matrix-rust-sdk/pull/4745))
 - [**breaking**] The `server_url` and `server_response` methods of
   `SsoLoginBuilder` are replaced by `server_builder()`, which allows more
   fine-grained settings for the server.

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -119,7 +119,7 @@ reqwest = { workspace = true, features = ["gzip", "http2"] }
 tokio = { workspace = true, features = ["macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-backoff = { version = "0.4.0", features = ["tokio"] }
+backon = "1.5.0"
 # only activate reqwest's stream feature on non-wasm, the wasm part seems to not
 # support *sending* streams, which makes it useless for us.
 reqwest = { workspace = true, features = ["stream", "gzip", "http2"] }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2739,12 +2739,12 @@ pub(crate) mod tests {
         let retry_timeout = Duration::from_secs(5);
         let server = MockServer::start().await;
         let client = test_client_builder(Some(server.uri()))
-            .request_config(RequestConfig::new().retry_timeout(retry_timeout))
+            .request_config(RequestConfig::new().max_retry_time(retry_timeout))
             .build()
             .await
             .unwrap();
 
-        assert!(client.request_config().retry_timeout.unwrap() == retry_timeout);
+        assert!(client.request_config().max_retry_time.unwrap() == retry_timeout);
 
         Mock::given(method("POST"))
             .and(path("/_matrix/client/r0/login"))


### PR DESCRIPTION
Since backon also has WASM support, this should mean that we can get rid of the WASM specific HTTP client implementation.

This closes #4243.

- [x] Public API changes documented in changelogs (optional)


