### PR TITLE
refactor(crypto): Properly encapsulate internal `OutboundGroupSession` state

### DIFF
--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -645,7 +645,7 @@ impl GossipMachine {
         // at. For this, we need an outbound session because this
         // information is recorded there.
         } else if let Some(outbound) = outbound_session {
-            match outbound.is_shared_with(&device.inner) {
+            match outbound.sharing_view().get_share_state(&device.inner) {
                 ShareState::Shared { message_index, olm_wedging_index: _ } => {
                     Ok(Some(message_index))
                 }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -837,7 +837,7 @@ mod tests {
     /// specificity of the value.
     #[test]
     fn test_share_state_ordering() {
-        let mut values = [
+        let values = [
             ShareState::NotShared,
             ShareState::SharedButChangedSenderKey,
             ShareState::Shared { message_index: 1, olm_wedging_index: Default::default() },
@@ -848,9 +848,7 @@ mod tests {
             | ShareState::SharedButChangedSenderKey
             | ShareState::Shared { .. } => {}
         }
-        let orig = values.clone();
-        values.sort();
-        assert_eq!(orig, values);
+        assert!(values.is_sorted());
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_arch = "wasm32"))]

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
@@ -122,7 +122,7 @@ impl GroupSessionCache {
 
     /// Returns whether any session is withheld with the given device and code.
     fn has_session_withheld_to(&self, device: &DeviceData, code: &WithheldCode) -> bool {
-        self.sessions.read().values().any(|s| s.is_withheld_to(device, code))
+        self.sessions.read().values().any(|s| s.sharing_view().is_withheld_to(device, code))
     }
 
     fn remove_from_being_shared(&self, id: &TransactionId) -> Option<OutboundGroupSession> {
@@ -500,7 +500,7 @@ impl GroupSessionManager {
         if code == &WithheldCode::NoOlm {
             device.was_withheld_code_sent() || self.sessions.has_session_withheld_to(device, code)
         } else {
-            group_session.is_withheld_to(device, code)
+            group_session.sharing_view().is_withheld_to(device, code)
         }
     }
 
@@ -696,7 +696,7 @@ impl GroupSessionManager {
         let devices: Vec<_> = devices
             .into_iter()
             .flat_map(|(_, d)| {
-                d.into_iter().filter(|d| match outbound.is_shared_with(d) {
+                d.into_iter().filter(|d| match outbound.sharing_view().get_share_state(d) {
                     ShareState::NotShared => true,
                     ShareState::Shared { message_index: _, olm_wedging_index } => {
                         // If the recipient device's Olm wedging index is higher


### PR DESCRIPTION
As discussed in #4975. Previously, the `share_strategy` was breaking the abstraction provided by `OutboundGroupSession` by accessing its internal fields in an inconsistent and adhoc way. Now all fields are private and a proper abstraction was added to access the required state in a consistent API.

NOTE: Mostly used this to practice my Rust, I'm not heavily invested in it