### PR TITLE
refactor(widget): simplify a few things

### DIFF
--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -70,10 +70,6 @@ where
         Self { request_meta: Some(request_meta), _phantom: PhantomData }
     }
 
-    pub(crate) fn null() -> Self {
-        Self { request_meta: None, _phantom: PhantomData }
-    }
-
     /// Setup a callback function that will be called once the matrix driver has
     /// processed the request.
     pub(crate) fn then(

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -230,7 +230,7 @@ impl WidgetMachine {
             FromWidgetRequest::ContentLoaded {} => {
                 let mut response =
                     vec![Self::send_from_widget_response(raw_request, Ok(JsonObject::new()))];
-                if self.capabilities.is_unset() {
+                if matches!(self.capabilities, CapabilitiesState::Unset) {
                     response.append(&mut self.negotiate_capabilities());
                 }
                 response
@@ -664,11 +664,4 @@ enum CapabilitiesState {
     Negotiating,
     /// The capabilities have already been negotiated.
     Negotiated(Capabilities),
-}
-
-impl CapabilitiesState {
-    #[must_use]
-    fn is_unset(&self) -> bool {
-        matches!(self, Self::Unset)
-    }
 }


### PR DESCRIPTION
I didn't know we had implemented promises in the widget machine/driver/thingy. Anyhow, this includes a few tiny refactorings caused by "wtfs" emitted during previous reviews of the widget code, and which in my opinion make the code easier to read, etc.