### PR TITLE
feat(sdk,ui): Unset the unread flag when sending unthreaded receipts

### DIFF
--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project will be documented in this file.
   a remote timeline item before the `TimelineStart` virtual timeline item.
   ([#5000](https://github.com/matrix-org/matrix-rust-sdk/pull/5000))
 
+### Features
+
+- `Timeline::send_single_receipt()` and `Timeline::send_multiple_receipts()` now also unset the
+  unread flag of the room if an unthreaded read receipt is sent.
+  ([#5055](https://github.com/matrix-org/matrix-rust-sdk/pull/5055))
+- `Timeline::mark_as_read()` unsets the unread flag of the room if it was set.
+  ([#5055](https://github.com/matrix-org/matrix-rust-sdk/pull/5055))
+
 ## [0.11.0] - 2025-04-11
 
 ### Bug Fixes

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -545,7 +545,7 @@ impl Timeline {
                 "not sending receipt, because we already cover the event with a previous receipt"
             );
 
-            if thread == ReceiptThread::Unthreaded && self.room().is_marked_unread() {
+            if thread == ReceiptThread::Unthreaded {
                 // Unset the read marker.
                 self.room().set_unread_flag(false).await?;
             }
@@ -608,7 +608,7 @@ impl Timeline {
 
         if !receipts.is_empty() {
             self.room().send_multiple_receipts(receipts).await?;
-        } else if self.room().is_marked_unread() {
+        } else {
             self.room().set_unread_flag(false).await?;
         }
 
@@ -632,10 +632,8 @@ impl Timeline {
         } else {
             trace!("can't mark room as read because there's no latest event id");
 
-            if self.room().is_marked_unread() {
-                // Unset the read marker.
-                self.room().set_unread_flag(false).await?;
-            }
+            // Unset the read marker.
+            self.room().set_unread_flag(false).await?;
 
             Ok(false)
         }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -606,10 +606,12 @@ impl Timeline {
             }
         }
 
+        let room = self.room();
+
         if !receipts.is_empty() {
-            self.room().send_multiple_receipts(receipts).await?;
+            room.send_multiple_receipts(receipts).await?;
         } else {
-            self.room().set_unread_flag(false).await?;
+            room.set_unread_flag(false).await?;
         }
 
         Ok(())

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -33,9 +33,9 @@ use ruma::{
     events::{
         receipt::{ReceiptThread, ReceiptType as EventReceiptType},
         room::message::{MessageType, RoomMessageEventContent, SyncRoomMessageEvent},
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, RoomAccountDataEventType,
     },
-    room_id, uint, user_id, MilliSecondsSinceUnixEpoch, RoomVersionId,
+    owned_event_id, room_id, uint, user_id, MilliSecondsSinceUnixEpoch, RoomVersionId,
 };
 use serde_json::json;
 use stream_assert::{assert_pending, assert_ready};
@@ -731,6 +731,172 @@ async fn test_send_single_receipt() {
 }
 
 #[async_test]
+async fn test_send_single_receipt_with_unread_flag() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+    let own_user_id = client.user_id().unwrap();
+
+    let first_receipts_event_id = owned_event_id!("$first_receipts_event_id");
+    let second_receipts_event_id = owned_event_id!("$second_receipts_event_id");
+
+    // Initial sync with our test room, with read receipts and marked unread.
+    let f = EventFactory::new();
+    let room = server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::default()
+                .add_receipt(
+                    f.read_receipts()
+                        .add(
+                            &first_receipts_event_id,
+                            own_user_id,
+                            EventReceiptType::ReadPrivate,
+                            ReceiptThread::Unthreaded,
+                        )
+                        .add(
+                            &first_receipts_event_id,
+                            own_user_id,
+                            EventReceiptType::Read,
+                            ReceiptThread::Unthreaded,
+                        )
+                        .add(
+                            &first_receipts_event_id,
+                            own_user_id,
+                            EventReceiptType::Read,
+                            ReceiptThread::Main,
+                        )
+                        .into_event(),
+                )
+                .add_account_data(RoomAccountDataTestEvent::Custom(json!({
+                    "content": {
+                        "event_id": first_receipts_event_id,
+                    },
+                    "type": "m.fully_read",
+                })))
+                .add_account_data(RoomAccountDataTestEvent::MarkedUnread),
+        )
+        .await;
+    assert!(room.is_marked_unread());
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let timeline = room.timeline().await.unwrap();
+
+    // Unchanged unthreaded receipts are not sent, but the unread flag is unset.
+    {
+        let _guard = server
+            .mock_set_room_account_data(RoomAccountDataEventType::MarkedUnread)
+            .ok()
+            .expect(3)
+            .mount_as_scoped()
+            .await;
+
+        timeline
+            .send_single_receipt(
+                CreateReceiptType::Read,
+                ReceiptThread::Unthreaded,
+                first_receipts_event_id.clone(),
+            )
+            .await
+            .unwrap();
+        timeline
+            .send_single_receipt(
+                CreateReceiptType::ReadPrivate,
+                ReceiptThread::Unthreaded,
+                first_receipts_event_id.clone(),
+            )
+            .await
+            .unwrap();
+        timeline
+            .send_single_receipt(
+                CreateReceiptType::FullyRead,
+                ReceiptThread::Unthreaded,
+                first_receipts_event_id,
+            )
+            .await
+            .unwrap();
+    }
+
+    // Unthreaded receipts on unknown events are set and the unread flag is unset.
+    {
+        let _guards = (
+            server
+                .mock_send_receipt(CreateReceiptType::Read)
+                .ok()
+                .expect(1)
+                .named("Public read receipt")
+                .mount_as_scoped()
+                .await,
+            server
+                .mock_send_receipt(CreateReceiptType::ReadPrivate)
+                .ok()
+                .expect(1)
+                .named("Private read receipt")
+                .mount_as_scoped()
+                .await,
+            server
+                .mock_send_receipt(CreateReceiptType::FullyRead)
+                .ok()
+                .expect(1)
+                .named("Fully-read marker")
+                .mount_as_scoped()
+                .await,
+            server
+                .mock_set_room_account_data(RoomAccountDataEventType::MarkedUnread)
+                .ok()
+                .expect(3)
+                .mount_as_scoped()
+                .await,
+        );
+
+        timeline
+            .send_single_receipt(
+                CreateReceiptType::Read,
+                ReceiptThread::Unthreaded,
+                second_receipts_event_id.clone(),
+            )
+            .await
+            .unwrap();
+        timeline
+            .send_single_receipt(
+                CreateReceiptType::ReadPrivate,
+                ReceiptThread::Unthreaded,
+                second_receipts_event_id.clone(),
+            )
+            .await
+            .unwrap();
+        timeline
+            .send_single_receipt(
+                CreateReceiptType::FullyRead,
+                ReceiptThread::Unthreaded,
+                second_receipts_event_id.clone(),
+            )
+            .await
+            .unwrap();
+    }
+
+    // Threaded receipt with unknown previous receipt is sent, but the unread flag
+    // is not unset.
+    {
+        let _guard = server
+            .mock_send_receipt(CreateReceiptType::Read)
+            .ok()
+            .expect(1)
+            .mount_as_scoped()
+            .await;
+
+        timeline
+            .send_single_receipt(
+                CreateReceiptType::Read,
+                ReceiptThread::Main,
+                second_receipts_event_id,
+            )
+            .await
+            .unwrap();
+    }
+}
+
+#[async_test]
 async fn test_mark_as_read() {
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
@@ -801,6 +967,111 @@ async fn test_mark_as_read() {
 
     // It works.
     assert!(has_sent);
+}
+
+#[async_test]
+async fn test_mark_as_read_with_unread_flag() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    // Initial sync with our test room, marked unread.
+    let room = server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::default().add_account_data(RoomAccountDataTestEvent::MarkedUnread),
+        )
+        .await;
+    assert!(room.is_marked_unread());
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let timeline = room.timeline().await.unwrap();
+
+    let original_event_id = event_id!("$original_event_id");
+    let reaction_event_id = event_id!("$reaction_event_id");
+
+    // When I receive an event with a reaction on it,
+    let f = EventFactory::new();
+    let own_user_id = client.user_id().unwrap();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::default()
+                .add_timeline_event(
+                    f.text_msg("I like big Rust and I cannot lie")
+                        .sender(user_id!("@sir-axalot:example.org"))
+                        .event_id(original_event_id),
+                )
+                .add_receipt(
+                    f.read_receipts()
+                        .add(
+                            original_event_id,
+                            own_user_id,
+                            EventReceiptType::Read,
+                            ReceiptThread::Unthreaded,
+                        )
+                        .into_event(),
+                )
+                .add_timeline_event(
+                    f.reaction(original_event_id, "🔥🔥🔥")
+                        .sender(user_id!("@prime-minirusta:example.org"))
+                        .event_id(reaction_event_id),
+                ),
+        )
+        .await;
+
+    {
+        let _send_receipt_guard = server
+            .mock_send_receipt(CreateReceiptType::Read)
+            .ok()
+            .expect(1)
+            .mount_as_scoped()
+            .await;
+        let _set_room_account_data_guard = server
+            .mock_set_room_account_data(RoomAccountDataEventType::MarkedUnread)
+            .ok()
+            .expect(1)
+            .mount_as_scoped()
+            .await;
+
+        // When I mark the room as read by sending a read receipt to the latest event,
+        let has_sent = timeline.mark_as_read(CreateReceiptType::Read).await.unwrap();
+
+        // The receipt is sent and the unread flag was unset.
+        assert!(has_sent);
+    }
+
+    // Mock receiving the read receipt only.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::default().add_receipt(
+                f.read_receipts()
+                    .add(
+                        reaction_event_id,
+                        own_user_id,
+                        EventReceiptType::Read,
+                        ReceiptThread::Unthreaded,
+                    )
+                    .into_event(),
+            ),
+        )
+        .await;
+
+    {
+        let _set_room_account_data_guard = server
+            .mock_set_room_account_data(RoomAccountDataEventType::MarkedUnread)
+            .ok()
+            .expect(1)
+            .mount_as_scoped()
+            .await;
+
+        // When I mark the room as read by sending a read receipt to the latest event,
+        let has_sent = timeline.mark_as_read(CreateReceiptType::Read).await.unwrap();
+
+        // The receipt is not sent but the unread flag was unset.
+        assert!(!has_sent);
+    }
 }
 
 #[async_test]
@@ -956,6 +1227,94 @@ async fn test_send_multiple_receipts() {
         .await;
 
     timeline.send_multiple_receipts(second_receipts.clone()).await.unwrap();
+}
+
+#[async_test]
+async fn test_send_multiple_receipts_with_unread_flag() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+    let own_user_id = client.user_id().unwrap();
+
+    let first_receipts_event_id = owned_event_id!("$first_receipts_event_id");
+    let second_receipts_event_id = owned_event_id!("$second_receipts_event_id");
+
+    // Initial sync with our test room, with read receipts and marked unread.
+    let f = EventFactory::new();
+    let room = server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::default()
+                .add_receipt(
+                    f.read_receipts()
+                        .add(
+                            &first_receipts_event_id,
+                            own_user_id,
+                            EventReceiptType::ReadPrivate,
+                            ReceiptThread::Unthreaded,
+                        )
+                        .add(
+                            &first_receipts_event_id,
+                            own_user_id,
+                            EventReceiptType::Read,
+                            ReceiptThread::Unthreaded,
+                        )
+                        .add(
+                            &first_receipts_event_id,
+                            own_user_id,
+                            EventReceiptType::Read,
+                            ReceiptThread::Main,
+                        )
+                        .into_event(),
+                )
+                .add_account_data(RoomAccountDataTestEvent::Custom(json!({
+                    "content": {
+                        "event_id": first_receipts_event_id,
+                    },
+                    "type": "m.fully_read",
+                })))
+                .add_account_data(RoomAccountDataTestEvent::MarkedUnread),
+        )
+        .await;
+    assert!(room.is_marked_unread());
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let timeline = room.timeline().await.unwrap();
+
+    // Unchanged receipts are not sent, but the unread flag is unset.
+    {
+        let _guard = server
+            .mock_set_room_account_data(RoomAccountDataEventType::MarkedUnread)
+            .ok()
+            .expect(1)
+            .mount_as_scoped()
+            .await;
+
+        let first_receipts = Receipts::new()
+            .fully_read_marker(Some(first_receipts_event_id.clone()))
+            .public_read_receipt(Some(first_receipts_event_id.clone()))
+            .private_read_receipt(Some(first_receipts_event_id));
+        timeline.send_multiple_receipts(first_receipts).await.unwrap();
+    }
+
+    // Receipts with unknown previous receipts are always sent, and the unread flag
+    // is unset.
+    {
+        let _read_markers_guard =
+            server.mock_send_read_markers().ok().expect(1).mount_as_scoped().await;
+        let _marked_unread_guard = server
+            .mock_set_room_account_data(RoomAccountDataEventType::MarkedUnread)
+            .ok()
+            .expect(1)
+            .mount_as_scoped()
+            .await;
+
+        let second_receipts = Receipts::new()
+            .fully_read_marker(Some(second_receipts_event_id.clone()))
+            .public_read_receipt(Some(second_receipts_event_id.clone()))
+            .private_read_receipt(Some(second_receipts_event_id));
+        timeline.send_multiple_receipts(second_receipts.clone()).await.unwrap();
+    }
 }
 
 #[async_test]

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -25,11 +25,14 @@ All notable changes to this project will be documented in this file.
 - `Room::set_unread_flag()` now sets the stable `m.marked_unread` room account data, which was
   stabilized in Matrix 1.12. `Room::is_marked_unread()` also ignores the unstable
   `com.famedly.marked_unread` room account data if the stable variant is present.
