### PR TITLE
fix(base): The room computed display name is persisted

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -533,7 +533,7 @@ impl BaseClient {
 
         let push_rules = self.get_push_rules(&global_account_data_processor).await?;
 
-        let mut new_rooms = RoomUpdates::default();
+        let mut room_updates = RoomUpdates::default();
         let mut notifications = Default::default();
 
         let mut updated_members_in_room: BTreeMap<OwnedRoomId, BTreeSet<OwnedUserId>> =
@@ -564,7 +564,7 @@ impl BaseClient {
             )
             .await?;
 
-            new_rooms.joined.insert(room_id, joined_room_update);
+            room_updates.joined.insert(room_id, joined_room_update);
         }
 
         for (room_id, left_room) in response.rooms.leave {
@@ -591,7 +591,7 @@ impl BaseClient {
             )
             .await?;
 
-            new_rooms.left.insert(room_id, left_room_update);
+            room_updates.left.insert(room_id, left_room_update);
         }
 
         for (room_id, invited_room) in response.rooms.invite {
@@ -608,7 +608,7 @@ impl BaseClient {
             )
             .await?;
 
-            new_rooms.invited.insert(room_id, invited_room_update);
+            room_updates.invited.insert(room_id, invited_room_update);
         }
 
         for (room_id, knocked_room) in response.rooms.knock {
@@ -625,7 +625,7 @@ impl BaseClient {
             )
             .await?;
 
-            new_rooms.knocked.insert(room_id, knocked_room_update);
+            room_updates.knocked.insert(room_id, knocked_room_update);
         }
 
         global_account_data_processor.apply(&mut context, &self.state_store).await;
@@ -654,12 +654,19 @@ impl BaseClient {
             .await?;
         }
 
+        let mut context = Context::default();
+
         // Now that all the rooms information have been saved, update the display name
