### PR TITLE
Mechanical move from target_arch="wasm32" to target_family="wasm"

### DIFF
--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -90,10 +90,10 @@ matrix-sdk-test = { workspace = true }
 stream_assert = { workspace = true }
 similar-asserts = { workspace = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test = { workspace = true }
 
 [lints]

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -114,8 +114,8 @@ pub fn check_test_event(event: &TimelineEvent, text: &str) {
 ///
 /// This trait is not meant to be used directly, but will be used with the
 /// `event_cache_store_integration_tests!` macro.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait EventCacheStoreIntegrationTests {
     /// Test media content storage.
     async fn test_media_content(&self);
@@ -154,8 +154,8 @@ pub trait EventCacheStoreIntegrationTests {
     async fn test_save_event(&self);
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl EventCacheStoreIntegrationTests for DynEventCacheStore {
     async fn test_media_content(&self) {
         let uri = mxc_uri!("mxc://localhost/media");
@@ -1141,7 +1141,7 @@ macro_rules! event_cache_store_integration_tests {
 #[macro_export]
 macro_rules! event_cache_store_integration_tests_time {
     () => {
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         mod event_cache_store_integration_tests_time {
             use std::time::Duration;
 

--- a/crates/matrix-sdk-base/src/event_cache/store/media/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/media/integration_tests.rs
@@ -31,8 +31,8 @@ use crate::media::{MediaFormat, MediaRequestParameters};
 ///
 /// This trait is not meant to be used directly, but will be used with the
 /// `event_cache_store_media_integration_tests!` macro.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait EventCacheStoreMediaIntegrationTests {
     /// Test media retention policy storage.
     async fn test_store_media_retention_policy(&self);
@@ -58,8 +58,8 @@ pub trait EventCacheStoreMediaIntegrationTests {
     async fn test_store_last_media_cleanup_time(&self);
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl<Store> EventCacheStoreMediaIntegrationTests for Store
 where
     Store: EventCacheStoreMedia + std::fmt::Debug,

--- a/crates/matrix-sdk-base/src/event_cache/store/media/media_service.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/media/media_service.rs
@@ -356,8 +356,8 @@ where
 /// [`MediaRetentionPolicy`] by wrapping this in a [`MediaService`], and to
 /// simplify the implementation of tests by being able to have complete control
 /// over the `SystemTime`s provided to the store.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait EventCacheStoreMedia: AsyncTraitDeps + Clone {
     /// The error type used by this media cache store.
     type Error: fmt::Debug + fmt::Display + Into<EventCacheStoreError>;
@@ -630,8 +630,8 @@ mod tests {
         }
     }
 
-    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_family = "wasm", async_trait(?Send))]
+    #[cfg_attr(not(target_family = "wasm"), async_trait)]
     impl EventCacheStoreMedia for MockEventCacheStoreMedia {
         type Error = MockEventCacheStoreMediaError;
 

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -110,8 +110,8 @@ impl MemoryStore {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl EventCacheStore for MemoryStore {
     type Error = EventCacheStoreError;
 
@@ -364,8 +364,8 @@ impl EventCacheStore for MemoryStore {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl EventCacheStoreMedia for MemoryStore {
     type Error = EventCacheStoreError;
 

--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -185,8 +185,8 @@ pub type Result<T, E = EventCacheStoreError> = std::result::Result<T, E>;
 #[derive(Clone, Debug)]
 struct LockableEventCacheStore(Arc<DynEventCacheStore>);
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl BackingStore for LockableEventCacheStore {
     type LockError = EventCacheStoreError;
 

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -37,8 +37,8 @@ pub const DEFAULT_CHUNK_CAPACITY: usize = 128;
 
 /// An abstract trait that can be used to implement different store backends
 /// for the event cache of the SDK.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait EventCacheStore: AsyncTraitDeps {
     /// The error type used by this event cache store.
     type Error: fmt::Debug + Into<EventCacheStoreError>;
@@ -277,8 +277,8 @@ impl<T: fmt::Debug> fmt::Debug for EraseEventCacheStoreError<T> {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
     type Error = EventCacheStoreError;
 

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -15,7 +15,7 @@
 
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
+#![cfg_attr(target_family = "wasm", allow(clippy::arc_with_non_send_sync))]
 #![warn(missing_docs, missing_debug_implementations)]
 
 pub use matrix_sdk_common::*;

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -47,8 +47,8 @@ use crate::{
 ///
 /// This trait is not meant to be used directly, but will be used with the
 /// `statestore_integration_tests!` macro.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait StateStoreIntegrationTests {
     /// Populate the given `StateStore`.
     async fn populate(&self) -> Result<()>;
@@ -98,8 +98,8 @@ pub trait StateStoreIntegrationTests {
     async fn test_get_room_infos(&self);
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl StateStoreIntegrationTests for DynStateStore {
     async fn populate(&self) -> Result<()> {
         let mut changes = StateChanges::default();

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -138,8 +138,8 @@ impl MemoryStore {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl StateStore for MemoryStore {
     type Error = StoreError;
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -54,8 +54,8 @@ use crate::{
 
 /// An abstract state store trait that can be used to implement different stores
 /// for the SDK.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait StateStore: AsyncTraitDeps {
     /// The error type used by this state store.
     type Error: fmt::Debug + Into<StoreError> + From<serde_json::Error>;
@@ -485,8 +485,8 @@ impl<T: fmt::Debug> fmt::Debug for EraseStateStoreError<T> {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl<T: StateStore> StateStore for EraseStateStoreError<T> {
     type Error = StoreError;
 
@@ -770,8 +770,8 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
 }
 
 /// Convenience functionality for state stores.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait StateStoreExt: StateStore {
     /// Get a specific state event of statically-known type.
     ///
@@ -909,8 +909,8 @@ pub trait StateStoreExt: StateStore {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl<T: StateStore + ?Sized> StateStoreExt for T {}
 
 /// A type-erased [`StateStore`].

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -38,7 +38,7 @@ tracing = { workspace = true }
 tokio = { workspace = true, features = ["rt", "time"] }
 uniffi = { workspace = true, optional = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 futures-util = { workspace = true, features = ["channel"] }
 wasm-bindgen-futures = { version = "0.4.33", optional = true }
 gloo-timers = { workspace = true, features = ["futures"] }
@@ -53,11 +53,11 @@ matrix-sdk-test-macros = { path = "../../testing/matrix-sdk-test-macros" }
 wasm-bindgen-test = { workspace = true }
 insta = { workspace = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 # Enable the test macro.
 tokio = { workspace = true, features = ["rt", "macros"] }
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
 # Enable the JS feature for getrandom.
 getrandom = { workspace = true, default-features = false, features = ["js"] }
 js-sys = { workspace = true }

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -26,7 +26,7 @@ use ruma::{
     DeviceKeyAlgorithm, OwnedDeviceId, OwnedEventId, OwnedUserId,
 };
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use crate::debug::{DebugRawEvent, DebugStructExt};
@@ -252,7 +252,7 @@ pub enum ShieldState {
 /// A machine-readable representation of the authenticity for a `ShieldState`.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub enum ShieldStateCode {
     /// Not enough information available to check the authenticity.
     AuthenticityNotGuaranteed,

--- a/crates/matrix-sdk-common/src/executor.rs
+++ b/crates/matrix-sdk-common/src/executor.rs
@@ -15,24 +15,24 @@
 //! Abstraction over an executor so we can spawn tasks under WASM the same way
 //! we do usually.
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub use futures_util::future::Aborted as JoinError;
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use futures_util::{
     future::{AbortHandle, Abortable, RemoteHandle},
     FutureExt,
 };
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub use tokio::task::{spawn, JoinError, JoinHandle};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub fn spawn<F, T>(future: F) -> JoinHandle<T>
 where
     F: Future<Output = T> + 'static,
@@ -50,14 +50,14 @@ where
     JoinHandle { remote_handle: Some(remote_handle), abort_handle }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[derive(Debug)]
 pub struct JoinHandle<T> {
     remote_handle: Option<RemoteHandle<T>>,
     abort_handle: AbortHandle,
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 impl<T> JoinHandle<T> {
     pub fn abort(&self) {
         self.abort_handle.abort();
@@ -68,7 +68,7 @@ impl<T> JoinHandle<T> {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 impl<T> Drop for JoinHandle<T> {
     fn drop(&mut self) {
         // don't abort the spawned future
@@ -78,7 +78,7 @@ impl<T> Drop for JoinHandle<T> {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 impl<T: 'static> Future for JoinHandle<T> {
     type Output = Result<T, JoinError>;
 

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -37,37 +37,37 @@ pub mod ttl_cache;
 // We cannot currently measure test coverage in the WASM environment, so
 // js_tracing is incorrectly flagged as untested. Disable coverage checking for
 // it.
-#[cfg(all(target_arch = "wasm32", not(tarpaulin_include)))]
+#[cfg(all(target_family = "wasm", not(tarpaulin_include)))]
 pub mod js_tracing;
 
 pub use store_locks::LEASE_DURATION_MS;
 
 /// Alias for `Send` on non-wasm, empty trait (implemented by everything) on
 /// wasm.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub trait SendOutsideWasm: Send {}
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 impl<T: Send> SendOutsideWasm for T {}
 
 /// Alias for `Send` on non-wasm, empty trait (implemented by everything) on
 /// wasm.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub trait SendOutsideWasm {}
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 impl<T> SendOutsideWasm for T {}
 
 /// Alias for `Sync` on non-wasm, empty trait (implemented by everything) on
 /// wasm.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub trait SyncOutsideWasm: Sync {}
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 impl<T: Sync> SyncOutsideWasm for T {}
 
 /// Alias for `Sync` on non-wasm, empty trait (implemented by everything) on
 /// wasm.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub trait SyncOutsideWasm {}
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 impl<T> SyncOutsideWasm for T {}
 
 /// Super trait that is used for our store traits, this trait will differ if
@@ -83,11 +83,11 @@ macro_rules! boxed_into_future {
         $crate::boxed_into_future!(extra_bounds: );
     };
     (extra_bounds: $($extra_bounds:tt)*) => {
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         type IntoFuture = ::std::pin::Pin<::std::boxed::Box<
             dyn ::std::future::Future<Output = Self::Output> + $($extra_bounds)*
         >>;
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         type IntoFuture = ::std::pin::Pin<::std::boxed::Box<
             dyn ::std::future::Future<Output = Self::Output> + Send + $($extra_bounds)*
         >>;
@@ -95,9 +95,9 @@ macro_rules! boxed_into_future {
 }
 
 /// A `Box::pin` future that is `Send` on non-wasm, and without `Send` on wasm.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 #[cfg(feature = "uniffi")]

--- a/crates/matrix-sdk-common/src/linked_chunk/as_vector.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/as_vector.rs
@@ -934,7 +934,7 @@ mod tests {
         );
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     mod proptests {
         use proptest::prelude::*;
 

--- a/crates/matrix-sdk-common/src/sleep.rs
+++ b/crates/matrix-sdk-common/src/sleep.rs
@@ -19,10 +19,10 @@ use std::time::Duration;
 /// This is a cross-platform sleep implementation that works on both wasm32 and
 /// non-wasm32 targets.
 pub async fn sleep(duration: Duration) {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     tokio::time::sleep(duration).await;
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     gloo_timers::future::TimeoutFuture::new(u32::try_from(duration.as_millis()).unwrap_or_else(
         |_| {
             tracing::error!("Sleep duration too long, sleeping for u32::MAX ms");
@@ -38,7 +38,7 @@ mod tests {
 
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[async_test]

--- a/crates/matrix-sdk-common/src/store_locks.rs
+++ b/crates/matrix-sdk-common/src/store_locks.rs
@@ -56,8 +56,8 @@ use crate::{
 };
 
 /// Backing store for a cross-process lock.
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 pub trait BackingStore {
     type LockError: Error + Send + Sync;
 
@@ -214,7 +214,7 @@ impl<S: BackingStore + Clone + SendOutsideWasm + 'static> CrossProcessStoreLock<
         //   operation running in a transaction.
 
         if let Some(_prev) = renew_task.take() {
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(not(target_family = "wasm"))]
             if !_prev.is_finished() {
                 trace!("aborting the previous renew task");
                 _prev.abort();
@@ -335,7 +335,7 @@ pub enum LockStoreError {
 }
 
 #[cfg(test)]
-#[cfg(not(target_arch = "wasm32"))] // These tests require tokio::time, which is not implemented on wasm.
+#[cfg(not(target_family = "wasm"))] // These tests require tokio::time, which is not implemented on wasm.
 mod tests {
     use std::{
         collections::HashMap,
@@ -369,8 +369,8 @@ mod tests {
     #[derive(Debug, thiserror::Error)]
     enum DummyError {}
 
-    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
     impl BackingStore for TestStore {
         type LockError = DummyError;
 

--- a/crates/matrix-sdk-common/src/timeout.rs
+++ b/crates/matrix-sdk-common/src/timeout.rs
@@ -15,11 +15,11 @@
 use std::{error::Error, fmt, time::Duration};
 
 use futures_core::Future;
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use futures_util::future::{select, Either};
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use gloo_timers::future::TimeoutFuture;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 use tokio::time::timeout as tokio_timeout;
 
 /// Error type notifying that a timeout has elapsed.
@@ -43,10 +43,10 @@ pub async fn timeout<F, T>(future: F, duration: Duration) -> Result<T, ElapsedEr
 where
     F: Future<Output = T>,
 {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     return tokio_timeout(duration, future).await.map_err(|_| ElapsedError());
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     {
         let timeout_future =
             TimeoutFuture::new(u32::try_from(duration.as_millis()).expect("Overlong duration"));
@@ -66,7 +66,7 @@ pub(crate) mod tests {
 
     use super::timeout;
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[async_test]

--- a/crates/matrix-sdk-common/src/tracing_timer.rs
+++ b/crates/matrix-sdk-common/src/tracing_timer.rs
@@ -121,7 +121,7 @@ macro_rules! timer {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     #[matrix_sdk_test_macros::async_test]
     async fn test_timer_name() {
         use tracing::{span, Level};

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -73,10 +73,10 @@ uniffi = { workspace = true, optional = true }
 vodozemac = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 tokio = { workspace = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]

--- a/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
@@ -208,7 +208,7 @@ fn decrypt_helper(ciphertext: &str, passphrase: &str) -> Result<String, KeyExpor
     Ok(ret?)
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod proptests {
     use proptest::prelude::*;
 

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -805,9 +805,9 @@ impl DeviceData {
         event_type: &str,
         content: impl Serialize,
     ) -> OlmResult<(Session, Raw<ToDeviceEncryptedEventContent>)> {
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         let message_id = ulid::Ulid::new().to_string();
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         let message_id = ruma::TransactionId::new().to_string();
 
         tracing::Span::current().record("message_id", &message_id);

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs, missing_debug_implementations)]
-#![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
+#![cfg_attr(target_family = "wasm", allow(clippy::arc_with_non_send_sync))]
 
 pub mod backups;
 mod ciphers;

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -851,7 +851,7 @@ mod tests {
         assert!(values.is_sorted());
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos", target_arch = "wasm32"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_family = "wasm"))]
     mod expiration {
         use std::{sync::atomic::Ordering, time::Duration};
 

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -183,8 +183,8 @@ impl MemoryStore {
 
 type Result<T> = std::result::Result<T, Infallible>;
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl CryptoStore for MemoryStore {
     type Error = Infallible;
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -2075,8 +2075,8 @@ impl Deref for Store {
 #[derive(Clone, Debug)]
 pub struct LockableCryptoStore(Arc<dyn CryptoStore<Error = CryptoStoreError>>);
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl matrix_sdk_common::store_locks::BackingStore for LockableCryptoStore {
     type LockError = CryptoStoreError;
 

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -38,8 +38,8 @@ use crate::{
 
 /// Represents a store that the `OlmMachine` uses to store E2EE data (such as
 /// cryptographic keys).
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait CryptoStore: AsyncTraitDeps {
     /// The error type used by this crypto store.
     type Error: fmt::Debug + Into<CryptoStoreError>;
@@ -386,8 +386,8 @@ impl<T: fmt::Debug> fmt::Debug for EraseCryptoStoreError<T> {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
     type Error = CryptoStoreError;
 

--- a/crates/matrix-sdk-crypto/src/verification/sas/helpers.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/helpers.rs
@@ -490,7 +490,7 @@ pub fn get_decimal(
     bytes.decimals()
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use ruma::{
         events::key::verification::start::ToDeviceKeyVerificationStartEventContent, serde::Base64,

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -43,7 +43,7 @@ hkdf = { workspace = true }
 zeroize = { workspace = true }
 sha2 = { workspace = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 # for wasm32 we need to activate this
 getrandom = { workspace = true, features = ["js"] }
 

--- a/crates/matrix-sdk-indexeddb/README.md
+++ b/crates/matrix-sdk-indexeddb/README.md
@@ -8,7 +8,7 @@ The most common usage pattern would be to have this included via `matrix-sdk` in
 instantiation to it.
 
 ```toml,no_test
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 matrix-sdk = { version = "0.5, default-features = false, features = ["indexeddb", "e2e-encryption"] }
 ```
 

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
@@ -232,7 +232,7 @@ fn add_unique_index<'a>(
     object_store.create_index_with_params(name, &IdbKeyPath::str(key_path), &params)
 }
 
-#[cfg(all(test, target_arch = "wasm32"))]
+#[cfg(all(test, target_family = "wasm"))]
 mod tests {
     use std::{cell::Cell, future::Future, rc::Rc, sync::Arc};
 

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -670,7 +670,7 @@ impl IndexeddbCryptoStore {
 // this hack allows us to still have most of rust-analyzer's IDE functionality
 // within the impl block without having to set it up to check things against
 // the wasm target (which would disable many other parts of the codebase).
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 macro_rules! impl_crypto_store {
     ( $($body:tt)* ) => {
         #[async_trait(?Send)]
@@ -682,7 +682,7 @@ macro_rules! impl_crypto_store {
     };
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 macro_rules! impl_crypto_store {
     ( $($body:tt)* ) => {
         impl IndexeddbCryptoStore {
@@ -1866,7 +1866,7 @@ mod unit_tests {
     }
 }
 
-#[cfg(all(test, target_arch = "wasm32"))]
+#[cfg(all(test, target_family = "wasm"))]
 mod wasm_unit_tests {
     use std::collections::BTreeMap;
 
@@ -1930,7 +1930,7 @@ mod wasm_unit_tests {
     }
 }
 
-#[cfg(all(test, target_arch = "wasm32"))]
+#[cfg(all(test, target_family = "wasm"))]
 mod tests {
     use matrix_sdk_crypto::cryptostore_integration_tests;
 
@@ -1959,7 +1959,7 @@ mod tests {
     cryptostore_integration_tests!();
 }
 
-#[cfg(all(test, target_arch = "wasm32"))]
+#[cfg(all(test, target_family = "wasm"))]
 mod encrypted_tests {
     use matrix_sdk_crypto::{
         cryptostore_integration_tests,

--- a/crates/matrix-sdk-indexeddb/src/lib.rs
+++ b/crates/matrix-sdk-indexeddb/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(target_arch = "wasm32"), allow(unused))]
+#![cfg_attr(not(target_family = "wasm"), allow(unused))]
 
 #[cfg(feature = "state-store")]
 use matrix_sdk_base::store::StoreError;

--- a/crates/matrix-sdk-indexeddb/src/serializer.rs
+++ b/crates/matrix-sdk-indexeddb/src/serializer.rs
@@ -321,7 +321,7 @@ impl IndexeddbSerializer {
     }
 }
 
-#[cfg(all(test, target_arch = "wasm32"))]
+#[cfg(all(test, target_family = "wasm"))]
 mod tests {
     use std::{collections::BTreeMap, sync::Arc};
 

--- a/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
@@ -793,7 +793,7 @@ async fn migrate_to_v12(db: IdbDatabase) -> Result<IdbDatabase> {
     Ok(IdbDatabase::open_u32(&name, 12)?.await?)
 }
 
-#[cfg(all(test, target_arch = "wasm32"))]
+#[cfg(all(test, target_family = "wasm"))]
 mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -493,7 +493,7 @@ impl PersistedQueuedRequest {
 // this hack allows us to still have most of rust-analyzer's IDE functionality
 // within the impl block without having to set it up to check things against
 // the wasm target (which would disable many other parts of the codebase).
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 macro_rules! impl_state_store {
     ({ $($body:tt)* }) => {
         #[async_trait(?Send)]
@@ -505,7 +505,7 @@ macro_rules! impl_state_store {
     };
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 macro_rules! impl_state_store {
     ({ $($body:tt)* }) => {
         impl IndexeddbStateStore {
@@ -1850,9 +1850,9 @@ mod migration_tests {
     }
 }
 
-#[cfg(all(test, target_arch = "wasm32"))]
+#[cfg(all(test, target_family = "wasm"))]
 mod tests {
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     use matrix_sdk_base::statestore_integration_tests;
@@ -1868,9 +1868,9 @@ mod tests {
     statestore_integration_tests!();
 }
 
-#[cfg(all(test, target_arch = "wasm32"))]
+#[cfg(all(test, target_family = "wasm"))]
 mod encrypted_tests {
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     use matrix_sdk_base::statestore_integration_tests;

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -1238,8 +1238,8 @@ impl EventCacheStore for SqliteEventCacheStore {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl EventCacheStoreMedia for SqliteEventCacheStore {
     type Error = Error;
 

--- a/crates/matrix-sdk-ui/src/lib.rs
+++ b/crates/matrix-sdk-ui/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
+#![cfg_attr(target_family = "wasm", allow(clippy::arc_with_non_send_sync))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub use eyeball_im;

--- a/crates/matrix-sdk-ui/src/timeline/futures.rs
+++ b/crates/matrix-sdk-ui/src/timeline/futures.rs
@@ -49,7 +49,7 @@ impl<'a> SendAttachment<'a> {
     }
 
     /// Get a subscriber to observe the progress of sending the request body.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub fn subscribe_to_send_progress(&self) -> eyeball::Subscriber<TransmissionProgress> {
         self.send_progress.subscribe()
     }

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(not(target_arch = "wasm32"))]
+#![cfg(not(target_family = "wasm"))]
 
 use std::{
     io::Cursor,

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -649,7 +649,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))] // wasm32 has no time for that
+    #[cfg(not(target_family = "wasm"))] // wasm32 has no time for that
     #[async_test]
     async fn test_delayed_utd() {
         // If I create a dummy hook,
@@ -693,7 +693,7 @@ mod tests {
         assert!(wrapper.pending_delayed.lock().unwrap().is_empty());
     }
 
-    #[cfg(not(target_arch = "wasm32"))] // wasm32 has no time for that
+    #[cfg(not(target_family = "wasm"))] // wasm32 has no time for that
     #[async_test]
     async fn test_delayed_late_decryption() {
         // If I create a dummy hook,

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -119,12 +119,12 @@ vodozemac = { workspace = true }
 zeroize = { workspace = true }
 cfg-if = "1.0.0"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 gloo-timers = { workspace = true, features = ["futures"] }
 reqwest = { workspace = true, features = ["gzip", "http2"] }
 tokio = { workspace = true, features = ["macros"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 backon = "1.5.0"
 # only activate reqwest's stream feature on non-wasm, the wasm part seems to not
 # support *sending* streams, which makes it useless for us.
@@ -148,10 +148,10 @@ stream_assert = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tokio-test = "0.4.4"
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test = { workspace = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 proptest = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 wiremock = { workspace = true }

--- a/crates/matrix-sdk/src/authentication/matrix/login_builder.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/login_builder.rs
@@ -12,7 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![cfg_attr(not(target_arch = "wasm32"), deny(clippy::future_not_send))]
+#![cfg_attr(not(target_family = "wasm"), deny(clippy::future_not_send))]
 
 #[cfg(feature = "sso-login")]
 use std::future::Future;

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -244,7 +244,7 @@ pub enum CrossProcessRefreshLockError {
     DuplicatedLock,
 }
 
-#[cfg(all(test, feature = "e2e-encryption", feature = "sqlite", not(target_arch = "wasm32")))]
+#[cfg(all(test, feature = "e2e-encryption", feature = "sqlite", not(target_family = "wasm")))]
 mod tests {
 
     use anyhow::Context as _;

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -174,7 +174,7 @@ use error::{
     OAuthAuthorizationCodeError, OAuthClientRegistrationError, OAuthDiscoveryError,
     OAuthTokenRevocationError, RedirectUriQueryParseError,
 };
-#[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
 use matrix_sdk_base::crypto::types::qr_login::QrCodeData;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::once_cell::sync::OnceCell;
@@ -208,15 +208,15 @@ mod cross_process;
 pub mod error;
 mod http_client;
 mod oidc_discovery;
-#[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
 pub mod qrcode;
 pub mod registration;
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests;
 
 #[cfg(feature = "e2e-encryption")]
 use self::cross_process::{CrossProcessRefreshLockGuard, CrossProcessRefreshManager};
-#[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
 use self::qrcode::LoginWithQrCode;
 pub use self::{
     account_management_url::{AccountManagementActionFull, AccountManagementUrlBuilder},
@@ -454,7 +454,7 @@ impl OAuth {
     /// println!("Successfully logged in: {:?} {:?}", client.user_id(), client.device_id());
     /// # anyhow::Ok(()) };
     /// ```
-    #[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+    #[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
     pub fn login_with_qr_code<'a>(
         &'a self,
         data: &'a QrCodeData,
@@ -1154,7 +1154,7 @@ impl OAuth {
 
     /// Request codes from the authorization server for logging in with another
     /// device.
-    #[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+    #[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
     async fn request_device_authorization(
         &self,
         server_metadata: &AuthorizationServerMetadata,
@@ -1182,7 +1182,7 @@ impl OAuth {
     }
 
     /// Exchange the device code against an access token.
-    #[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+    #[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
     async fn exchange_device_code(
         &self,
         server_metadata: &AuthorizationServerMetadata,

--- a/crates/matrix-sdk/src/client/builder/homeserver_config.rs
+++ b/crates/matrix-sdk/src/client/builder/homeserver_config.rs
@@ -199,7 +199,7 @@ pub(super) async fn get_supported_versions(
         .await
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use matrix_sdk_test::async_test;
     use ruma::OwnedServerName;

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -36,7 +36,7 @@ use super::{Client, ClientInner};
 use crate::crypto::{CollectStrategy, TrustRequirement};
 #[cfg(feature = "e2e-encryption")]
 use crate::encryption::EncryptionSettings;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 use crate::http_client::HttpSettings;
 use crate::{
     authentication::{oauth::OAuthCtx, AuthCtx},
@@ -314,21 +314,21 @@ impl ClientBuilder {
     ///
     /// let client_config = Client::builder().proxy("http://localhost:8080");
     /// ```
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub fn proxy(mut self, proxy: impl AsRef<str>) -> Self {
         self.http_settings().proxy = Some(proxy.as_ref().to_owned());
         self
     }
 
     /// Disable SSL verification for the HTTP requests.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub fn disable_ssl_verification(mut self) -> Self {
         self.http_settings().disable_ssl_verification = true;
         self
     }
 
     /// Set a custom HTTP user agent for the client.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub fn user_agent(mut self, user_agent: impl AsRef<str>) -> Self {
         self.http_settings().user_agent = Some(user_agent.as_ref().to_owned());
         self
@@ -342,7 +342,7 @@ impl ClientBuilder {
     ///
     /// Internally this will call the
     /// [`reqwest::ClientBuilder::add_root_certificate()`] method.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub fn add_root_certificates(mut self, certificates: Vec<reqwest::Certificate>) -> Self {
         self.http_settings().additional_root_certificates = certificates;
         self
@@ -351,7 +351,7 @@ impl ClientBuilder {
     /// Don't trust any system root certificates, only trust the certificates
     /// provided through
     /// [`add_root_certificates`][ClientBuilder::add_root_certificates].
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub fn disable_built_in_root_certificates(mut self) -> Self {
         self.http_settings().disable_built_in_root_certificates = true;
         self
@@ -380,7 +380,7 @@ impl ClientBuilder {
         self
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     fn http_settings(&mut self) -> &mut HttpSettings {
         self.http_cfg.get_or_insert_with(Default::default).settings()
     }
@@ -477,9 +477,9 @@ impl ClientBuilder {
         let homeserver_cfg = self.homeserver_cfg.ok_or(ClientBuildError::MissingHomeserver)?;
         Span::current().record("homeserver", debug(&homeserver_cfg));
 
-        #[cfg_attr(target_arch = "wasm32", allow(clippy::infallible_destructuring_match))]
+        #[cfg_attr(target_family = "wasm", allow(clippy::infallible_destructuring_match))]
         let inner_http_client = match self.http_cfg.unwrap_or_default() {
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(not(target_family = "wasm"))]
             HttpConfig::Settings(mut settings) => {
                 settings.timeout = self.request_config.timeout;
                 settings.make_client()?
@@ -629,7 +629,7 @@ async fn build_store_config(
 
 // The indexeddb stores only implement `IntoStateStore` and `IntoCryptoStore` on
 // wasm32, so this only compiles there.
-#[cfg(all(target_arch = "wasm32", feature = "indexeddb"))]
+#[cfg(all(target_family = "wasm", feature = "indexeddb"))]
 async fn build_indexeddb_store_config(
     name: &str,
     passphrase: Option<&str>,
@@ -660,7 +660,7 @@ async fn build_indexeddb_store_config(
     Ok(store_config)
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "indexeddb"))]
+#[cfg(all(not(target_family = "wasm"), feature = "indexeddb"))]
 #[allow(clippy::unused_async)]
 async fn build_indexeddb_store_config(
     _name: &str,
@@ -672,12 +672,12 @@ async fn build_indexeddb_store_config(
 
 #[derive(Clone, Debug)]
 enum HttpConfig {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     Settings(HttpSettings),
     Custom(reqwest::Client),
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 impl HttpConfig {
     fn settings(&mut self) -> &mut HttpSettings {
         match self {
@@ -695,10 +695,10 @@ impl HttpConfig {
 
 impl Default for HttpConfig {
     fn default() -> Self {
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         return Self::Settings(HttpSettings::default());
 
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         return Self::Custom(reqwest::Client::new());
     }
 }
@@ -779,7 +779,7 @@ pub enum ClientBuildError {
 }
 
 // The http mocking library is not supported for wasm32
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 pub(crate) mod tests {
     use assert_matches::assert_matches;
     use matrix_sdk_test::{async_test, test_json};

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -17,7 +17,7 @@
 use std::{fmt::Debug, future::IntoFuture};
 
 use eyeball::SharedObservable;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 use eyeball::Subscriber;
 use matrix_sdk_common::boxed_into_future;
 use oauth2::{basic::BasicErrorResponseType, RequestTokenError};
@@ -65,7 +65,7 @@ impl<R> SendRequest<R> {
 
     /// Get a subscriber to observe the progress of sending the request
     /// body.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub fn subscribe_to_send_progress(&self) -> Subscriber<TransmissionProgress> {
         self.send_progress.subscribe()
     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -109,15 +109,15 @@ pub(crate) mod futures;
 
 pub use self::builder::{sanitize_server_name, ClientBuildError, ClientBuilder};
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 type NotificationHandlerFut = Pin<Box<dyn Future<Output = ()> + Send>>;
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 type NotificationHandlerFut = Pin<Box<dyn Future<Output = ()>>>;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 type NotificationHandlerFn =
     Box<dyn Fn(Notification, Room, Client) -> NotificationHandlerFut + Send + Sync>;
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 type NotificationHandlerFn = Box<dyn Fn(Notification, Room, Client) -> NotificationHandlerFut>;
 
 /// Enum controlling if a loop running callbacks should continue or abort.
@@ -1499,7 +1499,7 @@ impl Client {
     /// client.public_rooms(limit, since, server).await;
     /// # };
     /// ```
-    #[cfg_attr(not(target_arch = "wasm32"), deny(clippy::future_not_send))]
+    #[cfg_attr(not(target_family = "wasm"), deny(clippy::future_not_send))]
     pub async fn public_rooms(
         &self,
         limit: Option<u32>,
@@ -2584,7 +2584,7 @@ struct ClientServerCapabilities {
 }
 
 // The http mocking library is not supported for wasm32
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 pub(crate) mod tests {
     use std::{sync::Arc, time::Duration};
 
@@ -2598,7 +2598,7 @@ pub(crate) mod tests {
         async_test, test_json, GlobalAccountDataTestEvent, JoinedRoomBuilder, StateTestEvent,
         SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
     };
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     use ruma::{

--- a/crates/matrix-sdk/src/deduplicating_handler.rs
+++ b/crates/matrix-sdk/src/deduplicating_handler.rs
@@ -147,7 +147,7 @@ impl<Key: Clone + Ord + std::hash::Hash> DeduplicatingHandler<Key> {
 }
 
 // Sorry wasm32, you don't have tokio::join :(
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -1030,7 +1030,7 @@ impl Backups {
     }
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod test {
     use std::time::Duration;
 

--- a/crates/matrix-sdk/src/encryption/futures.rs
+++ b/crates/matrix-sdk/src/encryption/futures.rs
@@ -20,7 +20,7 @@
 use std::{future::IntoFuture, io::Read};
 
 use eyeball::SharedObservable;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 use eyeball::Subscriber;
 use matrix_sdk_common::boxed_into_future;
 use ruma::events::room::{EncryptedFile, EncryptedFileInit};
@@ -66,7 +66,7 @@ impl<'a, R: ?Sized> UploadEncryptedFile<'a, R> {
 
     /// Get a subscriber to observe the progress of sending the request
     /// body.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub fn subscribe_to_send_progress(&self) -> Subscriber<TransmissionProgress> {
         self.send_progress.subscribe()
     }

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -108,7 +108,7 @@ impl UserIdentity {
         Self { inner: identity, client }
     }
 
-    #[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+    #[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
     pub(crate) fn underlying_identity(&self) -> CryptoUserIdentity {
         self.inner.clone()
     }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 #![doc = include_str!("../docs/encryption.md")]
-#![cfg_attr(target_arch = "wasm32", allow(unused_imports))]
+#![cfg_attr(target_family = "wasm", allow(unused_imports))]
 
 #[cfg(feature = "experimental-send-custom-to-device")]
 use std::ops::Deref;
@@ -723,7 +723,7 @@ impl Encryption {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub(crate) async fn import_secrets_bundle(
         &self,
         bundle: &matrix_sdk_base::crypto::types::SecretsBundle,
@@ -1353,7 +1353,7 @@ impl Encryption {
     ///     .await?;
     /// # anyhow::Ok(()) };
     /// ```
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub async fn export_room_keys(
         &self,
         path: PathBuf,
@@ -1415,7 +1415,7 @@ impl Encryption {
     /// );
     /// # anyhow::Ok(()) };
     /// ```
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub async fn import_room_keys(
         &self,
         path: PathBuf,
@@ -1691,7 +1691,7 @@ impl Encryption {
     /// **Warning**: Do not use this method if we're already calling
     /// [`Client::send_outgoing_request()`]. This method is intended for
     /// explicitly uploading the device keys before starting a sync.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub(crate) async fn ensure_device_keys_upload(&self) -> Result<()> {
         let olm = self.client.olm_machine().await;
         let olm = olm.as_ref().ok_or(Error::NoOlmMachine)?;
@@ -1819,7 +1819,7 @@ impl Encryption {
     }
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::{
         ops::Not,

--- a/crates/matrix-sdk/src/encryption/recovery/futures.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/futures.rs
@@ -137,7 +137,7 @@ impl<'a> IntoFuture for Enable<'a> {
                     progress.set(EnableProgress::RoomKeyUploadError);
                 }
 
-                #[cfg(not(target_arch = "wasm32"))]
+                #[cfg(not(target_family = "wasm"))]
                 progress_task.abort();
             } else {
                 recovery.client.encryption().backups().maybe_trigger_backup();

--- a/crates/matrix-sdk/src/encryption/secret_storage/futures.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/futures.rs
@@ -41,9 +41,9 @@ impl<'a> CreateStore<'a> {
 
 impl<'a> IntoFuture for CreateStore<'a> {
     type Output = Result<SecretStore>;
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + 'a>>;
 
     fn into_future(self) -> Self::IntoFuture {

--- a/crates/matrix-sdk/src/encryption/tasks.rs
+++ b/crates/matrix-sdk/src/encryption/tasks.rs
@@ -57,7 +57,7 @@ pub(crate) struct BackupUploadingTask {
 #[cfg(feature = "e2e-encryption")]
 impl Drop for BackupUploadingTask {
     fn drop(&mut self) {
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         self.join_handle.abort();
     }
 }
@@ -134,7 +134,7 @@ pub(crate) struct BackupDownloadTask {
 #[cfg(feature = "e2e-encryption")]
 impl Drop for BackupDownloadTask {
     fn drop(&mut self) {
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         self.join_handle.abort();
     }
 }
@@ -389,7 +389,7 @@ impl BackupDownloadTaskListenerState {
     }
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod test {
     use matrix_sdk_test::async_test;
     use ruma::{event_id, room_id};

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -195,7 +195,7 @@ pub(crate) enum RetryKind {
     /// `retry_after`.
     Transient {
         // This is used only for attempts to retry, so on non-wasm32 code (in the `native` module).
-        #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+        #[cfg_attr(target_family = "wasm", allow(dead_code))]
         retry_after: Option<Duration>,
     },
 

--- a/crates/matrix-sdk/src/event_cache/deduplicator.rs
+++ b/crates/matrix-sdk/src/event_cache/deduplicator.rs
@@ -139,7 +139,7 @@ pub(super) struct DeduplicationOutcome {
 }
 
 #[cfg(test)]
-#[cfg(not(target_arch = "wasm32"))] // These tests uses the cross-process lock, so need time support.
+#[cfg(not(target_family = "wasm"))] // These tests uses the cross-process lock, so need time support.
 mod tests {
     use matrix_sdk_base::{deserialized_responses::TimelineEvent, linked_chunk::ChunkIdentifier};
     use matrix_sdk_test::{async_test, event_factory::EventFactory};

--- a/crates/matrix-sdk/src/event_cache/paginator.rs
+++ b/crates/matrix-sdk/src/event_cache/paginator.rs
@@ -478,7 +478,7 @@ impl PaginableRoom for WeakRoom {
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), test))]
+#[cfg(all(not(target_family = "wasm"), test))]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1541,7 +1541,7 @@ mod tests {
         assert_eq!(related_event_id, associated_related_id);
     }
 
-    #[cfg(not(target_arch = "wasm32"))] // This uses the cross-process lock, so needs time support.
+    #[cfg(not(target_family = "wasm"))] // This uses the cross-process lock, so needs time support.
     #[async_test]
     async fn test_write_to_storage() {
         use matrix_sdk_base::linked_chunk::lazy_loader::from_all_chunks;
@@ -1607,7 +1607,7 @@ mod tests {
         assert!(chunks.next().is_none());
     }
 
-    #[cfg(not(target_arch = "wasm32"))] // This uses the cross-process lock, so needs time support.
+    #[cfg(not(target_family = "wasm"))] // This uses the cross-process lock, so needs time support.
     #[async_test]
     async fn test_write_to_storage_strips_bundled_relations() {
         use matrix_sdk_base::linked_chunk::lazy_loader::from_all_chunks;
@@ -1689,7 +1689,7 @@ mod tests {
         assert!(chunks.next().is_none());
     }
 
-    #[cfg(not(target_arch = "wasm32"))] // This uses the cross-process lock, so needs time support.
+    #[cfg(not(target_family = "wasm"))] // This uses the cross-process lock, so needs time support.
     #[async_test]
     async fn test_clear() {
         use eyeball_im::VectorDiff;
@@ -1832,7 +1832,7 @@ mod tests {
         assert_eq!(linked_chunk.num_items(), 0);
     }
 
-    #[cfg(not(target_arch = "wasm32"))] // This uses the cross-process lock, so needs time support.
+    #[cfg(not(target_family = "wasm"))] // This uses the cross-process lock, so needs time support.
     #[async_test]
     async fn test_load_from_storage() {
         use eyeball_im::VectorDiff;
@@ -1955,7 +1955,7 @@ mod tests {
         assert_eq!(items[1].event_id().unwrap(), event_id2);
     }
 
-    #[cfg(not(target_arch = "wasm32"))] // This uses the cross-process lock, so needs time support.
+    #[cfg(not(target_family = "wasm"))] // This uses the cross-process lock, so needs time support.
     #[async_test]
     async fn test_load_from_storage_resilient_to_failure() {
         let room_id = room_id!("!fondue:patate.ch");
@@ -2021,7 +2021,7 @@ mod tests {
         assert!(raw_chunks.is_empty());
     }
 
-    #[cfg(not(target_arch = "wasm32"))] // This uses the cross-process lock, so needs time support.
+    #[cfg(not(target_family = "wasm"))] // This uses the cross-process lock, so needs time support.
     #[async_test]
     async fn test_no_useless_gaps() {
         use crate::event_cache::room::LoadMoreEventsBackwardsOutcome;
@@ -2173,7 +2173,7 @@ mod tests {
         assert_eq!(related_event_id, related_id);
     }
 
-    #[cfg(not(target_arch = "wasm32"))] // This uses the cross-process lock, so needs time support.
+    #[cfg(not(target_family = "wasm"))] // This uses the cross-process lock, so needs time support.
     #[async_test]
     async fn test_shrink_to_last_chunk() {
         use eyeball_im::VectorDiff;
@@ -2288,7 +2288,7 @@ mod tests {
         assert!(outcome.reached_start);
     }
 
-    #[cfg(not(target_arch = "wasm32"))] // This uses the cross-process lock, so needs time support.
+    #[cfg(not(target_family = "wasm"))] // This uses the cross-process lock, so needs time support.
     #[async_test]
     async fn test_auto_shrink_after_all_subscribers_are_gone() {
         use eyeball_im::VectorDiff;

--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -68,14 +68,14 @@ mod static_events;
 
 pub use self::context::{Ctx, EventHandlerContext, RawEvent};
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 type EventHandlerFut = Pin<Box<dyn Future<Output = ()> + Send>>;
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 type EventHandlerFut = Pin<Box<dyn Future<Output = ()>>>;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 type EventHandlerFn = dyn Fn(EventHandlerData<'_>) -> EventHandlerFut + Send + Sync;
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 type EventHandlerFn = dyn Fn(EventHandlerData<'_>) -> EventHandlerFut;
 
 type AnyMap = anymap2::Map<dyn CloneAnySendSync + Send + Sync>;
@@ -677,7 +677,7 @@ mod tests {
         InvitedRoomBuilder, JoinedRoomBuilder, DEFAULT_TEST_ROOM_ID,
     };
     use stream_assert::{assert_closed, assert_pending, assert_ready};
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
     use std::{
         future,

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -36,12 +36,12 @@ use tracing::{debug, field::debug, instrument, trace};
 
 use crate::{config::RequestConfig, error::HttpError};
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 mod native;
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 mod wasm;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub(crate) use native::HttpSettings;
 
 pub(crate) const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -250,7 +250,7 @@ async fn response_to_http_response(
     Ok(http_builder.body(body).expect("Can't construct a response using the given body"))
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::{
         num::NonZeroUsize,

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -139,7 +139,7 @@ impl HttpClient {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[derive(Clone, Debug)]
 pub(crate) struct HttpSettings {
     pub(crate) disable_ssl_verification: bool,
@@ -150,7 +150,7 @@ pub(crate) struct HttpSettings {
     pub(crate) disable_built_in_root_certificates: bool,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 impl Default for HttpSettings {
     fn default() -> Self {
         Self {
@@ -164,7 +164,7 @@ impl Default for HttpSettings {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 impl HttpSettings {
     /// Build a client with the specified configuration.
     pub(crate) fn make_client(&self) -> Result<reqwest::Client, HttpError> {

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -15,7 +15,7 @@
 
 #![doc = include_str!("../README.md")]
 #![warn(missing_debug_implementations, missing_docs)]
-#![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
+#![cfg_attr(target_family = "wasm", allow(clippy::arc_with_non_send_sync))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub use async_trait::async_trait;

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -18,7 +18,7 @@
 #[cfg(feature = "e2e-encryption")]
 use std::io::Read;
 use std::time::Duration;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 use std::{fmt, fs::File, path::Path};
 
 use eyeball::SharedObservable;
@@ -35,9 +35,9 @@ use ruma::{
     events::room::{MediaSource, ThumbnailInfo},
     MilliSecondsSinceUnixEpoch, MxcUri, OwnedMxcUri, TransactionId, UInt,
 };
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 use tempfile::{Builder as TempFileBuilder, NamedTempFile, TempDir};
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 use tokio::{fs::File as TokioFile, io::AsyncWriteExt};
 
 use crate::{
@@ -69,7 +69,7 @@ pub struct Media {
 /// A file handle that takes ownership of a media file on disk. When the handle
 /// is dropped, the file will be removed from the disk.
 #[derive(Debug)]
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub struct MediaFileHandle {
     /// The temporary file that contains the media.
     file: NamedTempFile,
@@ -79,7 +79,7 @@ pub struct MediaFileHandle {
     _directory: Option<TempDir>,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 impl MediaFileHandle {
     /// Get the media file's path.
     pub fn path(&self) -> &Path {
@@ -96,7 +96,7 @@ impl MediaFileHandle {
 }
 
 /// Error returned when [`MediaFileHandle::persist`] fails.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub struct PersistError {
     /// The underlying IO error.
     pub error: std::io::Error,
@@ -104,14 +104,14 @@ pub struct PersistError {
     pub file: MediaFileHandle,
 }
 
-#[cfg(not(any(target_arch = "wasm32", tarpaulin_include)))]
+#[cfg(not(any(target_family = "wasm", tarpaulin_include)))]
 impl fmt::Debug for PersistError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "PersistError({:?})", self.error)
     }
 }
 
-#[cfg(not(any(target_arch = "wasm32", tarpaulin_include)))]
+#[cfg(not(any(target_family = "wasm", tarpaulin_include)))]
 impl fmt::Display for PersistError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "failed to persist temporary file: {}", self.error)
@@ -324,7 +324,7 @@ impl Media {
     ///   created. If not provided, a default, global temporary directory will
     ///   be used; this may not work properly on Android, where the default
     ///   location may require root access on some older Android versions.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub async fn get_media_file(
         &self,
         request: &MediaRequestParameters,

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -570,7 +570,7 @@ impl NotificationSettings {
 }
 
 // The http mocking library is not supported for wasm32
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::sync::{
         atomic::{AtomicBool, Ordering},

--- a/crates/matrix-sdk/src/pusher.rs
+++ b/crates/matrix-sdk/src/pusher.rs
@@ -49,7 +49,7 @@ impl Pusher {
 }
 
 // The http mocking library is not supported for wasm32
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use matrix_sdk_test::{async_test, test_json};
     use ruma::{

--- a/crates/matrix-sdk/src/room/identity_status_changes.rs
+++ b/crates/matrix-sdk/src/room/identity_status_changes.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Facility to track changes to the identity of members of rooms.
-#![cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+#![cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
 
 use std::collections::BTreeMap;
 

--- a/crates/matrix-sdk/src/room/knock_requests.rs
+++ b/crates/matrix-sdk/src/room/knock_requests.rs
@@ -103,7 +103,7 @@ impl KnockRequestMemberInfo {
 }
 
 // The http mocking library is not supported for wasm32
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder};
     use ruma::{

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -28,9 +28,9 @@ use eyeball::SharedObservable;
 use futures_core::Stream;
 use futures_util::{future::join_all, stream::FuturesUnordered};
 use http::StatusCode;
-#[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
 pub use identity_status_changes::IdentityStatusChanges;
-#[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
 use matrix_sdk_base::crypto::{IdentityStatusChange, RoomIdentityProvider, UserIdentity};
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::{
@@ -47,7 +47,7 @@ use matrix_sdk_base::{
     ComposerDraft, EncryptionState, RoomInfoNotableUpdateReasons, RoomMemberships, SendOutsideWasm,
     StateChanges, StateStoreDataKey, StateStoreDataValue,
 };
-#[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
 use matrix_sdk_common::BoxFuture;
 use matrix_sdk_common::{
     deserialized_responses::TimelineEvent,
@@ -447,7 +447,7 @@ impl Room {
     /// Note that if a user who is in pin violation leaves the room, a `Pinned`
     /// update is sent, to indicate that the warning should be removed, even
     /// though the user's identity is not necessarily pinned.
-    #[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+    #[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
     pub async fn subscribe_to_identity_status_changes(
         &self,
     ) -> Result<impl Stream<Item = Vec<IdentityStatusChange>>> {
@@ -3616,7 +3616,7 @@ impl Room {
     }
 }
 
-#[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
 impl RoomIdentityProvider for Room {
     fn is_member<'a>(&'a self, user_id: &'a UserId) -> BoxFuture<'a, bool> {
         Box::pin(async { self.get_member(user_id).await.unwrap_or(None).is_some() })
@@ -3926,7 +3926,7 @@ pub struct RoomMemberWithSenderInfo {
     pub sender_info: Option<RoomMember>,
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use matrix_sdk_base::{store::ComposerDraftType, ComposerDraft};
     use matrix_sdk_test::{

--- a/crates/matrix-sdk/src/room/privacy_settings.rs
+++ b/crates/matrix-sdk/src/room/privacy_settings.rs
@@ -161,7 +161,7 @@ impl<'a> RoomPrivacySettings<'a> {
     }
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::ops::Not;
 

--- a/crates/matrix-sdk/src/room_directory_search.rs
+++ b/crates/matrix-sdk/src/room_directory_search.rs
@@ -214,7 +214,7 @@ impl RoomDirectorySearch {
     }
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use assert_matches::assert_matches;
     use eyeball_im::VectorDiff;

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -2252,7 +2252,7 @@ fn canonicalize_dependent_requests(
     by_txn.into_iter().flat_map(|(_parent_txn_id, entries)| entries.into_iter().cloned()).collect()
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::{sync::Arc, time::Duration};
 

--- a/crates/matrix-sdk/src/test_utils/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mod.rs
@@ -11,7 +11,7 @@ use ruma::{
 use url::Url;
 
 pub mod client;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub mod mocks;
 
 use self::client::mock_matrix_session;
@@ -68,7 +68,7 @@ pub async fn logged_in_client(homeserver_url: Option<String>) -> Client {
 }
 
 /// Like [`test_client_builder`], but with a mocked server too.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub async fn test_client_builder_with_server() -> (ClientBuilder, wiremock::MockServer) {
     let server = wiremock::MockServer::start().await;
     let builder = test_client_builder(Some(server.uri()));
@@ -76,7 +76,7 @@ pub async fn test_client_builder_with_server() -> (ClientBuilder, wiremock::Mock
 }
 
 /// Like [`no_retry_test_client`], but with a mocked server too.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub async fn no_retry_test_client_with_server() -> (Client, wiremock::MockServer) {
     let server = wiremock::MockServer::start().await;
     let client = no_retry_test_client(Some(server.uri().to_string())).await;
@@ -84,7 +84,7 @@ pub async fn no_retry_test_client_with_server() -> (Client, wiremock::MockServer
 }
 
 /// Like [`logged_in_client`], but with a mocked server too.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub async fn logged_in_client_with_server() -> (Client, wiremock::MockServer) {
     let server = wiremock::MockServer::start().await;
     let client = logged_in_client(Some(server.uri().to_string())).await;

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -407,7 +407,7 @@ async fn test_subscribe_all_room_updates() {
 // Check that the `Room::latest_encryption_state().await?.is_encrypted()` is
 // properly deduplicated, meaning we only make a single request to the server,
 // and that multiple calls do return the same result.
-#[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
 #[async_test]
 async fn test_request_encryption_event_before_sending() {
     let (client, server) = logged_in_client_with_server().await;
@@ -1217,7 +1217,7 @@ async fn test_test_ambiguity_changes() {
     assert_pending!(updates);
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[async_test]
 async fn test_rooms_stream() {
     use futures_util::StreamExt as _;

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -1,5 +1,5 @@
 // The http mocking library is not supported for wasm32
-#![cfg(not(target_arch = "wasm32"))]
+#![cfg(not(target_family = "wasm"))]
 use matrix_sdk::test_utils::logged_in_client_with_server;
 use serde::Serialize;
 use wiremock::{

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -487,7 +487,7 @@ async fn test_room_redact() {
     assert_eq!(response.event_id, event_id);
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_fetch_members_deduplication() {
     let server = MatrixMockServer::new().await;

--- a/testing/matrix-sdk-test-macros/src/lib.rs
+++ b/testing/matrix-sdk-test-macros/src/lib.rs
@@ -15,8 +15,8 @@ pub fn async_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // on the regular return-case, we can just use cfg_attr and quit early
     if fun.sig.output == syn::ReturnType::Default {
         let attrs = r#"
-            #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+            #[cfg_attr(not(target_family = "wasm"), tokio::test)]
+            #[cfg_attr(target_family = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
         "#;
 
         let mut out: TokenStream = attrs.parse().expect("Static works");
@@ -33,7 +33,7 @@ pub fn async_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // that calls the first in wasm32 cases.
 
     let attrs = r#"
-        #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+        #[cfg_attr(not(target_family = "wasm"), tokio::test)]
     "#;
 
     let mut out: TokenStream = attrs.parse().expect("Static works.");
@@ -64,7 +64,7 @@ pub fn async_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     out.extend(inner);
 
     let attrs = r#"
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[wasm_bindgen_test::wasm_bindgen_test]
     "#;
     let outer_attrs: TokenStream = attrs.parse().expect("Static works.");

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -29,13 +29,13 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 vodozemac = { workspace = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 ctor = "0.2.9"
 tokio = { workspace = true, features = ["rt", "macros"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 wiremock = { workspace = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2.6", default-features = false, features = ["js"] }
 wasm-bindgen-test = { workspace = true }
 

--- a/testing/matrix-sdk-test/src/lib.rs
+++ b/testing/matrix-sdk-test/src/lib.rs
@@ -80,7 +80,7 @@ macro_rules! stripped_state_event {
 #[macro_export]
 macro_rules! init_tracing_for_tests {
     () => {
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         #[$crate::__macro_support::ctor]
         fn init_logging() {
             use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -105,13 +105,13 @@ macro_rules! init_tracing_for_tests {
 
 #[doc(hidden)]
 pub mod __macro_support {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub use ctor::ctor;
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub use tracing_subscriber;
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub mod mocks;
 
 pub mod event_factory;


### PR DESCRIPTION
Mechanical find+replace of all instances of target_arch = "wasm32" in favor of the more future-proof target_family = "wasm".

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
