### PR TITLE
Widget driver: Distinguish room state and timeline events

### DIFF
--- a/crates/matrix-sdk/src/widget/filter.rs
+++ b/crates/matrix-sdk/src/widget/filter.rs
@@ -14,7 +14,8 @@
 
 use ruma::{
     events::{
-        AnyTimelineEvent, AnyToDeviceEvent, MessageLikeEventType, StateEventType, ToDeviceEventType,
+        AnyStateEvent, AnyTimelineEvent, AnyToDeviceEvent, MessageLikeEventType, StateEventType,
+        ToDeviceEventType,
     },
     serde::Raw,
 };
@@ -220,6 +221,16 @@ impl<'a> TryFrom<&'a Raw<AnyTimelineEvent>> for FilterInput<'a> {
     fn try_from(raw_event: &'a Raw<AnyTimelineEvent>) -> Result<Self, Self::Error> {
         // FilterInput first checks if it can deserialize as a state event (state_key
         // exists) and then as a message-like event.
+        raw_event.deserialize_as()
+    }
+}
+
+/// Create a filter input based on [`AnyStateEvent`].
+/// This will create a [`FilterInput::State`].
+impl<'a> TryFrom<&'a Raw<AnyStateEvent>> for FilterInput<'a> {
+    type Error = serde_json::Error;
+
+    fn try_from(raw_event: &'a Raw<AnyStateEvent>) -> Result<Self, Self::Error> {
         raw_event.deserialize_as()
     }
 }

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -21,7 +21,7 @@ use ruma::{
         account::request_openid_token, delayed_events::update_delayed_event,
         to_device::send_event_to_device,
     },
-    events::{AnyTimelineEvent, AnyToDeviceEventContent},
+    events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEventContent},
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
     OwnedUserId,
@@ -48,11 +48,11 @@ pub(crate) enum MatrixDriverRequestData {
     /// Get OpenId token for a given request ID.
     GetOpenId,
 
-    /// Read message event(s).
-    ReadMessageLikeEvent(ReadMessageLikeEventRequest),
+    /// Read events from the timeline.
+    ReadEvents(ReadEventsRequest),
 
-    /// Read state event(s).
-    ReadStateEvent(ReadStateEventRequest),
+    /// Read room state entries.
+    ReadState(ReadStateRequest),
 
     /// Send Matrix event that corresponds to the given description.
     SendEvent(SendEventRequest),
@@ -170,26 +170,32 @@ impl FromMatrixDriverResponse for request_openid_token::v3::Response {
     }
 }
 
-/// Ask the client to read Matrix event(s) that corresponds to the given
+/// Ask the client to read Matrix events that correspond to the given
 /// description and return a list of events as a response.
 #[derive(Clone, Debug)]
