### PR TITLE
fix(sdk): Remove `include_heroes` in sliding sync requests

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -780,8 +780,7 @@ fn process_room_properties(
     }
 
     // Sliding sync doesn't have a room summary, nevertheless it contains the joined
-    // and invited member counts, in addition to the heroes if it's been configured
-    // to return them (see the [`http::RequestRoomSubscription::include_heroes`]).
+    // and invited member counts, in addition to the heroes.
     if let Some(count) = room_data.joined_count {
         room_info.update_joined_member_count(count.into());
     }

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -161,7 +161,6 @@ impl RoomListService {
                             .map(|(state_event, value)| (state_event.clone(), (*value).to_owned()))
                             .collect(),
                     )
-                    .include_heroes(Some(true))
                     .filters(Some(assign!(http::request::ListFilters::default(), {
                         // As defined in the [SlidingSync MSC](https://github.com/matrix-org/matrix-spec-proposals/blob/9450ced7fb9cf5ea9077d029b3adf36aebfa8709/proposals/3575-sync.md?plain=1#L444)
                         // If unset, both invited and joined rooms are returned. If false, no invited rooms are

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -368,7 +368,6 @@ async fn test_sync_all_states() -> Result<(), Error> {
                         ["m.room.history_visibility", ""],
                         ["io.element.functional_members", ""],
                     ],
-                    "include_heroes": true,
                     "filters": {
                         "not_room_types": ["m.space"],
                     },

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -34,7 +34,6 @@ struct SlidingSyncListCachedData {
 pub struct SlidingSyncListBuilder {
     sync_mode: SlidingSyncMode,
     required_state: Vec<(StateEventType, String)>,
-    include_heroes: Option<bool>,
     filters: Option<http::request::ListFilters>,
     timeline_limit: Bound,
     pub(crate) name: String,
@@ -57,7 +56,6 @@ impl fmt::Debug for SlidingSyncListBuilder {
             .debug_struct("SlidingSyncListBuilder")
             .field("sync_mode", &self.sync_mode)
             .field("required_state", &self.required_state)
-            .field("include_heroes", &self.include_heroes)
             .field("filters", &self.filters)
             .field("timeline_limit", &self.timeline_limit)
             .field("name", &self.name)
@@ -73,7 +71,6 @@ impl SlidingSyncListBuilder {
                 (StateEventType::RoomEncryption, "".to_owned()),
                 (StateEventType::RoomTombstone, "".to_owned()),
             ],
-            include_heroes: None,
             filters: None,
             timeline_limit: 1,
             name: name.into(),
@@ -105,12 +102,6 @@ impl SlidingSyncListBuilder {
     /// Required states to return per room.
     pub fn required_state(mut self, value: Vec<(StateEventType, String)>) -> Self {
         self.required_state = value;
-        self
-    }
-
-    /// Include heroes.
-    pub fn include_heroes(mut self, value: Option<bool>) -> Self {
-        self.include_heroes = value;
         self
     }
 
@@ -172,11 +163,7 @@ impl SlidingSyncListBuilder {
 
                 // From the builder
                 sticky: StdRwLock::new(SlidingSyncStickyManager::new(
-                    SlidingSyncListStickyParameters::new(
-                        self.required_state,
-                        self.include_heroes,
-                        self.filters,
-                    ),
+                    SlidingSyncListStickyParameters::new(self.required_state, self.filters),
                 )),
                 timeline_limit: StdRwLock::new(self.timeline_limit),
                 name: self.name,

--- a/crates/matrix-sdk/src/sliding_sync/list/sticky.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/sticky.rs
@@ -9,10 +9,6 @@ pub(super) struct SlidingSyncListStickyParameters {
     /// Required states to return per room.
     required_state: Vec<(StateEventType, String)>,
 
-    /// Return a stripped variant of membership events for the users used to
-    /// calculate the room name.
-    include_heroes: Option<bool>,
-
     /// Any filters to apply to the query.
     filters: Option<http::request::ListFilters>,
 }
@@ -20,12 +16,11 @@ pub(super) struct SlidingSyncListStickyParameters {
 impl SlidingSyncListStickyParameters {
     pub fn new(
         required_state: Vec<(StateEventType, String)>,
-        include_heroes: Option<bool>,
         filters: Option<http::request::ListFilters>,
     ) -> Self {
         // Consider that each list will have at least one parameter set, so invalidate
         // it by default.
-        Self { required_state, include_heroes, filters }
+        Self { required_state, filters }
     }
 }
 
@@ -34,7 +29,6 @@ impl StickyData for SlidingSyncListStickyParameters {
 
     fn apply(&self, request: &mut Self::Request) {
         request.room_details.required_state = self.required_state.to_vec();
-        request.include_heroes = self.include_heroes;
         request.filters = self.filters.clone();
     }
 }


### PR DESCRIPTION
This patch removes all mentions of `include_heroes`. This field isn't part of the MSC4186. We have the `test_compute_heroes_from_sliding_sync` which continues to pass, everything fine on that side. There is no mention of `include_heroes` in Synapse at the time of writing. It seems to be an artifact from the sliding sync proxy experiment.

---

* Related to https://github.com/ruma/ruma/pull/2058