### PR TITLE
refactor(widget): rename some concepts

### DIFF
--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -29,7 +29,7 @@ use crate::{widget::StateKeySelector, Error, HttpError, RumaApiError};
 
 #[derive(Deserialize, Debug)]
 #[serde(tag = "action", rename_all = "snake_case", content = "data")]
-pub(super) enum FromWidgetRequest {
+pub(super) enum WidgetToDriverRequest {
     SupportedApiVersions {},
     ContentLoaded {},
     #[serde(rename = "get_openid")]
@@ -41,8 +41,8 @@ pub(super) enum FromWidgetRequest {
     DelayedEventUpdate(UpdateDelayedEventRequest),
 }
 
-/// The full response a client sends to a [`FromWidgetRequest`] in case of an
-/// error.
+/// The full response a client sends to a [`WidgetToDriverRequest`] in case of
+/// an error.
 #[derive(Serialize)]
 pub(super) struct FromWidgetErrorResponse {
     error: FromWidgetError,
@@ -86,7 +86,7 @@ impl FromWidgetErrorResponse {
 }
 
 /// Serializable section of an error response send by the client as a
-/// response to a [`FromWidgetRequest`].
+/// response to a [`WidgetToDriverRequest`].
 #[derive(Serialize)]
 struct FromWidgetError {
     /// Unspecified error message text that caused this widget action to

--- a/crates/matrix-sdk/src/widget/machine/incoming.rs
+++ b/crates/matrix-sdk/src/widget/machine/incoming.rs
@@ -22,7 +22,7 @@ use serde_json::value::RawValue as RawJsonValue;
 use uuid::Uuid;
 
 use super::{
-    from_widget::{FromWidgetRequest, SendEventResponse},
+    from_widget::{SendEventResponse, WidgetToDriverRequest},
     to_widget::ToWidgetResponse,
 };
 use crate::widget::Capabilities;
@@ -76,7 +76,7 @@ pub(super) struct IncomingWidgetMessage {
 
 #[derive(Debug)]
 pub(super) enum IncomingWidgetMessageKind {
-    Request(Raw<FromWidgetRequest>),
+    Request(Raw<WidgetToDriverRequest>),
     Response(ToWidgetResponse),
 }
 

--- a/crates/matrix-sdk/src/widget/machine/tests/send_event.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/send_event.rs
@@ -3,7 +3,7 @@ use ruma::events::TimelineEventType;
 
 use super::WIDGET_ID;
 use crate::widget::machine::{
-    from_widget::FromWidgetRequest,
+    from_widget::WidgetToDriverRequest,
     incoming::{IncomingWidgetMessage, IncomingWidgetMessageKind},
 };
 
@@ -27,7 +27,8 @@ fn parse_delayed_event_widget_action() {
             serde_json::from_str::<IncomingWidgetMessage>(&raw).unwrap().kind
     );
     assert_let!(
-        FromWidgetRequest::SendEvent(send_event_request) = incoming_request.deserialize().unwrap()
+        WidgetToDriverRequest::SendEvent(send_event_request) =
+            incoming_request.deserialize().unwrap()
     );
     assert_let!(delay = send_event_request.delay.unwrap());
 


### PR DESCRIPTION
After reading the widget code for *a long time* this afternoon, I think I finally understand some things about it. It seems there are two channels between the widget and the "machine", and the direction is indicated in the name of some structs. For instance, `ToWidgetRequest` = "some request has been sent from the machine to the widget", aka it's always from the point of view of the *sender*.  For the second channel, there's `FromWidgetRequest`, aka it's a request sent from the widget to the machine.

Now, this is where it gets confusing for me: `ToWidgetResponse` is the response from the widget to the machine. In other words, what I think motivated the name is that, this is the response to a request of kind "ToWidget". Bizarrely, there's no equivalent for responses to a `FromWidgetRequest`; the responses are plain serialized from their original types.

If I'm right, then I'm super super confused by this, because I'd imagine a response to a `ToWidgetRequest` (from machine to widget) would be named after the fact **it's sent back by the machine to the widget**, so I'd intuit it should be the `FromWidgetResponse`. But that's the opposite: it is the `ToWidgetResponse`, which I imagined was the response from the machine to the widget.

I think some renaming is due here, but I'm not sure how yet.