### PR TITLE
feat(bindings): added APIs to get the media preview config from the store

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1401,12 +1401,32 @@ impl Client {
     }
 
     /// Get the media previews timeline display policy
+    /// currently stored in the cache.
+    pub async fn get_stored_media_preview_display_policy(
+        &self,
+    ) -> Result<MediaPreviews, ClientError> {
+        let configuration =
+            self.inner.account().get_stored_media_preview_config_event_content().await?;
+        Ok(configuration.media_previews.into())
+    }
+
+    /// Set the invite request avatars display policy
     pub async fn set_invite_avatars_display_policy(
         &self,
         policy: InviteAvatars,
     ) -> Result<(), ClientError> {
         self.inner.account().set_invite_avatars_display_policy(policy.into()).await?;
         Ok(())
+    }
+
+    /// Get the invite request avatars display policy
+    /// currently stored in the cache.
+    pub async fn get_stored_invite_avatars_display_policy(
+        &self,
+    ) -> Result<InviteAvatars, ClientError> {
+        let configuration =
+            self.inner.account().get_stored_media_preview_config_event_content().await?;
+        Ok(configuration.invite_avatars.into())
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1402,11 +1402,8 @@ impl Client {
 
     /// Get the media previews timeline display policy
     /// currently stored in the cache.
-    pub async fn get_stored_media_preview_display_policy(
-        &self,
-    ) -> Result<MediaPreviews, ClientError> {
-        let configuration =
-            self.inner.account().get_stored_media_preview_config_event_content().await?;
+    pub async fn get_media_preview_display_policy(&self) -> Result<MediaPreviews, ClientError> {
+        let configuration = self.inner.account().get_media_preview_config_event_content().await?;
         Ok(configuration.media_previews.into())
     }
 
@@ -1421,11 +1418,8 @@ impl Client {
 
     /// Get the invite request avatars display policy
     /// currently stored in the cache.
-    pub async fn get_stored_invite_avatars_display_policy(
-        &self,
-    ) -> Result<InviteAvatars, ClientError> {
-        let configuration =
-            self.inner.account().get_stored_media_preview_config_event_content().await?;
+    pub async fn get_invite_avatars_display_policy(&self) -> Result<InviteAvatars, ClientError> {
+        let configuration = self.inner.account().get_media_preview_config_event_content().await?;
         Ok(configuration.invite_avatars.into())
     }
 }

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -1059,7 +1059,7 @@ impl Account {
         // We need to get the initial value of the media preview config event
         // we do this after creating the observers to make sure that we don't
         // create a race condition
-        let initial_value = self.get_media_preview_config_event_content().await?;
+        let initial_value = self.get_stored_media_preview_config_event_content().await?;
 
         Ok((initial_value, result_stream))
     }

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -1087,6 +1087,30 @@ impl Account {
         Ok(media_preview_config)
     }
 
+    /// Get the media preview configuration event content stored in the cache.
+    ///
+    /// This will return the default configuration if no value was found.
+    /// Will check first for the stable event and then for the unstable one.
+    pub async fn get_stored_media_preview_config_event_content(
+        &self,
+    ) -> Result<MediaPreviewConfigEventContent> {
+        let media_preview_config = self
+            .account_data::<MediaPreviewConfigEventContent>()
+            .await?
+            .and_then(|r| r.deserialize().ok());
+
+        let media_preview_config = if let Some(media_preview_config) = media_preview_config {
+            media_preview_config
+        } else {
+            self.account_data::<UnstableMediaPreviewConfigEventContent>()
+                .await?
+                .and_then(|r| r.deserialize().ok())
+                .unwrap_or_default()
+                .into()
+        };
+        Ok(media_preview_config)
+    }
+
     /// Set the media previews display policy in the timeline.
     ///
     /// This will always use the unstable event until we know which Matrix

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -1059,16 +1059,16 @@ impl Account {
         // We need to get the initial value of the media preview config event
         // we do this after creating the observers to make sure that we don't
         // create a race condition
-        let initial_value = self.get_stored_media_preview_config_event_content().await?;
+        let initial_value = self.get_media_preview_config_event_content().await?;
 
         Ok((initial_value, result_stream))
     }
 
-    /// Get the media preview configuration event content from the server.
+    /// Fetch the media preview configuration event content from the server.
     ///
     /// If no value was found in either the stable and unstable type, the
     /// default configuration will be returned.
-    pub async fn get_media_preview_config_event_content(
+    pub async fn fetch_media_preview_config_event_content(
         &self,
     ) -> Result<MediaPreviewConfigEventContent> {
         // First we check if there is avalue in the stable event
@@ -1095,7 +1095,7 @@ impl Account {
     ///
     /// This will return the default configuration if no value was found.
     /// Will check first for the stable event and then for the unstable one.
-    pub async fn get_stored_media_preview_config_event_content(
+    pub async fn get_media_preview_config_event_content(
         &self,
     ) -> Result<MediaPreviewConfigEventContent> {
         let media_preview_config = self
@@ -1120,7 +1120,7 @@ impl Account {
     /// This will always use the unstable event until we know which Matrix
     /// version will support it.
     pub async fn set_media_previews_display_policy(&self, policy: MediaPreviews) -> Result<()> {
-        let mut media_preview_config = self.get_media_preview_config_event_content().await?;
+        let mut media_preview_config = self.fetch_media_preview_config_event_content().await?;
         media_preview_config.media_previews = policy;
 
         // Updating the unstable account data
@@ -1135,7 +1135,7 @@ impl Account {
     /// This will always use the unstable event until we know which matrix
     /// version will support it.
     pub async fn set_invite_avatars_display_policy(&self, policy: InviteAvatars) -> Result<()> {
-        let mut media_preview_config = self.get_media_preview_config_event_content().await?;
+        let mut media_preview_config = self.fetch_media_preview_config_event_content().await?;
         media_preview_config.invite_avatars = policy;
 
         // Updating the unstable account data

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -1064,7 +1064,11 @@ impl Account {
         Ok((initial_value, result_stream))
     }
 
-    async fn get_media_preview_config_event_content(
+    /// Get the media preview configuration event content from the server.
+    ///
+    /// If no value was found in either the stable and unstable type, the default
+    /// configuration will be returned.
+    pub async fn get_media_preview_config_event_content(
         &self,
     ) -> Result<MediaPreviewConfigEventContent> {
         // First we check if there is avalue in the stable event

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -1066,8 +1066,8 @@ impl Account {
 
     /// Get the media preview configuration event content from the server.
     ///
-    /// If no value was found in either the stable and unstable type, the default
-    /// configuration will be returned.
+    /// If no value was found in either the stable and unstable type, the
+    /// default configuration will be returned.
     pub async fn get_media_preview_config_event_content(
         &self,
     ) -> Result<MediaPreviewConfigEventContent> {

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3341,16 +3341,16 @@ pub(crate) mod tests {
         let client = server.client_builder().build().await;
 
         server
-            .mock_global_account_data()
-            .ok(
-                client.user_id().unwrap(),
-                ruma::events::GlobalAccountDataEventType::MediaPreviewConfig,
-                json!({
+            .mock_sync()
+            .ok_and_run(&client, |builder| {
+                builder.add_global_account_data_event(GlobalAccountDataTestEvent::Custom(json!({
+                "content": {
                     "media_previews": "private",
                     "invite_avatars": "off"
-                }),
-            )
-            .mount()
+                },
+                "type": "m.media_preview_config"
+                  })));
+            })
             .await;
 
         let (initial_value, stream) =
@@ -3391,25 +3391,16 @@ pub(crate) mod tests {
         let client = server.client_builder().build().await;
 
         server
-            .mock_global_account_data()
-            .not_found(
-                client.user_id().unwrap(),
-                ruma::events::GlobalAccountDataEventType::MediaPreviewConfig,
-            )
-            .mount()
-            .await;
-
-        server
-            .mock_global_account_data()
-            .ok(
-                client.user_id().unwrap(),
-                ruma::events::GlobalAccountDataEventType::UnstableMediaPreviewConfig,
-                json!({
+            .mock_sync()
+            .ok_and_run(&client, |builder| {
+                builder.add_global_account_data_event(GlobalAccountDataTestEvent::Custom(json!({
+                "content": {
                     "media_previews": "private",
                     "invite_avatars": "off"
-                }),
-            )
-            .mount()
+                },
+                "type": "io.element.msc4278.media_preview_config"
+                  })));
+            })
             .await;
 
         let (initial_value, stream) =
@@ -3448,24 +3439,6 @@ pub(crate) mod tests {
     async fn test_media_preview_config_not_found() {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
-
-        server
-            .mock_global_account_data()
-            .not_found(
-                client.user_id().unwrap(),
-                ruma::events::GlobalAccountDataEventType::MediaPreviewConfig,
-            )
-            .mount()
-            .await;
-
-        server
-            .mock_global_account_data()
-            .not_found(
-                client.user_id().unwrap(),
-                ruma::events::GlobalAccountDataEventType::UnstableMediaPreviewConfig,
-            )
-            .mount()
-            .await;
 
         let (initial_value, _) = client.account().observe_media_preview_config().await.unwrap();
 

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1026,6 +1026,7 @@ impl MatrixMockServer {
     /// tokio_test::block_on(async {
     /// use matrix_sdk::test_utils::mocks::MatrixMockServer;
     /// use serde_json::json;
+    /// use ruma::events::media_preview_config::MediaPreviews;
     ///
     /// let mock_server = MatrixMockServer::new().await;
     /// let client = mock_server.client_builder().build().await;
@@ -1042,7 +1043,7 @@ impl MatrixMockServer {
     /// .mount()
     /// .await;
     ///
-    /// let (_, _) = client.account().observe_media_preview_config().await.unwrap();
+    /// client.account().set_media_previews_display_policy(MediaPreviews::Private).await.unwrap();
     ///
     /// # anyhow::Ok(()) });
     /// ```

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1033,7 +1033,7 @@ impl MatrixMockServer {
     ///
     /// mock_server.mock_global_account_data().ok(
     ///     client.user_id().unwrap(),
-    ///     ruma::events::GlobalAccountDataEventType::MediaPreviewConfig,
+    ///     ruma::events::GlobalAccountDataEventType::UnstableMediaPreviewConfig,
     ///     json!({
     ///         "media_previews": "private",
     ///         "invite_avatars": "off"

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1033,7 +1033,7 @@ impl MatrixMockServer {
     ///
     /// mock_server.mock_global_account_data().ok(
     ///     client.user_id().unwrap(),
-    ///     ruma::events::GlobalAccountDataEventType::UnstableMediaPreviewConfig,
+    ///     ruma::events::GlobalAccountDataEventType::MediaPreviewConfig,
     ///     json!({
     ///         "media_previews": "private",
     ///         "invite_avatars": "off"
@@ -1043,7 +1043,7 @@ impl MatrixMockServer {
     /// .mount()
     /// .await;
     ///
-    /// client.account().set_media_previews_display_policy(MediaPreviews::Private).await.unwrap();
+    /// client.account().get_media_preview_config_event_content().await.unwrap();
     ///
     /// # anyhow::Ok(()) });
     /// ```

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1043,7 +1043,7 @@ impl MatrixMockServer {
     /// .mount()
     /// .await;
     ///
-    /// client.account().get_media_preview_config_event_content().await.unwrap();
+    /// client.account().fetch_media_preview_config_event_content().await.unwrap();
     ///
     /// # anyhow::Ok(()) });
     /// ```


### PR DESCRIPTION
The reason behind this PR, is to extend https://github.com/matrix-org/matrix-rust-sdk/pull/5040 
While the observable value is very useful in the context of the main app, it may be problematic in the context of parallel processes that aim to aid the main app process, like for example the Notification Service Extension on iOS, which is treated as a different process, and has some very harsh memory contraints, and a limited lifetime, which would make the observable values not quite useful.

Also while we do have a [`get_media_preview_config_event_content`](https://github.com/matrix-org/matrix-rust-sdk/blob/0cfb4b1c55dd2ff8e90a6bb804944592ea819222/crates/matrix-sdk/src/account.rs#L1067) that is used by the observable API, this sends a request to the server to check for the current account data value of such event, and in the context of the NSE which already waits for a sync, we probably do not want to slow it down with another request to the server (not mentioning that sending a request for each notification might be also problematic for the servers).
For the NSE scenario I think getting whatever is currently in the store would be fine.