### PR TITLE
test: Enable the historic room key bundle storage test, except on Wasm

### DIFF
--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -1278,7 +1278,8 @@ macro_rules! cryptostore_integration_tests {
             }
 
             #[async_test]
-            #[ignore] // not yet implemented for all stores
+            // Not yet implemented in the indexedDB store so we're disabling it on WASM.
+            #[cfg_attr(target_arch = "wasm32", ignore)]
             async fn test_received_room_key_bundle() {
                 let store = get_store("received_room_key_bundle", None, true).await;
                 let test_room = room_id!("!room:example.org");


### PR DESCRIPTION
The test was ignored since the functionality was only implemented for the memory and SQLite store. This caused a bug in the SQLite implementation to go unnoticed.

Let's just disable it for Wasm since this is the only place where we didn't yet implement the necessary methods.

Based on top of #5071 since the fix for a bug this test should have catched is on that branch.