### PR TITLE
fix(integration-tests): Fixes #4871 (hopefully). Repeatedly sync in a test after other user cross-signs

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -873,6 +873,13 @@ async fn test_new_users_first_messages_dont_warn_about_insecure_device_if_it_is_
     // But when alice becomes cross-signed and bob finds out about it
     cross_sign(&alice).await;
     bob.sync_once(SyncSettings::new()).await.expect("should not fail to sync");
+
+    // Sync again to make sure the server has notified us about the update to
+    // alice's device info.
+    bob.sync_once(SyncSettings::new().timeout(Duration::from_millis(2000)))
+        .await
+        .expect("should not fail to sync");
+
     fetch_user_identity(&bob, alice.user_id()).await;
     let update2 = assert_next_with_timeout!(timeline_stream);
 


### PR DESCRIPTION
Fixes #4871 (hopefully). In `test_new_users_first_messages_dont_warn_about_insecure_device_if_it_is_secure`, we think we might need to sync twice to persuade the client or server to notice the update to alice's idenitity.