-        // cache (which relies on information stored in the database). This will
-        // live in memory, until the next sync which will saves the room info to
-        // disk; we do this to avoid saving that would be redundant with the
-        // above. Oh well.
-        new_rooms.update_in_memory_caches(&self.state_store).await;
+        // of the updated rooms (which relies on information stored in the database).
+        processors::room::display_name::update_for_rooms(
+            &mut context,
+            &room_updates,
+            &self.state_store,
+        )
+        .await;
+
+        // Save the new display name updates if any.
+        processors::changes::save_only(context, &self.state_store).await?;
 
         for (room_id, member_ids) in updated_members_in_room {
             if let Some(room) = self.get_room(&room_id) {
@@ -673,7 +680,7 @@ impl BaseClient {
         }
 
         let response = SyncResponse {
-            rooms: new_rooms,
+            rooms: room_updates,
             presence: response.presence.events,
             account_data: response.account_data.events,
             to_device,

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1325,7 +1325,7 @@ mod tests {
         let room = client.get_room(room_id).expect("Room not found");
         assert_eq!(room.state(), RoomState::Invited);
         assert_eq!(
-            room.compute_display_name().await.expect("fetching display name failed"),
+            room.compute_display_name().await.expect("fetching display name failed").into_inner(),
             RoomDisplayName::Calculated("Kyra".to_owned())
         );
     }

--- a/crates/matrix-sdk-base/src/response_processors/changes.rs
+++ b/crates/matrix-sdk-base/src/response_processors/changes.rs
@@ -25,6 +25,13 @@ use crate::{
     Result, StateChanges,
 };
 
+/// Save the [`StateChanges`] from the [`Context`] inside the [`BaseStateStore`]
+/// only! The changes aren't applied on the in-memory rooms.
+#[instrument(skip_all)]
+pub async fn save_only(context: Context, state_store: &BaseStateStore) -> Result<()> {
+    save_changes(&context.state_changes, state_store, None).await
+}
+
 /// Save the [`StateChanges`] from the [`Context`] inside the
 /// [`BaseStateStore`], and apply them on the in-memory rooms.
 #[instrument(skip_all)]

--- a/crates/matrix-sdk-base/src/response_processors/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/mod.rs
@@ -46,10 +46,4 @@ impl Context {
     pub fn new(state_changes: StateChanges) -> Self {
         Self { state_changes, room_info_notable_updates: Default::default() }
     }
-
-    pub fn into_parts(self) -> (StateChanges, RoomInfoNotableUpdates) {
-        let Self { state_changes, room_info_notable_updates } = self;
-
-        (state_changes, room_info_notable_updates)
-    }
 }

--- a/crates/matrix-sdk-base/src/response_processors/room/display_name.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/display_name.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use super::super::Context;
-use crate::{rooms::UpdatedRoomDisplayName, store::BaseStateStore, sync::RoomUpdates};
+use crate::{
+    rooms::UpdatedRoomDisplayName, store::BaseStateStore, sync::RoomUpdates,
+    RoomInfoNotableUpdateReasons,
+};
 
 pub async fn update_for_rooms(
     context: &mut Context,
@@ -31,7 +34,14 @@ pub async fn update_for_rooms(
         // Compute the display name. If it's different, let's register the `RoomInfo` in
         // the `StateChanges`.
         if let Ok(UpdatedRoomDisplayName::New(_)) = room.compute_display_name().await {
-            context.state_changes.room_infos.insert(room.room_id().to_owned(), room.clone_info());
+            let room_id = room.room_id().to_owned();
+
+            context.state_changes.room_infos.insert(room_id.clone(), room.clone_info());
+            context
+                .room_info_notable_updates
+                .entry(room_id)
+                .or_default()
+                .insert(RoomInfoNotableUpdateReasons::DISPLAY_NAME);
         }
     }
 }

--- a/crates/matrix-sdk-base/src/response_processors/room/display_name.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/display_name.rs
@@ -1,0 +1,37 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::Context;
+use crate::{rooms::UpdatedRoomDisplayName, store::BaseStateStore, sync::RoomUpdates};
+
+pub async fn update_for_rooms(
+    context: &mut Context,
+    room_updates: &RoomUpdates,
+    state_store: &BaseStateStore,
+) {
+    for room in room_updates
+        .left
+        .keys()
+        .chain(room_updates.joined.keys())
+        .chain(room_updates.invited.keys())
+        .chain(room_updates.knocked.keys())
+        .filter_map(|room_id| state_store.room(room_id))
+    {
+        // Compute the display name. If it's different, let's register the `RoomInfo` in
+        // the `StateChanges`.
+        if let Ok(UpdatedRoomDisplayName::New(_)) = room.compute_display_name().await {
+            context.state_changes.room_infos.insert(room.room_id().to_owned(), room.clone_info());
+        }
+    }
+}

--- a/crates/matrix-sdk-base/src/response_processors/room/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/mod.rs
@@ -17,6 +17,7 @@ use tokio::sync::broadcast::Sender;
 
 use crate::{store::ambiguity_map::AmbiguityCache, RequestedRequiredStates, RoomInfoNotableUpdate};
 
+pub mod display_name;
 pub mod msc4186;
 pub mod sync_v2;
 

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -66,6 +66,23 @@ pub enum RoomDisplayName {
     Empty,
 }
 
+/// An internal representing whether a room display name is new or not when
+/// computed.
+pub(crate) enum UpdatedRoomDisplayName {
+    New(RoomDisplayName),
+    Same(RoomDisplayName),
+}
+
+impl UpdatedRoomDisplayName {
+    /// Get the inner [`RoomDisplayName`].
+    pub fn into_inner(self) -> RoomDisplayName {
+        match self {
+            UpdatedRoomDisplayName::New(room_display_name) => room_display_name,
+            UpdatedRoomDisplayName::Same(room_display_name) => room_display_name,
+        }
+    }
+}
+
 const WHITESPACE_REGEX: &str = r"\s+";
 const INVALID_SYMBOLS_REGEX: &str = r"[#,:\{\}\\]+";
 

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -3285,7 +3285,7 @@ mod tests {
         assert!(context.room_info_notable_updates.contains_key(room_id));
 
         // The subscriber isn't notified at this point.
-        assert!(room_info_notable_update.try_recv().is_err());
+        assert!(room_info_notable_update.is_empty());
 
         // Then updating the room info will store the event,
         processors::changes::save_and_apply(

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -113,6 +113,15 @@ bitflags! {
 
         /// A membership change happened for the current user.
         const MEMBERSHIP = 0b0001_0000;
+
+        /// The display name has changed.
+        const DISPLAY_NAME = 0b0010_0000;
+    }
+}
+
+impl Default for RoomInfoNotableUpdateReasons {
+    fn default() -> Self {
+        Self::empty()
     }
 }
 
@@ -131,12 +140,6 @@ struct ComputedSummary {
     /// The number of joined and invited members, not including any service
     /// members.
     num_joined_invited_guess: u64,
-}
-
-impl Default for RoomInfoNotableUpdateReasons {
-    fn default() -> Self {
-        Self::empty()
-    }
 }
 
 /// The underlying room data structure collecting state for joined, left and

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -116,6 +116,18 @@ bitflags! {
 
         /// The display name has changed.
         const DISPLAY_NAME = 0b0010_0000;
+
+        /// This is a temporary hack.
+        ///
+        /// So here is the thing. Ideally, we DO NOT want to emit this reason. It does not
+        /// makes sense. However, all notable update reasons are not clearly identified
+        /// so far. Why is it a problem? The `matrix_sdk_ui::room_list_service::RoomList`
+        /// is listening this stream of [`RoomInfoNotableUpdate`], and emits an update on a
+        /// room item if it receives a notable reason. Because all reasons are not
+        /// identified, we are likely to miss particular updates, and it can feel broken.
+        /// Ultimately, we want to clearly identify all the notable update reasons, and
+        /// remove this one.
+        const NONE = 0b1000_0000;
     }
 }
 
@@ -1073,6 +1085,14 @@ impl Room {
             let _ = self.room_info_notable_update_sender.send(RoomInfoNotableUpdate {
                 room_id: self.room_id.clone(),
                 reasons: room_info_notable_update_reasons,
+            });
+        } else {
+            // TODO: remove this block!
+            // Read `RoomInfoNotableUpdateReasons::NONE` to understand why it must be
+            // removed.
+            let _ = self.room_info_notable_update_sender.send(RoomInfoNotableUpdate {
+                room_id: self.room_id.clone(),
+                reasons: RoomInfoNotableUpdateReasons::NONE,
             });
         }
     }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1068,11 +1068,13 @@ impl Room {
     ) {
         self.inner.set(room_info);
 
-        // Ignore error if no receiver exists.
-        let _ = self.room_info_notable_update_sender.send(RoomInfoNotableUpdate {
-            room_id: self.room_id.clone(),
-            reasons: room_info_notable_update_reasons,
-        });
+        if !room_info_notable_update_reasons.is_empty() {
+            // Ignore error if no receiver exists.
+            let _ = self.room_info_notable_update_sender.send(RoomInfoNotableUpdate {
+                room_id: self.room_id.clone(),
+                reasons: room_info_notable_update_reasons,
+            });
+        }
     }
 
     /// Get the `RoomMember` with the given `user_id`.

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -416,7 +416,10 @@ mod tests {
         // No m.room.name event, no heroes, no members => considered an empty room!
         let client_room = client.get_room(room_id).expect("No room found");
         assert!(client_room.name().is_none());
-        assert_eq!(client_room.compute_display_name().await.unwrap().to_string(), "Empty Room");
+        assert_eq!(
+            client_room.compute_display_name().await.unwrap().into_inner().to_string(),
+            "Empty Room"
+        );
         assert_eq!(client_room.state(), RoomState::Joined);
 
         // And it is added to the list of joined rooms only.
@@ -448,7 +451,10 @@ mod tests {
         // The name is known.
         let client_room = client.get_room(room_id).expect("No room found");
         assert_eq!(client_room.name().as_deref(), Some("The Name"));
-        assert_eq!(client_room.compute_display_name().await.unwrap().to_string(), "The Name");
+        assert_eq!(
+            client_room.compute_display_name().await.unwrap().into_inner().to_string(),
+            "The Name"
+        );
     }
 
     #[async_test]
@@ -475,7 +481,7 @@ mod tests {
         assert!(client_room.name().is_none());
 
         // No m.room.name event, no heroes => using the invited member.
-        assert_eq!(client_room.compute_display_name().await.unwrap().to_string(), "w");
+        assert_eq!(client_room.compute_display_name().await.unwrap().into_inner().to_string(), "w");
 
         assert_eq!(client_room.state(), RoomState::Invited);
 
@@ -512,7 +518,10 @@ mod tests {
         // The name is known.
         let client_room = client.get_room(room_id).expect("No room found");
         assert_eq!(client_room.name().as_deref(), Some("The Name"));
-        assert_eq!(client_room.compute_display_name().await.unwrap().to_string(), "The Name");
+        assert_eq!(
+            client_room.compute_display_name().await.unwrap().into_inner().to_string(),
+            "The Name"
+        );
     }
 
     #[async_test]
@@ -1063,7 +1072,10 @@ mod tests {
 
         // Then the room's name is NOT overridden by the server-computed display name.
         let client_room = client.get_room(room_id).expect("No room found");
-        assert_eq!(client_room.compute_display_name().await.unwrap().to_string(), "myroom");
+        assert_eq!(
+            client_room.compute_display_name().await.unwrap().into_inner().to_string(),
+            "myroom"
+        );
         assert!(client_room.name().is_none());
     }
 

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -1111,6 +1111,13 @@ mod tests {
             room_info_notable_update.recv().await,
             Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons }) => {
                 assert_eq!(received_room_id, room_id);
+                assert!(reasons.contains(RoomInfoNotableUpdateReasons::NONE));
+            }
+        );
+        assert_matches!(
+            room_info_notable_update.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons }) => {
+                assert_eq!(received_room_id, room_id);
                 // The reason we are looking for :-].
                 assert!(reasons.contains(RoomInfoNotableUpdateReasons::DISPLAY_NAME));
             }
@@ -1813,6 +1820,13 @@ mod tests {
                 assert!(!received_reasons.contains(RoomInfoNotableUpdateReasons::RECENCY_STAMP));
             }
         );
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::DISPLAY_NAME));
+            }
+        );
         assert!(room_info_notable_update_stream.is_empty());
 
         // When I send sliding sync response containing a room with a recency stamp.
