### PR TITLE
Update logging of device verification request timestamp valdiation

### DIFF
--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -353,7 +353,7 @@ impl VerificationMachine {
                 };
 
                 if !Self::is_timestamp_valid(timestamp) {
-                    trace!(
+                    info!(
                         from_device = r.from_device().as_str(),
                         ?timestamp,
                         "The received verification request was too old or too far into the future",


### PR DESCRIPTION


<!-- description of the changes in this PR -->

Validation errors on the timestamp of the device verification request are now logged on a visible level.
In element-hq/element-web#29625 it was found to be useful to give more visibility to this kind of verification error.

- [ ] ~~Public API changes documented in changelogs (optional)~~

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: mpeter50 <83356418+mpeter50@users.noreply.github.com>