+  ([#5034](https://github.com/matrix-org/matrix-rust-sdk/pull/5034))
 - `Encryption::encrypt_and_send_raw_to_device`: Introduced as an experimental method for
   sending custom encrypted to-device events. This feature is gated behind the
   `experimental-send-custom-to-device` flag, as it remains under active development and may undergo changes.
   ([4998](https://github.com/matrix-org/matrix-rust-sdk/pull/4998))
-
+- `Room::send_single_receipt()` and `Room::send_multiple_receipts()` now also unset the unread
+  flag of the room if an unthreaded read receipt is sent.
+  ([#5055](https://github.com/matrix-org/matrix-rust-sdk/pull/5055))
 
 ### Bug fixes
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -53,6 +53,8 @@ All notable changes to this project will be documented in this file.
   `get_all_rooms`, `get_rooms`, `get_number_of_rooms`, and
   `FrozenSlidingSync` methods and type have been removed.
   ([#5047](https://github.com/matrix-org/matrix-rust-sdk/pull/5047))
+- `Room::set_unread_flag()` is now a no-op if the unread flag already has the wanted value.
+  ([#5055](https://github.com/matrix-org/matrix-rust-sdk/pull/5055))
 
 ## [0.11.0] - 2025-04-11
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3163,8 +3163,8 @@ impl Room {
     /// Set a flag on the room to indicate that the user has explicitly marked
     /// it as (un)read.
     ///
-    /// This is a no-op if [`Room::is_marked_unread()`] returns the same value
-    /// as `unread`.
+    /// This is a no-op if [`BaseRoom::is_marked_unread()`] returns the same
+    /// value as `unread`.
     pub async fn set_unread_flag(&self, unread: bool) -> Result<()> {
         if self.is_marked_unread() == unread {
             // The request is not necessary.

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -29,12 +29,12 @@ use matrix_sdk_test::{
 };
 use percent_encoding::{AsciiSet, CONTROLS};
 use ruma::{
-    api::client::room::Visibility,
+    api::client::{receipt::create_receipt::v3::ReceiptType, room::Visibility},
     device_id,
     directory::PublicRoomsChunk,
     events::{
         room::member::RoomMemberEvent, AnyStateEvent, AnyTimelineEvent, GlobalAccountDataEventType,
-        MessageLikeEventType, StateEventType,
+        MessageLikeEventType, RoomAccountDataEventType, StateEventType,
     },
     serde::Raw,
     time::Duration,
@@ -1049,6 +1049,34 @@ impl MatrixMockServer {
     pub fn mock_global_account_data(&self) -> MockEndpoint<'_, GlobalAccountDataEndpoint> {
         let mock = Mock::given(method("GET"));
         self.mock_endpoint(mock, GlobalAccountDataEndpoint).expect_default_access_token()
+    }
+
+    /// Create a prebuilt mock for the endpoint used to send a single receipt.
+    pub fn mock_send_receipt(
+        &self,
+        receipt_type: ReceiptType,
+    ) -> MockEndpoint<'_, ReceiptEndpoint> {
+        let mock = Mock::given(method("POST"))
+            .and(path_regex(format!("^/_matrix/client/v3/rooms/.*/receipt/{receipt_type}/")));
+        self.mock_endpoint(mock, ReceiptEndpoint).expect_default_access_token()
+    }
+
+    /// Create a prebuilt mock for the endpoint used to send multiple receipts.
+    pub fn mock_send_read_markers(&self) -> MockEndpoint<'_, ReadMarkersEndpoint> {
+        let mock = Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/v3/rooms/.*/read_markers"));
+        self.mock_endpoint(mock, ReadMarkersEndpoint).expect_default_access_token()
+    }
+
+    /// Create a prebuilt mock for the endpoint used to set room account data.
+    pub fn mock_set_room_account_data(
+        &self,
+        data_type: RoomAccountDataEventType,
+    ) -> MockEndpoint<'_, RoomAccountDataEndpoint> {
+        let mock = Mock::given(method("PUT")).and(path_regex(format!(
+            "^/_matrix/client/v3/user/.*/rooms/.*/account_data/{data_type}"
+        )));
+        self.mock_endpoint(mock, RoomAccountDataEndpoint).expect_default_access_token()
     }
 }
 
@@ -2798,5 +2826,37 @@ impl RoomRelationsResponseTemplate {
     pub fn recursion_depth(mut self, depth: u32) -> Self {
         self.recursion_depth = Some(depth);
         self
+    }
+}
+
+/// A prebuilt mock for `POST /rooms/{roomId}/receipt/{receiptType}/{eventId}`
+/// request.
+pub struct ReceiptEndpoint;
+
+impl<'a> MockEndpoint<'a, ReceiptEndpoint> {
+    /// Returns a successful empty response.
+    pub fn ok(self) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+    }
+}
+
+/// A prebuilt mock for `POST /rooms/{roomId}/read_markers` request.
+pub struct ReadMarkersEndpoint;
+
+impl<'a> MockEndpoint<'a, ReadMarkersEndpoint> {
+    /// Returns a successful empty response.
+    pub fn ok(self) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+    }
+}
+
+/// A prebuilt mock for `PUT /user/{userId}/rooms/{roomId}/account_data/{type}`
+/// request.
+pub struct RoomAccountDataEndpoint;
+
+impl<'a> MockEndpoint<'a, RoomAccountDataEndpoint> {
+    /// Returns a successful empty response.
+    pub fn ok(self) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }

--- a/testing/matrix-sdk-test/src/sync_builder/test_event.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/test_event.rs
@@ -93,6 +93,7 @@ impl StrippedStateTestEvent {
 pub enum RoomAccountDataTestEvent {
     FullyRead,
     Tags,
+    MarkedUnread,
     Custom(JsonValue),
 }
 
@@ -102,6 +103,7 @@ impl RoomAccountDataTestEvent {
         match self {
             Self::FullyRead => test_json::sync_events::FULLY_READ.to_owned(),
             Self::Tags => test_json::sync_events::TAG.to_owned(),
+            Self::MarkedUnread => test_json::sync_events::MARKED_UNREAD.to_owned(),
             Self::Custom(json) => json,
         }
     }

--- a/testing/matrix-sdk-test/src/test_json/sync_events.rs
+++ b/testing/matrix-sdk-test/src/test_json/sync_events.rs
@@ -706,3 +706,12 @@ pub static TOPIC_REDACTION: Lazy<JsonValue> = Lazy::new(|| {
         }
     })
 });
+
+pub static MARKED_UNREAD: Lazy<JsonValue> = Lazy::new(|| {
+    json!({
+        "content": {
+            "unread": true,
+        },
+        "type": "m.marked_unread",
+    })
+});


### PR DESCRIPTION
This allows to follow [these recommendations from the spec](https://spec.matrix.org/v1.14/client-server-api/#client-behaviour-6) automatically:

> Clients SHOULD reset the unread marker by setting unread to false when opening a room to display its timeline.
>
> Clients that offer functionality to mark a room as read by sending a read receipt for the last event, SHOULD reset the unread marker simultaneously.

Note that there was a function in the bindings doing a similar thing that was removed in https://github.com/matrix-org/matrix-rust-sdk/pull/3119, but it doesn't seem that it was necessary to fix the bug that it was trying to fix.
