### PR TITLE
Crypto: Take into account pending to-device room key sharing requests when collecting devices

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to this project will be documented in this file.
   presence of blacklisted/withheld devices in the room.
   ([#4954](https://github.com/matrix-org/matrix-rust-sdk/pull/4954))
 
+- Fix [#2729](https://github.com/matrix-org/matrix-rust-sdk/issues/2729) which in rare
+  cases can cause room key oversharing.
+  ([#4975](https://github.com/matrix-org/matrix-rust-sdk/pull/4975))
+
 ## [0.11.0] - 2025-04-11
 
 ### Features

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -160,7 +160,7 @@ pub struct OutboundGroupSession {
     pub(crate) shared_with_set:
         Arc<StdRwLock<BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceId, ShareInfo>>>>,
     #[allow(clippy::type_complexity)]
-    to_share_with_set:
+    pub(crate) to_share_with_set:
         Arc<StdRwLock<BTreeMap<OwnedTransactionId, (Arc<ToDeviceRequest>, ShareInfoSet)>>>,
 }
 

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -427,22 +427,55 @@ fn is_session_overshared_for_user(
     let recipient_device_ids: BTreeSet<&DeviceId> =
         recipient_devices.iter().map(|d| d.device_id()).collect();
 
+    let mut shared: Vec<&DeviceId> = Vec::new();
+
+    // This duplicates a conservative subset of the logic in
+    // `OutboundGroupSession::is_shared_with`, because we
+    // don't have corresponding DeviceData at hand
+    fn is_actually_shared(info: &ShareInfo) -> bool {
+        match info {
+            ShareInfo::Shared(_) => true,
+            ShareInfo::Withheld(_) => false,
+        }
+    }
+
+    // Collect the devices that have definitely received the session already
     let guard = outbound_session.shared_with_set.read();
+    if let Some(for_user) = guard.get(user_id) {
+        shared.extend(for_user.iter().filter_map(|(d, info)| {
+            if is_actually_shared(info) {
+                Some(AsRef::<DeviceId>::as_ref(d))
+            } else {
+                None
+            }
+        }));
+    }
 
-    let Some(shared) = guard.get(user_id) else {
+    // To be conservative, also collect the devices that would still receive the
+    // session from a pending to-device request if we don't rotate beforehand
+    let guard = outbound_session.to_share_with_set.read();
+    for (_txid, share_infos) in guard.values() {
+        if let Some(for_user) = share_infos.get(user_id) {
+            shared.extend(for_user.iter().filter_map(|(d, info)| {
+                if is_actually_shared(info) {
+                    Some(AsRef::<DeviceId>::as_ref(d))
+                } else {
+                    None
+                }
+            }));
+        }
+    }
+
+    if shared.is_empty() {
         return false;
-    };
+    }
 
-    // Devices that received this session
-    let shared: BTreeSet<&DeviceId> = shared
-        .iter()
-        .filter(|(_, info)| matches!(info, ShareInfo::Shared(_)))
-        .map(|(d, _)| d.as_ref())
-        .collect();
+    let shared: BTreeSet<&DeviceId> = shared.into_iter().collect();
 
     // The set difference between
     //
-    // 1. Devices that had previously received the session, and
+    // 1. Devices that had previously received (or are queued to receive) the
+    //    session, and
     // 2. Devices that would now receive the session
     //
     // Represents newly deleted or blacklisted devices. If this


### PR DESCRIPTION
Attempted fix for #2729 based on previous discussion in https://github.com/matrix-org/matrix-rust-sdk/pull/4954.

To summarize, the situation of pending room key sharing requests prior to calls to `GroupSessionManager::share_room_key` can indeed occur if `matrix-sdk-crypto` is used directly. In the case where `matrix-sdk` wraps it, [`Room::share_room_key`](https://github.com/matrix-org/matrix-rust-sdk/blob/a60e336f8572252e26f8dacb42e096f0f6d1fce3/crates/matrix-sdk/src/room/mod.rs#L1799) makes sure to send pending requests right after, as well as mark them as sent which will cause the corresponding entry in `to_share_with_set` to be moved to `shared_with_set`. If there is a failure, the room key [is discarded](https://github.com/matrix-org/matrix-rust-sdk/blob/a60e336f8572252e26f8dacb42e096f0f6d1fce3/crates/matrix-sdk/src/room/mod.rs#L1774-L1785) right after (to avoid UTD errors from missing keys).

This is of course racy, since this entire sequence is not atomic. After an interruption and restart, we can end up back in `GroupSessionManager::share_room_key` with pending requests (which after all is the point of persisting the pending requests in the first place).

It seems ugly to export `shared_with_set` and `to_share_with_set`. It feels like there should be abstractions similar to `is_shared_with` that provide a semantic view into `GroupSessionManager`'s state carrying sufficient information for all existing uses of `shared_with_set` and `to_share_with_set` outside of the impl (all of which are in `share_strategy.rs`). If you prefer this approach let me know.

Signed-off-by: Niklas Baumstark [niklas.baumstark@gmail.com](mailto:niklas.baumstark@gmail.com)
