### PR TITLE
fix: Do not retrieve notification events sent by ignored users

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -4,10 +4,13 @@ use std::{
 };
 
 use assert_matches::assert_matches;
-use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
+use matrix_sdk::{
+    config::SyncSettings,
+    test_utils::{logged_in_client_with_server, mocks::MatrixMockServer},
+};
 use matrix_sdk_test::{
-    async_test, mocks::mock_encryption_state, sync_timeline_event, JoinedRoomBuilder,
-    StateTestEvent, SyncResponseBuilder,
+    async_test, event_factory::EventFactory, mocks::mock_encryption_state, sync_timeline_event,
+    JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder,
 };
 use matrix_sdk_ui::{
     notification_client::{
@@ -1058,4 +1061,228 @@ async fn test_notification_client_mixed() {
     assert_eq!(item.sender_avatar_url.as_deref(), Some(sender_avatar_url));
     assert_eq!(item.room_computed_display_name, sender_display_name);
     assert_eq!(item.is_noisy, Some(false));
+}
+
+#[async_test]
+async fn test_notification_client_sliding_sync_filters_out_events_from_ignored_users() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let sender = user_id!("@user:example.org");
+    let my_user_id = client.user_id().unwrap().to_owned();
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let room_name = "The Maltese Falcon";
+    let sender_display_name = "John Mastodon";
+    let sender_avatar_url = "https://example.org/avatar.jpeg";
+    let event_id = event_id!("$example_event_id");
+
+    let raw_event = EventFactory::new()
+        .room(room_id)
+        .sender(sender)
+        .text_msg("Heya")
+        .event_id(event_id)
+        .into_raw_sync();
+
+    let pos = Mutex::new(0);
+    Mock::given(SlidingSyncMatcher)
+        .respond_with(move |request: &Request| {
+            let partial_request: PartialSlidingSyncRequest = request.body_json().unwrap();
+            // Repeat the transaction id in the response, to validate sticky parameters.
+            let mut pos = pos.lock().unwrap();
+            *pos += 1;
+            let pos_as_str = (*pos).to_string();
+            ResponseTemplate::new(200).set_body_json(json!({
+                "txn_id": partial_request.txn_id,
+                "pos": pos_as_str,
+                "rooms": {
+                    room_id: {
+                        "name": room_name,
+                        "initial": true,
+
+                        "required_state": [
+                            // Sender's member information.
+                            {
+                                "content": {
+                                    "avatar_url": sender_avatar_url,
+                                    "displayname": sender_display_name,
+                                    "membership": "join"
+                                },
+                                "room_id": room_id,
+                                "event_id": "$151800140517rfvjc:example.org",
+                                "membership": "join",
+                                "origin_server_ts": 151800140,
+                                "sender": sender,
+                                "state_key": sender,
+                                "type": "m.room.member",
+                                "unsigned": {
+                                    "age": 2970366,
+                                }
+                            },
+
+                            // Own member information.
+                            {
+                                "content": {
+                                    "avatar_url": null,
+                                    "displayname": "My Self",
+                                    "membership": "join"
+                                },
+                                "room_id": room_id,
+                                "event_id": "$151800140517rflkc:example.org",
+                                "membership": "join",
+                                "origin_server_ts": 151800140,
+                                "sender": my_user_id.clone(),
+                                "state_key": my_user_id,
+                                "type": "m.room.member",
+                                "unsigned": {
+                                    "age": 2970366,
+                                }
+                            },
+
+                            // Power levels.
+                            {
+                                "content": {
+                                    "ban": 50,
+                                    "events": {
+                                        "m.room.avatar": 50,
+                                        "m.room.canonical_alias": 50,
+                                        "m.room.history_visibility": 100,
+                                        "m.room.name": 50,
+                                        "m.room.power_levels": 100,
+                                        "m.room.message": 25,
+                                    },
+                                    "events_default": 0,
+                                    "invite": 0,
+                                    "kick": 50,
+                                    "redact": 50,
+                                    "state_default": 50,
+                                    "users": {
+                                        "@example:localhost": 100,
+                                        sender: 0,
+                                    },
+                                    "users_default": 0,
+                                },
+                                "event_id": "$15139375512JaHAW:localhost",
+                                "origin_server_ts": 151393755,
+                                "sender": "@example:localhost",
+                                "state_key": "",
+                                "type": "m.room.power_levels",
+                                "unsigned": {
+                                    "age": 703422,
+                                },
+                            },
+                        ],
+
+                        "timeline": [
+                            raw_event,
+                        ]
+                    }
+                },
+
+                "extensions": {
+                    "account_data": {
+                        "global": [{
+                            "type": "m.ignored_user_list",
+                            "content": {
+                                "ignored_users": { sender: {} }
+                            }
+                        }]
+                    }
+                }
+            }))
+        })
+        .mount(server.server())
+        .await;
+
+    let dummy_sync_service = Arc::new(SyncService::builder(client.clone()).build().await.unwrap());
+    let process_setup =
+        NotificationProcessSetup::SingleProcess { sync_service: dummy_sync_service };
+    let notification_client = NotificationClient::new(client, process_setup).await.unwrap();
+    let mut result = notification_client
+        .get_notifications_with_sliding_sync(&[NotificationItemsRequest {
+            room_id: room_id.to_owned(),
+            event_ids: vec![event_id.to_owned()],
+        }])
+        .await
+        .unwrap();
+
+    let Some(Ok(item)) = result.remove(event_id) else {
+        panic!("fetching notification for {event_id} failed");
+    };
+    let NotificationStatus::EventFilteredOut = item else {
+        panic!("notification for {event_id} was not filtered out");
+    };
+}
+
+#[async_test]
+async fn test_notification_client_context_filters_out_events_from_ignored_users() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let sender = user_id!("@user:example.org");
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let event_id = event_id!("$example_event_id");
+
+    server.sync_joined_room(&client, room_id).await;
+
+    // Add mock for sliding sync so we get the ignored user list from its account
+    // data
+    let pos = Mutex::new(0);
+    Mock::given(SlidingSyncMatcher)
+        .respond_with(move |request: &Request| {
+            let partial_request: PartialSlidingSyncRequest = request.body_json().unwrap();
+            // Repeat the transaction id in the response, to validate sticky parameters.
+            let mut pos = pos.lock().unwrap();
+            *pos += 1;
+            let pos_as_str = (*pos).to_string();
+            ResponseTemplate::new(200).set_body_json(json!({
+                "txn_id": partial_request.txn_id,
+                "pos": pos_as_str,
+                "rooms": {},
+
+                "extensions": {
+                    "account_data": {
+                        "global": [{
+                            "type": "m.ignored_user_list",
+                            "content": {
+                                "ignored_users": { sender: {} }
+                            }
+                        }]
+                    }
+                }
+            }))
+        })
+        .mount(server.server())
+        .await;
+
+    let event = EventFactory::new()
+        .room(room_id)
+        .sender(sender)
+        .text_msg("Heya")
+        .event_id(event_id)
+        .into_event();
+
+    // Mock the /context response
+    server.mock_room_event_context().ok(event, "start", "end").mock_once().mount().await;
+
+    let dummy_sync_service = Arc::new(SyncService::builder(client.clone()).build().await.unwrap());
+    let process_setup =
+        NotificationProcessSetup::SingleProcess { sync_service: dummy_sync_service };
+    let notification_client = NotificationClient::new(client, process_setup).await.unwrap();
+
+    // Call sync first so we get the list of ignored users in the notification
+    // client This should still work in a real life usage
+    let _ = notification_client
+        .get_notifications_with_sliding_sync(&[NotificationItemsRequest {
+            room_id: room_id.to_owned(),
+            event_ids: vec![event_id.to_owned()],
+        }])
+        .await;
+
+    // If the event is not found even though there was a mocked response for it, it
+    // was discarded as expected
+    let result =
+        notification_client.get_notification_with_context(room_id, event_id).await.unwrap();
+
+    assert!(result.is_none());
 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2541,6 +2541,13 @@ impl Client {
         let base_room = self.inner.base_client.room_knocked(&response.room_id).await?;
         Ok(Room::new(self.clone(), base_room))
     }
+
+    /// Checks whether the provided `user_id` belongs to an ignored user.
+    pub fn is_user_ignored(&self, user_id: &UserId) -> bool {
+        let raw_user_id = user_id.to_string();
+        let current_ignored_user_list = self.subscribe_to_ignore_user_list_changes().get();
+        current_ignored_user_list.contains(&raw_user_id)
+    }
 }
 
 /// A weak reference to the inner client, useful when trying to get a handle
