### PR TITLE
Test: Replace `sync_timeline_event!` with `EventFactory` for room canonical alias events in room integration test

### DIFF
--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -7,9 +7,9 @@ use matrix_sdk::{
     RoomMemberships,
 };
 use matrix_sdk_test::{
-    async_test, bulk_room_members, event_factory::EventFactory, sync_state_event,
-    sync_timeline_event, test_json, GlobalAccountDataTestEvent, JoinedRoomBuilder, LeftRoomBuilder,
-    StateTestEvent, SyncResponseBuilder, BOB, DEFAULT_TEST_ROOM_ID,
+    async_test, bulk_room_members, event_factory::EventFactory, sync_state_event, test_json,
+    GlobalAccountDataTestEvent, JoinedRoomBuilder, LeftRoomBuilder, StateTestEvent,
+    SyncResponseBuilder, BOB, DEFAULT_TEST_ROOM_ID,
 };
 use ruma::{
     event_id,

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -39,6 +39,7 @@ use ruma::{
         relation::{Annotation, InReplyTo, Replacement, Thread},
         room::{
             avatar::{self, RoomAvatarEventContent},
+            canonical_alias::RoomCanonicalAliasEventContent,
             create::RoomCreateEventContent,
             encrypted::{EncryptedEventScheme, RoomEncryptedEventContent},
             member::{MembershipState, RoomMemberEventContent},
@@ -59,8 +60,8 @@ use ruma::{
     },
     serde::Raw,
     server_name, EventId, Int, MilliSecondsSinceUnixEpoch, MxcUri, OwnedEventId, OwnedMxcUri,
-    OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId, TransactionId, UInt,
-    UserId,
+    OwnedRoomAliasId, OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId,
+    TransactionId, UInt, UserId,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -751,6 +752,18 @@ impl EventFactory {
         deny: Vec<String>,
     ) -> EventBuilder<RoomServerAclEventContent> {
         self.event(RoomServerAclEventContent::new(allow_ip_literals, allow, deny))
+    }
+
+    /// Create a new `m.room.canonical_alias` event.
+    pub fn canonical_alias(
+        &self,
+        alias: Option<OwnedRoomAliasId>,
+        alt_aliases: Vec<OwnedRoomAliasId>,
+    ) -> EventBuilder<RoomCanonicalAliasEventContent> {
+        let mut event = RoomCanonicalAliasEventContent::new();
+        event.alias = alias;
+        event.alt_aliases = alt_aliases;
+        self.event(event)
     }
 
     /// Set the next server timestamp.


### PR DESCRIPTION
Part of #3716

I inlined the creation of the `EventFactory` in the second test since it's only used once and I thought it was a tad neater than having a separate binding. Hopefully the extra level of indentation is tolerable, but I'm happy to define the `EventFactory` instance separately if it's too unsightly :slightly_smiling_face: 

Signed-off-by: Yousef Moazzam <yousefmoazzam@hotmail.co.uk>
