### PR TITLE
feat(timeline): pass the encryption info for a bundled edit

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -574,8 +574,18 @@ impl TimelineEventKind {
     pub fn encryption_info(&self) -> Option<&EncryptionInfo> {
         match self {
             TimelineEventKind::Decrypted(d) => Some(&d.encryption_info),
-            TimelineEventKind::UnableToDecrypt { .. } => None,
-            TimelineEventKind::PlainText { .. } => None,
+            TimelineEventKind::UnableToDecrypt { .. } | TimelineEventKind::PlainText { .. } => None,
+        }
+    }
+
+    /// If the event was a decrypted event that was successfully decrypted, get
+    /// the map of decryption metadata related to the bundled events.
+    pub fn unsigned_encryption_map(
+        &self,
+    ) -> Option<&BTreeMap<UnsignedEventLocation, UnsignedDecryptionResult>> {
+        match self {
+            TimelineEventKind::Decrypted(d) => d.unsigned_encryption_info.as_ref(),
+            TimelineEventKind::UnableToDecrypt { .. } | TimelineEventKind::PlainText { .. } => None,
         }
     }
 
@@ -701,6 +711,17 @@ pub enum UnsignedDecryptionResult {
     Decrypted(EncryptionInfo),
     /// The event failed to be decrypted.
     UnableToDecrypt(UnableToDecryptInfo),
+}
+
+impl UnsignedDecryptionResult {
+    /// Returns the encryption info for this bundled event if it was
+    /// successfully decrypted.
+    pub fn encryption_info(&self) -> Option<&EncryptionInfo> {
+        match self {
+            Self::Decrypted(info) => Some(info),
+            Self::UnableToDecrypt(_) => None,
+        }
+    }
 }
 
 /// Metadata about an event that could not be decrypted.

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -183,7 +183,7 @@ impl TimelineState {
         let mut date_divider_adjuster = DateDividerAdjuster::new(date_divider_mode);
 
         if let Some(timeline_action) =
-            TimelineAction::from_content(content, None, None, None, &txn.items, &mut txn.meta)
+            TimelineAction::from_content(content, None, None, None, None, &txn.items, &mut txn.meta)
         {
             TimelineEventHandler::new(&mut txn, ctx)
                 .handle_event(&mut date_divider_adjuster, timeline_action)

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -183,7 +183,7 @@ impl TimelineState {
         let mut date_divider_adjuster = DateDividerAdjuster::new(date_divider_mode);
 
         if let Some(timeline_action) =
-            TimelineAction::from_content(content, None, None, None, None, &txn.items, &mut txn.meta)
+            TimelineAction::from_content(content, None, &txn.items, &mut txn.meta)
         {
             TimelineEventHandler::new(&mut txn, ctx)
                 .handle_event(&mut date_divider_adjuster, timeline_action)

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -186,6 +186,7 @@ impl TimelineAction {
         raw_event: &Raw<AnySyncTimelineEvent>,
         room_data_provider: &P,
         unable_to_decrypt_info: Option<UnableToDecryptInfo>,
+        bundled_edit_encryption_info: Option<EncryptionInfo>,
         timeline_items: &Vector<Arc<TimelineItem>>,
         meta: &mut TimelineMetadata,
     ) -> Option<Self> {
@@ -245,6 +246,7 @@ impl TimelineAction {
                             Some(raw_event),
                             Some(ev.relations()),
                             Some(ev.event_id()),
+                            bundled_edit_encryption_info,
                             timeline_items,
                             meta,
                         );
@@ -257,6 +259,7 @@ impl TimelineAction {
                         Some(raw_event),
                         Some(ev.relations()),
                         Some(ev.event_id()),
+                        bundled_edit_encryption_info,
                         timeline_items,
                         meta,
                     );
@@ -306,6 +309,7 @@ impl TimelineAction {
         raw_event: Option<&Raw<AnySyncTimelineEvent>>,
         relations: Option<BundledMessageLikeRelations<AnySyncMessageLikeEvent>>,
         event_id: Option<&EventId>,
+        bundled_edit_encryption_info: Option<EncryptionInfo>,
         timeline_items: &Vector<Arc<TimelineItem>>,
         meta: &mut TimelineMetadata,
     ) -> Option<Self> {
@@ -387,8 +391,7 @@ impl TimelineAction {
                                         new_content,
                                     )),
                                     edit_json,
-                                    // TODO maybe we could provide it?
-                                    encryption_info: None,
+                                    encryption_info: bundled_edit_encryption_info,
                                 }),
                             );
                             meta.aggregations.add(
@@ -434,8 +437,7 @@ impl TimelineAction {
                                         new_content,
                                     )),
                                     edit_json,
-                                    // TODO maybe we could provide it?
-                                    encryption_info: None,
+                                    encryption_info: bundled_edit_encryption_info,
                                 }),
                             );
                             meta.aggregations.add(


### PR DESCRIPTION
This is a direct follow up to #4823, because it was deemed a bit too big for that PR. Also nicely groups all the parameters of `TimelineAction::from_content` when the event is a remote echo.

(I get more and more ideas to refactor this part of the timeline, please send help, in the form of contributor time or financial support to Element :D)