### PR TITLE
refactor(sdk): compute a push context only once when computing push actions for a bunch of events

### DIFF
--- a/crates/matrix-sdk-base/src/response_processors/notification.rs
+++ b/crates/matrix-sdk-base/src/response_processors/notification.rs
@@ -55,14 +55,14 @@ impl<'a> Notification<'a> {
 
     /// Push a new [`sync::Notification`] in [`Self::notifications`] from
     /// `event` if and only if `predicate` returns `true` for at least one of
-    /// the [`Action`]s associated to this event and this `push_context`
-    /// (based on `Self::push_rules`).
+    /// the [`Action`]s associated to this event and this
+    /// `push_condition_room_ctx`. (based on `Self::push_rules`).
     ///
     /// This method returns the fetched [`Action`]s.
     pub fn push_notification_from_event_if<E, P>(
         &mut self,
         room_id: &RoomId,
-        push_context: &PushConditionRoomCtx,
+        push_condition_room_ctx: &PushConditionRoomCtx,
         event: &Raw<E>,
         predicate: P,
     ) -> &[Action]
@@ -70,7 +70,7 @@ impl<'a> Notification<'a> {
         Raw<E>: Into<RawAnySyncOrStrippedTimelineEvent>,
         P: Fn(&Action) -> bool,
     {
-        let actions = self.push_rules.get_actions(event, push_context);
+        let actions = self.push_rules.get_actions(event, push_condition_room_ctx);
 
         if actions.iter().any(predicate) {
             self.push_notification(room_id, actions.to_owned(), event.clone().into());

--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -179,7 +179,7 @@ pub mod stripped {
 
         // We need to check for notifications after we have handled all state
         // events, to make sure we have the full push context.
-        if let Some(push_context) =
+        if let Some(push_condition_room_ctx) =
             timeline::get_push_room_context(context, room, room_info, notification.state_store)
                 .await?
         {
@@ -189,7 +189,7 @@ pub mod stripped {
             for event in state_events.values().flat_map(|map| map.values()) {
                 notification.push_notification_from_event_if(
                     room_id,
-                    &push_context,
+                    &push_condition_room_ctx,
                     event,
                     Action::should_notify,
                 );

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -54,7 +54,7 @@ pub async fn build<'notification, 'e2ee>(
     #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'e2ee>,
 ) -> Result<Timeline> {
     let mut timeline = Timeline::new(timeline_inputs.limited, timeline_inputs.prev_batch);
-    let mut push_context =
+    let mut push_condition_room_ctx =
         get_push_room_context(context, room, room_info, notification.state_store).await?;
     let room_id = room.room_id();
 
@@ -127,18 +127,23 @@ pub async fn build<'notification, 'e2ee>(
                     AnySyncTimelineEvent::MessageLike(_) => (),
                 }
 
-                if let Some(push_context) = &mut push_context {
-                    update_push_room_context(context, push_context, room.own_user_id(), room_info)
+                if let Some(push_condition_room_ctx) = &mut push_condition_room_ctx {
+                    update_push_room_context(
+                        context,
+                        push_condition_room_ctx,
+                        room.own_user_id(),
+                        room_info,
+                    )
                 } else {
-                    push_context =
+                    push_condition_room_ctx =
                         get_push_room_context(context, room, room_info, notification.state_store)
                             .await?;
                 }
 
-                if let Some(push_context) = &push_context {
+                if let Some(push_condition_room_ctx) = &push_condition_room_ctx {
                     let actions = notification.push_notification_from_event_if(
                         room_id,
-                        push_context,
+                        push_condition_room_ctx,
                         timeline_event.raw(),
                         Action::should_notify,
                     );

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -188,7 +188,7 @@ impl NotificationClient {
             NotificationProcessSetup::MultipleProcesses
         ));
 
-        let push_action_ctx = room.push_action_ctx().await?;
+        let push_action_ctx = room.push_context().await?;
         let sync_permit_guard = match &self.process_setup {
             NotificationProcessSetup::MultipleProcesses => {
                 // We're running on our own process, dedicated for notifications. In that case,
@@ -516,12 +516,12 @@ impl NotificationClient {
                     raw_event = RawNotificationEvent::Timeline(timeline_event.into_raw());
                     push_actions
                 } else {
-                    room.push_action_ctx().await?.for_event(timeline_event)
+                    room.push_context().await?.for_event(timeline_event)
                 }
             }
             RawNotificationEvent::Invite(invite_event) => {
                 // Invite events can't be encrypted, so they should be in clear text.
-                room.push_action_ctx().await?.for_event(invite_event)
+                room.push_context().await?.for_event(invite_event)
             }
         };
 

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -188,7 +188,7 @@ impl NotificationClient {
             NotificationProcessSetup::MultipleProcesses
         ));
 
-        let push_action_ctx = room.push_context().await?;
+        let push_ctx = room.push_context().await?;
         let sync_permit_guard = match &self.process_setup {
             NotificationProcessSetup::MultipleProcesses => {
                 // We're running on our own process, dedicated for notifications. In that case,
@@ -218,9 +218,8 @@ impl NotificationClient {
 
                         sleep(Duration::from_millis(wait)).await;
 
-                        let new_event = room
-                            .decrypt_event(raw_event.cast_ref(), push_action_ctx.as_ref())
-                            .await?;
+                        let new_event =
+                            room.decrypt_event(raw_event.cast_ref(), push_ctx.as_ref()).await?;
 
                         match new_event.kind {
                             matrix_sdk::deserialized_responses::TimelineEventKind::UnableToDecrypt {
@@ -261,7 +260,7 @@ impl NotificationClient {
 
         match encryption_sync {
             Ok(sync) => match sync.run_fixed_iterations(2, sync_permit_guard).await {
-                Ok(()) => match room.decrypt_event(raw_event.cast_ref(), push_action_ctx.as_ref()).await {
+                Ok(()) => match room.decrypt_event(raw_event.cast_ref(), push_ctx.as_ref()).await {
                     Ok(new_event) => match new_event.kind {
                         matrix_sdk::deserialized_responses::TimelineEventKind::UnableToDecrypt {
                             utd_info, ..

--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -255,8 +255,8 @@ async fn decrypt_by_index<D: Decryptor>(
     should_retry: impl Fn(&str) -> bool,
     retry_indices: Vec<usize>,
 ) {
-    let push_context = room_data_provider.push_context().await;
-    let push_context = push_context.as_ref();
+    let push_ctx = room_data_provider.push_context().await;
+    let push_ctx = push_ctx.as_ref();
     let unable_to_decrypt_hook = state.meta.unable_to_decrypt_hook.clone();
 
     let retry_one = |item: Arc<TimelineItem>| {
@@ -291,7 +291,7 @@ async fn decrypt_by_index<D: Decryptor>(
                 return None;
             };
 
-            match decryptor.decrypt_event_impl(original_json, push_context).await {
+            match decryptor.decrypt_event_impl(original_json, push_ctx).await {
                 Ok(event) => {
                     if let SdkTimelineEventKind::UnableToDecrypt { utd_info, .. } = event.kind {
                         info!(

--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -255,7 +255,7 @@ async fn decrypt_by_index<D: Decryptor>(
     should_retry: impl Fn(&str) -> bool,
     retry_indices: Vec<usize>,
 ) {
-    let push_rules_context = room_data_provider.push_rules_and_context().await;
+    let push_context = room_data_provider.push_context().await;
     let unable_to_decrypt_hook = state.meta.unable_to_decrypt_hook.clone();
 
     let retry_one = |item: Arc<TimelineItem>| {
@@ -324,7 +324,7 @@ async fn decrypt_by_index<D: Decryptor>(
         .retry_event_decryption(
             retry_one,
             retry_indices,
-            push_rules_context,
+            push_context,
             room_data_provider,
             settings,
         )

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1500,7 +1500,7 @@ impl TimelineController {
 
     #[instrument(skip(self), fields(room_id = ?self.room().room_id()))]
     pub(super) async fn retry_event_decryption(&self, session_ids: Option<BTreeSet<String>>) {
-        self.retry_event_decryption_inner(self.room().to_owned(), session_ids).await
+        self.retry_event_decryption_inner(self.room().clone(), session_ids).await
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -15,9 +15,7 @@
 use std::{future::Future, sync::Arc};
 
 use eyeball_im::VectorDiff;
-use matrix_sdk::{
-    deserialized_responses::TimelineEvent, room::PushContext, send_queue::SendHandle,
-};
+use matrix_sdk::{deserialized_responses::TimelineEvent, send_queue::SendHandle};
 #[cfg(test)]
 use ruma::events::receipt::ReceiptEventContent;
 use ruma::{
@@ -180,7 +178,6 @@ impl TimelineState {
         &mut self,
         retry_one: impl Fn(Arc<TimelineItem>) -> Fut,
         retry_indices: Vec<usize>,
-        push_context: Option<PushContext>,
         room_data_provider: &P,
         settings: &TimelineSettings,
     ) where
@@ -197,11 +194,9 @@ impl TimelineState {
         let mut offset = 0;
         for idx in retry_indices {
             let idx = idx - offset;
-            let Some(mut event) = retry_one(txn.items[idx].clone()).await else {
+            let Some(event) = retry_one(txn.items[idx].clone()).await else {
                 continue;
             };
-
-            event.push_actions = push_context.as_ref().map(|ctx| ctx.for_event(event.raw()));
 
             let handle_one_res = txn
                 .handle_remote_event(

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -31,7 +31,7 @@ use matrix_sdk::{
     crypto::OlmMachine,
     deserialized_responses::{EncryptionInfo, TimelineEvent},
     event_cache::paginator::{PaginableRoom, PaginatorError},
-    room::{EventWithContextResponse, Messages, MessagesOptions},
+    room::{EventWithContextResponse, Messages, MessagesOptions, PushContext},
     send_queue::RoomSendQueueUpdate,
     BoxFuture,
 };
@@ -387,7 +387,7 @@ impl RoomDataProvider for TestRoomDataProvider {
         map
     }
 
-    async fn push_rules_and_context(&self) -> Option<(Ruleset, PushConditionRoomCtx)> {
+    async fn push_context(&self) -> Option<PushContext> {
         let push_rules = Ruleset::server_default(&ALICE);
         let power_levels = PushConditionPowerLevelsCtx {
             users: BTreeMap::new(),
@@ -402,7 +402,7 @@ impl RoomDataProvider for TestRoomDataProvider {
             power_levels: Some(power_levels),
         };
 
-        Some((push_rules, push_context))
+        Some(PushContext::new(push_context, push_rules))
     }
 
     async fn load_fully_read_marker(&self) -> Option<OwnedEventId> {

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -394,15 +394,14 @@ impl RoomDataProvider for TestRoomDataProvider {
             users_default: int!(0),
             notifications: NotificationPowerLevels::new(),
         };
-        let push_context = PushConditionRoomCtx {
+        let push_condition_room_ctx = PushConditionRoomCtx {
             room_id: room_id!("!my_room:server.name").to_owned(),
             member_count: uint!(2),
             user_id: ALICE.to_owned(),
             user_display_name: "Alice".to_owned(),
             power_levels: Some(power_levels),
         };
-
-        Some(PushContext::new(push_context, push_rules))
+        Some(PushContext::new(push_condition_room_ctx, push_rules))
     }
 
     async fn load_fully_read_marker(&self) -> Option<OwnedEventId> {

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -305,7 +305,8 @@ pub(super) trait Decryptor: AsyncTraitDeps + Clone + 'static {
 
 impl Decryptor for Room {
     async fn decrypt_event_impl(&self, raw: &Raw<AnySyncTimelineEvent>) -> Result<TimelineEvent> {
-        self.decrypt_event(raw.cast_ref()).await
+        let push_action_ctx = self.push_action_ctx().await?;
+        self.decrypt_event(raw.cast_ref(), &push_action_ctx).await
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -306,7 +306,7 @@ pub(super) trait Decryptor: AsyncTraitDeps + Clone + 'static {
 impl Decryptor for Room {
     async fn decrypt_event_impl(&self, raw: &Raw<AnySyncTimelineEvent>) -> Result<TimelineEvent> {
         let push_action_ctx = self.push_context().await?;
-        self.decrypt_event(raw.cast_ref(), &push_action_ctx).await
+        self.decrypt_event(raw.cast_ref(), push_action_ctx.as_ref()).await
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -225,7 +225,7 @@ impl RoomDataProvider for Room {
     }
 
     async fn push_rules_and_context(&self) -> Option<(Ruleset, PushConditionRoomCtx)> {
-        match self.push_context().await {
+        match self.push_condition_room_ctx().await {
             Ok(Some(push_context)) => match self.client().account().push_rules().await {
                 Ok(push_rules) => Some((push_rules, push_context)),
                 Err(e) => {

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -282,7 +282,7 @@ pub(super) trait Decryptor: AsyncTraitDeps + Clone + 'static {
     fn decrypt_event_impl(
         &self,
         raw: &Raw<AnySyncTimelineEvent>,
-        push_context: Option<&PushContext>,
+        push_ctx: Option<&PushContext>,
     ) -> impl Future<Output = Result<TimelineEvent>> + SendOutsideWasm;
 }
 
@@ -290,9 +290,9 @@ impl Decryptor for Room {
     async fn decrypt_event_impl(
         &self,
         raw: &Raw<AnySyncTimelineEvent>,
-        push_context: Option<&PushContext>,
+        push_ctx: Option<&PushContext>,
     ) -> Result<TimelineEvent> {
-        self.decrypt_event(raw.cast_ref(), push_context).await
+        self.decrypt_event(raw.cast_ref(), push_ctx).await
     }
 }
 
@@ -301,7 +301,7 @@ impl Decryptor for (matrix_sdk_base::crypto::OlmMachine, ruma::OwnedRoomId) {
     async fn decrypt_event_impl(
         &self,
         raw: &Raw<AnySyncTimelineEvent>,
-        push_context: Option<&PushContext>,
+        push_ctx: Option<&PushContext>,
     ) -> Result<TimelineEvent> {
         let (olm_machine, room_id) = self;
         let decryption_settings =
@@ -318,7 +318,7 @@ impl Decryptor for (matrix_sdk_base::crypto::OlmMachine, ruma::OwnedRoomId) {
         };
 
         // Fill the push actions here, to mimic what `Room::decrypt_event` does.
-        timeline_event.push_actions = push_context.map(|ctx| ctx.for_event(timeline_event.raw()));
+        timeline_event.push_actions = push_ctx.map(|ctx| ctx.for_event(timeline_event.raw()));
 
         Ok(timeline_event)
     }

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -22,6 +22,7 @@ use matrix_sdk::{
     crypto::types::events::CryptoContextInfo,
     deserialized_responses::{EncryptionInfo, TimelineEvent},
     event_cache::paginator::PaginableRoom,
+    room::PushContext,
     AsyncTraitDeps, Result, Room, SendOutsideWasm,
 };
 use matrix_sdk_base::{latest_event::LatestEvent, RoomInfo};
@@ -31,11 +32,10 @@ use ruma::{
         receipt::{Receipt, ReceiptThread, ReceiptType},
         AnyMessageLikeEventContent, AnySyncTimelineEvent,
     },
-    push::{PushConditionRoomCtx, Ruleset},
     serde::Raw,
     EventId, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId, UserId,
 };
-use tracing::{debug, error};
+use tracing::error;
 
 use super::{Profile, RedactError, TimelineBuilder};
 use crate::timeline::{self, pinned_events_loader::PinnedEventsRoom, Timeline};
@@ -104,9 +104,7 @@ pub(super) trait RoomDataProvider:
     /// Load the current fully-read event id, from storage.
     fn load_fully_read_marker(&self) -> impl Future<Output = Option<OwnedEventId>> + '_;
 
-    fn push_rules_and_context(
-        &self,
-    ) -> impl Future<Output = Option<(Ruleset, PushConditionRoomCtx)>> + SendOutsideWasm + '_;
+    fn push_context(&self) -> impl Future<Output = Option<PushContext>> + SendOutsideWasm + '_;
 
     /// Send an event to that room.
     fn send(
@@ -224,24 +222,8 @@ impl RoomDataProvider for Room {
         unthreaded_receipts
     }
 
-    async fn push_rules_and_context(&self) -> Option<(Ruleset, PushConditionRoomCtx)> {
-        match self.push_condition_room_ctx().await {
-            Ok(Some(push_context)) => match self.client().account().push_rules().await {
-                Ok(push_rules) => Some((push_rules, push_context)),
-                Err(e) => {
-                    error!("Could not get push rules: {e}");
-                    None
-                }
-            },
-            Ok(None) => {
-                debug!("Could not aggregate push context");
-                None
-            }
-            Err(e) => {
-                error!("Could not get push context: {e}");
-                None
-            }
-        }
+    async fn push_context(&self) -> Option<PushContext> {
+        self.push_context().await.ok().flatten()
     }
 
     async fn load_fully_read_marker(&self) -> Option<OwnedEventId> {

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -305,7 +305,7 @@ pub(super) trait Decryptor: AsyncTraitDeps + Clone + 'static {
 
 impl Decryptor for Room {
     async fn decrypt_event_impl(&self, raw: &Raw<AnySyncTimelineEvent>) -> Result<TimelineEvent> {
-        let push_action_ctx = self.push_action_ctx().await?;
+        let push_action_ctx = self.push_context().await?;
         self.decrypt_event(raw.cast_ref(), &push_action_ctx).await
     }
 }

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+### Bug fixes
+
+### Refactor
+
+- The `Room::push_context()` has been renamed into `Room::push_condition_room_ctx()`.
+
 ## [0.11.0] - 2025-04-11
 
 ### Features

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -12,7 +12,9 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
-- The `Room::push_context()` has been renamed into `Room::push_condition_room_ctx()`.
+- The `Room::push_context()` has been renamed into `Room::push_condition_room_ctx()`. The newer
+  `Room::push_context` now returns a `matrix_sdk::Room::PushContext`, which can be used to compute
+  the push actions for any event.
 
 ## [0.11.0] - 2025-04-11
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -12,9 +12,13 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
-- The `Room::push_context()` has been renamed into `Room::push_condition_room_ctx()`. The newer
+- `Room::push_context()` has been renamed into `Room::push_condition_room_ctx()`. The newer
   `Room::push_context` now returns a `matrix_sdk::Room::PushContext`, which can be used to compute
   the push actions for any event.
+  ([#4962](https://github.com/matrix-org/matrix-rust-sdk/pull/4962))
+- `Room::decrypt_event()` now requires an extra `matrix_sdk::Room::PushContext` parameter to
+  compute the push notifications for the decrypted event.
+  ([#4962](https://github.com/matrix-org/matrix-rust-sdk/pull/4962))
 
 ## [0.11.0] - 2025-04-11
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -374,7 +374,7 @@ impl Room {
             state: http_response.state,
         };
 
-        if let Some(push_context) = self.push_context().await? {
+        if let Some(push_context) = self.push_condition_room_ctx().await? {
             let push_rules = self.client().account().push_rules().await?;
 
             for event in &mut response.chunk {
@@ -2935,7 +2935,7 @@ impl Room {
     ///
     /// Returns `None` if some data couldn't be found. This should only happen
     /// in brand new rooms, while we process its state.
-    pub async fn push_context(&self) -> Result<Option<PushConditionRoomCtx>> {
+    pub async fn push_condition_room_ctx(&self) -> Result<Option<PushConditionRoomCtx>> {
         let room_id = self.room_id();
         let user_id = self.own_user_id();
         let room_info = self.clone_info();
@@ -2965,7 +2965,7 @@ impl Room {
     /// Retrieves a [`PushActionCtx`] that can be used to compute the push
     /// actions for events.
     pub async fn push_action_ctx(&self) -> Result<PushActionCtx> {
-        let push_condition_room_ctx = self.push_context().await?;
+        let push_condition_room_ctx = self.push_condition_room_ctx().await?;
         if push_condition_room_ctx.is_none() {
             debug!("Could not aggregate push context");
         }
@@ -2981,7 +2981,7 @@ impl Room {
         note = "Use `Room::push_action_ctx` to retrieve a `PushActionCtx` instead, and call `PushActionCtx::for_event` on your event."
     )]
     pub async fn event_push_actions<T>(&self, event: &Raw<T>) -> Result<Option<Vec<Action>>> {
-        let Some(push_context) = self.push_context().await? else {
+        let Some(push_context) = self.push_condition_room_ctx().await? else {
             debug!("Could not aggregate push context");
             return Ok(None);
         };

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -207,6 +207,11 @@ pub struct PushContext {
 }
 
 impl PushContext {
+    /// Create a new [`PushContext`] from its inner components.
+    pub fn new(push_condition_room_ctx: PushConditionRoomCtx, push_rules: Ruleset) -> Self {
+        Self { push_condition_room_ctx, push_rules }
+    }
+
     /// Compute the push rules for a given event.
     pub fn for_event<T>(&self, event: &Raw<T>) -> Vec<Action> {
         self.push_rules.get_actions(event, &self.push_condition_room_ctx).to_owned()
@@ -2957,7 +2962,7 @@ impl Room {
             return Ok(None);
         };
         let push_rules = self.client().account().push_rules().await?;
-        Ok(Some(PushContext { push_condition_room_ctx, push_rules }))
+        Ok(Some(PushContext::new(push_condition_room_ctx, push_rules)))
     }
 
     /// Get the push actions for the given event with the current room state.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -364,23 +364,12 @@ impl Room {
         )
         .await;
 
-        let mut response = Messages {
+        Ok(Messages {
             start: http_response.start,
             end: http_response.end,
             chunk,
             state: http_response.state,
-        };
-
-        if let Some(push_context) = self.push_condition_room_ctx().await? {
-            let push_rules = self.client().account().push_rules().await?;
-
-            for event in &mut response.chunk {
-                event.push_actions =
-                    Some(push_rules.get_actions(event.raw(), &push_context).to_owned());
-            }
-        }
-
-        Ok(response)
+        })
     }
 
     /// Register a handler for events of a specific type, within this room.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -197,7 +197,7 @@ const TYPING_NOTICE_RESEND_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Context allowing to compute the push actions for a given event.
 #[derive(Debug)]
-pub struct PushActionCtx {
+pub struct PushContext {
     /// The Ruma context used to compute the push actions.
     ///
     /// May be missing if some state events were missing for the current room
@@ -209,7 +209,7 @@ pub struct PushActionCtx {
     push_rules: Ruleset,
 }
 
-impl PushActionCtx {
+impl PushContext {
     /// Compute the push rules for a given event.
     ///
     /// Will return `None` if and only if the underlying
@@ -361,7 +361,7 @@ impl Room {
         let request = options.into_request(room_id);
         let http_response = self.client.send(request).await?;
 
-        let push_action_ctx = self.push_action_ctx().await?;
+        let push_action_ctx = self.push_context().await?;
         let chunk = join_all(
             http_response.chunk.into_iter().map(|ev| self.try_decrypt_event(ev, &push_action_ctx)),
         )
@@ -474,7 +474,7 @@ impl Room {
     async fn try_decrypt_event(
         &self,
         event: Raw<AnyTimelineEvent>,
-        push_ctx: &PushActionCtx,
+        push_ctx: &PushContext,
     ) -> TimelineEvent {
         #[cfg(feature = "e2e-encryption")]
         if let Ok(AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomEncrypted(
@@ -505,7 +505,7 @@ impl Room {
             get_room_event::v3::Request::new(self.room_id().to_owned(), event_id.to_owned());
 
         let raw_event = self.client.send(request).with_request_config(request_config).await?.event;
-        let push_action_ctx = self.push_action_ctx().await?;
+        let push_action_ctx = self.push_context().await?;
         let event = self.try_decrypt_event(raw_event, &push_action_ctx).await;
 
         // Save the event into the event cache, if it's set up.
@@ -562,7 +562,7 @@ impl Room {
 
         let response = self.client.send(request).with_request_config(request_config).await?;
 
-        let push_action_ctx = self.push_action_ctx().await?;
+        let push_action_ctx = self.push_context().await?;
         let target_event = if let Some(event) = response.event {
             Some(self.try_decrypt_event(event, &push_action_ctx).await)
         } else {
@@ -1372,7 +1372,7 @@ impl Room {
     pub async fn decrypt_event(
         &self,
         event: &Raw<OriginalSyncRoomEncryptedEvent>,
-        push_ctx: &PushActionCtx,
+        push_ctx: &PushContext,
     ) -> Result<TimelineEvent> {
         let machine = self.client.olm_machine().await;
         let machine = machine.as_ref().ok_or(Error::NoOlmMachine)?;
@@ -2962,15 +2962,15 @@ impl Room {
         }))
     }
 
-    /// Retrieves a [`PushActionCtx`] that can be used to compute the push
+    /// Retrieves a [`PushContext`] that can be used to compute the push
     /// actions for events.
-    pub async fn push_action_ctx(&self) -> Result<PushActionCtx> {
+    pub async fn push_context(&self) -> Result<PushContext> {
         let push_condition_room_ctx = self.push_condition_room_ctx().await?;
         if push_condition_room_ctx.is_none() {
             debug!("Could not aggregate push context");
         }
         let push_rules = self.client().account().push_rules().await?;
-        Ok(PushActionCtx { push_condition_room_ctx, push_rules })
+        Ok(PushContext { push_condition_room_ctx, push_rules })
     }
 
     /// Get the push actions for the given event with the current room state.
@@ -2978,7 +2978,7 @@ impl Room {
     /// Note that it is possible that no push action is returned because the
     /// current room state does not have all the required state events.
     #[deprecated(
-        note = "Use `Room::push_action_ctx` to retrieve a `PushActionCtx` instead, and call `PushActionCtx::for_event` on your event."
+        note = "Use `Room::push_context` to retrieve a `PushContext` instead, and call `PushContext::for_event` on your event."
     )]
     pub async fn event_push_actions<T>(&self, event: &Raw<T>) -> Result<Option<Vec<Action>>> {
         let Some(push_context) = self.push_condition_room_ctx().await? else {

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -340,37 +340,16 @@ impl Room {
         let request = options.into_request(room_id);
         let http_response = self.client.send(request).await?;
 
-        #[allow(unused_mut)]
+        let chunk =
+            try_join_all(http_response.chunk.into_iter().map(|ev| self.try_decrypt_event(ev)))
+                .await?;
+
         let mut response = Messages {
             start: http_response.start,
             end: http_response.end,
-            #[cfg(not(feature = "e2e-encryption"))]
-            chunk: http_response
-                .chunk
-                .into_iter()
-                .map(|raw| TimelineEvent::new(raw.cast()))
-                .collect(),
-            #[cfg(feature = "e2e-encryption")]
-            chunk: Vec::with_capacity(http_response.chunk.len()),
+            chunk,
             state: http_response.state,
         };
-
-        #[cfg(feature = "e2e-encryption")]
-        for event in http_response.chunk {
-            let decrypted_event = if let Ok(AnySyncTimelineEvent::MessageLike(
-                AnySyncMessageLikeEvent::RoomEncrypted(SyncMessageLikeEvent::Original(_)),
-            )) = event.deserialize_as::<AnySyncTimelineEvent>()
-            {
-                if let Ok(event) = self.decrypt_event(event.cast_ref()).await {
-                    event
-                } else {
-                    TimelineEvent::new(event.cast())
-                }
-            } else {
-                TimelineEvent::new(event.cast())
-            };
-            response.chunk.push(decrypted_event);
-        }
 
         if let Some(push_context) = self.push_context().await? {
             let push_rules = self.client().account().push_rules().await?;

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -459,6 +459,7 @@ impl Room {
     /// decrypted if needs be.
     ///
     /// Only logs from the crypto crate will indicate a failure to decrypt.
+    #[allow(clippy::unused_async)] // Used only in e2e-encryption.
     async fn try_decrypt_event(
         &self,
         event: Raw<AnyTimelineEvent>,

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -771,7 +771,7 @@ async fn test_encrypt_room_event() {
     .cast();
 
     let push_action_ctx =
-        room.push_action_ctx().await.expect("We should be able to get the push action context");
+        room.push_context().await.expect("We should be able to get the push action context");
     let timeline_event = room
         .decrypt_event(&event, &push_action_ctx)
         .await

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -770,8 +770,10 @@ async fn test_encrypt_room_event() {
     .expect("We should be able to construct a full event from the encrypted event content")
     .cast();
 
+    let push_action_ctx =
+        room.push_action_ctx().await.expect("We should be able to get the push action context");
     let timeline_event = room
-        .decrypt_event(&event)
+        .decrypt_event(&event, &push_action_ctx)
         .await
         .expect("We should be able to decrypt an event that we ourselves have encrypted");
 

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -770,10 +770,10 @@ async fn test_encrypt_room_event() {
     .expect("We should be able to construct a full event from the encrypted event content")
     .cast();
 
-    let push_action_ctx =
+    let push_ctx =
         room.push_context().await.expect("We should be able to get the push action context");
     let timeline_event = room
-        .decrypt_event(&event, push_action_ctx.as_ref())
+        .decrypt_event(&event, push_ctx.as_ref())
         .await
         .expect("We should be able to decrypt an event that we ourselves have encrypted");
 

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -773,7 +773,7 @@ async fn test_encrypt_room_event() {
     let push_action_ctx =
         room.push_context().await.expect("We should be able to get the push action context");
     let timeline_event = room
-        .decrypt_event(&event, &push_action_ctx)
+        .decrypt_event(&event, push_action_ctx.as_ref())
         .await
         .expect("We should be able to decrypt an event that we ourselves have encrypted");
 

--- a/testing/matrix-sdk-integration-testing/src/tests/nse.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/nse.rs
@@ -425,8 +425,8 @@ async fn decrypt_event(
     event: &Raw<OriginalSyncMessageLikeEvent<RoomEncryptedEventContent>>,
 ) -> Option<(OwnedEventId, String)> {
     let room = client.get_room(room_id).unwrap();
-    let push_action_ctx = room.push_context().await.unwrap();
-    let Ok(decrypted) = room.decrypt_event(event, push_action_ctx.as_ref()).await else {
+    let push_ctx = room.push_context().await.unwrap();
+    let Ok(decrypted) = room.decrypt_event(event, push_ctx.as_ref()).await else {
         return None;
     };
 

--- a/testing/matrix-sdk-integration-testing/src/tests/nse.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/nse.rs
@@ -426,7 +426,7 @@ async fn decrypt_event(
 ) -> Option<(OwnedEventId, String)> {
     let room = client.get_room(room_id).unwrap();
     let push_action_ctx = room.push_context().await.unwrap();
-    let Ok(decrypted) = room.decrypt_event(event, &push_action_ctx).await else {
+    let Ok(decrypted) = room.decrypt_event(event, push_action_ctx.as_ref()).await else {
         return None;
     };
 

--- a/testing/matrix-sdk-integration-testing/src/tests/nse.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/nse.rs
@@ -425,7 +425,7 @@ async fn decrypt_event(
     event: &Raw<OriginalSyncMessageLikeEvent<RoomEncryptedEventContent>>,
 ) -> Option<(OwnedEventId, String)> {
     let room = client.get_room(room_id).unwrap();
-    let push_action_ctx = room.push_action_ctx().await.unwrap();
+    let push_action_ctx = room.push_context().await.unwrap();
     let Ok(decrypted) = room.decrypt_event(event, &push_action_ctx).await else {
         return None;
     };

--- a/testing/matrix-sdk-integration-testing/src/tests/nse.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/nse.rs
@@ -424,7 +424,9 @@ async fn decrypt_event(
     room_id: &RoomId,
     event: &Raw<OriginalSyncMessageLikeEvent<RoomEncryptedEventContent>>,
 ) -> Option<(OwnedEventId, String)> {
-    let Ok(decrypted) = client.get_room(room_id).unwrap().decrypt_event(event).await else {
+    let room = client.get_room(room_id).unwrap();
+    let push_action_ctx = room.push_action_ctx().await.unwrap();
+    let Ok(decrypted) = room.decrypt_event(event, &push_action_ctx).await else {
         return None;
     };
 


### PR DESCRIPTION
This has three benefits:

- we don't need to recompute the full push context (which requires a few database accesses each time) when we're calling `try_decrypt_event()` for lots of events (which can happen when doing `/context` queries).
- this makes the workflow very explicit: you may get (or not) a `PushContext`, and use that to compute the push actions after decrypting
- we will properly fill the push actions for non-encrypted messages received with `/messages` at the right time (in `self.try_decrypt_event`), so we don't need to do it in an extra processing step

This is a preparatory refactoring for threads, since we'll want to use similar logic when fetching the thread roots, or when back-paginating inside a thread.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/4869.