### PR TITLE
refactor(base): Continue to extract response processors, take 6

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -542,11 +542,13 @@ impl BaseClient {
         for (room_id, joined_room) in response.rooms.join {
             let joined_room_update = processors::room::sync_v2::update_joined_room(
                 &mut context,
-                &room_id,
+                processors::room::Room::new(
+                    &room_id,
+                    self.room_info_notable_update_sender.clone(),
+                    requested_required_states,
+                    &mut ambiguity_cache,
+                ),
                 joined_room,
-                requested_required_states,
-                self.room_info_notable_update_sender.clone(),
-                &mut ambiguity_cache,
                 &mut updated_members_in_room,
                 processors::notification::Notification::new(
                     &push_rules,
@@ -568,11 +570,13 @@ impl BaseClient {
         for (room_id, left_room) in response.rooms.leave {
             let left_room_update = processors::room::sync_v2::update_left_room(
                 &mut context,
-                &room_id,
+                processors::room::Room::new(
+                    &room_id,
+                    self.room_info_notable_update_sender.clone(),
+                    requested_required_states,
+                    &mut ambiguity_cache,
+                ),
                 left_room,
-                requested_required_states,
-                self.room_info_notable_update_sender.clone(),
-                &mut ambiguity_cache,
                 processors::notification::Notification::new(
                     &push_rules,
                     &mut notifications,

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -542,7 +542,7 @@ impl BaseClient {
         for (room_id, joined_room) in response.rooms.join {
             let joined_room_update = processors::room::sync_v2::update_joined_room(
                 &mut context,
-                processors::room::Room::new(
+                processors::room::RoomCreationData::new(
                     &room_id,
                     self.room_info_notable_update_sender.clone(),
                     requested_required_states,
@@ -570,7 +570,7 @@ impl BaseClient {
         for (room_id, left_room) in response.rooms.leave {
             let left_room_update = processors::room::sync_v2::update_left_room(
                 &mut context,
-                processors::room::Room::new(
+                processors::room::RoomCreationData::new(
                     &room_id,
                     self.room_info_notable_update_sender.clone(),
                     requested_required_states,

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -545,7 +545,6 @@ impl BaseClient {
                 &room_id,
                 joined_room,
                 requested_required_states,
-                &self.state_store,
                 self.room_info_notable_update_sender.clone(),
                 &mut ambiguity_cache,
                 &mut updated_members_in_room,
@@ -572,7 +571,6 @@ impl BaseClient {
                 &room_id,
                 left_room,
                 requested_required_states,
-                &self.state_store,
                 self.room_info_notable_update_sender.clone(),
                 &mut ambiguity_cache,
                 processors::notification::Notification::new(
@@ -597,7 +595,6 @@ impl BaseClient {
                 &mut context,
                 &room_id,
                 invited_room,
-                &self.state_store,
                 self.room_info_notable_update_sender.clone(),
                 processors::notification::Notification::new(
                     &push_rules,
@@ -615,7 +612,6 @@ impl BaseClient {
                 &mut context,
                 &room_id,
                 knocked_room,
-                &self.state_store,
                 self.room_info_notable_update_sender.clone(),
                 processors::notification::Notification::new(
                     &push_rules,

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -563,7 +563,7 @@ impl BaseClient {
             )
             .await?;
 
-            new_rooms.join.insert(room_id, joined_room_update);
+            new_rooms.joined.insert(room_id, joined_room_update);
         }
 
         for (room_id, left_room) in response.rooms.leave {
@@ -589,7 +589,7 @@ impl BaseClient {
             )
             .await?;
 
-            new_rooms.leave.insert(room_id, left_room_update);
+            new_rooms.left.insert(room_id, left_room_update);
         }
 
         for (room_id, invited_room) in response.rooms.invite {
@@ -607,7 +607,7 @@ impl BaseClient {
             )
             .await?;
 
-            new_rooms.invite.insert(room_id, invited_room_update);
+            new_rooms.invited.insert(room_id, invited_room_update);
         }
 
         for (room_id, knocked_room) in response.rooms.knock {

--- a/crates/matrix-sdk-base/src/response_processors/ephemeral_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/ephemeral_events.rs
@@ -24,12 +24,12 @@ pub fn dispatch(
     room_id: &RoomId,
 ) {
     for raw_event in raw_events {
-        dispatch_one(context, raw_event, room_id);
+        dispatch_receipt(context, raw_event, room_id);
     }
 }
 
-/// Dispatch a single [`AnySyncEphemeralRoomEvent`] on the [`Context`].
-pub fn dispatch_one(
+/// Dispatch the [`AnySyncEphemeralRoomEvent::Receipt`] on the [`Context`].
+pub(super) fn dispatch_receipt(
     context: &mut Context,
     raw_event: &Raw<AnySyncEphemeralRoomEvent>,
     room_id: &RoomId,

--- a/crates/matrix-sdk-base/src/response_processors/room/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/mod.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod msc4186;
 pub mod sync_v2;

--- a/crates/matrix-sdk-base/src/response_processors/room/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/mod.rs
@@ -21,14 +21,14 @@ pub mod msc4186;
 pub mod sync_v2;
 
 /// A classical set of data used by some processors in this module.
-pub struct Room<'a> {
+pub struct RoomCreationData<'a> {
     room_id: &'a RoomId,
     room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
     requested_required_states: &'a RequestedRequiredStates,
     ambiguity_cache: &'a mut AmbiguityCache,
 }
 
-impl<'a> Room<'a> {
+impl<'a> RoomCreationData<'a> {
     pub fn new(
         room_id: &'a RoomId,
         room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,

--- a/crates/matrix-sdk-base/src/response_processors/room/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/mod.rs
@@ -12,5 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use ruma::RoomId;
+use tokio::sync::broadcast::Sender;
+
+use crate::{store::ambiguity_map::AmbiguityCache, RequestedRequiredStates, RoomInfoNotableUpdate};
+
 pub mod msc4186;
 pub mod sync_v2;
+
+/// A classical set of data used by some processors in this module.
+pub struct Room<'a> {
+    room_id: &'a RoomId,
+    room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
+    requested_required_states: &'a RequestedRequiredStates,
+    ambiguity_cache: &'a mut AmbiguityCache,
+}
+
+impl<'a> Room<'a> {
+    pub fn new(
+        room_id: &'a RoomId,
+        room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
+        requested_required_states: &'a RequestedRequiredStates,
+        ambiguity_cache: &'a mut AmbiguityCache,
+    ) -> Self {
+        Self {
+            room_id,
+            room_info_notable_update_sender,
+            requested_required_states,
+            ambiguity_cache,
+        }
+    }
+}

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186.rs
@@ -1,0 +1,529 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use matrix_sdk_common::deserialized_responses::TimelineEvent;
+use ruma::{
+    api::client::sync::sync_events::{
+        v3::{InviteState, InvitedRoom, KnockState, KnockedRoom},
+        v5 as http,
+    },
+    assign,
+    events::{
+        room::member::MembershipState, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
+        AnySyncStateEvent, StateEventType,
+    },
+    serde::Raw,
+    JsOption, OwnedRoomId, RoomId, UserId,
+};
+use tokio::sync::broadcast::Sender;
+
+#[cfg(feature = "e2e-encryption")]
+use super::super::e2ee;
+use super::super::{notification, state_events, timeline, Context};
+use crate::{
+    store::{ambiguity_map::AmbiguityCache, BaseStateStore},
+    sync::{InvitedRoomUpdate, JoinedRoomUpdate, KnockedRoomUpdate, LeftRoomUpdate},
+    Result, Room, RoomHero, RoomInfo, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons,
+    RoomState, SessionMeta, StateChanges,
+};
+
+#[allow(clippy::too_many_arguments)]
+pub async fn update_any_room(
+    context: &mut Context,
+    user_id: &UserId,
+    room_id: &RoomId,
+    requested_required_states: &[(StateEventType, String)],
+    room_data: &http::response::Room,
+    room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
+    rooms_account_data: &mut BTreeMap<OwnedRoomId, Vec<Raw<AnyRoomAccountDataEvent>>>,
+    #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'_>,
+    mut notification: notification::Notification<'_>,
+    ambiguity_cache: &mut AmbiguityCache,
+    session_meta: Option<&SessionMeta>,
+) -> Result<(
+    RoomInfo,
+    Option<JoinedRoomUpdate>,
+    Option<LeftRoomUpdate>,
+    Option<InvitedRoomUpdate>,
+    Option<KnockedRoomUpdate>,
+)> {
+    // Read state events from the `required_state` field.
+    //
+    // Don't read state events from the `timeline` field, because they might be
+    // incomplete or staled already. We must only read state events from
+    // `required_state`.
+    let (raw_state_events, state_events) =
+        state_events::sync::collect(context, &room_data.required_state);
+
+    let state_store = notification.state_store;
+
+    // Find or create the room in the store
+    let is_new_room = !state_store.room_exists(room_id);
+
+    let invite_state_events = room_data
+        .invite_state
+        .as_ref()
+        .map(|events| state_events::stripped::collect(context, events));
+
+    #[allow(unused_mut)] // Required for some feature flag combinations
+    let (mut room, mut room_info, invited_room, knocked_room) = membership(
+        context,
+        &state_events,
+        &invite_state_events,
+        state_store,
+        user_id,
+        room_id,
+        room_info_notable_update_sender,
+        session_meta,
+    );
+
+    room_info.mark_state_partially_synced();
+    room_info.handle_encryption_state(requested_required_states);
+
+    #[cfg_attr(not(feature = "e2e-encryption"), allow(unused))]
+    let new_user_ids = state_events::sync::dispatch_and_get_new_users(
+        context,
+        (&raw_state_events, &state_events),
+        &mut room_info,
+        ambiguity_cache,
+    )
+    .await?;
+
+    // This will be used for both invited and knocked rooms.
+    if let Some((raw_events, events)) = invite_state_events {
+        state_events::stripped::dispatch_invite_or_knock(
+            context,
+            (&raw_events, &events),
+            &room,
+            &mut room_info,
+            notification::Notification::new(
+                &notification.push_rules,
+                &mut notification.notifications,
+                &notification.state_store,
+            ),
+        )
+        .await?;
+    }
+
+    properties(context, room_id, room_data, &mut room_info, is_new_room);
+
+    let timeline = timeline::build(
+        context,
+        &room,
+        &mut room_info,
+        timeline::builder::Timeline::from(room_data),
+        notification,
+        #[cfg(feature = "e2e-encryption")]
+        e2ee.clone(),
+    )
+    .await?;
+
+    // Cache the latest decrypted event in room_info, and also keep any later
+    // encrypted events, so we can slot them in when we get the keys.
+    #[cfg(feature = "e2e-encryption")]
+    cache_latest_events(
+        &room,
+        &mut room_info,
+        &timeline.events,
+        Some(&context.state_changes),
+        Some(state_store),
+    )
+    .await;
+
+    #[cfg(feature = "e2e-encryption")]
+    e2ee::tracked_users::update_or_set_if_room_is_newly_encrypted(
+        context,
+        e2ee.olm_machine.clone(),
+        &new_user_ids,
+        room_info.encryption_state(),
+        room.encryption_state(),
+        room_id,
+        state_store,
+    )
+    .await?;
+
+    let notification_count = room_data.unread_notifications.clone().into();
+    room_info.update_notification_count(notification_count);
+
+    let ambiguity_changes = ambiguity_cache.changes.remove(room_id).unwrap_or_default();
+    let room_account_data = rooms_account_data.get(room_id).cloned();
+
+    match room_info.state() {
+        RoomState::Joined => {
+            // Ephemeral events are added separately, because we might not
+            // have a room subsection in the response, yet we may have receipts for
+            // that room.
+            let ephemeral = Vec::new();
+
+            Ok((
+                room_info,
+                Some(JoinedRoomUpdate::new(
+                    timeline,
+                    raw_state_events,
+                    room_account_data.unwrap_or_default(),
+                    ephemeral,
+                    notification_count,
+                    ambiguity_changes,
+                )),
+                None,
+                None,
+                None,
+            ))
+        }
+
+        RoomState::Left | RoomState::Banned => Ok((
+            room_info,
+            None,
+            Some(LeftRoomUpdate::new(
+                timeline,
+                raw_state_events,
+                room_account_data.unwrap_or_default(),
+                ambiguity_changes,
+            )),
+            None,
+            None,
+        )),
+
+        RoomState::Invited => Ok((room_info, None, None, invited_room, None)),
+
+        RoomState::Knocked => Ok((room_info, None, None, None, knocked_room)),
+    }
+}
+
+/// Look through the sliding sync data for this room, find/create it in the
+/// store, and process any invite information.
+/// If any invite state events exist, we take it to mean that we are invited to
+/// this room, unless that state contains membership events that specify
+/// otherwise. https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md#room-list-parameters
+fn membership(
+    context: &mut Context,
+    state_events: &[AnySyncStateEvent],
+    invite_state_events: &Option<(Vec<Raw<AnyStrippedStateEvent>>, Vec<AnyStrippedStateEvent>)>,
+    store: &BaseStateStore,
+    user_id: &UserId,
+    room_id: &RoomId,
+    room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
+    session_meta: Option<&SessionMeta>,
+) -> (Room, RoomInfo, Option<InvitedRoomUpdate>, Option<KnockedRoomUpdate>) {
+    if let Some(state_events) = invite_state_events {
+        let room =
+            store.get_or_create_room(room_id, RoomState::Invited, room_info_notable_update_sender);
+        let mut room_info = room.clone_info();
+
+        // We need to find the membership event since it could be for either an invited
+        // or knocked room
+        let membership_event_content = state_events.1.iter().find_map(|event| {
+            if let AnyStrippedStateEvent::RoomMember(membership_event) = event {
+                if membership_event.state_key == user_id {
+                    return Some(membership_event.content.clone());
+                }
+            }
+            None
+        });
+
+        if let Some(membership_event_content) = membership_event_content {
+            if membership_event_content.membership == MembershipState::Knock {
+                // If we have a `Knock` membership state, set the room as such
+                room_info.mark_as_knocked();
+                let raw_events = state_events.0.clone();
+                let knock_state = assign!(KnockState::default(), { events: raw_events });
+                let knocked_room = assign!(KnockedRoom::default(), { knock_state: knock_state });
+                return (room, room_info, None, Some(knocked_room));
+            }
+        }
+
+        // Otherwise assume it's an invited room
+        room_info.mark_as_invited();
+        let raw_events = state_events.0.clone();
+        let invited_room = InvitedRoom::from(InviteState::from(raw_events));
+        (room, room_info, Some(invited_room), None)
+    } else {
+        let room =
+            store.get_or_create_room(room_id, RoomState::Joined, room_info_notable_update_sender);
+        let mut room_info = room.clone_info();
+
+        // We default to considering this room joined if it's not an invite. If it's
+        // actually left (and we remembered to request membership events in
+        // our sync request), then we can find this out from the events in
+        // required_state by calling handle_own_room_membership.
+        room_info.mark_as_joined();
+
+        // We don't need to do this in a v2 sync, because the membership of a room can
+        // be figured out by whether the room is in the "join", "leave" etc.
+        // property. In sliding sync we only have invite_state,
+        // required_state and timeline, so we must process required_state and timeline
+        // looking for relevant membership events.
+        own_membership(context, session_meta, state_events, &mut room_info);
+
+        (room, room_info, None, None)
+    }
+}
+
+/// Find any `m.room.member` events that refer to the current user, and update
+/// the state in room_info to reflect the "membership" property.
+fn own_membership(
+    context: &mut Context,
+    session_meta: Option<&SessionMeta>,
+    state_events: &[AnySyncStateEvent],
+    room_info: &mut RoomInfo,
+) {
+    let Some(meta) = session_meta else {
+        return;
+    };
+
+    // Start from the last event; the first membership event we see in that order is
+    // the last in the regular order, so that's the only one we need to
+    // consider.
+    for event in state_events.iter().rev() {
+        if let AnySyncStateEvent::RoomMember(member) = &event {
+            // If this event updates the current user's membership, record that in the
+            // room_info.
+            if member.state_key() == meta.user_id.as_str() {
+                let new_state: RoomState = member.membership().into();
+
+                if new_state != room_info.state() {
+                    room_info.set_state(new_state);
+                    // Update an existing notable update entry or create a new one
+                    context
+                        .room_info_notable_updates
+                        .entry(room_info.room_id.to_owned())
+                        .or_default()
+                        .insert(RoomInfoNotableUpdateReasons::MEMBERSHIP);
+                }
+
+                break;
+            }
+        }
+    }
+}
+
+fn properties(
+    context: &mut Context,
+    room_id: &RoomId,
+    room_data: &http::response::Room,
+    room_info: &mut RoomInfo,
+    is_new_room: bool,
+) {
+    // Handle the room's avatar.
+    //
+    // It can be updated via the state events, or via the
+    // [`http::ResponseRoom::avatar`] field. This part of the code handles the
+    // latter case. The former case is handled by [`BaseClient::handle_state`].
+    match &room_data.avatar {
+        // A new avatar!
+        JsOption::Some(avatar_uri) => room_info.update_avatar(Some(avatar_uri.to_owned())),
+        // Avatar must be removed.
+        JsOption::Null => room_info.update_avatar(None),
+        // Nothing to do.
+        JsOption::Undefined => {}
+    }
+
+    // Sliding sync doesn't have a room summary, nevertheless it contains the joined
+    // and invited member counts, in addition to the heroes.
+    if let Some(count) = room_data.joined_count {
+        room_info.update_joined_member_count(count.into());
+    }
+    if let Some(count) = room_data.invited_count {
+        room_info.update_invited_member_count(count.into());
+    }
+
+    if let Some(heroes) = &room_data.heroes {
+        room_info.update_heroes(
+            heroes
+                .iter()
+                .map(|hero| RoomHero {
+                    user_id: hero.user_id.clone(),
+                    display_name: hero.name.clone(),
+                    avatar_url: hero.avatar.clone(),
+                })
+                .collect(),
+        );
+    }
+
+    room_info.set_prev_batch(room_data.prev_batch.as_deref());
+
+    if room_data.limited {
+        room_info.mark_members_missing();
+    }
+
+    if let Some(recency_stamp) = &room_data.bump_stamp {
+        let recency_stamp: u64 = (*recency_stamp).into();
+
+        if room_info.recency_stamp.as_ref() != Some(&recency_stamp) {
+            room_info.update_recency_stamp(recency_stamp);
+
+            // If it's not a new room, let's emit a `RECENCY_STAMP` update.
+            // For a new room, the room will appear as new, so we don't care about this
+            // update.
+            if !is_new_room {
+                context
+                    .room_info_notable_updates
+                    .entry(room_id.to_owned())
+                    .or_default()
+                    .insert(RoomInfoNotableUpdateReasons::RECENCY_STAMP);
+            }
+        }
+    }
+}
+
+/// Find the most recent decrypted event and cache it in the supplied RoomInfo.
+///
+/// If any encrypted events are found after that one, store them in the RoomInfo
+/// too so we can use them when we get the relevant keys.
+///
+/// It is the responsibility of the caller to update the `RoomInfo` instance
+/// stored in the `Room`.
+#[cfg(feature = "e2e-encryption")]
+pub(crate) async fn cache_latest_events(
+    room: &Room,
+    room_info: &mut RoomInfo,
+    events: &[TimelineEvent],
+    changes: Option<&StateChanges>,
+    store: Option<&BaseStateStore>,
+) {
+    use tracing::warn;
+
+    use crate::{
+        deserialized_responses::DisplayName,
+        latest_event::{is_suitable_for_latest_event, LatestEvent, PossibleLatestEvent},
+        store::ambiguity_map::is_display_name_ambiguous,
+    };
+
+    let mut encrypted_events =
+        Vec::with_capacity(room.latest_encrypted_events.read().unwrap().capacity());
+
+    // Try to get room power levels from the current changes
+    let power_levels_from_changes = || {
+        let state_changes = changes?.state.get(room_info.room_id())?;
+        let room_power_levels_state =
+            state_changes.get(&StateEventType::RoomPowerLevels)?.values().next()?;
+        match room_power_levels_state.deserialize().ok()? {
+            AnySyncStateEvent::RoomPowerLevels(ev) => Some(ev.power_levels()),
+            _ => None,
+        }
+    };
+
+    // If we didn't get any info, try getting it from local data
+    let power_levels = match power_levels_from_changes() {
+        Some(power_levels) => Some(power_levels),
+        None => room.power_levels().await.ok(),
+    };
+
+    let power_levels_info = Some(room.own_user_id()).zip(power_levels.as_ref());
+
+    for event in events.iter().rev() {
+        if let Ok(timeline_event) = event.raw().deserialize() {
+            match is_suitable_for_latest_event(&timeline_event, power_levels_info) {
+                PossibleLatestEvent::YesRoomMessage(_)
+                | PossibleLatestEvent::YesPoll(_)
+                | PossibleLatestEvent::YesCallInvite(_)
+                | PossibleLatestEvent::YesCallNotify(_)
+                | PossibleLatestEvent::YesSticker(_)
+                | PossibleLatestEvent::YesKnockedStateEvent(_) => {
+                    // We found a suitable latest event. Store it.
+
+                    // In order to make the latest event fast to read, we want to keep the
+                    // associated sender in cache. This is a best-effort to gather enough
+                    // information for creating a user profile as fast as possible. If information
+                    // are missing, let's go back on the “slow” path.
+
+                    let mut sender_profile = None;
+                    let mut sender_name_is_ambiguous = None;
+
+                    // First off, look up the sender's profile from the `StateChanges`, they are
+                    // likely to be the most recent information.
+                    if let Some(changes) = changes {
+                        sender_profile = changes
+                            .profiles
+                            .get(room.room_id())
+                            .and_then(|profiles_by_user| {
+                                profiles_by_user.get(timeline_event.sender())
+                            })
+                            .cloned();
+
+                        if let Some(sender_profile) = sender_profile.as_ref() {
+                            sender_name_is_ambiguous = sender_profile
+                                .as_original()
+                                .and_then(|profile| profile.content.displayname.as_ref())
+                                .and_then(|display_name| {
+                                    let display_name = DisplayName::new(display_name);
+
+                                    changes.ambiguity_maps.get(room.room_id()).and_then(
+                                        |map_for_room| {
+                                            map_for_room.get(&display_name).map(|users| {
+                                                is_display_name_ambiguous(&display_name, users)
+                                            })
+                                        },
+                                    )
+                                });
+                        }
+                    }
+
+                    // Otherwise, look up the sender's profile from the `Store`.
+                    if sender_profile.is_none() {
+                        if let Some(store) = store {
+                            sender_profile = store
+                                .get_profile(room.room_id(), timeline_event.sender())
+                                .await
+                                .ok()
+                                .flatten();
+
+                            // TODO: need to update `sender_name_is_ambiguous`,
+                            // but how?
+                        }
+                    }
+
+                    let latest_event = Box::new(LatestEvent::new_with_sender_details(
+                        event.clone(),
+                        sender_profile,
+                        sender_name_is_ambiguous,
+                    ));
+
+                    // Store it in the return RoomInfo (it will be saved for us in the room later).
+                    room_info.latest_event = Some(latest_event);
+                    // We don't need any of the older encrypted events because we have a new
+                    // decrypted one.
+                    room.latest_encrypted_events.write().unwrap().clear();
+                    // We can stop looking through the timeline now because everything else is
+                    // older.
+                    break;
+                }
+                PossibleLatestEvent::NoEncrypted => {
+                    // m.room.encrypted - this might be the latest event later - we can't tell until
+                    // we are able to decrypt it, so store it for now
+                    //
+                    // Check how many encrypted events we have seen. Only store another if we
+                    // haven't already stored the maximum number.
+                    if encrypted_events.len() < encrypted_events.capacity() {
+                        encrypted_events.push(event.raw().clone());
+                    }
+                }
+                _ => {
+                    // Ignore unsuitable events
+                }
+            }
+        } else {
+            warn!(
+                "Failed to deserialize event as AnySyncTimelineEvent. ID={}",
+                event.event_id().expect("Event has no ID!")
+            );
+        }
+    }
+
+    // Push the encrypted events we found into the Room, in reverse order, so
+    // the latest is last
+    room.latest_encrypted_events.write().unwrap().extend(encrypted_events.into_iter().rev());
+}

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
@@ -25,7 +25,7 @@ use crate::{
     RoomState,
 };
 
-pub fn ephemeral_events(
+pub fn dispatch_ephemeral_events(
     context: &mut Context,
     receipts: &http::response::Receipts,
     typing: &http::response::Typing,

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
@@ -21,7 +21,7 @@ use super::super::super::{
 };
 use crate::{
     store::BaseStateStore,
-    sync::{JoinedRoomUpdate, LeftRoomUpdate, RoomUpdates},
+    sync::{JoinedRoomUpdate, RoomUpdates},
     RoomState,
 };
 
@@ -36,7 +36,7 @@ pub fn ephemeral_events(
 
         joined_room_updates
             .entry(room_id.to_owned())
-            .or_insert_with(JoinedRoomUpdate::default)
+            .or_default()
             .ephemeral
             .push(raw.clone().cast());
     }
@@ -44,7 +44,7 @@ pub fn ephemeral_events(
     for (room_id, raw) in &typing.rooms {
         joined_room_updates
             .entry(room_id.to_owned())
-            .or_insert_with(JoinedRoomUpdate::default)
+            .or_default()
             .ephemeral
             .push(raw.clone().cast());
     }
@@ -64,13 +64,13 @@ pub async fn room_account_data(
                 RoomState::Joined => room_updates
                     .joined
                     .entry(room_id.to_owned())
-                    .or_insert_with(JoinedRoomUpdate::default)
+                    .or_default()
                     .account_data
                     .append(&mut raw.to_vec()),
                 RoomState::Left | RoomState::Banned => room_updates
                     .left
                     .entry(room_id.to_owned())
-                    .or_insert_with(LeftRoomUpdate::default)
+                    .or_default()
                     .account_data
                     .append(&mut raw.to_vec()),
                 RoomState::Invited | RoomState::Knocked => {}

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
@@ -1,0 +1,45 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use ruma::{api::client::sync::sync_events::v5 as http, OwnedRoomId};
+
+use super::super::super::{ephemeral_events::dispatch_receipt, Context};
+use crate::sync::JoinedRoomUpdate;
+
+pub fn ephemeral_events(
+    context: &mut Context,
+    receipts: &http::response::Receipts,
+    typing: &http::response::Typing,
+    joined_room_updates: &mut BTreeMap<OwnedRoomId, JoinedRoomUpdate>,
+) {
+    for (room_id, raw) in &receipts.rooms {
+        dispatch_receipt(context, raw.cast_ref(), room_id);
+
+        joined_room_updates
+            .entry(room_id.to_owned())
+            .or_insert_with(JoinedRoomUpdate::default)
+            .ephemeral
+            .push(raw.clone().cast());
+    }
+
+    for (room_id, raw) in &typing.rooms {
+        joined_room_updates
+            .entry(room_id.to_owned())
+            .or_insert_with(JoinedRoomUpdate::default)
+            .ephemeral
+            .push(raw.clone().cast());
+    }
+}

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -65,7 +65,7 @@ pub async fn update_any_room(
     room_response: &http::response::Room,
     rooms_account_data: &BTreeMap<OwnedRoomId, Vec<Raw<AnyRoomAccountDataEvent>>>,
     #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'_>,
-    mut notification: notification::Notification<'_>,
+    notification: notification::Notification<'_>,
 ) -> Result<Option<(RoomInfo, RoomUpdateKind)>> {
     let RoomCreationData {
         room_id,
@@ -123,9 +123,9 @@ pub async fn update_any_room(
             &room,
             &mut room_info,
             notification::Notification::new(
-                &notification.push_rules,
-                &mut notification.notifications,
-                &notification.state_store,
+                notification.push_rules,
+                notification.notifications,
+                notification.state_store,
             ),
         )
         .await?;
@@ -159,7 +159,7 @@ pub async fn update_any_room(
     #[cfg(feature = "e2e-encryption")]
     e2ee::tracked_users::update_or_set_if_room_is_newly_encrypted(
         context,
-        e2ee.olm_machine.clone(),
+        e2ee.olm_machine,
         &new_user_ids,
         room_info.encryption_state(),
         room.encryption_state(),

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod extensions;
+
 use std::collections::BTreeMap;
 
 use matrix_sdk_common::deserialized_responses::TimelineEvent;

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -39,7 +39,7 @@ use tokio::sync::broadcast::Sender;
 use super::super::e2ee;
 use super::{
     super::{notification, state_events, timeline, Context},
-    Room as RoomCreationData,
+    RoomCreationData,
 };
 #[cfg(feature = "e2e-encryption")]
 use crate::StateChanges;

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -16,7 +16,10 @@ pub mod extensions;
 
 use std::collections::BTreeMap;
 
+#[cfg(feature = "e2e-encryption")]
 use matrix_sdk_common::deserialized_responses::TimelineEvent;
+#[cfg(feature = "e2e-encryption")]
+use ruma::events::StateEventType;
 use ruma::{
     api::client::sync::sync_events::{
         v3::{InviteState, InvitedRoom, KnockState, KnockedRoom},
@@ -25,7 +28,7 @@ use ruma::{
     assign,
     events::{
         room::member::{MembershipState, RoomMemberEventContent},
-        AnyRoomAccountDataEvent, AnyStrippedStateEvent, AnySyncStateEvent, StateEventType,
+        AnyRoomAccountDataEvent, AnyStrippedStateEvent, AnySyncStateEvent,
     },
     serde::Raw,
     JsOption, OwnedRoomId, RoomId, UserId,
@@ -38,11 +41,13 @@ use super::{
     super::{notification, state_events, timeline, Context},
     Room as RoomCreationData,
 };
+#[cfg(feature = "e2e-encryption")]
+use crate::StateChanges;
 use crate::{
     store::BaseStateStore,
     sync::{InvitedRoomUpdate, JoinedRoomUpdate, KnockedRoomUpdate, LeftRoomUpdate},
     Result, Room, RoomHero, RoomInfo, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons,
-    RoomState, StateChanges,
+    RoomState,
 };
 
 /// Represent any kind of room updates.

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -58,7 +58,7 @@ pub async fn update_any_room(
     user_id: &UserId,
     room_creation_data: RoomCreationData<'_>,
     room_response: &http::response::Room,
-    rooms_account_data: &mut BTreeMap<OwnedRoomId, Vec<Raw<AnyRoomAccountDataEvent>>>,
+    rooms_account_data: &BTreeMap<OwnedRoomId, Vec<Raw<AnyRoomAccountDataEvent>>>,
     #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'_>,
     mut notification: notification::Notification<'_>,
 ) -> Result<Option<(RoomInfo, RoomUpdateKind)>> {
@@ -167,7 +167,7 @@ pub async fn update_any_room(
     room_info.update_notification_count(notification_count);
 
     let ambiguity_changes = ambiguity_cache.changes.remove(room_id).unwrap_or_default();
-    let room_account_data = rooms_account_data.get(room_id).cloned();
+    let room_account_data = rooms_account_data.get(room_id);
 
     match (room_info.state(), maybe_room_update_kind) {
         (RoomState::Joined, None) => {
@@ -181,7 +181,7 @@ pub async fn update_any_room(
                 RoomUpdateKind::Joined(JoinedRoomUpdate::new(
                     timeline,
                     raw_state_events,
-                    room_account_data.unwrap_or_default(),
+                    room_account_data.cloned().unwrap_or_default(),
                     ephemeral,
                     notification_count,
                     ambiguity_changes,
@@ -194,7 +194,7 @@ pub async fn update_any_room(
             RoomUpdateKind::Left(LeftRoomUpdate::new(
                 timeline,
                 raw_state_events,
-                room_account_data.unwrap_or_default(),
+                room_account_data.cloned().unwrap_or_default(),
                 ambiguity_changes,
             )),
         ))),

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -24,7 +24,7 @@ use tokio::sync::broadcast::Sender;
 use super::super::e2ee;
 use super::super::{account_data, ephemeral_events, notification, state_events, timeline, Context};
 use crate::{
-    store::{ambiguity_map::AmbiguityCache, BaseStateStore},
+    store::ambiguity_map::AmbiguityCache,
     sync::{InvitedRoomUpdate, JoinedRoomUpdate, KnockedRoomUpdate, LeftRoomUpdate},
     RequestedRequiredStates, Result, RoomInfoNotableUpdate, RoomState,
 };
@@ -36,13 +36,14 @@ pub async fn update_joined_room(
     room_id: &RoomId,
     joined_room: JoinedRoom,
     requested_required_states: &RequestedRequiredStates,
-    state_store: &BaseStateStore,
     room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
     ambiguity_cache: &mut AmbiguityCache,
     updated_members_in_room: &mut BTreeMap<OwnedRoomId, BTreeSet<OwnedUserId>>,
     notification: notification::Notification<'_>,
     #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'_>,
 ) -> Result<JoinedRoomUpdate> {
+    let state_store = notification.state_store;
+
     let room =
         state_store.get_or_create_room(room_id, RoomState::Joined, room_info_notable_update_sender);
 
@@ -149,12 +150,13 @@ pub async fn update_left_room(
     room_id: &RoomId,
     left_room: LeftRoom,
     requested_required_states: &RequestedRequiredStates,
-    state_store: &BaseStateStore,
     room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
     ambiguity_cache: &mut AmbiguityCache,
     notification: notification::Notification<'_>,
     #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'_>,
 ) -> Result<LeftRoomUpdate> {
+    let state_store = notification.state_store;
+
     let room =
         state_store.get_or_create_room(room_id, RoomState::Left, room_info_notable_update_sender);
 
@@ -216,10 +218,11 @@ pub async fn update_invited_room(
     context: &mut Context,
     room_id: &RoomId,
     invited_room: InvitedRoom,
-    state_store: &BaseStateStore,
     room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
     notification: notification::Notification<'_>,
 ) -> Result<InvitedRoomUpdate> {
+    let state_store = notification.state_store;
+
     let room = state_store.get_or_create_room(
         room_id,
         RoomState::Invited,
@@ -252,10 +255,11 @@ pub async fn update_knocked_room(
     context: &mut Context,
     room_id: &RoomId,
     knocked_room: KnockedRoom,
-    state_store: &BaseStateStore,
     room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
     notification: notification::Notification<'_>,
 ) -> Result<KnockedRoomUpdate> {
+    let state_store = notification.state_store;
+
     let room = state_store.get_or_create_room(
         room_id,
         RoomState::Knocked,

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -22,7 +22,10 @@ use tokio::sync::broadcast::Sender;
 
 #[cfg(feature = "e2e-encryption")]
 use super::super::e2ee;
-use super::super::{account_data, ephemeral_events, notification, state_events, timeline, Context};
+use super::{
+    super::{account_data, ephemeral_events, notification, state_events, timeline, Context},
+    Room as RoomCreationData,
+};
 use crate::{
     store::ambiguity_map::AmbiguityCache,
     sync::{InvitedRoomUpdate, JoinedRoomUpdate, KnockedRoomUpdate, LeftRoomUpdate},
@@ -33,15 +36,19 @@ use crate::{
 #[allow(clippy::too_many_arguments)]
 pub async fn update_joined_room(
     context: &mut Context,
-    room_id: &RoomId,
+    room_creation_data: RoomCreationData<'_>,
     joined_room: JoinedRoom,
-    requested_required_states: &RequestedRequiredStates,
-    room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
-    ambiguity_cache: &mut AmbiguityCache,
     updated_members_in_room: &mut BTreeMap<OwnedRoomId, BTreeSet<OwnedUserId>>,
     notification: notification::Notification<'_>,
     #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'_>,
 ) -> Result<JoinedRoomUpdate> {
+    let RoomCreationData {
+        room_id,
+        room_info_notable_update_sender,
+        requested_required_states,
+        ambiguity_cache,
+    } = room_creation_data;
+
     let state_store = notification.state_store;
 
     let room =
@@ -147,14 +154,18 @@ pub async fn update_joined_room(
 #[allow(clippy::too_many_arguments)]
 pub async fn update_left_room(
     context: &mut Context,
-    room_id: &RoomId,
+    room_creation_data: RoomCreationData<'_>,
     left_room: LeftRoom,
-    requested_required_states: &RequestedRequiredStates,
-    room_info_notable_update_sender: Sender<RoomInfoNotableUpdate>,
-    ambiguity_cache: &mut AmbiguityCache,
     notification: notification::Notification<'_>,
     #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'_>,
 ) -> Result<LeftRoomUpdate> {
+    let RoomCreationData {
+        room_id,
+        room_info_notable_update_sender,
+        requested_required_states,
+        ambiguity_cache,
+    } = room_creation_data;
+
     let state_store = notification.state_store;
 
     let room =

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -27,9 +27,8 @@ use super::{
     Room as RoomCreationData,
 };
 use crate::{
-    store::ambiguity_map::AmbiguityCache,
     sync::{InvitedRoomUpdate, JoinedRoomUpdate, KnockedRoomUpdate, LeftRoomUpdate},
-    RequestedRequiredStates, Result, RoomInfoNotableUpdate, RoomState,
+    Result, RoomInfoNotableUpdate, RoomState,
 };
 
 /// Process updates of a joined room.

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -24,7 +24,7 @@ use tokio::sync::broadcast::Sender;
 use super::super::e2ee;
 use super::{
     super::{account_data, ephemeral_events, notification, state_events, timeline, Context},
-    Room as RoomCreationData,
+    RoomCreationData,
 };
 use crate::{
     sync::{InvitedRoomUpdate, JoinedRoomUpdate, KnockedRoomUpdate, LeftRoomUpdate},

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -199,28 +199,13 @@ impl BaseClient {
         // Handle read receipts and typing notifications independently of the rooms:
         // these both live in a different subsection of the server's response,
         // so they may exist without any update for the associated room.
-
-        for (room_id, raw) in &extensions.receipts.rooms {
-            processors::ephemeral_events::dispatch_one(&mut context, raw.cast_ref(), room_id);
-
+        processors::room::msc4186::extensions::ephemeral_events(
+            &mut context,
+            &extensions.receipts,
+            &extensions.typing,
             // We assume this can only happen in joined rooms, or something's very wrong.
-            room_updates
-                .joined
-                .entry(room_id.to_owned())
-                .or_insert_with(JoinedRoomUpdate::default)
-                .ephemeral
-                .push(raw.clone().cast());
-        }
-
-        for (room_id, raw) in &extensions.typing.rooms {
-            // We assume this can only happen in joined rooms, or something's very wrong.
-            room_updates
-                .joined
-                .entry(room_id.to_owned())
-                .or_insert_with(JoinedRoomUpdate::default)
-                .ephemeral
-                .push(raw.clone().cast());
-        }
+            &mut room_updates.joined,
+        );
 
         // Handle room account data
         for (room_id, raw) in &rooms_account_data {

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -148,7 +148,7 @@ impl BaseClient {
             let Some((room_info, room_update)) = processors::room::msc4186::update_any_room(
                 &mut context,
                 &user_id,
-                processors::room::Room::new(
+                processors::room::RoomCreationData::new(
                     room_id,
                     self.room_info_notable_update_sender.clone(),
                     requested_required_states,

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -198,7 +198,7 @@ impl BaseClient {
         // Handle read receipts and typing notifications independently of the rooms:
         // these both live in a different subsection of the server's response,
         // so they may exist without any update for the associated room.
-        processors::room::msc4186::extensions::ephemeral_events(
+        processors::room::msc4186::extensions::dispatch_ephemeral_events(
             &mut context,
             &extensions.receipts,
             &extensions.typing,

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -166,7 +166,6 @@ impl BaseClient {
                     &self.state_store,
                 ),
                 &mut ambiguity_cache,
-                self.session_meta(),
             )
             .await?
             else {

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -145,13 +145,13 @@ impl BaseClient {
             .user_id
             .to_owned();
 
-        for (room_id, response_room_data) in rooms {
+        for (room_id, room_response) in rooms {
             let Some((room_info, room_update)) = processors::room::msc4186::update_any_room(
                 &mut context,
                 &user_id,
                 room_id,
                 requested_required_states.for_room(room_id),
-                response_room_data,
+                room_response,
                 self.room_info_notable_update_sender.clone(),
                 &mut rooms_account_data,
                 #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -149,10 +149,13 @@ impl BaseClient {
             let Some((room_info, room_update)) = processors::room::msc4186::update_any_room(
                 &mut context,
                 &user_id,
-                room_id,
-                requested_required_states.for_room(room_id),
+                processors::room::Room::new(
+                    room_id,
+                    self.room_info_notable_update_sender.clone(),
+                    requested_required_states,
+                    &mut ambiguity_cache,
+                ),
                 room_response,
-                self.room_info_notable_update_sender.clone(),
                 &mut rooms_account_data,
                 #[cfg(feature = "e2e-encryption")]
                 processors::e2ee::E2EE::new(
@@ -165,7 +168,6 @@ impl BaseClient {
                     &mut notifications,
                     &self.state_store,
                 ),
-                &mut ambiguity_cache,
             )
             .await?
             else {

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -136,17 +136,7 @@ impl BaseClient {
         previous_events_provider: &PEP,
         requested_required_states: &RequestedRequiredStates,
     ) -> Result<SyncResponse> {
-        let http::Response {
-            // FIXME not yet supported by sliding sync. see
-            // https://github.com/matrix-org/matrix-rust-sdk/issues/1014
-            // next_batch,
-            rooms,
-            lists,
-            extensions,
-            // FIXME: missing compared to v3::Response
-            //presence,
-            ..
-        } = response;
+        let http::Response { rooms, lists, extensions, .. } = response;
 
         trace!(
             rooms = rooms.len(),
@@ -300,16 +290,6 @@ impl BaseClient {
 
         global_account_data_processor.apply(&mut context, &state_store).await;
 
-        // FIXME not yet supported by sliding sync.
-        // changes.presence = presence
-        //     .events
-        //     .iter()
-        //     .filter_map(|e| {
-        //         let event = e.deserialize().ok()?;
-        //         Some((event.sender, e.clone()))
-        //     })
-        //     .collect();
-
         context.state_changes.ambiguity_maps = ambiguity_cache.cache;
 
         processors::changes::save_and_apply(
@@ -330,7 +310,6 @@ impl BaseClient {
         Ok(SyncResponse {
             rooms: new_rooms,
             notifications,
-            // FIXME not yet supported by sliding sync.
             presence: Default::default(),
             account_data: extensions.account_data.global.clone(),
             to_device: Default::default(),

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -14,9 +14,9 @@
 
 //! Extend `BaseClient` with capabilities to handle MSC4186.
 
+use ruma::api::client::sync::sync_events::v5 as http;
 #[cfg(feature = "e2e-encryption")]
-use ruma::events::AnyToDeviceEvent;
-use ruma::{api::client::sync::sync_events::v5 as http, serde::Raw};
+use ruma::{events::AnyToDeviceEvent, serde::Raw};
 use tracing::{instrument, trace};
 
 use super::BaseClient;
@@ -31,7 +31,6 @@ use crate::{
 };
 
 impl BaseClient {
-    #[cfg(feature = "e2e-encryption")]
     /// Processes the E2EE-related events from the Sliding Sync response.
     ///
     /// In addition to writes to the crypto store, this may also write into the
@@ -39,6 +38,7 @@ impl BaseClient {
     /// store.
     ///
     /// Returns whether any change happened.
+    #[cfg(feature = "e2e-encryption")]
     pub async fn process_sliding_sync_e2ee(
         &self,
         to_device: Option<&http::response::ToDevice>,

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -14,45 +14,20 @@
 
 //! Extend `BaseClient` with capabilities to handle MSC4186.
 
-use std::collections::BTreeMap;
-
-#[cfg(feature = "e2e-encryption")]
-use matrix_sdk_common::deserialized_responses::TimelineEvent;
 #[cfg(feature = "e2e-encryption")]
 use ruma::events::AnyToDeviceEvent;
-use ruma::{
-    api::client::sync::sync_events::{
-        v3::{self, InvitedRoom, KnockedRoom},
-        v5 as http,
-    },
-    events::{
-        room::member::MembershipState, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncStateEvent, StateEventType,
-    },
-    serde::Raw,
-    JsOption, OwnedRoomId, RoomId, UserId,
-};
-#[cfg(feature = "e2e-encryption")]
-use tracing::warn;
+use ruma::{api::client::sync::sync_events::v5 as http, serde::Raw};
 use tracing::{instrument, trace};
 
 use super::BaseClient;
-#[cfg(feature = "e2e-encryption")]
-use crate::latest_event::{is_suitable_for_latest_event, LatestEvent, PossibleLatestEvent};
-#[cfg(feature = "e2e-encryption")]
-use crate::store::StateChanges;
 use crate::{
     error::Result,
     read_receipts::{compute_unread_counts, PreviousEventsProvider},
     response_processors as processors,
-    rooms::{
-        normal::{RoomHero, RoomInfoNotableUpdateReasons},
-        RoomState,
-    },
-    ruma::assign,
-    store::{ambiguity_map::AmbiguityCache, BaseStateStore},
-    sync::{JoinedRoomUpdate, LeftRoomUpdate, Notification, RoomUpdates, SyncResponse},
-    RequestedRequiredStates, Room, RoomInfo,
+    rooms::{normal::RoomInfoNotableUpdateReasons, RoomState},
+    store::ambiguity_map::AmbiguityCache,
+    sync::{JoinedRoomUpdate, LeftRoomUpdate, RoomUpdates, SyncResponse},
+    RequestedRequiredStates,
 };
 
 impl BaseClient {
@@ -158,6 +133,7 @@ impl BaseClient {
 
         let global_account_data_processor =
             processors::account_data::global(&extensions.account_data.global);
+        let push_rules = self.get_push_rules(&global_account_data_processor).await?;
 
         let mut new_rooms = RoomUpdates::default();
         let mut notifications = Default::default();
@@ -170,18 +146,28 @@ impl BaseClient {
             .to_owned();
 
         for (room_id, response_room_data) in rooms {
-            let (room_info, joined_room, left_room, invited_room, knocked_room) = self
-                .process_sliding_sync_room(
+            let (room_info, joined_room, left_room, invited_room, knocked_room) =
+                processors::room::msc4186::update_any_room(
                     &mut context,
+                    &user_id,
                     room_id,
                     requested_required_states.for_room(room_id),
                     response_room_data,
+                    self.room_info_notable_update_sender.clone(),
                     &mut rooms_account_data,
-                    &state_store,
-                    &user_id,
-                    &global_account_data_processor,
-                    &mut notifications,
+                    #[cfg(feature = "e2e-encryption")]
+                    processors::e2ee::E2EE::new(
+                        self.olm_machine().await.as_ref(),
+                        self.decryption_trust_requirement,
+                        self.handle_verification_events,
+                    ),
+                    processors::notification::Notification::new(
+                        &push_rules,
+                        &mut notifications,
+                        &self.state_store,
+                    ),
                     &mut ambiguity_cache,
+                    self.session_meta(),
                 )
                 .await?;
 
@@ -315,501 +301,6 @@ impl BaseClient {
             to_device: Default::default(),
         })
     }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn process_sliding_sync_room(
-        &self,
-        context: &mut processors::Context,
-        room_id: &RoomId,
-        requested_required_states: &[(StateEventType, String)],
-        room_data: &http::response::Room,
-        rooms_account_data: &mut BTreeMap<OwnedRoomId, Vec<Raw<AnyRoomAccountDataEvent>>>,
-        state_store: &BaseStateStore,
-        user_id: &UserId,
-        global_account_data_processor: &processors::account_data::Global,
-        notifications: &mut BTreeMap<OwnedRoomId, Vec<Notification>>,
-        ambiguity_cache: &mut AmbiguityCache,
-    ) -> Result<(
-        RoomInfo,
-        Option<JoinedRoomUpdate>,
-        Option<LeftRoomUpdate>,
-        Option<InvitedRoom>,
-        Option<KnockedRoom>,
-    )> {
-        // Read state events from the `required_state` field.
-        //
-        // Don't read state events from the `timeline` field, because they might be
-        // incomplete or staled already. We must only read state events from
-        // `required_state`.
-        let (raw_state_events, state_events) =
-            processors::state_events::sync::collect(context, &room_data.required_state);
-
-        // Find or create the room in the store
-        let is_new_room = !state_store.room_exists(room_id);
-
-        let invite_state_events = room_data
-            .invite_state
-            .as_ref()
-            .map(|events| processors::state_events::stripped::collect(context, events));
-
-        #[allow(unused_mut)] // Required for some feature flag combinations
-        let (mut room, mut room_info, invited_room, knocked_room) = self
-            .process_sliding_sync_room_membership(
-                context,
-                &state_events,
-                &invite_state_events,
-                state_store,
-                user_id,
-                room_id,
-            );
-
-        room_info.mark_state_partially_synced();
-        room_info.handle_encryption_state(requested_required_states);
-
-        #[cfg_attr(not(feature = "e2e-encryption"), allow(unused))]
-        let new_user_ids = processors::state_events::sync::dispatch_and_get_new_users(
-            context,
-            (&raw_state_events, &state_events),
-            &mut room_info,
-            ambiguity_cache,
-        )
-        .await?;
-
-        let push_rules = self.get_push_rules(global_account_data_processor).await?;
-
-        // This will be used for both invited and knocked rooms.
-        if let Some((raw_events, events)) = invite_state_events {
-            processors::state_events::stripped::dispatch_invite_or_knock(
-                context,
-                (&raw_events, &events),
-                &room,
-                &mut room_info,
-                processors::notification::Notification::new(
-                    &push_rules,
-                    notifications,
-                    &self.state_store,
-                ),
-            )
-            .await?;
-        }
-
-        process_room_properties(context, room_id, room_data, &mut room_info, is_new_room);
-
-        let timeline = processors::timeline::build(
-            context,
-            &room,
-            &mut room_info,
-            processors::timeline::builder::Timeline::from(room_data),
-            processors::notification::Notification::new(
-                &push_rules,
-                notifications,
-                &self.state_store,
-            ),
-            #[cfg(feature = "e2e-encryption")]
-            processors::e2ee::E2EE::new(
-                self.olm_machine().await.as_ref(),
-                self.decryption_trust_requirement,
-                self.handle_verification_events,
-            ),
-        )
-        .await?;
-
-        // Cache the latest decrypted event in room_info, and also keep any later
-        // encrypted events, so we can slot them in when we get the keys.
-        #[cfg(feature = "e2e-encryption")]
-        cache_latest_events(
-            &room,
-            &mut room_info,
-            &timeline.events,
-            Some(&context.state_changes),
-            Some(state_store),
-        )
-        .await;
-
-        #[cfg(feature = "e2e-encryption")]
-        processors::e2ee::tracked_users::update_or_set_if_room_is_newly_encrypted(
-            context,
-            self.olm_machine().await.as_ref(),
-            &new_user_ids,
-            room_info.encryption_state(),
-            room.encryption_state(),
-            room_id,
-            state_store,
-        )
-        .await?;
-
-        let notification_count = room_data.unread_notifications.clone().into();
-        room_info.update_notification_count(notification_count);
-
-        let ambiguity_changes = ambiguity_cache.changes.remove(room_id).unwrap_or_default();
-        let room_account_data = rooms_account_data.get(room_id).cloned();
-
-        match room_info.state() {
-            RoomState::Joined => {
-                // Ephemeral events are added separately, because we might not
-                // have a room subsection in the response, yet we may have receipts for
-                // that room.
-                let ephemeral = Vec::new();
-
-                Ok((
-                    room_info,
-                    Some(JoinedRoomUpdate::new(
-                        timeline,
-                        raw_state_events,
-                        room_account_data.unwrap_or_default(),
-                        ephemeral,
-                        notification_count,
-                        ambiguity_changes,
-                    )),
-                    None,
-                    None,
-                    None,
-                ))
-            }
-
-            RoomState::Left | RoomState::Banned => Ok((
-                room_info,
-                None,
-                Some(LeftRoomUpdate::new(
-                    timeline,
-                    raw_state_events,
-                    room_account_data.unwrap_or_default(),
-                    ambiguity_changes,
-                )),
-                None,
-                None,
-            )),
-
-            RoomState::Invited => Ok((room_info, None, None, invited_room, None)),
-
-            RoomState::Knocked => Ok((room_info, None, None, None, knocked_room)),
-        }
-    }
-
-    /// Look through the sliding sync data for this room, find/create it in the
-    /// store, and process any invite information.
-    /// If any invite_state exists, we take it to mean that we are invited to
-    /// this room, unless that state contains membership events that specify
-    /// otherwise. https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md#room-list-parameters
-    fn process_sliding_sync_room_membership(
-        &self,
-        context: &mut processors::Context,
-        state_events: &[AnySyncStateEvent],
-        invite_state_events: &Option<(Vec<Raw<AnyStrippedStateEvent>>, Vec<AnyStrippedStateEvent>)>,
-        store: &BaseStateStore,
-        user_id: &UserId,
-        room_id: &RoomId,
-    ) -> (Room, RoomInfo, Option<InvitedRoom>, Option<KnockedRoom>) {
-        if let Some(state_events) = invite_state_events {
-            let room = store.get_or_create_room(
-                room_id,
-                RoomState::Invited,
-                self.room_info_notable_update_sender.clone(),
-            );
-            let mut room_info = room.clone_info();
-
-            // We need to find the membership event since it could be for either an invited
-            // or knocked room
-            let membership_event_content = state_events.1.iter().find_map(|event| {
-                if let AnyStrippedStateEvent::RoomMember(membership_event) = event {
-                    if membership_event.state_key == user_id {
-                        return Some(membership_event.content.clone());
-                    }
-                }
-                None
-            });
-
-            if let Some(membership_event_content) = membership_event_content {
-                if membership_event_content.membership == MembershipState::Knock {
-                    // If we have a `Knock` membership state, set the room as such
-                    room_info.mark_as_knocked();
-                    let raw_events = state_events.0.clone();
-                    let knock_state = assign!(v3::KnockState::default(), { events: raw_events });
-                    let knocked_room =
-                        assign!(KnockedRoom::default(), { knock_state: knock_state });
-                    return (room, room_info, None, Some(knocked_room));
-                }
-            }
-
-            // Otherwise assume it's an invited room
-            room_info.mark_as_invited();
-            let raw_events = state_events.0.clone();
-            let invited_room = InvitedRoom::from(v3::InviteState::from(raw_events));
-            (room, room_info, Some(invited_room), None)
-        } else {
-            let room = store.get_or_create_room(
-                room_id,
-                RoomState::Joined,
-                self.room_info_notable_update_sender.clone(),
-            );
-            let mut room_info = room.clone_info();
-
-            // We default to considering this room joined if it's not an invite. If it's
-            // actually left (and we remembered to request membership events in
-            // our sync request), then we can find this out from the events in
-            // required_state by calling handle_own_room_membership.
-            room_info.mark_as_joined();
-
-            // We don't need to do this in a v2 sync, because the membership of a room can
-            // be figured out by whether the room is in the "join", "leave" etc.
-            // property. In sliding sync we only have invite_state,
-            // required_state and timeline, so we must process required_state and timeline
-            // looking for relevant membership events.
-            self.handle_own_room_membership(context, state_events, &mut room_info);
-
-            (room, room_info, None, None)
-        }
-    }
-
-    /// Find any m.room.member events that refer to the current user, and update
-    /// the state in room_info to reflect the "membership" property.
-    fn handle_own_room_membership(
-        &self,
-        context: &mut processors::Context,
-        state_events: &[AnySyncStateEvent],
-        room_info: &mut RoomInfo,
-    ) {
-        let Some(meta) = self.session_meta() else {
-            return;
-        };
-
-        // Start from the last event; the first membership event we see in that order is
-        // the last in the regular order, so that's the only one we need to
-        // consider.
-        for event in state_events.iter().rev() {
-            if let AnySyncStateEvent::RoomMember(member) = &event {
-                // If this event updates the current user's membership, record that in the
-                // room_info.
-                if member.state_key() == meta.user_id.as_str() {
-                    let new_state: RoomState = member.membership().into();
-                    if new_state != room_info.state() {
-                        room_info.set_state(new_state);
-                        // Update an existing notable update entry or create a new one
-                        context
-                            .room_info_notable_updates
-                            .entry(room_info.room_id.to_owned())
-                            .or_default()
-                            .insert(RoomInfoNotableUpdateReasons::MEMBERSHIP);
-                    }
-                    break;
-                }
-            }
-        }
-    }
-}
-
-/// Find the most recent decrypted event and cache it in the supplied RoomInfo.
-///
-/// If any encrypted events are found after that one, store them in the RoomInfo
-/// too so we can use them when we get the relevant keys.
-///
-/// It is the responsibility of the caller to update the `RoomInfo` instance
-/// stored in the `Room`.
-#[cfg(feature = "e2e-encryption")]
-async fn cache_latest_events(
-    room: &Room,
-    room_info: &mut RoomInfo,
-    events: &[TimelineEvent],
-    changes: Option<&StateChanges>,
-    store: Option<&BaseStateStore>,
-) {
-    use crate::{
-        deserialized_responses::DisplayName, store::ambiguity_map::is_display_name_ambiguous,
-    };
-
-    let mut encrypted_events =
-        Vec::with_capacity(room.latest_encrypted_events.read().unwrap().capacity());
-
-    // Try to get room power levels from the current changes
-    let power_levels_from_changes = || {
-        let state_changes = changes?.state.get(room_info.room_id())?;
-        let room_power_levels_state =
-            state_changes.get(&StateEventType::RoomPowerLevels)?.values().next()?;
-        match room_power_levels_state.deserialize().ok()? {
-            AnySyncStateEvent::RoomPowerLevels(ev) => Some(ev.power_levels()),
-            _ => None,
-        }
-    };
-
-    // If we didn't get any info, try getting it from local data
-    let power_levels = match power_levels_from_changes() {
-        Some(power_levels) => Some(power_levels),
-        None => room.power_levels().await.ok(),
-    };
-
-    let power_levels_info = Some(room.own_user_id()).zip(power_levels.as_ref());
-
-    for event in events.iter().rev() {
-        if let Ok(timeline_event) = event.raw().deserialize() {
-            match is_suitable_for_latest_event(&timeline_event, power_levels_info) {
-                PossibleLatestEvent::YesRoomMessage(_)
-                | PossibleLatestEvent::YesPoll(_)
-                | PossibleLatestEvent::YesCallInvite(_)
-                | PossibleLatestEvent::YesCallNotify(_)
-                | PossibleLatestEvent::YesSticker(_)
-                | PossibleLatestEvent::YesKnockedStateEvent(_) => {
-                    // We found a suitable latest event. Store it.
-
-                    // In order to make the latest event fast to read, we want to keep the
-                    // associated sender in cache. This is a best-effort to gather enough
-                    // information for creating a user profile as fast as possible. If information
-                    // are missing, let's go back on the “slow” path.
-
-                    let mut sender_profile = None;
-                    let mut sender_name_is_ambiguous = None;
-
-                    // First off, look up the sender's profile from the `StateChanges`, they are
-                    // likely to be the most recent information.
-                    if let Some(changes) = changes {
-                        sender_profile = changes
-                            .profiles
-                            .get(room.room_id())
-                            .and_then(|profiles_by_user| {
-                                profiles_by_user.get(timeline_event.sender())
-                            })
-                            .cloned();
-
-                        if let Some(sender_profile) = sender_profile.as_ref() {
-                            sender_name_is_ambiguous = sender_profile
-                                .as_original()
-                                .and_then(|profile| profile.content.displayname.as_ref())
-                                .and_then(|display_name| {
-                                    let display_name = DisplayName::new(display_name);
-
-                                    changes.ambiguity_maps.get(room.room_id()).and_then(
-                                        |map_for_room| {
-                                            map_for_room.get(&display_name).map(|users| {
-                                                is_display_name_ambiguous(&display_name, users)
-                                            })
-                                        },
-                                    )
-                                });
-                        }
-                    }
-
-                    // Otherwise, look up the sender's profile from the `Store`.
-                    if sender_profile.is_none() {
-                        if let Some(store) = store {
-                            sender_profile = store
-                                .get_profile(room.room_id(), timeline_event.sender())
-                                .await
-                                .ok()
-                                .flatten();
-
-                            // TODO: need to update `sender_name_is_ambiguous`,
-                            // but how?
-                        }
-                    }
-
-                    let latest_event = Box::new(LatestEvent::new_with_sender_details(
-                        event.clone(),
-                        sender_profile,
-                        sender_name_is_ambiguous,
-                    ));
-
-                    // Store it in the return RoomInfo (it will be saved for us in the room later).
-                    room_info.latest_event = Some(latest_event);
-                    // We don't need any of the older encrypted events because we have a new
-                    // decrypted one.
-                    room.latest_encrypted_events.write().unwrap().clear();
-                    // We can stop looking through the timeline now because everything else is
-                    // older.
-                    break;
-                }
-                PossibleLatestEvent::NoEncrypted => {
-                    // m.room.encrypted - this might be the latest event later - we can't tell until
-                    // we are able to decrypt it, so store it for now
-                    //
-                    // Check how many encrypted events we have seen. Only store another if we
-                    // haven't already stored the maximum number.
-                    if encrypted_events.len() < encrypted_events.capacity() {
-                        encrypted_events.push(event.raw().clone());
-                    }
-                }
-                _ => {
-                    // Ignore unsuitable events
-                }
-            }
-        } else {
-            warn!(
-                "Failed to deserialize event as AnySyncTimelineEvent. ID={}",
-                event.event_id().expect("Event has no ID!")
-            );
-        }
-    }
-
-    // Push the encrypted events we found into the Room, in reverse order, so
-    // the latest is last
-    room.latest_encrypted_events.write().unwrap().extend(encrypted_events.into_iter().rev());
-}
-
-fn process_room_properties(
-    context: &mut processors::Context,
-    room_id: &RoomId,
-    room_data: &http::response::Room,
-    room_info: &mut RoomInfo,
-    is_new_room: bool,
-) {
-    // Handle the room's avatar.
-    //
-    // It can be updated via the state events, or via the
-    // [`http::ResponseRoom::avatar`] field. This part of the code handles the
-    // latter case. The former case is handled by [`BaseClient::handle_state`].
-    match &room_data.avatar {
-        // A new avatar!
-        JsOption::Some(avatar_uri) => room_info.update_avatar(Some(avatar_uri.to_owned())),
-        // Avatar must be removed.
-        JsOption::Null => room_info.update_avatar(None),
-        // Nothing to do.
-        JsOption::Undefined => {}
-    }
-
-    // Sliding sync doesn't have a room summary, nevertheless it contains the joined
-    // and invited member counts, in addition to the heroes.
-    if let Some(count) = room_data.joined_count {
-        room_info.update_joined_member_count(count.into());
-    }
-    if let Some(count) = room_data.invited_count {
-        room_info.update_invited_member_count(count.into());
-    }
-
-    if let Some(heroes) = &room_data.heroes {
-        room_info.update_heroes(
-            heroes
-                .iter()
-                .map(|hero| RoomHero {
-                    user_id: hero.user_id.clone(),
-                    display_name: hero.name.clone(),
-                    avatar_url: hero.avatar.clone(),
-                })
-                .collect(),
-        );
-    }
-
-    room_info.set_prev_batch(room_data.prev_batch.as_deref());
-
-    if room_data.limited {
-        room_info.mark_members_missing();
-    }
-
-    if let Some(recency_stamp) = &room_data.bump_stamp {
-        let recency_stamp: u64 = (*recency_stamp).into();
-
-        if room_info.recency_stamp.as_ref() != Some(&recency_stamp) {
-            room_info.update_recency_stamp(recency_stamp);
-
-            // If it's not a new room, let's emit a `RECENCY_STAMP` update.
-            // For a new room, the room will appear as new, so we don't care about this
-            // update.
-            if !is_new_room {
-                context
-                    .room_info_notable_updates
-                    .entry(room_id.to_owned())
-                    .or_default()
-                    .insert(RoomInfoNotableUpdateReasons::RECENCY_STAMP);
-            }
-        }
-    }
 }
 
 #[cfg(all(test, not(target_family = "wasm")))]
@@ -849,9 +340,9 @@ mod tests {
     };
     use serde_json::json;
 
-    #[cfg(feature = "e2e-encryption")]
-    use super::cache_latest_events;
     use super::http;
+    #[cfg(feature = "e2e-encryption")]
+    use super::processors::room::msc4186::cache_latest_events;
     use crate::{
         rooms::normal::{RoomHero, RoomInfoNotableUpdateReasons},
         test_utils::logged_in_base_client,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -321,7 +321,7 @@ impl BaseStateStore {
     pub fn get_or_create_room(
         &self,
         room_id: &RoomId,
-        room_type: RoomState,
+        room_state: RoomState,
         room_info_notable_update_sender: broadcast::Sender<RoomInfoNotableUpdate>,
     ) -> Room {
         let user_id =
@@ -335,7 +335,7 @@ impl BaseStateStore {
                     user_id,
                     self.inner.clone(),
                     room_id,
-                    room_type,
+                    room_state,
                     room_info_notable_update_sender,
                 )
             })

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -72,11 +72,11 @@ impl fmt::Debug for SyncResponse {
 #[derive(Clone, Default)]
 pub struct RoomUpdates {
     /// The rooms that the user has left or been banned from.
-    pub leave: BTreeMap<OwnedRoomId, LeftRoomUpdate>,
+    pub left: BTreeMap<OwnedRoomId, LeftRoomUpdate>,
     /// The rooms that the user has joined.
-    pub join: BTreeMap<OwnedRoomId, JoinedRoomUpdate>,
+    pub joined: BTreeMap<OwnedRoomId, JoinedRoomUpdate>,
     /// The rooms that the user has been invited to.
-    pub invite: BTreeMap<OwnedRoomId, InvitedRoomUpdate>,
+    pub invited: BTreeMap<OwnedRoomId, InvitedRoomUpdate>,
     /// The rooms that the user has knocked on.
     pub knocked: BTreeMap<OwnedRoomId, KnockedRoomUpdate>,
 }
@@ -87,10 +87,10 @@ impl RoomUpdates {
     /// This will only fill the in-memory caches, not save the info on disk.
     pub(crate) async fn update_in_memory_caches(&self, store: &BaseStateStore) {
         for room in self
-            .leave
+            .left
             .keys()
-            .chain(self.join.keys())
-            .chain(self.invite.keys())
+            .chain(self.joined.keys())
+            .chain(self.invited.keys())
             .chain(self.knocked.keys())
             .filter_map(|room_id| store.room(room_id))
         {
@@ -103,9 +103,9 @@ impl RoomUpdates {
 impl fmt::Debug for RoomUpdates {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RoomUpdates")
-            .field("leave", &self.leave)
-            .field("join", &self.join)
-            .field("invite", &DebugInvitedRoomUpdates(&self.invite))
+            .field("leave", &self.left)
+            .field("join", &self.joined)
+            .field("invite", &DebugInvitedRoomUpdates(&self.invited))
             .field("knocked", &DebugKnockedRoomUpdates(&self.knocked))
             .finish()
     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2203,7 +2203,7 @@ impl Client {
     /// client
     ///     .sync_with_callback(sync_settings, |response| async move {
     ///         let channel = sync_channel;
-    ///         for (room_id, room) in response.rooms.join {
+    ///         for (room_id, room) in response.rooms.joined {
     ///             for event in room.timeline.events {
     ///                 channel.send(event).await.unwrap();
     ///             }
@@ -2283,7 +2283,7 @@ impl Client {
     ///     .sync_with_result_callback(sync_settings, |response| async move {
     ///         let channel = sync_channel;
     ///         let sync_response = response?;
-    ///         for (room_id, room) in sync_response.rooms.join {
+    ///         for (room_id, room) in sync_response.rooms.joined {
     ///              for event in room.timeline.events {
     ///                  channel.send(event).await.unwrap();
     ///               }
@@ -2356,7 +2356,7 @@ impl Client {
     ///     Box::pin(client.sync_stream(SyncSettings::default()).await);
     ///
     /// while let Some(Ok(response)) = sync_stream.next().await {
-    ///     for room in response.rooms.join.values() {
+    ///     for room in response.rooms.joined.values() {
     ///         for e in &room.timeline.events {
     ///             if let Ok(event) = e.raw().deserialize() {
     ///                 println!("Received event {:?}", event);

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -538,7 +538,7 @@ impl EventCacheInner {
         let _lock = self.multiple_room_updates_lock.lock().await;
 
         // Left rooms.
-        for (room_id, left_room_update) in updates.leave {
+        for (room_id, left_room_update) in updates.left {
             let room = self.for_room(&room_id).await?;
 
             if let Err(err) =
@@ -550,7 +550,7 @@ impl EventCacheInner {
         }
 
         // Joined rooms.
-        for (room_id, joined_room_update) in updates.join {
+        for (room_id, joined_room_update) in updates.joined {
             let room = self.for_room(&room_id).await?;
 
             if let Err(err) =
@@ -810,8 +810,8 @@ mod tests {
         };
 
         let mut updates = RoomUpdates::default();
-        updates.join.insert(room_id1.to_owned(), joined_room_update1);
-        updates.join.insert(room_id2.to_owned(), joined_room_update2);
+        updates.joined.insert(room_id1.to_owned(), joined_room_update1);
+        updates.joined.insert(room_id2.to_owned(), joined_room_update2);
 
         // Have the event cache handle them.
         event_cache.inner.handle_room_updates(updates).await.unwrap();

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -248,7 +248,7 @@ impl<'a> SlidingSyncResponseProcessor<'a> {
 ///
 /// This will only fill the in-memory caches, not save the info on disk.
 async fn update_in_memory_caches(client: &Client, response: &SyncResponse) -> Result<()> {
-    for room_id in response.rooms.join.keys() {
+    for room_id in response.rooms.joined.keys() {
         let Some(room) = client.get_room(room_id) else {
             error!(room_id = ?room_id, "Cannot post process a room in sliding sync because it is missing");
             continue;

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -321,14 +321,14 @@ impl SlidingSync {
             let updated_rooms = {
                 let mut rooms_map = self.inner.rooms.write().await;
 
-                let mut updated_rooms = Vec::with_capacity(sync_response.rooms.join.len());
+                let mut updated_rooms = Vec::with_capacity(sync_response.rooms.joined.len());
 
                 for (room_id, mut room_data) in sliding_sync_response.rooms.into_iter() {
                     // `sync_response` contains the rooms with decrypted events if any, so look at
                     // the timeline events here first if the room exists.
                     // Otherwise, let's look at the timeline inside the `sliding_sync_response`.
                     let timeline =
-                        if let Some(joined_room) = sync_response.rooms.join.remove(&room_id) {
+                        if let Some(joined_room) = sync_response.rooms.joined.remove(&room_id) {
                             joined_room.timeline.events
                         } else {
                             room_data.timeline.drain(..).map(TimelineEvent::new).collect()
@@ -363,7 +363,7 @@ impl SlidingSync {
                 // Since we've removed rooms that were in the room subsection from
                 // `sync_response.rooms.join`, the remaining ones aren't already present in
                 // `updated_rooms` and wouldn't cause any duplicates.
-                updated_rooms.extend(sync_response.rooms.join.keys().cloned());
+                updated_rooms.extend(sync_response.rooms.joined.keys().cloned());
 
                 updated_rooms
             };

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -178,7 +178,7 @@ impl Client {
         // Ignore errors when there are no receivers.
         let _ = self.inner.room_updates_sender.send(rooms.clone());
 
-        for (room_id, room_info) in &rooms.join {
+        for (room_id, room_info) in &rooms.joined {
             let Some(room) = self.get_room(room_id) else {
                 error!(?room_id, "Can't call event handler, room not found");
                 continue;
@@ -207,7 +207,7 @@ impl Client {
             self.handle_sync_events(HandlerKind::EphemeralRoomData, room, ephemeral).await?;
         }
 
-        for (room_id, room_info) in &rooms.leave {
+        for (room_id, room_info) in &rooms.left {
             let Some(room) = self.get_room(room_id) else {
                 error!(?room_id, "Can't call event handler, room not found");
                 continue;
@@ -226,7 +226,7 @@ impl Client {
             self.handle_sync_timeline_events(room, &timeline.events).await?;
         }
 
-        for (room_id, room_info) in &rooms.invite {
+        for (room_id, room_info) in &rooms.invited {
             let Some(room) = self.get_room(room_id) else {
                 error!(?room_id, "Can't call event handler, room not found");
                 continue;

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -349,13 +349,13 @@ async fn test_subscribe_all_room_updates() {
     client.sync_once(sync_settings).await.unwrap();
 
     let room_updates = rx.recv().now_or_never().unwrap().unwrap();
-    assert_let!(RoomUpdates { leave, join, invite, knocked } = room_updates);
+    assert_let!(RoomUpdates { left, joined, invited, knocked } = room_updates);
 
     // Check the left room updates.
     {
-        assert_eq!(leave.len(), 1);
+        assert_eq!(left.len(), 1);
 
-        let (room_id, update) = leave.iter().next().unwrap();
+        let (room_id, update) = left.iter().next().unwrap();
 
         assert_eq!(room_id, *MIXED_LEFT_ROOM_ID);
         assert!(update.state.is_empty());
@@ -365,9 +365,9 @@ async fn test_subscribe_all_room_updates() {
 
     // Check the joined room updates.
     {
-        assert_eq!(join.len(), 1);
+        assert_eq!(joined.len(), 1);
 
-        let (room_id, update) = join.iter().next().unwrap();
+        let (room_id, update) = joined.iter().next().unwrap();
 
         assert_eq!(room_id, *MIXED_JOINED_ROOM_ID);
 
@@ -385,9 +385,9 @@ async fn test_subscribe_all_room_updates() {
 
     // Check the invited room updates.
     {
-        assert_eq!(invite.len(), 1);
+        assert_eq!(invited.len(), 1);
 
-        let (room_id, update) = invite.iter().next().unwrap();
+        let (room_id, update) = invited.iter().next().unwrap();
 
         assert_eq!(room_id, *MIXED_INVITED_ROOM_ID);
         assert_eq!(update.invite_state.events.len(), 2);
@@ -938,7 +938,7 @@ async fn test_test_ambiguity_changes() {
 
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
 
-    let changes = &response.rooms.join.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
+    let changes = &response.rooms.joined.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
 
     // A new member always triggers an ambiguity change.
     let example_change = changes.get(event_id!("$151800140517rfvjc:localhost")).unwrap();
@@ -1009,7 +1009,7 @@ async fn test_test_ambiguity_changes() {
     let response = client.sync_once(SyncSettings::default()).await.unwrap();
     server.reset().await;
 
-    let changes = &response.rooms.join.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
+    let changes = &response.rooms.joined.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
 
     // First joined member made both members ambiguous.
     let example_2_change = changes.get(example_2_rename_1_event_id).unwrap();
@@ -1068,7 +1068,7 @@ async fn test_test_ambiguity_changes() {
     let response = client.sync_once(SyncSettings::default()).await.unwrap();
     server.reset().await;
 
-    let changes = &response.rooms.join.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
+    let changes = &response.rooms.joined.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
 
     // example 2 is not ambiguous anymore.
     let example_2_change = changes.get(example_2_rename_2_event_id).unwrap();
@@ -1114,7 +1114,7 @@ async fn test_test_ambiguity_changes() {
     let response = client.sync_once(SyncSettings::default()).await.unwrap();
     server.reset().await;
 
-    let changes = &response.rooms.join.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
+    let changes = &response.rooms.joined.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
 
     // example 3 is now ambiguous with example 2, not example.
     let example_3_change = changes.get(example_3_rename_event_id).unwrap();
@@ -1160,7 +1160,7 @@ async fn test_test_ambiguity_changes() {
     let response = client.sync_once(SyncSettings::default()).await.unwrap();
     server.reset().await;
 
-    let changes = &response.rooms.join.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
+    let changes = &response.rooms.joined.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
 
     // name change, even if still not ambiguous, triggers ambiguity change.
     let example_change = changes.get(example_rename_event_id).unwrap();
@@ -1207,7 +1207,7 @@ async fn test_test_ambiguity_changes() {
     server.reset().await;
 
     // Avatar change does not trigger ambiguity change.
-    assert!(response.rooms.join.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes.is_empty());
+    assert!(response.rooms.joined.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes.is_empty());
 
     let changes = assert_next_matches!(updates, Ok(RoomUpdate::Joined { updates, .. }) => updates.ambiguity_changes);
     assert!(changes.is_empty());

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -61,7 +61,7 @@ async fn test_notification() -> Result<()> {
     let bob_invite_response = bob.sync_once(Default::default()).await?;
     let sync_token = bob_invite_response.next_batch;
 
-    let mut invited_rooms = bob_invite_response.rooms.invite;
+    let mut invited_rooms = bob_invite_response.rooms.invited;
 
     assert_eq!(invited_rooms.len(), 1, "must be only one invitation");
 
@@ -145,7 +145,7 @@ async fn test_notification() -> Result<()> {
     // In this sync, Bob receives the message from Alice.
     let bob_response = bob.sync_once(SyncSettings::default().token(sync_token)).await?;
 
-    let mut joined_rooms = bob_response.rooms.join.into_iter();
+    let mut joined_rooms = bob_response.rooms.joined.into_iter();
     let (_, bob_room) = joined_rooms.next().expect("must have joined one room");
     assert!(joined_rooms.next().is_none(), "no more joined rooms: {joined_rooms:#?}");
 


### PR DESCRIPTION
 Sequel of https://github.com/matrix-org/matrix-rust-sdk/pull/4928.

This PR continues to refactor and clean up the response workflow as so-called response processors.

Each patch should be reviewed individually. There is nothing fancy, it's mostly code moves.

This time, the sliding sync (`BaseClient::process_sliding_sync`) is now fully using response processors. This PR introduces the new `rooms::msc4186` processors! It does several things, but the most notable is: a nice clean up around 4 `Option`s being returned by a method, and the removal of a large `clone` of room account data.