### PR TITLE
feat: implement and observe MSC4278 config value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4451,7 +4451,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.2"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7#a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7"
 dependencies = [
  "assign",
  "js_int",
@@ -4467,7 +4467,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.2"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7#a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7"
 dependencies = [
  "as_variant",
  "assign",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.2"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7#a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7"
 dependencies = [
  "as_variant",
  "base64",
@@ -4522,7 +4522,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.2"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7#a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4547,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.1"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7#a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7"
 dependencies = [
  "http",
  "js_int",
@@ -4561,7 +4561,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.0"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7#a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4573,7 +4573,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7#a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7"
 dependencies = [
  "js_int",
  "thiserror 2.0.11",
@@ -4582,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.1"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7#a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ reqwest = { version = "0.12.12", default-features = false }
 rmp-serde = "1.3.0"
 # Be careful to use commits from the https://github.com/ruma/ruma/tree/ruma-0.12
 # branch until a proper release with breaking changes happens.
-ruma = { git = "https://github.com/ruma/ruma", rev = "689d9613a985edc089b5b729e6d9362f09b5df4f", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -77,7 +77,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "689d9613a985edc089b5b729e6
     "unstable-msc4171",
     "unstable-msc4278",
     ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "689d9613a985edc089b5b729e6d9362f09b5df4f" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "a8fd1b0322649bf59e2a5cfc73ab4fe46b21edd7" }
 serde = "1.0.217"
 serde_html_form = "0.2.7"
 serde_json = "1.0.138"

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -1111,9 +1111,12 @@ pub enum AccountDataEvent {
 /// The policy that decides if media previews should be shown in the timeline.
 #[derive(Clone, uniffi::Enum, Default)]
 pub enum MediaPreviews {
+    /// Always show media previews in the timeline.
     #[default]
     On,
+    /// Show media previews in the timeline only if the room is private.
     Private,
+    /// Never show media previews in the timeline.
     Off,
 }
 
@@ -1138,11 +1141,13 @@ impl From<MediaPreviews> for RumaMediaPreviews {
     }
 }
 
-/// The policy that decides if avarars should be shown in invite requests.
+/// The policy that decides if avatars should be shown in invite requests.
 #[derive(Clone, uniffi::Enum, Default)]
 pub enum InviteAvatars {
+    /// Always show avatars in invite requests.
     #[default]
     On,
+    /// Never show avatars in invite requests.
     Off,
 }
 

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -30,6 +30,10 @@ use ruma::{
         ignored_user_list::{IgnoredUser as RumaIgnoredUser, IgnoredUserListEventContent},
         location::AssetType as RumaAssetType,
         marked_unread::{MarkedUnreadEventContent, UnstableMarkedUnreadEventContent},
+        media_preview_config::{
+            InviteAvatars as RumaInviteAvatars, MediaPreviewConfigEventContent,
+            MediaPreviews as RumaMediaPreviews,
+        },
         poll::start::PollKind as RumaPollKind,
         push_rules::PushRulesEventContent,
         room::{
@@ -1104,6 +1108,63 @@ pub enum AccountDataEvent {
     },
 }
 
+/// The policy that decides if media previews should be shown in the timeline.
+#[derive(Clone, uniffi::Enum, Default)]
+pub enum MediaPreviews {
+    #[default]
+    On,
+    Private,
+    Off,
+}
+
+impl From<RumaMediaPreviews> for MediaPreviews {
+    fn from(value: RumaMediaPreviews) -> Self {
+        match value {
+            RumaMediaPreviews::On => Self::On,
+            RumaMediaPreviews::Private => Self::Private,
+            RumaMediaPreviews::Off => Self::Off,
+            _ => Default::default(),
+        }
+    }
+}
+
+impl From<MediaPreviews> for RumaMediaPreviews {
+    fn from(value: MediaPreviews) -> Self {
+        match value {
+            MediaPreviews::On => Self::On,
+            MediaPreviews::Private => Self::Private,
+            MediaPreviews::Off => Self::Off,
+        }
+    }
+}
+
+/// The policy that decides if avarars should be shown in invite requests.
+#[derive(Clone, uniffi::Enum, Default)]
+pub enum InviteAvatars {
+    #[default]
+    On,
+    Off,
+}
+
+impl From<RumaInviteAvatars> for InviteAvatars {
+    fn from(value: RumaInviteAvatars) -> Self {
+        match value {
+            RumaInviteAvatars::On => Self::On,
+            RumaInviteAvatars::Off => Self::Off,
+            _ => Default::default(),
+        }
+    }
+}
+
+impl From<InviteAvatars> for RumaInviteAvatars {
+    fn from(value: InviteAvatars) -> Self {
+        match value {
+            InviteAvatars::On => Self::On,
+            InviteAvatars::Off => Self::Off,
+        }
+    }
+}
+
 /// Details about an ignored user.
 ///
 /// This is currently empty.
@@ -1347,6 +1408,28 @@ impl From<RumaSecretStorageV1AesHmacSha2Properties> for SecretStorageV1AesHmacSh
         Self {
             iv: value.iv.map(|base64| base64.encode()),
             mac: value.mac.map(|base64| base64.encode()),
+        }
+    }
+}
+
+/// The content of an `m.media_preview_config` event.
+///
+/// Is also the content of the unstable
+/// `io.element.msc4278.media_preview_config`.
+#[derive(Clone, uniffi::Record, Default)]
+pub struct MediaPreviewConfig {
+    /// The media previews setting for the user.
+    pub media_previews: MediaPreviews,
+
+    /// The invite avatars setting for the user.
+    pub invite_avatars: InviteAvatars,
+}
+
+impl From<MediaPreviewConfigEventContent> for MediaPreviewConfig {
+    fn from(value: MediaPreviewConfigEventContent) -> Self {
+        Self {
+            media_previews: value.media_previews.into(),
+            invite_avatars: value.invite_avatars.into(),
         }
     }
 }

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -1028,8 +1028,6 @@ impl Account {
         (MediaPreviewConfigEventContent, impl Stream<Item = MediaPreviewConfigEventContent>),
         Error,
     > {
-        let initial_value = self.get_media_preview_config_event_content().await?;
-
         // We need to create two observers, one for the stable event and one for the
         // unstable and combine them into a single stream.
         let first_observer = self
@@ -1056,6 +1054,11 @@ impl Account {
                 yield item
             }
         };
+
+        // We need to get the initial value of the media preview config event
+        // we do this after creating the observers to make sure that we don't
+        // create a race condition
+        let initial_value = self.get_media_preview_config_event_content().await?;
 
         Ok((initial_value, result_stream))
     }

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -17,7 +17,6 @@
 use futures_core::Stream;
 use futures_util::{stream, StreamExt};
 use matrix_sdk_base::{
-    event_cache::store::media,
     media::{MediaFormat, MediaRequestParameters},
     store::StateStoreExt,
     StateStoreDataKey, StateStoreDataValue,
@@ -40,7 +39,7 @@ use ruma::{
     events::{
         ignored_user_list::{IgnoredUser, IgnoredUserListEventContent},
         media_preview_config::{
-            self, InviteAvatars, MediaPreviewConfigEventContent, MediaPreviews,
+            InviteAvatars, MediaPreviewConfigEventContent, MediaPreviews,
             UnstableMediaPreviewConfigEventContent,
         },
         push_rules::PushRulesEventContent,
@@ -1004,6 +1003,7 @@ impl Account {
     /// # Examples
     ///
     /// ```no_run
+    /// # use futures_util::StreamExt;
     /// # use matrix_sdk::Client;
     /// # use matrix_sdk::ruma::events::media_preview_config::MediaPreviews;
     /// # use url::Url;

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -1003,7 +1003,7 @@ impl Account {
     /// # Examples
     ///
     /// ```no_run
-    /// # use futures_util::StreamExt;
+    /// # use futures_util::{pin_mut, StreamExt};
     /// # use matrix_sdk::Client;
     /// # use matrix_sdk::ruma::events::media_preview_config::MediaPreviews;
     /// # use url::Url;
@@ -1012,11 +1012,12 @@ impl Account {
     /// # let client = Client::new(homeserver).await?;
     /// let account = client.account();
     ///
-    /// let (initial_config, mut config_stream) =
+    /// let (initial_config, config_stream) =
     ///     account.observe_media_preview_config().await?;
     ///
     /// println!("Initial media preview config: {:?}", initial_config);
     ///
+    /// pin_mut!(config_stream);
     /// while let Some(new_config) = config_stream.next().await {
     ///     println!("Updated media preview config: {:?}", new_config);
     /// }

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use futures_core::Stream;
+use futures_util::{stream, StreamExt};
 use matrix_sdk_base::{
     media::{MediaFormat, MediaRequestParameters},
     store::StateStoreExt,
@@ -36,9 +38,13 @@ use ruma::{
     assign,
     events::{
         ignored_user_list::{IgnoredUser, IgnoredUserListEventContent},
+        media_preview_config::{
+            InviteAvatars, MediaPreviewConfigEventContent, MediaPreviews,
+            UnstableMediaPreviewConfigEventContent,
+        },
         push_rules::PushRulesEventContent,
         room::MediaSource,
-        AnyGlobalAccountDataEventContent, GlobalAccountDataEventContent,
+        AnyGlobalAccountDataEventContent, GlobalAccountDataEvent, GlobalAccountDataEventContent,
         GlobalAccountDataEventType, StaticEventContent,
     },
     push::Ruleset,
@@ -978,6 +984,123 @@ impl Account {
             .state_store()
             .set_kv_data(StateStoreDataKey::RecentlyVisitedRooms(user_id), data)
             .await?;
+        Ok(())
+    }
+
+    /// Observes the media preview configuration.
+    ///
+    /// This value is linked to the [MSC 4278](https://github.com/matrix-org/matrix-spec-proposals/pull/4278) which is still in an unstable state.
+    ///
+    /// This will return the initial value of the configuration and a stream
+    /// that will yield new values as they are received.
+    ///
+    /// The initial value is the one that was stored in the account data
+    /// when the client was started. If no value was found in either the stable
+    /// and unstable type, the default configuration will be returned.
+    /// and the following code is using a temporary solution until we know which
+    /// Matrix version will support the stable type.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use matrix_sdk::Client;
+    /// # use matrix_sdk::ruma::events::media_preview_config::MediaPreviews;
+    /// # use url::Url;
+    /// # async {
+    /// # let homeserver = Url::parse("http://localhost:8080")?;
+    /// # let client = Client::new(homeserver).await?;
+    /// let account = client.account();
+    ///
+    /// let (initial_config, mut config_stream) =
+    ///     account.observe_media_preview_config().await?;
+    ///
+    /// println!("Initial media preview config: {:?}", initial_config);
+    ///
+    /// while let Some(new_config) = config_stream.next().await {
+    ///     println!("Updated media preview config: {:?}", new_config);
+    /// }
+    /// # anyhow::Ok(()) };
+    /// ```
+    pub async fn observe_media_preview_config(
+        &self,
+    ) -> Result<
+        (MediaPreviewConfigEventContent, impl Stream<Item = MediaPreviewConfigEventContent>),
+        Error,
+    > {
+        // First we check if there is avalue in the stable event
+        let initial_value =
+            self.fetch_account_data(GlobalAccountDataEventType::MediaPreviewConfig).await?;
+
+        let initial_value = if let Some(initial_value) = initial_value {
+            Some(initial_value)
+        } else {
+            // If there is no value in the stable event, we check the unstable
+            self.fetch_account_data(GlobalAccountDataEventType::UnstableMediaPreviewConfig).await?
+        };
+
+        // We deserialize the content of the event, if is not found we return the
+        // default
+        let initial_value = initial_value
+            .and_then(|value| value.deserialize_as::<MediaPreviewConfigEventContent>().ok())
+            .unwrap_or_default();
+
+        // We need to create two observers, one for the stable event and one for the
+        // unstable and combine them into a single stream.
+        let first_observer = self
+            .client
+            .observe_events::<GlobalAccountDataEvent<MediaPreviewConfigEventContent>, ()>();
+
+        let stream = first_observer.subscribe().map(|event| event.0.content);
+
+        let second_observer = self
+            .client
+            .observe_events::<GlobalAccountDataEvent<UnstableMediaPreviewConfigEventContent>, ()>();
+
+        let second_stream = second_observer.subscribe().map(|event| event.0.content.0);
+
+        let mut combined_stream = stream::select(stream, second_stream);
+
+        let result_stream = async_stream::stream! {
+            // The observers need to be alive for the individual streams to be alive, so let's now
+            // create a stream that takes ownership of them.
+            let _first_observer = first_observer;
+            let _second_observer = second_observer;
+
+            while let Some(item) = combined_stream.next().await {
+                yield item
+            }
+        };
+
+        Ok((initial_value, result_stream))
+    }
+
+    /// Set the media previews display policy in the timeline.
+    ///
+    /// This will always use the unstable event until we know which Matrix
+    /// version will support it.
+    pub async fn set_media_previews_display_policy(&self, policy: MediaPreviews) -> Result<()> {
+        let (mut media_preview_config, _) = self.observe_media_preview_config().await?;
+        media_preview_config.media_previews = policy;
+
+        // Updating the unstable account data
+        let unstable_media_preview_config =
+            UnstableMediaPreviewConfigEventContent::from(media_preview_config);
+        self.set_account_data(unstable_media_preview_config).await?;
+        Ok(())
+    }
+
+    /// Set the display policy for avatars in invite requests.
+    ///
+    /// This will always use the unstable event until we know which matrix
+    /// version will support it.
+    pub async fn set_invite_avatars_display_policy(&self, policy: InviteAvatars) -> Result<()> {
+        let (mut media_preview_config, _) = self.observe_media_preview_config().await?;
+        media_preview_config.invite_avatars = policy;
+
+        // Updating the unstable account data
+        let unstable_media_preview_config =
+            UnstableMediaPreviewConfigEventContent::from(media_preview_config);
+        self.set_account_data(unstable_media_preview_config).await?;
         Ok(())
     }
 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2589,7 +2589,7 @@ pub(crate) mod tests {
     use std::{sync::Arc, time::Duration};
 
     use assert_matches::assert_matches;
-    use futures_util::{pin_mut, FutureExt, StreamExt};
+    use futures_util::{pin_mut, FutureExt};
     use matrix_sdk_base::{
         store::{MemoryStore, StoreConfig},
         RoomState,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2589,14 +2589,14 @@ pub(crate) mod tests {
     use std::{sync::Arc, time::Duration};
 
     use assert_matches::assert_matches;
-    use futures_util::FutureExt;
+    use futures_util::{pin_mut, FutureExt, StreamExt};
     use matrix_sdk_base::{
         store::{MemoryStore, StoreConfig},
         RoomState,
     };
     use matrix_sdk_test::{
-        async_test, test_json, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder,
-        DEFAULT_TEST_ROOM_ID,
+        async_test, test_json, GlobalAccountDataTestEvent, JoinedRoomBuilder, StateTestEvent,
+        SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
     };
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
@@ -2604,10 +2604,14 @@ pub(crate) mod tests {
     use ruma::{
         api::{client::room::create_room::v3::Request as CreateRoomRequest, MatrixVersion},
         assign,
-        events::ignored_user_list::IgnoredUserListEventContent,
+        events::{
+            ignored_user_list::IgnoredUserListEventContent,
+            media_preview_config::{InviteAvatars, MediaPreviewConfigEventContent, MediaPreviews},
+        },
         owned_room_id, room_alias_id, room_id, RoomId, ServerName, UserId,
     };
     use serde_json::json;
+    use stream_assert::{assert_next_matches, assert_pending};
     use tokio::{
         spawn,
         time::{sleep, timeout},
@@ -3332,24 +3336,140 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn test_room_preview_for_banned_room_retrieves_local_room_info() {
+    async fn test_media_preview_config() {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
 
-        let room_id = room_id!("!a-room:matrix.org");
+        server
+            .mock_global_account_data()
+            .ok(
+                client.user_id().unwrap(),
+                ruma::events::GlobalAccountDataEventType::MediaPreviewConfig,
+                json!({
+                    "media_previews": "private",
+                    "invite_avatars": "off"
+                }),
+            )
+            .mount()
+            .await;
 
-        // Make sure the summary endpoint is not called
-        server.mock_room_summary().ok(room_id).never().mount().await;
+        let (initial_value, stream) =
+            client.account().observe_media_preview_config().await.unwrap();
 
-        // We create a locally cached banned room
-        let banned_room = client.inner.base_client.get_or_create_room(room_id, RoomState::Banned);
+        assert_eq!(initial_value.invite_avatars, InviteAvatars::Off);
+        assert_eq!(initial_value.media_previews, MediaPreviews::Private);
+        pin_mut!(stream);
+        assert_pending!(stream);
 
-        // And we get a preview, no server endpoint was reached
-        let preview = client
-            .get_room_preview(room_id.into(), Vec::new())
-            .await
-            .expect("Room preview should be retrieved");
+        server
+            .mock_sync()
+            .ok_and_run(&client, |builder| {
+                builder.add_global_account_data_event(GlobalAccountDataTestEvent::Custom(json!({
+                "content": {
+                    "media_previews": "off",
+                    "invite_avatars": "on"
+                },
+                "type": "m.media_preview_config"
+                  })));
+            })
+            .await;
 
-        assert_eq!(banned_room.room_id().to_owned(), preview.room_id);
+        assert_next_matches!(
+            stream,
+            MediaPreviewConfigEventContent {
+                media_previews: MediaPreviews::Off,
+                invite_avatars: InviteAvatars::On,
+                ..
+            }
+        );
+        assert_pending!(stream);
+    }
+
+    #[async_test]
+    async fn test_unstable_media_preview_config() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        server
+            .mock_global_account_data()
+            .not_found(
+                client.user_id().unwrap(),
+                ruma::events::GlobalAccountDataEventType::MediaPreviewConfig,
+            )
+            .mount()
+            .await;
+
+        server
+            .mock_global_account_data()
+            .ok(
+                client.user_id().unwrap(),
+                ruma::events::GlobalAccountDataEventType::UnstableMediaPreviewConfig,
+                json!({
+                    "media_previews": "private",
+                    "invite_avatars": "off"
+                }),
+            )
+            .mount()
+            .await;
+
+        let (initial_value, stream) =
+            client.account().observe_media_preview_config().await.unwrap();
+
+        assert_eq!(initial_value.invite_avatars, InviteAvatars::Off);
+        assert_eq!(initial_value.media_previews, MediaPreviews::Private);
+        pin_mut!(stream);
+        assert_pending!(stream);
+
+        server
+            .mock_sync()
+            .ok_and_run(&client, |builder| {
+                builder.add_global_account_data_event(GlobalAccountDataTestEvent::Custom(json!({
+                "content": {
+                    "media_previews": "off",
+                    "invite_avatars": "on"
+                },
+                "type": "io.element.msc4278.media_preview_config"
+                  })));
+            })
+            .await;
+
+        assert_next_matches!(
+            stream,
+            MediaPreviewConfigEventContent {
+                media_previews: MediaPreviews::Off,
+                invite_avatars: InviteAvatars::On,
+                ..
+            }
+        );
+        assert_pending!(stream);
+    }
+
+    #[async_test]
+    async fn test_media_preview_config_not_found() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        server
+            .mock_global_account_data()
+            .not_found(
+                client.user_id().unwrap(),
+                ruma::events::GlobalAccountDataEventType::MediaPreviewConfig,
+            )
+            .mount()
+            .await;
+
+        server
+            .mock_global_account_data()
+            .not_found(
+                client.user_id().unwrap(),
+                ruma::events::GlobalAccountDataEventType::UnstableMediaPreviewConfig,
+            )
+            .mount()
+            .await;
+
+        let (initial_value, _) = client.account().observe_media_preview_config().await.unwrap();
+
+        assert_eq!(initial_value.invite_avatars, InviteAvatars::On);
+        assert_eq!(initial_value.media_previews, MediaPreviews::On);
     }
 }

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1042,6 +1042,8 @@ impl MatrixMockServer {
     /// .mount()
     /// .await;
     ///
+    /// let (_, _) = client.account().observe_media_preview_config().await.unwrap();
+    ///
     /// # anyhow::Ok(()) });
     /// ```
     pub fn mock_global_account_data(&self) -> MockEndpoint<'_, GlobalAccountDataEndpoint> {

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1025,6 +1025,7 @@ impl MatrixMockServer {
     /// ```
     /// tokio_test::block_on(async {
     /// use matrix_sdk::test_utils::mocks::MatrixMockServer;
+    /// use serde_json::json;
     ///
     /// let mock_server = MatrixMockServer::new().await;
     /// let client = mock_server.client_builder().build().await;

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1024,24 +1024,22 @@ impl MatrixMockServer {
     ///
     /// ```
     /// tokio_test::block_on(async {
-    /// use matrix_sdk::{
-    ///     ruma::room_id,
-    ///     test_utils::mocks::MatrixMockServer,
-    /// };
+    /// use matrix_sdk::test_utils::mocks::MatrixMockServer;
     ///
     /// let mock_server = MatrixMockServer::new().await;
     /// let client = mock_server.client_builder().build().await;
     ///
-    /// mock_server.mock_global_account_data()..ok(
+    /// mock_server.mock_global_account_data().ok(
     ///     client.user_id().unwrap(),
     ///     ruma::events::GlobalAccountDataEventType::MediaPreviewConfig,
     ///     json!({
     ///         "media_previews": "private",
     ///         "invite_avatars": "off"
     ///     })
-    ///     .mock_once()
-    ///     .mount()
-    ///     .await;
+    /// )
+    /// .mock_once()
+    /// .mount()
+    /// .await;
     ///
     /// # anyhow::Ok(()) });
     /// ```


### PR DESCRIPTION
This PR
- Updates Ruma to use the improved MediaPreviewConfig event type that also supports a `Default` for the content type
- Implemented a way to observe the stable and unstable values of the event and return the used one accordingly, if no one is present the default will be used
- Set the value (will only use unstable type for now)