### PR TITLE
Test: Replace `sync_timeline_event!` with `EventFactory` for beacon events in room integration test

### DIFF
--- a/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
@@ -234,13 +234,14 @@ async fn test_most_recent_event_in_stream() {
 
     let f = EventFactory::new();
     for nth in 0..25 {
+        let event_id = format!("$event_for_stream_{nth}");
         timeline_events.push(
             f.beacon(
                 owned_event_id!("$15139375514XsgmR:localhost"),
                 format!("geo:{nth}.9575274619722,12.494122581370175;u={nth}"),
                 Some(MilliSecondsSinceUnixEpoch(1_636_829_458u32.into())),
             )
-            .event_id(<&EventId>::try_from(format!("$event_for_stream_{nth}").as_str()).unwrap())
+            .event_id(<&EventId>::try_from(event_id.as_str()).unwrap())
             .server_ts(1_636_829_458)
             .sender(user_id!("@example2:localhost"))
             .age(598971)

--- a/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
@@ -7,8 +7,8 @@ use matrix_sdk::{
     test_utils::mocks::MatrixMockServer,
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, sync_timeline_event,
-    test_json, JoinedRoomBuilder, SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
+    async_test, event_factory::EventFactory, mocks::mock_encryption_state, test_json,
+    JoinedRoomBuilder, SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
 };
 use ruma::{
     event_id,

--- a/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
@@ -238,7 +238,9 @@ async fn test_most_recent_event_in_stream() {
         timeline_events.push(
             f.beacon(
                 owned_event_id!("$15139375514XsgmR:localhost"),
-                format!("geo:{nth}.9575274619722,12.494122581370175;u={nth}"),
+                nth as f64 + 0.9575274619722,
+                12.494122581370175,
+                nth,
                 Some(MilliSecondsSinceUnixEpoch(1_636_829_458u32.into())),
             )
             .event_id(<&EventId>::try_from(event_id.as_str()).unwrap())
@@ -264,7 +266,10 @@ async fn test_most_recent_event_in_stream() {
 
     assert_eq!(user_id.to_string(), "@example2:localhost");
 
-    assert_eq!(last_location.location.uri, "geo:24.9575274619722,12.494122581370175;u=24");
+    assert_eq!(
+        last_location.location.uri,
+        format!("geo:{},{};u=24", 24.9575274619722, 12.494122581370175)
+    );
 
     assert!(last_location.location.description.is_none());
     assert!(last_location.location.zoom_level.is_none());
@@ -337,7 +342,9 @@ async fn test_observe_single_live_location_share() {
     let timeline_event = EventFactory::new()
         .beacon(
             owned_event_id!("$test_beacon_info"),
-            "geo:10.000000,20.000000;u=5".to_owned(),
+            10.000000,
+            20.000000,
+            5,
             Some(MilliSecondsSinceUnixEpoch(1_636_829_458u32.into())),
         )
         .event_id(event_id!("$location_event"))
@@ -363,7 +370,7 @@ async fn test_observe_single_live_location_share() {
         stream.next().await.expect("Another live location was expected");
 
     assert_eq!(user_id.to_string(), "@example2:localhost");
-    assert_eq!(last_location.location.uri, "geo:10.000000,20.000000;u=5");
+    assert_eq!(last_location.location.uri, format!("geo:{},{};u=5", 10.000000, 20.000000));
     assert_eq!(last_location.ts, current_time);
 
     let beacon_info = beacon_info.expect("Live location share is missing the beacon_info");

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -114,12 +114,21 @@ struct Unsigned<C: EventContent> {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     redacted_because: Option<RedactedBecause>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    age: Option<Int>,
 }
 
 // rustc can't derive Default because C isn't marked as `Default` 🤔 oh well.
 impl<C: EventContent> Default for Unsigned<C> {
     fn default() -> Self {
-        Self { prev_content: None, transaction_id: None, relations: None, redacted_because: None }
+        Self {
+            prev_content: None,
+            transaction_id: None,
+            relations: None,
+            redacted_because: None,
+            age: None,
+        }
     }
 }
 
@@ -174,6 +183,12 @@ where
     pub fn unsigned_transaction_id(mut self, transaction_id: &TransactionId) -> Self {
         self.unsigned.get_or_insert_with(Default::default).transaction_id =
             Some(transaction_id.to_owned());
+        self
+    }
+
+    /// Add age to unsigned data in this event.
+    pub fn age(mut self, age: impl Into<Int>) -> Self {
+        self.unsigned.get_or_insert_with(Default::default).age = Some(age.into());
         self
     }
 

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -807,6 +807,29 @@ impl EventFactory {
     }
 
     /// Create a new `org.matrix.msc3672.beacon` event.
+    ///
+    /// ```
+    /// use matrix_sdk_test::event_factory::EventFactory;
+    /// use ruma::{
+    ///     events::{beacon::BeaconEventContent, MessageLikeEvent},
+    ///     owned_event_id, room_id,
+    ///     serde::Raw,
+    ///     user_id, MilliSecondsSinceUnixEpoch,
+    /// };
+    ///
+    /// let factory = EventFactory::new().room(room_id!("!test:localhost"));
+    ///
+    /// let event: Raw<MessageLikeEvent<BeaconEventContent>> = factory
+    ///     .beacon(
+    ///         owned_event_id!("$123456789abc:localhost"),
+    ///         10.1,
+    ///         15.2,
+    ///         5,
+    ///         Some(MilliSecondsSinceUnixEpoch(1000u32.into())),
+    ///     )
+    ///     .sender(user_id!("@alice:localhost"))
+    ///     .into_raw();
+    /// ```
     pub fn beacon(
         &self,
         beacon_info_event_id: OwnedEventId,

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -810,9 +810,12 @@ impl EventFactory {
     pub fn beacon(
         &self,
         beacon_info_event_id: OwnedEventId,
-        geo_uri: String,
+        latitude: f64,
+        longitude: f64,
+        uncertainty: u32,
         ts: Option<MilliSecondsSinceUnixEpoch>,
     ) -> EventBuilder<BeaconEventContent> {
+        let geo_uri = format!("geo:{latitude},{longitude};u={uncertainty}");
         self.event(BeaconEventContent::new(beacon_info_event_id, geo_uri, ts))
     }
 

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -25,6 +25,7 @@ use matrix_sdk_common::deserialized_responses::{
 };
 use ruma::{
     events::{
+        beacon::BeaconEventContent,
         member_hints::MemberHintsEventContent,
         poll::{
             unstable_end::UnstablePollEndEventContent,
@@ -788,6 +789,16 @@ impl EventFactory {
         event.alias = alias;
         event.alt_aliases = alt_aliases;
         self.event(event)
+    }
+
+    /// Create a new `org.matrix.msc3672.beacon` event.
+    pub fn beacon(
+        &self,
+        beacon_info_event_id: OwnedEventId,
+        geo_uri: String,
+        ts: Option<MilliSecondsSinceUnixEpoch>,
+    ) -> EventBuilder<BeaconEventContent> {
+        self.event(BeaconEventContent::new(beacon_info_event_id, geo_uri, ts))
     }
 
     /// Set the next server timestamp.


### PR DESCRIPTION
Part of #3716

I _think_ I've done something sensible for adding the ability to put age into the unsigned data of an event, but it's possible I've misunderstood how the fields on `Unsigned` are being used.

It seemed like fields from different `*Unsigned` types from `ruma` were all put onto the single `Unsigned` struct (ie, `transaction_id` and `relations` from `RoomMemberUnsigned`, and `redacted_because` from `RedactedUnsigned`), and that some but not all fields on an `Unsigned` instance within an `EventBuilder` would be made a `Some` value depending on what event type was being created.

So, I just stuck another field onto `Unsigned` to allow `age` to be in the unsigned data, even though it's not a field that's available on every `*Unsigned` type, imagining it'd be used only for events which actually could have `age` in the unsigned data. Hope that makes sense!

And apologies for the slightly gnarly `<&EventId>::try_from` bit. I would have just used the `event_id!` macro, but rust doesn't allow doing `event_id!(format!(...))` (ie, trying to run one macro and then pass its output as input to another macro).

Signed-off-by: Yousef Moazzam <yousefmoazzam@hotmail.co.uk>