### PR TITLE
test: attempt to deflake history-sharing integ test

### DIFF
--- a/crates/matrix-sdk-common/src/timeout.rs
+++ b/crates/matrix-sdk-common/src/timeout.rs
@@ -24,7 +24,7 @@ use tokio::time::timeout as tokio_timeout;
 
 /// Error type notifying that a timeout has elapsed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ElapsedError(());
+pub struct ElapsedError();
 
 impl fmt::Display for ElapsedError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -44,7 +44,7 @@ where
     F: Future<Output = T>,
 {
     #[cfg(not(target_arch = "wasm32"))]
-    return tokio_timeout(duration, future).await.map_err(|_| ElapsedError(()));
+    return tokio_timeout(duration, future).await.map_err(|_| ElapsedError());
 
     #[cfg(target_arch = "wasm32")]
     {
@@ -53,7 +53,7 @@ where
 
         match select(std::pin::pin!(future), timeout_future).await {
             Either::Left((res, _)) => Ok(res),
-            Either::Right((_, _)) => Err(ElapsedError(())),
+            Either::Right((_, _)) => Err(ElapsedError()),
         }
     }
 }

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -199,7 +199,7 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
                     // Note we do it all the time, because we might have sync'd members before
                     // sending a message (so didn't enter the above branch), but
                     // could have not query their keys ever.
-                    room.query_keys_for_untracked_users().await?;
+                    room.query_keys_for_untracked_or_dirty_users().await?;
 
                     room.preshare_room_key().await?;
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1911,9 +1911,10 @@ impl Room {
         SendMessageLikeEvent::new(self, content)
     }
 
-    /// Run /keys/query requests for all the non-tracked users.
+    /// Run /keys/query requests for all the non-tracked users, and for users
+    /// with an out-of-date device list.
     #[cfg(feature = "e2e-encryption")]