@@ -1858,6 +1872,13 @@ mod tests {
             Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
                 assert_eq!(received_room_id, room_id);
                 assert!(!received_reasons.contains(RoomInfoNotableUpdateReasons::READ_RECEIPT));
+            }
+        );
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::DISPLAY_NAME));
             }
         );
         assert!(room_info_notable_update_stream.is_empty());
@@ -1910,6 +1931,13 @@ mod tests {
             room_info_notable_update_stream.recv().await,
             Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
                 assert_eq!(received_room_id, room_id);
+                assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::NONE));
+            }
+        );
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
                 assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::DISPLAY_NAME));
             }
         );
@@ -1938,6 +1966,13 @@ mod tests {
             .expect("Failed to process sync");
 
         // Room was already joined, no `MEMBERSHIP` update should be triggered here
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::NONE));
+            }
+        );
         assert!(room_info_notable_update_stream.is_empty());
 
         let events = vec![Raw::from_json_string(
@@ -1987,7 +2022,14 @@ mod tests {
             .await
             .expect("Failed to process sync");
 
-        // Another notable update is received, but not the one we are interested by.
+        // Other notable updates are received, but not the ones we are interested by.
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::NONE), "{received_reasons:?}");
+            }
+        );
         assert_matches!(
             room_info_notable_update_stream.recv().await,
             Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
@@ -2034,6 +2076,13 @@ mod tests {
             .await
             .expect("Failed to process sync");
 
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::NONE), "{received_reasons:?}");
+            }
+        );
         assert!(room_info_notable_update_stream.is_empty());
 
         // …Unless its value changes!

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -35,7 +35,6 @@ use serde::{Deserialize, Serialize};
 use crate::{
     debug::{DebugInvitedRoom, DebugKnockedRoom, DebugListOfRawEvents, DebugListOfRawEventsNoId},
     deserialized_responses::{AmbiguityChange, RawAnySyncOrStrippedTimelineEvent},
-    store::BaseStateStore,
 };
 
 /// Generalized representation of a `/sync` response.
