### PR TITLE
refactor(crypto): Move `session_id` from `EncryptionInfo` to `AlgorithmInfo` as it is megolm specific

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -917,21 +917,21 @@ impl OlmMachine {
         let event_json: Event<'_> = serde_json::from_str(decrypted.event.json().get())?;
 
         Ok(match &encryption_info.algorithm_info {
-            AlgorithmInfo::MegolmV1AesSha2 { curve25519_key, sender_claimed_keys } => {
-                DecryptedEvent {
-                    clear_event: serde_json::to_string(&event_json)?,
-                    sender_curve25519_key: curve25519_key.to_owned(),
-                    claimed_ed25519_key: sender_claimed_keys
-                        .get(&DeviceKeyAlgorithm::Ed25519)
-                        .cloned(),
-                    forwarding_curve25519_chain: vec![],
-                    shield_state: if strict_shields {
-                        encryption_info.verification_state.to_shield_state_strict().into()
-                    } else {
-                        encryption_info.verification_state.to_shield_state_lax().into()
-                    },
-                }
-            }
+            AlgorithmInfo::MegolmV1AesSha2 {
+                curve25519_key,
+                sender_claimed_keys,
+                session_id: _,
+            } => DecryptedEvent {
+                clear_event: serde_json::to_string(&event_json)?,
+                sender_curve25519_key: curve25519_key.to_owned(),
+                claimed_ed25519_key: sender_claimed_keys.get(&DeviceKeyAlgorithm::Ed25519).cloned(),
+                forwarding_curve25519_chain: vec![],
+                shield_state: if strict_shields {
+                    encryption_info.verification_state.to_shield_state_strict().into()
+                } else {
+                    encryption_info.verification_state.to_shield_state_lax().into()
+                },
+            },
         })
     }
 

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -62,9 +62,9 @@ pub fn make_test_event_with_event_id(
         algorithm_info: AlgorithmInfo::MegolmV1AesSha2 {
             curve25519_key: "1337".to_owned(),
             sender_claimed_keys: Default::default(),
+            session_id: Some("mysessionid9".to_owned()),
         },
         verification_state: VerificationState::Verified,
-        session_id: Some("mysessionid9".to_owned()),
     };
 
     let mut builder = EventFactory::new().text_msg(content).room(room_id).sender(*ALICE);

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -599,14 +599,11 @@ impl TimelineEventKind {
     pub fn session_id(&self) -> Option<&str> {
         match self {
             TimelineEventKind::Decrypted(decrypted_room_event) => {
-                let AlgorithmInfo::MegolmV1AesSha2 { session_id, .. } =
-                    &decrypted_room_event.encryption_info.algorithm_info;
-                session_id.as_ref()
+                decrypted_room_event.encryption_info.session_id()
             }
-            TimelineEventKind::UnableToDecrypt { utd_info, .. } => utd_info.session_id.as_ref(),
+            TimelineEventKind::UnableToDecrypt { utd_info, .. } => utd_info.session_id.as_deref(),
             TimelineEventKind::PlainText { .. } => None,
         }
-        .map(String::as_str)
     }
 }
 

--- a/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__encryption_info_migration.snap
+++ b/crates/matrix-sdk-common/src/snapshots/matrix_sdk_common__deserialized_responses__tests__encryption_info_migration.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/matrix-sdk-common/src/deserialized_responses.rs
-expression: info
+expression: deserialized
 ---
 {
   "sender": "@alice:localhost",

--- a/crates/matrix-sdk-common/src/snapshots/snapshot_test_sync_timeline_event.snap
+++ b/crates/matrix-sdk-common/src/snapshots/snapshot_test_sync_timeline_event.snap
@@ -12,12 +12,12 @@ expression: "serde_json::to_value(&room_event).unwrap()"
             "sender_claimed_keys": {
               "curve25519": "qzdW3F5IMPFl0HQgz5w/L5Oi/npKUFn8Um84acIHfPY",
               "ed25519": "I3YsPwqMZQXHkSQbjFNEs7b529uac2xBpI83eN3LUXo"
-            }
+            },
+            "session_id": "mysessionid112"
           }
         },
         "sender": "@sender:example.com",
         "sender_device": "ABCDEFGHIJ",
