### PR TITLE
fix(ui): Introduce `Timeline` regions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3321,6 +3321,7 @@ dependencies = [
  "async-rx",
  "async-stream",
  "async_cell",
+ "bitflags 2.9.0",
  "chrono",
  "emojis",
  "eyeball",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ async-stream = "0.3.5"
 async-trait = "0.1.85"
 as_variant = "1.3.0"
 base64 = "0.22.1"
+bitflags = "2.8.0"
 byteorder = "1.5.0"
 chrono = "0.4.39"
 eyeball = { version = "0.8.8", features = ["tracing"] }

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -51,7 +51,7 @@ as_variant = { workspace = true }
 assert_matches = { workspace = true, optional = true }
 assert_matches2 = { workspace = true, optional = true }
 async-trait = { workspace = true }
-bitflags = { version = "2.8.0", features = ["serde"] }
+bitflags = { workspace = true, features = ["serde"] }
 decancer = "3.2.8"
 eyeball = { workspace = true, features = ["async-lock"] }
 eyeball-im = { workspace = true }

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Bug Fixes
+
+- Introduce `Timeline` regions, which helps to remove a class of bugs in the
+  `Timeline` where items could be inserted in the wrong _regions_, such as
+  a remote timeline item before the `TimelineStart` virtual timeline item.
+  ([#5000](https://github.com/matrix-org/matrix-rust-sdk/pull/5000))
+
 ## [0.11.0] - 2025-04-11
 
 ### Bug Fixes
@@ -13,15 +20,15 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - [**breaking**] Optionally allow starting threads with `Timeline::send_reply`.
-  ([4819](https://github.com/matrix-org/matrix-rust-sdk/pull/4819))
+  ([#4819](https://github.com/matrix-org/matrix-rust-sdk/pull/4819))
 - [**breaking**] Push `RepliedToInfo`, `ReplyContent`, `EnforceThread` and
   `UnsupportedReplyItem` (becoming `ReplyError`) down into matrix_sdk.
   [`Timeline::send_reply()`] now takes an event ID rather than a `RepliedToInfo`.
   `Timeline::replied_to_info_from_event_id` has been made private in `matrix_sdk`.
-  ([4842](https://github.com/matrix-org/matrix-rust-sdk/pull/4842))
+  ([#4842](https://github.com/matrix-org/matrix-rust-sdk/pull/4842))
 - Allow sending media as (thread) replies. The reply behaviour can be configured
   through new fields on [`AttachmentConfig`].
-  ([4852](https://github.com/matrix-org/matrix-rust-sdk/pull/4852))
+  ([#4852](https://github.com/matrix-org/matrix-rust-sdk/pull/4852))
 
 ### Refactor
 

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -25,6 +25,7 @@ async_cell = "0.2.2"
 async-once-cell = "0.5.4"
 async-rx = { workspace = true }
 async-stream = { workspace = true }
+bitflags = { workspace = true }
 chrono = { workspace = true }
 eyeball = { workspace = true }
 eyeball-im = { workspace = true }

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -23,10 +23,7 @@ use ruma::{EventId, OwnedEventId, OwnedUserId, RoomVersionId};
 use tracing::trace;
 
 use super::{
-    super::{
-        rfind_event_by_id, subscriber::skip::SkipCount, TimelineItem, TimelineItemKind,
-        TimelineUniqueId,
-    },
+    super::{subscriber::skip::SkipCount, TimelineItem, TimelineItemKind, TimelineUniqueId},
     read_receipts::ReadReceipts,
     Aggregations, AllRemoteEvents, ObservableItemsTransaction, PendingEdit,
 };
@@ -196,12 +193,16 @@ impl TimelineMetadata {
         let Some(fully_read_event) = &self.fully_read_event else { return };
         trace!(?fully_read_event, "Updating read marker");
 
-        let read_marker_idx = items.iter().rposition(|item| item.is_read_marker());
+        let read_marker_idx = items
+            .iter_remotes_region()
+            .rev()
+            .find_map(|(idx, item)| item.is_read_marker().then_some(idx));
 
-        let mut fully_read_event_idx =
-            rfind_event_by_id(items, fully_read_event).map(|(idx, _)| idx);
+        let mut fully_read_event_idx = items.iter_remotes_region().rev().find_map(|(idx, item)| {
+            (item.as_event()?.event_id() == Some(fully_read_event)).then_some(idx)
+        });
 
-        if let Some(i) = &mut fully_read_event_idx {
+        if let Some(fully_read_event_idx) = &mut fully_read_event_idx {
             // The item at position `i` is the first item that's fully read, we're about to
             // insert a read marker just after it.
             //
@@ -209,24 +210,26 @@ impl TimelineMetadata {
 
             // Find the position of the first element…
             let next = items
-                .iter()
-                .enumerate()
+                .iter_remotes_region()
                 // …strictly *after* the fully read event…
-                .skip(*i + 1)
+                .skip_while(|(idx, _)| idx <= fully_read_event_idx)
                 // …that's not virtual and not sent by us…
-                .find(|(_, item)| {
-                    item.as_event().is_some_and(|event| event.sender() != self.own_user_id)
-                })
-                .map(|(i, _)| i);
+                .find_map(|(idx, item)| {
+                    (item.as_event()?.sender() != self.own_user_id).then_some(idx)
+                });
 
             if let Some(next) = next {
                 // `next` point to the first item that's not sent by us, so the *previous* of
                 // next is the right place where to insert the fully read marker.
-                *i = next.wrapping_sub(1);
+                *fully_read_event_idx = next.wrapping_sub(1);
             } else {
                 // There's no event after the read marker that's not sent by us, i.e. the full
-                // timeline has been read: the fully read marker goes to the end.
-                *i = items.len().wrapping_sub(1);
+                // timeline has been read: the fully read marker goes to the end, even after the
+                // local timeline items.
+                //
+                // TODO (@hywan): Should we introduce a `items.position_of_last_remote()` to
+                // insert before the local timeline items?
+                *fully_read_event_idx = items.len().wrapping_sub(1);
             }
         }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1318,10 +1318,9 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
     pub async fn insert_timeline_start_if_missing(&self) {
         let mut state = self.state.write().await;
         let mut txn = state.transaction();
-        if txn.items.get(0).is_some_and(|item| item.is_timeline_start()) {
-            return;
-        }
-        txn.items.push_front(txn.meta.new_timeline_item(VirtualTimelineItem::TimelineStart), None);
+        txn.items.push_timeline_start_if_missing(
+            txn.meta.new_timeline_item(VirtualTimelineItem::TimelineStart),
+        );
         txn.commit();
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -1822,7 +1822,7 @@ mod observable_items_tests {
         transaction.push_local(local_item("t1"));
         transaction.push_local(local_item("t2"));
 
-        // Iterate the remotes region.
+        // Iterate the locals region.
         let mut iter = transaction.iter_locals_region();
         assert_matches!(iter.next(), Some((4, item)) => {
             assert_transaction_id!(item, "t0");

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -553,6 +553,7 @@ impl<'e> ObservableItemsTransactionIterBuilder<'e> {
     }
 
     /// Build the iterator.
+    #[allow(clippy::iter_skip_zero)]
     fn build(self) -> ObservableItemsTransactionIter<'e> {
         // Calculate the size of the _start_ region.
         let size_of_start_region = if matches!(
@@ -626,6 +627,7 @@ impl<'e> ObservableItemsTransactionIterBuilder<'e> {
 
 /// An iterator over timeline items.
 pub(crate) struct ObservableItemsTransactionIter<'observable_items_transaction> {
+    #[allow(clippy::type_complexity)]
     inner: Take<
         Skip<
             Enumerate<
@@ -647,13 +649,13 @@ impl<'e> Iterator for ObservableItemsTransactionIter<'e> {
     }
 }
 
-impl<'e> ExactSizeIterator for ObservableItemsTransactionIter<'e> {
+impl ExactSizeIterator for ObservableItemsTransactionIter<'_> {
     fn len(&self) -> usize {
         self.inner.len()
     }
 }
 
-impl<'e> DoubleEndedIterator for ObservableItemsTransactionIter<'e> {
+impl DoubleEndedIterator for ObservableItemsTransactionIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.inner.next_back()
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -320,11 +320,18 @@ impl<'observable_items> ObservableItemsTransaction<'observable_items> {
         self.push_back(timeline_item, None);
     }
 
+    /// Check whether there is at least one [`Local`] timeline item.
+    ///
+    /// [`Local`]: super::EventTimelineItemKind::Local
+    pub fn has_local(&self) -> bool {
+        matches!(self.items.last(), Some(timeline_item) if timeline_item.is_local_echo())
+    }
+
     /// Push a new [`TimelineStart`] virtual timeline item.
     ///
     /// # Invariant
     ///
-    /// A [`TimelineStart`] is always the first item if present..
+    /// A [`TimelineStart`] is always the first item if present.
     ///
     /// # Panics
     ///

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -377,8 +377,7 @@ impl ReadReceiptTimelineUpdate {
 
         let item_pos = self.old_item_pos.or_else(|| {
             items
-                .iter()
-                .enumerate()
+                .iter_remotes_region()
                 .rev()
                 .filter_map(|(nth, item)| Some((nth, item.as_event()?)))
                 .find_map(|(nth, event_item)| {
@@ -429,14 +428,14 @@ impl ReadReceiptTimelineUpdate {
             return;
         };
 
+        let old_item_pos = self.old_item_pos.unwrap_or(0);
+
         let item_pos = self.new_item_pos.or_else(|| {
             items
-                .iter()
-                .enumerate()
+                .iter_remotes_region()
                 // Don't iterate over all items if the `old_item_pos` is known: the `item_pos`
                 // for the new item is necessarily _after_ the old item.
-                .skip(self.old_item_pos.unwrap_or(0))
-                .rev()
+                .skip_while(|(nth, _)| *nth < old_item_pos)
                 .filter_map(|(nth, item)| Some((nth, item.as_event()?)))
                 .find_map(|(nth, event_item)| {
                     (event_item.event_id() == Some(&event_id)).then_some(nth)

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -476,14 +476,12 @@ impl<'a> TimelineStateTransaction<'a> {
     }
 
     pub(super) fn clear(&mut self) {
-        let has_local_echoes = self.items.iter().any(|item| item.is_local_echo());
-
         // By first checking if there are any local echoes first, we do a bit
         // more work in case some are found, but it should be worth it because
         // there will often not be any, and only emitting a single
         // `VectorDiff::Clear` should be much more efficient to process for
         // subscribers.
-        if has_local_echoes {
+        if self.items.has_local() {
             // Remove all remote events and virtual items that aren't date dividers.
             self.items.for_each(|entry| {
                 if entry.is_remote_event()

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -182,7 +182,7 @@ impl<'a> TimelineStateTransaction<'a> {
         let mut by_user_id = HashMap::new();
         let mut duplicates = HashSet::new();
 
-        for item in self.items.iter().filter_map(|item| item.as_event()) {
+        for item in self.items.iter_remotes_region().filter_map(|(_, item)| item.as_event()) {
             if let Some(event_id) = item.event_id() {
                 for (user_id, _read_receipt) in item.read_receipts() {
                     if let Some(prev_event_id) = by_user_id.insert(user_id, event_id) {
@@ -208,9 +208,9 @@ impl<'a> TimelineStateTransaction<'a> {
     fn check_no_unused_unique_ids(&self) {
         let duplicates = self
             .items
-            .iter()
-            .duplicates_by(|item| item.unique_id())
-            .map(|item| item.unique_id())
+            .iter_all_regions()
+            .duplicates_by(|(_nth, item)| item.unique_id())
+            .map(|(_nth, item)| item.unique_id())
             .collect::<Vec<_>>();
 
         if !duplicates.is_empty() {

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -1174,7 +1174,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         .iter_remotes_region()
                         .rev()
                         .find_map(|(timeline_item_index, timeline_item)| {
-                            timeline_item.as_event().and_then(|_| Some(timeline_item_index + 1))
+                            timeline_item.as_event().map(|_| timeline_item_index + 1)
                         })
                         .unwrap_or_else(|| {
                             // There is no remote timeline item, so we could insert at the start of
@@ -1209,7 +1209,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     .iter_remotes_region()
                     .rev()
                     .find_map(|(timeline_item_index, timeline_item)| {
-                        timeline_item.as_event().and_then(|_| Some(timeline_item_index + 1))
+                        timeline_item.as_event().map(|_| timeline_item_index + 1)
                     })
                     .unwrap_or_else(|| {
                         // There is no remote timeline item, so we could insert at the start of

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -1115,7 +1115,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
                 let item = self.meta.new_timeline_item(item);
 
-                self.items.push_back(item, None);
+                self.items.push_local(item);
             }
 
             Flow::Remote {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -152,7 +152,6 @@ macro_rules! assert_timeline_stream {
         )
     };
 
-
     // `prepend --- timeline start ---`
     ( @_ [ $iterator:ident ] [ prepend --- timeline start --- ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
         assert_timeline_stream!(
@@ -201,6 +200,32 @@ macro_rules! assert_timeline_stream {
                                     );
                                 },
                                 concat!("`prepend ", $event_id, "` has failed: timeline item kind does not match"),
+                            );
+                        }
+                    );
+                }
+            ]
+        )
+    };
+
+    // `insert [$nth] --- date divider ---`
+    ( @_ [ $iterator:ident ] [ insert [$index:literal] --- date divider --- ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
+        assert_timeline_stream!(
+            @_
+            [ $iterator ]
+            [ $( $rest )* ]
+            [
+                $( $accumulator )*
+                {
+                    assert_matches!(
+                        $iterator .next(),
+                        Some(eyeball_im::VectorDiff::Insert { index: $index, value }) => {
+                            assert_matches!(
+                                &**value,
+                                matrix_sdk_ui::timeline::TimelineItemKind::Virtual(
+                                    matrix_sdk_ui::timeline::VirtualTimelineItem::DateDivider(_)
+                                ),
+                                concat!("`insert [", $index, "] --- date divider ---` has failed"),
                             );
                         }
                     );

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -86,7 +86,8 @@ macro_rules! assert_timeline_stream {
                                 **value,
                                 matrix_sdk_ui::timeline::TimelineItemKind::Virtual(
                                     matrix_sdk_ui::timeline::VirtualTimelineItem::DateDivider(_)
-                                )
+                                ),
+                                "`--- date divider ---` has failed",
                             );
                         }
                     );
@@ -110,8 +111,13 @@ macro_rules! assert_timeline_stream {
                             assert_matches!(
                                 &**value,
                                 matrix_sdk_ui::timeline::TimelineItemKind::Event(event_timeline_item) => {
-                                    assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
-                                }
+                                    assert_eq!(
+                                        event_timeline_item.event_id().unwrap().as_str(),
+                                        $event_id,
+                                    concat!("`append ", $event_id, "` has failed: event ID does not match"),
+                                    );
+                                },
+                                concat!("`append ", $event_id, "` has failed: timeline item kind does not match"),
                             );
                         }
                     );
@@ -136,7 +142,8 @@ macro_rules! assert_timeline_stream {
                                 &**value,
                                 matrix_sdk_ui::timeline::TimelineItemKind::Virtual(
                                     matrix_sdk_ui::timeline::VirtualTimelineItem::DateDivider(_)
-                                ) => {}
+                                ),
+                                "`prepend --- date divider ---` has failed",
                             );
                         }
                     );
@@ -162,7 +169,8 @@ macro_rules! assert_timeline_stream {
                                 &**value,
                                 matrix_sdk_ui::timeline::TimelineItemKind::Virtual(
                                     matrix_sdk_ui::timeline::VirtualTimelineItem::TimelineStart
-                                ) => {}
+                                ),
+                                "`prepend --- timeline start ---` has failed",
                             );
                         }
                     );
@@ -186,8 +194,13 @@ macro_rules! assert_timeline_stream {
                             assert_matches!(
                                 &**value,
                                 matrix_sdk_ui::timeline::TimelineItemKind::Event(event_timeline_item) => {
-                                    assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
-                                }
+                                    assert_eq!(
+                                        event_timeline_item.event_id().unwrap().as_str(),
+                                        $event_id,
+                                        concat!("`prepend ", $event_id, "` has failed: event ID does not match"),
+                                    );
+                                },
+                                concat!("`prepend ", $event_id, "` has failed: timeline item kind does not match"),
                             );
                         }
                     );
@@ -211,8 +224,13 @@ macro_rules! assert_timeline_stream {
                             assert_matches!(
                                 &**value,
                                 matrix_sdk_ui::timeline::TimelineItemKind::Event(event_timeline_item) => {
-                                    assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
-                                }
+                                    assert_eq!(
+                                        event_timeline_item.event_id().unwrap().as_str(),
+                                        $event_id,
+                                        concat!("`insert [", $index, "] ", $event_id, "` has failed: event ID does not match"),
+                                    );
+                                },
+                                concat!("`insert [", $index, "] ", $event_id, "` has failed: timeline item kind does not match"),
                             );
                         }
                     );
@@ -236,8 +254,13 @@ macro_rules! assert_timeline_stream {
                             assert_matches!(
                                 &**value,
                                 matrix_sdk_ui::timeline::TimelineItemKind::Event(event_timeline_item) => {
-                                    assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
-                                }
+                                    assert_eq!(
+                                        event_timeline_item.event_id().unwrap().as_str(),
+                                        $event_id,
+                                        concat!("`update [", $index, "] ", $event_id, "` has failed: event ID does not match"),
+                                    );
+                                },
+                                concat!("`update [", $index, "] ", $event_id, "` has failed: timeline item kind does not match"),
                             );
                         }
                     );
@@ -257,7 +280,8 @@ macro_rules! assert_timeline_stream {
                 {
                     assert_matches!(
                         $iterator .next(),
-                        Some(eyeball_im::VectorDiff::Remove { index: $index })
+                        Some(eyeball_im::VectorDiff::Remove { index: $index }),
+                        concat!("`remove [", $index, "]` has failed"),
                     );
                 }
             ]
@@ -275,7 +299,8 @@ macro_rules! assert_timeline_stream {
                 {
                     assert_matches!(
                         $iterator .next(),
-                        Some(eyeball_im::VectorDiff::Clear)
+                        Some(eyeball_im::VectorDiff::Clear),
+                        "clear has failed",
                     );
                 }
             ]
@@ -285,7 +310,9 @@ macro_rules! assert_timeline_stream {
     ( @_ [ $iterator:ident ] [] [ $( $accumulator:tt )* ] ) => {
         $( $accumulator )*
 
-        assert!($iterator .next().is_none(), concat!(stringify!($iterator), " has not been entirely read"));
+        let next = $iterator .next();
+
+        assert!(next.is_none(), "`{}` has not been entirely read; received `{:?}`", stringify!( $iterator ), next);
     };
 
     ( [ $stream:ident ] $( $all:tt )* ) => {


### PR DESCRIPTION
This patch is twofold.

### First part

This patch fixes the insertion of a new `TimelineItem` in the presence of a `TimelineStart` that shifts/offsets the timeline index of 1. It fixes https://github.com/matrix-org/matrix-rust-sdk/issues/4976. It also contains a regression test.

### Second part

Based on https://github.com/matrix-org/matrix-rust-sdk/pull/4816#pullrequestreview-2705148141, I'm proposing a new concept in `timeline::controller::ObservableItems`: **regions**.

The `ObservableItems` holds all the invariants about the _position_ of the items. It defines three regions where items can live:

1. the _start_ region, which can only contain a single `TimelineStart`,
2. the _remotes_ region, which can only contain many `Remote` timeline items with their decorations (only `DateDivider`s and `ReadMarker`s),
3. the _locals_ region, which can only contain many `Local` timeline items with their decorations (only `DateDivider`s).

The `iter_all_regions` method allows to iterate over all regions. `iter_remotes_region` will restrict the iterator over the _remotes_ region, and so on. These iterators provide the absolute indices of the items, so that it's harder to make mistakes when manipulating the indices of items with operations like `insert`, `remove`, `replace` etc.

Other methods like `push_local` or `push_date_divider` insert the items in the correct region, and check a couple of invariants. I've first introduced the invariants, then 12 tests were failing, which indicates that the `TimelineStart` could have been a problem in multiple situations. Moving the code to use `iter_remotes_regions` & siblings have fixed the tests, which indicates that this class of bugs has been fixed.

### Review

It's better to review patch-by-patch. There are quite small and I hope easy to understand. The concept of _regions_ removes an entire class of bugs in our `Timeline`, and I'm pretty happy with that 🙂.

---

* Fix https://github.com/matrix-org/matrix-rust-sdk/issues/4976
* Address https://github.com/element-hq/customer-success/issues/482