### PR TITLE
refactor: when leaving an `Invited` room also forget it

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_preview.rs
+++ b/bindings/matrix-sdk-ffi/src/room_preview.rs
@@ -59,15 +59,7 @@ impl RoomPreview {
         let room =
             self.client.get_room(&self.inner.room_id).context("missing room for a room preview")?;
 
-        let should_forget = matches!(room.state(), matrix_sdk::RoomState::Invited);
-
-        room.leave().await.map_err(ClientError::from)?;
-
-        if should_forget {
-            _ = self.forget().await;
-        }
-
-        Ok(())
+        Ok(room.leave().await?)
     }
 
     /// Get the user who created the invite, if any.

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -996,6 +996,13 @@ impl MatrixMockServer {
         self.mock_endpoint(mock, RoomLeaveEndpoint).expect_default_access_token()
     }
 
+    /// Creates a prebuilt mock for the endpoint used to forget a room.
+    pub fn mock_room_forget(&self) -> MockEndpoint<'_, RoomForgetEndpoint> {
+        let mock =
+            Mock::given(method("POST")).and(path_regex(r"^/_matrix/client/v3/rooms/.*/forget"));
+        self.mock_endpoint(mock, RoomForgetEndpoint).expect_default_access_token()
+    }
+
     /// Create a prebuilt mock for the endpoint use to log out a session.
     pub fn mock_logout(&self) -> MockEndpoint<'_, LogoutEndpoint> {
         let mock = Mock::given(method("POST")).and(path("/_matrix/client/v3/logout"));
@@ -2636,6 +2643,17 @@ impl<'a> MockEndpoint<'a, RoomLeaveEndpoint> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "room_id": room_id,
         })))
+    }
+}
+
+/// A prebuilt mock for the room forget endpoint.
+pub struct RoomForgetEndpoint;
+
+impl<'a> MockEndpoint<'a, RoomForgetEndpoint> {
+    /// Returns a successful response with some default data for the given room
+    /// id.
+    pub fn ok(self) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
 }
 


### PR DESCRIPTION
This behaviour was added only at the `RoomPreview::leave` method, but since we're slowly moving away from it we should move the forget action to the `Room::leave` method instead.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
