### PR TITLE
feat(base): Create `Room::predecessor_room()` and `Room::successor_room()`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -96,7 +96,7 @@ impl RoomInfo {
             is_direct: room.is_direct().await?,
             is_public: room.is_public(),
             is_space: room.is_space(),
-            tombstone: room.tombstone().map(Into::into),
+            tombstone: room.tombstone_content().map(Into::into),
             is_favourite: room.is_favourite(),
             canonical_alias: room.canonical_alias().map(Into::into),
             alternative_aliases: room.alt_aliases().into_iter().map(Into::into).collect(),

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -24,6 +24,7 @@ mod members;
 mod room_info;
 mod state;
 mod tags;
+mod tombstone;
 
 #[cfg(feature = "e2e-encryption")]
 use std::sync::RwLock as SyncRwLock;
@@ -57,7 +58,6 @@ use ruma::{
             history_visibility::HistoryVisibility,
             join_rules::JoinRule,
             power_levels::{RoomPowerLevels, RoomPowerLevelsEventContent},
-            tombstone::RoomTombstoneEventContent,
         },
     },
     room::RoomType,
@@ -373,16 +373,6 @@ impl Room {
     /// missing from storage.
     pub fn name(&self) -> Option<String> {
         self.inner.read().name().map(ToOwned::to_owned)
-    }
-
-    /// Has the room been tombstoned.
-    pub fn is_tombstoned(&self) -> bool {
-        self.inner.read().base_info.tombstone.is_some()
-    }
-
-    /// Get the `m.room.tombstone` content of this room if there is one.
-    pub fn tombstone(&self) -> Option<RoomTombstoneEventContent> {
-        self.inner.read().tombstone().cloned()
     }
 
     /// Get the topic of the room.

--- a/crates/matrix-sdk-base/src/room/tombstone.rs
+++ b/crates/matrix-sdk-base/src/room/tombstone.rs
@@ -12,18 +12,268 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ruma::events::room::tombstone::RoomTombstoneEventContent;
+use std::ops::Not;
+
+use ruma::{events::room::tombstone::RoomTombstoneEventContent, OwnedEventId, OwnedRoomId};
 
 use super::Room;
 
 impl Room {
     /// Has the room been tombstoned.
+    ///
+    /// A room is tombstoned if it has received a [`m.room.tombstone`] state
+    /// event; see [`Room::tombstone_content`].
+    ///
+    /// [`m.room.tombstone`]: https://spec.matrix.org/v1.14/client-server-api/#mroomtombstone
     pub fn is_tombstoned(&self) -> bool {
         self.inner.read().base_info.tombstone.is_some()
     }
 
-    /// Get the `m.room.tombstone` content of this room if there is one.
-    pub fn tombstone(&self) -> Option<RoomTombstoneEventContent> {
+    /// Get the [`m.room.tombstone`] state event's content of this room if one
+    /// has been received.
+    ///
+    /// Also see [`Room::is_tombstoned`] to check if the [`m.room.tombstone`]
+    /// event has been received. It's faster than using this method.
+    ///
+    /// [`m.room.tombstone`]: https://spec.matrix.org/v1.14/client-server-api/#mroomtombstone
+    pub fn tombstone_content(&self) -> Option<RoomTombstoneEventContent> {
         self.inner.read().tombstone().cloned()
+    }
+
+    /// If this room is tombstoned, return the “reference” to the successor room
+    /// —i.e. the room replacing this one.
+    ///
+    /// A room is tombstoned if it has received a [`m.room.tombstone`] state
+    /// event; see [`Room::tombstone_content`].
+    ///
+    /// [`m.room.tombstone`]: https://spec.matrix.org/v1.14/client-server-api/#mroomtombstone
+    pub fn successor_room(&self) -> Option<SuccessorRoom> {
+        self.tombstone_content().map(|tombstone_event| SuccessorRoom {
+            room_id: tombstone_event.replacement_room,
+            reason: tombstone_event.body.is_empty().not().then_some(tombstone_event.body),
+        })
+    }
+
+    /// If this room is the successor of a tombstoned room, return the
+    /// “reference” to the predecessor room.
+    ///
+    /// A room is tombstoned if it has received a [`m.room.tombstone`] state
+    /// event; see [`Room::tombstone_content`].
+    ///
+    /// To determine if a room is the successor of a tombstoned room, the
+    /// [`m.room.create`] must have been received, **with** a `predecessor`
+    /// field. See [`Room::create_content`].
+    ///
+    /// [`m.room.tombstone`]: https://spec.matrix.org/v1.14/client-server-api/#mroomtombstone
+    /// [`m.room.create`]: https://spec.matrix.org/v1.14/client-server-api/#mroomcreate
+    pub fn predecessor_room(&self) -> Option<PredecessorRoom> {
+        self.create_content().and_then(|content_event| content_event.predecessor).map(
+            |predecessor| PredecessorRoom {
+                room_id: predecessor.room_id,
+                last_event_id: predecessor.event_id,
+            },
+        )
+    }
+}
+
+/// When a room A is tombstoned, it is replaced by a room B. The room A is the
+/// predecessor of B, and B is the successor of A. This type holds information
+/// about the successor room. See [`Room::successor_room`].
+///
+/// A room is tombstoned if it has received a [`m.room.tombstone`] state event.
+///
+/// [`m.room.tombstone`]: https://spec.matrix.org/v1.14/client-server-api/#mroomtombstone
+#[derive(Debug)]
+pub struct SuccessorRoom {
+    /// The ID of the next room replacing this (tombstoned) room.
+    pub room_id: OwnedRoomId,
+
+    /// The reason why the room has been tombstoned.
+    pub reason: Option<String>,
+}
+
+/// When a room A is tombstoned, it is replaced by a room B. The room A is the
+/// predecessor of B, and B is the successor of A. This type holds information
+/// about the predecessor room. See [`Room::predecessor_room`].
+///
+/// To know the predecessor of a room, the [`m.room.create`] state event must
+/// have been received.
+///
+/// [`m.room.tombstone`]: https://spec.matrix.org/v1.14/client-server-api/#mroomtombstone
+/// [`m.room.create`]: https://spec.matrix.org/v1.14/client-server-api/#mroomcreate
+#[derive(Debug)]
+pub struct PredecessorRoom {
+    /// The ID of the old room.
+    pub room_id: OwnedRoomId,
+
+    /// The event ID of the last known event in the predecesssor room.
+    pub last_event_id: OwnedEventId,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Not;
+
+    use assert_matches::assert_matches;
+    use matrix_sdk_test::{
+        async_test, event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent,
+        SyncResponseBuilder,
+    };
+    use ruma::{event_id, room_id, user_id};
+    use serde_json::json;
+
+    use crate::{test_utils::logged_in_base_client, RoomState};
+
+    #[async_test]
+    async fn test_no_successor_room() {
+        let client = logged_in_base_client(None).await;
+        let room = client.get_or_create_room(room_id!("!r0"), RoomState::Joined);
+
+        assert!(room.is_tombstoned().not());
+        assert!(room.tombstone_content().is_none());
+        assert!(room.successor_room().is_none());
+    }
+
+    #[async_test]
+    async fn test_successor_room() {
+        let client = logged_in_base_client(None).await;
+        let sender = user_id!("@mnt_io:matrix.org");
+        let room_id = room_id!("!r0");
+        let successor_room_id = room_id!("!r1");
+        let room = client.get_or_create_room(room_id, RoomState::Joined);
+
+        let mut sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
+            .add_joined_room(
+                JoinedRoomBuilder::new(room_id).add_timeline_event(
+                    EventFactory::new()
+                        .sender(sender)
+                        .room_tombstone("traces of you", successor_room_id),
+                ),
+            )
+            .build_sync_response();
+
+        client.receive_sync_response(response).await.unwrap();
+
+        assert!(room.is_tombstoned());
+        assert!(room.tombstone_content().is_some());
+        assert_matches!(room.successor_room(), Some(successor_room) => {
+            assert_eq!(successor_room.room_id, successor_room_id);
+            assert_matches!(successor_room.reason, Some(reason) => {
+                assert_eq!(reason, "traces of you");
+            });
+        });
+    }
+
+    #[async_test]
+    async fn test_successor_room_no_reason() {
+        let client = logged_in_base_client(None).await;
+        let sender = user_id!("@mnt_io:matrix.org");
+        let room_id = room_id!("!r0");
+        let successor_room_id = room_id!("!r1");
+        let room = client.get_or_create_room(room_id, RoomState::Joined);
+
+        let mut sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
+            .add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+                EventFactory::new().sender(sender).room_tombstone(
+                    // An empty reason will result in `None` in `SuccessorRoom::reason`.
+                    "",
+                    successor_room_id,
+                ),
+            ))
+            .build_sync_response();
+
+        client.receive_sync_response(response).await.unwrap();
+
+        assert!(room.is_tombstoned());
+        assert!(room.tombstone_content().is_some());
+        assert_matches!(room.successor_room(), Some(successor_room) => {
+            assert_eq!(successor_room.room_id, successor_room_id);
+            assert!(successor_room.reason.is_none());
+        });
+    }
+
+    #[async_test]
+    async fn test_no_predecessor_room() {
+        let client = logged_in_base_client(None).await;
+        let room = client.get_or_create_room(room_id!("!r0"), RoomState::Joined);
+
+        assert!(room.create_content().is_none());
+        assert!(room.predecessor_room().is_none());
+    }
+
+    #[async_test]
+    async fn test_no_predecessor_room_with_create_event() {
+        let client = logged_in_base_client(None).await;
+        let sender = user_id!("@mnt_io:matrix.org");
+        let room_id = room_id!("!r1");
+        let room = client.get_or_create_room(room_id, RoomState::Joined);
+
+        let mut sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
+            .add_joined_room(JoinedRoomBuilder::new(room_id).add_state_event(
+                StateTestEvent::Custom(json!({
+                    "content": {
+                        "creator": sender,
+                        // no `predecessor` field!
+                    },
+                    "event_id": "$ev0",
+                    "origin_server_ts": 42,
+                    "sender": sender,
+                    "state_key": "",
+                    "type": "m.room.create",
+                    "unsigned": {
+                        "age": 43
+                    }
+                })),
+            ))
+            .build_sync_response();
+
+        client.receive_sync_response(response).await.unwrap();
+
+        assert!(room.create_content().is_some());
+        assert!(room.predecessor_room().is_none());
+    }
+
+    #[async_test]
+    async fn test_predecessor_room() {
+        let client = logged_in_base_client(None).await;
+        let sender = user_id!("@mnt_io:matrix.org");
+        let room_id = room_id!("!r1");
+        let predecessor_room_id = room_id!("!r0");
+        let predecessor_last_event_id = event_id!("$ev42");
+        let room = client.get_or_create_room(room_id, RoomState::Joined);
+
+        let mut sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
+            .add_joined_room(JoinedRoomBuilder::new(room_id).add_state_event(
+                StateTestEvent::Custom(json!({
+                    "content": {
+                        "creator": sender,
+                        "predecessor": {
+                            "event_id": predecessor_last_event_id,
+                            "room_id": predecessor_room_id,
+                        },
+                    },
+                    "event_id": "$ev0",
+                    "origin_server_ts": 42,
+                    "sender": sender,
+                    "state_key": "",
+                    "type": "m.room.create",
+                    "unsigned": {
+                        "age": 43
+                    }
+                })),
+            ))
+            .build_sync_response();
+
+        client.receive_sync_response(response).await.unwrap();
+
+        assert!(room.create_content().is_some());
+        assert_matches!(room.predecessor_room(), Some(predecessor_room) => {
+            assert_eq!(predecessor_room.room_id, predecessor_room_id);
+            assert_eq!(predecessor_room.last_event_id, predecessor_last_event_id);
+        });
     }
 }