-pub(crate) struct ReadMessageLikeEventRequest {
+pub(crate) struct ReadEventsRequest {
     /// The event type to read.
     // TODO: This wants to be `MessageLikeEventType`` but we need a type which supports `as_str()`
     // as soon as ruma supports `as_str()` on `MessageLikeEventType` we can use it here.
     pub(crate) event_type: String,
 
+    /// The `state_key` to read. If None, this will read events regardless of
+    /// whether they are state events. If `Some(Any)`, this will only read state
+    /// events of the given type. If set to a specific state key, this will only
+    /// read state events of the given type matching that state key.
+    pub(crate) state_key: Option<StateKeySelector>,
+
     /// The maximum number of events to return.
     pub(crate) limit: u32,
 }
 
-impl From<ReadMessageLikeEventRequest> for MatrixDriverRequestData {
-    fn from(value: ReadMessageLikeEventRequest) -> Self {
-        MatrixDriverRequestData::ReadMessageLikeEvent(value)
+impl From<ReadEventsRequest> for MatrixDriverRequestData {
+    fn from(value: ReadEventsRequest) -> Self {
+        MatrixDriverRequestData::ReadEvents(value)
     }
 }
 
-impl MatrixDriverRequest for ReadMessageLikeEventRequest {
+impl MatrixDriverRequest for ReadEventsRequest {
     type Response = Vec<Raw<AnyTimelineEvent>>;
 }
 
@@ -205,28 +211,40 @@ impl FromMatrixDriverResponse for Vec<Raw<AnyTimelineEvent>> {
     }
 }
 
-/// Ask the client to read Matrix event(s) that corresponds to the given
-/// description and return a list of events as a response.
+/// Ask the client to read Matrix room state entries corresponding to the given
+/// description and return a list of state events as a response.
 #[derive(Clone, Debug)]
-pub(crate) struct ReadStateEventRequest {
+pub(crate) struct ReadStateRequest {
     /// The event type to read.
     // TODO: This wants to be `TimelineEventType` but we need a type which supports `as_str()`
     // as soon as ruma supports `as_str()` on `TimelineEventType` we can use it here.
     pub(crate) event_type: String,
 
-    /// The `state_key` to read, or `Any` to receive any/all events of the given
-    /// type, regardless of their `state_key`.
+    /// The `state_key` to read, or `Any` to receive any/all room state entries
+    /// of the given type, regardless of their `state_key`.
     pub(crate) state_key: StateKeySelector,
 }
 
-impl From<ReadStateEventRequest> for MatrixDriverRequestData {
-    fn from(value: ReadStateEventRequest) -> Self {
-        MatrixDriverRequestData::ReadStateEvent(value)
+impl From<ReadStateRequest> for MatrixDriverRequestData {
+    fn from(value: ReadStateRequest) -> Self {
+        MatrixDriverRequestData::ReadState(value)
     }
 }
 
-impl MatrixDriverRequest for ReadStateEventRequest {
-    type Response = Vec<Raw<AnyTimelineEvent>>;
+impl MatrixDriverRequest for ReadStateRequest {
+    type Response = Vec<Raw<AnyStateEvent>>;
+}
+
+impl FromMatrixDriverResponse for Vec<Raw<AnyStateEvent>> {
+    fn from_response(ev: MatrixDriverResponse) -> Option<Self> {
+        match ev {
+            MatrixDriverResponse::StateRead(response) => Some(response),
+            _ => {
+                error!("bug in MatrixDriver, received wrong event response");
+                None
+            }
+        }
+    }
 }
 
 /// Ask the client to send Matrix event that corresponds to the given

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -55,7 +55,7 @@ pub(crate) enum MatrixDriverRequestData {
     ReadStateEvent(ReadStateEventRequest),
 
     /// Send Matrix event that corresponds to the given description.
-    SendMatrixEvent(SendEventRequest),
+    SendEvent(SendEventRequest),
 
     /// Send a to-device message over the Matrix homeserver.
     SendToDeviceEvent(SendToDeviceRequest),
@@ -196,7 +196,7 @@ impl MatrixDriverRequest for ReadMessageLikeEventRequest {
 impl FromMatrixDriverResponse for Vec<Raw<AnyTimelineEvent>> {
     fn from_response(ev: MatrixDriverResponse) -> Option<Self> {
         match ev {
-            MatrixDriverResponse::MatrixEventRead(response) => Some(response),
+            MatrixDriverResponse::EventsRead(response) => Some(response),
             _ => {
                 error!("bug in MatrixDriver, received wrong event response");
                 None
@@ -251,7 +251,7 @@ pub(crate) struct SendEventRequest {
 
 impl From<SendEventRequest> for MatrixDriverRequestData {
     fn from(value: SendEventRequest) -> Self {
-        MatrixDriverRequestData::SendMatrixEvent(value)
+        MatrixDriverRequestData::SendEvent(value)
     }
 }
 
@@ -262,7 +262,7 @@ impl MatrixDriverRequest for SendEventRequest {
 impl FromMatrixDriverResponse for SendEventResponse {
     fn from_response(ev: MatrixDriverResponse) -> Option<Self> {
         match ev {
-            MatrixDriverResponse::MatrixEventSent(response) => Some(response),
+            MatrixDriverResponse::EventSent(response) => Some(response),
             _ => {
                 error!("bug in MatrixDriver, received wrong event response");
                 None
@@ -303,7 +303,7 @@ impl TryInto<send_event_to_device::v3::Response> for MatrixDriverResponse {
 
     fn try_into(self) -> Result<send_event_to_device::v3::Response, Self::Error> {
         match self {
-            MatrixDriverResponse::MatrixToDeviceSent(response) => Ok(response),
+            MatrixDriverResponse::ToDeviceSent(response) => Ok(response),
             _ => Err(de::Error::custom("bug in MatrixDriver, received wrong event response")),
         }
     }
@@ -330,7 +330,7 @@ impl MatrixDriverRequest for UpdateDelayedEventRequest {
 impl FromMatrixDriverResponse for update_delayed_event::unstable::Response {
     fn from_response(ev: MatrixDriverResponse) -> Option<Self> {
         match ev {
-            MatrixDriverResponse::MatrixDelayedEventUpdate(response) => Some(response),
+            MatrixDriverResponse::DelayedEventUpdated(response) => Some(response),
             _ => {
                 error!("bug in MatrixDriver, received wrong event response");
                 None

--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -35,7 +35,7 @@ pub(super) enum FromWidgetRequest {
     #[serde(rename = "get_openid")]
     GetOpenId {},
     #[serde(rename = "org.matrix.msc2876.read_events")]
-    ReadEvent(ReadEventRequest),
+    ReadEvent(ReadEventsRequest),
     SendEvent(SendEventRequest),
     SendToDevice(SendToDeviceRequest),
     #[serde(rename = "org.matrix.msc4157.update_delayed_event")]
@@ -133,6 +133,7 @@ impl SupportedApiVersionsResponse {
                 ApiVersion::V0_0_1,
                 ApiVersion::V0_0_2,
                 ApiVersion::MSC2762,
+                ApiVersion::MSC2762UpdateState,
                 ApiVersion::MSC2871,
                 ApiVersion::MSC3819,
             ],
@@ -154,6 +155,10 @@ pub(super) enum ApiVersion {
     /// Supports sending and receiving of events.
     #[serde(rename = "org.matrix.msc2762")]
     MSC2762,
+
+    /// Supports receiving of room state with the `update_state` action.
+    #[serde(rename = "org.matrix.msc2762_update_state")]
+    MSC2762UpdateState,
 
     /// Supports sending of approved capabilities back to the widget.
     #[serde(rename = "org.matrix.msc2871")]
@@ -181,22 +186,15 @@ pub(super) enum ApiVersion {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(untagged)]
-pub(super) enum ReadEventRequest {
-    ReadStateEvent {
-        #[serde(rename = "type")]
-        event_type: String,
-        state_key: StateKeySelector,
-    },
-    ReadMessageLikeEvent {
-        #[serde(rename = "type")]
-        event_type: String,
-        limit: Option<u32>,
-    },
+pub(super) struct ReadEventsRequest {
+    #[serde(rename = "type")]
+    pub(super) event_type: String,
+    pub(super) state_key: Option<StateKeySelector>,
+    pub(super) limit: Option<u32>,
 }
 
 #[derive(Debug, Serialize)]
-pub(super) struct ReadEventResponse {
+pub(super) struct ReadEventsResponse {
     pub(super) events: Vec<Raw<AnyTimelineEvent>>,
 }
 

--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -152,15 +152,15 @@ pub(super) enum ApiVersion {
     #[serde(rename = "0.0.2")]
     V0_0_2,
 
-    /// Supports sending and receiving of events.
+    /// Supports sending and receiving events.
     #[serde(rename = "org.matrix.msc2762")]
     MSC2762,
 
-    /// Supports receiving of room state with the `update_state` action.
+    /// Supports receiving room state with the `update_state` action.
     #[serde(rename = "org.matrix.msc2762_update_state")]
     MSC2762UpdateState,
 
-    /// Supports sending of approved capabilities back to the widget.
+    /// Supports sending approved capabilities back to the widget.
     #[serde(rename = "org.matrix.msc2871")]
     MSC2871,
 
@@ -176,7 +176,7 @@ pub(super) enum ApiVersion {
     #[serde(rename = "org.matrix.msc2876")]
     MSC2876,
 
-    /// Supports sending and receiving of to-device events.
+    /// Supports sending and receiving to-device events.
     #[serde(rename = "org.matrix.msc3819")]
     MSC3819,
 

--- a/crates/matrix-sdk/src/widget/machine/incoming.rs
+++ b/crates/matrix-sdk/src/widget/machine/incoming.rs
@@ -64,13 +64,16 @@ pub(crate) enum MatrixDriverResponse {
     /// A response to an `Action::GetOpenId` command.
     OpenIdReceived(request_openid_token::v3::Response),
     /// Client read some Matrix event(s).
-    /// A response to an `Action::ReadMatrixEvent` commands.
-    MatrixEventRead(Vec<Raw<AnyTimelineEvent>>),
+    /// A response to a `Action::ReadEvent` command.
+    EventsRead(Vec<Raw<AnyTimelineEvent>>),
     /// Client sent some Matrix event. The response contains the event ID.
-    /// A response to an `Action::SendMatrixEvent` command.
-    MatrixEventSent(SendEventResponse),
-    MatrixToDeviceSent(send_event_to_device::v3::Response),
-    MatrixDelayedEventUpdate(delayed_events::update_delayed_event::unstable::Response),
+    /// A response to a `Action::SendEvent` command.
+    EventSent(SendEventResponse),
+    /// A response to a `Action::SendToDevice` command.
+    ToDeviceSent(send_event_to_device::v3::Response),
+    /// Client updated a delayed event.
+    /// A response to a `Action::UpdateDelayedEvent` command.
+    DelayedEventUpdated(delayed_events::update_delayed_event::unstable::Response),
 }
 
 pub(super) struct IncomingWidgetMessage {

--- a/crates/matrix-sdk/src/widget/machine/incoming.rs
+++ b/crates/matrix-sdk/src/widget/machine/incoming.rs
@@ -14,13 +14,15 @@
 
 use ruma::{
     api::client::{account::request_openid_token, delayed_events, to_device::send_event_to_device},
-    events::{AnyTimelineEvent, AnyToDeviceEvent},
+    events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEvent},
     serde::Raw,
 };
 use serde::{de, Deserialize, Deserializer};
 use serde_json::value::RawValue as RawJsonValue;
 use uuid::Uuid;
 
+#[cfg(doc)]
+use super::MatrixDriverRequestData;
 use super::{
     from_widget::{FromWidgetRequest, SendEventResponse},
     to_widget::ToWidgetResponse,
@@ -50,6 +52,13 @@ pub(crate) enum IncomingMessage {
     /// ([`crate::widget::Action::SubscribeTimeline`] request).
     MatrixEventReceived(Raw<AnyTimelineEvent>),
 
+    /// The `MatrixDriver` notified the `WidgetMachine` of a change in room
+    /// state.
+    ///
+    /// This means that the machine previously subscribed to some events
+    /// ([`crate::widget::Action::Subscribe`] request).
+    StateUpdateReceived(Vec<Raw<AnyStateEvent>>),
+
     /// The `MatrixDriver` notified the `WidgetMachine` of a new to-device
     /// event.
     ToDeviceReceived(Raw<AnyToDeviceEvent>),
@@ -57,22 +66,25 @@ pub(crate) enum IncomingMessage {
 
 pub(crate) enum MatrixDriverResponse {
     /// Client acquired capabilities from the user.
-    ///
-    /// A response to an `Action::AcquireCapabilities` command.
+    /// A response to a [`MatrixDriverRequestData::AcquireCapabilities`]
+    /// command.
     CapabilitiesAcquired(Capabilities),
     /// Client got OpenId token for a given request ID.
-    /// A response to an `Action::GetOpenId` command.
+    /// A response to a [`MatrixDriverRequestData::GetOpenId`] command.
     OpenIdReceived(request_openid_token::v3::Response),
     /// Client read some Matrix event(s).
-    /// A response to a `Action::ReadEvent` command.
+    /// A response to a [`MatrixDriverRequestData::ReadEvents`] command.
     EventsRead(Vec<Raw<AnyTimelineEvent>>),
+    /// Client read some Matrix room state entries.
+    /// A response to a [`MatrixDriverRequestData::ReadState`] command.
+    StateRead(Vec<Raw<AnyStateEvent>>),
     /// Client sent some Matrix event. The response contains the event ID.
-    /// A response to a `Action::SendEvent` command.
+    /// A response to a [`MatrixDriverRequestData::SendEvent`] command.
     EventSent(SendEventResponse),
     /// A response to a `Action::SendToDevice` command.
     ToDeviceSent(send_event_to_device::v3::Response),
     /// Client updated a delayed event.
-    /// A response to a `Action::UpdateDelayedEvent` command.
+    /// A response to a [`MatrixDriverRequestData::UpdateDelayedEvent`] command.
     DelayedEventUpdated(delayed_events::update_delayed_event::unstable::Response),
 }
 

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -713,6 +713,8 @@ impl WidgetMachine {
     fn negotiate_capabilities(&mut self) -> Vec<Action> {
         let mut actions = Vec::new();
 
+        // XXX: This branch appears to be accounting for capability **re**negotiation
+        // (MSC2974), which isn't implemented yet
         if matches!(&self.capabilities, CapabilitiesState::Negotiated(c) if !c.read.is_empty()) {
             actions.push(Action::Unsubscribe);
         }

--- a/crates/matrix-sdk/src/widget/machine/tests/api_versions.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/api_versions.rs
@@ -48,6 +48,7 @@ fn test_get_supported_api_versions() {
                     "0.0.1",
                     "0.0.2",
                     "org.matrix.msc2762",
+                    "org.matrix.msc2762_update_state",
                     "org.matrix.msc2871",
                     "org.matrix.msc3819",
                 ]

--- a/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
@@ -200,6 +200,19 @@ pub(super) fn assert_capabilities_dance(
         assert_matches!(action, Action::Subscribe);
     }
 
+    // We get the `ReadState` command if we requested some state reading
+    // capabilities.
+    if capability.starts_with("org.matrix.msc2762.receive.state_event") {
+        let action = actions.remove(0);
+        assert_matches!(
+            action,
+            Action::MatrixDriverRequest {
+                request_id: _,
+                data: MatrixDriverRequestData::ReadState(_)
+            }
+        );
+    }
+
     // Inform the widget about the acquired capabilities.
     {
         let [action]: [Action; 1] = actions.try_into().unwrap();

--- a/crates/matrix-sdk/src/widget/machine/tests/error.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/error.rs
@@ -96,7 +96,7 @@ fn test_read_request_for_non_allowed_message_like_events() {
     assert_eq!(msg["action"], "org.matrix.msc2876.read_events");
     assert_eq!(
         msg["response"]["error"]["message"].as_str().unwrap(),
-        "Not allowed to read message like event"
+        "Not allowed to read message-like event"
     );
 }
 
@@ -222,6 +222,6 @@ fn test_read_request_for_message_like_with_disallowed_msg_type_fails() {
     assert_eq!(msg["action"], "org.matrix.msc2876.read_events");
     assert_eq!(
         msg["response"]["error"]["message"].as_str().unwrap(),
-        "Not allowed to read message like event"
+        "Not allowed to read message-like event"
     );
 }

--- a/crates/matrix-sdk/src/widget/machine/to_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/to_widget.rs
@@ -15,7 +15,7 @@
 use std::marker::PhantomData;
 
 use ruma::{
-    events::{AnyTimelineEvent, AnyToDeviceEvent},
+    events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEvent},
     serde::Raw,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -122,6 +122,18 @@ pub(crate) struct NotifyNewMatrixEvent(pub(crate) Raw<AnyTimelineEvent>);
 
 impl ToWidgetRequest for NotifyNewMatrixEvent {
     const ACTION: &'static str = "send_event";
+    type ResponseData = Empty;
+}
+
+/// Notify the widget that room state has changed.
+/// This is a "response" to the widget subscribing to the events in the room.
+#[derive(Serialize)]
+pub(crate) struct NotifyStateUpdate {
+    pub(super) state: Vec<Raw<AnyStateEvent>>,
+}
+
+impl ToWidgetRequest for NotifyStateUpdate {
+    const ACTION: &'static str = "update_state";
     type ResponseData = Empty;
 }
 

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -215,14 +215,14 @@ impl WidgetDriver {
                     MatrixDriverRequestData::ReadMessageLikeEvent(cmd) => matrix_driver
                         .read_message_like_events(cmd.event_type.into(), cmd.limit)
                         .await
-                        .map(MatrixDriverResponse::MatrixEventRead),
+                        .map(MatrixDriverResponse::EventsRead),
 
                     MatrixDriverRequestData::ReadStateEvent(cmd) => matrix_driver
                         .read_state_events(cmd.event_type.into(), &cmd.state_key)
                         .await
-                        .map(MatrixDriverResponse::MatrixEventRead),
+                        .map(MatrixDriverResponse::EventsRead),
 
-                    MatrixDriverRequestData::SendMatrixEvent(req) => {
+                    MatrixDriverRequestData::SendEvent(req) => {
                         let SendEventRequest { event_type, state_key, content, delay } = req;
                         // The widget api action does not use the unstable prefix:
                         // `org.matrix.msc4140.delay` so we
@@ -234,13 +234,13 @@ impl WidgetDriver {
                         matrix_driver
                             .send(event_type.into(), state_key, content, delay_event_parameter)
                             .await
-                            .map(MatrixDriverResponse::MatrixEventSent)
+                            .map(MatrixDriverResponse::EventSent)
                     }
 
                     MatrixDriverRequestData::UpdateDelayedEvent(req) => matrix_driver
                         .update_delayed_event(req.delay_id, req.action)
                         .await
-                        .map(MatrixDriverResponse::MatrixDelayedEventUpdate),
+                        .map(MatrixDriverResponse::DelayedEventUpdated),
 
                     MatrixDriverRequestData::SendToDeviceEvent(send_to_device_request) => {
                         matrix_driver
@@ -250,7 +250,7 @@ impl WidgetDriver {
                                 send_to_device_request.messages,
                             )
                             .await
-                            .map(MatrixDriverResponse::MatrixToDeviceSent)
+                            .map(MatrixDriverResponse::ToDeviceSent)
                     }
                 };
 

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -878,7 +878,7 @@ async fn test_call_notifications_dont_notify_room_without_mention_powerlevel() {
     let (client, server) = logged_in_client_with_server().await;
 
     let mut sync_builder = SyncResponseBuilder::new();
-    let mut power_level_event = StateTestEvent::PowerLevels.into_json_value();
+    let mut power_level_event: Value = StateTestEvent::PowerLevels.into();
     // Allow noone to send room notify events.
     *power_level_event.get_mut("content").unwrap().get_mut("notifications").unwrap() =
         json!({"room": 101});

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -29,9 +29,11 @@ use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder
 use once_cell::sync::Lazy;
 use ruma::{
     event_id,
-    events::{room::member::MembershipState, MessageLikeEventType, StateEventType},
+    events::{
+        room::member::MembershipState, AnySyncStateEvent, MessageLikeEventType, StateEventType,
+    },
     owned_room_id,
-    serde::JsonObject,
+    serde::{JsonObject, Raw},
     user_id, OwnedRoomId,
 };
 use serde::Serialize;
@@ -333,6 +335,13 @@ async fn test_read_messages_with_msgtype_capabilities() {
     assert_eq!(first_event["content"]["body"], "hello");
 }
 
+async fn assert_state_synced(driver_handle: &WidgetDriverHandle, state: JsonValue) {
+    let msg = recv_message(driver_handle).await;
+    assert_eq!(msg["api"], "toWidget");
+    assert_eq!(msg["action"], "update_state");
+    assert_eq!(msg["data"]["state"], state);
+}
+
 #[async_test]
 async fn test_read_room_members() {
     let (_, mock_server, driver_handle) = run_test_driver(false).await;
@@ -343,32 +352,62 @@ async fn test_read_room_members() {
     )
     .await;
 
-    // No messages from the driver
+    // Wait for the state to be synced
+    assert_state_synced(&driver_handle, json!([])).await;
+    // No further messages from the driver yet
     assert_matches!(recv_message(&driver_handle).now_or_never(), None);
 
-    {
-        // The read-events request is fulfilled from the state store
-        drop(mock_server);
+    let f = EventFactory::new().room(&ROOM_ID);
 
-        // Ask the driver to read state events
-        send_request(
-            &driver_handle,
-            "2-read-messages",
-            "org.matrix.msc2876.read_events",
-            json!({ "type": "m.room.member", "state_key": true }),
-        )
+    let leave_event = f
+        .member(user_id!("@example:localhost"))
+        .membership(MembershipState::Leave)
+        .previous(MembershipState::Join)
+        .into_raw_timeline();
+    let join_event = f
+        .member(user_id!("@example:localhost"))
+        .membership(MembershipState::Join)
+        .previous(MembershipState::Leave)
+        .into_raw_timeline();
+
+    let response_json = json!({
+        "chunk": [*HELLO_EVENT, *TOMBSTONE_EVENT, leave_event, join_event],
+        "end": "t47409-4357353_219380_26003_2269",
+        "start": "t392-516_47314_0_7_1_1_1_11444_1"
+    });
+    mock_server
+        .mock_room_messages()
+        .match_limit(3)
+        .respond_with(ResponseTemplate::new(200).set_body_json(response_json))
+        .mock_once()
+        .mount()
         .await;
 
-        // Receive the response
-        let msg = recv_message(&driver_handle).await;
-        assert_eq!(msg["api"], "fromWidget");
-        assert_eq!(msg["action"], "org.matrix.msc2876.read_events");
-        let events = msg["response"]["events"].as_array().unwrap();
+    // Ask the driver to read messages
+    send_request(
+        &driver_handle,
+        "2-read-messages",
+        "org.matrix.msc2876.read_events",
+        json!({
+            "type": "m.room.member",
+            "state_key": true,
+            "limit": 3,
+        }),
+    )
+    .await;
 
-        // No useful data in the state store, that's fine for this test
-        // (we just want to know that a successful response is generated)
-        assert_eq!(events.len(), 0);
-    }
+    // Receive the response
+    let msg = recv_message(&driver_handle).await;
+    assert_eq!(msg["api"], "fromWidget");
+    assert_eq!(msg["action"], "org.matrix.msc2876.read_events");
+    println!("{:?}", msg["response"]);
+    let events = msg["response"]["events"].as_array().unwrap();
+
+    // We should get both the leave event and the join event, because the
+    // `read_events` action reads from the timeline, not the room state
+    let [first_event, second_event]: &[_; 2] = events.as_slice().try_into().unwrap();
+    assert_eq!(first_event, &leave_event.deserialize_as::<JsonValue>().unwrap());
+    assert_eq!(second_event, &join_event.deserialize_as::<JsonValue>().unwrap());
 }
 
 #[async_test]
@@ -388,7 +427,9 @@ async fn test_receive_live_events() {
     )
     .await;
 
-    // No messages from the driver yet
+    // Wait for the state to be synced
+    assert_state_synced(&driver_handle, json!([])).await;
+    // No further messages from the driver yet
     assert_matches!(recv_message(&driver_handle).now_or_never(), None);
 
     let f = EventFactory::new();
@@ -480,6 +521,105 @@ async fn test_receive_live_events() {
 
     // No more messages from the driver
     assert_matches!(recv_message(&driver_handle).now_or_never(), None);
+}
+
+#[async_test]
+async fn test_receive_state() {
+    let (client, mock_server, driver_handle) = run_test_driver(false).await;
+
+    let f = EventFactory::new().room(&ROOM_ID);
+    let name_event_1: Raw<AnySyncStateEvent> = f.room_name("room name").sender(&BOB).into();
+
+    mock_server
+        .mock_sync()
+        .ok_and_run(&client, |sync_builder| {
+            sync_builder.add_joined_room(
+                // set room name - matches filter
+                JoinedRoomBuilder::new(&ROOM_ID).add_state_event(name_event_1),
+            );
+        })
+        .await;
+
+    negotiate_capabilities(
+        &driver_handle,
+        json!(["org.matrix.msc2762.receive.state_event:m.room.name#"]),
+    )
+    .await;
+
+    // Wait for the state to be synced
+    let msg = recv_message(&driver_handle).await;
+    assert_eq!(msg["api"], "toWidget");
+    assert_eq!(msg["action"], "update_state");
+    assert_eq!(msg["data"]["state"].as_array().unwrap().len(), 1);
+    assert_eq!(msg["data"]["state"][0]["type"], "m.room.name");
+    assert_eq!(msg["data"]["state"][0]["room_id"], ROOM_ID.as_str());
+    assert_eq!(msg["data"]["state"][0]["sender"], BOB.as_str());
+    assert_eq!(msg["data"]["state"][0]["state_key"], "");
+    assert_eq!(msg["data"]["state"][0]["content"]["name"], "room name");
+    // No further messages from the driver yet
+    assert_matches!(recv_message(&driver_handle).now_or_never(), None);
+
+    let topic_event: Raw<AnySyncStateEvent> = f.room_topic("new room topic").sender(&BOB).into();
+    let name_event_2 = f.room_name("new room name").sender(&BOB);
+    let name_event_3: Raw<AnySyncStateEvent> =
+        f.room_name("even newer room name").sender(&BOB).into();
+
+    mock_server
+        .mock_sync()
+        .ok_and_run(&client, |sync_builder| {
+            sync_builder.add_joined_room(
+                JoinedRoomBuilder::new(&ROOM_ID)
+                    // text message from alice - doesn't match
+                    .add_timeline_event(f.text_msg("simple text message").sender(&ALICE))
+                    // set room topic - doesn't match
+                    .add_timeline_event(topic_event.clone().cast())
+                    .add_state_event(topic_event)
+                    // set room name - matches filter but not reported in the state block
+                    .add_timeline_event(name_event_2)
+                    // set room name - matches filter
+                    .add_timeline_event(name_event_3.clone().cast())
+                    .add_state_event(name_event_3),
+            );
+        })
+        .await;
+
+    // Driver should have exactly 3 messages for us
+    let msg1 = recv_message(&driver_handle).await;
+    let msg2 = recv_message(&driver_handle).await;
+    let msg3 = recv_message(&driver_handle).await;
+    assert_matches!(recv_message(&driver_handle).now_or_never(), None);
+
+    let (update_state, send_events): (Vec<_>, _) =
+        [msg1, msg2, msg3].into_iter().partition(|msg| msg["action"] == "update_state");
+    assert_eq!(update_state.len(), 1);
+    assert_eq!(send_events.len(), 2);
+
+    let msg = &update_state[0];
+    assert_eq!(msg["api"], "toWidget");
+    assert_eq!(msg["data"]["state"].as_array().unwrap().len(), 1);
+    assert_eq!(msg["data"]["state"][0]["type"], "m.room.name");
+    assert_eq!(msg["data"]["state"][0]["room_id"], ROOM_ID.as_str());
+    assert_eq!(msg["data"]["state"][0]["sender"], BOB.as_str());
+    assert_eq!(msg["data"]["state"][0]["state_key"], "");
+    assert_eq!(msg["data"]["state"][0]["content"]["name"], "even newer room name");
+
+    let msg = &send_events[0];
+    assert_eq!(msg["api"], "toWidget");
+    assert_eq!(msg["action"], "send_event");
+    assert_eq!(msg["data"]["type"], "m.room.name");
+    assert_eq!(msg["data"]["room_id"], ROOM_ID.as_str());
+    assert_eq!(msg["data"]["sender"], BOB.as_str());
+    assert_eq!(msg["data"]["state_key"], "");
+    assert_eq!(msg["data"]["content"]["name"], "new room name");
+
+    let msg = &send_events[1];
+    assert_eq!(msg["api"], "toWidget");
+    assert_eq!(msg["action"], "send_event");
+    assert_eq!(msg["data"]["type"], "m.room.name");
+    assert_eq!(msg["data"]["room_id"], ROOM_ID.as_str());
+    assert_eq!(msg["data"]["sender"], BOB.as_str());
+    assert_eq!(msg["data"]["state_key"], "");
+    assert_eq!(msg["data"]["content"]["name"], "even newer room name");
 }
 
 #[async_test]

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -57,8 +57,9 @@ use ruma::{
             topic::RoomTopicEventContent,
         },
         typing::TypingEventContent,
-        AnySyncTimelineEvent, AnyTimelineEvent, BundledMessageLikeRelations, EventContent,
-        RedactedMessageLikeEventContent, RedactedStateEventContent,
+        AnyStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent,
+        BundledMessageLikeRelations, EventContent, RedactedMessageLikeEventContent,
+        RedactedStateEventContent, StateEventContent,
     },
     serde::Raw,
     server_name, EventId, Int, MilliSecondsSinceUnixEpoch, MxcUri, OwnedEventId, OwnedMxcUri,
@@ -438,6 +439,24 @@ where
 {
     fn from(val: EventBuilder<E>) -> Self {
         val.into_event()
+    }
+}
+
+impl<E: StateEventContent> From<EventBuilder<E>> for Raw<AnySyncStateEvent>
+where
+    E::EventType: Serialize,
+{
+    fn from(val: EventBuilder<E>) -> Self {
+        Raw::new(&val.construct_json(false)).unwrap().cast()
+    }
+}
+
+impl<E: StateEventContent> From<EventBuilder<E>> for Raw<AnyStateEvent>
+where
+    E::EventType: Serialize,
+{
+    fn from(val: EventBuilder<E>) -> Self {
+        Raw::new(&val.construct_json(true)).unwrap().cast()
     }
 }
 

--- a/testing/matrix-sdk-test/src/sync_builder/invited_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/invited_room.rs
@@ -27,7 +27,7 @@ impl InvitedRoomBuilder {
 
     /// Add an event to the state.
     pub fn add_state_event(mut self, event: StrippedStateTestEvent) -> Self {
-        self.inner.invite_state.events.push(event.into_raw_event());
+        self.inner.invite_state.events.push(event.into());
         self
     }
 

--- a/testing/matrix-sdk-test/src/sync_builder/joined_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/joined_room.rs
@@ -9,7 +9,7 @@ use ruma::{
 };
 use serde_json::{from_value as from_json_value, Value as JsonValue};
 
-use super::{RoomAccountDataTestEvent, StateTestEvent};
+use super::RoomAccountDataTestEvent;
 use crate::{event_factory::EventBuilder, DEFAULT_TEST_ROOM_ID};
 
 pub struct JoinedRoomBuilder {
@@ -74,8 +74,8 @@ impl JoinedRoomBuilder {
     }
 
     /// Add an event to the state.
-    pub fn add_state_event(mut self, event: StateTestEvent) -> Self {
-        self.inner.state.events.push(event.into_raw_event());
+    pub fn add_state_event(mut self, event: impl Into<Raw<AnySyncStateEvent>>) -> Self {
+        self.inner.state.events.push(event.into());
         self
     }
 
@@ -102,7 +102,7 @@ impl JoinedRoomBuilder {
 
     /// Add room account data.
     pub fn add_account_data(mut self, event: RoomAccountDataTestEvent) -> Self {
-        self.inner.account_data.events.push(event.into_raw_event());
+        self.inner.account_data.events.push(event.into());
         self
     }
 

--- a/testing/matrix-sdk-test/src/sync_builder/knocked_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/knocked_room.rs
@@ -27,7 +27,7 @@ impl KnockedRoomBuilder {
 
     /// Add an event to the state.
     pub fn add_state_event(mut self, event: StrippedStateTestEvent) -> Self {
-        self.inner.knock_state.events.push(event.into_raw_event());
+        self.inner.knock_state.events.push(event.into());
         self
     }
 

--- a/testing/matrix-sdk-test/src/sync_builder/left_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/left_room.rs
@@ -71,7 +71,7 @@ impl LeftRoomBuilder {
 
     /// Add an event to the state.
     pub fn add_state_event(mut self, event: StateTestEvent) -> Self {
-        self.inner.state.events.push(event.into_raw_event());
+        self.inner.state.events.push(event.into());
         self
     }
 
@@ -86,7 +86,7 @@ impl LeftRoomBuilder {
 
     /// Add room account data.
     pub fn add_account_data(mut self, event: RoomAccountDataTestEvent) -> Self {
-        self.inner.account_data.events.push(event.into_raw_event());
+        self.inner.account_data.events.push(event.into());
         self
     }
 

--- a/testing/matrix-sdk-test/src/sync_builder/test_event.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/test_event.rs
@@ -33,36 +33,42 @@ pub enum StateTestEvent {
     Custom(JsonValue),
 }
 
-impl StateTestEvent {
-    /// Get the JSON representation of this test event.
-    pub fn into_json_value(self) -> JsonValue {
-        match self {
-            Self::Alias => test_json::sync_events::ALIAS.to_owned(),
-            Self::Aliases => test_json::sync_events::ALIASES.to_owned(),
-            Self::Create => test_json::sync_events::CREATE.to_owned(),
-            Self::Encryption => test_json::sync_events::ENCRYPTION.to_owned(),
-            Self::HistoryVisibility => test_json::sync_events::HISTORY_VISIBILITY.to_owned(),
-            Self::JoinRules => test_json::sync_events::JOIN_RULES.to_owned(),
-            Self::Member => test_json::sync_events::MEMBER.to_owned(),
-            Self::MemberAdditional => test_json::sync_events::MEMBER_ADDITIONAL.to_owned(),
-            Self::MemberBan => test_json::sync_events::MEMBER_BAN.to_owned(),
-            Self::MemberInvite => test_json::sync_events::MEMBER_INVITE.to_owned(),
-            Self::MemberLeave => test_json::sync_events::MEMBER_LEAVE.to_owned(),
-            Self::MemberNameChange => test_json::sync_events::MEMBER_NAME_CHANGE.to_owned(),
-            Self::PowerLevels => test_json::sync_events::POWER_LEVELS.to_owned(),
-            Self::RedactedInvalid => test_json::sync_events::REDACTED_INVALID.to_owned(),
-            Self::RedactedState => test_json::sync_events::REDACTED_STATE.to_owned(),
-            Self::RoomAvatar => test_json::sync_events::ROOM_AVATAR.to_owned(),
-            Self::RoomName => test_json::sync_events::NAME.to_owned(),
-            Self::RoomPinnedEvents => test_json::sync_events::PINNED_EVENTS.to_owned(),
-            Self::RoomTopic => test_json::sync_events::TOPIC.to_owned(),
-            Self::Custom(json) => json,
+impl From<StateTestEvent> for JsonValue {
+    fn from(val: StateTestEvent) -> Self {
+        match val {
+            StateTestEvent::Alias => test_json::sync_events::ALIAS.to_owned(),
+            StateTestEvent::Aliases => test_json::sync_events::ALIASES.to_owned(),
+            StateTestEvent::Create => test_json::sync_events::CREATE.to_owned(),
+            StateTestEvent::Encryption => test_json::sync_events::ENCRYPTION.to_owned(),
+            StateTestEvent::HistoryVisibility => {
+                test_json::sync_events::HISTORY_VISIBILITY.to_owned()
+            }
+            StateTestEvent::JoinRules => test_json::sync_events::JOIN_RULES.to_owned(),
+            StateTestEvent::Member => test_json::sync_events::MEMBER.to_owned(),
+            StateTestEvent::MemberAdditional => {
+                test_json::sync_events::MEMBER_ADDITIONAL.to_owned()
+            }
+            StateTestEvent::MemberBan => test_json::sync_events::MEMBER_BAN.to_owned(),
+            StateTestEvent::MemberInvite => test_json::sync_events::MEMBER_INVITE.to_owned(),
+            StateTestEvent::MemberLeave => test_json::sync_events::MEMBER_LEAVE.to_owned(),
+            StateTestEvent::MemberNameChange => {
+                test_json::sync_events::MEMBER_NAME_CHANGE.to_owned()
+            }
+            StateTestEvent::PowerLevels => test_json::sync_events::POWER_LEVELS.to_owned(),
+            StateTestEvent::RedactedInvalid => test_json::sync_events::REDACTED_INVALID.to_owned(),
+            StateTestEvent::RedactedState => test_json::sync_events::REDACTED_STATE.to_owned(),
+            StateTestEvent::RoomAvatar => test_json::sync_events::ROOM_AVATAR.to_owned(),
+            StateTestEvent::RoomName => test_json::sync_events::NAME.to_owned(),
+            StateTestEvent::RoomPinnedEvents => test_json::sync_events::PINNED_EVENTS.to_owned(),
+            StateTestEvent::RoomTopic => test_json::sync_events::TOPIC.to_owned(),
+            StateTestEvent::Custom(json) => json,
         }
     }
+}
 
-    /// Get the typed JSON representation of this test event.
-    pub fn into_raw_event(self) -> Raw<AnySyncStateEvent> {
-        from_json_value(self.into_json_value()).unwrap()
+impl From<StateTestEvent> for Raw<AnySyncStateEvent> {
+    fn from(val: StateTestEvent) -> Self {
+        from_json_value(val.into()).unwrap()
     }
 }
 
@@ -73,19 +79,19 @@ pub enum StrippedStateTestEvent {
     Custom(JsonValue),
 }
 
-impl StrippedStateTestEvent {
-    /// Get the JSON representation of this test event.
-    pub fn into_json_value(self) -> JsonValue {
-        match self {
-            Self::Member => test_json::sync_events::MEMBER_STRIPPED.to_owned(),
-            Self::RoomName => test_json::sync_events::NAME_STRIPPED.to_owned(),
-            Self::Custom(json) => json,
+impl From<StrippedStateTestEvent> for JsonValue {
+    fn from(val: StrippedStateTestEvent) -> Self {
+        match val {
+            StrippedStateTestEvent::Member => test_json::sync_events::MEMBER_STRIPPED.to_owned(),
+            StrippedStateTestEvent::RoomName => test_json::sync_events::NAME_STRIPPED.to_owned(),
+            StrippedStateTestEvent::Custom(json) => json,
         }
     }
+}
 
-    /// Get the typed JSON representation of this test event.
-    pub fn into_raw_event(self) -> Raw<AnyStrippedStateEvent> {
-        from_json_value(self.into_json_value()).unwrap()
+impl From<StrippedStateTestEvent> for Raw<AnyStrippedStateEvent> {
+    fn from(val: StrippedStateTestEvent) -> Self {
+        from_json_value(val.into()).unwrap()
     }
 }
 
@@ -97,20 +103,22 @@ pub enum RoomAccountDataTestEvent {
     Custom(JsonValue),
 }
 
-impl RoomAccountDataTestEvent {
-    /// Get the JSON representation of this test event.
-    pub fn into_json_value(self) -> JsonValue {
-        match self {
-            Self::FullyRead => test_json::sync_events::FULLY_READ.to_owned(),
-            Self::Tags => test_json::sync_events::TAG.to_owned(),
-            Self::MarkedUnread => test_json::sync_events::MARKED_UNREAD.to_owned(),
-            Self::Custom(json) => json,
+impl From<RoomAccountDataTestEvent> for JsonValue {
+    fn from(val: RoomAccountDataTestEvent) -> Self {
+        match val {
+            RoomAccountDataTestEvent::FullyRead => test_json::sync_events::FULLY_READ.to_owned(),
+            RoomAccountDataTestEvent::Tags => test_json::sync_events::TAG.to_owned(),
+            RoomAccountDataTestEvent::MarkedUnread => {
+                test_json::sync_events::MARKED_UNREAD.to_owned()
+            }
+            RoomAccountDataTestEvent::Custom(json) => json,
         }
     }
+}
 
-    /// Get the typed JSON representation of this test event.
-    pub fn into_raw_event(self) -> Raw<AnyRoomAccountDataEvent> {
-        from_json_value(self.into_json_value()).unwrap()
+impl From<RoomAccountDataTestEvent> for Raw<AnyRoomAccountDataEvent> {
+    fn from(val: RoomAccountDataTestEvent) -> Self {
+        from_json_value(val.into()).unwrap()
     }
 }
 
@@ -120,18 +128,18 @@ pub enum PresenceTestEvent {
     Custom(JsonValue),
 }
 
-impl PresenceTestEvent {
-    /// Get the JSON representation of this test event.
-    pub fn into_json_value(self) -> JsonValue {
-        match self {
-            Self::Presence => test_json::sync_events::PRESENCE.to_owned(),
-            Self::Custom(json) => json,
+impl From<PresenceTestEvent> for JsonValue {
+    fn from(val: PresenceTestEvent) -> Self {
+        match val {
+            PresenceTestEvent::Presence => test_json::sync_events::PRESENCE.to_owned(),
+            PresenceTestEvent::Custom(json) => json,
         }
     }
+}
 
-    /// Get the typed JSON representation of this test event.
-    pub fn into_raw_event(self) -> Raw<PresenceEvent> {
-        from_json_value(self.into_json_value()).unwrap()
+impl From<PresenceTestEvent> for Raw<PresenceEvent> {
+    fn from(val: PresenceTestEvent) -> Self {
+        from_json_value(val.into()).unwrap()
     }
 }
 
@@ -142,18 +150,18 @@ pub enum GlobalAccountDataTestEvent {
     Custom(JsonValue),
 }
 
-impl GlobalAccountDataTestEvent {
-    /// Get the JSON representation of this test event.
-    pub fn into_json_value(self) -> JsonValue {
-        match self {
-            Self::Direct => test_json::sync_events::DIRECT.to_owned(),
-            Self::PushRules => test_json::sync_events::PUSH_RULES.to_owned(),
-            Self::Custom(json) => json,
+impl From<GlobalAccountDataTestEvent> for JsonValue {
+    fn from(val: GlobalAccountDataTestEvent) -> Self {
+        match val {
+            GlobalAccountDataTestEvent::Direct => test_json::sync_events::DIRECT.to_owned(),
+            GlobalAccountDataTestEvent::PushRules => test_json::sync_events::PUSH_RULES.to_owned(),
+            GlobalAccountDataTestEvent::Custom(json) => json,
         }
     }
+}
 
-    /// Get the typed JSON representation of this test event.
-    pub fn into_raw_event(self) -> Raw<AnyGlobalAccountDataEvent> {
-        from_json_value(self.into_json_value()).unwrap()
+impl From<GlobalAccountDataTestEvent> for Raw<AnyGlobalAccountDataEvent> {
+    fn from(val: GlobalAccountDataTestEvent) -> Self {
+        from_json_value(val.into()).unwrap()
     }
 }


### PR DESCRIPTION
This is an implementation of [an update to MSC2762](https://github.com/matrix-org/matrix-spec-proposals/pull/4237). It changes the widget driver to split state updates out into an `update_state` action and use the `send_event` action exclusively for forwarding timeline events. Accordingly, `read_events` now always reads from /messages, never the state store.

For https://github.com/element-hq/voip-internal/issues/289