### PR TITLE
task(tests): Ignore test_new_users_first_messages_dont_warn_about_insecure_device_if_it_is_secure because it is flaky

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -713,6 +713,7 @@ async fn test_room_keys_received_on_notification_client_trigger_redecryption() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "Flaky: times out waiting for timeline update that message was from a secure device"]
 async fn test_new_users_first_messages_dont_warn_about_insecure_device_if_it_is_secure() {
     async fn timeline_messages(timeline: &Timeline) -> Vec<EventTimelineItem> {
         timeline


### PR DESCRIPTION
Ignores a test that is flaking, tracked here: https://github.com/matrix-org/matrix-rust-sdk/issues/4871