### PR TITLE
feat(widgets): Add the `controlledMediaOutput` url parameter to the `VirtualElementCallWidgetOptions`.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -248,6 +248,11 @@ pub struct VirtualElementCallWidgetOptions {
     /// Sentry [environment](https://docs.sentry.io/concepts/key-terms/key-terms/)
     /// Supported since Element Call v0.9.0. Only used by the embedded package.
     pub sentry_environment: Option<String>,
+    //// - `true`: The webview should show the list of media devices it detects using
+    ////   `enumerateDevices`.
+    ///  - `false`: the webview shows a a list of devices injected by the
+    ///    client. (used on ios & android)
+    pub controlled_media_devices: bool,
 }
 
 impl From<VirtualElementCallWidgetOptions> for matrix_sdk::widget::VirtualElementCallWidgetOptions {
@@ -271,6 +276,7 @@ impl From<VirtualElementCallWidgetOptions> for matrix_sdk::widget::VirtualElemen
             rageshake_submit_url: value.rageshake_submit_url,
             sentry_dsn: value.sentry_dsn,
             sentry_environment: value.sentry_environment,
+            controlled_media_devices: value.controlled_media_devices,
         }
     }
 }


### PR DESCRIPTION
This is used to configure EC on devices that need to control media outputs on their own (android, ios).
If set, EC will display a list of devices provided by the app.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
