### PR TITLE
feat: MSC 4278 implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4451,8 +4451,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fdaae631940eda62844a8a3026aba2ba84c22588c888ebec44861ba4d0c18"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "assign",
  "js_int",
@@ -4468,8 +4467,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a89ac03a0f4451f946ed9aed6fdd16ef5a78a3a2849e87af4b2474a176b2fb"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "as_variant",
  "assign",
@@ -4492,8 +4490,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b75da013b362664c3e161662902e5da3f77e990525681b59c6035bac27e87b4"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "as_variant",
  "base64",
@@ -4525,8 +4522,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c100eb6c7691ef010f18d9af315f486fc4da621b7203c431e88352148e84551"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4551,8 +4547,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373bc5a30b84574dfce3e75c33d79d6ba9843bf0eee1bf351f904eef9bea001a"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "http",
  "js_int",
@@ -4566,8 +4561,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3257ce3398e171ff15245767b1a3d201cfc5cce75f5af7ec7f6b8b5e1d2bdb"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4579,8 +4573,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad674b5e5368c53a2c90fde7dac7e30747004aaf7b1827b72874a25fc06d4d8"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "js_int",
  "thiserror 2.0.11",
@@ -4589,8 +4582,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1182e83ee5cd10121974f163337b16af68a93eedfc7cdbdbd52307ac7e1d743"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ reqwest = { version = "0.12.12", default-features = false }
 rmp-serde = "1.3.0"
 # Be careful to use commits from the https://github.com/ruma/ruma/tree/ruma-0.12
 # branch until a proper release with breaking changes happens.
-ruma = { version = "0.12.2", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "689d9613a985edc089b5b729e6d9362f09b5df4f", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -74,8 +74,9 @@ ruma = { version = "0.12.2", features = [
     "unstable-msc4075",
     "unstable-msc4140",
     "unstable-msc4171",
-] }
-ruma-common = "0.15.2"
+    "unstable-msc4278",
+    ] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "689d9613a985edc089b5b729e6d9362f09b5df4f" }
 serde = "1.0.217"
 serde_html_form = "0.2.7"
 serde_json = "1.0.138"

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -33,7 +33,7 @@ matrix-sdk-ffi-macros = { workspace = true }
 matrix-sdk-ui = { workspace = true, features = ["uniffi"] }
 mime = "0.3.16"
 once_cell = { workspace = true }
-ruma = { workspace = true, features = ["html", "unstable-unspecified", "unstable-msc3488", "compat-unset-avatar", "unstable-msc3245-v1-compat"] }
+ruma = { workspace = true, features = ["html", "unstable-unspecified", "unstable-msc3488", "compat-unset-avatar", "unstable-msc3245-v1-compat", "unstable-msc4278"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -47,6 +47,9 @@ use ruma::{
     events::{
         ignored_user_list::IgnoredUserListEventContent,
         key::verification::request::ToDeviceKeyVerificationRequestEvent,
+        media_preview_config::{
+            InviteAvatars as RumaInviteAvatars, MediaPreviews as RumaMediaPreviews,
+        },
         room::{
             history_visibility::RoomHistoryVisibilityEventContent,
             join_rules::{
@@ -1206,6 +1209,91 @@ impl Client {
     /// Checks if the server supports the report room API.
     pub async fn is_report_room_api_supported(&self) -> Result<bool, ClientError> {
         Ok(self.inner.server_versions().await?.contains(&ruma::api::MatrixVersion::V1_13))
+    }
+
+    /// Get the media previews display policy setting.
+    pub async fn get_media_previews(&self) -> Result<MediaPreviews, ClientError> {
+        let media_previews = self.inner.account().get_media_previews_setting().await?;
+        Ok(media_previews.into())
+    }
+
+    /// Set the media previews display policy setting.
+    pub async fn set_media_previews(
+        &self,
+        media_previews: MediaPreviews,
+    ) -> Result<(), ClientError> {
+        self.inner.account().set_media_previews_setting(media_previews.into()).await?;
+        Ok(())
+    }
+
+    /// Get the invite avatars display policy setting.
+    pub async fn get_invite_avatars(&self) -> Result<InviteAvatars, ClientError> {
+        let invite_avatars = self.inner.account().get_invite_avatars_setting().await?;
+        Ok(invite_avatars.into())
+    }
+
+    /// Set the invite avatars display policy setting.
+    pub async fn set_invite_avatars(
+        &self,
+        invite_avatars: InviteAvatars,
+    ) -> Result<(), ClientError> {
+        self.inner.account().set_invite_avatars_setting(invite_avatars.into()).await?;
+        Ok(())
+    }
+}
+
+#[derive(uniffi::Enum)]
+pub enum MediaPreviews {
+    On,
+    Private,
+    Off,
+}
+
+impl From<RumaMediaPreviews> for MediaPreviews {
+    fn from(value: RumaMediaPreviews) -> Self {
+        match value {
+            RumaMediaPreviews::On => MediaPreviews::On,
+            RumaMediaPreviews::Private => MediaPreviews::Private,
+            RumaMediaPreviews::Off => MediaPreviews::Off,
+            // Use the default value of On for unhandled cases.
+            _ => MediaPreviews::On,
+        }
+    }
+}
+
+impl From<MediaPreviews> for RumaMediaPreviews {
+    fn from(value: MediaPreviews) -> Self {
+        match value {
+            MediaPreviews::On => RumaMediaPreviews::On,
+            MediaPreviews::Private => RumaMediaPreviews::Private,
+            MediaPreviews::Off => RumaMediaPreviews::Off,
+        }
+    }
+}
+
+#[derive(uniffi::Enum)]
+pub enum InviteAvatars {
+    On,
+    Off,
+}
+
+impl From<RumaInviteAvatars> for InviteAvatars {
+    fn from(value: RumaInviteAvatars) -> Self {
+        match value {
+            RumaInviteAvatars::On => InviteAvatars::On,
+            RumaInviteAvatars::Off => InviteAvatars::Off,
+            // Use the default value of On for unhandled cases.
+            _ => InviteAvatars::On,
+        }
+    }
+}
+
+impl From<InviteAvatars> for RumaInviteAvatars {
+    fn from(value: InviteAvatars) -> Self {
+        match value {
+            InviteAvatars::On => RumaInviteAvatars::On,
+            InviteAvatars::Off => RumaInviteAvatars::Off,
+        }
     }
 }
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -100,6 +100,7 @@ ruma = { workspace = true, features = [
     "unstable-msc4230",
     "unstable-msc2967",
     "unstable-msc4108",
+    "unstable-msc4278",
 ] }
 serde = { workspace = true }
 serde_html_form = { workspace = true }


### PR DESCRIPTION
This PR updates Ruma and implements new APIs to use the unstable [MSC 4278](https://github.com/matrix-org/matrix-spec-proposals/pull/4278).

This new global account data setting, will be used by clients to decide what policy to follow in display the media previews in the timeline, and the avatars in invite requests