--- a/crates/matrix-sdk-base/src/room/tombstone.rs
+++ b/crates/matrix-sdk-base/src/room/tombstone.rs
@@ -1,0 +1,29 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ruma::events::room::tombstone::RoomTombstoneEventContent;
+
+use super::Room;
+
+impl Room {
+    /// Has the room been tombstoned.
+    pub fn is_tombstoned(&self) -> bool {
+        self.inner.read().base_info.tombstone.is_some()
+    }
+
+    /// Get the `m.room.tombstone` content of this room if there is one.
+    pub fn tombstone(&self) -> Option<RoomTombstoneEventContent> {
+        self.inner.read().tombstone().cloned()
+    }
+}

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -288,7 +288,7 @@ where
     }
 
     pub fn into_raw_timeline(self) -> Raw<AnyTimelineEvent> {
-        Raw::new(&self.construct_json(true)).unwrap().cast()
+        self.into_raw()
     }
 
     pub fn into_raw_sync(self) -> Raw<AnySyncTimelineEvent> {

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -41,7 +41,7 @@ use ruma::{
         room::{
             avatar::{self, RoomAvatarEventContent},
             canonical_alias::RoomCanonicalAliasEventContent,
-            create::RoomCreateEventContent,
+            create::{PreviousRoom, RoomCreateEventContent},
             encrypted::{EncryptedEventScheme, RoomEncryptedEventContent},
             member::{MembershipState, RoomMemberEventContent},
             message::{
@@ -396,6 +396,20 @@ impl EventBuilder<UnstablePollStartEventContent> {
         if let UnstablePollStartEventContent::New(content) = &mut self.content {
             content.relates_to = Some(RelationWithoutReplacement::Thread(thread));
         };
+        self
+    }
+}
+
+impl EventBuilder<RoomCreateEventContent> {
+    /// Define the predecessor fields.
+    pub fn predecessor(mut self, room_id: &RoomId, event_id: &EventId) -> Self {
+        self.content.predecessor = Some(PreviousRoom::new(room_id.to_owned(), event_id.to_owned()));
+        self
+    }
+
+    /// Erase the predecessor if any.
+    pub fn no_predecessor(mut self) -> Self {
+        self.content.predecessor = None;
         self
     }
 }

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -766,12 +766,21 @@ impl EventFactory {
     /// Create a new `m.room.create` event.
     pub fn create(
         &self,
-        user_id: &UserId,
+        creator_user_id: &UserId,
         room_version: RoomVersionId,
     ) -> EventBuilder<RoomCreateEventContent> {
-        let mut event = RoomCreateEventContent::new_v1(user_id.to_owned());
-        event.room_version = room_version;
-        self.event(event)
+        let mut event = self.event(RoomCreateEventContent::new_v1(creator_user_id.to_owned()));
+        event.content.room_version = room_version;
+
+        if self.sender.is_some() {
+            event.sender = self.sender.clone();
+        } else {
+            event.sender = Some(creator_user_id.to_owned());
+        }
+
+        event.state_key = Some("".to_owned());
+
+        event
     }
 
     /// Create a new `m.room.power_levels` event.

--- a/testing/matrix-sdk-test/src/test_json/sync_events.rs
+++ b/testing/matrix-sdk-test/src/test_json/sync_events.rs
@@ -52,7 +52,7 @@ pub static CREATE: Lazy<JsonValue> = Lazy::new(|| {
         "state_key": "",
         "type": "m.room.create",
         "unsigned": {
-          "age": 139298
+            "age": 139298
         }
     })
 });


### PR DESCRIPTION
This patch adds 2 methods on `Room`:

1. `predecessor_room()`,
2. `successor_room()`.

If a room A is tombstoned, it is replaced by a room B. Room A is the predecessor, and room B is the successor. Having this clear semantics is helpful, and will help to solve https://github.com/matrix-org/matrix-rust-sdk/issues/5050.

Documentation has been improved, along with adding missing tests, and writing new tests.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/5050