### PR TITLE
feat(ffi): Add extra details to `ClientError`.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -486,7 +486,7 @@ impl Client {
                 auth_session,
                 room_load_settings
                     .try_into()
-                    .map_err(|error| ClientError::Generic { msg: error })?,
+                    .map_err(|error| ClientError::from_str(error, None))?,
             )
             .await?;
         self.inner.set_sliding_sync_version(sliding_sync_version.try_into()?);
@@ -525,7 +525,7 @@ impl Client {
             loop {
                 match subscriber.recv().await {
                     Ok(report) => listener
-                        .on_error(report.room_id.to_string(), ClientError::new(report.error)),
+                        .on_error(report.room_id.to_string(), ClientError::from_err(report.error)),
                     Err(err) => {
                         error!("error when listening to the send queue error reporter: {err}");
                     }
@@ -1519,7 +1519,8 @@ impl TryFrom<CreateRoomParameters> for create_room::v3::Request {
                 Err(e) => {
                     return Err(ClientError::Generic {
                         msg: format!("Failed to serialize power levels, error: {e}"),
-                    })
+                        details: Some(format!("{e:?}")),
+                    });
                 }
             }
         }

--- a/bindings/matrix-sdk-ffi/src/element.rs
+++ b/bindings/matrix-sdk-ffi/src/element.rs
@@ -18,5 +18,5 @@ pub struct ElementWellKnown {
 /// Helper function to parse a string into a ElementWellKnown struct
 #[matrix_sdk_ffi_macros::export]
 pub fn make_element_well_known(string: String) -> Result<ElementWellKnown, ClientError> {
-    serde_json::from_str(&string).map_err(ClientError::new)
+    serde_json::from_str(&string).map_err(ClientError::from_err)
 }

--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -369,12 +369,8 @@ impl Encryption {
     /// Completely reset the current user's crypto identity: reset the cross
     /// signing keys, delete the existing backup and recovery key.
     pub async fn reset_identity(&self) -> Result<Option<Arc<IdentityResetHandle>>, ClientError> {
-        if let Some(reset_handle) = self
-            .inner
-            .recovery()
-            .reset_identity()
-            .await
-            .map_err(|e| ClientError::Generic { msg: e.to_string() })?
+        if let Some(reset_handle) =
+            self.inner.recovery().reset_identity().await.map_err(ClientError::from_err)?
         {
             return Ok(Some(Arc::new(IdentityResetHandle { inner: reset_handle })));
         }
@@ -541,12 +537,9 @@ impl IdentityResetHandle {
     /// 4. Finally, re-enable key backups only if they were enabled before
     pub async fn reset(&self, auth: Option<AuthData>) -> Result<(), ClientError> {
         if let Some(auth) = auth {
-            self.inner
-                .reset(Some(auth.into()))
-                .await
-                .map_err(|e| ClientError::Generic { msg: e.to_string() })
+            self.inner.reset(Some(auth.into())).await.map_err(ClientError::from_err)
         } else {
-            self.inner.reset(None).await.map_err(|e| ClientError::Generic { msg: e.to_string() })
+            self.inner.reset(None).await.map_err(ClientError::from_err)
         }
     }
 

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -258,10 +258,10 @@ pub(crate) impl MediaSourceExt for RumaMediaSource {
     fn verify(&self) -> Result<(), ClientError> {
         match self {
             RumaMediaSource::Plain(url) => {
-                url.validate().map_err(|e| ClientError::Generic { msg: e.to_string() })?;
+                url.validate().map_err(ClientError::from_err)?;
             }
             RumaMediaSource::Encrypted(file) => {
-                file.url.validate().map_err(|e| ClientError::Generic { msg: e.to_string() })?;
+                file.url.validate().map_err(ClientError::from_err)?;
             }
         }
 

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -94,7 +94,7 @@ impl SessionVerificationController {
             .encryption
             .get_verification_request(&sender_id, flow_id)
             .await
-            .ok_or(ClientError::new("Unknown session verification request"))?;
+            .ok_or(ClientError::from_str("Unknown session verification request", None))?;
 
         self.set_ongoing_verification_request(verification_request)
     }
@@ -131,10 +131,10 @@ impl SessionVerificationController {
             .encryption
             .get_user_identity(&user_id)
             .await?
-            .ok_or(ClientError::new("Unknown user identity"))?;
+            .ok_or(ClientError::from_str("Unknown user identity", None))?;
 
         if user_identity.is_verified() {
-            return Err(ClientError::new("User is already verified"));
+            return Err(ClientError::from_str("User is already verified", None));
         }
 
         let methods = vec![VerificationMethod::SasV1];
@@ -153,7 +153,7 @@ impl SessionVerificationController {
         let verification_request = self.verification_request.read().unwrap().clone();
 
         let Some(verification_request) = verification_request else {
-            return Err(ClientError::new("Verification request missing."));
+            return Err(ClientError::from_str("Verification request missing.", None));
         };
 
         match verification_request.start_sas().await {
@@ -183,7 +183,7 @@ impl SessionVerificationController {
         let sas_verification = self.sas_verification.read().unwrap().clone();
 
         let Some(sas_verification) = sas_verification else {
-            return Err(ClientError::new("SAS verification missing"));
+            return Err(ClientError::from_str("SAS verification missing", None));
         };
 
         Ok(sas_verification.confirm().await?)
@@ -194,7 +194,7 @@ impl SessionVerificationController {
         let sas_verification = self.sas_verification.read().unwrap().clone();
 
         let Some(sas_verification) = sas_verification else {
-            return Err(ClientError::new("SAS verification missing"));
+            return Err(ClientError::from_str("SAS verification missing", None));
         };
 
         Ok(sas_verification.mismatch().await?)
@@ -205,7 +205,7 @@ impl SessionVerificationController {
         let verification_request = self.verification_request.read().unwrap().clone();
 
         let Some(verification_request) = verification_request else {
-            return Err(ClientError::new("Verification request missing."));
+            return Err(ClientError::from_str("Verification request missing.", None));
         };
 
         Ok(verification_request.cancel().await?)
@@ -285,7 +285,10 @@ impl SessionVerificationController {
             if !ongoing_verification_request.is_done()
                 && !ongoing_verification_request.is_cancelled()
             {
-                return Err(ClientError::new("There is another verification flow ongoing."));
+                return Err(ClientError::from_str(
+                    "There is another verification flow ongoing.",
+                    None,
+                ));
             }
         }
 


### PR DESCRIPTION
Also split `ClientError::new` into `ClientError::from_str` and `ClientError::from_err` so we can automatically get the details from the 2nd one.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
