### PR TITLE
Toger5/widget-to-device-with-encryption

### DIFF
--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -321,9 +321,7 @@ pub fn get_element_call_required_permissions(
             event_type: "org.matrix.rageshake_request".to_owned(),
         },
         // To read and send encryption keys
-        WidgetEventFilter::ToDeviceWithType {
-            event_type: "io.element.call.encryption_keys".to_owned(),
-        },
+        WidgetEventFilter::ToDevice { event_type: "io.element.call.encryption_keys".to_owned() },
         // TODO change this to the appropriate to-device version once ready
         // remove this once all calling supports to-device encryption
         WidgetEventFilter::MessageLikeWithType {

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -321,7 +321,11 @@ pub fn get_element_call_required_permissions(
             event_type: "org.matrix.rageshake_request".to_owned(),
         },
         // To read and send encryption keys
+        WidgetEventFilter::ToDeviceWithType {
+            event_type: "io.element.call.encryption_keys".to_owned(),
+        },
         // TODO change this to the appropriate to-device version once ready
+        // remove this once all calling supports to-device encryption
         WidgetEventFilter::MessageLikeWithType {
             event_type: "io.element.call.encryption_keys".to_owned(),
         },

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -778,6 +778,56 @@ impl MatrixMockServer {
         self.mock_endpoint(mock, DeleteRoomKeysVersionEndpoint).expect_default_access_token()
     }
 
+    /// Creates a prebuilt mock for the `/sendToDevice` endpoint.
+    ///
+    /// This mock can be used to simulate sending to-device messages in tests.
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(feature = "e2e-encryption")]
+    /// # {
+    /// # tokio_test::block_on(async {
+    /// use std::collections::BTreeMap;
+    /// use matrix_sdk::{
+    ///     ruma::{
+    ///         serde::Raw,
+    ///         api::client::to_device::send_event_to_device::v3::Request as ToDeviceRequest,
+    ///         to_device::DeviceIdOrAllDevices,
+    ///         user_id,owned_device_id
+    ///     },
+    ///     test_utils::mocks::MatrixMockServer,
+    /// };
+    /// use serde_json::json;
+    ///
+    /// let mock_server = MatrixMockServer::new().await;
+    /// let client = mock_server.client_builder().build().await;
+    ///
+    /// mock_server.mock_send_to_device().ok().mock_once().mount().await;
+    ///
+    /// let request = ToDeviceRequest::new_raw(
+    ///     "m.custom.event".into(),
+    ///     "txn_id".into(),
+    /// BTreeMap::from([
+    /// (user_id!("@alice:localhost").to_owned(), BTreeMap::from([(
+    ///     DeviceIdOrAllDevices::AllDevices,
+    ///     Raw::new(&ruma::events::AnyToDeviceEventContent::Dummy(ruma::events::dummy::ToDeviceDummyEventContent {})).unwrap(),
+    /// )])),
+    /// ])
+    /// );
+    ///
+    /// client
+    ///     .send(request)
+    ///     .await
+    ///     .expect("We should be able to send a to-device message");
+    /// # anyhow::Ok(()) });
+    /// # }
+    /// ```
+    pub fn mock_send_to_device(&self) -> MockEndpoint<'_, SendToDeviceEndpoint> {
+        let mock =
+            Mock::given(method("PUT")).and(path_regex(r"^/_matrix/client/v3/sendToDevice/.*/.*"));
+        self.mock_endpoint(mock, SendToDeviceEndpoint).expect_default_access_token()
+    }
+
     /// Create a prebuilt mock for getting the room members in a room.
     ///
     /// # Examples
@@ -2312,6 +2362,17 @@ impl<'a> MockEndpoint<'a, DeleteRoomKeysVersionEndpoint> {
     pub fn ok(self) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
             .named("DELETE for the backup deletion")
+    }
+}
+
+/// A prebuilt mock for the `/sendToDevice` endpoint.
+///
+/// This mock can be used to simulate sending to-device messages in tests.
+pub struct SendToDeviceEndpoint;
+impl<'a> MockEndpoint<'a, SendToDeviceEndpoint> {
+    /// Returns a successful response with default data.
+    pub fn ok(self) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }
 

