### PR TITLE
ffi: Refactor timeline creation and lifetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,12 +317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-once-cell"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
-
-[[package]]
 name = "async-rx"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3316,7 +3310,6 @@ dependencies = [
  "assert-json-diff",
  "assert_matches",
  "assert_matches2",
- "async-once-cell",
  "async-rx",
  "async-stream",
  "async_cell",

--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -7,10 +7,7 @@ use matrix_sdk_base::{
 };
 use matrix_sdk_sqlite::SqliteStateStore;
 use matrix_sdk_test::{event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent};
-use matrix_sdk_ui::{
-    timeline::{TimelineBuilder, TimelineFocus},
-    Timeline,
-};
+use matrix_sdk_ui::timeline::{TimelineBuilder, TimelineFocus};
 use ruma::{
     api::client::membership::get_member_events,
     device_id,

--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -7,7 +7,10 @@ use matrix_sdk_base::{
 };
 use matrix_sdk_sqlite::SqliteStateStore;
 use matrix_sdk_test::{event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent};
-use matrix_sdk_ui::{timeline::TimelineFocus, Timeline};
+use matrix_sdk_ui::{
+    timeline::{TimelineBuilder, TimelineFocus},
+    Timeline,
+};
 use ruma::{
     api::client::membership::get_member_events,
     device_id,
@@ -182,7 +185,7 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
                 .await
                 .unwrap();
 
-            let timeline = Timeline::builder(&room)
+            let timeline = TimelineBuilder::new(&room)
                 .with_focus(TimelineFocus::PinnedEvents {
                     max_events_to_load: 100,
                     max_concurrent_requests: 10,

--- a/benchmarks/benches/timeline.rs
+++ b/benchmarks/benches/timeline.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use matrix_sdk::test_utils::mocks::MatrixMockServer;
 use matrix_sdk_test::{event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent};
-use matrix_sdk_ui::{timeline::TimelineBuilder, Timeline};
+use matrix_sdk_ui::timeline::TimelineBuilder;
 use ruma::{
     events::room::message::RoomMessageEventContentWithoutRelation, owned_room_id, owned_user_id,
     EventId,

--- a/benchmarks/benches/timeline.rs
+++ b/benchmarks/benches/timeline.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use matrix_sdk::test_utils::mocks::MatrixMockServer;
 use matrix_sdk_test::{event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent};
-use matrix_sdk_ui::Timeline;
+use matrix_sdk_ui::{timeline::TimelineBuilder, Timeline};
 use ruma::{
     events::room::message::RoomMessageEventContentWithoutRelation, owned_room_id, owned_user_id,
     EventId,
@@ -102,7 +102,7 @@ pub fn create_timeline_with_initial_events(c: &mut Criterion) {
         BenchmarkId::new("create_timeline_with_initial_events", format!("{NUM_EVENTS} events")),
         |b| {
             b.to_async(&runtime).iter(|| async {
-                let timeline = Timeline::builder(&room)
+                let timeline = TimelineBuilder::new(&room)
                     .track_read_marker_and_receipts()
                     .build()
                     .await

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -166,7 +166,6 @@ impl From<PushFormat> for RumaPushFormat {
 #[matrix_sdk_ffi_macros::export(callback_interface)]
 pub trait ClientDelegate: Sync + Send {
     fn did_receive_auth_error(&self, is_soft_logout: bool);
-    fn did_refresh_tokens(&self);
 }
 
 #[matrix_sdk_ffi_macros::export(callback_interface)]
@@ -1492,9 +1491,7 @@ impl Client {
                 SessionChange::UnknownToken { soft_logout } => {
                     delegate.did_receive_auth_error(soft_logout);
                 }
-                SessionChange::TokensRefreshed => {
-                    delegate.did_refresh_tokens();
-                }
+                SessionChange::TokensRefreshed => {}
             });
         } else {
             debug!(

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -26,7 +26,7 @@ use zeroize::Zeroizing;
 use super::client::Client;
 use crate::{
     authentication::OidcConfiguration, client::ClientSessionDelegate, error::ClientError,
-    helpers::unwrap_or_clone_arc, task_handle::TaskHandle, utd::UnableToDecryptDelegate,
+    helpers::unwrap_or_clone_arc, task_handle::TaskHandle,
 };
 
 /// A list of bytes containing a certificate in DER or PEM form.
@@ -288,7 +288,6 @@ pub struct ClientBuilder {
     room_key_recipient_strategy: CollectStrategy,
     decryption_trust_requirement: TrustRequirement,
     request_config: Option<RequestConfig>,
-    utd_hook: Option<Arc<dyn UnableToDecryptDelegate>>,
 }
 
 #[matrix_sdk_ffi_macros::export]
@@ -323,7 +322,6 @@ impl ClientBuilder {
             room_key_recipient_strategy: Default::default(),
             decryption_trust_requirement: TrustRequirement::Untrusted,
             request_config: Default::default(),
-            utd_hook: Default::default(),
         })
     }
 
@@ -561,15 +559,6 @@ impl ClientBuilder {
         Arc::new(builder)
     }
 
-    pub async fn with_utd_hook(
-        self: Arc<Self>,
-        utd_hook: Box<dyn UnableToDecryptDelegate>,
-    ) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.utd_hook = Some(utd_hook.into());
-        Arc::new(builder)
-    }
-
     pub async fn build(self: Arc<Self>) -> Result<Arc<Client>, ClientBuildError> {
         let builder = unwrap_or_clone_arc(self);
         let mut inner_builder = MatrixClient::builder();
@@ -729,13 +718,8 @@ impl ClientBuilder {
         let sdk_client = inner_builder.build().await?;
 
         Ok(Arc::new(
-            Client::new(
-                sdk_client,
-                builder.enable_oidc_refresh_lock,
-                builder.session_delegate,
-                builder.utd_hook,
-            )
-            .await?,
+            Client::new(sdk_client, builder.enable_oidc_refresh_lock, builder.session_delegate)
+                .await?,
         ))
     }
 

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -31,6 +31,7 @@ mod sync_service;
 mod task_handle;
 mod timeline;
 mod tracing;
+mod utd;
 mod utils;
 mod widget;
 

--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -108,7 +108,7 @@ impl NotificationClient {
     pub fn get_room(&self, room_id: String) -> Result<Option<Arc<Room>>, ClientError> {
         let room_id = RoomId::parse(room_id)?;
         let sdk_room = self.inner.get_room(&room_id);
-        let room = sdk_room.map(|room| Arc::new(Room::new(room)));
+        let room = sdk_room.map(|room| Arc::new(Room::new(room, None)));
         Ok(room)
     }
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -236,6 +236,8 @@ impl Room {
         if configuration.report_utds {
             if let Some(utd_hook_manager) = self.utd_hook_manager.clone() {
                 builder = builder.with_unable_to_decrypt_hook(utd_hook_manager);
+            } else {
+                return Err(ClientError::Generic { msg: "Failed creating timeline because the configuration is set to report UTDs but no hook manager is set".to_owned(), details: None });
             }
         }
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -12,7 +12,7 @@ use matrix_sdk::{
     ComposerDraft as SdkComposerDraft, ComposerDraftType as SdkComposerDraftType, EncryptionState,
     RoomHero as SdkRoomHero, RoomMemberships, RoomState,
 };
-use matrix_sdk_ui::timeline::{default_event_filter, RoomExt};
+use matrix_sdk_ui::timeline::{default_event_filter, RoomExt, TimelineBuilder};
 use mime::Mime;
 use ruma::{
     assign,
@@ -189,7 +189,7 @@ impl Room {
         &self,
         configuration: TimelineConfiguration,
     ) -> Result<Arc<Timeline>, ClientError> {
-        let mut builder = matrix_sdk_ui::timeline::Timeline::builder(&self.inner);
+        let mut builder = matrix_sdk_ui::timeline::TimelineBuilder::new(&self.inner);
 
         builder = builder
             .with_focus(configuration.focus.try_into()?)

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -656,11 +656,11 @@ impl Room {
     /// Mark a room as read, by attaching a read receipt on the latest event.
     ///
     /// Note: this does NOT unset the unread flag; it's the caller's
-    /// responsibility to do so, if needs be.
+    /// responsibility to do so, if need be.
     pub async fn mark_as_read(&self, receipt_type: ReceiptType) -> Result<(), ClientError> {
-        let timeline = self.timeline().await?;
+        let timeline = TimelineBuilder::new(&self.inner).build().await?;
 
-        timeline.mark_as_read(receipt_type).await?;
+        timeline.mark_as_read(receipt_type.into()).await?;
         Ok(())
     }
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -86,10 +86,6 @@ impl Room {
     pub(crate) fn new(inner: SdkRoom, utd_hook: Option<Arc<UtdHookManager>>) -> Self {
         Room { inner, timeline: Default::default(), utd_hook }
     }
-
-    pub(crate) fn with_timeline(inner: SdkRoom, timeline: TimelineLock) -> Self {
-        Room { inner, timeline, utd_hook: None }
-    }
 }
 
 #[matrix_sdk_ffi_macros::export]

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -78,13 +78,13 @@ pub(crate) type TimelineLock = Arc<RwLock<Option<Arc<Timeline>>>>;
 #[derive(uniffi::Object)]
 pub struct Room {
     pub(super) inner: SdkRoom,
-    utd_hook: Option<Arc<UtdHookManager>>,
+    utd_hook_manager: Option<Arc<UtdHookManager>>,
     timeline: TimelineLock,
 }
 
 impl Room {
-    pub(crate) fn new(inner: SdkRoom, utd_hook: Option<Arc<UtdHookManager>>) -> Self {
-        Room { inner, timeline: Default::default(), utd_hook }
+    pub(crate) fn new(inner: SdkRoom, utd_hook_manager: Option<Arc<UtdHookManager>>) -> Self {
+        Room { inner, timeline: Default::default(), utd_hook_manager }
     }
 }
 
@@ -234,8 +234,8 @@ impl Room {
         }
 
         if configuration.report_utds {
-            if let Some(utd_hook) = self.utd_hook.clone() {
-                builder = builder.with_unable_to_decrypt_hook(utd_hook);
+            if let Some(utd_hook_manager) = self.utd_hook_manager.clone() {
+                builder = builder.with_unable_to_decrypt_hook(utd_hook_manager);
             }
         }
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -237,8 +237,10 @@ impl Room {
             builder = builder.with_internal_id_prefix(internal_id_prefix);
         }
 
-        if let Some(utd_hook) = self.utd_hook.clone() {
-            builder = builder.with_unable_to_decrypt_hook(utd_hook);
+        if configuration.report_utds {
+            if let Some(utd_hook) = self.utd_hook.clone() {
+                builder = builder.with_unable_to_decrypt_hook(utd_hook);
+            }
         }
 
         let timeline = builder.build().await?;

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -4,31 +4,22 @@ use std::{fmt::Debug, mem::MaybeUninit, ptr::addr_of_mut, sync::Arc, time::Durat
 
 use async_compat::get_runtime_handle;
 use eyeball_im::VectorDiff;
-use futures_util::{pin_mut, StreamExt, TryFutureExt};
+use futures_util::{pin_mut, StreamExt};
 use matrix_sdk::ruma::{
     api::client::sync::sync_events::UnreadNotificationsCount as RumaUnreadNotificationsCount,
     RoomId,
 };
-use matrix_sdk_ui::{
-    room_list_service::filters::{
-        new_filter_all, new_filter_any, new_filter_category, new_filter_favourite,
-        new_filter_fuzzy_match_room_name, new_filter_invite, new_filter_joined,
-        new_filter_non_left, new_filter_none, new_filter_normalized_match_room_name,
-        new_filter_unread, BoxedFilterFn, RoomCategory,
-    },
-    timeline::default_event_filter,
+use matrix_sdk_ui::room_list_service::filters::{
+    new_filter_all, new_filter_any, new_filter_category, new_filter_favourite,
+    new_filter_fuzzy_match_room_name, new_filter_invite, new_filter_joined, new_filter_non_left,
+    new_filter_none, new_filter_normalized_match_room_name, new_filter_unread, BoxedFilterFn,
+    RoomCategory,
 };
 use ruma::{OwnedRoomOrAliasId, OwnedServerName, ServerName};
-use tokio::sync::RwLock;
 
 use crate::{
-    error::ClientError,
-    room::{Membership, Room},
-    room_info::RoomInfo,
-    room_preview::RoomPreview,
-    timeline::{configuration::TimelineEventTypeFilter, EventTimelineItem, Timeline},
-    utils::AsyncRuntimeDropped,
-    TaskHandle,
+    error::ClientError, room::Membership, room_info::RoomInfo, room_preview::RoomPreview,
+    timeline::EventTimelineItem, utils::AsyncRuntimeDropped, TaskHandle,
 };
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
@@ -591,67 +582,6 @@ impl RoomListItem {
         let room_preview = client.get_room_preview(&room_or_alias_id, server_names).await?;
 
         Ok(Arc::new(RoomPreview::new(AsyncRuntimeDropped::new(client), room_preview)))
-    }
-
-    /// Build a full `Room` FFI object, filling its associated timeline.
-    ///
-    /// An error will be returned if the room is a state different than joined
-    /// or if its internal timeline hasn't been initialized.
-    fn full_room(&self) -> Result<Arc<Room>, RoomListError> {
-        if !matches!(self.membership(), Membership::Joined) {
-            return Err(RoomListError::IncorrectRoomMembership {
-                expected: vec![Membership::Joined],
-                actual: self.membership(),
-            });
-        }
-
-        if let Some(timeline) = self.inner.timeline() {
-            Ok(Arc::new(Room::with_timeline(
-                self.inner.inner_room().clone(),
-                Arc::new(RwLock::new(Some(Timeline::from_arc(timeline)))),
-            )))
-        } else {
-            Err(RoomListError::TimelineNotInitialized {
-                room_name: self.inner.inner_room().room_id().to_string(),
-            })
-        }
-    }
-
-    /// Checks whether the Room's timeline has been initialized before.
-    fn is_timeline_initialized(&self) -> bool {
-        self.inner.is_timeline_initialized()
-    }
-
-    /// Initializes the timeline for this room using the provided parameters.
-    ///
-    /// * `event_type_filter` - An optional [`TimelineEventTypeFilter`] to be
-    ///   used to filter timeline events besides the default timeline filter. If
-    ///   `None` is passed, only the default timeline filter will be used.
-    /// * `internal_id_prefix` - An optional String that will be prepended to
-    ///   all the timeline item's internal IDs, making it possible to
-    ///   distinguish different timeline instances from each other.
-    async fn init_timeline(
-        &self,
-        event_type_filter: Option<Arc<TimelineEventTypeFilter>>,
-        internal_id_prefix: Option<String>,
-    ) -> Result<(), RoomListError> {
-        let mut timeline_builder = self
-            .inner
-            .default_room_timeline_builder()
-            .map_err(|err| RoomListError::InitializingTimeline { error: err.to_string() })?;
-
-        if let Some(event_type_filter) = event_type_filter {
-            timeline_builder = timeline_builder.event_filter(move |event, room_version_id| {
-                // Always perform the default filter first
-                default_event_filter(event, room_version_id) && event_type_filter.filter(event)
-            });
-        }
-
-        if let Some(internal_id_prefix) = internal_id_prefix {
-            timeline_builder = timeline_builder.with_internal_id_prefix(internal_id_prefix);
-        }
-
-        self.inner.init_timeline_with_builder(timeline_builder).map_err(RoomListError::from).await
     }
 
     /// Checks whether the room is encrypted or not.

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -12,21 +12,18 @@
 // See the License for that specific language governing permissions and
 // limitations under the License.
 
-use std::{fmt::Debug, sync::Arc, time::Duration};
+use std::{fmt::Debug, sync::Arc};
 
 use async_compat::get_runtime_handle;
 use futures_util::pin_mut;
-use matrix_sdk::{crypto::types::events::UtdCause, Client};
+use matrix_sdk::Client;
 use matrix_sdk_ui::{
     sync_service::{
         State as MatrixSyncServiceState, SyncService as MatrixSyncService,
         SyncServiceBuilder as MatrixSyncServiceBuilder,
     },
-    unable_to_decrypt_hook::{
-        UnableToDecryptHook, UnableToDecryptInfo as SdkUnableToDecryptInfo, UtdHookManager,
-    },
+    unable_to_decrypt_hook::UtdHookManager,
 };
-use tracing::error;
 
 use crate::{
     error::ClientError, helpers::unwrap_or_clone_arc, room_list::RoomListService, TaskHandle,
@@ -127,117 +124,11 @@ impl SyncServiceBuilder {
         Arc::new(Self { client: this.client, builder, utd_hook: this.utd_hook })
     }
 
-    pub async fn with_utd_hook(
-        self: Arc<Self>,
-        delegate: Box<dyn UnableToDecryptDelegate>,
-    ) -> Arc<Self> {
-        // UTDs detected before this duration may be reclassified as "late decryption"
-        // events (or discarded, if they get decrypted fast enough).
-        const UTD_HOOK_GRACE_PERIOD: Duration = Duration::from_secs(60);
-
-        let this = unwrap_or_clone_arc(self);
-
-        let mut utd_hook = UtdHookManager::new(Arc::new(UtdHook { delegate }), this.client.clone())
-            .with_max_delay(UTD_HOOK_GRACE_PERIOD);
-
-        if let Err(e) = utd_hook.reload_from_store().await {
-            error!("Unable to reload UTD hook data from data store: {}", e);
-            // Carry on with the setup anyway; we shouldn't fail setup just
-            // because the UTD hook failed to load its data.
-        }
-
-        Arc::new(Self {
-            client: this.client,
-            builder: this.builder,
-            utd_hook: Some(Arc::new(utd_hook)),
-        })
-    }
-
     pub async fn finish(self: Arc<Self>) -> Result<Arc<SyncService>, ClientError> {
         let this = unwrap_or_clone_arc(self);
         Ok(Arc::new(SyncService {
             inner: Arc::new(this.builder.build().await?),
             utd_hook: this.utd_hook,
         }))
-    }
-}
-
-#[matrix_sdk_ffi_macros::export(callback_interface)]
-pub trait UnableToDecryptDelegate: Sync + Send {
-    fn on_utd(&self, info: UnableToDecryptInfo);
-}
-
-struct UtdHook {
-    delegate: Box<dyn UnableToDecryptDelegate>,
-}
-
-impl std::fmt::Debug for UtdHook {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("UtdHook").finish_non_exhaustive()
-    }
-}
-
-impl UnableToDecryptHook for UtdHook {
-    fn on_utd(&self, info: SdkUnableToDecryptInfo) {
-        const IGNORE_UTD_PERIOD: Duration = Duration::from_secs(4);
-
-        // UTDs that have been decrypted in the `IGNORE_UTD_PERIOD` are just ignored and
-        // not considered UTDs.
-        if let Some(duration) = &info.time_to_decrypt {
-            if *duration < IGNORE_UTD_PERIOD {
-                return;
-            }
-        }
-
-        // Report the UTD to the client.
-        self.delegate.on_utd(info.into());
-    }
-}
-
-#[derive(uniffi::Record)]
-pub struct UnableToDecryptInfo {
-    /// The identifier of the event that couldn't get decrypted.
-    event_id: String,
-
-    /// If the event could be decrypted late (that is, the event was encrypted
-    /// at first, but could be decrypted later on), then this indicates the
-    /// time it took to decrypt the event. If it is not set, this is
-    /// considered a definite UTD.
-    ///
-    /// If set, this is in milliseconds.
-    pub time_to_decrypt_ms: Option<u64>,
-
-    /// What we know about what caused this UTD. E.g. was this event sent when
-    /// we were not a member of this room?
-    pub cause: UtdCause,
-
-    /// The difference between the event creation time (`origin_server_ts`) and
-    /// the time our device was created. If negative, this event was sent
-    /// *before* our device was created.
-    pub event_local_age_millis: i64,
-
-    /// Whether the user had verified their own identity at the point they
-    /// received the UTD event.
-    pub user_trusts_own_identity: bool,
-
-    /// The homeserver of the user that sent the undecryptable event.
-    pub sender_homeserver: String,
-
-    /// Our local user's own homeserver, or `None` if the client is not logged
-    /// in.
-    pub own_homeserver: Option<String>,
-}
-
-impl From<SdkUnableToDecryptInfo> for UnableToDecryptInfo {
-    fn from(value: SdkUnableToDecryptInfo) -> Self {
-        Self {
-            event_id: value.event_id.to_string(),
-            time_to_decrypt_ms: value.time_to_decrypt.map(|ttd| ttd.as_millis() as u64),
-            cause: value.cause,
-            event_local_age_millis: value.event_local_age_millis,
-            user_trusts_own_identity: value.user_trusts_own_identity,
-            sender_homeserver: value.sender_homeserver.to_string(),
-            own_homeserver: value.own_homeserver.map(String::from),
-        }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/configuration.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/configuration.rs
@@ -157,4 +157,8 @@ pub struct TimelineConfiguration {
     /// As this has a non negligible performance impact, make sure to enable it
     /// only when you need it.
     pub track_read_receipts: bool,
+
+    /// Whether this timeline instance should report UTDs through the client's
+    /// delegate.
+    pub report_utds: bool,
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -99,11 +99,6 @@ impl Timeline {
         Arc::new(Self { inner })
     }
 
-    pub(crate) fn from_arc(inner: Arc<matrix_sdk_ui::timeline::Timeline>) -> Arc<Self> {
-        // SAFETY: repr(transparent) means transmuting the arc this way is allowed
-        unsafe { Arc::from_raw(Arc::into_raw(inner) as _) }
-    }
-
     fn send_attachment(
         self: Arc<Self>,
         params: UploadParameters,

--- a/bindings/matrix-sdk-ffi/src/utd.rs
+++ b/bindings/matrix-sdk-ffi/src/utd.rs
@@ -1,0 +1,100 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{fmt::Debug, sync::Arc, time::Duration};
+
+use matrix_sdk::crypto::types::events::UtdCause;
+use matrix_sdk_ui::unable_to_decrypt_hook::{
+    UnableToDecryptHook, UnableToDecryptInfo as SdkUnableToDecryptInfo,
+};
+
+#[matrix_sdk_ffi_macros::export(callback_interface)]
+pub trait UnableToDecryptDelegate: Sync + Send {
+    fn on_utd(&self, info: UnableToDecryptInfo);
+}
+
+pub struct UtdHook {
+    pub delegate: Arc<dyn UnableToDecryptDelegate>,
+}
+
+impl std::fmt::Debug for UtdHook {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UtdHook").finish_non_exhaustive()
+    }
+}
+
+impl UnableToDecryptHook for UtdHook {
+    fn on_utd(&self, info: SdkUnableToDecryptInfo) {
+        const IGNORE_UTD_PERIOD: Duration = Duration::from_secs(4);
+
+        // UTDs that have been decrypted in the `IGNORE_UTD_PERIOD` are just ignored and
+        // not considered UTDs.
+        if let Some(duration) = &info.time_to_decrypt {
+            if *duration < IGNORE_UTD_PERIOD {
+                return;
+            }
+        }
+
+        // Report the UTD to the client.
+        self.delegate.on_utd(info.into());
+    }
+}
+
+#[derive(uniffi::Record)]
+pub struct UnableToDecryptInfo {
+    /// The identifier of the event that couldn't get decrypted.
+    event_id: String,
+
+    /// If the event could be decrypted late (that is, the event was encrypted
+    /// at first, but could be decrypted later on), then this indicates the
+    /// time it took to decrypt the event. If it is not set, this is
+    /// considered a definite UTD.
+    ///
+    /// If set, this is in milliseconds.
+    pub time_to_decrypt_ms: Option<u64>,
+
+    /// What we know about what caused this UTD. E.g. was this event sent when
+    /// we were not a member of this room?
+    pub cause: UtdCause,
+
+    /// The difference between the event creation time (`origin_server_ts`) and
+    /// the time our device was created. If negative, this event was sent
+    /// *before* our device was created.
+    pub event_local_age_millis: i64,
+
+    /// Whether the user had verified their own identity at the point they
+    /// received the UTD event.
+    pub user_trusts_own_identity: bool,
+
+    /// The homeserver of the user that sent the undecryptable event.
+    pub sender_homeserver: String,
+
+    /// Our local user's own homeserver, or `None` if the client is not logged
+    /// in.
+    pub own_homeserver: Option<String>,
+}
+
+impl From<SdkUnableToDecryptInfo> for UnableToDecryptInfo {
+    fn from(value: SdkUnableToDecryptInfo) -> Self {
+        Self {
+            event_id: value.event_id.to_string(),
+            time_to_decrypt_ms: value.time_to_decrypt.map(|ttd| ttd.as_millis() as u64),
+            cause: value.cause,
+            event_local_age_millis: value.event_local_age_millis,
+            user_trusts_own_identity: value.user_trusts_own_identity,
+            sender_homeserver: value.sender_homeserver.to_string(),
+            own_homeserver: value.own_homeserver.map(String::from),
+        }
+    }
+}

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -25,7 +25,6 @@ unstable-msc3956 = ["ruma/unstable-msc3956"]
 [dependencies]
 as_variant = { workspace = true }
 async_cell = "0.2.2"
-async-once-cell = "0.5.4"
 async-rx = { workspace = true }
 async-stream = { workspace = true }
 bitflags = { workspace = true }

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -76,8 +76,6 @@ pub use state::*;
 use thiserror::Error;
 use tracing::debug;
 
-use crate::timeline;
-
 /// The default `required_state` constant value for sliding sync lists and
 /// sliding sync room subscriptions.
 const DEFAULT_REQUIRED_STATE: &[(StateEventType, &str)] = &[
@@ -430,12 +428,6 @@ pub enum Error {
     /// The requested room doesn't exist.
     #[error("Room `{0}` not found")]
     RoomNotFound(OwnedRoomId),
-
-    #[error("A timeline instance already exists for room {0}")]
-    TimelineAlreadyExists(OwnedRoomId),
-
-    #[error(transparent)]
-    InitializingTimeline(#[from] timeline::Error),
 
     #[error(transparent)]
     EventCache(#[from] EventCacheError),

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -17,14 +17,10 @@
 use core::fmt;
 use std::{ops::Deref, sync::Arc};
 
-use async_once_cell::OnceCell as AsyncOnceCell;
 use ruma::RoomId;
 
 use super::Error;
-use crate::{
-    timeline::{EventTimelineItem, TimelineBuilder},
-    Timeline,
-};
+use crate::timeline::{EventTimelineItem, TimelineBuilder};
 
 /// A room in the room list.
 ///
@@ -43,9 +39,6 @@ impl fmt::Debug for Room {
 struct RoomInner {
     /// The underlying client room.
     room: matrix_sdk::Room,
-
-    /// The timeline of the room.
-    timeline: AsyncOnceCell<Arc<Timeline>>,
 }
 
 impl Deref for Room {
@@ -59,7 +52,7 @@ impl Deref for Room {
 impl Room {
     /// Create a new `Room`.
     pub(super) fn new(room: matrix_sdk::Room) -> Self {
-        Self { inner: Arc::new(RoomInner { room, timeline: AsyncOnceCell::new() }) }
+        Self { inner: Arc::new(RoomInner { room }) }
     }
 
     /// Get the room ID.
@@ -77,56 +70,13 @@ impl Room {
         &self.inner.room
     }
 
-    /// Get the timeline of the room if one exists.
-    pub fn timeline(&self) -> Option<Arc<Timeline>> {
-        self.inner.timeline.get().cloned()
-    }
-
-    /// Get whether the timeline has been already initialised or not.
-    pub fn is_timeline_initialized(&self) -> bool {
-        self.inner.timeline.get().is_some()
-    }
-
-    /// Initialize the timeline of the room with an event type filter so only
-    /// some events are returned. If a previous timeline exists, it'll
-    /// return an error. Otherwise, a Timeline will be returned.
-    pub async fn init_timeline_with_builder(&self, builder: TimelineBuilder) -> Result<(), Error> {
-        if self.inner.timeline.get().is_some() {
-            Err(Error::TimelineAlreadyExists(self.inner.room.room_id().to_owned()))
-        } else {
-            self.inner
-                .timeline
-                .get_or_try_init(async { Ok(Arc::new(builder.build().await?)) })
-                .await
-                .map_err(Error::InitializingTimeline)?;
-            Ok(())
-        }
-    }
-
-    /// Get the latest event in the timeline.
-    ///
-    /// The latest event comes first from the `Timeline`, it can be a local or a
-    /// remote event. Note that the `Timeline` can have more information esp. if
-    /// it has run a backpagination for example. Otherwise if the `Timeline`
-    /// doesn't have any latest event, it comes from the cache. This method
-    /// does not fetch any events or calculate anything — if it's not already
-    /// available, we return `None`.
+    /// Get the room's latest event from the cache. This method does not fetch
+    /// any events or calculate anything — if it's not already available, we
+    /// return `None`.
     ///
     /// Reminder: this method also returns `None` is the latest event is not
     /// suitable for use in a message preview.
     pub async fn latest_event(&self) -> Option<EventTimelineItem> {
-        // Look for a local event in the `Timeline`.
-        //
-        // First off, let's see if a `Timeline` exists…
-        if let Some(timeline) = self.inner.timeline.get() {
-            // If it contains a `latest_event`…
-            if let Some(timeline_last_event) = timeline.latest_event().await {
-                // If it's a local event or a remote event, we return it.
-                return Some(timeline_last_event);
-            }
-        }
-
-        // Otherwise, fallback to the classical path.
         if let Some(latest_event) = self.inner.room.latest_event() {
             EventTimelineItem::from_latest_event(
                 self.inner.room.client(),

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -144,6 +144,6 @@ impl Room {
     /// If the room was synced before some initial events will be added to the
     /// [`TimelineBuilder`].
     pub fn default_room_timeline_builder(&self) -> Result<TimelineBuilder, Error> {
-        Ok(Timeline::builder(&self.inner.room).track_read_marker_and_receipts())
+        Ok(TimelineBuilder::new(&self.inner.room).track_read_marker_and_receipts())
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -57,7 +57,7 @@ pub struct TimelineBuilder {
 }
 
 impl TimelineBuilder {
-    pub(super) fn new(room: &Room) -> Self {
+    pub fn new(room: &Room) -> Self {
         Self {
             room: room.clone(),
             settings: TimelineSettings::default(),

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -148,11 +148,6 @@ pub enum DateDividerMode {
 }
 
 impl Timeline {
-    /// Create a new [`TimelineBuilder`] for the given room.
-    pub fn builder(room: &Room) -> TimelineBuilder {
-        TimelineBuilder::new(room)
-    }
-
     /// Returns the room for this timeline.
     pub fn room(&self) -> &Room {
         self.controller.room()

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -68,7 +68,7 @@ impl RoomExt for Room {
     }
 
     fn timeline_builder(&self) -> TimelineBuilder {
-        Timeline::builder(self).track_read_marker_and_receipts()
+        TimelineBuilder::new(self).track_read_marker_and_receipts()
     }
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2464,8 +2464,7 @@ async fn test_room_timeline() -> Result<(), Error> {
     mock_encryption_state(&server, false).await;
 
     let room = room_list.room(room_id)?;
-    room.init_timeline_with_builder(room.default_room_timeline_builder().unwrap()).await?;
-    let timeline = room.timeline().unwrap();
+    let timeline = room.default_room_timeline_builder().unwrap().build().await?;
 
     let (previous_timeline_items, mut timeline_items_stream) = timeline.subscribe().await;
 
@@ -2566,7 +2565,7 @@ async fn test_room_latest_event() -> Result<(), Error> {
     };
 
     let room = room_list.room(room_id)?;
-    room.init_timeline_with_builder(room.default_room_timeline_builder().unwrap()).await?;
+    let timeline = room.default_room_timeline_builder().unwrap().build().await?;
 
     // The latest event does not exist.
     assert!(room.latest_event().await.is_none());
@@ -2617,9 +2616,6 @@ async fn test_room_latest_event() -> Result<(), Error> {
     assert!(latest_event.is_local_echo().not());
     assert_eq!(latest_event.event_id(), Some(event_id!("$x1:bar.org")));
 
-    // Now let's compare with the result of the `Timeline`.
-    let timeline = room.timeline().unwrap();
-
     // The latest event matches the latest event of the `Timeline`.
     assert_matches!(
         timeline.latest_event().await,
@@ -2640,15 +2636,6 @@ async fn test_room_latest_event() -> Result<(), Error> {
         Some(timeline_event) => {
             assert!(timeline_event.is_local_echo());
             assert_eq!(timeline_event.event_id(), None);
-        }
-    );
-
-    // The latest event is a local event.
-    assert_matches!(
-        room.latest_event().await,
-        Some(event) => {
-            assert!(event.is_local_echo());
-            assert_eq!(event.event_id(), None);
         }
     );
 
@@ -2893,10 +2880,7 @@ async fn test_multiple_timeline_init() {
         // Get a RoomListService::Room, initialize the timeline, start a pagination.
         let room = room_list.room(room_id).unwrap();
 
-        let builder = room.default_room_timeline_builder().unwrap();
-        room.init_timeline_with_builder(builder).await.unwrap();
-
-        let timeline = room.timeline().unwrap();
+        let timeline = room.default_room_timeline_builder().unwrap().build().await.unwrap();
 
         spawn(async move { timeline.paginate_backwards(20).await })
     };
@@ -2909,6 +2893,5 @@ async fn test_multiple_timeline_init() {
     task.abort();
 
     // A new timeline for the same room can still be constructed.
-    let builder = room.default_room_timeline_builder().unwrap();
-    room.init_timeline_with_builder(builder).await.unwrap();
+    room.default_room_timeline_builder().unwrap().build().await.unwrap();
 }

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2464,7 +2464,7 @@ async fn test_room_timeline() -> Result<(), Error> {
     mock_encryption_state(&server, false).await;
 
     let room = room_list.room(room_id)?;
-    let timeline = room.default_room_timeline_builder().unwrap().build().await?;
+    let timeline = room.default_room_timeline_builder().unwrap().build().await.unwrap();
 
     let (previous_timeline_items, mut timeline_items_stream) = timeline.subscribe().await;
 
@@ -2565,7 +2565,7 @@ async fn test_room_latest_event() -> Result<(), Error> {
     };
 
     let room = room_list.room(room_id)?;
-    let timeline = room.default_room_timeline_builder().unwrap().build().await?;
+    let timeline = room.default_room_timeline_builder().unwrap().build().await.unwrap();
 
     // The latest event does not exist.
     assert!(room.latest_event().await.is_none());

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -24,7 +24,7 @@ use matrix_sdk_test::{
     async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
     SyncResponseBuilder, ALICE, BOB,
 };
-use matrix_sdk_ui::{timeline::TimelineFocus, Timeline};
+use matrix_sdk_ui::timeline::{TimelineBuilder, TimelineFocus};
 use ruma::{event_id, events::room::message::RoomMessageEventContent, room_id};
 use stream_assert::assert_pending;
 use tokio::time::sleep;
@@ -70,7 +70,7 @@ async fn test_new_focused() {
     mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Timeline::builder(&room)
+    let timeline = TimelineBuilder::new(&room)
         .with_focus(TimelineFocus::Event {
             target: target_event.to_owned(),
             num_context_events: 20,
@@ -218,7 +218,7 @@ async fn test_focused_timeline_does_not_react() {
     mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Timeline::builder(&room)
+    let timeline = TimelineBuilder::new(&room)
         .with_focus(TimelineFocus::Event {
             target: target_event.to_owned(),
             num_context_events: 20,
@@ -292,7 +292,7 @@ async fn test_focused_timeline_local_echoes() {
     mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Timeline::builder(&room)
+    let timeline = TimelineBuilder::new(&room)
         .with_focus(TimelineFocus::Event {
             target: target_event.to_owned(),
             num_context_events: 20,
@@ -371,7 +371,7 @@ async fn test_focused_timeline_doesnt_show_local_echoes() {
     mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Timeline::builder(&room)
+    let timeline = TimelineBuilder::new(&room)
         .with_focus(TimelineFocus::Event {
             target: target_event.to_owned(),
             num_context_events: 20,

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -29,7 +29,7 @@ use matrix_sdk_test::{
 use matrix_sdk_ui::{
     timeline::{
         AnyOtherFullStateEventContent, Error, EventSendState, RedactError, RoomExt,
-        TimelineEventItemId, TimelineItemContent, VirtualTimelineItem,
+        TimelineBuilder, TimelineEventItemId, TimelineItemContent, VirtualTimelineItem,
     },
     Timeline,
 };
@@ -667,7 +667,7 @@ async fn test_timeline_without_encryption_can_update() {
     // Previously this would have panicked.
     // We're creating a timeline without read receipts tracking to check only the
     // encryption changes.
-    let timeline = Timeline::builder(&room).build().await.unwrap();
+    let timeline = TimelineBuilder::new(&room).build().await.unwrap();
 
     let (items, mut stream) = timeline.subscribe().await;
     assert_eq!(items.len(), 2);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -16,10 +16,7 @@ use matrix_sdk_test::{
     async_test, event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent,
     SyncResponseBuilder, BOB,
 };
-use matrix_sdk_ui::{
-    timeline::{RoomExt, TimelineFocus},
-    Timeline,
-};
+use matrix_sdk_ui::timeline::{RoomExt, TimelineBuilder, TimelineFocus};
 use ruma::{
     assign, event_id,
     events::{
@@ -70,7 +67,7 @@ async fn test_new_pinned_events_are_not_added_on_sync() {
         .await
         .expect("Room should be synced");
     let timeline =
-        Timeline::builder(&room).with_focus(pinned_events_focus(100)).build().await.unwrap();
+        TimelineBuilder::new(&room).with_focus(pinned_events_focus(100)).build().await.unwrap();
 
     assert!(
         timeline.live_back_pagination_status().await.is_none(),
@@ -151,7 +148,7 @@ async fn test_new_pinned_event_ids_reload_the_timeline() {
         .expect("Room should be synced");
 
     let timeline =
-        Timeline::builder(&room).with_focus(pinned_events_focus(100)).build().await.unwrap();
+        TimelineBuilder::new(&room).with_focus(pinned_events_focus(100)).build().await.unwrap();
 
     assert!(
         timeline.live_back_pagination_status().await.is_none(),
@@ -226,7 +223,7 @@ async fn test_max_events_to_load_is_honored() {
         .await
         .expect("Sync failed");
 
-    let ret = Timeline::builder(&room).with_focus(pinned_events_focus(1)).build().await;
+    let ret = TimelineBuilder::new(&room).with_focus(pinned_events_focus(1)).build().await;
 
     // We're only taking the last event id, `$2`, and it's not available so the
     // timeline fails to initialise.
@@ -263,7 +260,7 @@ async fn test_cached_events_are_kept_for_different_room_instances() {
 
     let (room_cache, _drop_handles) = room.event_cache().await.unwrap();
     let timeline =
-        Timeline::builder(&room).with_focus(pinned_events_focus(2)).build().await.unwrap();
+        TimelineBuilder::new(&room).with_focus(pinned_events_focus(2)).build().await.unwrap();
 
     assert!(
         timeline.live_back_pagination_status().await.is_none(),
@@ -292,7 +289,7 @@ async fn test_cached_events_are_kept_for_different_room_instances() {
 
     // And a new timeline one
     let timeline =
-        Timeline::builder(&room).with_focus(pinned_events_focus(2)).build().await.unwrap();
+        TimelineBuilder::new(&room).with_focus(pinned_events_focus(2)).build().await.unwrap();
 
     let (items, _) = timeline.subscribe().await;
     assert!(!items.is_empty()); // These events came from the cache
@@ -317,7 +314,7 @@ async fn test_pinned_timeline_with_pinned_event_ids_and_empty_result_fails() {
         .mock_and_sync(&client, &server)
         .await
         .expect("Sync failed");
-    let ret = Timeline::builder(&room).with_focus(pinned_events_focus(1)).build().await;
+    let ret = TimelineBuilder::new(&room).with_focus(pinned_events_focus(1)).build().await;
 
     // The timeline couldn't load any events so it fails to initialise
     assert!(ret.is_err());
@@ -336,7 +333,7 @@ async fn test_pinned_timeline_with_no_pinned_event_ids_is_just_empty() {
         .await
         .expect("Sync failed");
     let timeline =
-        Timeline::builder(&room).with_focus(pinned_events_focus(1)).build().await.unwrap();
+        TimelineBuilder::new(&room).with_focus(pinned_events_focus(1)).build().await.unwrap();
 
     // The timeline couldn't load any events, but it expected none, so it just
     // returns an empty list
@@ -364,7 +361,7 @@ async fn test_pinned_timeline_with_no_pinned_events_and_an_utd_on_sync_is_just_e
     mock_events_endpoint(&server, room_id, vec![utd_event]).await;
 
     let timeline =
-        Timeline::builder(&room).with_focus(pinned_events_focus(1)).build().await.unwrap();
+        TimelineBuilder::new(&room).with_focus(pinned_events_focus(1)).build().await.unwrap();
 
     // The timeline couldn't load any events, but it expected none, so it just
     // returns an empty list
@@ -387,7 +384,7 @@ async fn test_pinned_timeline_with_no_pinned_events_on_pagination_is_just_empty(
         .await
         .expect("Sync failed");
     let pinned_timeline =
-        Timeline::builder(&room).with_focus(pinned_events_focus(1)).build().await.unwrap();
+        TimelineBuilder::new(&room).with_focus(pinned_events_focus(1)).build().await.unwrap();
 
     // The timeline couldn't load any events, but it expected none, so it just
     // returns an empty list
@@ -448,7 +445,7 @@ async fn test_pinned_timeline_with_pinned_utd_on_sync_contains_it() {
     mock_events_endpoint(&server, room_id, vec![utd_event]).await;
 
     let timeline =
-        Timeline::builder(&room).with_focus(pinned_events_focus(1)).build().await.unwrap();
+        TimelineBuilder::new(&room).with_focus(pinned_events_focus(1)).build().await.unwrap();
 
     // The timeline loaded with just a day divider and the pinned UTD
     let (items, _) = timeline.subscribe().await;
@@ -481,7 +478,7 @@ async fn test_edited_events_are_not_reflected_in_sync() {
         .await
         .expect("Sync failed");
     let timeline =
-        Timeline::builder(&room).with_focus(pinned_events_focus(100)).build().await.unwrap();
+        TimelineBuilder::new(&room).with_focus(pinned_events_focus(100)).build().await.unwrap();
 
     assert!(
         timeline.live_back_pagination_status().await.is_none(),
@@ -558,7 +555,7 @@ async fn test_redacted_events_are_not_reflected_in_sync() {
         .await
         .expect("Sync failed");
     let timeline =
-        Timeline::builder(&room).with_focus(pinned_events_focus(100)).build().await.unwrap();
+        TimelineBuilder::new(&room).with_focus(pinned_events_focus(100)).build().await.unwrap();
 
     assert!(
         timeline.live_back_pagination_status().await.is_none(),

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -24,10 +24,7 @@ use matrix_sdk::{
     SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
 };
 use matrix_sdk_test::{async_test, mocks::mock_encryption_state};
-use matrix_sdk_ui::{
-    timeline::{TimelineItem, TimelineItemKind},
-    Timeline,
-};
+use matrix_sdk_ui::timeline::{TimelineBuilder, TimelineItem, TimelineItemKind};
 use ruma::{room_id, user_id, RoomId};
 use serde_json::json;
 use wiremock::{http::Method, Match, Mock, MockServer, Request, ResponseTemplate};
@@ -411,7 +408,7 @@ async fn timeline_test_helper(
         anyhow::anyhow!("Room {room_id} not found in client. Can't provide a timeline for it")
     })?;
 
-    let timeline = Timeline::builder(&sdk_room).track_read_marker_and_receipts().build().await?;
+    let timeline = TimelineBuilder::new(&sdk_room).track_read_marker_and_receipts().build().await?;
 
     Ok(timeline.subscribe().await)
 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -17,7 +17,7 @@ use eyeball_im::VectorDiff;
 use futures_util::StreamExt as _;
 use matrix_sdk::test_utils::mocks::{MatrixMockServer, RoomRelationsResponseTemplate};
 use matrix_sdk_test::{async_test, event_factory::EventFactory};
-use matrix_sdk_ui::{timeline::TimelineFocus, Timeline};
+use matrix_sdk_ui::timeline::{TimelineBuilder, TimelineFocus};
 use ruma::{event_id, events::AnyTimelineEvent, owned_event_id, room_id, serde::Raw, user_id};
 use stream_assert::assert_pending;
 
@@ -55,7 +55,7 @@ async fn test_new_thread() {
 
     let room = server.sync_joined_room(&client, room_id).await;
 
-    let timeline = Timeline::builder(&room)
+    let timeline = TimelineBuilder::new(&room)
         .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id, num_events: 1 })
         .build()
         .await
@@ -121,7 +121,7 @@ async fn test_thread_backpagination() {
 
     let room = server.sync_joined_room(&client, room_id).await;
 
-    let timeline = Timeline::builder(&room)
+    let timeline = TimelineBuilder::new(&room)
         .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id, num_events: 1 })
         .build()
         .await

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -12,7 +12,6 @@ use matrix_sdk::{
     },
     RoomState,
 };
-use matrix_sdk_ui::timeline::TimelineBuilder;
 use ratatui::{prelude::*, widgets::*};
 use tokio::{spawn, task::JoinHandle};
 
@@ -320,21 +319,14 @@ impl RoomView {
 
     /// Mark the currently selected room as read.
     pub async fn mark_as_read(&mut self) {
-        let selected = self.selected_room.as_deref();
-
-        let Some(room) = selected.and_then(|room_id| self.ui_rooms.lock().get(room_id).cloned())
-        else {
-            self.status_handle.set_message("missing room or nothing to show".to_owned());
+        let Some(sdk_timeline) = self.selected_room.as_deref().and_then(|room_id| {
+            self.timelines.lock().get(room_id).map(|timeline| timeline.timeline.clone())
+        }) else {
+            self.status_handle.set_message("missing timeline for room".to_owned());
             return;
         };
 
-        // Mark as read!
-        let Ok(timeline) = TimelineBuilder::new(&room).build().await else {
-            self.status_handle.set_message("failed creating timeline".to_owned());
-            return;
-        };
-
-        match timeline.mark_as_read(ReceiptType::Read).await {
+        match sdk_timeline.mark_as_read(ReceiptType::Read).await {
             Ok(did) => {
                 self.status_handle.set_message(format!(
                     "did {}send a read receipt!",

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -12,6 +12,7 @@ use matrix_sdk::{
     },
     RoomState,
 };
+use matrix_sdk_ui::timeline::TimelineBuilder;
 use ratatui::{prelude::*, widgets::*};
 use tokio::{spawn, task::JoinHandle};
 
@@ -328,7 +329,12 @@ impl RoomView {
         };
 
         // Mark as read!
-        match room.timeline().unwrap().mark_as_read(ReceiptType::Read).await {
+        let Ok(timeline) = TimelineBuilder::new(&room).build().await else {
+            self.status_handle.set_message("failed creating timeline".to_owned());
+            return;
+        };
+
+        match timeline.mark_as_read(ReceiptType::Read).await {
             Ok(did) => {
                 self.status_handle.set_message(format!(
                     "did {}send a read receipt!",


### PR DESCRIPTION
This PR implements the plan laid out in #4718: it removes long living timeline instances from the room list service and its items in favor of directly creating a timeline through its parent room and the `timeline_with_configuration` method.

In order to do so it also moves the previously internally configured UTD hook to the FFI client and exposes an option to use it on the aforementioned timeline configuration method.

NB: the event filter is already exposed in the configuration and the event cache is now enabled by default.