### PR TITLE
crypto: fix changelog for 0.10.0 and 0.11.0

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -27,6 +27,10 @@ All notable changes to this project will be documented in this file.
   `shared_history` field that defaults to `false.`
   ([#4700](https://github.com/matrix-org/matrix-rust-sdk/pull/4700))
 
+- Have the `RoomIdentityProvider` return processing changes when identities transition
+  to `IdentityState::Verified` too.
+  ([#4670](https://github.com/matrix-org/matrix-rust-sdk/pull/4670))
+
 ## [0.10.0] - 2025-02-04
 
 ### Features
@@ -43,10 +47,6 @@ All notable changes to this project will be documented in this file.
 - Room keys are not shared with unsigned dehydrated devices.
   ([#4551](https://github.com/matrix-org/matrix-rust-sdk/pull/4551))
   
-- Have the `RoomIdentityProvider` return processing changes when identities transition
-  to `IdentityState::Verified` too.
-  ([#4670](https://github.com/matrix-org/matrix-rust-sdk/pull/4670))
-
 ## [0.9.0] - 2024-12-18
 
 ### Features


### PR DESCRIPTION
PR #4670 didn't land until 0.11.0.