@@ -2608,7 +2615,7 @@ pub(crate) mod tests {
             ignored_user_list::IgnoredUserListEventContent,
             media_preview_config::{InviteAvatars, MediaPreviewConfigEventContent, MediaPreviews},
         },
-        owned_room_id, room_alias_id, room_id, RoomId, ServerName, UserId,
+        owned_room_id, room_alias_id, room_id, user_id, RoomId, ServerName, UserId,
     };
     use serde_json::json;
     use stream_assert::{assert_next_matches, assert_pending};
@@ -3444,5 +3451,26 @@ pub(crate) mod tests {
 
         assert_eq!(initial_value.invite_avatars, InviteAvatars::On);
         assert_eq!(initial_value.media_previews, MediaPreviews::On);
+    }
+
+    #[async_test]
+    async fn test_is_user_ignored() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        let user_id = user_id!("@alice:host");
+        assert!(!client.is_user_ignored(user_id));
+
+        server
+            .mock_sync()
+            .ok_and_run(&client, |builder| {
+                builder.add_global_account_data_event(GlobalAccountDataTestEvent::Custom(json!({
+                    "type": "m.ignored_user_list",
+                    "content": IgnoredUserListEventContent::users([user_id.to_owned()])
+                })));
+            })
+            .await;
+
+        assert!(client.is_user_ignored(user_id));
     }
 }

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -496,6 +496,13 @@ impl MatrixMockServer {
             .expect_default_access_token()
     }
 
