### PR TITLE
feat(ffi): expose whether a room is public or not in the `NotificationItem`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -26,6 +26,7 @@ pub struct NotificationRoomInfo {
     pub avatar_url: Option<String>,
     pub canonical_alias: Option<String>,
     pub joined_members_count: u64,
+    pub is_public: bool,
     pub is_encrypted: Option<bool>,
     pub is_direct: bool,
 }
@@ -67,6 +68,7 @@ impl NotificationItem {
                 avatar_url: item.room_avatar_url,
                 canonical_alias: item.room_canonical_alias,
                 joined_members_count: item.joined_members_count,
+                is_public: item.is_room_public,
                 is_encrypted: item.is_room_encrypted,
                 is_direct: item.is_direct_message_room,
             },

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -672,6 +672,8 @@ pub struct NotificationItem {
     pub room_avatar_url: Option<String>,
     /// Room canonical alias.
     pub room_canonical_alias: Option<String>,
+    /// Is this room public?
+    pub is_room_public: bool,
     /// Is this room encrypted?
     pub is_room_encrypted: Option<bool>,
     /// Is this room considered a direct message?
@@ -763,12 +765,13 @@ impl NotificationItem {
             room_computed_display_name: room.display_name().await?.to_string(),
             room_avatar_url: room.avatar_url().map(|s| s.to_string()),
             room_canonical_alias: room.canonical_alias().map(|c| c.to_string()),
-            is_direct_message_room: room.is_direct().await?,
+            is_room_public: room.is_public(),
             is_room_encrypted: room
                 .latest_encryption_state()
                 .await
                 .map(|state| state.is_encrypted())
                 .ok(),
+            is_direct_message_room: room.is_direct().await?,
             joined_members_count: room.joined_members_count(),
             is_noisy,
             has_mention,


### PR DESCRIPTION
- this will be used to determine if media should be shown in the notification or not

Relates to https://github.com/element-hq/element-internal/issues/667