### PR TITLE
refactor(widgets): Rename the then() function into add_response_handler()

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -26,7 +26,7 @@ use caches::ClientCaches;
 use eyeball::{SharedObservable, Subscriber};
 use eyeball_im::{Vector, VectorDiff};
 use futures_core::Stream;
-use futures_util::StreamExt;
+use futures_util::{FutureExt, StreamExt};
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::store::LockableCryptoStore;
 use matrix_sdk_base::{

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -26,7 +26,7 @@ use caches::ClientCaches;
 use eyeball::{SharedObservable, Subscriber};
 use eyeball_im::{Vector, VectorDiff};
 use futures_core::Stream;
-use futures_util::{FutureExt, StreamExt};
+use futures_util::StreamExt;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::store::LockableCryptoStore;
 use matrix_sdk_base::{

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -72,7 +72,7 @@ where
 
     /// Setup a callback function that will be called once the Matrix driver has
     /// processed the request.
-    pub(crate) fn then(
+    pub(crate) fn add_response_handler(
         self,
         response_handler: impl FnOnce(Result<T, crate::Error>, &mut WidgetMachine) -> Vec<Action>
             + Send

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -259,7 +259,7 @@ impl WidgetMachine {
                     return actions;
                 };
 
-                request.then(|res, machine| {
+                request.add_response_handler(|res, machine| {
                     let response = match res {
                         Ok(res) => OpenIdResponse::Allowed(OpenIdState::new(request_id, res)),
                         Err(msg) => {
@@ -298,7 +298,7 @@ impl WidgetMachine {
                     delay_id: req.delay_id,
                 })
                 .map(|(request, request_action)| {
-                    request.then(|result, _machine| {
+                    request.add_response_handler(|result, _machine| {
                         vec![Self::send_from_widget_response(
                             raw_request,
                             // This is mapped to another type because the
@@ -343,7 +343,7 @@ impl WidgetMachine {
                 let request = ReadMessageLikeEventRequest { event_type, limit };
 
                 self.send_matrix_driver_request(request).map(|(request, action)| {
-                    request.then(|result, machine| {
+                    request.add_response_handler(|result, machine| {
                         let response = match &machine.capabilities {
                             CapabilitiesState::Unset => Err(FromWidgetErrorResponse::from_string(
                                 "Received read event request before capabilities negotiation",
@@ -384,7 +384,7 @@ impl WidgetMachine {
                 if allowed {
                     self.send_matrix_driver_request(ReadStateEventRequest { event_type, state_key })
                         .map(|(request, action)| {
-                            request.then(|result, _machine| {
+                            request.add_response_handler(|result, _machine| {
                                 let response = result
                                     .map(|events| ReadEventResponse { events })
                                     .map_err(FromWidgetErrorResponse::from_error);
@@ -428,7 +428,7 @@ impl WidgetMachine {
 
         let (request, action) = self.send_matrix_driver_request(request)?;
 
-        request.then(|mut result, machine| {
+        request.add_response_handler(|mut result, machine| {
             if let Ok(r) = result.as_mut() {
                 r.set_room_id(machine.room_id.clone());
             }
@@ -610,7 +610,7 @@ impl WidgetMachine {
             return actions;
         };
 
-        request.then(|response, machine| {
+        request.add_response_handler(|response, machine| {
             let requested_capabilities = response.capabilities;
 
             let Some((request, action)) = machine.send_matrix_driver_request(AcquireCapabilities {
@@ -620,7 +620,7 @@ impl WidgetMachine {
                 return Vec::new();
             };
 
-            request.then(|result, machine| {
+            request.add_response_handler(|result, machine| {
                 let approved_capabilities = result.unwrap_or_else(|e| {
                     error!("Acquiring capabilities failed: {e}");
                     Capabilities::default()

--- a/crates/matrix-sdk/src/widget/machine/to_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/to_widget.rs
@@ -36,7 +36,7 @@ where
         Self { request_meta, _phantom: PhantomData }
     }
 
-    pub(crate) fn then(
+    pub(crate) fn add_response_handler(
         self,
         response_handler: impl FnOnce(T, &mut WidgetMachine) -> Vec<Action> + Send + 'static,
     ) {


### PR DESCRIPTION
The then() function can be used with booleans and futures to execute a piece of code if the boolean is true or once the future is completed.

In contrast, the then() function in the widget driver is not executed immediately. Instead it only adds a callback that is later on executed by the widget driver.