### PR TITLE
multiverse: prefer rendering back-paginated events instead of timeline's tail

### DIFF
--- a/labs/multiverse/src/widgets/room_view/timeline.rs
+++ b/labs/multiverse/src/widgets/room_view/timeline.rs
@@ -102,11 +102,6 @@ impl Widget for &mut TimelineView<'_> {
         let list = List::new(list_items).highlight_spacing(HighlightSpacing::Always);
 
         let mut dummy_list_state = ListState::default();
-        // Scroll down to the bottom, so we always see the latest message.
-        //
-        // TODO: We should probably use the offset here instead of just scrolling down
-        // since this now selects the last item in the list.
-        dummy_list_state.scroll_down_by(list.len() as u16);
 
         StatefulWidget::render(list, area, buf, &mut dummy_list_state);
     }


### PR DESCRIPTION
This is useful to observe the virtyual start of timeline item in manual testing.