### PR TITLE
fix(ui): populate the `thread_root` and `in_reply_to` fields for stickers and polls

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -31,7 +31,8 @@ use ruma::{
         receipt::Receipt,
         relation::Replacement,
         room::message::{
-            Relation, RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
+            Relation, RelationWithoutReplacement, RoomMessageEventContent,
+            RoomMessageEventContentWithoutRelation,
         },
         AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncStateEvent,
         AnySyncTimelineEvent, BundledMessageLikeRelations, EventContent, FullStateEventContent,
@@ -354,11 +355,44 @@ impl TimelineAction {
             }
 
             AnyMessageLikeEventContent::Sticker(content) => {
+                let mut replied_to_event_id = None;
+                let mut thread_root = None;
+                let in_reply_to_details =
+                    content.relates_to.as_ref().and_then(|relation| match relation {
+                        Relation::Reply { in_reply_to } => {
+                            replied_to_event_id = Some(in_reply_to.event_id.clone());
+                            Some(InReplyToDetails::new(
+                                in_reply_to.event_id.clone(),
+                                timeline_items,
+                            ))
+                        }
+                        Relation::Thread(thread) => {
+                            thread_root = Some(thread.event_id.clone());
+                            thread.in_reply_to.as_ref().map(|in_reply_to| {
+                                replied_to_event_id = Some(in_reply_to.event_id.clone());
+                                InReplyToDetails::new(in_reply_to.event_id.clone(), timeline_items)
+                            })
+                        }
+                        _ => None,
+                    });
+
+                // If this message is a reply to another message, add an entry in the
+                // inverted mapping.
+                if let Some(event_id) = event_id {
+                    if let Some(replied_to_event_id) = replied_to_event_id {
+                        // This is a reply! Add an entry.
+                        meta.replies
+                            .entry(replied_to_event_id)
+                            .or_default()
+                            .insert(event_id.to_owned());
+                    }
+                }
+
                 Self::add_item(TimelineItemContent::MsgLike(MsgLikeContent {
                     kind: MsgLikeKind::Sticker(Sticker { content }),
                     reactions: Default::default(),
-                    thread_root: None,
-                    in_reply_to: None,
+                    thread_root,
+                    in_reply_to: in_reply_to_details,
                     thread_summary: None,
                 }))
             }
@@ -393,6 +427,39 @@ impl TimelineAction {
                     .or(pending_edit)
                     .unzip();
 
+                let mut replied_to_event_id = None;
+                let mut thread_root = None;
+                let in_reply_to_details =
+                    c.relates_to.as_ref().and_then(|relation| match relation {
+                        RelationWithoutReplacement::Reply { in_reply_to } => {
+                            replied_to_event_id = Some(in_reply_to.event_id.clone());
+                            Some(InReplyToDetails::new(
+                                in_reply_to.event_id.clone(),
+                                timeline_items,
+                            ))
+                        }
+                        RelationWithoutReplacement::Thread(thread) => {
+                            thread_root = Some(thread.event_id.clone());
+                            thread.in_reply_to.as_ref().map(|in_reply_to| {
+                                replied_to_event_id = Some(in_reply_to.event_id.clone());
+                                InReplyToDetails::new(in_reply_to.event_id.clone(), timeline_items)
+                            })
+                        }
+                        _ => None,
+                    });
+
+                // If this message is a reply to another message, add an entry in the
+                // inverted mapping.
+                if let Some(event_id) = event_id {
+                    if let Some(replied_to_event_id) = replied_to_event_id {
+                        // This is a reply! Add an entry.
+                        meta.replies
+                            .entry(replied_to_event_id)
+                            .or_default()
+                            .insert(event_id.to_owned());
+                    }
+                }
+
                 let poll_state = PollState::new(c, edit_content);
 
                 let edit_json = edit_json.flatten();
@@ -401,8 +468,8 @@ impl TimelineAction {
                     content: TimelineItemContent::MsgLike(MsgLikeContent {
                         kind: MsgLikeKind::Poll(poll_state),
                         reactions: Default::default(),
-                        thread_root: None,
-                        in_reply_to: None,
+                        thread_root,
+                        in_reply_to: in_reply_to_details,
                         thread_summary: None,
                     }),
                     edit_json,

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -22,6 +22,7 @@ use matrix_sdk_test::{
     async_test, event_factory::PreviousMembership, sync_timeline_event, ALICE, BOB, CAROL,
 };
 use ruma::{
+    event_id,
     events::{
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::{
@@ -141,6 +142,13 @@ async fn test_sticker() {
                     "w": 394
                 },
                 "url": "mxc://server.name/JWEIFJgwEIhweiWJE",
+                "m.relates_to": {
+                    "rel_type": "m.thread",
+                    "event_id": "$thread_root",
+                    "m.in_reply_to": {
+                        "event_id": "$in_reply_to"
+                    }
+                }
             },
             "event_id": "$143273582443PhrSn",
             "origin_server_ts": 143273582,
@@ -151,6 +159,11 @@ async fn test_sticker() {
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     assert!(item.content().is_sticker());
+
+    assert_eq!(item.content().thread_root(), Some(event_id!("$thread_root").to_owned()));
+
+    assert_let!(Some(details) = item.content().in_reply_to());
+    assert_eq!(details.event_id, event_id!("$in_reply_to").to_owned())
 }
 
 #[async_test]


### PR DESCRIPTION
They have never been set and there was no way of telling if stickers and polls belong on a thread or come in reply of any other message.

This patch also exposes methods for setting these relations on the event factory level for polls.