--- a/crates/matrix-sdk/src/widget/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/capabilities.rs
@@ -288,9 +288,8 @@ impl<'de> Deserialize<'de> for Capabilities {
 mod tests {
     use ruma::events::StateEventType;
 
-    use crate::widget::filter::ToDeviceEventFilter;
-
     use super::*;
+    use crate::widget::filter::ToDeviceEventFilter;
 
     #[test]
     fn deserialization_of_no_capabilities() {

--- a/crates/matrix-sdk/src/widget/filter.rs
+++ b/crates/matrix-sdk/src/widget/filter.rs
@@ -228,8 +228,8 @@ impl<'a> TryFrom<&'a Raw<AnyTimelineEvent>> for FilterInput<'a> {
     type Error = serde_json::Error;
 
     fn try_from(raw_event: &'a Raw<AnyTimelineEvent>) -> Result<Self, Self::Error> {
-        // FilterInput first checks if it can deserialize as a state event (state_key exists)
-        // and then as a message like event.
+        // FilterInput first checks if it can deserialize as a state event (state_key
+        // exists) and then as a message like event.
         raw_event.deserialize_as()
     }
 }
@@ -244,9 +244,9 @@ pub struct FilterInputToDevice<'a> {
 impl<'a> TryFrom<&'a Raw<AnyToDeviceEvent>> for FilterInput<'a> {
     type Error = serde_json::Error;
     fn try_from(raw_event: &'a Raw<AnyToDeviceEvent>) -> Result<Self, Self::Error> {
-        // deserialize_as::<FilterInput> will first try state, message like and then to-device.
-        // The `AnyToDeviceEvent` would match message like first, so we need to explicitly
-        // deserialize as `FilterInputToDevice`.
+        // deserialize_as::<FilterInput> will first try state, message like and then
+        // to-device. The `AnyToDeviceEvent` would match message like first, so
+        // we need to explicitly deserialize as `FilterInputToDevice`.
         raw_event.deserialize_as::<FilterInputToDevice<'a>>().map(FilterInput::ToDevice)
     }
 }
@@ -515,7 +515,7 @@ mod tests {
     fn test_to_device_filter_does_match() {
         let f = Filter::ToDevice(ToDeviceEventFilter::new("my.custom.to.device".into()));
         assert!(f.matches(&FilterInput::ToDevice(FilterInputToDevice {
-            event_type: "my.custom.to.device".into(),
+            event_type: "my.custom.to.device",
         })));
     }
 }

--- a/crates/matrix-sdk/src/widget/machine/to_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/to_widget.rs
@@ -128,7 +128,7 @@ impl ToWidgetRequest for NotifyNewMatrixEvent {
 #[derive(Deserialize)]
 pub(crate) struct Empty {}
 
-/// Notify the widget that we received a new matrix event.
+/// Notify the widget that we received a new matrix to device event.
 /// This is a "response" to the widget subscribing to the events in the room.
 #[derive(Serialize)]
 #[serde(transparent)]

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -399,10 +399,11 @@ mod to_device_crypto {
                 let content = content.clone();
 
                 async move {
-                    if !device.is_cross_signed_by_owner() {
-                        info!("Device {} is not verified, skipping encryption", device.device_id());
-                        return None;
-                    }
+                    // This is not yet used. It is incompatible with the spa guest mode (the spa will not verify its crypto identity)
+                    // if !device.is_cross_signed_by_owner() {
+                    //     info!("Device {} is not verified, skipping encryption", device.device_id());
+                    //     return None;
+                    // }
                     match device
                         .inner
                         .encrypt_event_raw(&event_type.to_string(), &content)
@@ -437,14 +438,15 @@ mod to_device_crypto {
                             warn!("Failed to get user devices for user: {}", user_id);
                             return None;
                         };
-                        let Ok(user_identity) = client.encryption().get_user_identity(&user_id).await else{
-                            warn!("Failed to get user identity for user: {}", user_id);
-                            return None;
-                        };
-                        if user_identity.map(|i|i.has_verification_violation()).unwrap_or(false) {
-                            info!("User {} has a verification violation, skipping encryption", user_id);
-                            return None;
-                        }
+                        // This is not yet used. It is incompatible with the spa guest mode (the spa will not verify its crypto identity)
+                        // let Ok(user_identity) = client.encryption().get_user_identity(&user_id).await else{
+                        //     warn!("Failed to get user identity for user: {}", user_id);
+                        //     return None;
+                        // };
+                        // if user_identity.map(|i|i.has_verification_violation()).unwrap_or(false) {
+                        //     info!("User {} has a verification violation, skipping encryption", user_id);
+                        //     return None;
+                        // }
                         let devices: Vec<Device> = match device_or_all_id {
                             DeviceIdOrAllDevices::DeviceId(device_id) => {
                                 vec![user_devices.get(&device_id)].into_iter().flatten().collect()

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -17,21 +17,24 @@
 
 use std::collections::BTreeMap;
 
-use matrix_sdk_base::deserialized_responses::RawAnySyncOrStrippedState;
+use matrix_sdk_base::deserialized_responses::{EncryptionInfo, RawAnySyncOrStrippedState};
 use ruma::{
     api::client::{
         account::request_openid_token::v3::{Request as OpenIdRequest, Response as OpenIdResponse},
         delayed_events::{self, update_delayed_event::unstable::UpdateAction},
         filter::RoomEventFilter,
+        to_device::send_event_to_device::{self, v3::Request as RumaToDeviceRequest},
     },
     assign,
     events::{
         AnyMessageLikeEventContent, AnyStateEventContent, AnySyncMessageLikeEvent,
-        AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent, MessageLikeEventType,
-        StateEventType, TimelineEventType,
+        AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent, AnyToDeviceEvent,
+        AnyToDeviceEventContent, MessageLikeEventType, StateEventType, TimelineEventType,
+        ToDeviceEventType,
     },
     serde::{from_raw_json_value, Raw},
-    EventId, RoomId, TransactionId,
+    to_device::DeviceIdOrAllDevices,
+    EventId, OwnedUserId, RoomId, TransactionId,
 };
 use serde_json::{value::RawValue as RawJsonValue, Value};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
@@ -86,7 +89,11 @@ impl MatrixDriver {
     ) -> Result<Vec<Raw<AnyTimelineEvent>>> {
         let room_id = self.room.room_id();
         let convert = |sync_or_stripped_state| match sync_or_stripped_state {
-            RawAnySyncOrStrippedState::Sync(ev) => Some(attach_room_id(ev.cast_ref(), room_id)),
+            RawAnySyncOrStrippedState::Sync(ev) => with_attached_room_id(ev.cast_ref(), room_id)
+                .map_err(|e| {
+                    error!("failed to convert event from `get_state_event` response:{}", e)
+                })
+                .ok(),
             RawAnySyncOrStrippedState::Stripped(_) => {
                 error!("MatrixDriver can't operate in invited rooms");
                 None
@@ -181,7 +188,7 @@ impl MatrixDriver {
 
     /// Starts forwarding new room events. Once the returned `EventReceiver`
     /// is dropped, forwarding will be stopped.
-    pub(crate) fn events(&self) -> EventReceiver {
+    pub(crate) fn events(&self) -> EventReceiver<Raw<AnyTimelineEvent>> {
         let (tx, rx) = unbounded_channel();
         let room_id = self.room.room_id().to_owned();
 
@@ -190,14 +197,29 @@ impl MatrixDriver {
         let _room_id = room_id.clone();
         let handle_msg_like =
             self.room.add_event_handler(move |raw: Raw<AnySyncMessageLikeEvent>| {
-                let _ = _tx.send(attach_room_id(raw.cast_ref(), &_room_id));
+                match with_attached_room_id(raw.cast_ref(), &_room_id) {
+                    Ok(event_with_room_id) => {
+                        let _ = _tx.send(event_with_room_id);
+                    }
+                    Err(e) => {
+                        error!("Failed to attach room id to message like event: {}", e);
+                    }
+                }
                 async {}
             });
         let drop_guard_msg_like = self.room.client().event_handler_drop_guard(handle_msg_like);
-
+        let _room_id = room_id;
+        let _tx = tx;
         // Get only all state events from the state section of the sync.
         let handle_state = self.room.add_event_handler(move |raw: Raw<AnySyncStateEvent>| {
-            let _ = tx.send(attach_room_id(raw.cast_ref(), &room_id));
+            match with_attached_room_id(raw.cast_ref(), &_room_id) {
+                Ok(event_with_room_id) => {
+                    let _ = _tx.send(event_with_room_id);
+                }
+                Err(e) => {
+                    error!("Failed to attach room id to state event: {}", e);
+                }
+            }
             async {}
         });
         let drop_guard_state = self.room.client().event_handler_drop_guard(handle_state);
@@ -208,25 +230,102 @@ impl MatrixDriver {
         // section of the sync will not be forwarded to the widget.
         // TODO annotate the events and send both timeline and state section state
         // events.
-        EventReceiver { rx, _drop_guards: [drop_guard_msg_like, drop_guard_state] }
+        EventReceiver { rx, _drop_guards: vec![drop_guard_msg_like, drop_guard_state] }
+    }
+
+    /// Starts forwarding new room events. Once the returned `EventReceiver`
+    /// is dropped, forwarding will be stopped.
+    pub(crate) fn to_device_events(&self) -> EventReceiver<Raw<AnyToDeviceEvent>> {
+        let (tx, rx) = unbounded_channel();
+
+        let to_device_handle = self.room.client().add_event_handler(
+            move |raw: Raw<AnyToDeviceEvent>, encryption_info: Option<EncryptionInfo>| {
+                match with_attached_encryption_flag(raw, &encryption_info) {
+                    Ok(ev) => {
+                        let _ = tx.send(ev);
+                    }
+                    Err(e) => {
+                        error!("Failed to attach encryption flag to to_device event: {}", e);
+                    }
+                }
+                async {}
+            },
+        );
+
+        let drop_guard = self.room.client().event_handler_drop_guard(to_device_handle);
+        EventReceiver { rx, _drop_guards: vec![drop_guard] }
+    }
+
+    /// It will ignore all devices where errors occurred or where the device is
+    /// not verified or where th user has a has_verification_violation.
+    pub(crate) async fn send_to_device(
+        &self,
+        event_type: ToDeviceEventType,
+        encrypted: bool,
+        messages: BTreeMap<
+            OwnedUserId,
+            BTreeMap<DeviceIdOrAllDevices, Raw<AnyToDeviceEventContent>>,
+        >,
+    ) -> Result<send_event_to_device::v3::Response> {
+        let client = self.room.client();
+
+        let request = if encrypted {
+            return Err(Error::UnknownError(
+                "Sending encrypted to_device events is not supported by the widget driver.".into(),
+            ));
+        } else {
+            RumaToDeviceRequest::new_raw(event_type, TransactionId::new(), messages)
+        };
+
+        let response = client.send(request).await;
+
+        response.map_err(Into::into)
     }
 }
 
 /// A simple entity that wraps an `UnboundedReceiver`
 /// along with the drop guard for the room event handler.
-pub(crate) struct EventReceiver {
-    rx: UnboundedReceiver<Raw<AnyTimelineEvent>>,
-    _drop_guards: [EventHandlerDropGuard; 2],
+pub(crate) struct EventReceiver<E> {
+    rx: UnboundedReceiver<E>,
+    _drop_guards: Vec<EventHandlerDropGuard>,
 }
 
-impl EventReceiver {
-    pub(crate) async fn recv(&mut self) -> Option<Raw<AnyTimelineEvent>> {
+impl<T> EventReceiver<T> {
+    pub(crate) async fn recv(&mut self) -> Option<T> {
         self.rx.recv().await
     }
 }
 
-fn attach_room_id(raw_ev: &Raw<AnySyncTimelineEvent>, room_id: &RoomId) -> Raw<AnyTimelineEvent> {
-    let mut ev_obj = raw_ev.deserialize_as::<BTreeMap<String, Box<RawJsonValue>>>().unwrap();
-    ev_obj.insert("room_id".to_owned(), serde_json::value::to_raw_value(room_id).unwrap());
-    Raw::new(&ev_obj).unwrap().cast()
+/// Attach a room id to the event. This is needed because the widget API
+/// requires the room id to be present in the event.
+
+fn with_attached_room_id(
+    raw: &Raw<AnySyncTimelineEvent>,
+    room_id: &RoomId,
+) -> Result<Raw<AnyTimelineEvent>> {
+    // This is the only modification we need to do to the events otherwise they are
+    // just forwarded raw to the widget.
+    // This is why we do the serialization dance here to allow the optimization of
+    // using `BTreeMap<String, Box<RawJsonValue>` instead of serializing the full event.
+    match raw.deserialize_as::<BTreeMap<String, Box<RawJsonValue>>>() {
+        Ok(mut ev_mut) => {
+            ev_mut.insert("room_id".to_owned(), serde_json::value::to_raw_value(room_id)?);
+            Ok(Raw::new(&ev_mut)?.cast())
+        }
+        Err(e) => Err(Error::from(e)),
+    }
+}
+
+fn with_attached_encryption_flag(
+    raw: Raw<AnyToDeviceEvent>,
+    encryption_info: &Option<EncryptionInfo>,
+) -> Result<Raw<AnyToDeviceEvent>> {
+    match raw.deserialize_as::<BTreeMap<String, Box<RawJsonValue>>>() {
+        Ok(mut ev_mut) => {
+            let encrypted = encryption_info.is_some();
+            ev_mut.insert("encrypted".to_owned(), serde_json::value::to_raw_value(&encrypted)?);
+            Ok(Raw::new(&ev_mut)?.cast())
+        }
+        Err(e) => Err(Error::from(e)),
+    }
 }

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -237,7 +237,16 @@ impl WidgetDriver {
                         .await
                         .map(MatrixDriverResponse::MatrixDelayedEventUpdate),
 
-                    MatrixDriverRequestData::SendToDeviceEvent(req) => todo!(),
+                    MatrixDriverRequestData::SendToDeviceEvent(send_to_device_request) => {
+                        matrix_driver
+                            .send_to_device(
+                                send_to_device_request.event_type.into(),
+                                send_to_device_request.encrypted,
+                                send_to_device_request.messages,
+                            )
+                            .await
+                            .map(MatrixDriverResponse::MatrixToDeviceSent)
+                    }
                 };
 
                 // Forward the matrix driver response to the incoming message stream.
@@ -259,7 +268,8 @@ impl WidgetDriver {
 
                 self.event_forwarding_guard = Some(guard);
 
-                let mut matrix = matrix_driver.events();
+                let mut events_receiver = matrix_driver.events();
+                let mut to_device_receiver = matrix_driver.to_device_events();
                 let incoming_msg_tx = incoming_msg_tx.clone();
 
                 spawn(async move {
@@ -270,9 +280,14 @@ impl WidgetDriver {
                                 return;
                             }
 
-                            Some(event) = matrix.recv() => {
+                            Some(event) = events_receiver.recv() => {
                                 // Forward all events to the incoming messages stream.
                                 let _ = incoming_msg_tx.send(IncomingMessage::MatrixEventReceived(event));
+                            }
+
+                            Some(event) = to_device_receiver.recv() => {
+                                // Forward all events to the incoming messages stream.
+                                let _ = incoming_msg_tx.send(IncomingMessage::ToDeviceReceived(event));
                             }
                         }
                     }

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -967,8 +967,8 @@ async fn test_send_encrypted_to_device_event() {
                 },
             }
         }),
-        json! {{"error":{"message":"Sending encrypted to_device events is not supported by the widget driver."}}},
-        0,
+        json! {{}},
+        1,
     )
     .await;
 }

--- a/testing/matrix-sdk-test/src/sync_builder/mod.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/mod.rs
@@ -8,7 +8,7 @@ use ruma::{
         },
         IncomingResponse,
     },
-    events::{presence::PresenceEvent, AnyGlobalAccountDataEvent},
+    events::{presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyToDeviceEvent},
     serde::Raw,
     OwnedRoomId, OwnedUserId, UserId,
 };
@@ -58,6 +58,7 @@ pub struct SyncResponseBuilder {
     batch_counter: i64,
     /// The device lists of the user.
     changed_device_lists: Vec<OwnedUserId>,
+    to_device_events: Vec<Raw<AnyToDeviceEvent>>,
 }
 
 impl SyncResponseBuilder {
@@ -162,6 +163,12 @@ impl SyncResponseBuilder {
         self
     }
 
+    /// Add a to device event.
+    pub fn add_to_device_event(&mut self, event: JsonValue) -> &mut Self {
+        self.to_device_events.push(from_json_value(event).unwrap());
+        self
+    }
+
     /// Builds a sync response as a JSON Value containing the events we queued
     /// so far.
     ///
@@ -191,7 +198,7 @@ impl SyncResponseBuilder {
                     "knock": self.knocked_rooms,
                 },
                 "to_device": {
-                    "events": []
+                    "events": self.to_device_events,
                 },
                 "presence": {
                     "events": self.presence,


### PR DESCRIPTION
This is based on the main branch and the commits from matrix-org:toger5/widget-to-device-without-encryption.

It adds two commits:
 - add capabilites to the element call widget for sending call encryption to device messages
 - add temp to-device encryption methods that should be part of the crypto crate. (they are in the submodule of `widget::matrix::to_device_crypto` which will be removed once the same methods are available through the matrix sdk crypto crate.

For now this pr is mostly a stop gap to work/use the sdk with the full to-device feature but is subject to change.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