@@ -79,24 +78,6 @@ pub struct RoomUpdates {
     pub invited: BTreeMap<OwnedRoomId, InvitedRoomUpdate>,
     /// The rooms that the user has knocked on.
     pub knocked: BTreeMap<OwnedRoomId, KnockedRoomUpdate>,
-}
-
-impl RoomUpdates {
-    /// Update the caches for the rooms that received updates.
-    ///
-    /// This will only fill the in-memory caches, not save the info on disk.
-    pub(crate) async fn update_in_memory_caches(&self, store: &BaseStateStore) {
-        for room in self
-            .left
-            .keys()
-            .chain(self.joined.keys())
-            .chain(self.invited.keys())
-            .chain(self.knocked.keys())
-            .filter_map(|room_id| store.room(room_id))
-        {
-            let _ = room.compute_display_name().await;
-        }
-    }
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -1488,8 +1488,20 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
         push front [ "!r4:bar.org" ];
         end;
     };
-    // TODO (@hywan): Must be removed once we restore `RoomInfoNotableUpdate`
-    // filtering inside `RoomList`.
+    // TODO (@hywan): Remove as soon as `RoomInfoNotableUpdateReasons::NONE` is
+    // removed.
+    assert_entries_batch! {
+        [dynamic_entries_stream]
+        set [ 1 ] [ "!r1:bar.org" ];
+        end;
+    };
+    assert_entries_batch! {
+        [dynamic_entries_stream]
+        set [ 0 ] [ "!r4:bar.org" ];
+        end;
+    };
+    // TODO (@hywan): Remove as soon as `RoomInfoNotableUpdateReasons::NONE` is
+    // removed.
     assert_entries_batch! {
         [dynamic_entries_stream]
         set [ 1 ] [ "!r1:bar.org" ];
@@ -1581,13 +1593,28 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
         push front [ "!r7:bar.org" ];
         end;
     };
