### PR TITLE
refactor(timeline): finish the aggregations refactoring

### DIFF
--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Refactor
+
+- [**breaking**] [`TimelineItemContent::reactions()`] returns an `Option<&ReactionsByKeyBySender>`
+  instead of `ReactionsByKeyBySender`. This reflects the fact that some timeline items cannot hold
+  reactions at all.
+
 ### Bug Fixes
 
 - Introduce `Timeline` regions, which helps to remove a class of bugs in the

--- a/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
@@ -353,7 +353,7 @@ impl Aggregations {
     /// Will return an error at the first aggregation that couldn't be applied;
     /// see [`Aggregation::apply`] which explains under which conditions it can
     /// happen.
-    pub fn apply(
+    pub fn apply_all(
         &self,
         item_id: &TimelineEventItemId,
         event: &mut EventTimelineItem,

--- a/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
@@ -378,7 +378,6 @@ impl Aggregations {
     ///
     /// May return an error if it found an aggregation, but it couldn't be
     /// properly applied.
-    #[must_use]
     pub fn try_remove_aggregation(
         &mut self,
         aggregation_id: &TimelineEventItemId,

--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -521,13 +521,16 @@ mod tests {
             origin: RemoteEventOrigin::Sync,
         });
 
+        let content = RoomMessageEventContent::text_plain("hi");
+
         TimelineItem::new(
             TimelineItemKind::Event(EventTimelineItem::new(
                 owned_user_id!("@u:s.to"),
                 TimelineDetails::Pending,
                 timestamp(),
                 TimelineItemContent::message(
-                    RoomMessageEventContent::text_plain("hi"),
+                    content.msgtype,
+                    content.mentions,
                     ReactionsByKeyBySender::default(),
                     None,
                     None,

--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -528,7 +528,6 @@ mod tests {
                 timestamp(),
                 TimelineItemContent::message(
                     RoomMessageEventContent::text_plain("hi"),
-                    None,
                     ReactionsByKeyBySender::default(),
                     None,
                     None,

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -75,6 +75,8 @@ pub(in crate::timeline) struct TimelineMetadata {
     pub aggregations: Aggregations,
 
     /// Given an event, what are all the events that are replies to it?
+    ///
+    /// Only works for remote events *and* replies which are remote-echoed.
     pub replies: HashMap<OwnedEventId, BTreeSet<OwnedEventId>>,
 
     /// Identifier of the fully-read event, helping knowing where to introduce

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -607,9 +607,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
         let prev_status = item
             .content()
             .reactions()
-            .get(key)
-            .and_then(|group| group.get(user_id))
-            .map(|reaction_info| reaction_info.status.clone());
+            .and_then(|map| Some(map.get(key)?.get(user_id)?.status.clone()));
 
         let Some(prev_status) = prev_status else {
             match &item.kind {
@@ -685,7 +683,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                     return Ok(false);
                 };
 
-                let mut reactions = item.content().reactions().clone();
+                let mut reactions = item.content().reactions().cloned().unwrap_or_default();
                 let reaction_info = reactions.remove_reaction(user_id, key);
 
                 if reaction_info.is_some() {
@@ -708,7 +706,8 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                             rfind_event_by_id(&state.items, &annotated_event_id)
                         {
                             // Re-add the reaction to the mapping.
-                            let mut reactions = item.content().reactions();
+                            let mut reactions =
+                                item.content().reactions().cloned().unwrap_or_default();
                             reactions
                                 .entry(key.to_owned())
                                 .or_default()
@@ -1057,7 +1056,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
             prev_item.with_kind(ti_kind).with_content(TimelineItemContent::message(
                 content,
                 None,
-                prev_item.content().reactions(),
+                prev_item.content().reactions().cloned().unwrap_or_default(),
                 prev_item.content().thread_root(),
                 prev_item.content().in_reply_to(),
                 prev_item.content().thread_summary(),

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -59,7 +59,7 @@ pub(super) use self::{
         AllRemoteEvents, ObservableItems, ObservableItemsEntry, ObservableItemsTransaction,
         ObservableItemsTransactionEntry,
     },
-    state::{PendingEdit, PendingEditKind, TimelineState},
+    state::TimelineState,
     state_transaction::TimelineStateTransaction,
 };
 use super::{
@@ -84,7 +84,7 @@ use crate::{
     unable_to_decrypt_hook::UtdHookManager,
 };
 
-mod aggregations;
+pub(in crate::timeline) mod aggregations;
 mod decryption_retry_task;
 mod metadata;
 mod observable_items;
@@ -1242,7 +1242,13 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
         );
 
         tr.meta.aggregations.add(target.clone(), aggregation.clone());
-        find_item_and_apply_aggregation(&mut tr.items, &target, aggregation, &tr.meta.room_version);
+        find_item_and_apply_aggregation(
+            &tr.meta.aggregations,
+            &mut tr.items,
+            &target,
+            aggregation,
+            &tr.meta.room_version,
+        );
 
         tr.commit();
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -905,15 +905,14 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                             if let Some((item_pos, item)) =
                                 rfind_event_by_item_id(&txn.items, &target)
                             {
-                                let mut content = item.content().clone();
-                                match aggregation.apply(&mut content) {
+                                let mut event_item = item.clone();
+                                match aggregation.apply(&mut event_item, &txn.meta.room_version) {
                                     ApplyAggregationResult::UpdatedItem => {
                                         trace!("reapplied aggregation in the event");
                                         let internal_id = item.internal_id.to_owned();
-                                        let new_item = item.with_content(content);
                                         txn.items.replace(
                                             item_pos,
-                                            TimelineItem::new(new_item, internal_id),
+                                            TimelineItem::new(event_item, internal_id),
                                         );
                                         txn.commit();
                                     }
@@ -1281,7 +1280,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
         );
 
         tr.meta.aggregations.add(target.clone(), aggregation.clone());
-        find_item_and_apply_aggregation(&mut tr.items, &target, aggregation);
+        find_item_and_apply_aggregation(&mut tr.items, &target, aggregation, &tr.meta.room_version);
 
         tr.commit();
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1018,7 +1018,6 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
         let new_item = TimelineItem::new(
             prev_item.with_kind(ti_kind).with_content(TimelineItemContent::message(
                 content,
-                None,
                 prev_item.content().reactions().cloned().unwrap_or_default(),
                 prev_item.content().thread_root(),
                 prev_item.content().in_reply_to(),

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1017,7 +1017,8 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
         // Replace the local-related state (kind) and the content state.
         let new_item = TimelineItem::new(
             prev_item.with_kind(ti_kind).with_content(TimelineItemContent::message(
-                content,
+                content.msgtype,
+                content.mentions,
                 prev_item.content().reactions().cloned().unwrap_or_default(),
                 prev_item.content().thread_root(),
                 prev_item.content().in_reply_to(),

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeSet, fmt, sync::Arc};
+use std::{borrow::Cow, collections::BTreeSet, fmt, sync::Arc};
 
 use as_variant::as_variant;
 use decryption_retry_task::DecryptionRetryTask;
@@ -904,14 +904,14 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                             if let Some((item_pos, item)) =
                                 rfind_event_by_item_id(&txn.items, &target)
                             {
-                                let mut event_item = item.clone();
-                                match aggregation.apply(&mut event_item, &txn.meta.room_version) {
+                                let mut cowed = Cow::Borrowed(&*item);
+                                match aggregation.apply(&mut cowed, &txn.meta.room_version) {
                                     ApplyAggregationResult::UpdatedItem => {
                                         trace!("reapplied aggregation in the event");
                                         let internal_id = item.internal_id.to_owned();
                                         txn.items.replace(
                                             item_pos,
-                                            TimelineItem::new(event_item, internal_id),
+                                            TimelineItem::new(cowed.into_owned(), internal_id),
                                         );
                                         txn.commit();
                                     }
@@ -997,13 +997,14 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                 return false;
             };
 
-            let mut content = item.content().clone();
-            match aggregation.unapply(&mut content) {
+            let mut cowed = Cow::Borrowed(&*item);
+            match aggregation.unapply(&mut cowed) {
                 ApplyAggregationResult::UpdatedItem => {
                     trace!("removed local reaction to local echo");
-                    let internal_id = item.internal_id.clone();
-                    let new_item = item.with_content(content);
-                    state.items.replace(item_pos, TimelineItem::new(new_item, internal_id));
+                    state.items.replace(
+                        item_pos,
+                        TimelineItem::new(cowed.into_owned(), item.internal_id.clone()),
+                    );
                 }
                 ApplyAggregationResult::LeftItemIntact => {}
                 ApplyAggregationResult::Error(err) => {

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -1949,14 +1949,11 @@ impl AllRemoteEvents {
     pub fn position_by_event_id(&self, event_id: &EventId) -> Option<usize> {
         // Reverse the iterator to start looking at the end. Since this will give us the
         // "reverse" position, reverse the index after finding the event.
-        //
-        // If the reversed index was 0 in a array of size 1, then it should stay 0, so
-        // that justifies the `- 1` in the formula below.
         self.0
             .iter()
+            .enumerate()
             .rev()
-            .position(|event_meta| event_meta.event_id == event_id)
-            .map(|rev_index| self.0.len() - 1 - rev_index)
+            .find_map(|(i, event_meta)| (event_meta.event_id == event_id).then_some(i))
     }
 
     /// Shift to the right all timeline item indexes that are equal to or

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -275,6 +275,11 @@ impl<'observable_items> ObservableItemsTransaction<'observable_items> {
         self.all_remote_events.get_by_event_id(event_id)
     }
 
+    /// Get the position of an event in the events array by its ID.
+    pub fn position_by_event_id(&self, event_id: &EventId) -> Option<usize> {
+        self.all_remote_events.position_by_event_id(event_id)
+    }
+
     /// Replace a timeline item at position `timeline_item_index` by
     /// `timeline_item`.
     pub fn replace(
@@ -1938,6 +1943,11 @@ impl AllRemoteEvents {
     /// Get an immutable reference to a specific remote event by its ID.
     pub fn get_by_event_id(&self, event_id: &EventId) -> Option<&EventMeta> {
         self.0.iter().rev().find(|event_meta| event_meta.event_id == event_id)
+    }
+
+    /// Get the position of an event in the events array by its ID.
+    pub fn position_by_event_id(&self, event_id: &EventId) -> Option<usize> {
+        self.0.iter().position(|event_meta| event_meta.event_id == event_id)
     }
 
     /// Shift to the right all timeline item indexes that are equal to or

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -1947,7 +1947,16 @@ impl AllRemoteEvents {
 
     /// Get the position of an event in the events array by its ID.
     pub fn position_by_event_id(&self, event_id: &EventId) -> Option<usize> {
-        self.0.iter().position(|event_meta| event_meta.event_id == event_id)
+        // Reverse the iterator to start looking at the end. Since this will give us the
+        // "reverse" position, reverse the index after finding the event.
+        //
+        // If the reversed index was 0 in a array of size 1, then it should stay 0, so
+        // that justifies the `- 1` in the formula below.
+        self.0
+            .iter()
+            .rev()
+            .position(|event_meta| event_meta.event_id == event_id)
+            .map(|rev_index| self.0.len() - 1 - rev_index)
     }
 
     /// Shift to the right all timeline item indexes that are equal to or

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -19,14 +19,9 @@ use matrix_sdk::{deserialized_responses::TimelineEvent, send_queue::SendHandle};
 #[cfg(test)]
 use ruma::events::receipt::ReceiptEventContent;
 use ruma::{
-    events::{
-        poll::unstable_start::NewUnstablePollStartEventContentWithoutRelation,
-        relation::Replacement, room::message::RoomMessageEventContentWithoutRelation,
-        AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent, AnySyncTimelineEvent,
-    },
+    events::{AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent},
     serde::Raw,
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
-    RoomVersionId,
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId,
 };
 use tracing::{instrument, trace, warn};
 
@@ -281,38 +276,5 @@ impl TimelineState {
 
     pub(super) fn transaction(&mut self) -> TimelineStateTransaction<'_> {
         TimelineStateTransaction::new(&mut self.items, &mut self.meta, self.timeline_focus)
-    }
-}
-
-#[derive(Clone)]
-pub(in crate::timeline) enum PendingEditKind {
-    RoomMessage(Replacement<RoomMessageEventContentWithoutRelation>),
-    Poll(Replacement<NewUnstablePollStartEventContentWithoutRelation>),
-}
-
-#[derive(Clone)]
-pub(in crate::timeline) struct PendingEdit {
-    pub kind: PendingEditKind,
-    pub event_json: Raw<AnySyncTimelineEvent>,
-}
-
-impl PendingEdit {
-    pub fn edited_event(&self) -> &EventId {
-        match &self.kind {
-            PendingEditKind::RoomMessage(Replacement { event_id, .. })
-            | PendingEditKind::Poll(Replacement { event_id, .. }) => event_id,
-        }
-    }
-}
-
-#[cfg(not(tarpaulin_include))]
-impl std::fmt::Debug for PendingEdit {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind {
-            PendingEditKind::RoomMessage(_) => {
-                f.debug_struct("RoomMessage").finish_non_exhaustive()
-            }
-            PendingEditKind::Poll(_) => f.debug_struct("Poll").finish_non_exhaustive(),
-        }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -372,14 +372,13 @@ impl TimelineAction {
                 c,
             )) => {
                 // Record the bundled edit in the aggregations set, if any.
-                if let Some(new_content) = relations.and_then(extract_poll_edit_content) {
-                    let edit_json = raw_event.and_then(extract_bundled_edit_event_json);
-
-                    if let Some(target_id) = event_id {
+                if let Some(target_id) = event_id {
+                    if let Some(new_content) = relations.and_then(extract_poll_edit_content) {
                         // It is replacing the current event.
                         if let Some(edit_event_id) = raw_event.and_then(|raw_event| {
                             raw_event.get_field::<OwnedEventId>("event_id").ok().flatten()
                         }) {
+                            let edit_json = raw_event.and_then(extract_bundled_edit_event_json);
                             let aggregation = Aggregation::new(
                                 TimelineEventItemId::EventId(edit_event_id),
                                 AggregationKind::Edit(PendingEdit {
@@ -420,14 +419,13 @@ impl TimelineAction {
 
             AnyMessageLikeEventContent::RoomMessage(msg) => {
                 // Record the bundled edit in the aggregations set, if any.
-                if let Some(new_content) = relations.and_then(extract_room_msg_edit_content) {
-                    let edit_json = raw_event.and_then(extract_bundled_edit_event_json);
-
-                    if let Some(target_id) = event_id {
+                if let Some(target_id) = event_id {
+                    if let Some(new_content) = relations.and_then(extract_room_msg_edit_content) {
                         // It is replacing the current event.
                         if let Some(edit_event_id) = raw_event.and_then(|raw_event| {
                             raw_event.get_field::<OwnedEventId>("event_id").ok().flatten()
                         }) {
+                            let edit_json = raw_event.and_then(extract_bundled_edit_event_json);
                             let aggregation = Aggregation::new(
                                 TimelineEventItemId::EventId(edit_event_id),
                                 AggregationKind::Edit(PendingEdit {

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -1140,7 +1140,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         );
 
         // Apply any pending or stashed aggregations.
-        if let Err(err) = self.meta.aggregations.apply(
+        if let Err(err) = self.meta.aggregations.apply_all(
             &self.ctx.flow.timeline_item_id(),
             &mut item,
             &self.meta.room_version,

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -416,6 +416,8 @@ impl TimelineAction {
                                         new_content,
                                     )),
                                     edit_json,
+                                    // TODO maybe we could provide it?
+                                    encryption_info: None,
                                 }),
                             );
                             meta.aggregations.add(
@@ -491,6 +493,8 @@ impl TimelineAction {
                                         new_content,
                                     )),
                                     edit_json,
+                                    // TODO maybe we could provide it?
+                                    encryption_info: None,
                                 }),
                             );
                             meta.aggregations.add(
@@ -735,11 +739,14 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
     fn handle_edit(&mut self, edited_event_id: OwnedEventId, edit_kind: PendingEditKind) {
         let target = TimelineEventItemId::EventId(edited_event_id.clone());
 
+        let encryption_info =
+            as_variant!(&self.ctx.flow, Flow::Remote { encryption_info, .. } => encryption_info.clone()).flatten();
         let aggregation = Aggregation::new(
             self.ctx.flow.timeline_item_id(),
             AggregationKind::Edit(PendingEdit {
                 kind: edit_kind,
                 edit_json: self.ctx.flow.raw_event().cloned(),
+                encryption_info,
             }),
         );
 

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -447,14 +447,15 @@ impl TimelineAction {
                 }
 
                 let (in_reply_to, thread_root) = Self::extract_reply_and_thread_root(
-                    msg.relates_to.clone().and_then(|rel| rel.try_into().ok()),
+                    msg.relates_to.and_then(|rel| rel.try_into().ok()),
                     timeline_items,
                 );
                 Self::mark_response(meta, event_id, in_reply_to.as_ref());
 
                 Self::AddItem {
                     content: TimelineItemContent::message(
-                        msg,
+                        msg.msgtype,
+                        msg.mentions,
                         Default::default(),
                         thread_root,
                         in_reply_to,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -23,8 +23,7 @@ use ruma::{
             UnstablePollStartEventContent,
         },
         room::message::{
-            MessageType, Relation, RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
-            SyncRoomMessageEvent,
+            MessageType, Relation, RoomMessageEventContentWithoutRelation, SyncRoomMessageEvent,
         },
         AnySyncMessageLikeEvent, AnySyncTimelineEvent, BundledMessageLikeRelations, Mentions,
     },
@@ -46,14 +45,14 @@ pub struct Message {
 impl Message {
     /// Construct a `Message` from a `m.room.message` event.
     pub(in crate::timeline) fn from_event(
-        c: RoomMessageEventContent,
+        mut msgtype: MessageType,
+        mentions: Option<Mentions>,
         edit: Option<RoomMessageEventContentWithoutRelation>,
         remove_reply_fallback: RemoveReplyFallback,
     ) -> Self {
-        let mut msgtype = c.msgtype;
         msgtype.sanitize(DEFAULT_SANITIZER_MODE, remove_reply_fallback);
 
-        let mut ret = Self { msgtype, edited: false, mentions: c.mentions };
+        let mut ret = Self { msgtype, edited: false, mentions };
 
         if let Some(edit) = edit {
             ret.apply_edit(edit);

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -531,9 +531,9 @@ impl TimelineItemContent {
 
     /// Return the reactions, grouped by key and then by sender, for a given
     /// content.
-    pub fn reactions(&self) -> ReactionsByKeyBySender {
+    pub fn reactions(&self) -> Option<&ReactionsByKeyBySender> {
         match self {
-            TimelineItemContent::MsgLike(msglike) => msglike.reactions.clone(),
+            TimelineItemContent::MsgLike(msglike) => Some(&msglike.reactions),
 
             TimelineItemContent::MembershipChange(..)
             | TimelineItemContent::ProfileChange(..)
@@ -543,7 +543,7 @@ impl TimelineItemContent {
             | TimelineItemContent::CallInvite
             | TimelineItemContent::CallNotify => {
                 // No reactions for these kind of items.
-                Default::default()
+                None
             }
         }
     }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -39,7 +39,7 @@ use ruma::{
             history_visibility::RoomHistoryVisibilityEventContent,
             join_rules::RoomJoinRulesEventContent,
             member::{Change, RoomMemberEventContent, SyncRoomMemberEvent},
-            message::{Relation, RoomMessageEventContent, SyncRoomMessageEvent},
+            message::{MessageType, Relation, SyncRoomMessageEvent},
             name::RoomNameEventContent,
             pinned_events::RoomPinnedEventsEventContent,
             power_levels::{RoomPowerLevels, RoomPowerLevelsEventContent},
@@ -50,7 +50,7 @@ use ruma::{
         },
         space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
         sticker::{StickerEventContent, SyncStickerEvent},
-        AnyFullStateEventContent, AnySyncTimelineEvent, FullStateEventContent,
+        AnyFullStateEventContent, AnySyncTimelineEvent, FullStateEventContent, Mentions,
         MessageLikeEventType, StateEventType,
     },
     html::RemoveReplyFallback,
@@ -199,7 +199,8 @@ impl TimelineItemContent {
 
                 let msglike = MsgLikeContent {
                     kind: MsgLikeKind::Message(Message::from_event(
-                        event_content,
+                        event_content.msgtype,
+                        event_content.mentions,
                         edit,
                         RemoveReplyFallback::Yes,
                     )),
@@ -410,7 +411,8 @@ impl TimelineItemContent {
     // These constructors could also be `From` implementations, but that would
     // allow users to call them directly, which should not be supported
     pub(crate) fn message(
-        c: RoomMessageEventContent,
+        msgtype: MessageType,
+        mentions: Option<Mentions>,
         reactions: ReactionsByKeyBySender,
         thread_root: Option<OwnedEventId>,
         in_reply_to: Option<InReplyToDetails>,
@@ -420,7 +422,12 @@ impl TimelineItemContent {
             if in_reply_to.is_some() { RemoveReplyFallback::Yes } else { RemoveReplyFallback::No };
 
         Self::MsgLike(MsgLikeContent {
-            kind: MsgLikeKind::Message(Message::from_event(c, None, remove_reply_fallback)),
+            kind: MsgLikeKind::Message(Message::from_event(
+                msgtype,
+                mentions,
+                None,
+                remove_reply_fallback,
+            )),
             reactions,
             thread_root,
             in_reply_to,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/polls.rs
@@ -50,24 +50,13 @@ pub(in crate::timeline) struct ResponseData {
 }
 
 impl PollState {
-    pub(crate) fn new(
-        content: NewUnstablePollStartEventContent,
-        edit: Option<NewUnstablePollStartEventContentWithoutRelation>,
-    ) -> Self {
-        let mut ret = Self {
+    pub(crate) fn new(content: NewUnstablePollStartEventContent) -> Self {
+        Self {
             start_event_content: content,
             response_data: vec![],
             end_event_timestamp: None,
             has_been_edited: false,
-        };
-
-        if let Some(edit) = edit {
-            // SAFETY: [`Self::edit`] only returns `None` when the poll has ended, not the
-            // case here.
-            ret = ret.edit(edit).unwrap();
         }
-
-        ret
     }
 
     /// Applies an edit to a poll, returns `None` if the poll was already marked

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -145,7 +145,8 @@ impl RepliedToEvent {
 
                     TimelineItemContent::MsgLike(MsgLikeContent {
                         kind: MsgLikeKind::Message(Message::from_event(
-                            c,
+                            c.msgtype,
+                            c.mentions,
                             extract_room_msg_edit_content(event.relations()),
                             RemoveReplyFallback::Yes,
                         )),

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -199,7 +199,7 @@ impl RepliedToEvent {
                     let thread_summary = None;
 
                     // TODO: could we provide the bundled edit here?
-                    let poll_state = PollState::new(content, None);
+                    let poll_state = PollState::new(content);
                     TimelineItemContent::MsgLike(MsgLikeContent {
                         kind: MsgLikeKind::Poll(poll_state),
                         reactions,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -314,6 +314,11 @@ impl EventTimelineItem {
         &self.content
     }
 
+    /// Get a mutable handle to the content of this item.
+    pub(crate) fn content_mut(&mut self) -> &mut TimelineItemContent {
+        &mut self.content
+    }
+
     /// Get the read receipts of this item.
     ///
     /// The key is the ID of a room member and the value are details about the

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -426,18 +426,16 @@ async fn test_updated_reply_doesnt_lose_latest_edit() {
         )
         .await;
 
-    {
-        // The reply is updated.
-        let item = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
-        // And still has the latest edit JSON.
-        assert!(item.latest_edit_json().is_some());
-        assert_eq!(item.content().as_message().unwrap().body(), "guten tag");
+    // The original is updated.
+    let item = assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
+    // And now has a latest edit JSON.
+    assert!(item.latest_edit_json().is_some());
 
-        // The original is updated.
-        let item = assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
-        // And now has a latest edit JSON.
-        assert!(item.latest_edit_json().is_some());
+    // The reply is updated.
+    let item = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    // And still has the latest edit JSON.
+    assert!(item.latest_edit_json().is_some());
+    assert_eq!(item.content().as_message().unwrap().body(), "guten tag");
 
-        assert_pending!(stream);
-    }
+    assert_pending!(stream);
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -83,7 +83,10 @@ async fn test_default_filter() {
     timeline.handle_live_event(f.reaction(third_event_id, "+1").sender(&BOB)).await;
     timeline.handle_live_event(f.redaction(second_event_id).sender(&BOB)).await;
     let item = assert_next_matches!(stream, VectorDiff::Set { index: 3, value } => value);
-    assert_eq!(item.as_event().unwrap().content().reactions().len(), 1);
+    assert_eq!(
+        item.as_event().unwrap().content().reactions().cloned().unwrap_or_default().len(),
+        1
+    );
 
     // TODO: After adding raw timeline items, check for one here.
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -130,7 +130,7 @@ async fn test_redaction_before_event() {
     assert_matches!(first_item.latest_edit_json(), None);
 
     // And the reactions didn't get applied.
-    assert!(first_item.content().reactions().is_empty());
+    assert!(first_item.content().reactions().cloned().unwrap_or_default().is_empty());
 }
 
 #[async_test]
@@ -142,13 +142,13 @@ async fn test_reaction_redaction() {
 
     timeline.handle_live_event(f.text_msg("hi!").sender(&ALICE)).await;
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
-    assert_eq!(item.content().reactions().len(), 0);
+    assert_eq!(item.content().reactions().cloned().unwrap_or_default().len(), 0);
 
     let msg_event_id = item.event_id().unwrap();
 
     timeline.handle_live_event(f.reaction(msg_event_id, "+1").sender(&BOB)).await;
     let item = assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
-    assert_eq!(item.content().reactions().len(), 1);
+    assert_eq!(item.content().reactions().cloned().unwrap_or_default().len(), 1);
 
     // TODO: After adding raw timeline items, check for one here
 
@@ -156,7 +156,7 @@ async fn test_reaction_redaction() {
 
     timeline.handle_live_event(f.redaction(reaction_event_id).sender(&BOB)).await;
     let item = assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
-    assert_eq!(item.content().reactions().len(), 0);
+    assert_eq!(item.content().reactions().cloned().unwrap_or_default().len(), 0);
 }
 
 #[async_test]
@@ -200,6 +200,6 @@ async fn test_reaction_redaction_timeline_filter() {
     // Redacting the reaction doesn't add a timeline item.
     timeline.handle_live_event(f.redaction(reaction_event_id).sender(&BOB)).await;
     let item = assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
-    assert_eq!(item.content().reactions().len(), 0);
+    assert_eq!(item.content().reactions().cloned().unwrap_or_default().len(), 0);
     assert_eq!(timeline.controller.items().await.len(), 2);
 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -236,7 +236,7 @@ async fn test_focused_timeline_does_not_react() {
 
     let event_item = items[1].as_event().unwrap();
     assert_eq!(event_item.content().as_message().unwrap().body(), "yolo");
-    assert_eq!(event_item.content().reactions().len(), 0);
+    assert_eq!(event_item.content().reactions().cloned().unwrap_or_default().len(), 0);
 
     assert_pending!(timeline_stream);
 
@@ -310,7 +310,7 @@ async fn test_focused_timeline_local_echoes() {
 
     let event_item = items[1].as_event().unwrap();
     assert_eq!(event_item.content().as_message().unwrap().body(), "yolo");
-    assert_eq!(event_item.content().reactions().len(), 0);
+    assert_eq!(event_item.content().reactions().cloned().unwrap_or_default().len(), 0);
 
     sleep(Duration::from_millis(100)).await;
     assert_pending!(timeline_stream);
@@ -328,7 +328,7 @@ async fn test_focused_timeline_local_echoes() {
     // Text hasn't changed.
     assert_eq!(event_item.content().as_message().unwrap().body(), "yolo");
     // But now there's one reaction to the event.
-    let reactions = event_item.content().reactions();
+    let reactions = event_item.content().reactions().cloned().unwrap_or_default();
     assert_eq!(reactions.len(), 1);
     assert!(reactions.get("✨").unwrap().get(client.user_id().unwrap()).is_some());
 
@@ -389,7 +389,7 @@ async fn test_focused_timeline_doesnt_show_local_echoes() {
 
     let event_item = items[1].as_event().unwrap();
     assert_eq!(event_item.content().as_message().unwrap().body(), "yolo");
-    assert_eq!(event_item.content().reactions().len(), 0);
+    assert_eq!(event_item.content().reactions().cloned().unwrap_or_default().len(), 0);
 
     assert_pending!(timeline_stream);
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
@@ -295,7 +295,7 @@ async fn test_react_to_local_media() {
         assert_eq!(get_filename_and_caption(msg.msgtype()), ("test.bin", None));
 
         // The item starts with no reactions.
-        assert!(item.content().reactions().is_empty());
+        assert!(item.content().reactions().cloned().unwrap_or_default().is_empty());
 
         item.identifier()
     };
@@ -308,7 +308,7 @@ async fn test_react_to_local_media() {
     assert_eq!(get_filename_and_caption(msg.msgtype()), ("test.bin", None));
 
     // There's a reaction for the current user for the given emoji.
-    let reactions = item.content().reactions();
+    let reactions = item.content().reactions().cloned().unwrap_or_default();
     let own_user_id = client.user_id().unwrap();
     reactions.get("🤪").unwrap().get(own_user_id).unwrap();
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -110,7 +110,7 @@ async fn test_reaction() {
     assert_let!(Some(msg) = event_item.content().as_message());
     assert!(!msg.is_edited());
     assert_eq!(event_item.read_receipts().len(), 2);
-    assert_eq!(event_item.content().reactions().len(), 0);
+    assert_eq!(event_item.content().reactions().cloned().unwrap_or_default().len(), 0);
 
     // Then the reaction is taken into account.
     assert_let!(VectorDiff::Set { index: 0, value: updated_message } = &timeline_updates[2]);
@@ -118,8 +118,9 @@ async fn test_reaction() {
     assert_let!(Some(msg) = event_item.content().as_message());
     assert!(!msg.is_edited());
     assert_eq!(event_item.read_receipts().len(), 2);
-    assert_eq!(event_item.content().reactions().len(), 1);
-    let group = &event_item.content().reactions()["👍"];
+    let reactions = event_item.content().reactions().cloned().unwrap_or_default();
+    assert_eq!(reactions.len(), 1);
+    let group = &reactions["👍"];
     assert_eq!(group.len(), 1);
     let senders: Vec<_> = group.keys().collect();
     assert_eq!(senders.as_slice(), [*BOB]);
@@ -145,7 +146,7 @@ async fn test_reaction() {
     let event_item = updated_message.as_event().unwrap();
     assert_let!(Some(msg) = event_item.content().as_message());
     assert!(!msg.is_edited());
-    assert_eq!(event_item.content().reactions().len(), 0);
+    assert_eq!(event_item.content().reactions().cloned().unwrap_or_default().len(), 0);
 
     assert_pending!(timeline_stream);
 }

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -186,7 +186,7 @@ async fn test_toggling_reaction() -> Result<()> {
         // Local echo is added.
         {
             let event = assert_event_is_updated!(timeline_updates[0], event_id, message_position);
-            let reactions = event.content().reactions();
+            let reactions = event.content().reactions().cloned().unwrap_or_default();
             let reactions = reactions.get(&reaction_key).unwrap();
             let reaction = reactions.get(&user_id).unwrap();
             assert_matches!(reaction.status, ReactionStatus::LocalToRemote(..));
@@ -196,7 +196,7 @@ async fn test_toggling_reaction() -> Result<()> {
         {
             let event = assert_event_is_updated!(timeline_updates[1], event_id, message_position);
 
-            let reactions = event.content().reactions();
+            let reactions = event.content().reactions().cloned().unwrap_or_default();
             let reactions = reactions.get(&reaction_key).unwrap();
             assert_eq!(reactions.keys().count(), 1);
 
@@ -223,7 +223,7 @@ async fn test_toggling_reaction() -> Result<()> {
 
         // The reaction is removed.
         let event = assert_event_is_updated!(timeline_updates[0], event_id, message_position);
-        assert!(event.content().reactions().is_empty());
+        assert!(event.content().reactions().cloned().unwrap_or_default().is_empty());
 
         assert_pending!(stream);
     }


### PR DESCRIPTION
This uses the `Aggregations` manager to take care of redactions and edits, allowing us to get rid of the `pending_edits` in the `TimelineMetadata` \o/ Aggregations are now handled in a single manner, which is nice for consistency.

For redactions, this means we now stash a redaction even if we've seen it before the event it redacts, making sure we won't display something that should've been redacted.

For edits, we now do "the right thing", and will look at the position of each edit event we know about, and use the most "recent" one, if we've found any. This will help handling edits within threads as well (as such, helps with #4869), instead of having us implement some more complicated logic for those.

Part of #4823.