### PR TITLE
feat(timeline): don't reset the pinned events timeline when underlying events haven't changed

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -326,8 +326,9 @@ where
 
     while pinned_event_ids_stream.next().await.is_some() {
         trace!("received a pinned events update");
+
         match timeline_controller.reload_pinned_events().await {
-            Ok(events) => {
+            Ok(Some(events)) => {
                 trace!("successfully reloaded pinned events");
                 timeline_controller
                     .replace_with_initial_remote_events(
@@ -336,6 +337,12 @@ where
                     )
                     .await;
             }
+
+            Ok(None) => {
+                // The list of pinned events hasn't changed since the previous
+                // time.
+            }
+
             Err(err) => {
                 warn!("Failed to reload pinned events: {err}");
             }

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -397,7 +397,12 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
             }
 
             TimelineFocusData::PinnedEvents { loader } => {
-                let loaded_events = loader.load_events().await.map_err(Error::PinnedEventsError)?;
+                let Some(loaded_events) =
+                    loader.load_events().await.map_err(Error::PinnedEventsError)?
+                else {
+                    // There wasn't any events.
+                    return Ok(false);
+                };
 
                 drop(focus_guard);
 
@@ -447,7 +452,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
 
     pub(crate) async fn reload_pinned_events(
         &self,
-    ) -> Result<Vec<TimelineEvent>, PinnedEventsLoaderError> {
+    ) -> Result<Option<Vec<TimelineEvent>>, PinnedEventsLoaderError> {
         let focus_guard = self.focus.read().await;
 
         if let TimelineFocusData::PinnedEvents { loader } = &*focus_guard {


### PR DESCRIPTION
This avoids a few spurious pinned event timeline resets, as shown by the test changes.