+    /// Creates a prebuilt mock for retrieving an event with /room/.../context.
+    pub fn mock_room_event_context(&self) -> MockEndpoint<'_, RoomEventContextEndpoint> {
+        let mock = Mock::given(method("GET"));
+        self.mock_endpoint(mock, RoomEventContextEndpoint { room: None, match_event_id: false })
+            .expect_default_access_token()
+    }
+
     /// Create a prebuild mock for paginating room message with the `/messages`
     /// endpoint.
     pub fn mock_room_messages(&self) -> MockEndpoint<'_, RoomMessagesEndpoint> {
@@ -2136,6 +2143,57 @@ impl<'a> MockEndpoint<'a, RoomEventEndpoint> {
             .mock
             .and(path_regex(format!(r"^/_matrix/client/v3/rooms/{room_path}/event/{event_path}")))
             .respond_with(ResponseTemplate::new(200).set_body_json(event.into_raw().json()));
+        MatrixMock { server: self.server, mock }
+    }
+}
+
+/// A prebuilt mock for getting a single event with its context in a room.
+pub struct RoomEventContextEndpoint {
+    room: Option<OwnedRoomId>,
+    match_event_id: bool,
+}
+
+impl<'a> MockEndpoint<'a, RoomEventContextEndpoint> {
+    /// Limits the scope of this mock to a specific room.
+    pub fn room(mut self, room: impl Into<OwnedRoomId>) -> Self {
+        self.endpoint.room = Some(room.into());
+        self
+    }
+
+    /// Whether the mock checks for the event id from the event.
+    pub fn match_event_id(mut self) -> Self {
+        self.endpoint.match_event_id = true;
+        self
+    }
+
+    /// Returns an endpoint that emulates success
+    pub fn ok(
+        self,
+        event: TimelineEvent,
+        start: impl Into<String>,
+        end: impl Into<String>,
+    ) -> MatrixMock<'a> {
+        let event_path = if self.endpoint.match_event_id {
+            let event_id = event.kind.event_id().expect("an event id is required");
+            // The event id should begin with `$`, which would be taken as the end of the
+            // regex so we need to escape it
+            event_id.as_str().replace("$", "\\$")
+        } else {
+            // Event is at the end, so no need to add anything.
+            "".to_owned()
+        };
+
+        let room_path = self.endpoint.room.map_or_else(|| ".*".to_owned(), |room| room.to_string());
+
+        let mock = self
+            .mock
+            .and(path_regex(format!(r"^/_matrix/client/v3/rooms/{room_path}/context/{event_path}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "event": event.into_raw().json(),
+                "end": end.into(),
+                "start": start.into(),
+                "state": []
+            })));
         MatrixMock { server: self.server, mock }
     }
 }


### PR DESCRIPTION
When retrieving notifications using either sliding sync or the `/context` endpoint, check if the sender is ignored by the user before returning it. If it is, just filter out the notification.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
