### PR TITLE
Test: Replace `sync_timeline_event!` with `EventFactory` for room create and room member events in room integration test

### DIFF
--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -18,7 +18,7 @@ use ruma::{
         room::{avatar, member::MembershipState, message::RoomMessageEventContent},
         AnySyncStateEvent, AnySyncTimelineEvent, StateEventType,
     },
-    mxc_uri, room_id, user_id,
+    mxc_uri, room_id, room_version_id, user_id,
 };
 use serde_json::json;
 use wiremock::{
@@ -303,17 +303,14 @@ async fn test_room_route() {
     // Without eligible server
     sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(sync_timeline_event!({
-                "content": {
-                    "creator": "@creator:127.0.0.1",
-                    "room_version": "6",
-                },
-                "event_id": "$151957878228ekrDs",
-                "origin_server_ts": 15195787,
-                "sender": "@creator:127.0.0.1",
-                "state_key": "",
-                "type": "m.room.create",
-            }))
+            .add_timeline_event(
+                f.create(user_id!("@creator:127.0.0.1"), room_version_id!("6"))
+                    .event_id(event_id!("$151957878228ekrDs"))
+                    .server_ts(15195787)
+                    .sender(user_id!("@creator:127.0.0.1"))
+                    .state_key("")
+                    .into_raw_sync(),
+            )
             .add_timeline_event(
                 f.member(user_id!("@creator:127.0.0.1"))
                     .membership(MembershipState::Join)

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -302,24 +302,21 @@ async fn test_room_route() {
 
     // Without eligible server
     sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(
-                f.create(user_id!("@creator:127.0.0.1"), room_version_id!("6"))
-                    .event_id(event_id!("$151957878228ekrDs"))
-                    .server_ts(15195787)
-                    .sender(user_id!("@creator:127.0.0.1"))
-                    .state_key("")
-                    .into_raw_sync(),
-            )
-            .add_timeline_event(
-                f.member(user_id!("@creator:127.0.0.1"))
-                    .membership(MembershipState::Join)
-                    .event_id(event_id!("$151800140517rfvjc"))
-                    .server_ts(151800140)
-                    .sender(user_id!("@creator:127.0.0.1"))
-                    .state_key("@creator:127.0.0.1")
-                    .into_raw_sync(),
-            ),
+        JoinedRoomBuilder::new(room_id).add_timeline_bulk([
+            f.create(user_id!("@creator:127.0.0.1"), room_version_id!("6"))
+                .event_id(event_id!("$151957878228ekrDs"))
+                .server_ts(15195787)
+                .sender(user_id!("@creator:127.0.0.1"))
+                .state_key("")
+                .into_raw_sync(),
+            f.member(user_id!("@creator:127.0.0.1"))
+                .membership(MembershipState::Join)
+                .event_id(event_id!("$151800140517rfvjc"))
+                .server_ts(151800140)
+                .sender(user_id!("@creator:127.0.0.1"))
+                .state_key("@creator:127.0.0.1")
+                .into_raw_sync(),
+        ]),
     );
 
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -39,6 +39,7 @@ use ruma::{
         relation::{Annotation, InReplyTo, Replacement, Thread},
         room::{
             avatar::{self, RoomAvatarEventContent},
+            create::RoomCreateEventContent,
             encrypted::{EncryptedEventScheme, RoomEncryptedEventContent},
             member::{MembershipState, RoomMemberEventContent},
             message::{
@@ -56,7 +57,8 @@ use ruma::{
     },
     serde::Raw,
     server_name, EventId, MilliSecondsSinceUnixEpoch, MxcUri, OwnedEventId, OwnedMxcUri,
-    OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UInt, UserId,
+    OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId, TransactionId, UInt,
+    UserId,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -716,6 +718,17 @@ impl EventFactory {
     /// Create a read receipt event.
     pub fn read_receipts(&self) -> ReadReceiptBuilder<'_> {
         ReadReceiptBuilder { factory: self, content: ReceiptEventContent(Default::default()) }
+    }
+
+    /// Create a new `m.room.create` event.
+    pub fn create(
+        &self,
+        user_id: &UserId,
+        room_version: RoomVersionId,
+    ) -> EventBuilder<RoomCreateEventContent> {
+        let mut event = RoomCreateEventContent::new_v1(user_id.to_owned());
+        event.room_version = room_version;
+        self.event(event)
     }
 
     /// Set the next server timestamp.


### PR DESCRIPTION
Part of #3716

I was working on replacing all uses of `sync_timeline_event!` in this test file, but after seeing that it probably requires adding more than one new method on `EventFactory`, I thought I'd make a PR for a subset of the changes I've done so far which I think are still useful in isolation and self-contained, to keep the diff smaller.

On the other hand, if these code changes alone are too small to warrant a PR then I'm happy to keep adding the rest of the changes to get rid of `sync_timeline_event!` from that file :slightly_smiling_face: 

Signed-off-by: Yousef Moazzam <yousefmoazzam@hotmail.co.uk>