-        "session_id": "mysessionid112",
         "verification_state": "Verified"
       },
       "event": {

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] Move `session_id` from `EncryptionInfo` to `AlgorithmInfo` as it is megolm specific. 
+  Use `EncryptionInfo::session_id()` helper for quick access.
+
 - Send stable identifier `sender_device_keys` for MSC4147 (Including device
   keys with Olm-encrypted events).
   ([#4964](https://github.com/matrix-org/matrix-rust-sdk/pull/4964))

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -1719,9 +1719,9 @@ impl OlmMachine {
                     .iter()
                     .map(|(k, v)| (k.to_owned(), v.to_base64()))
                     .collect(),
+                session_id: Some(session.session_id().to_owned()),
             },
             verification_state,
-            session_id: Some(session.session_id().to_owned()),
         })
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -174,10 +174,7 @@ fn compute_event_indices_to_retry_decryption(
         } else {
             // Non-UTDs only have a session ID if they are remote and have it in the
             // EncryptionInfo
-            event
-                .as_remote()
-                .and_then(|remote| remote.encryption_info.as_ref()?.session_id.as_ref())
-                .map(String::as_str)
+            event.as_remote().and_then(|remote| remote.encryption_info.as_ref()?.session_id())
         };
 
         if let Some(session_id) = session_id {
@@ -232,7 +229,7 @@ async fn make_replacement_for<P: RoomDataProvider>(
     let item = item?;
     let event = item.as_event()?;
     let remote = event.as_remote()?;
-    let session_id = remote.encryption_info.as_ref()?.session_id.as_deref()?;
+    let session_id = remote.encryption_info.as_ref()?.session_id()?;
 
     let new_encryption_info =
         room_data_provider.get_encryption_info(session_id, &event.sender).await;
@@ -515,9 +512,9 @@ mod tests {
                 algorithm_info: AlgorithmInfo::MegolmV1AesSha2 {
                     curve25519_key: "".to_owned(),
                     sender_claimed_keys: BTreeMap::new(),
+                    session_id: Some(session_id.to_owned()),
                 },
                 verification_state: VerificationState::Verified,
-                session_id: Some(session_id.to_owned()),
             }),
             original_json: None,
             latest_edit_json: None,

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -173,9 +173,9 @@ async fn test_edit_updates_encryption_info() {
         algorithm_info: AlgorithmInfo::MegolmV1AesSha2 {
             curve25519_key: "123".to_owned(),
             sender_claimed_keys: BTreeMap::new(),
+            session_id: Some("mysessionid6333".to_owned()),
         },
         verification_state: VerificationState::Verified,
-        session_id: Some("mysessionid6333".to_owned()),
     };
 
     let original_event: TimelineEvent = DecryptedRoomEvent {

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -697,9 +697,9 @@ fn make_encryption_info(session_id: &str, verification_state: VerificationState)
         algorithm_info: AlgorithmInfo::MegolmV1AesSha2 {
             curve25519_key: Default::default(),
             sender_claimed_keys: Default::default(),
+            session_id: Some(session_id.to_owned()),
         },
         verification_state,
-        session_id: Some(session_id.to_owned()),
     }
 }
 


### PR DESCRIPTION
Moves the `session_id` field from EncryptionInfo to AlgorithmInfo::MegolmV1AesSha2 as it is specific to megolm. Provides transparent migration of serialized data.

In the future we plan to reuse `EncryptionInfo` for to_device decryption (using olm not megolm). So megolm session_id should move to algorithm specific data.

This is a follow-up of https://github.com/matrix-org/matrix-rust-sdk/pull/4935 and also ground work for future changes.
As discussed here https://github.com/matrix-org/matrix-rust-sdk/pull/4935#discussion_r2049153547

This PR also provides migration for old serialized `EncryptionInfo` (serialized in the event cache).

I only provide specific migration for `EncryptionInfo`.
I don't think more migration it is needed for `AlgorithmInfo::MegolmV1AesSha2` as the added `session_id` is an Option and a `serde/default`is added. Migration for AlgorithmInfo is just done via `#[serde(default, skip_serializing_if = "Option::is_none")]`. `skip_serializing_if` is used in order to not break existing snapshots to avoid noise. But not sure if the right choice.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
