### PR TITLE
Tweak some store-related comments

### DIFF
--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -17,7 +17,7 @@
 //! The storage layer for the [`OlmMachine`] can be customized using a trait.
 //! Implementing your own [`CryptoStore`]
 //!
-//! An in-memory only store is provided as well as a SQLite-based one, depending
+//! An in-memory only store is provided as well as an SQLite-based one, depending
 //! on your needs and targets a custom store may be implemented, e.g. for
 //! `wasm-unknown-unknown` an indexeddb store would be needed
 //!

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -17,9 +17,9 @@
 //! The storage layer for the [`OlmMachine`] can be customized using a trait.
 //! Implementing your own [`CryptoStore`]
 //!
-//! An in-memory only store is provided as well as an SQLite-based one, depending
-//! on your needs and targets a custom store may be implemented, e.g. for
-//! `wasm-unknown-unknown` an indexeddb store would be needed
+//! An in-memory only store is provided as well as an SQLite-based one,
+//! depending on your needs and targets a custom store may be implemented, e.g.
+//! for `wasm-unknown-unknown` an indexeddb store would be needed
 //!
 //! ```
 //! # use std::sync::Arc;

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -102,8 +102,8 @@ impl SqliteCryptoStore {
         Ok(this)
     }
 
-    /// Create an SQLite-based crypto store using the given SQLite database pool.
-    /// The given passphrase will be used to encrypt private data.
+    /// Create an SQLite-based crypto store using the given SQLite database
+    /// pool. The given passphrase will be used to encrypt private data.
     async fn open_with_pool(
         pool: SqlitePool,
         passphrase: Option<&str>,

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -57,7 +57,7 @@ use crate::{
 /// The database name.
 const DATABASE_NAME: &str = "matrix-sdk-crypto.sqlite3";
 
-/// A sqlite based cryptostore.
+/// An SQLite-based crypto store.
 #[derive(Clone)]
 pub struct SqliteCryptoStore {
     store_cipher: Option<Arc<StoreCipher>>,
@@ -76,7 +76,7 @@ impl fmt::Debug for SqliteCryptoStore {
 }
 
 impl SqliteCryptoStore {
-    /// Open the sqlite-based crypto store at the given path using the given
+    /// Open the SQLite-based crypto store at the given path using the given
     /// passphrase to encrypt private data.
     pub async fn open(
         path: impl AsRef<Path>,
@@ -85,7 +85,7 @@ impl SqliteCryptoStore {
         Self::open_with_config(SqliteStoreConfig::new(path).passphrase(passphrase)).await
     }
 
-    /// Open the sqlite-based crypto store with the config open config.
+    /// Open the SQLite-based crypto store with the config open config.
     pub async fn open_with_config(config: SqliteStoreConfig) -> Result<Self, OpenStoreError> {
         let SqliteStoreConfig { path, passphrase, pool_config, runtime_config } = config;
 
@@ -102,7 +102,7 @@ impl SqliteCryptoStore {
         Ok(this)
     }
 
-    /// Create a sqlite-based crypto store using the given sqlite database pool.
+    /// Create an SQLite-based crypto store using the given SQLite database pool.
     /// The given passphrase will be used to encrypt private data.
     async fn open_with_pool(
         pool: SqlitePool,

--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -22,7 +22,7 @@ use matrix_sdk_crypto::CryptoStoreError;
 use thiserror::Error;
 use tokio::io;
 
-/// All the errors that can occur when opening a SQLite store.
+/// All the errors that can occur when opening an SQLite store.
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum OpenStoreError {

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! A sqlite-based backend for the [`EventCacheStore`].
+//! An SQLite-based backend for the [`EventCacheStore`].
 
 use std::{borrow::Cow, fmt, iter::once, path::Path, sync::Arc};
 
@@ -81,7 +81,7 @@ const CHUNK_TYPE_EVENT_TYPE_STRING: &str = "E";
 /// database.
 const CHUNK_TYPE_GAP_TYPE_STRING: &str = "G";
 
-/// A SQLite-based event cache store.
+/// An SQLite-based event cache store.
 #[derive(Clone)]
 pub struct SqliteEventCacheStore {
     store_cipher: Option<Arc<StoreCipher>>,
@@ -106,7 +106,7 @@ impl SqliteEventCacheStore {
         Self::open_with_config(SqliteStoreConfig::new(path).passphrase(passphrase)).await
     }
 
-    /// Open the sqlite-based event cache store with the config open config.
+    /// Open the SQLite-based event cache store with the config open config.
     pub async fn open_with_config(config: SqliteStoreConfig) -> Result<Self, OpenStoreError> {
         let SqliteStoreConfig { path, passphrase, pool_config, runtime_config } = config;
 
@@ -178,10 +178,10 @@ impl SqliteEventCacheStore {
     async fn acquire(&self) -> Result<SqliteAsyncConn> {
         let connection = self.pool.get().await?;
 
-        // Per https://www.sqlite.org/foreignkeys.html#fk_enable, foreign key support must be
-        // enabled on a per-connection basis. Execute it every time we try to get a
-        // connection, since we can't guarantee a previous connection did enable
-        // it before.
+        // Per https://www.sqlite.org/foreignkeys.html#fk_enable, foreign key
+        // support must be enabled on a per-connection basis. Execute it every
+        // time we try to get a connection, since we can't guarantee a previous
+        // connection did enable it before.
         connection.execute_batch("PRAGMA foreign_keys = ON;").await?;
 
         Ok(connection)
@@ -1922,7 +1922,7 @@ mod tests {
             assert_eq!(gap.prev_token, "tartiflette");
         });
 
-        // Check that cascading worked. Yes, sqlite, I doubt you.
+        // Check that cascading worked. Yes, SQLite, I doubt you.
         let gaps = store
             .acquire()
             .await
@@ -2188,7 +2188,7 @@ mod tests {
         let chunks = store.load_all_chunks(room_id).await.unwrap();
         assert!(chunks.is_empty());
 
-        // Check that cascading worked. Yes, sqlite, I doubt you.
+        // Check that cascading worked. Yes, SQLite, I doubt you.
         store
             .acquire()
             .await

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -68,12 +68,12 @@ const DATABASE_NAME: &str = "matrix-sdk-state.sqlite3";
 
 /// Identifier of the latest database version.
 ///
-/// This is used to figure whether the sqlite database requires a migration.
+/// This is used to figure whether the SQLite database requires a migration.
 /// Every new SQL migration should imply a bump of this number, and changes in
-/// the [`SqliteStateStore::run_migrations`] function..
+/// the [`SqliteStateStore::run_migrations`] function.
 const DATABASE_VERSION: u8 = 12;
 
-/// A sqlite based cryptostore.
+/// An SQLite-based state store.
 #[derive(Clone)]
 pub struct SqliteStateStore {
     store_cipher: Option<Arc<StoreCipher>>,
@@ -88,7 +88,7 @@ impl fmt::Debug for SqliteStateStore {
 }
 
 impl SqliteStateStore {
-    /// Open the sqlite-based state store at the given path using the given
+    /// Open the SQLite-based state store at the given path using the given
     /// passphrase to encrypt private data.
     pub async fn open(
         path: impl AsRef<Path>,
@@ -97,7 +97,7 @@ impl SqliteStateStore {
         Self::open_with_config(SqliteStoreConfig::new(path).passphrase(passphrase)).await
     }
 
-    /// Open the sqlite-based state store with the config open config.
+    /// Open the SQLite-based state store with the config open config.
     pub async fn open_with_config(config: SqliteStoreConfig) -> Result<Self, OpenStoreError> {
         let SqliteStoreConfig { path, passphrase, pool_config, runtime_config } = config;
 
@@ -114,7 +114,7 @@ impl SqliteStateStore {
         Ok(this)
     }
 
-    /// Create a sqlite-based state store using the given sqlite database pool.
+    /// Create an SQLite-based state store using the given SQLite database pool.
     /// The given passphrase will be used to encrypt private data.
     async fn open_with_pool(
         pool: SqlitePool,
@@ -2200,9 +2200,9 @@ mod encrypted_tests {
         let cache_size =
             conn.query_row("PRAGMA cache_size", (), |row| row.get::<_, i32>(0)).await.unwrap();
 
-        // The value passed to  `SqliteStoreConfig` is in bytes. Check it is converted
-        // to kibibytes. Also, it must be a negative value because it _is_ the size in
-        // kibibytes, not in page size.
+        // The value passed to `SqliteStoreConfig` is in bytes. Check it is
+        // converted to kibibytes. Also, it must be a negative value because it
+        // _is_ the size in kibibytes, not in page size.
         assert_eq!(cache_size, -(1500 / 1024));
     }
 
@@ -2219,8 +2219,8 @@ mod encrypted_tests {
             .await
             .unwrap();
 
-        // The value passed to  `SqliteStoreConfig` is in bytes. It stays in bytes in
-        // SQLite.
+        // The value passed to `SqliteStoreConfig` is in bytes. It stays in
+        // bytes in SQLite.
         assert_eq!(journal_size_limit, 1500);
     }
 

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -206,7 +206,7 @@ impl ClientBuilder {
         self
     }
 
-    /// Set up the store configuration for a SQLite store.
+    /// Set up the store configuration for an SQLite store.
     #[cfg(feature = "sqlite")]
     pub fn sqlite_store(mut self, path: impl AsRef<Path>, passphrase: Option<&str>) -> Self {
         let sqlite_store_config = SqliteStoreConfig::new(path).passphrase(passphrase);
@@ -216,7 +216,7 @@ impl ClientBuilder {
         self
     }
 
-    /// Set up the store configuration for a SQLite store with cached data
+    /// Set up the store configuration for an SQLite store with cached data
     /// separated out from state/crypto data.
     #[cfg(feature = "sqlite")]
     pub fn sqlite_store_with_cache_path(
@@ -234,7 +234,7 @@ impl ClientBuilder {
         self
     }
 
-    /// Set up the store configuration for a SQLite store with a store config,
+    /// Set up the store configuration for an SQLite store with a store config,
     /// and with an optional cache data separated out from state/crypto data.
     #[cfg(feature = "sqlite")]
     pub fn sqlite_store_with_config_and_cache_path(


### PR DESCRIPTION
- Doc comment for the SQLite-based state store incorrectly referred to
  it as a "cryptostore".
- Consistent capitalisation of SQLite.
- Consistent use of indefinite article "an" before SQLite.
- Fix line length.
