### PR TITLE
Test: Replace `sync_timeline_event!` with `EventFactory` for plain text room message event in notification client test

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -35,16 +35,18 @@ async fn test_notification_client_with_context() {
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
+    let content = "Hello world!";
     let event_id = event_id!("$example_event_id");
+    let server_ts = 152049794;
     let sender = user_id!("@user:example.org");
     let event_json = json!({
         "content": {
-            "body": "Hello world!",
+            "body": content,
             "msgtype": "m.text",
         },
         "room_id": room_id,
         "event_id": event_id,
-        "origin_server_ts": 152049794,
+        "origin_server_ts": server_ts,
         "sender": sender,
         "type": "m.room.message",
     });
@@ -53,9 +55,9 @@ async fn test_notification_client_with_context() {
     sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id).add_timeline_event(
             EventFactory::new()
-                .text_msg("Hello world!")
+                .text_msg(content)
                 .event_id(event_id)
-                .server_ts(152049794)
+                .server_ts(server_ts)
                 .sender(sender)
                 .into_raw_sync(),
         ),

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -6,7 +6,7 @@ use std::{
 use assert_matches::assert_matches;
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
-    async_test, mocks::mock_encryption_state, sync_timeline_event, JoinedRoomBuilder,
+    async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
     StateTestEvent, SyncResponseBuilder,
 };
 use matrix_sdk_ui::{
@@ -51,7 +51,14 @@ async fn test_notification_client_with_context() {
 
     let mut sync_builder = SyncResponseBuilder::new();
     sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id).add_timeline_event(sync_timeline_event!(event_json)),
+        JoinedRoomBuilder::new(room_id).add_timeline_event(
+            EventFactory::new()
+                .text_msg("Hello world!")
+                .event_id(event_id)
+                .server_ts(152049794)
+                .sender(sender)
+                .into_raw_sync(),
+        ),
     );
 
     // First, mock a sync that contains a text message.


### PR DESCRIPTION
Part of #3716

I added some extra variables to avoid duplicating hardcoded values which could go out of sync if one is changed but the other isn't, hope that's a reasonable thing to do alongside the change I was making!

Signed-off-by: Yousef Moazzam <yousefmoazzam@hotmail.co.uk>