### PR TITLE
FFI: Remove unused contacts field from OidcConfiguration.

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -10,6 +10,10 @@ Additions:
 
 - Add room topic string to `StateEventContent`
 
+Breaking changes:
+
+- `contacts` has been removed from `OidcConfiguration` (it was unused since the switch to OAuth). 
+
 ## [0.11.0] - 2025-04-11
 
 Breaking changes:

--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -119,8 +119,6 @@ pub struct OidcConfiguration {
     pub tos_uri: Option<String>,
     /// A URI that contains the client's privacy policy.
     pub policy_uri: Option<String>,
-    /// An array of e-mail addresses of people responsible for this client.
-    pub contacts: Option<Vec<String>>,
 
     /// Pre-configured registrations for use with homeservers that don't support
     /// dynamic client registration.


### PR DESCRIPTION
The usage of this was removed in #4789, so it seems unnecessary to leave it in the configuration.