### PR TITLE
doc: Generate doc with `--generate-link-to-definition`

### DIFF
--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.11.0"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [features]
 default = []

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.11.0"
 [package.metadata.docs.rs]
 default-target = "x86_64-unknown-linux-gnu"
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+rustdoc-args = ["--generate-link-to-definition"]
 
 [features]
 js = ["wasm-bindgen-futures"]

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = { workspace = true }
 version = "0.11.0"
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [features]
 default = []

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [package.metadata.docs.rs]
 all-features = true
 default-target = "wasm32-unknown-unknown"
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [features]
 default = ["e2e-encryption", "state-store"]

--- a/crates/matrix-sdk-qrcode/Cargo.toml
+++ b/crates/matrix-sdk-qrcode/Cargo.toml
@@ -16,7 +16,7 @@ js = ["vodozemac/js"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [dependencies]
 byteorder = { workspace = true }

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -7,6 +7,9 @@ description = "Sqlite storage backend for matrix-sdk"
 license = "Apache-2.0"
 rust-version = { workspace = true }
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]
+
 [features]
 default = ["state-store", "event-cache"]
 testing = ["matrix-sdk-crypto?/testing"]

--- a/crates/matrix-sdk-store-encryption/Cargo.toml
+++ b/crates/matrix-sdk-store-encryption/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [features]
 js = ["dep:getrandom", "getrandom?/js"]

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -7,6 +7,9 @@ repository = "https://github.com/matrix-org/matrix-rust-sdk"
 license = "Apache-2.0"
 rust-version = { workspace = true }
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]
+
 [features]
 default = ["native-tls"]
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.11.0"
 
 [package.metadata.docs.rs]
 features = ["docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [features]
 default = ["e2e-encryption", "automatic-room-key-forwarding", "sqlite", "native-tls"]


### PR DESCRIPTION
This patch adds the `--generate-link-to-definition` argument to `rustdoc` for `docs.rs`. This is using https://github.com/rust-lang/rust/pull/84176 to add links in the source code page.