-    async fn query_keys_for_untracked_users(&self) -> Result<()> {
+    async fn query_keys_for_untracked_or_dirty_users(&self) -> Result<()> {
         let olm = self.client.olm_machine().await;
         let olm = olm.as_ref().expect("Olm machine wasn't started");
 

--- a/testing/matrix-sdk-integration-testing/src/helpers.rs
+++ b/testing/matrix-sdk-integration-testing/src/helpers.rs
@@ -1,4 +1,5 @@
 use std::{
+    future::Future,
     ops::Deref,
     option_env,
     path::{Path, PathBuf},
@@ -13,10 +14,12 @@ use matrix_sdk::{
     encryption::EncryptionSettings,
     ruma::{
         api::client::{account::register::v3::Request as RegistrationRequest, uiaa},
+        time::Instant,
         RoomId,
     },
     sliding_sync::VersionBuilder,
     sync::SyncResponse,
+    timeout::ElapsedError,
     Client, ClientBuilder, Room,
 };
 use once_cell::sync::Lazy;
@@ -212,19 +215,50 @@ impl Deref for SyncTokenAwareClient {
     }
 }
 
+/// Repeatedly run the given callback, at increasing intervals, until it returns
+/// `Some`, or the given timeout has elapsed.
+///
+/// The callback `cb` is called with the attempt number as an argument.
+///
+/// # Returns
+///
+/// The result of `cb` if it returned `Some`. If the timeout elapses, an error
+/// of type [`ElapsedError`].
+pub async fn wait_until_some<F, Fut, R>(
+    mut cb: F,
+    timeout_duration: Duration,
+) -> Result<R, ElapsedError>
+where
+    F: FnMut(u32) -> Fut,
+    Fut: Future<Output = Option<R>>,
+{
+    let start = Instant::now();
+    let mut attempt_count = 1;
+    loop {
+        if let Some(r) = cb(attempt_count).await {
+            return Ok(r);
+        };
+        if start - Instant::now() > timeout_duration {
+            return Err(ElapsedError());
+        }
+        sleep(Duration::from_millis(125) * attempt_count).await;
+        attempt_count += 1;
+    }
+}
+
 /// Waits for a room to arrive from a sync, for ~2 seconds.
 ///
 /// Note: this doesn't run any sync, it assumes a sync has been running in the
 /// background.
 pub async fn wait_for_room(client: &Client, room_id: &RoomId) -> Room {
-    for i in 1..5 {
-        // Linear backoff: wait at most (1+2+3+4+5)*150ms > 2s for the response to come
-        // back from the server.
-        if let Some(room) = client.get_room(room_id) {
-            return room;
-        };
-        tracing::warn!("attempt #{i}, alice couldn't see the room, retrying in a few…");
-        sleep(Duration::from_millis(i * 150)).await;
-    }
-    panic!("room couldn't be fetched after all attempts");
+    let cb = async |i| {
+        client.get_room(room_id).or_else(|| {
+            tracing::warn!("attempt #{i}, alice couldn't see the room, retrying in a few…");
+            None
+        })
+    };
+
+    wait_until_some(cb, Duration::from_secs(2))
+        .await
+        .expect("room couldn't be fetched after all attempts")
 }

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
@@ -1,5 +1,4 @@
 use std::{
-    future::IntoFuture,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -20,10 +19,7 @@ use matrix_sdk::{
         BackupDownloadStrategy, EncryptionSettings, LocalTrust,
     },
     ruma::{
-        api::client::{
-            message::send_message_event,
-            room::create_room::v3::{Request as CreateRoomRequest, RoomPreset},
-        },
+        api::client::room::create_room::v3::{Request as CreateRoomRequest, RoomPreset},
         events::{
             key::verification::{request::ToDeviceKeyVerificationRequestEvent, VerificationMethod},
             room::message::{
@@ -31,10 +27,9 @@ use matrix_sdk::{
                 SyncRoomMessageEvent,
             },
             secret_storage::secret::SecretEventContent,
-            GlobalAccountDataEventType, MessageLikeEventType, OriginalSyncMessageLikeEvent,
+            GlobalAccountDataEventType, OriginalSyncMessageLikeEvent,
         },
-        serde::Raw,
-        OwnedEventId, TransactionId, UserId,
+        OwnedEventId, UserId,
     },
     timeout::timeout,
     Client,
@@ -46,7 +41,7 @@ use matrix_sdk_ui::{
 use similar_asserts::assert_eq;
 use tracing::{debug, info, warn, Instrument};
 
-use crate::helpers::{SyncTokenAwareClient, TestClientBuilder};
+use crate::helpers::{wait_until_some, SyncTokenAwareClient, TestClientBuilder};
 
 // This test reproduces a bug seen on clients that use the same `Client`
 // instance for both the usual sliding sync loop and for getting the event for a
@@ -1227,19 +1222,25 @@ async fn test_history_share_on_invite() -> Result<()> {
             .await
             .expect("Bob should have joined the room");
 
-        // Bob sends a message to trigger another sync from Alice, which causes her to
-        // send out the outgoing requests
+        // Alice should now have a pending `/keys/query` request for Bob, but we need
+        // her to actually send it, which we do by having her wait for Bob to join, and
+        // then send an encrypted message.
         //
-        // FIXME: this appears to be needed due to a bug in the sliding sync client,
-        //   which means it does not send out outgoing requests caused by a
-        //   /sync response
-        let request = send_message_event::v3::Request::new_raw(
-            shared_room_id.to_owned(),
-            TransactionId::new(),
-            MessageLikeEventType::Message,
-            Raw::new(&RoomMessageEventContent::text_plain("")).unwrap().cast(),
-        );
-        bob.send(request).into_future().instrument(bob_span.clone()).await?;
+        // (The `room-list` sync loop will register Bob's keys as out of date, but that
+        // loop doesn't handle pending outgoing crypto requests. So an alternative would
+        // be to get the `encryption` sync loop to cycle, but this is more direct.)
+
+        wait_until_some(
+            async |_| alice_shared_room.get_member(bob.user_id().unwrap()).await.unwrap(),
+            Duration::from_secs(30),
+        )
+        .await
+        .expect("Alice did not see bob in room");
+
+        alice_shared_room
+            .send(RoomMessageEventContent::text_plain(""))
+            .await
+            .expect("Alice could not send message in room");
 
         // Sanity check: Both users see the others' device
         async fn devices_seen(client: &Client, other: &UserId) -> UserDevices {


### PR DESCRIPTION
Rather than attempting to trigger Alice's encryption sync loop with an incoming message from Bob, instead have Alice send a message once Bob has joined the room.

Hopefully, fixes https://github.com/matrix-org/matrix-rust-sdk/issues/4945.