### PR TITLE
refactor: Reduce the size of different types

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -1337,7 +1337,8 @@ impl OlmMachine {
                 let (sas, request) = self.runtime.block_on(device.start_verification())?;
 
                 Some(StartSasResult {
-                    sas: Sas { inner: sas, runtime: self.runtime.handle().to_owned() }.into(),
+                    sas: Sas { inner: Box::new(sas), runtime: self.runtime.handle().to_owned() }
+                        .into(),
                     request: request.into(),
                 })
             } else {

--- a/bindings/matrix-sdk-crypto-ffi/src/responses.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/responses.rs
@@ -224,8 +224,8 @@ impl From<&ToDeviceRequest> for Request {
     }
 }
 
-impl From<&RoomMessageRequest> for Request {
-    fn from(r: &RoomMessageRequest) -> Self {
+impl From<&Box<RoomMessageRequest>> for Request {
+    fn from(r: &Box<RoomMessageRequest>) -> Self {
         Self::RoomMessage {
             request_id: r.txn_id.to_string(),
             room_id: r.room_id.to_string(),

--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use anyhow::{bail, Context};
 use matrix_sdk::IdParseError;
 use matrix_sdk_ui::timeline::TimelineEventItemId;
@@ -22,7 +24,7 @@ use crate::{
 };
 
 #[derive(uniffi::Object)]
-pub struct TimelineEvent(pub(crate) AnySyncTimelineEvent);
+pub struct TimelineEvent(pub(crate) Box<AnySyncTimelineEvent>);
 
 #[matrix_sdk_ffi_macros::export]
 impl TimelineEvent {
@@ -39,7 +41,7 @@ impl TimelineEvent {
     }
 
     pub fn event_type(&self) -> Result<TimelineEventType, ClientError> {
-        let event_type = match &self.0 {
+        let event_type = match self.0.deref() {
             AnySyncTimelineEvent::MessageLike(event) => {
                 TimelineEventType::MessageLike { content: event.clone().try_into()? }
             }
@@ -53,7 +55,7 @@ impl TimelineEvent {
 
 impl From<AnyTimelineEvent> for TimelineEvent {
     fn from(event: AnyTimelineEvent) -> Self {
-        Self(event.into())
+        Self(Box::new(event.into()))
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -60,6 +60,14 @@ impl From<AnyTimelineEvent> for TimelineEvent {
 }
 
 #[derive(uniffi::Enum)]
+// A note about this `allow(clippy::large_enum_variant)`.
+// In order to reduce the size of `TimelineEventType`, we would need to
+// put some parts in a `Box`, or an `Arc`. Sadly, it doesn't play well with
+// UniFFI. We would need to change the `uniffi::Record` of the subtypes into
+// `uniffi::Object`, which is a radical change. It would simplify the memory
+// usage, but it would slow down the performance around the FFI border. Thus,
+// let's consider this is a false-positive lint in this particular case.
+#[allow(clippy::large_enum_variant)]
 pub enum TimelineEventType {
     MessageLike { content: MessageLikeEventContent },
     State { content: StateEventContent },
@@ -134,6 +142,14 @@ impl TryFrom<AnySyncStateEvent> for StateEventContent {
 }
 
 #[derive(uniffi::Enum)]
+// A note about this `allow(clippy::large_enum_variant)`.
+// In order to reduce the size of `MessageLineEventContent`, we would need to
+// put some parts in a `Box`, or an `Arc`. Sadly, it doesn't play well with
+// UniFFI. We would need to change the `uniffi::Record` of the subtypes into
+// `uniffi::Object`, which is a radical change. It would simplify the memory
+// usage, but it would slow down the performance around the FFI border. Thus,
+// let's consider this is a false-positive lint in this particular case.
+#[allow(clippy::large_enum_variant)]
 pub enum MessageLikeEventContent {
     CallAnswer,
     CallInvite,

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -96,6 +96,14 @@ impl From<matrix_sdk_ui::timeline::TimelineItemContent> for TimelineItemContent 
 }
 
 #[derive(Clone, uniffi::Enum)]
+// A note about this `allow(clippy::large_enum_variant)`.
+// In order to reduce the size of `TimelineItemContent`, we would need to
+// put some parts in a `Box`, or an `Arc`. Sadly, it doesn't play well with
+// UniFFI. We would need to change the `uniffi::Record` of the subtypes into
+// `uniffi::Object`, which is a radical change. It would simplify the memory
+// usage, but it would slow down the performance around the FFI border. Thus,
+// let's consider this is a false-positive lint in this particular case.
+#[allow(clippy::large_enum_variant)]
 pub enum TimelineItemContent {
     MsgLike {
         content: MsgLikeContent,

--- a/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
@@ -252,6 +252,7 @@ impl ThreadSummary {
 }
 
 #[derive(Clone, uniffi::Enum)]
+#[allow(clippy::large_enum_variant)]
 pub enum ThreadSummaryLatestEventDetails {
     Unavailable,
     Pending,

--- a/bindings/matrix-sdk-ffi/src/timeline/reply.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/reply.rs
@@ -60,6 +60,7 @@ impl From<matrix_sdk_ui::timeline::InReplyToDetails> for InReplyToDetails {
 }
 
 #[derive(Clone, uniffi::Enum)]
+#[allow(clippy::large_enum_variant)]
 pub enum RepliedToEventDetails {
     Unavailable,
     Pending,

--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -14,7 +14,7 @@
 
 use std::{
     collections::BTreeMap,
-    io::{Error as IoError, ErrorKind, Read},
+    io::{Error as IoError, Read},
 };
 
 use aes::{
@@ -66,7 +66,7 @@ impl<R: Read> Read for AttachmentDecryptor<'_, R> {
             if hash.as_slice() == self.expected_hash.as_slice() {
                 Ok(0)
             } else {
-                Err(IoError::new(ErrorKind::Other, "Hash mismatch while decrypting"))
+                Err(IoError::other("Hash mismatch while decrypting"))
             }
         } else {
             self.sha.update(&buf[0..read_bytes]);

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -60,8 +60,10 @@ use crate::{
 
 pub enum MaybeEncryptedRoomKey {
     Encrypted {
-        used_session: Session,
-        share_info: ShareInfo,
+        // `Box` the session to reduce the size of `Encrypted`.
+        used_session: Box<Session>,
+        // `Box` the session to reduce the size of `Encrypted`.
+        share_info: Box<ShareInfo>,
         message: Raw<AnyToDeviceEventContent>,
     },
     /// We could not encrypt a message to this device because there is no active
@@ -832,12 +834,12 @@ impl DeviceData {
 
         match self.encrypt(store, &event_type, content).await {
             Ok((session, encrypted)) => Ok(MaybeEncryptedRoomKey::Encrypted {
-                share_info: ShareInfo::new_shared(
+                share_info: Box::new(ShareInfo::new_shared(
                     session.sender_key().to_owned(),
                     message_index,
                     self.olm_wedging_index,
-                ),
-                used_session: session,
+                )),
+                used_session: Box::new(session),
                 message: encrypted.cast(),
             }),
 

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
@@ -310,14 +310,14 @@ impl GroupSessionManager {
 
             match result.maybe_encrypted_room_key {
                 MaybeEncryptedRoomKey::Encrypted { used_session, share_info, message } => {
-                    result_builder.on_successful_encryption(&result.device, used_session, message);
+                    result_builder.on_successful_encryption(&result.device, *used_session, message);
 
                     let user_id = result.device.user_id().to_owned();
                     let device_id = result.device.device_id().to_owned();
                     share_infos
                         .entry(user_id)
                         .or_insert_with(BTreeMap::new)
-                        .insert(device_id, share_info);
+                        .insert(device_id, *share_info);
                 }
                 MaybeEncryptedRoomKey::MissingSession => {
                     result_builder.on_missing_session(result.device);

--- a/crates/matrix-sdk-crypto/src/types/requests/enums.rs
+++ b/crates/matrix-sdk-crypto/src/types/requests/enums.rs
@@ -129,7 +129,7 @@ impl From<OutgoingVerificationRequest> for AnyOutgoingRequest {
     fn from(request: OutgoingVerificationRequest) -> Self {
         match request {
             OutgoingVerificationRequest::ToDevice(r) => AnyOutgoingRequest::ToDeviceRequest(r),
-            OutgoingVerificationRequest::InRoom(r) => AnyOutgoingRequest::RoomMessage(Box::new(r)),
+            OutgoingVerificationRequest::InRoom(r) => AnyOutgoingRequest::RoomMessage(r),
         }
     }
 }

--- a/crates/matrix-sdk-crypto/src/types/requests/enums.rs
+++ b/crates/matrix-sdk-crypto/src/types/requests/enums.rs
@@ -58,7 +58,8 @@ pub enum AnyOutgoingRequest {
     SignatureUpload(SignatureUploadRequest),
     /// A room message request, usually for sending in-room interactive
     /// verification events.
-    RoomMessage(RoomMessageRequest),
+    // `Box` the `RoomMessageRequest` to reduce the size of the enum.
+    RoomMessage(Box<RoomMessageRequest>),
 }
 
 #[cfg(test)]
@@ -96,7 +97,7 @@ impl From<ToDeviceRequest> for AnyOutgoingRequest {
 
 impl From<RoomMessageRequest> for AnyOutgoingRequest {
     fn from(request: RoomMessageRequest) -> Self {
-        Self::RoomMessage(request)
+        Self::RoomMessage(Box::new(request))
     }
 }
 
@@ -128,7 +129,7 @@ impl From<OutgoingVerificationRequest> for AnyOutgoingRequest {
     fn from(request: OutgoingVerificationRequest) -> Self {
         match request {
             OutgoingVerificationRequest::ToDevice(r) => AnyOutgoingRequest::ToDeviceRequest(r),
-            OutgoingVerificationRequest::InRoom(r) => AnyOutgoingRequest::RoomMessage(r),
+            OutgoingVerificationRequest::InRoom(r) => AnyOutgoingRequest::RoomMessage(Box::new(r)),
         }
     }
 }

--- a/crates/matrix-sdk-crypto/src/types/requests/room_message.rs
+++ b/crates/matrix-sdk-crypto/src/types/requests/room_message.rs
@@ -28,5 +28,5 @@ pub struct RoomMessageRequest {
     pub txn_id: OwnedTransactionId,
 
     /// The event content to send.
-    pub content: AnyMessageLikeEventContent,
+    pub content: Box<AnyMessageLikeEventContent>,
 }

--- a/crates/matrix-sdk-crypto/src/types/requests/verification.rs
+++ b/crates/matrix-sdk-crypto/src/types/requests/verification.rs
@@ -22,7 +22,8 @@ pub enum OutgoingVerificationRequest {
     /// The to-device verification request variant.
     ToDevice(ToDeviceRequest),
     /// The in-room verification request variant.
-    InRoom(RoomMessageRequest),
+    // `Box` the `RoomMessageRequest` to reduce the size of the enum.
+    InRoom(Box<RoomMessageRequest>),
 }
 
 impl OutgoingVerificationRequest {
@@ -43,6 +44,6 @@ impl From<ToDeviceRequest> for OutgoingVerificationRequest {
 
 impl From<RoomMessageRequest> for OutgoingVerificationRequest {
     fn from(r: RoomMessageRequest) -> Self {
-        OutgoingVerificationRequest::InRoom(r)
+        OutgoingVerificationRequest::InRoom(Box::new(r))
     }
 }

--- a/crates/matrix-sdk-crypto/src/verification/cache.rs
+++ b/crates/matrix-sdk-crypto/src/verification/cache.rs
@@ -140,7 +140,7 @@ impl VerificationCache {
     }
 
     #[cfg(feature = "qrcode")]
-    pub fn get_qr(&self, sender: &UserId, flow_id: &str) -> Option<QrVerification> {
+    pub fn get_qr(&self, sender: &UserId, flow_id: &str) -> Option<Box<QrVerification>> {
         self.get(sender, flow_id).and_then(as_variant!(Verification::QrV1))
     }
 
@@ -177,7 +177,7 @@ impl VerificationCache {
             .collect()
     }
 
-    pub fn get_sas(&self, user_id: &UserId, flow_id: &str) -> Option<Sas> {
+    pub fn get_sas(&self, user_id: &UserId, flow_id: &str) -> Option<Box<Sas>> {
         self.get(user_id, flow_id).and_then(as_variant!(Verification::SasV1))
     }
 

--- a/crates/matrix-sdk-crypto/src/verification/event_enums.rs
+++ b/crates/matrix-sdk-crypto/src/verification/event_enums.rs
@@ -345,7 +345,7 @@ macro_rules! try_from_outgoing_content {
                         }
                     }
                     OutgoingContent::ToDevice(c) => {
-                        if let AnyToDeviceEventContent::$enum_variant(c) = c {
+                        if let AnyToDeviceEventContent::$enum_variant(c) = c.as_ref() {
                             Ok(Self::ToDevice(c))
                         } else {
                             Err(())
@@ -382,7 +382,7 @@ impl<'a> TryFrom<&'a OutgoingContent> for RequestContent<'a> {
                 }
             }
             OutgoingContent::ToDevice(c) => {
-                if let AnyToDeviceEventContent::KeyVerificationRequest(c) = c {
+                if let AnyToDeviceEventContent::KeyVerificationRequest(c) = c.as_ref() {
                     Ok(Self::ToDevice(c))
                 } else {
                     Err(())
@@ -651,7 +651,7 @@ impl OwnedAcceptContent {
 #[derive(Clone, Debug)]
 pub enum OutgoingContent {
     Room(OwnedRoomId, Box<AnyMessageLikeEventContent>),
-    ToDevice(AnyToDeviceEventContent),
+    ToDevice(Box<AnyToDeviceEventContent>),
 }
 
 impl From<OwnedStartContent> for OutgoingContent {
@@ -669,7 +669,7 @@ impl From<OwnedStartContent> for OutgoingContent {
 
 impl From<AnyToDeviceEventContent> for OutgoingContent {
     fn from(content: AnyToDeviceEventContent) -> Self {
-        OutgoingContent::ToDevice(content)
+        OutgoingContent::ToDevice(Box::new(content))
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/verification/event_enums.rs
+++ b/crates/matrix-sdk-crypto/src/verification/event_enums.rs
@@ -701,6 +701,12 @@ impl From<RoomMessageRequest> for OutgoingContent {
     }
 }
 
+impl From<Box<RoomMessageRequest>> for OutgoingContent {
+    fn from(value: Box<RoomMessageRequest>) -> Self {
+        (value.room_id, value.content).into()
+    }
+}
+
 impl TryFrom<ToDeviceRequest> for OutgoingContent {
     type Error = String;
 

--- a/crates/matrix-sdk-crypto/src/verification/event_enums.rs
+++ b/crates/matrix-sdk-crypto/src/verification/event_enums.rs
@@ -338,7 +338,7 @@ macro_rules! try_from_outgoing_content {
             fn try_from(value: &'a OutgoingContent) -> Result<Self, Self::Error> {
                 match value {
                     OutgoingContent::Room(_, c) => {
-                        if let AnyMessageLikeEventContent::$enum_variant(c) = c {
+                        if let AnyMessageLikeEventContent::$enum_variant(c) = c.as_ref() {
                             Ok(Self::Room(c))
                         } else {
                             Err(())
@@ -371,7 +371,7 @@ impl<'a> TryFrom<&'a OutgoingContent> for RequestContent<'a> {
     fn try_from(value: &'a OutgoingContent) -> Result<Self, Self::Error> {
         match value {
             OutgoingContent::Room(_, c) => {
-                if let AnyMessageLikeEventContent::RoomMessage(m) = c {
+                if let AnyMessageLikeEventContent::RoomMessage(m) = c.as_ref() {
                     if let MessageType::VerificationRequest(c) = &m.msgtype {
                         Ok(Self::Room(c))
                     } else {
@@ -650,7 +650,7 @@ impl OwnedAcceptContent {
 
 #[derive(Clone, Debug)]
 pub enum OutgoingContent {
-    Room(OwnedRoomId, AnyMessageLikeEventContent),
+    Room(OwnedRoomId, Box<AnyMessageLikeEventContent>),
     ToDevice(AnyToDeviceEventContent),
 }
 
@@ -675,6 +675,12 @@ impl From<AnyToDeviceEventContent> for OutgoingContent {
 
 impl From<(OwnedRoomId, AnyMessageLikeEventContent)> for OutgoingContent {
     fn from(content: (OwnedRoomId, AnyMessageLikeEventContent)) -> Self {
+        OutgoingContent::Room(content.0, Box::new(content.1))
+    }
+}
+
+impl From<(OwnedRoomId, Box<AnyMessageLikeEventContent>)> for OutgoingContent {
+    fn from(content: (OwnedRoomId, Box<AnyMessageLikeEventContent>)) -> Self {
         OutgoingContent::Room(content.0, content.1)
     }
 }

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -257,17 +257,16 @@ impl VerificationMachine {
         requests.extend(self.verifications.garbage_collect());
 
         for request in requests {
-            if let Ok(OutgoingContent::ToDevice(AnyToDeviceEventContent::KeyVerificationCancel(
-                content,
-            ))) = request.clone().try_into()
-            {
-                let event = ToDeviceEvent { content, sender: self.own_user_id().to_owned() };
+            if let Ok(OutgoingContent::ToDevice(to_device)) = request.clone().try_into() {
+                if let AnyToDeviceEventContent::KeyVerificationCancel(content) = *to_device {
+                    let event = ToDeviceEvent { content, sender: self.own_user_id().to_owned() };
 
-                events.push(
-                    Raw::new(&event)
-                        .expect("Failed to serialize m.key_verification.cancel event")
-                        .cast(),
-                );
+                    events.push(
+                        Raw::new(&event)
+                            .expect("Failed to serialize m.key_verification.cancel event")
+                            .cast(),
+                    );
+                }
             }
 
             self.verifications.add_verification_request(request)

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -204,7 +204,7 @@ impl VerificationMachine {
         self.verifications.get(user_id, flow_id)
     }
 
-    pub fn get_sas(&self, user_id: &UserId, flow_id: &str) -> Option<Sas> {
+    pub fn get_sas(&self, user_id: &UserId, flow_id: &str) -> Option<Box<Sas>> {
         self.verifications.get_sas(user_id, flow_id)
     }
 

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -781,7 +781,7 @@ pub(crate) mod tests {
         let content = if let OutgoingContent::ToDevice(c) = content { c } else { unreachable!() };
         let sender = sender.to_owned();
 
-        match content {
+        match *content {
             AnyToDeviceEventContent::KeyVerificationRequest(c) => {
                 ToDeviceEvents::KeyVerificationRequest(ToDeviceEvent { sender, content: c })
             }

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -184,21 +184,23 @@ impl VerificationStore {
 #[non_exhaustive]
 pub enum Verification {
     /// The `m.sas.v1` verification variant.
-    SasV1(Sas),
+    // `Box` the `Sas` to reduce the enum size.
+    SasV1(Box<Sas>),
     /// The `m.qr_code.*.v1` verification variant.
+    // `Box` the `QrVerification` to reduce the enum size.
     #[cfg(feature = "qrcode")]
-    QrV1(QrVerification),
+    QrV1(Box<QrVerification>),
 }
 
 impl Verification {
     /// Try to deconstruct this verification enum into a SAS verification.
-    pub fn sas_v1(self) -> Option<Sas> {
+    pub fn sas_v1(self) -> Option<Box<Sas>> {
         as_variant!(self, Verification::SasV1)
     }
 
     /// Try to deconstruct this verification enum into a QR code verification.
     #[cfg(feature = "qrcode")]
-    pub fn qr_v1(self) -> Option<QrVerification> {
+    pub fn qr_v1(self) -> Option<Box<QrVerification>> {
         as_variant!(self, Verification::QrV1)
     }
 
@@ -267,14 +269,14 @@ impl Verification {
 
 impl From<Sas> for Verification {
     fn from(sas: Sas) -> Self {
-        Self::SasV1(sas)
+        Self::SasV1(Box::new(sas))
     }
 }
 
 #[cfg(feature = "qrcode")]
 impl From<QrVerification> for Verification {
     fn from(qr: QrVerification) -> Self {
-        Self::QrV1(qr)
+        Self::QrV1(Box::new(qr))
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -467,7 +467,9 @@ impl Sas {
                     OwnedAcceptContent::Room(room_id, content) => RoomMessageRequest {
                         room_id,
                         txn_id: TransactionId::new(),
-                        content: AnyMessageLikeEventContent::KeyVerificationAccept(content),
+                        content: Box::new(AnyMessageLikeEventContent::KeyVerificationAccept(
+                            content,
+                        )),
                     }
                     .into(),
                 })

--- a/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
@@ -319,7 +319,8 @@ pub struct SasState<S: Clone> {
     our_public_key: Curve25519PublicKey,
 
     /// Struct holding the identities that are doing the SAS dance.
-    ids: SasIds,
+    // `Box` it to reduce the struct size.
+    ids: Box<SasIds>,
 
     /// The instant when the SAS object was created. If this more than
     /// MAX_AGE seconds are elapsed, the event will be canceled with a
@@ -584,7 +585,7 @@ impl SasState<Created> {
         SasState {
             inner: Arc::new(Mutex::new(Some(sas))),
             our_public_key,
-            ids: SasIds { account, other_device, other_identity, own_identity },
+            ids: Box::new(SasIds { account, other_device, other_identity, own_identity }),
             verification_flow_id: flow_id.into(),
 
             creation_time: Arc::new(Instant::now()),
@@ -692,12 +693,12 @@ impl SasState<Started> {
             last_event_time: Arc::new(Instant::now()),
             started_from_request,
 
-            ids: SasIds {
+            ids: Box::new(SasIds {
                 account: account.clone(),
                 other_device: other_device.clone(),
                 own_identity: own_identity.clone(),
                 other_identity: other_identity.clone(),
-            },
+            }),
 
             verification_flow_id: flow_id.clone(),
             state: Arc::new(Cancelled::new(true, CancelCode::UnknownMethod)),
@@ -731,7 +732,7 @@ impl SasState<Started> {
             inner: Arc::new(Mutex::new(Some(sas))),
             our_public_key,
 
-            ids: SasIds { account, other_device, other_identity, own_identity },
+            ids: Box::new(SasIds { account, other_device, other_identity, own_identity }),
 
             creation_time: Arc::new(Instant::now()),
             last_event_time: Arc::new(Instant::now()),

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -153,7 +153,7 @@ impl NotificationClient {
         event_id: &EventId,
     ) -> Result<Option<NotificationItem>, Error> {
         match self.get_notification_with_sliding_sync(room_id, event_id).await? {
-            NotificationStatus::Event(event) => Ok(Some(event)),
+            NotificationStatus::Event(event) => Ok(Some(*event)),
             NotificationStatus::EventFilteredOut => Ok(None),
             NotificationStatus::EventNotFound => {
                 self.get_notification_with_context(room_id, event_id).await
@@ -185,7 +185,7 @@ impl NotificationClient {
             for event_id in &request.event_ids {
                 match notifications.remove(event_id) {
                     Some(Ok(NotificationStatus::Event(item))) => {
-                        notification_items.add_notification(event_id.to_owned(), item);
+                        notification_items.add_notification(event_id.to_owned(), *item);
                     }
                     Some(Ok(NotificationStatus::EventNotFound)) | None => {
                         match self.get_notification_with_context(&request.room_id, event_id).await {
@@ -688,7 +688,7 @@ impl NotificationClient {
                         Vec::new(),
                     )
                     .await
-                    .map(NotificationStatus::Event);
+                    .map(|event| NotificationStatus::Event(Box::new(event)));
 
                     match notification_status {
                         Ok(notification_item) => {
@@ -771,7 +771,7 @@ fn is_event_encrypted(event_type: TimelineEventType) -> bool {
 
 #[derive(Debug)]
 pub enum NotificationStatus {
-    Event(NotificationItem),
+    Event(Box<NotificationItem>),
     EventNotFound,
     EventFilteredOut,
 }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -148,6 +148,7 @@ pub(super) enum HandleAggregationKind {
 
 /// An action that we want to cause on the timeline.
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub(super) enum TimelineAction {
     /// Add a new timeline item.
     ///

--- a/crates/matrix-sdk/src/authentication/matrix/login_builder.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/login_builder.rs
@@ -309,7 +309,7 @@ where
     /// Panics if a session was already restored or logged in.
     #[instrument(target = "matrix_sdk::client", name = "login", skip_all, fields(method = "sso"))]
     pub async fn send(self) -> Result<login::v3::Response> {
-        use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+        use std::io::Error as IoError;
 
         use serde::Deserialize;
 
@@ -333,11 +333,10 @@ where
 
         (self.use_sso_login_url)(sso_url).await?;
 
-        let query_string = server_handle
-            .await
-            .ok_or_else(|| IoError::new(IoErrorKind::Other, "Could not get the loginToken"))?;
+        let query_string =
+            server_handle.await.ok_or_else(|| IoError::other("Could not get the loginToken"))?;
         let token = serde_html_form::from_str::<QueryParameters>(&query_string)
-            .map_err(|e| IoError::new(IoErrorKind::Other, e))?
+            .map_err(IoError::other)?
             .login_token;
 
         let login_builder = LoginBuilder {

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel.rs
@@ -39,12 +39,14 @@ type Etag = String;
 fn get_header(
     header_map: &HeaderMap,
     header_name: &HeaderName,
-) -> Result<String, FromHttpResponseError<RumaApiError>> {
+) -> Result<String, Box<FromHttpResponseError<RumaApiError>>> {
     let header = header_map
         .get(header_name)
-        .ok_or(HeaderDeserializationError::MissingHeader(ETAG.to_string()))?;
+        .ok_or(HeaderDeserializationError::MissingHeader(ETAG.to_string()))
+        .map_err(|error| Box::new(FromHttpResponseError::from(error)))?;
 
-    let header = header.to_str()?.to_owned();
+    let header =
+        header.to_str().map_err(|error| Box::new(FromHttpResponseError::from(error)))?.to_owned();
 
     Ok(header)
 }

--- a/crates/matrix-sdk/src/client/builder/homeserver_config.rs
+++ b/crates/matrix-sdk/src/client/builder/homeserver_config.rs
@@ -174,7 +174,7 @@ async fn discover_homeserver(
         )
         .await
         .map_err(|e| match e {
-            HttpError::Api(err) => ClientBuildError::AutoDiscovery(err),
+            HttpError::Api(err) => ClientBuildError::AutoDiscovery(*err),
             err => ClientBuildError::Http(err),
         })?;
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3027,12 +3027,7 @@ pub(crate) mod tests {
         assert_eq!(client.server_versions().await.unwrap().len(), 1);
 
         // This second call hits the in-memory cache.
-        assert!(client
-            .server_versions()
-            .await
-            .unwrap()
-            .iter()
-            .any(|version| *version == MatrixVersion::V1_0));
+        assert!(client.server_versions().await.unwrap().contains(&MatrixVersion::V1_0));
 
         drop(client);
 
@@ -3069,12 +3064,7 @@ pub(crate) mod tests {
         // Hits network again.
         assert_eq!(client.server_versions().await.unwrap().len(), 1);
         // Hits in-memory cache again.
-        assert!(client
-            .server_versions()
-            .await
-            .unwrap()
-            .iter()
-            .any(|version| *version == MatrixVersion::V1_0));
+        assert!(client.server_versions().await.unwrap().contains(&MatrixVersion::V1_0));
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/encryption/identities/devices.rs
+++ b/crates/matrix-sdk/src/encryption/identities/devices.rs
@@ -236,7 +236,7 @@ impl Device {
         let (sas, request) = self.inner.start_verification().await?;
         self.client.send_to_device(&request).await?;
 
-        Ok(SasVerification { inner: sas, client: self.client.clone() })
+        Ok(SasVerification { inner: Box::new(sas), client: self.client.clone() })
     }
 
     /// Manually verify this device.

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -554,7 +554,7 @@ impl Client {
 
         self.get_room(room_id)
             .expect("Can't send a message to a room that isn't known to the store")
-            .send(content)
+            .send(*content)
             .with_transaction_id(txn_id)
             .await
     }
@@ -783,8 +783,8 @@ impl Encryption {
         let olm = olm.as_ref()?;
         #[allow(clippy::bind_instead_of_map)]
         olm.get_verification(user_id, flow_id).and_then(|v| match v {
-            matrix_sdk_base::crypto::Verification::SasV1(s) => {
-                Some(SasVerification { inner: s, client: self.client.clone() }.into())
+            matrix_sdk_base::crypto::Verification::SasV1(sas) => {
+                Some(SasVerification { inner: sas, client: self.client.clone() }.into())
             }
             #[cfg(feature = "qrcode")]
             matrix_sdk_base::crypto::Verification::QrV1(qr) => {

--- a/crates/matrix-sdk/src/encryption/verification/qrcode.rs
+++ b/crates/matrix-sdk/src/encryption/verification/qrcode.rs
@@ -24,7 +24,7 @@ use crate::{Client, Result};
 /// An object controlling QR code style key verification flows.
 #[derive(Debug, Clone)]
 pub struct QrVerification {
-    pub(crate) inner: BaseQrVerification,
+    pub(crate) inner: Box<BaseQrVerification>,
     pub(crate) client: Client,
 }
 

--- a/crates/matrix-sdk/src/encryption/verification/sas.rs
+++ b/crates/matrix-sdk/src/encryption/verification/sas.rs
@@ -23,7 +23,7 @@ use crate::{error::Result, Client};
 /// An object controlling the short auth string verification flow.
 #[derive(Debug, Clone)]
 pub struct SasVerification {
-    pub(crate) inner: BaseSas,
+    pub(crate) inner: Box<BaseSas>,
     pub(crate) client: Client,
 }
 

--- a/crates/matrix-sdk/src/room/identity_status_changes.rs
+++ b/crates/matrix-sdk/src/room/identity_status_changes.rs
@@ -186,7 +186,8 @@ fn wrap_room_member_events(
             if *event.state_key() == own_user_id {
                 return;
             }
-            let _: Result<_, _> = sender.send(RoomIdentityChange::SyncRoomMemberEvent(event)).await;
+            let _: Result<_, _> =
+                sender.send(RoomIdentityChange::SyncRoomMemberEvent(Box::new(event))).await;
         });
     let drop_guard = room.client.event_handler_drop_guard(handle);
     (drop_guard, ReceiverStream::new(receiver))

--- a/crates/matrix-sdk/src/room/reply.rs
+++ b/crates/matrix-sdk/src/room/reply.rs
@@ -61,7 +61,7 @@ struct RepliedToInfo {
 #[derive(Debug, Clone)]
 enum ReplyContent {
     /// Content of a message event.
-    Message(RoomMessageEventContent),
+    Message(Box<RoomMessageEventContent>),
     /// Content of any other kind of event stored as raw JSON.
     Raw(Raw<AnySyncTimelineEvent>),
 }
@@ -144,7 +144,7 @@ async fn make_reply_event<S: EventSource>(
                 sender: replied_to_info.sender,
                 origin_server_ts: replied_to_info.timestamp,
                 room_id: room_id.to_owned(),
-                content: replied_to_content,
+                content: *replied_to_content,
                 unsigned: Default::default(),
             };
 
@@ -244,7 +244,7 @@ async fn replied_to_info_from_event_id<S: EventSource>(
                 original_event,
             )) = event
             {
-                ReplyContent::Message(original_event.content.clone())
+                ReplyContent::Message(Box::new(original_event.content.clone()))
             } else {
                 ReplyContent::Raw(raw_event)
             }

--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -52,7 +52,12 @@ impl FromWidgetErrorResponse {
     /// Create a error response to send to the widget from an http error.
     pub(crate) fn from_http_error(error: HttpError) -> Self {
         let message = error.to_string();
-        let matrix_api_error = as_variant!(error, HttpError::Api(ruma::api::error::FromHttpResponseError::Server(RumaApiError::ClientApi(err))) => err);
+        let matrix_api_error = match error {
+            HttpError::Api(error) => {
+                as_variant!(*error, ruma::api::error::FromHttpResponseError::Server(RumaApiError::ClientApi(err)) => err)
+            }
+            _ => None,
+        };
 
         Self {
             error: FromWidgetError {

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::large_enum_variant)]
+
 use std::{
     collections::HashMap,
     io::{self, stdout, Write},

--- a/testing/matrix-sdk-integration-testing/src/tests/nse.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/nse.rs
@@ -389,17 +389,17 @@ impl NotificationClientWrapper {
                 .expect("Failed to get_notification");
 
             if let Some(item) = item {
-                if let NotificationEvent::Timeline(AnySyncTimelineEvent::MessageLike(e)) =
-                    item.event
-                {
-                    if let AnyMessageLikeEventContent::RoomMessage(c) =
-                        e.original_content().expect("Empty original content")
-                    {
-                        self.events
-                            .lock()
-                            .unwrap()
-                            .push((event_info.0.clone(), c.body().to_owned()));
-                        return;
+                if let NotificationEvent::Timeline(sync_timeline_event) = item.event {
+                    if let AnySyncTimelineEvent::MessageLike(event) = sync_timeline_event.as_ref() {
+                        if let AnyMessageLikeEventContent::RoomMessage(event_content) =
+                            event.original_content().expect("Empty original content")
+                        {
+                            self.events
+                                .lock()
+                                .unwrap()
+                                .push((event_info.0.clone(), event_content.body().to_owned()));
+                            return;
+                        }
                     }
                 }
             };

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -183,19 +183,25 @@ async fn test_notification() -> Result<()> {
         assert_matches!(
             notification.event,
             NotificationEvent::Timeline(
-                matrix_sdk::ruma::events::AnySyncTimelineEvent::MessageLike(
-                    matrix_sdk::ruma::events::AnySyncMessageLikeEvent::RoomMessage(
-                        SyncMessageLikeEvent::Original(event)
-                    )
-                )
+                sync_timeline_event
             ) => {
-                assert_matches!(event.content.msgtype,
-                    matrix_sdk::ruma::events::room::message::MessageType::Text(text) => {
-                        assert_eq!(text.body, "Hello world!");
-                    });
-                }
+                assert_matches!(
+                    sync_timeline_event.as_ref(),
+                    matrix_sdk::ruma::events::AnySyncTimelineEvent::MessageLike(
+                        matrix_sdk::ruma::events::AnySyncMessageLikeEvent::RoomMessage(
+                            SyncMessageLikeEvent::Original(event)
+                        )
+                    ) => {
+                        assert_matches!(
+                            &event.content.msgtype,
+                            matrix_sdk::ruma::events::room::message::MessageType::Text(text) => {
+                                assert_eq!(text.body, "Hello world!");
+                            }
+                        );
+                    }
+                );
+            }
         );
-
         assert_eq!(notification.sender_display_name.as_deref(), Some(ALICE_NAME));
         assert_eq!(notification.room_computed_display_name, ROOM_NAME);
     };

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -207,7 +207,7 @@ async fn test_notification() -> Result<()> {
         NotificationStatus::Event(notification) =
             notification_client.get_notification_with_sliding_sync(&room_id, &event_id).await?
     );
-    check_notification(true, notification);
+    check_notification(true, *notification);
 
     // Check with `/context`.
     let notification_client = NotificationClient::new(bob.clone(), process_setup).await.unwrap();


### PR DESCRIPTION
Since the migration to Rust 1.87, Clippy is emitting warnings: [`enum_large_variant`](https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant). The tl;dr is:

> Enum size is bounded by the largest variant. Having one large variant can penalize the memory layout of that enum.

In most cases, this is relevant. In a few places, we consider this is a false-positive (esp. in `matrix-sdk-ffi` where it could hurt performances). Please, review this pull request patch-by-patch for more clarity.