### PR TITLE
feat(bindings): check if report room api is supported

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1202,6 +1202,11 @@ impl Client {
 
         Ok(closure().await?)
     }
+
+    /// Checks if the server supports the report room API.
+    pub async fn is_report_room_api_supported(&self) -> Result<bool, ClientError> {
+        Ok(self.inner.server_versions().await?.contains(&ruma::api::MatrixVersion::V1_13))
+    }
 }
 
 #[matrix_sdk_ffi_macros::export(callback_interface)]


### PR DESCRIPTION
Since only homeservers that support matrix v1.13 are able to use this API, clients might need to know if the report room API is available or not, to display an action to the user