### PR TITLE
WidgetDriver: to-device support, refactor `Filter`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -490,7 +490,7 @@ pub enum WidgetEventFilter {
     StateWithTypeAndStateKey { event_type: String, state_key: String },
 }
 
-impl From<WidgetEventFilter> for matrix_sdk::widget::EventFilter {
+impl From<WidgetEventFilter> for matrix_sdk::widget::Filter {
     fn from(value: WidgetEventFilter) -> Self {
         match value {
             WidgetEventFilter::MessageLikeWithType { event_type } => {
@@ -509,9 +509,9 @@ impl From<WidgetEventFilter> for matrix_sdk::widget::EventFilter {
     }
 }
 
-impl From<matrix_sdk::widget::EventFilter> for WidgetEventFilter {
-    fn from(value: matrix_sdk::widget::EventFilter) -> Self {
-        use matrix_sdk::widget::EventFilter as F;
+impl From<matrix_sdk::widget::Filter> for WidgetEventFilter {
+    fn from(value: matrix_sdk::widget::Filter) -> Self {
+        use matrix_sdk::widget::Filter as F;
 
         match value {
             F::MessageLike(MessageLikeEventFilter::WithType(event_type)) => {

--- a/crates/matrix-sdk/src/widget/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/capabilities.rs
@@ -22,9 +22,7 @@ use ruma::{events::AnyTimelineEvent, serde::Raw};
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use tracing::{debug, error};
 
-use super::{
-    filter::MatrixEventFilterInput, EventFilter, MessageLikeEventFilter, StateEventFilter,
-};
+use super::{filter::FilterInput, Filter, MessageLikeEventFilter, StateEventFilter};
 
 /// Must be implemented by a component that provides functionality of deciding
 /// whether a widget is allowed to use certain capabilities (typically by
@@ -42,9 +40,9 @@ pub trait CapabilitiesProvider: Send + Sync + 'static {
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Capabilities {
     /// Types of the messages that a widget wants to be able to fetch.
-    pub read: Vec<EventFilter>,
+    pub read: Vec<Filter>,
     /// Types of the messages that a widget wants to be able to send.
-    pub send: Vec<EventFilter>,
+    pub send: Vec<Filter>,
     /// If this capability is requested by the widget, it can not operate
     /// separately from the matrix client.
     ///
@@ -60,7 +58,7 @@ pub struct Capabilities {
 impl Capabilities {
     /// Tells if a given raw event matches the read filter.
     pub fn raw_event_matches_read_filter(&self, raw: &Raw<AnyTimelineEvent>) -> bool {
-        let filter_in = match raw.deserialize_as::<MatrixEventFilterInput>() {
+        let filter_in = match raw.deserialize_as::<FilterInput>() {
             Ok(filter) => filter,
             Err(err) => {
                 error!("Failed to deserialize raw event as MatrixEventFilterInput: {err}");
@@ -85,12 +83,12 @@ impl Serialize for Capabilities {
     where
         S: Serializer,
     {
-        struct PrintEventFilter<'a>(&'a EventFilter);
+        struct PrintEventFilter<'a>(&'a Filter);
         impl fmt::Display for PrintEventFilter<'_> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match self.0 {
-                    EventFilter::MessageLike(filter) => PrintMessageLikeEventFilter(filter).fmt(f),
-                    EventFilter::State(filter) => PrintStateEventFilter(filter).fmt(f),
+                    Filter::MessageLike(filter) => PrintMessageLikeEventFilter(filter).fmt(f),
+                    Filter::State(filter) => PrintStateEventFilter(filter).fmt(f),
                 }
             }
         }
@@ -136,15 +134,15 @@ impl Serialize for Capabilities {
         }
         for filter in &self.read {
             let name = match filter {
-                EventFilter::MessageLike(_) => READ_EVENT,
-                EventFilter::State(_) => READ_STATE,
+                Filter::MessageLike(_) => READ_EVENT,
+                Filter::State(_) => READ_STATE,
             };
             seq.serialize_element(&format!("{name}:{}", PrintEventFilter(filter)))?;
         }
         for filter in &self.send {
             let name = match filter {
-                EventFilter::MessageLike(_) => SEND_EVENT,
-                EventFilter::State(_) => SEND_STATE,
+                Filter::MessageLike(_) => SEND_EVENT,
+                Filter::State(_) => SEND_STATE,
             };
             seq.serialize_element(&format!("{name}:{}", PrintEventFilter(filter)))?;
         }
@@ -162,8 +160,8 @@ impl<'de> Deserialize<'de> for Capabilities {
             RequiresClient,
             UpdateDelayedEvent,
             SendDelayedEvent,
-            Read(EventFilter),
-            Send(EventFilter),
+            Read(Filter),
+            Send(Filter),
             Unknown,
         }
 
@@ -184,17 +182,17 @@ impl<'de> Deserialize<'de> for Capabilities {
                 }
 
                 match s.split_once(':') {
-                    Some((READ_EVENT, filter_s)) => Ok(Permission::Read(EventFilter::MessageLike(
+                    Some((READ_EVENT, filter_s)) => Ok(Permission::Read(Filter::MessageLike(
                         parse_message_event_filter(filter_s),
                     ))),
-                    Some((SEND_EVENT, filter_s)) => Ok(Permission::Send(EventFilter::MessageLike(
+                    Some((SEND_EVENT, filter_s)) => Ok(Permission::Send(Filter::MessageLike(
                         parse_message_event_filter(filter_s),
                     ))),
                     Some((READ_STATE, filter_s)) => {
-                        Ok(Permission::Read(EventFilter::State(parse_state_event_filter(filter_s))))
+                        Ok(Permission::Read(Filter::State(parse_state_event_filter(filter_s))))
                     }
                     Some((SEND_STATE, filter_s)) => {
-                        Ok(Permission::Send(EventFilter::State(parse_state_event_filter(filter_s))))
+                        Ok(Permission::Send(Filter::State(parse_state_event_filter(filter_s))))
                     }
                     _ => {
                         debug!("Unknown capability `{s}`");
@@ -272,19 +270,17 @@ mod tests {
         let parsed = serde_json::from_str::<Capabilities>(capabilities_str).unwrap();
         let expected = Capabilities {
             read: vec![
-                EventFilter::MessageLike(MessageLikeEventFilter::WithType(
+                Filter::MessageLike(MessageLikeEventFilter::WithType(
                     "org.matrix.rageshake_request".into(),
                 )),
-                EventFilter::State(StateEventFilter::WithType(StateEventType::RoomMember)),
-                EventFilter::State(StateEventFilter::WithType(
-                    "org.matrix.msc3401.call.member".into(),
-                )),
+                Filter::State(StateEventFilter::WithType(StateEventType::RoomMember)),
+                Filter::State(StateEventFilter::WithType("org.matrix.msc3401.call.member".into())),
             ],
             send: vec![
-                EventFilter::MessageLike(MessageLikeEventFilter::WithType(
+                Filter::MessageLike(MessageLikeEventFilter::WithType(
                     "org.matrix.rageshake_request".into(),
                 )),
-                EventFilter::State(StateEventFilter::WithTypeAndStateKey(
+                Filter::State(StateEventFilter::WithTypeAndStateKey(
                     "org.matrix.msc3401.call.member".into(),
                     "@user:matrix.server".into(),
                 )),
@@ -301,20 +297,16 @@ mod tests {
     fn serialization_and_deserialization_are_symmetrical() {
         let capabilities = Capabilities {
             read: vec![
-                EventFilter::MessageLike(MessageLikeEventFilter::WithType(
-                    "io.element.custom".into(),
-                )),
-                EventFilter::State(StateEventFilter::WithType(StateEventType::RoomMember)),
-                EventFilter::State(StateEventFilter::WithTypeAndStateKey(
+                Filter::MessageLike(MessageLikeEventFilter::WithType("io.element.custom".into())),
+                Filter::State(StateEventFilter::WithType(StateEventType::RoomMember)),
+                Filter::State(StateEventFilter::WithTypeAndStateKey(
                     "org.matrix.msc3401.call.member".into(),
                     "@user:matrix.server".into(),
                 )),
             ],
             send: vec![
-                EventFilter::MessageLike(MessageLikeEventFilter::WithType(
-                    "io.element.custom".into(),
-                )),
-                EventFilter::State(StateEventFilter::WithTypeAndStateKey(
+                Filter::MessageLike(MessageLikeEventFilter::WithType("io.element.custom".into())),
+                Filter::State(StateEventFilter::WithTypeAndStateKey(
                     "org.matrix.msc3401.call.member".into(),
                     "@user:matrix.server".into(),
                 )),

--- a/crates/matrix-sdk/src/widget/filter.rs
+++ b/crates/matrix-sdk/src/widget/filter.rs
@@ -197,34 +197,19 @@ mod tests {
     }
 
     #[test]
-    fn reaction_event_filter_matches_reaction() {
-        assert!(reaction_event_filter().matches(&message_event(TimelineEventType::Reaction)));
+    fn test_reaction_event_filter_matches_reaction() {
+        assert!(reaction_event_filter()
+            .matches(&message_event(&MessageLikeEventType::Reaction.to_string())));
     }
 
     #[test]
-    fn reaction_event_filter_does_not_match_room_message() {
-        assert!(!reaction_event_filter().matches(&message_event_with_msgtype(
-            TimelineEventType::RoomMessage,
-            "m.text".to_owned()
-        )));
+    fn test_reaction_event_filter_does_not_match_room_message() {
+        assert!(!reaction_event_filter().matches(&FilterInput::message_with_msgtype("m.text")));
     }
 
     #[test]
-    fn reaction_event_filter_does_not_match_state_event() {
-        assert!(!reaction_event_filter().matches(&state_event(
-            // Use the `m.reaction` event type to make sure the event would pass
-            // the filter without state event checks, even though in practice
-            // that event type won't be used for a state event.
-            TimelineEventType::Reaction,
-            "".to_owned()
-        )));
-    }
-
-    #[test]
-    fn reaction_event_filter_does_not_match_state_event_any_key() {
-        assert!(
-            !reaction_event_filter().matches_state_event_with_any_state_key(&"m.reaction".into())
-        );
+    fn test_reaction_event_filter_does_not_match_state_event_any_key() {
+        assert!(!reaction_event_filter().matches(&FilterInput::state("m.reaction", "")));
     }
 
     // Tests against an `m.room.member` filter with `state_key = "@self:example.me"`
@@ -236,36 +221,37 @@ mod tests {
     }
 
     #[test]
-    fn self_member_event_filter_matches_self_member_event() {
-        assert!(self_member_event_filter()
-            .matches(&state_event(TimelineEventType::RoomMember, "@self:example.me".to_owned())));
+    fn test_self_member_event_filter_matches_self_member_event() {
+        assert!(self_member_event_filter().matches(&FilterInput::state(
+            &TimelineEventType::RoomMember.to_string(),
+            "@self:example.me"
+        )));
     }
 
     #[test]
-    fn self_member_event_filter_does_not_match_somebody_elses_member_event() {
-        assert!(!self_member_event_filter().matches(&state_event(
-            TimelineEventType::RoomMember,
-            "@somebody_else.example.me".to_owned()
+    fn test_self_member_event_filter_does_not_match_somebody_elses_member_event() {
+        assert!(!self_member_event_filter().matches(&FilterInput::state(
+            &TimelineEventType::RoomMember.to_string(),
+            "@somebody_else.example.me"
         )));
     }
 
     #[test]
     fn self_member_event_filter_does_not_match_unrelated_state_event_with_same_state_key() {
-        assert!(!self_member_event_filter().matches(&state_event(
-            TimelineEventType::from("io.element.test_state_event"),
-            "@self.example.me".to_owned()
-        )));
-    }
-
-    #[test]
-    fn self_member_event_filter_does_not_match_reaction_event() {
-        assert!(!self_member_event_filter().matches(&message_event(TimelineEventType::Reaction)));
-    }
-
-    #[test]
-    fn self_member_event_filter_only_matches_specific_state_key() {
         assert!(!self_member_event_filter()
-            .matches_state_event_with_any_state_key(&StateEventType::RoomMember));
+            .matches(&FilterInput::state("io.element.test_state_event", "@self.example.me")));
+    }
+
+    #[test]
+    fn test_self_member_event_filter_does_not_match_reaction_event() {
+        assert!(!self_member_event_filter()
+            .matches(&message_event(&MessageLikeEventType::Reaction.to_string())));
+    }
+
+    #[test]
+    fn test_self_member_event_filter_only_matches_specific_state_key() {
+        assert!(!self_member_event_filter()
+            .matches(&FilterInput::state(&StateEventType::RoomMember.to_string(), "")));
     }
 
     // Tests against an `m.room.member` filter with any `state_key`.
@@ -274,26 +260,29 @@ mod tests {
     }
 
     #[test]
-    fn member_event_filter_matches_some_member_event() {
-        assert!(member_event_filter()
-            .matches(&state_event(TimelineEventType::RoomMember, "@foo.bar.baz".to_owned())));
+    fn test_member_event_filter_matches_some_member_event() {
+        assert!(member_event_filter().matches(&FilterInput::state(
+            &TimelineEventType::RoomMember.to_string(),
+            "@foo.bar.baz"
+        )));
     }
 
     #[test]
-    fn member_event_filter_does_not_match_room_name_event() {
+    fn test_member_event_filter_does_not_match_room_name_event() {
         assert!(!member_event_filter()
-            .matches(&state_event(TimelineEventType::RoomName, "".to_owned())));
+            .matches(&FilterInput::state(&TimelineEventType::RoomName.to_string(), "")));
     }
 
     #[test]
-    fn member_event_filter_does_not_match_reaction_event() {
-        assert!(!member_event_filter().matches(&message_event(TimelineEventType::Reaction)));
+    fn test_member_event_filter_does_not_match_reaction_event() {
+        assert!(!member_event_filter()
+            .matches(&message_event(&MessageLikeEventType::Reaction.to_string())));
     }
 
     #[test]
-    fn member_event_filter_matches_any_state_key() {
+    fn test_member_event_filter_matches_any_state_key() {
         assert!(member_event_filter()
-            .matches_state_event_with_any_state_key(&StateEventType::RoomMember));
+            .matches(&FilterInput::state(&StateEventType::RoomMember.to_string(), "")));
     }
 
     // Tests against an `m.room.topic` filter with `state_key = ""`
@@ -305,9 +294,9 @@ mod tests {
     }
 
     #[test]
-    fn topic_event_filter_does_not_match_any_state_key() {
-        assert!(!topic_event_filter()
-            .matches_state_event_with_any_state_key(&StateEventType::RoomTopic));
+    fn test_topic_event_filter_does_match() {
+        assert!(topic_event_filter()
+            .matches(&FilterInput::state(&StateEventType::RoomTopic.to_string(), "")));
     }
 
     // Tests against an `m.room.message` filter with `msgtype = m.custom`
@@ -321,33 +310,27 @@ mod tests {
     }
 
     #[test]
-    fn room_message_event_type_matches_room_message_text_event_filter() {
-        assert!(room_message_text_event_filter()
-            .matches_message_like_event_type(&MessageLikeEventType::RoomMessage));
-    }
-
-    #[test]
-    fn reaction_event_type_does_not_match_room_message_text_event_filter() {
+    fn test_reaction_event_type_does_not_match_room_message_text_event_filter() {
         assert!(!room_message_text_event_filter()
-            .matches_message_like_event_type(&MessageLikeEventType::Reaction));
+            .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string())));
     }
 
     #[test]
-    fn room_message_event_type_matches_room_message_custom_event_filter() {
-        assert!(room_message_custom_event_filter()
-            .matches_message_like_event_type(&MessageLikeEventType::RoomMessage));
-    }
-
-    #[test]
-    fn reaction_event_type_does_not_match_room_message_custom_event_filter() {
+    fn test_room_message_event_without_msgtype_does_not_match_custom_msgtype_filter() {
         assert!(!room_message_custom_event_filter()
-            .matches_message_like_event_type(&MessageLikeEventType::Reaction));
+            .matches(&FilterInput::message_like(&MessageLikeEventType::RoomMessage.to_string())));
     }
 
     #[test]
-    fn room_message_event_type_matches_room_message_event_filter() {
+    fn test_reaction_event_type_does_not_match_room_message_custom_event_filter() {
+        assert!(!room_message_custom_event_filter()
+            .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string())));
+    }
+
+    #[test]
+    fn test_room_message_event_type_matches_room_message_event_filter() {
         assert!(room_message_filter()
-            .matches_message_like_event_type(&MessageLikeEventType::RoomMessage));
+            .matches(&FilterInput::message_like(&MessageLikeEventType::RoomMessage.to_string())));
     }
 
     #[test]

--- a/crates/matrix-sdk/src/widget/filter.rs
+++ b/crates/matrix-sdk/src/widget/filter.rs
@@ -12,10 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ruma::events::{MessageLikeEventType, StateEventType, TimelineEventType};
+use ruma::{
+    events::{AnyTimelineEvent, MessageLikeEventType, StateEventType},
+    serde::Raw,
+};
 use serde::Deserialize;
+use tracing::debug;
 
-/// Different kinds of filters for timeline events.
+use super::machine::SendEventRequest;
+
+/// A Filter for Matrix events. That is used to decide if a given event can be
+/// sent to the widget and if a widgets is allowed to send an event to to a
+/// Matrix room or not.
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum Filter {
@@ -26,31 +34,24 @@ pub enum Filter {
 }
 
 impl Filter {
-    pub(super) fn matches(&self, matrix_event: &FilterInput) -> bool {
+    /// Checks if this filter matches with the given filter_input.
+    /// A filter input can be create by using the `From` trait on FilterInput
+    /// for [`Raw<AnyTimelineEvent>`] or [`SendEventRequest`].
+    pub(super) fn matches(&self, filter_input: &FilterInput<'_>) -> bool {
         match self {
-            Filter::MessageLike(message_filter) => message_filter.matches(matrix_event),
-            Filter::State(state_filter) => state_filter.matches(matrix_event),
+            Self::MessageLike(filter) => filter.matches(filter_input),
+            Self::State(filter) => filter.matches(filter_input),
         }
     }
-
-    pub(super) fn matches_state_event_with_any_state_key(
-        &self,
-        event_type: &StateEventType,
-    ) -> bool {
-        matches!(
-            self,
-            Self::State(filter) if filter.matches_state_event_with_any_state_key(event_type)
-        )
-    }
-
-    pub(super) fn matches_message_like_event_type(
-        &self,
-        event_type: &MessageLikeEventType,
-    ) -> bool {
-        matches!(
-            self,
-            Self::MessageLike(filter) if filter.matches_message_like_event_type(event_type)
-        )
+    /// Returns the event type that this filter is configured to match.
+    ///
+    /// This method provides a string representation of the event type
+    /// associated with the filter.
+    pub(super) fn filter_event_type(&self) -> String {
+        match self {
+            Self::MessageLike(filter) => filter.filter_event_type(),
+            Self::State(filter) => filter.filter_event_type(),
+        }
     }
 }
 
@@ -64,30 +65,26 @@ pub enum MessageLikeEventFilter {
     RoomMessageWithMsgtype(String),
 }
 
-impl MessageLikeEventFilter {
-    fn matches(&self, matrix_event: &FilterInput) -> bool {
-        if matrix_event.state_key.is_some() {
-            // State event doesn't match a message-like event filter.
+impl<'a> MessageLikeEventFilter {
+    fn matches(&self, filter_input: &FilterInput<'a>) -> bool {
+        let FilterInput::MessageLike(message_like_filter_input) = filter_input else {
             return false;
-        }
-
+        };
         match self {
-            MessageLikeEventFilter::WithType(event_type) => {
-                matrix_event.event_type == TimelineEventType::from(event_type.clone())
+            Self::WithType(filter_event_type) => {
+                message_like_filter_input.event_type == filter_event_type.to_string()
             }
-            MessageLikeEventFilter::RoomMessageWithMsgtype(msgtype) => {
-                matrix_event.event_type == TimelineEventType::RoomMessage
-                    && matrix_event.content.msgtype.as_ref() == Some(msgtype)
+            Self::RoomMessageWithMsgtype(msgtype) => {
+                message_like_filter_input.event_type == "m.room.message"
+                    && message_like_filter_input.content.msgtype == Some(msgtype)
             }
         }
     }
 
-    fn matches_message_like_event_type(&self, event_type: &MessageLikeEventType) -> bool {
+    fn filter_event_type(&self) -> String {
         match self {
-            MessageLikeEventFilter::WithType(filter_event_type) => filter_event_type == event_type,
-            MessageLikeEventFilter::RoomMessageWithMsgtype(_) => {
-                event_type == &MessageLikeEventType::RoomMessage
-            }
+            Self::WithType(filter_event_type) => filter_event_type.to_string(),
+            Self::RoomMessageWithMsgtype(_) => MessageLikeEventType::RoomMessage.to_string(),
         }
     }
 }
@@ -102,92 +99,172 @@ pub enum StateEventFilter {
     WithTypeAndStateKey(StateEventType, String),
 }
 
-impl StateEventFilter {
-    fn matches(&self, matrix_event: &FilterInput) -> bool {
-        let Some(state_key) = &matrix_event.state_key else {
-            // Message-like event doesn't match a state event filter.
+impl<'a> StateEventFilter {
+    fn matches(&self, filter_input: &FilterInput<'a>) -> bool {
+        let FilterInput::State(state_filter_input) = filter_input else {
             return false;
         };
 
         match self {
-            StateEventFilter::WithType(event_type) => {
-                matrix_event.event_type == TimelineEventType::from(event_type.clone())
+            StateEventFilter::WithType(filter_type) => {
+                state_filter_input.event_type == filter_type.to_string()
             }
             StateEventFilter::WithTypeAndStateKey(event_type, filter_state_key) => {
-                matrix_event.event_type == TimelineEventType::from(event_type.clone())
-                    && state_key == filter_state_key
+                state_filter_input.event_type == event_type.to_string()
+                    && state_filter_input.state_key == *filter_state_key
             }
         }
     }
-
-    fn matches_state_event_with_any_state_key(&self, event_type: &StateEventType) -> bool {
-        matches!(self, Self::WithType(ty) if ty == event_type)
+    fn filter_event_type(&self) -> String {
+        match self {
+            Self::WithType(filter_event_type) => filter_event_type.to_string(),
+            Self::WithTypeAndStateKey(event_type, _) => event_type.to_string(),
+        }
     }
 }
 
+// Filter input:
+
+/// The input data for the filter. This can either be constructed from a
+/// [`Raw<AnyTimelineEvent>`] or a [`SendEventRequest`].
 #[derive(Debug, Deserialize)]
-pub(super) struct FilterInput {
-    #[serde(rename = "type")]
-    pub(super) event_type: TimelineEventType,
-    pub(super) state_key: Option<String>,
-    pub(super) content: MatrixEventContent,
+#[serde(untagged)]
+pub enum FilterInput<'a> {
+    #[serde(borrow)]
+    State(FilterInputState<'a>),
+    MessageLike(FilterInputMessageLike<'a>),
 }
 
+impl<'a> FilterInput<'a> {
+    pub fn message_like(event_type: &'a str) -> Self {
+        Self::MessageLike(FilterInputMessageLike {
+            event_type,
+            content: MessageLikeFilterEventContent { msgtype: None },
+        })
+    }
+
+    pub(super) fn message_with_msgtype(msgtype: &'a str) -> Self {
+        Self::MessageLike(FilterInputMessageLike {
+            event_type: "m.room.message",
+            content: MessageLikeFilterEventContent { msgtype: Some(msgtype) },
+        })
+    }
+
+    pub fn state(event_type: &'a str, state_key: &'a str) -> Self {
+        Self::State(FilterInputState { event_type, state_key })
+    }
+}
+
+/// Filter input data that is used for a [`FilterInput::State`] filter.
+#[derive(Debug, Deserialize)]
+pub struct FilterInputState<'a> {
+    #[serde(rename = "type")]
+    // TODO: This wants to be `StateEventType` but we need a type which supports `as_str()`
+    // as soon as ruma supports `as_str()` on `StateEventType` we can use it here.
+    pub(super) event_type: &'a str,
+    pub(super) state_key: &'a str,
+}
+
+// Filter input message like:
 #[derive(Debug, Default, Deserialize)]
-pub(super) struct MatrixEventContent {
-    pub(super) msgtype: Option<String>,
+pub(super) struct MessageLikeFilterEventContent<'a> {
+    #[serde(borrow)]
+    pub(super) msgtype: Option<&'a str>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FilterInputMessageLike<'a> {
+    // TODO: This wants to be `StateEventType` but we need a type which supports `as_str()`
+    // as soon as ruma supports `as_str()` on `StateEventType` we can use it here.
+    #[serde(rename = "type")]
+    pub(super) event_type: &'a str,
+    pub(super) content: MessageLikeFilterEventContent<'a>,
+}
+
+/// Create a filter input based on [`AnyTimelineEvent`].
+/// This will create a [`FilterInput::State`] or [`FilterInput::MessageLike`]
+/// depending on the event type.
+impl<'a> TryFrom<&'a Raw<AnyTimelineEvent>> for FilterInput<'a> {
+    type Error = serde_json::Error;
+
+    fn try_from(raw_event: &'a Raw<AnyTimelineEvent>) -> Result<Self, Self::Error> {
+        raw_event.deserialize_as()
+    }
+}
+
+impl<'a> From<&'a SendEventRequest> for FilterInput<'a> {
+    fn from(request: &'a SendEventRequest) -> Self {
+        match &request.state_key {
+            None => match request.event_type.as_str() {
+                "m.room.message" => {
+                    if let Some(msgtype) =
+                        serde_json::from_str::<MessageLikeFilterEventContent<'a>>(
+                            request.content.get(),
+                        )
+                        .unwrap_or_else(|e| {
+                            debug!("Failed to deserialize event content for filter: {e}");
+                            // Fallback to empty content is safe.
+                            // If we do have a filter matching any content type, it will match
+                            // independent of the body.
+                            // Any filter that does only match a specific content type will not
+                            // match the empty content.
+                            Default::default()
+                        })
+                        .msgtype
+                    {
+                        FilterInput::message_with_msgtype(msgtype)
+                    } else {
+                        FilterInput::message_like("m.room.message")
+                    }
+                }
+                _ => FilterInput::message_like(&request.event_type),
+            },
+            Some(state_key) => FilterInput::state(&request.event_type, state_key),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use ruma::events::{MessageLikeEventType, StateEventType, TimelineEventType};
-
-    use super::{
-        Filter, FilterInput, MatrixEventContent, MessageLikeEventFilter, StateEventFilter,
+    use ruma::{
+        events::{AnyTimelineEvent, MessageLikeEventType, StateEventType, TimelineEventType},
+        serde::Raw,
     };
 
-    fn message_event(event_type: TimelineEventType) -> FilterInput {
-        FilterInput { event_type, state_key: None, content: Default::default() }
+    use super::{
+        Filter, FilterInput, FilterInputMessageLike, MessageLikeEventFilter, StateEventFilter,
+    };
+    use crate::widget::filter::MessageLikeFilterEventContent;
+
+    fn message_event(event_type: &str) -> FilterInput<'_> {
+        FilterInput::MessageLike(FilterInputMessageLike { event_type, content: Default::default() })
     }
 
-    fn message_event_with_msgtype(event_type: TimelineEventType, msgtype: String) -> FilterInput {
-        FilterInput {
-            event_type,
-            state_key: None,
-            content: MatrixEventContent { msgtype: Some(msgtype) },
-        }
-    }
-
-    fn state_event(event_type: TimelineEventType, state_key: String) -> FilterInput {
-        FilterInput { event_type, state_key: Some(state_key), content: Default::default() }
-    }
-
-    // Tests against an `m.room.message` filter with `msgtype = m.text`
+    // Tests against a `m.room.message` filter with `msgtype = m.text`
     fn room_message_text_event_filter() -> Filter {
         Filter::MessageLike(MessageLikeEventFilter::RoomMessageWithMsgtype("m.text".to_owned()))
     }
 
     #[test]
-    fn text_event_filter_matches_text_event() {
-        assert!(room_message_text_event_filter().matches(&message_event_with_msgtype(
-            TimelineEventType::RoomMessage,
-            "m.text".to_owned()
-        )));
+    fn test_text_event_filter_matches_text_event() {
+        assert!(
+            room_message_text_event_filter().matches(&FilterInput::message_with_msgtype("m.text")),
+        );
     }
 
     #[test]
-    fn text_event_filter_does_not_match_image_event() {
-        assert!(!room_message_text_event_filter().matches(&message_event_with_msgtype(
-            TimelineEventType::RoomMessage,
-            "m.image".to_owned()
-        )));
+    fn test_text_event_filter_does_not_match_image_event() {
+        assert!(!room_message_text_event_filter()
+            .matches(&FilterInput::message_with_msgtype("m.image")));
     }
 
     #[test]
-    fn text_event_filter_does_not_match_custom_event_with_msgtype() {
-        assert!(!room_message_text_event_filter().matches(&message_event_with_msgtype(
-            "io.element.message".into(),
-            "m.text".to_owned()
+    fn test_text_event_filter_does_not_match_custom_event_with_msgtype() {
+        assert!(!room_message_text_event_filter().matches(&FilterInput::MessageLike(
+            FilterInputMessageLike {
+                event_type: "io.element.message",
+                content: MessageLikeFilterEventContent { msgtype: Some("m.text") }
+            }
         )));
     }
 
@@ -334,9 +411,36 @@ mod tests {
     }
 
     #[test]
-    fn reaction_event_type_does_not_match_room_message_event_filter() {
-        assert!(
-            !room_message_filter().matches_message_like_event_type(&MessageLikeEventType::Reaction)
-        );
+    fn test_reaction_event_type_does_not_match_room_message_event_filter() {
+        assert!(!room_message_filter()
+            .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string())));
+    }
+    #[test]
+    fn test_convert_raw_event_into_message_like_filter_input() {
+        let raw_event = &Raw::<AnyTimelineEvent>::from_json_string(
+            r#"{"type":"m.room.message","content":{"msgtype":"m.text"}}"#.to_owned(),
+        )
+        .unwrap();
+        let filter_input: FilterInput<'_> =
+            raw_event.try_into().expect("convert to FilterInput failed");
+        assert!(matches!(filter_input, FilterInput::MessageLike(_)));
+        if let FilterInput::MessageLike(message_like) = filter_input {
+            assert_eq!(message_like.event_type, "m.room.message");
+            assert_eq!(message_like.content.msgtype, Some("m.text"));
+        }
+    }
+    #[test]
+    fn test_convert_raw_event_into_state_filter_input() {
+        let raw_event = &Raw::<AnyTimelineEvent>::from_json_string(
+            r#"{"type":"m.room.member","state_key":"@alice:example.com"}"#.to_owned(),
+        )
+        .unwrap();
+        let filter_input: FilterInput<'_> =
+            raw_event.try_into().expect("convert to FilterInput failed");
+        assert!(matches!(filter_input, FilterInput::State(_)));
+        if let FilterInput::State(state) = filter_input {
+            assert_eq!(state.event_type, "m.room.member");
+            assert_eq!(state.state_key, "@alice:example.com");
+        }
     }
 }

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -18,7 +18,7 @@ use std::marker::PhantomData;
 
 use ruma::{
     api::client::{account::request_openid_token, delayed_events::update_delayed_event},
-    events::{AnyTimelineEvent, MessageLikeEventType, StateEventType, TimelineEventType},
+    events::AnyTimelineEvent,
     serde::Raw,
 };
 use serde::Deserialize;
@@ -157,7 +157,9 @@ impl FromMatrixDriverResponse for request_openid_token::v3::Response {
 #[derive(Clone, Debug)]
 pub(crate) struct ReadMessageLikeEventRequest {
     /// The event type to read.
-    pub(crate) event_type: MessageLikeEventType,
+    // TODO: This wants to be `MessageLikeEventType`` but we need a type which supports `as_str()`
+    // as soon as ruma supports `as_str()` on `MessageLikeEventType` we can use it here.
+    pub(crate) event_type: String,
 
     /// The maximum number of events to return.
     pub(crate) limit: u32,
@@ -190,7 +192,9 @@ impl FromMatrixDriverResponse for Vec<Raw<AnyTimelineEvent>> {
 #[derive(Clone, Debug)]
 pub(crate) struct ReadStateEventRequest {
     /// The event type to read.
-    pub(crate) event_type: StateEventType,
+    // TODO: This wants to be `TimelineEventType` but we need a type which supports `as_str()`
+    // as soon as ruma supports `as_str()` on `TimelineEventType` we can use it here.
+    pub(crate) event_type: String,
 
     /// The `state_key` to read, or `Any` to receive any/all events of the given
     /// type, regardless of their `state_key`.
@@ -213,8 +217,10 @@ impl MatrixDriverRequest for ReadStateEventRequest {
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct SendEventRequest {
     /// The type of the event.
+    // TODO: This wants to be `TimelineEventType` but we need a type which supports `as_str()`
+    // as soon as ruma supports `as_str()` on `TimelineEventType` we can use it here.
     #[serde(rename = "type")]
-    pub(crate) event_type: TimelineEventType,
+    pub(crate) event_type: String,
     /// State key of an event (if it's a state event).
     pub(crate) state_key: Option<String>,
     /// Raw content of an event.

--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -18,7 +18,7 @@ use ruma::{
         delayed_events::{delayed_message_event, delayed_state_event, update_delayed_event},
         error::{ErrorBody, StandardErrorBody},
     },
-    events::{AnyTimelineEvent, MessageLikeEventType, StateEventType},
+    events::AnyTimelineEvent,
     serde::Raw,
     OwnedEventId, OwnedRoomId,
 };
@@ -178,12 +178,12 @@ pub(super) enum ApiVersion {
 pub(super) enum ReadEventRequest {
     ReadStateEvent {
         #[serde(rename = "type")]
-        event_type: StateEventType,
+        event_type: String,
         state_key: StateKeySelector,
     },
     ReadMessageLikeEvent {
         #[serde(rename = "type")]
-        event_type: MessageLikeEventType,
+        event_type: String,
         limit: Option<u32>,
     },
 }

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -49,7 +49,7 @@ use self::{
 use super::WidgetDriver;
 use super::{
     capabilities::{SEND_DELAYED_EVENT, UPDATE_DELAYED_EVENT},
-    filter::{MatrixEventContent, MatrixEventFilterInput},
+    filter::{MatrixEventContent, FilterInput},
     Capabilities, StateKeySelector,
 };
 use crate::Result;
@@ -376,7 +376,7 @@ impl WidgetMachine {
                         .any(|filter| filter.matches_state_event_with_any_state_key(&event_type)),
 
                     StateKeySelector::Key(state_key) => {
-                        let filter_in = MatrixEventFilterInput {
+                        let filter_in = FilterInput {
                             event_type: event_type.to_string().into(),
                             state_key: Some(state_key.clone()),
                             // content doesn't matter for state events
@@ -418,7 +418,7 @@ impl WidgetMachine {
             return None;
         };
 
-        let filter_in = MatrixEventFilterInput {
+        let filter_in = FilterInput {
             event_type: request.event_type.clone(),
             state_key: request.state_key.clone(),
             content: serde_json::from_str(request.content.get()).unwrap_or_else(|e| {

--- a/crates/matrix-sdk/src/widget/machine/tests/send_event.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/send_event.rs
@@ -32,6 +32,6 @@ fn parse_delayed_event_widget_action() {
     assert_let!(delay = send_event_request.delay.unwrap());
 
     assert_eq!(delay, 10000);
-    assert_eq!(send_event_request.event_type, TimelineEventType::CallMember);
+    assert_eq!(send_event_request.event_type, TimelineEventType::CallMember.to_string());
     assert_eq!(send_event_request.state_key.unwrap(), "_@abc:example.org_VFKPEKYWMP".to_owned());
 }

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -40,7 +40,7 @@ mod settings;
 
 pub use self::{
     capabilities::{Capabilities, CapabilitiesProvider},
-    filter::{EventFilter, MessageLikeEventFilter, StateEventFilter},
+    filter::{Filter, MessageLikeEventFilter, StateEventFilter},
     settings::{
         ClientProperties, EncryptionSystem, Intent, VirtualElementCallWidgetOptions, WidgetSettings,
     },

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -208,12 +208,12 @@ impl WidgetDriver {
                     }
 
                     MatrixDriverRequestData::ReadMessageLikeEvent(cmd) => matrix_driver
-                        .read_message_like_events(cmd.event_type.clone(), cmd.limit)
+                        .read_message_like_events(cmd.event_type.into(), cmd.limit)
                         .await
                         .map(MatrixDriverResponse::MatrixEventRead),
 
                     MatrixDriverRequestData::ReadStateEvent(cmd) => matrix_driver
-                        .read_state_events(cmd.event_type.clone(), &cmd.state_key)
+                        .read_state_events(cmd.event_type.into(), &cmd.state_key)
                         .await
                         .map(MatrixDriverResponse::MatrixEventRead),
 
@@ -227,7 +227,7 @@ impl WidgetDriver {
                             timeout: Duration::from_millis(d),
                         });
                         matrix_driver
-                            .send(event_type, state_key, content, delay_event_parameter)
+                            .send(event_type.into(), state_key, content, delay_event_parameter)
                             .await
                             .map(MatrixDriverResponse::MatrixEventSent)
                     }


### PR DESCRIPTION
## WidgetDriver: to-device support step 1

This is a split out of: https://github.com/matrix-org/matrix-rust-sdk/pull/4856
It is the first step to introduce to-device events to the widget api.
With this PR we only focus on the current filter implementation and change improve it so that adding to-device
filters can be done in a cleaner way. The refactor is a result of what worked well when doing the full implementation in https://github.com/matrix-org/matrix-rust-sdk/pull/4856
(This PR does not yet include any to-device changes. It will make the introduction of the filtering for to-device events much cleaner and simpler to read)

 
The API for the filters was a bit confusing since it had a lot of special cases.
This commit also simplifies the filter public api.

Rethinking the public api we only need:
 - to know if events can be sent based on the capabilities
 - to know if events can be sent to the widget (read) based on the capabilities
 - if it even makes sense to sent a cs api read request or if all possibly returned events
   would not match the type.

To simplify the code in the machine it also made sense to add `From` implementation
to the FilterInputs instead of gathering the relevant data from all kinds of Raw events.

The new api is simpler:
All possible events we need to check can be converted into filter inputs (using `into()`).
`capabilites` has `allow_read`/`allow_send` that consume filter inputs.
`capabilites` can be asked if there is any filter for specific event types
to allow not send unnecassary requests.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
