### PR TITLE
refactor(base): Continue to extract response processors, take 5

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -621,12 +621,17 @@ impl BaseClient {
             )
             .await;
 
-            // `Self::handle_room_account_data` might have updated the `RoomInfo`. Let's
-            // fetch it again.
+            // `processors::account_data::from_room` might have updated the `RoomInfo`.
+            // Let's fetch it again.
             //
-            // SAFETY: `unwrap` is safe because the `RoomInfo` has been inserted 2 lines
+            // SAFETY: `expect` is safe because the `RoomInfo` has been inserted 2 lines
             // above.
-            let mut room_info = context.state_changes.room_infos.get(&room_id).unwrap().clone();
+            let mut room_info = context
+                .state_changes
+                .room_infos
+                .get(&room_id)
+                .expect("`RoomInfo` must exist in `StateChanges` at this point")
+                .clone();
 
             #[cfg(feature = "e2e-encryption")]
             processors::e2ee::tracked_users::update_or_set_if_room_is_newly_encrypted(

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -631,9 +631,11 @@ impl BaseClient {
                 (&raw_events, &events),
                 &room,
                 &mut room_info,
-                &push_rules,
-                &mut notifications,
-                &self.state_store,
+                processors::notification::Notification::new(
+                    &push_rules,
+                    &mut notifications,
+                    &self.state_store,
+                ),
             )
             .await?;
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -549,7 +549,7 @@ impl BaseClient {
                 self.room_info_notable_update_sender.clone(),
                 &mut ambiguity_cache,
                 &mut updated_members_in_room,
-                processors::timeline::builder::Notification::new(
+                processors::notification::Notification::new(
                     &push_rules,
                     &mut notifications,
                     &self.state_store,
@@ -575,7 +575,7 @@ impl BaseClient {
                 &self.state_store,
                 self.room_info_notable_update_sender.clone(),
                 &mut ambiguity_cache,
-                processors::timeline::builder::Notification::new(
+                processors::notification::Notification::new(
                     &push_rules,
                     &mut notifications,
                     &self.state_store,
@@ -599,7 +599,7 @@ impl BaseClient {
                 invited_room,
                 &self.state_store,
                 self.room_info_notable_update_sender.clone(),
-                processors::timeline::builder::Notification::new(
+                processors::notification::Notification::new(
                     &push_rules,
                     &mut notifications,
                     &self.state_store,
@@ -617,7 +617,7 @@ impl BaseClient {
                 knocked_room,
                 &self.state_store,
                 self.room_info_notable_update_sender.clone(),
-                processors::timeline::builder::Notification::new(
+                processors::notification::Notification::new(
                     &push_rules,
                     &mut notifications,
                     &self.state_store,

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -491,8 +491,7 @@ impl BaseClient {
         #[cfg(feature = "e2e-encryption")]
         let olm_machine = self.olm_machine().await;
 
-        let mut context =
-            Context::new(StateChanges::new(response.next_batch.clone()), Default::default());
+        let mut context = Context::new(StateChanges::new(response.next_batch.clone()));
 
         #[cfg(feature = "e2e-encryption")]
         let to_device = {
@@ -895,7 +894,7 @@ impl BaseClient {
         };
 
         let mut chunk = Vec::with_capacity(response.chunk.len());
-        let mut context = Context::new(StateChanges::default(), Default::default());
+        let mut context = Context::default();
 
         #[cfg(feature = "e2e-encryption")]
         let mut user_ids = BTreeSet::new();

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -47,7 +47,7 @@ use ruma::{
 use tokio::sync::{broadcast, Mutex};
 #[cfg(feature = "e2e-encryption")]
 use tokio::sync::{RwLock, RwLockReadGuard};
-use tracing::{debug, info, instrument};
+use tracing::{debug, enabled, info, instrument, Level};
 
 #[cfg(feature = "e2e-encryption")]
 use crate::RoomMemberships;
@@ -486,7 +486,7 @@ impl BaseClient {
             return Ok(SyncResponse::default());
         }
 
-        let now = Instant::now();
+        let now = if enabled!(Level::INFO) { Some(Instant::now()) } else { None };
 
         #[cfg(feature = "e2e-encryption")]
         let olm_machine = self.olm_machine().await;
@@ -849,7 +849,9 @@ impl BaseClient {
             }
         }
 
-        info!("Processed a sync response in {:?}", now.elapsed());
+        if enabled!(Level::INFO) {
+            info!("Processed a sync response in {:?}", now.map(|now| now.elapsed()));
+        }
 
         let response = SyncResponse {
             rooms: new_rooms,

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -512,9 +512,11 @@ impl BaseClient {
                     .flatten()
                     .filter_map(|room_key_info| self.get_room(&room_key_info.room_id))
                     .collect(),
-                olm_machine.as_ref(),
-                self.decryption_trust_requirement,
-                self.handle_verification_events,
+                processors::e2ee::E2EE::new(
+                    olm_machine.as_ref(),
+                    self.decryption_trust_requirement,
+                    self.handle_verification_events,
+                ),
             )
             .await?;
 

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -263,6 +263,18 @@ pub enum RawAnySyncOrStrippedTimelineEvent {
     Stripped(Raw<AnyStrippedStateEvent>),
 }
 
+impl From<Raw<AnySyncTimelineEvent>> for RawAnySyncOrStrippedTimelineEvent {
+    fn from(event: Raw<AnySyncTimelineEvent>) -> Self {
+        Self::Sync(event)
+    }
+}
+
+impl From<Raw<AnyStrippedStateEvent>> for RawAnySyncOrStrippedTimelineEvent {
+    fn from(event: Raw<AnyStrippedStateEvent>) -> Self {
+        Self::Stripped(event)
+    }
+}
+
 /// Wrapper around both versions of any raw state event.
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/mod.rs
@@ -12,6 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use matrix_sdk_crypto::{OlmMachine, TrustRequirement};
+
 pub mod decrypt;
 pub mod to_device;
 pub mod tracked_users;
+
+/// A classical set of data used by some processors in this module.
+#[derive(Clone)]
+pub struct E2EE<'a> {
+    pub olm_machine: Option<&'a OlmMachine>,
+    pub decryption_trust_requirement: TrustRequirement,
+    pub verification_is_allowed: bool,
+}
+
+impl<'a> E2EE<'a> {
+    pub fn new(
+        olm_machine: Option<&'a OlmMachine>,
+        decryption_trust_requirement: TrustRequirement,
+        verification_is_allowed: bool,
+    ) -> Self {
+        Self { olm_machine, decryption_trust_requirement, verification_is_allowed }
+    }
+}

--- a/crates/matrix-sdk-base/src/response_processors/latest_event.rs
+++ b/crates/matrix-sdk-base/src/response_processors/latest_event.rs
@@ -71,7 +71,7 @@ async fn find_suitable_and_decrypt(
         // async fn since it is likely that there aren't even any encrypted
         // events when calling it.
         let decrypt_sync_room_event =
-            Box::pin(decrypt_sync_room_event(context, event, &e2ee, room.room_id()));
+            Box::pin(decrypt_sync_room_event(context, event, e2ee, room.room_id()));
 
         if let Ok(decrypted) = decrypt_sync_room_event.await {
             // We found an event we can decrypt

--- a/crates/matrix-sdk-base/src/response_processors/latest_event.rs
+++ b/crates/matrix-sdk-base/src/response_processors/latest_event.rs
@@ -203,7 +203,7 @@ mod tests {
         assert!(room.latest_event().is_none());
 
         // When I tell it to do some decryption
-        let mut context = Context::new(StateChanges::default(), Default::default());
+        let mut context = Context::default();
 
         decrypt_from_rooms(
             &mut context,

--- a/crates/matrix-sdk-base/src/response_processors/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/mod.rs
@@ -34,17 +34,15 @@ use crate::{RoomInfoNotableUpdateReasons, StateChanges};
 type RoomInfoNotableUpdates = BTreeMap<OwnedRoomId, RoomInfoNotableUpdateReasons>;
 
 #[cfg_attr(test, derive(Clone))]
+#[derive(Default)]
 pub(crate) struct Context {
     pub(super) state_changes: StateChanges,
     pub(super) room_info_notable_updates: RoomInfoNotableUpdates,
 }
 
 impl Context {
-    pub fn new(
-        state_changes: StateChanges,
-        room_info_notable_updates: RoomInfoNotableUpdates,
-    ) -> Self {
-        Self { state_changes, room_info_notable_updates }
+    pub fn new(state_changes: StateChanges) -> Self {
+        Self { state_changes, room_info_notable_updates: Default::default() }
     }
 
     pub fn into_parts(self) -> (StateChanges, RoomInfoNotableUpdates) {

--- a/crates/matrix-sdk-base/src/response_processors/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/mod.rs
@@ -20,6 +20,7 @@ pub mod ephemeral_events;
 #[cfg(feature = "e2e-encryption")]
 pub mod latest_event;
 pub mod profiles;
+pub mod room;
 pub mod state_events;
 pub mod timeline;
 #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk-base/src/response_processors/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/mod.rs
@@ -19,6 +19,7 @@ pub mod e2ee;
 pub mod ephemeral_events;
 #[cfg(feature = "e2e-encryption")]
 pub mod latest_event;
+pub mod notification;
 pub mod profiles;
 pub mod room;
 pub mod state_events;

--- a/crates/matrix-sdk-base/src/response_processors/notification.rs
+++ b/crates/matrix-sdk-base/src/response_processors/notification.rs
@@ -1,0 +1,81 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use ruma::{
+    push::{Action, PushConditionRoomCtx, Ruleset},
+    serde::Raw,
+    OwnedRoomId, RoomId,
+};
+
+use crate::{
+    deserialized_responses::RawAnySyncOrStrippedTimelineEvent, store::BaseStateStore, sync,
+};
+
+/// A classical set of data used by some processors dealing with notifications
+/// and push rules.
+pub struct Notification<'a> {
+    pub push_rules: &'a Ruleset,
+    pub notifications: &'a mut BTreeMap<OwnedRoomId, Vec<sync::Notification>>,
+    pub state_store: &'a BaseStateStore,
+}
+
+impl<'a> Notification<'a> {
+    pub fn new(
+        push_rules: &'a Ruleset,
+        notifications: &'a mut BTreeMap<OwnedRoomId, Vec<sync::Notification>>,
+        state_store: &'a BaseStateStore,
+    ) -> Self {
+        Self { push_rules, notifications, state_store }
+    }
+
+    fn push_notification(
+        &mut self,
+        room_id: &RoomId,
+        actions: Vec<Action>,
+        event: RawAnySyncOrStrippedTimelineEvent,
+    ) {
+        self.notifications
+            .entry(room_id.to_owned())
+            .or_default()
+            .push(sync::Notification { actions, event });
+    }
+
+    /// Push a new [`sync::Notification`] in [`Self::notifications`] from
+    /// `event` if and only if `predicate` returns `true` for at least one of
+    /// the [`Action`]s associated to this event and this `push_context`
+    /// (based on `Self::push_rules`).
+    ///
+    /// This method returns the fetched [`Action`]s.
+    pub fn push_notification_from_event_if<E, P>(
+        &mut self,
+        room_id: &RoomId,
+        push_context: &PushConditionRoomCtx,
+        event: &Raw<E>,
+        predicate: P,
+    ) -> &[Action]
+    where
+        Raw<E>: Into<RawAnySyncOrStrippedTimelineEvent>,
+        P: Fn(&Action) -> bool,
+    {
+        let actions = self.push_rules.get_actions(event, push_context);
+
+        if actions.iter().any(predicate) {
+            self.push_notification(room_id, actions.to_owned(), event.clone().into());
+        }
+
+        actions
+    }
+}

--- a/crates/matrix-sdk-base/src/response_processors/room/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod sync_v2;

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -85,7 +85,7 @@ pub async fn update_joined_room(
     updated_members_in_room.insert(room_id.to_owned(), new_user_ids.clone());
 
     #[cfg(feature = "e2e-encryption")]
-    let olm_machine = e2ee.olm_machine.clone();
+    let olm_machine = e2ee.olm_machine;
 
     let timeline = timeline::build(
         context,

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -238,9 +238,7 @@ pub async fn update_invited_room(
         (&raw_events, &events),
         &room,
         &mut room_info,
-        notification.push_rules,
-        notification.notifications,
-        notification.state_store,
+        notification,
     )
     .await?;
 

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -22,7 +22,7 @@ use tokio::sync::broadcast::Sender;
 
 #[cfg(feature = "e2e-encryption")]
 use super::super::e2ee;
-use super::super::{account_data, ephemeral_events, state_events, timeline, Context};
+use super::super::{account_data, ephemeral_events, notification, state_events, timeline, Context};
 use crate::{
     store::{ambiguity_map::AmbiguityCache, BaseStateStore},
     sync::{InvitedRoomUpdate, JoinedRoomUpdate, KnockedRoomUpdate, LeftRoomUpdate},
@@ -40,7 +40,7 @@ pub async fn update_joined_room(
     room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
     ambiguity_cache: &mut AmbiguityCache,
     updated_members_in_room: &mut BTreeMap<OwnedRoomId, BTreeSet<OwnedUserId>>,
-    notification: timeline::builder::Notification<'_>,
+    notification: notification::Notification<'_>,
     #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'_>,
 ) -> Result<JoinedRoomUpdate> {
     let room =
@@ -152,7 +152,7 @@ pub async fn update_left_room(
     state_store: &BaseStateStore,
     room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
     ambiguity_cache: &mut AmbiguityCache,
-    notification: timeline::builder::Notification<'_>,
+    notification: notification::Notification<'_>,
     #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'_>,
 ) -> Result<LeftRoomUpdate> {
     let room =
@@ -218,7 +218,7 @@ pub async fn update_invited_room(
     invited_room: InvitedRoom,
     state_store: &BaseStateStore,
     room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
-    notification: timeline::builder::Notification<'_>,
+    notification: notification::Notification<'_>,
 ) -> Result<InvitedRoomUpdate> {
     let room = state_store.get_or_create_room(
         room_id,
@@ -254,7 +254,7 @@ pub async fn update_knocked_room(
     knocked_room: KnockedRoom,
     state_store: &BaseStateStore,
     room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
-    notification: timeline::builder::Notification<'_>,
+    notification: notification::Notification<'_>,
 ) -> Result<KnockedRoomUpdate> {
     let room = state_store.get_or_create_room(
         room_id,

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -1,0 +1,140 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use ruma::{api::client::sync::sync_events::v3::JoinedRoom, OwnedRoomId, OwnedUserId, RoomId};
+use tokio::sync::broadcast::Sender;
+
+#[cfg(feature = "e2e-encryption")]
+use super::super::e2ee;
+use super::super::{account_data, ephemeral_events, state_events, timeline, Context};
+use crate::{
+    store::{ambiguity_map::AmbiguityCache, BaseStateStore},
+    sync::JoinedRoomUpdate,
+    RequestedRequiredStates, Result, RoomInfoNotableUpdate, RoomState,
+};
+
+/// Process updates of a joined room.
+#[allow(clippy::too_many_arguments)]
+pub async fn update_joined_room(
+    context: &mut Context,
+    room_id: &RoomId,
+    joined_room: JoinedRoom,
+    requested_required_states: &RequestedRequiredStates,
+    state_store: &BaseStateStore,
+    room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
+    ambiguity_cache: &mut AmbiguityCache,
+    updated_members_in_room: &mut BTreeMap<OwnedRoomId, BTreeSet<OwnedUserId>>,
+    notification: timeline::builder::Notification<'_>,
+    #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'_>,
+) -> Result<JoinedRoomUpdate> {
+    let room =
+        state_store.get_or_create_room(room_id, RoomState::Joined, room_info_notable_update_sender);
+
+    let mut room_info = room.clone_info();
+
+    room_info.mark_as_joined();
+    room_info.update_from_ruma_summary(&joined_room.summary);
+    room_info.set_prev_batch(joined_room.timeline.prev_batch.as_deref());
+    room_info.mark_state_fully_synced();
+    room_info.handle_encryption_state(requested_required_states.for_room(room_id));
+
+    let (raw_state_events, state_events) =
+        state_events::sync::collect(context, &joined_room.state.events);
+
+    let mut new_user_ids = state_events::sync::dispatch_and_get_new_users(
+        context,
+        (&raw_state_events, &state_events),
+        &mut room_info,
+        ambiguity_cache,
+    )
+    .await?;
+
+    ephemeral_events::dispatch(context, &joined_room.ephemeral.events, room_id);
+
+    if joined_room.timeline.limited {
+        room_info.mark_members_missing();
+    }
+
+    let (raw_state_events_from_timeline, state_events_from_timeline) =
+        state_events::sync::collect_from_timeline(context, &joined_room.timeline.events);
+
+    let mut other_new_user_ids = state_events::sync::dispatch_and_get_new_users(
+        context,
+        (&raw_state_events_from_timeline, &state_events_from_timeline),
+        &mut room_info,
+        ambiguity_cache,
+    )
+    .await?;
+    new_user_ids.append(&mut other_new_user_ids);
+    updated_members_in_room.insert(room_id.to_owned(), new_user_ids.clone());
+
+    #[cfg(feature = "e2e-encryption")]
+    let olm_machine = e2ee.olm_machine.clone();
+
+    let timeline = timeline::build(
+        context,
+        &room,
+        &mut room_info,
+        timeline::builder::Timeline::from(joined_room.timeline),
+        notification,
+        #[cfg(feature = "e2e-encryption")]
+        e2ee,
+    )
+    .await?;
+
+    // Save the new `RoomInfo`.
+    context.state_changes.add_room(room_info);
+
+    account_data::for_room(context, room_id, &joined_room.account_data.events, state_store).await;
+
+    // `processors::account_data::from_room` might have updated the `RoomInfo`.
+    // Let's fetch it again.
+    //
+    // SAFETY: `expect` is safe because the `RoomInfo` has been inserted 2 lines
+    // above.
+    let mut room_info = context
+        .state_changes
+        .room_infos
+        .get(room_id)
+        .expect("`RoomInfo` must exist in `StateChanges` at this point")
+        .clone();
+
+    #[cfg(feature = "e2e-encryption")]
+    e2ee::tracked_users::update_or_set_if_room_is_newly_encrypted(
+        context,
+        olm_machine,
+        &new_user_ids,
+        room_info.encryption_state(),
+        room.encryption_state(),
+        room_id,
+        state_store,
+    )
+    .await?;
+
+    let notification_count = joined_room.unread_notifications.into();
+    room_info.update_notification_count(notification_count);
+
+    context.state_changes.add_room(room_info);
+
+    Ok(JoinedRoomUpdate::new(
+        timeline,
+        joined_room.state.events,
+        joined_room.account_data.events,
+        joined_room.ephemeral.events,
+        notification_count,
+        ambiguity_cache.changes.remove(room_id).unwrap_or_default(),
+    ))
+}

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -101,11 +101,9 @@ pub async fn build<'notification, 'e2ee>(
                                 if let Some(decrypted_timeline_event) =
                                     Box::pin(e2ee::decrypt::sync_timeline_event(
                                         context,
-                                        e2ee.olm_machine,
+                                        e2ee.clone(),
                                         timeline_event.raw(),
                                         room_id,
-                                        e2ee.decryption_trust_requirement,
-                                        e2ee.verification_is_allowed,
                                     ))
                                     .await?
                                 {
@@ -117,8 +115,7 @@ pub async fn build<'notification, 'e2ee>(
                                 Box::pin(verification::process_if_relevant(
                                     context,
                                     &sync_timeline_event,
-                                    e2ee.verification_is_allowed,
-                                    e2ee.olm_machine,
+                                    e2ee.clone(),
                                     room_id,
                                 ))
                                 .await?;
@@ -180,8 +177,6 @@ pub async fn build<'notification, 'e2ee>(
 pub mod builder {
     use std::collections::BTreeMap;
 
-    #[cfg(feature = "e2e-encryption")]
-    use matrix_sdk_crypto::{OlmMachine, TrustRequirement};
     use ruma::{
         api::client::sync::sync_events::{v3, v5},
         events::AnySyncTimelineEvent,
@@ -231,22 +226,7 @@ pub mod builder {
     }
 
     #[cfg(feature = "e2e-encryption")]
-    pub struct E2EE<'a> {
-        pub olm_machine: Option<&'a OlmMachine>,
-        pub decryption_trust_requirement: TrustRequirement,
-        pub verification_is_allowed: bool,
-    }
-
-    #[cfg(feature = "e2e-encryption")]
-    impl<'a> E2EE<'a> {
-        pub fn new(
-            olm_machine: Option<&'a OlmMachine>,
-            decryption_trust_requirement: TrustRequirement,
-            verification_is_allowed: bool,
-        ) -> Self {
-            Self { olm_machine, decryption_trust_requirement, verification_is_allowed }
-        }
-    }
+    pub use super::super::e2ee::E2EE;
 }
 
 /// Update the push context for the given room.

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -175,17 +175,11 @@ pub async fn build<'notification, 'e2ee>(
 /// Set of types used by [`build`] to reduce the number of arguments by grouping
 /// them by thematics.
 pub mod builder {
-    use std::collections::BTreeMap;
-
     use ruma::{
         api::client::sync::sync_events::{v3, v5},
         events::AnySyncTimelineEvent,
-        push::Ruleset,
         serde::Raw,
-        OwnedRoomId,
     };
-
-    use crate::{store::BaseStateStore, sync};
 
     pub struct Timeline {
         pub limited: bool,
@@ -209,24 +203,9 @@ pub mod builder {
         }
     }
 
-    pub struct Notification<'a> {
-        pub push_rules: &'a Ruleset,
-        pub notifications: &'a mut BTreeMap<OwnedRoomId, Vec<sync::Notification>>,
-        pub state_store: &'a BaseStateStore,
-    }
-
-    impl<'a> Notification<'a> {
-        pub fn new(
-            push_rules: &'a Ruleset,
-            notifications: &'a mut BTreeMap<OwnedRoomId, Vec<sync::Notification>>,
-            state_store: &'a BaseStateStore,
-        ) -> Self {
-            Self { push_rules, notifications, state_store }
-        }
-    }
-
     #[cfg(feature = "e2e-encryption")]
     pub use super::super::e2ee::E2EE;
+    pub use super::super::notification::Notification;
 }
 
 /// Update the push context for the given room.

--- a/crates/matrix-sdk-base/src/response_processors/verification.rs
+++ b/crates/matrix-sdk-base/src/response_processors/verification.rs
@@ -21,7 +21,7 @@ use ruma::{
     RoomId,
 };
 
-use super::Context;
+use super::{e2ee::E2EE, Context};
 use crate::Result;
 
 /// Process the given event as a verification event if it is a candidate. The
@@ -29,8 +29,7 @@ use crate::Result;
 pub async fn process_if_relevant(
     context: &mut Context,
     event: &AnySyncTimelineEvent,
-    verification_is_allowed: bool,
-    olm_machine: Option<&OlmMachine>,
+    e2ee: E2EE<'_>,
     room_id: &RoomId,
 ) -> Result<()> {
     if let AnySyncTimelineEvent::MessageLike(event) = event {
@@ -58,7 +57,8 @@ pub async fn process_if_relevant(
 
             _ => false,
         } {
-            verification(context, verification_is_allowed, olm_machine, event, room_id).await?;
+            verification(context, e2ee.verification_is_allowed, e2ee.olm_machine, event, room_id)
+                .await?;
         }
     }
 

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -2579,7 +2579,7 @@ mod tests {
         .cast();
 
         // When the new tag is handled and applied.
-        let mut context = processors::Context::new(StateChanges::default(), Default::default());
+        let mut context = processors::Context::default();
 
         processors::account_data::for_room(&mut context, room_id, &[tag_raw], &client.state_store)
             .await;
@@ -2675,7 +2675,7 @@ mod tests {
         .cast();
 
         // When the new tag is handled and applied.
-        let mut context = processors::Context::new(StateChanges::default(), Default::default());
+        let mut context = processors::Context::default();
 
         processors::account_data::for_room(&mut context, room_id, &[tag_raw], &client.state_store)
             .await;
@@ -3261,7 +3261,7 @@ mod tests {
         // And I provide a decrypted event to replace the encrypted one,
         let event = make_latest_event("$A");
 
-        let mut context = processors::Context::new(StateChanges::default(), Default::default());
+        let mut context = processors::Context::default();
         room.on_latest_event_decrypted(
             event.clone(),
             0,

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -405,9 +405,11 @@ impl BaseClient {
                 (&raw_events, &events),
                 &room,
                 &mut room_info,
-                &push_rules,
-                notifications,
-                &self.state_store,
+                processors::notification::Notification::new(
+                    &push_rules,
+                    notifications,
+                    &self.state_store,
+                ),
             )
             .await?;
         }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -421,13 +421,13 @@ impl BaseClient {
             &room,
             &mut room_info,
             processors::timeline::builder::Timeline::from(room_data),
-            processors::timeline::builder::Notification::new(
+            processors::notification::Notification::new(
                 &push_rules,
                 notifications,
                 &self.state_store,
             ),
             #[cfg(feature = "e2e-encryption")]
-            processors::timeline::builder::E2EE::new(
+            processors::e2ee::E2EE::new(
                 self.olm_machine().await.as_ref(),
                 self.decryption_trust_requirement,
                 self.handle_verification_events,

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -82,7 +82,7 @@ impl BaseClient {
 
         let olm_machine = self.olm_machine().await;
 
-        let mut context = processors::Context::new(StateChanges::default(), Default::default());
+        let mut context = processors::Context::default();
 
         let processors::e2ee::to_device::Output { decrypted_to_device_events, room_key_updates } =
             processors::e2ee::to_device::from_msc4186(
@@ -157,7 +157,7 @@ impl BaseClient {
             return Ok(SyncResponse::default());
         };
 
-        let mut context = processors::Context::new(StateChanges::default(), Default::default());
+        let mut context = processors::Context::default();
 
         let state_store = self.state_store.clone();
         let mut ambiguity_cache = AmbiguityCache::new(state_store.inner.clone());

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -17,11 +17,11 @@
 use std::{collections::BTreeMap, fmt};
 
 use matrix_sdk_common::{debug::DebugRawEvent, deserialized_responses::TimelineEvent};
+pub use ruma::api::client::sync::sync_events::v3::{
+    InvitedRoom as InvitedRoomUpdate, KnockedRoom as KnockedRoomUpdate,
+};
 use ruma::{
-    api::client::sync::sync_events::{
-        v3::{InvitedRoom as InvitedRoomUpdate, KnockedRoom as KnockedRoomUpdate},
-        UnreadNotificationsCount as RumaUnreadNotificationsCount,
-    },
+    api::client::sync::sync_events::UnreadNotificationsCount as RumaUnreadNotificationsCount,
     events::{
         presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
         AnySyncEphemeralRoomEvent, AnySyncStateEvent, AnyToDeviceEvent,


### PR DESCRIPTION
Sequel of https://github.com/matrix-org/matrix-rust-sdk/pull/4925.

This PR continues to refactor and clean up the response workflow as so-called response processors.

Each patch should be reviewed individually. There is nothing fancy, it's mostly code moves.

This time, the sync v2 (`BaseClient::receive_sync_response`) is now fully using response processors. This PR introduces the new `rooms::sync_v2::update_(joined|left|invited|knocked)_room` processors! It also removes duplicated code around push notifications by improving the `notification::Notification` type.