### PR TITLE
Notification client call members

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -9,6 +9,7 @@ use crate::{
     client::{Client, JoinRule},
     error::ClientError,
     event::TimelineEvent,
+    room::Room,
 };
 
 #[derive(uniffi::Enum)]
@@ -99,6 +100,17 @@ pub struct NotificationClient {
 
 #[matrix_sdk_ffi_macros::export]
 impl NotificationClient {
+    /// Fetches a room by its ID using the in-memory state store backed client.
+    ///
+    /// Useful to retrieve room information after running the limited
+    /// notification client sliding sync loop.
+    pub fn get_room(&self, room_id: String) -> Result<Option<Arc<Room>>, ClientError> {
+        let room_id = RoomId::parse(room_id)?;
+        let sdk_room = self.inner.get_room(&room_id);
+        let room = sdk_room.map(|room| Arc::new(Room::new(room)));
+        Ok(room)
+    }
+
     /// See also documentation of
     /// `MatrixNotificationClient::get_notification`.
     pub async fn get_notification(

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -125,6 +125,13 @@ impl NotificationClient {
         })
     }
 
+    /// Fetches a room by its ID using the in-memory state store backed client.
+    /// Useful to retrieve room information after running the limited
+    /// notification client sliding sync loop.
+    pub fn get_room(&self, room_id: &RoomId) -> Option<Room> {
+        self.client.get_room(room_id)
+    }
+
     /// Fetches the content of a notification.
     ///
     /// This will first try to get the notification using a short-lived sliding

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -411,6 +411,7 @@ impl NotificationClient {
             (StateEventType::RoomCanonicalAlias, "".to_owned()),
             (StateEventType::RoomName, "".to_owned()),
             (StateEventType::RoomPowerLevels, "".to_owned()),
+            (StateEventType::CallMember, "*".to_owned()),
         ];
 
         let invites = SlidingSyncList::builder("invites")

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -264,6 +264,7 @@ async fn test_notification_client_sliding_sync() {
                         ["m.room.canonical_alias", ""],
                         ["m.room.name", ""],
                         ["m.room.power_levels", ""],
+                        ["org.matrix.msc3401.call.member", "*"],
                     ],
                     "filters": {
                         "is_invite": true,
@@ -281,6 +282,7 @@ async fn test_notification_client_sliding_sync() {
                         ["m.room.canonical_alias", ""],
                         ["m.room.name", ""],
                         ["m.room.power_levels", ""],
+                        ["org.matrix.msc3401.call.member", "*"],
                     ],
                     "timeline_limit": 16,
                 },


### PR DESCRIPTION
This PR tweaks the NotificationClient so that it also requests the `org.matrix.msc3401.call.member` state and exposes a method for fetching rooms from its internal in-memory store backed client.

These will be used to check whether a room still has an ongoing call before showing the ringing screen.