### PR TITLE
refactor(crypto): Make the room key importing logic more generic

### DIFF
--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -35,8 +35,8 @@ use crate::types::events::forwarded_room_key::ForwardedMegolmV2AesSha2Content;
 use crate::types::{
     deserialize_curve_key, deserialize_curve_key_vec,
     events::forwarded_room_key::{ForwardedMegolmV1AesSha2Content, ForwardedRoomKeyContent},
-    serialize_curve_key, serialize_curve_key_vec, EventEncryptionAlgorithm, SigningKey,
-    SigningKeys,
+    serialize_curve_key, serialize_curve_key_vec, EventEncryptionAlgorithm, RoomKeyExport,
+    SigningKey, SigningKeys,
 };
 
 /// An error type for the creation of group sessions.
@@ -138,6 +138,20 @@ impl ExportedRoomKey {
             forwarding_curve25519_key_chain,
             shared_history,
         }
+    }
+}
+
+impl RoomKeyExport for &ExportedRoomKey {
+    fn room_id(&self) -> &ruma::RoomId {
+        &self.room_id
+    }
+
+    fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    fn sender_key(&self) -> Curve25519PublicKey {
+        self.sender_key
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/types/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/mod.rs
@@ -38,7 +38,7 @@ use matrix_sdk_common::deserialized_responses::PrivOwnedStr;
 use ruma::{
     events::AnyToDeviceEvent,
     serde::{Raw, StringEnum},
-    DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, OwnedUserId, UserId,
+    DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, OwnedUserId, RoomId, UserId,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, Ed25519Signature, KeyError};
@@ -659,4 +659,16 @@ impl ProcessedToDeviceEvent {
             ProcessedToDeviceEvent::Invalid(event) => event.clone(),
         }
     }
+}
+
+/// Trait to express the various room key export formats we have in a unified
+/// manner.
+pub trait RoomKeyExport {
+    /// The ID of the room where the exported room key was used.
+    fn room_id(&self) -> &RoomId;
+    /// The unique ID of the exported room key.
+    fn session_id(&self) -> &str;
+    /// The [Curve25519PublicKey] long-term identity key of the sender of this
+    /// room key.
+    fn sender_key(&self) -> Curve25519PublicKey;
 }


### PR DESCRIPTION
Part of https://github.com/matrix-org/matrix-rust-sdk/issues/4513 and necessary for https://github.com/matrix-org/matrix-rust-sdk/pull/4989.

Making this generic right now is a bit of a no-op, but eventually we'll also import the `HistoricRoomKey` type which requires this to be generic.