### PR TITLE
Test: Replace `sync_timeline_event!` with `EventFactory` for room server ACL event in room integration test

### DIFF
--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -431,20 +431,16 @@ async fn test_room_route() {
     assert_eq!(route[2], "yourmatrix");
 
     // With server ACLs
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
-        sync_timeline_event!({
-            "content": {
-                "allow": ["*"],
-                "allow_ip_literals": true,
-                "deny": ["notarealhs"],
-            },
-            "event_id": "$143273582443PhrSn",
-            "origin_server_ts": 1432735824,
-            "sender": "@creator:127.0.0.1",
-            "state_key": "",
-            "type": "m.room.server_acl",
-        }),
-    ));
+    sync_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id).add_timeline_event(
+            f.server_acl(true, vec!["*".to_owned()], vec!["notarealhs".to_owned()])
+                .event_id(event_id!("$143273582443PhrSn"))
+                .server_ts(1432735824)
+                .sender(user_id!("@creator:127.0.0.1"))
+                .state_key("")
+                .into_raw_sync(),
+        ),
+    );
     mock_sync(&server, sync_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
 

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -49,6 +49,7 @@ use ruma::{
             name::RoomNameEventContent,
             power_levels::RoomPowerLevelsEventContent,
             redaction::RoomRedactionEventContent,
+            server_acl::RoomServerAclEventContent,
             tombstone::RoomTombstoneEventContent,
             topic::RoomTopicEventContent,
         },
@@ -740,6 +741,16 @@ impl EventFactory {
         let mut event = RoomPowerLevelsEventContent::new();
         event.users.append(map);
         self.event(event)
+    }
+
+    /// Create a new `m.room.server_acl` event.
+    pub fn server_acl(
+        &self,
+        allow_ip_literals: bool,
+        allow: Vec<String>,
+        deny: Vec<String>,
+    ) -> EventBuilder<RoomServerAclEventContent> {
+        self.event(RoomServerAclEventContent::new(allow_ip_literals, allow, deny))
     }
 
     /// Set the next server timestamp.


### PR DESCRIPTION
Part of #3716

The added method to `EventFactory` could be thought of as redundant, since its args are simply being passed through to the `RoomServerAclEventContent` constructor.

I thought one reason to have it is so then `event_factory.rs` could be the single place where the `RoomServerAclEventContent` struct is imported, so that no test modules wanting to create this particular event would need to do the import themselves.

So I could understand both wanting it or not wanting it, I'm happy to go with whatever is preferred.

Signed-off-by: Yousef Moazzam <yousefmoazzam@hotmail.co.uk>