### PR TITLE
refactor(timeline): use `TimelineAction::from_event` to create a `RepliedToEvent` struct

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -692,13 +692,18 @@ impl Timeline {
         };
 
         match replied_to {
-            Ok(replied_to) => Ok(Arc::new(InReplyToDetails::new(
+            Ok(Some(replied_to)) => Ok(Arc::new(InReplyToDetails::new(
                 event_id_str,
                 RepliedToEventDetails::Ready {
                     content: replied_to.content().clone().into(),
                     sender: replied_to.sender().to_string(),
                     sender_profile: replied_to.sender_profile().into(),
                 },
+            ))),
+
+            Ok(None) => Ok(Arc::new(InReplyToDetails::new(
+                event_id_str,
+                RepliedToEventDetails::Error { message: "unsupported event".to_owned() },
             ))),
 
             Err(e) => Ok(Arc::new(InReplyToDetails::new(

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -32,7 +32,7 @@ use matrix_sdk::{
     },
 };
 use matrix_sdk_ui::timeline::{
-    self, AttachmentSource, EventItemOrigin, Profile, RepliedToEvent, TimelineDetails,
+    self, AttachmentSource, EventItemOrigin, Profile, TimelineDetails,
     TimelineUniqueId as SdkTimelineUniqueId,
 };
 use mime::Mime;
@@ -687,9 +687,7 @@ impl Timeline {
         let event_id = EventId::parse(&event_id_str)?;
 
         let replied_to = match self.inner.room().load_or_fetch_event(&event_id, None).await {
-            Ok(event) => RepliedToEvent::try_from_timeline_event_for_room(event, self.inner.room())
-                .await
-                .map_err(ClientError::from),
+            Ok(event) => self.inner.make_replied_to(event).await.map_err(ClientError::from),
             Err(e) => Err(ClientError::from(e)),
         };
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -15,30 +15,17 @@
 use std::sync::Arc;
 
 use imbl::Vector;
-use matrix_sdk::{
-    crypto::types::events::UtdCause,
-    deserialized_responses::{TimelineEvent, TimelineEventKind},
-    Room,
-};
-use ruma::{
-    events::{
-        poll::unstable_start::UnstablePollStartEventContent, AnyMessageLikeEventContent,
-        AnySyncTimelineEvent,
-    },
-    html::RemoveReplyFallback,
-    OwnedEventId, OwnedUserId, UserId,
-};
+use matrix_sdk::deserialized_responses::TimelineEvent;
+use ruma::{OwnedEventId, OwnedUserId, UserId};
 use tracing::{debug, instrument, warn};
 
 use super::TimelineItemContent;
 use crate::timeline::{
-    event_item::{
-        content::{MsgLikeContent, MsgLikeKind},
-        extract_room_msg_edit_content, EventTimelineItem, Profile, TimelineDetails,
-    },
+    controller::TimelineMetadata,
+    event_handler::TimelineAction,
+    event_item::{content::MsgLikeContent, EventTimelineItem, Profile, TimelineDetails},
     traits::RoomDataProvider,
-    EncryptedMessage, Error as TimelineError, Message, PollState, ReactionsByKeyBySender, Sticker,
-    TimelineItem,
+    Error as TimelineError, TimelineItem,
 };
 
 /// Details about an event being replied to.
@@ -104,26 +91,23 @@ impl RepliedToEvent {
         }
     }
 
-    /// Try to create a `RepliedToEvent` from a `TimelineEvent` by providing the
-    /// room.
-    pub async fn try_from_timeline_event_for_room(
-        timeline_event: TimelineEvent,
-        room_data_provider: &Room,
-    ) -> Result<Self, TimelineError> {
-        Self::try_from_timeline_event(timeline_event, room_data_provider).await
-    }
-
     #[instrument(skip_all)]
     pub(in crate::timeline) async fn try_from_timeline_event<P: RoomDataProvider>(
         timeline_event: TimelineEvent,
         room_data_provider: &P,
+        timeline_items: &Vector<Arc<TimelineItem>>,
+        meta: &mut TimelineMetadata,
     ) -> Result<Self, TimelineError> {
-        let event = match timeline_event.raw().deserialize() {
-            Ok(AnySyncTimelineEvent::MessageLike(event)) => event,
-            Ok(_) => {
-                warn!("can't get details, event isn't a message-like event");
-                return Err(TimelineError::UnsupportedEvent);
-            }
+        let (raw_event, unable_to_decrypt_info) = match timeline_event.kind {
+            matrix_sdk::deserialized_responses::TimelineEventKind::UnableToDecrypt {
+                utd_info,
+                event,
+            } => (event, Some(utd_info)),
+            _ => (timeline_event.kind.into_raw(), None),
+        };
+
+        let event = match raw_event.deserialize() {
+            Ok(event) => event,
             Err(err) => {
                 warn!("can't get details, event couldn't be deserialized: {err}");
                 return Err(TimelineError::UnsupportedEvent);
@@ -132,94 +116,24 @@ impl RepliedToEvent {
 
         debug!(event_type = %event.event_type(), "got deserialized event");
 
-        let content = match event.original_content() {
-            Some(content) => match content {
-                AnyMessageLikeEventContent::RoomMessage(c) => {
-                    // Assume we're not interested in aggregations in this context:
-                    // this is information for an embedded (replied-to) event, that will usually not
-                    // include detailed information like reactions.
-                    let reactions = ReactionsByKeyBySender::default();
-                    let thread_root = None;
-                    let in_reply_to = None;
-                    let thread_summary = None;
+        let sender = event.sender().to_owned();
+        let action = TimelineAction::from_event(
+            event,
+            &raw_event,
+            room_data_provider,
+            unable_to_decrypt_info,
+            timeline_items,
+            meta,
+        )
+        .await;
 
-                    TimelineItemContent::MsgLike(MsgLikeContent {
-                        kind: MsgLikeKind::Message(Message::from_event(
-                            c.msgtype,
-                            c.mentions,
-                            extract_room_msg_edit_content(event.relations()),
-                            RemoveReplyFallback::Yes,
-                        )),
-                        reactions,
-                        thread_root,
-                        in_reply_to,
-                        thread_summary,
-                    })
-                }
-
-                AnyMessageLikeEventContent::Sticker(content) => {
-                    // Assume we're not interested in aggregations in this context.
-                    // (See above an explanation as to why that's the case.)
-                    let reactions = Default::default();
-                    let thread_root = None;
-                    let in_reply_to = None;
-                    let thread_summary = None;
-
-                    TimelineItemContent::MsgLike(MsgLikeContent {
-                        kind: MsgLikeKind::Sticker(Sticker { content }),
-                        reactions,
-                        thread_root,
-                        in_reply_to,
-                        thread_summary,
-                    })
-                }
-
-                AnyMessageLikeEventContent::RoomEncrypted(content) => {
-                    let utd_cause = match &timeline_event.kind {
-                        TimelineEventKind::UnableToDecrypt { utd_info, .. } => UtdCause::determine(
-                            timeline_event.raw(),
-                            room_data_provider.crypto_context_info().await,
-                            utd_info,
-                        ),
-                        _ => UtdCause::Unknown,
-                    };
-
-                    TimelineItemContent::MsgLike(MsgLikeContent::unable_to_decrypt(
-                        EncryptedMessage::from_content(content, utd_cause),
-                    ))
-                }
-
-                AnyMessageLikeEventContent::UnstablePollStart(
-                    UnstablePollStartEventContent::New(content),
-                ) => {
-                    // Assume we're not interested in aggregations in this context.
-                    // (See above an explanation as to why that's the case.)
-                    let reactions = Default::default();
-                    let thread_root = None;
-                    let in_reply_to = None;
-                    let thread_summary = None;
-
-                    // TODO: could we provide the bundled edit here?
-                    let poll_state = PollState::new(content);
-                    TimelineItemContent::MsgLike(MsgLikeContent {
-                        kind: MsgLikeKind::Poll(poll_state),
-                        reactions,
-                        thread_root,
-                        in_reply_to,
-                        thread_summary,
-                    })
-                }
-
-                _ => {
-                    warn!("unsupported event type");
-                    return Err(TimelineError::UnsupportedEvent);
-                }
-            },
-
-            None => TimelineItemContent::MsgLike(MsgLikeContent::redacted()),
+        let content = if let Some(TimelineAction::AddItem { content, .. }) = action {
+            content
+        } else {
+            // TODO: need some kind of "unsupported" event here: return an option
+            TimelineItemContent::MsgLike(MsgLikeContent::redacted())
         };
 
-        let sender = event.sender().to_owned();
         let sender_profile = TimelineDetails::from_initial_value(
             room_data_provider.profile_from_user_id(&sender).await,
         );

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -25,6 +25,7 @@ use futures_core::Stream;
 use imbl::Vector;
 use matrix_sdk::{
     attachment::AttachmentConfig,
+    deserialized_responses::TimelineEvent,
     event_cache::{EventCacheDropHandles, RoomEventCache},
     event_handler::EventHandlerHandle,
     executor::JoinHandle,
@@ -666,6 +667,12 @@ impl Timeline {
         } else {
             Ok(false)
         }
+    }
+
+    /// Create a [`RepliedToEvent`] from an arbitrary event, be it in the
+    /// timeline or not.
+    pub async fn make_replied_to(&self, event: TimelineEvent) -> Result<RepliedToEvent, Error> {
+        self.controller.make_replied_to(event).await
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -671,7 +671,13 @@ impl Timeline {
 
     /// Create a [`RepliedToEvent`] from an arbitrary event, be it in the
     /// timeline or not.
-    pub async fn make_replied_to(&self, event: TimelineEvent) -> Result<RepliedToEvent, Error> {
+    ///
+    /// Can be `None` if the event cannot be represented as a standalone item,
+    /// because it's an aggregation.
+    pub async fn make_replied_to(
+        &self,
+        event: TimelineEvent,
+    ) -> Result<Option<RepliedToEvent>, Error> {
         self.controller.make_replied_to(event).await
     }
 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -350,7 +350,13 @@ async fn test_fetch_details_utd() {
         let in_reply_to = in_reply_to.clone().unwrap();
         assert_let!(TimelineDetails::Ready(replied_to) = &in_reply_to.event);
         assert_eq!(replied_to.sender(), *ALICE);
-        assert!(replied_to.content().is_unable_to_decrypt());
+        assert_matches!(
+            replied_to.content(),
+            TimelineItemContent::MsgLike(MsgLikeContent {
+                kind: MsgLikeKind::UnableToDecrypt(_),
+                ..
+            })
+        );
     }
 }
 


### PR DESCRIPTION
One more bullet item of #4823. The reply preview will now support all the types that are supported by the timeline, by default, and the UTD hook will also be called when creating a `RepliedToEvent` when the replied-to event is a UTD.

On top of #5046, so draft. Only the latest commit has been added on top of the aforementioned PR.