### PR TITLE
FFI: Allow file data to be passed through bindings when sending attachment

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -8,14 +8,16 @@ All notable changes to this project will be documented in this file.
 
 Breaking changes:
 
-- `UploadParameters` includes a new field, `file_data: Option<Vec<u8>>`, which allows a foreign
-  language to read file contents natively and then pass those contents to the foreign function
-  when uploading a file through the `Timeline`.
+- `UploadParameters` replaces field `filename: String` with `source: UploadSource`.
+  `UploadSource` is an enum which may take a filename or a filename and bytes, which
+  allows a foreign language to read file contents natively and then pass those contents to
+  the foreign function when uploading a file through the `Timeline`.
   ([#4948](https://github.com/matrix-org/matrix-rust-sdk/pull/4948))
 
 Additions:
 
 - Add room topic string to `StateEventContent`
+- Add `UploadSource` for representing upload data - this is analogous to `matrix_sdk_ui::timeline::AttachmentSource`
 
 ## [0.11.0] - 2025-04-11
 

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+Breaking changes:
+
+- `UploadParameters` includes a new field, `file_data: Option<Vec<u8>>`, which allows a foreign
+  language to read file contents natively and then pass those contents to the foreign function
+  when uploading a file through the `Timeline`.
+  ([#4948](https://github.com/matrix-org/matrix-rust-sdk/pull/4948))
+
 Additions:
 
 - Add room topic string to `StateEventContent`

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -227,9 +227,9 @@ pub enum UploadSource {
     },
     /// Upload source is data in memory
     Data {
-        /// Data being uploaded
-        data: Vec<u8>,
-        /// Filename to associate with data
+        /// Bytes being uploaded
+        bytes: Vec<u8>,
+        /// Filename to associate with bytes
         filename: String,
     },
 }
@@ -238,7 +238,7 @@ impl From<UploadSource> for AttachmentSource {
     fn from(value: UploadSource) -> Self {
         match value {
             UploadSource::File { filename } => Self::File(filename.into()),
-            UploadSource::Data { data, filename } => Self::Data { bytes: data, filename },
+            UploadSource::Data { bytes, filename } => Self::Data { bytes, filename },
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -223,6 +223,23 @@ pub struct UploadParameters {
     use_send_queue: bool,
 }
 
+/// A source for uploading a file
+#[derive(uniffi::Enum)]
+pub enum UploadSource {
+    /// Upload source is a file on disk
+    File {
+        /// Path to file
+        filename: String,
+    },
+    /// Upload source is data in memory
+    Data {
+        /// Data being uploaded
+        data: Vec<u8>,
+        /// Filename to associate with data
+        filename: String,
+    },
+}
+
 #[derive(uniffi::Record)]
 pub struct ReplyParameters {
     /// The ID of the event to reply to.


### PR DESCRIPTION
### Problem

`matrix_sdk_ffi` exposes functions for sending attachments through the [`Timeline`](https://github.com/matrix-org/matrix-rust-sdk/blob/bc50cae35fd32b902eac4d86d61ebe2ee7e11df2/bindings/matrix-sdk-ffi/src/timeline/mod.rs#L93). These functions, however, only allow the foreign language to provide the name of a file (see [UploadParameters](https://github.com/matrix-org/matrix-rust-sdk/blob/bc50cae35fd32b902eac4d86d61ebe2ee7e11df2/bindings/matrix-sdk-ffi/src/timeline/mod.rs#L203)) and require that the linked Rust library actually handle reading the files.

### Proposal

Add functionality to make it possible for a foreign language to read in a file's contents natively and then upload those contents through the `Timeline`.  

### Implementation

Currently, `UploadParameters.filename` is eventually transformed into an [`AttachmentSource::File`](https://github.com/matrix-org/matrix-rust-sdk/blob/bc50cae35fd32b902eac4d86d61ebe2ee7e11df2/crates/matrix-sdk-ui/src/timeline/mod.rs#L739). The addition of an extra field, `file_data: Option<Vec<u8>>`, allows mapping `UploadParameters` into an [`AttachmentSource::Data`](https://github.com/matrix-org/matrix-rust-sdk/blob/bc50cae35fd32b902eac4d86d61ebe2ee7e11df2/crates/matrix-sdk-ui/src/timeline/mod.rs#L728) when `file_data` is present.

#### Alternative

Another option would be to add a wrapped `AttachmentSource` to `matrix_sdk_ffi`, expose it through UniFFI, and replace `UploadParameters.filename` with `UploadParameters.source`. 

### Comments

#### Breaking Changes

Both implementations mentioned result in breaking changes. I opted for the current implementation, as opposed to the alternative mentioned above because, I believe, there are some cases where the current implementation does not result in a breaking change, as it is simply adding an optional field. On the other hand, the alternative implementation would result in a breaking change in all cases as it both removes a field and adds a field.

#### Tests

I tested these changes by generating Python bindings and running some of the `Timeline` functions, as I wasn't able to find any unit tests or integration tests against the bindings - I only found tests ensuring the bindings would be generated.

Are there tests to ensure the bindings work as they should? Or is this not of concern within this repository?

---

- [x] Public API changes documented in changelogs
