### PR TITLE
refactor(base): Continue to extract response processors, take 4

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -616,7 +616,7 @@ impl BaseClient {
             let (raw_state_events, state_events) =
                 processors::state_events::sync::collect(&mut context, &new_info.state.events);
 
-            let mut new_user_ids = processors::state_events::dispatch_and_get_new_users(
+            let mut new_user_ids = processors::state_events::sync::dispatch_and_get_new_users(
                 &mut context,
                 (&raw_state_events, &state_events),
                 &mut room_info,
@@ -651,13 +651,14 @@ impl BaseClient {
                     &new_info.timeline.events,
                 );
 
-            let mut other_new_user_ids = processors::state_events::dispatch_and_get_new_users(
-                &mut context,
-                (&raw_state_events_from_timeline, &state_events_from_timeline),
-                &mut room_info,
-                &mut ambiguity_cache,
-            )
-            .await?;
+            let mut other_new_user_ids =
+                processors::state_events::sync::dispatch_and_get_new_users(
+                    &mut context,
+                    (&raw_state_events_from_timeline, &state_events_from_timeline),
+                    &mut room_info,
+                    &mut ambiguity_cache,
+                )
+                .await?;
             new_user_ids.append(&mut other_new_user_ids);
             updated_members_in_room.insert(room_id.to_owned(), new_user_ids.clone());
 
@@ -745,7 +746,7 @@ impl BaseClient {
             let (raw_state_events, state_events) =
                 processors::state_events::sync::collect(&mut context, &new_info.state.events);
 
-            let mut new_user_ids = processors::state_events::dispatch_and_get_new_users(
+            let mut new_user_ids = processors::state_events::sync::dispatch_and_get_new_users(
                 &mut context,
                 (&raw_state_events, &state_events),
                 &mut room_info,
@@ -759,13 +760,14 @@ impl BaseClient {
                     &new_info.timeline.events,
                 );
 
-            let mut other_new_user_ids = processors::state_events::dispatch_and_get_new_users(
-                &mut context,
-                (&raw_state_events_from_timeline, &state_events_from_timeline),
-                &mut room_info,
-                &mut ambiguity_cache,
-            )
-            .await?;
+            let mut other_new_user_ids =
+                processors::state_events::sync::dispatch_and_get_new_users(
+                    &mut context,
+                    (&raw_state_events_from_timeline, &state_events_from_timeline),
+                    &mut room_info,
+                    &mut ambiguity_cache,
+                )
+                .await?;
             new_user_ids.append(&mut other_new_user_ids);
 
             let timeline = processors::timeline::build(

--- a/crates/matrix-sdk-base/src/response_processors/ephemeral_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/ephemeral_events.rs
@@ -1,0 +1,50 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ruma::{events::AnySyncEphemeralRoomEvent, serde::Raw, RoomId};
+use tracing::info;
+
+use super::Context;
+
+/// Dispatch [`AnySyncEphemeralRoomEvent`]s on the [`Context`].
+pub fn dispatch(
+    context: &mut Context,
+    raw_events: &[Raw<AnySyncEphemeralRoomEvent>],
+    room_id: &RoomId,
+) {
+    for raw_event in raw_events {
+        dispatch_one(context, raw_event, room_id);
+    }
+}
+
+/// Dispatch a single [`AnySyncEphemeralRoomEvent`] on the [`Context`].
+pub fn dispatch_one(
+    context: &mut Context,
+    raw_event: &Raw<AnySyncEphemeralRoomEvent>,
+    room_id: &RoomId,
+) {
+    match raw_event.deserialize() {
+        Ok(AnySyncEphemeralRoomEvent::Receipt(event)) => {
+            context.state_changes.add_receipts(room_id, event.content);
+        }
+
+        Ok(_) => {}
+
+        Err(e) => {
+            let event_id = raw_event.get_field::<String>("event_id").ok().flatten();
+
+            info!(?room_id, event_id, "Failed to deserialize ephemeral room event: {e}");
+        }
+    }
+}

--- a/crates/matrix-sdk-base/src/response_processors/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/mod.rs
@@ -16,6 +16,7 @@ pub mod account_data;
 pub mod changes;
 #[cfg(feature = "e2e-encryption")]
 pub mod e2ee;
+pub mod ephemeral_events;
 #[cfg(feature = "e2e-encryption")]
 pub mod latest_event;
 pub mod profiles;

--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -62,11 +62,11 @@ pub mod sync {
         }))
     }
 
-    /// Dispatch the state events and return the new users for this room.
+    /// Dispatch the sync state events and return the new users for this room.
     ///
-    /// `raw_events` and `events` must be generated from [`collect_sync`].
+    /// `raw_events` and `events` must be generated from [`collect`].
     /// Events must be exactly the same list of events that are in
-    /// raw_events, but deserialised. We demand them here to avoid
+    /// `raw_events`, but deserialised. We demand them here to avoid
     /// deserialising multiple times.
     #[instrument(skip_all, fields(room_id = ?room_info.room_id))]
     pub async fn dispatch_and_get_new_users(
@@ -115,9 +115,20 @@ pub mod sync {
 
 /// Collect [`AnyStrippedStateEvent`].
 pub mod stripped {
-    use ruma::events::AnyStrippedStateEvent;
+    use std::{collections::BTreeMap, iter};
 
-    use super::{Context, Raw};
+    use ruma::{
+        events::AnyStrippedStateEvent,
+        push::{Action, Ruleset},
+        OwnedRoomId,
+    };
+    use tracing::instrument;
+
+    use super::{super::timeline, Context, Raw};
+    use crate::{
+        deserialized_responses::RawAnySyncOrStrippedTimelineEvent, store::BaseStateStore,
+        sync::Notification, Result, Room, RoomInfo,
+    };
 
     /// Collect [`AnyStrippedStateEvent`] to [`AnyStrippedStateEvent`].
     pub fn collect(
@@ -125,6 +136,74 @@ pub mod stripped {
         raw_events: &[Raw<AnyStrippedStateEvent>],
     ) -> (Vec<Raw<AnyStrippedStateEvent>>, Vec<AnyStrippedStateEvent>) {
         super::collect(raw_events)
+    }
+
+    /// Dispatch the stripped state events.
+    ///
+    /// `raw_events` and `events` must be generated from [`collect`].
+    /// Events must be exactly the same list of events that are in
+    /// `raw_events`, but deserialised. We demand them here to avoid
+    /// deserialising multiple times.
+    ///
+    /// Dispatch the stripped state events in `invite_state` or `knock_state`,
+    /// modifying the room's info and posting notifications as needed.
+    ///
+    /// * `raw_events` and `events` - The contents of `invite_state` in the form
+    ///   of list of pairs of raw stripped state events with their deserialized
+    ///   counterpart.
+    /// * `room` - The [`Room`] to modify.
+    /// * `room_info` - The current room's info.
+    /// * `push_rules` - The push rules for this room.
+    /// * `changes` - The accumulated list of changes to apply once the
+    ///   processing is finished.
+    /// * `notifications` - Notifications to post for the current room.
+    /// * `state_store` — The state store.
+    #[instrument(skip_all, fields(room_id = ?room_info.room_id))]
+    pub(crate) async fn dispatch_invite_or_knock(
+        context: &mut Context,
+        (raw_events, events): (&[Raw<AnyStrippedStateEvent>], &[AnyStrippedStateEvent]),
+        room: &Room,
+        room_info: &mut RoomInfo,
+        push_rules: &Ruleset,
+        notifications: &mut BTreeMap<OwnedRoomId, Vec<Notification>>,
+        state_store: &BaseStateStore,
+    ) -> Result<()> {
+        let mut state_events = BTreeMap::new();
+
+        for (raw_event, event) in iter::zip(raw_events, events) {
+            room_info.handle_stripped_state_event(event);
+            state_events
+                .entry(event.event_type())
+                .or_insert_with(BTreeMap::new)
+                .insert(event.state_key().to_owned(), raw_event.clone());
+        }
+
+        context
+            .state_changes
+            .stripped_state
+            .insert(room_info.room_id().to_owned(), state_events.clone());
+
+        // We need to check for notifications after we have handled all state
+        // events, to make sure we have the full push context.
+        if let Some(push_context) =
+            timeline::get_push_room_context(context, room, room_info, state_store).await?
+        {
+            // Check every event again for notification.
+            for event in state_events.values().flat_map(|map| map.values()) {
+                let actions = push_rules.get_actions(event, &push_context);
+
+                if actions.iter().any(Action::should_notify) {
+                    notifications.entry(room.room_id().to_owned()).or_default().push(
+                        Notification {
+                            actions: actions.to_owned(),
+                            event: RawAnySyncOrStrippedTimelineEvent::Stripped(event.clone()),
+                        },
+                    );
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -405,14 +405,15 @@ impl BaseClient {
         let push_rules = self.get_push_rules(global_account_data_processor).await?;
 
         // This will be used for both invited and knocked rooms.
-        if let Some(invite_state) = invite_state_events {
-            self.handle_invited_state(
+        if let Some((raw_events, events)) = invite_state_events {
+            processors::state_events::stripped::dispatch_invite_or_knock(
                 context,
+                (&raw_events, &events),
                 &room,
-                invite_state,
-                &push_rules,
                 &mut room_info,
+                &push_rules,
                 notifications,
+                &self.state_store,
             )
             .await?;
         }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -394,7 +394,7 @@ impl BaseClient {
         room_info.handle_encryption_state(requested_required_states);
 
         #[cfg_attr(not(feature = "e2e-encryption"), allow(unused))]
-        let new_user_ids = processors::state_events::dispatch_and_get_new_users(
+        let new_user_ids = processors::state_events::sync::dispatch_and_get_new_users(
             context,
             (&raw_state_events, &state_events),
             &mut room_info,


### PR DESCRIPTION
Sequel of https://github.com/matrix-org/matrix-rust-sdk/pull/4914.

This PR continues to refactor and clean up the response workflow as so-called response processors.

Each patch should be reviewed individually. There is nothing fancy, it's mostly code moves.

This time, we remove the last `handle_` method on `BaseClient`! And we create another set of response processors, `ephemeral_events`, which remove duplicated code.