-    // TODO (@hywan): Must be removed once we restore `RoomInfoNotableUpdate`
-    // filtering inside `RoomList`.
+    // TODO (@hywan): Remove as soon as `RoomInfoNotableUpdateReasons::NONE` is
+    // removed.
     assert_entries_batch! {
         [dynamic_entries_stream]
         set [ 1 ] [ "!r5:bar.org" ];
         end;
     };
+    assert_entries_batch! {
+        [dynamic_entries_stream]
+        set [ 0 ] [ "!r7:bar.org" ];
+        end;
+    };
+
+    // TODO (@hywan): Remove as soon as `RoomInfoNotableUpdateReasons::NONE` is
+    // removed.
+    assert_entries_batch! {
+        [dynamic_entries_stream]
+        set [ 1 ] [ "!r5:bar.org" ];
+        end;
+    };
+    // TODO (@hywan): Remove as soon as `RoomInfoNotableUpdateReasons::NONE` is
+    // removed.
     assert_entries_batch! {
         [dynamic_entries_stream]
         set [ 0 ] [ "!r7:bar.org" ];
@@ -1990,8 +2017,16 @@ async fn test_room_sorting() -> Result<(), Error> {
     // | 4     | !r1     | 6       | Aaa  |
     // | 5     | !r4     | 5       |      |
 
-    // TODO (@hywan): Must be removed once we restore `RoomInfoNotableUpdate`
-    // filtering inside `RoomList`.
+    // TODO (@hywan): Remove as soon as `RoomInfoNotableUpdateReasons::NONE` is
+    // removed.
+    assert_entries_batch! {
+        [stream]
+        set [ 2 ] [ "!r6:bar.org" ];
+        end;
+    };
+
+    // TODO (@hywan): Remove as soon as `RoomInfoNotableUpdateReasons::NONE` is
+    // removed.
     assert_entries_batch! {
         [stream]
         set [ 2 ] [ "!r6:bar.org" ];


### PR DESCRIPTION
Sequel of https://github.com/matrix-org/matrix-rust-sdk/pull/4934.

This PR should be reviewed patch-by-patch.

The room display name is computed during the sync (for both sync v2 and sliding sync), and is kept in memory. To do that, the `StateChanges` needs to be saved in the state store, because computing the display name requires data from the state store. Problem is: the display name isn't saved after that. One needs to wait on another sync to happen for this particular room to persist/save the computed display name.

This PR fixes that by using the recently added response processors. A test confirms the problem is fixed.

---

Combo.

* Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/4051
* Fixes https://github.com/element-hq/element-x-ios/issues/3365
* Fixes https://github.com/element-hq/element-x-android/issues/3920
* Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/4825
* Closes https://github.com/element-hq/customer-success/issues/405
* Closes https://github.com/element-hq/customer-success/issues/469