### PR TITLE
WidgetDriver: Add `io.element.call.encryption_keys` to-device capability.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -321,7 +321,11 @@ pub fn get_element_call_required_permissions(
             event_type: "org.matrix.rageshake_request".to_owned(),
         },
         // To read and send encryption keys
+        WidgetEventFilter::ToDeviceWithType {
+            event_type: "io.element.call.encryption_keys".to_owned(),
+        },
         // TODO change this to the appropriate to-device version once ready
+        // remove this once all matrixRTC call apps supports to-device encryption.
         WidgetEventFilter::MessageLikeWithType {
             event_type: "io.element.call.encryption_keys".to_owned(),
         },


### PR DESCRIPTION
This needs to be part of the send/read capabilities so that to-device keys can be used.

Blocked by (depends on): https://github.com/matrix-org/matrix-rust-sdk/pull/4963
<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
