### PR TITLE
chore: check in the Cargo.lock file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,7 +3320,7 @@ dependencies = [
  "async-rx",
  "async-stream",
  "async_cell",
- "bitflags 2.9.0",
+ "bitflags 2.8.0",
  "chrono",
  "emojis",
  "eyeball",


### PR DESCRIPTION
Fallout of 4dd72d0543f83e9086c120a9acfc6b5c0560e133.