### PR TITLE
WidgetDriver: Use `matrix_sdk_common::executor::spawn` instead of `tokio::spawn` to make it wasm compatible.

### DIFF
--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -85,7 +85,7 @@ oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest", "
 once_cell = { workspace = true }
 percent-encoding = "2.3.1"
 pin-project-lite = { workspace = true }
-rand = { workspace = true , optional = true }
+rand = { workspace = true, optional = true }
 ruma = { workspace = true, features = [
     "rand",
     "unstable-msc2448",
@@ -104,6 +104,7 @@ sha2 = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio-stream = { workspace = true, features = ["sync"] }
+tokio-util = "0.7.13"
 tower = { version = "0.5.2", features = ["util"], optional = true }
 tracing = { workspace = true, features = ["attributes"] }
 uniffi = { workspace = true, optional = true }
@@ -124,7 +125,6 @@ backon = "1.5.0"
 # support *sending* streams, which makes it useless for us.
 reqwest = { workspace = true, features = ["stream", "gzip", "http2"] }
 tokio = { workspace = true, features = ["fs", "rt", "macros"] }
-tokio-util = "0.7.13"
 wiremock = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -17,6 +17,7 @@
 use std::{fmt, time::Duration};
 
 use async_channel::{Receiver, Sender};
+use matrix_sdk_common::executor::spawn;
 use ruma::api::client::delayed_events::DelayParameters;
 use serde::de::{self, Deserialize, Deserializer, Visitor};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
@@ -139,7 +140,7 @@ impl WidgetDriver {
         let (incoming_msg_tx, mut incoming_msg_rx) = unbounded_channel();
 
         // Forward all of the incoming messages from the widget.
-        matrix_sdk_common::executor::spawn({
+        spawn({
             let incoming_msg_tx = incoming_msg_tx.clone();
             let from_widget_rx = self.from_widget_rx.clone();
             async move {
@@ -259,7 +260,7 @@ impl WidgetDriver {
                 let mut matrix = matrix_driver.events();
                 let incoming_msg_tx = incoming_msg_tx.clone();
 
-                matrix_sdk_common::executor::spawn(async move {
+                spawn(async move {
                     loop {
                         tokio::select! {
                             _ = stop_forwarding.cancelled() => {

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -139,7 +139,7 @@ impl WidgetDriver {
         let (incoming_msg_tx, mut incoming_msg_rx) = unbounded_channel();
 
         // Forward all of the incoming messages from the widget.
-        tokio::spawn({
+        matrix_sdk_common::executor::spawn({
             let incoming_msg_tx = incoming_msg_tx.clone();
             let from_widget_rx = self.from_widget_rx.clone();
             async move {
@@ -259,7 +259,7 @@ impl WidgetDriver {
                 let mut matrix = matrix_driver.events();
                 let incoming_msg_tx = incoming_msg_tx.clone();
 
-                tokio::spawn(async move {
+                matrix_sdk_common::executor::spawn(async move {
                     loop {
                         tokio::select! {
                             _ = stop_forwarding.cancelled() => {


### PR DESCRIPTION
This PR is a revived version of: https://github.com/matrix-org/matrix-rust-sdk/pull/4707 since it is now possible to easily add wasm support thanks to: https://github.com/matrix-org/matrix-rust-sdk/pull/4572

Using the `executer::spawn` will select `tokio::spawn` or `wasm_bindgen_futures::spawn_local` based on what platform we are on.

~~They behave differently in that `tokio` actually starts the async block inside the spawn but the wasm `spawn` wrapper will only start the part that is not inside the `async` block and the join handle needs to be awaited for it to work.~~

This has now changed with: https://github.com/matrix-org/matrix-rust-sdk/pull/4572.
Now they behave the same and this PR becomes a very simple change.


- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
