### PR TITLE
change: have media preview config return an optional

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1492,6 +1492,13 @@ impl Client {
             None => Ok(None),
         }
     }
+
+    /// Fetch the media preview configuration from the server.
+    pub async fn fetch_media_preview_config(
+        &self,
+    ) -> Result<Option<MediaPreviewConfig>, ClientError> {
+        Ok(self.inner.account().fetch_media_preview_config_event_content().await?.map(Into::into))
+    }
 }
 
 #[matrix_sdk_ffi_macros::export(callback_interface)]

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1442,11 +1442,11 @@ impl Client {
         let (initial_value, stream) = self.inner.account().observe_media_preview_config().await?;
         Ok(Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
             // Send the initial value to the listener.
-            listener.on_change(initial_value.into());
+            listener.on_change(initial_value.map(|config| config.into()));
             // Listen for changes and notify the listener.
             pin_mut!(stream);
             while let Some(media_preview_config) = stream.next().await {
-                listener.on_change(media_preview_config.into());
+                listener.on_change(media_preview_config.map(|config| config.into()));
             }
         }))))
     }
@@ -1462,9 +1462,14 @@ impl Client {
 
     /// Get the media previews timeline display policy
     /// currently stored in the cache.
-    pub async fn get_media_preview_display_policy(&self) -> Result<MediaPreviews, ClientError> {
+    pub async fn get_media_preview_display_policy(
+        &self,
+    ) -> Result<Option<MediaPreviews>, ClientError> {
         let configuration = self.inner.account().get_media_preview_config_event_content().await?;
-        Ok(configuration.media_previews.into())
+        match configuration {
+            Some(configuration) => Ok(Some(configuration.media_previews.into())),
+            None => Ok(None),
+        }
     }
 
     /// Set the invite request avatars display policy
@@ -1478,15 +1483,20 @@ impl Client {
 
     /// Get the invite request avatars display policy
     /// currently stored in the cache.
-    pub async fn get_invite_avatars_display_policy(&self) -> Result<InviteAvatars, ClientError> {
+    pub async fn get_invite_avatars_display_policy(
+        &self,
+    ) -> Result<Option<InviteAvatars>, ClientError> {
         let configuration = self.inner.account().get_media_preview_config_event_content().await?;
-        Ok(configuration.invite_avatars.into())
+        match configuration {
+            Some(configuration) => Ok(Some(configuration.invite_avatars.into())),
+            None => Ok(None),
+        }
     }
 }
 
 #[matrix_sdk_ffi_macros::export(callback_interface)]
 pub trait MediaPreviewConfigListener: Sync + Send {
-    fn on_change(&self, media_preview_config: MediaPreviewConfig);
+    fn on_change(&self, media_preview_config: Option<MediaPreviewConfig>);
 }
 
 #[matrix_sdk_ffi_macros::export(callback_interface)]

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -1071,7 +1071,7 @@ impl Account {
     /// Will check first for the stable event and then for the unstable one.
     pub async fn fetch_media_preview_config_event_content(
         &self,
-    ) -> Result<MediaPreviewConfigEventContent> {
+    ) -> Result<Option<MediaPreviewConfigEventContent>> {
         // First we check if there is avalue in the stable event
         let media_preview_config =
             self.fetch_account_data(GlobalAccountDataEventType::MediaPreviewConfig).await?;
@@ -1086,8 +1086,7 @@ impl Account {
         // We deserialize the content of the event, if is not found we return the
         // default
         let media_preview_config = media_preview_config
-            .and_then(|value| value.deserialize_as::<MediaPreviewConfigEventContent>().ok())
-            .unwrap_or_default();
+            .and_then(|value| value.deserialize_as::<MediaPreviewConfigEventContent>().ok());
 
         Ok(media_preview_config)
     }
@@ -1119,7 +1118,8 @@ impl Account {
     /// This will always use the unstable event until we know which Matrix
     /// version will support it.
     pub async fn set_media_previews_display_policy(&self, policy: MediaPreviews) -> Result<()> {
-        let mut media_preview_config = self.fetch_media_preview_config_event_content().await?;
+        let mut media_preview_config =
+            self.fetch_media_preview_config_event_content().await?.unwrap_or_default();
         media_preview_config.media_previews = policy;
 
         // Updating the unstable account data
@@ -1134,7 +1134,8 @@ impl Account {
     /// This will always use the unstable event until we know which matrix
     /// version will support it.
     pub async fn set_invite_avatars_display_policy(&self, policy: InviteAvatars) -> Result<()> {
-        let mut media_preview_config = self.fetch_media_preview_config_event_content().await?;
+        let mut media_preview_config =
+            self.fetch_media_preview_config_event_content().await?.unwrap_or_default();
         media_preview_config.invite_avatars = policy;
 
         // Updating the unstable account data

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3356,6 +3356,7 @@ pub(crate) mod tests {
         let (initial_value, stream) =
             client.account().observe_media_preview_config().await.unwrap();
 
+        let initial_value: MediaPreviewConfigEventContent = initial_value.unwrap();
         assert_eq!(initial_value.invite_avatars, InviteAvatars::Off);
         assert_eq!(initial_value.media_previews, MediaPreviews::Private);
         pin_mut!(stream);
@@ -3376,11 +3377,11 @@ pub(crate) mod tests {
 
         assert_next_matches!(
             stream,
-            MediaPreviewConfigEventContent {
+            Some(MediaPreviewConfigEventContent {
                 media_previews: MediaPreviews::Off,
                 invite_avatars: InviteAvatars::On,
                 ..
-            }
+            })
         );
         assert_pending!(stream);
     }
@@ -3406,6 +3407,7 @@ pub(crate) mod tests {
         let (initial_value, stream) =
             client.account().observe_media_preview_config().await.unwrap();
 
+        let initial_value: MediaPreviewConfigEventContent = initial_value.unwrap();
         assert_eq!(initial_value.invite_avatars, InviteAvatars::Off);
         assert_eq!(initial_value.media_previews, MediaPreviews::Private);
         pin_mut!(stream);
@@ -3426,11 +3428,11 @@ pub(crate) mod tests {
 
         assert_next_matches!(
             stream,
-            MediaPreviewConfigEventContent {
+            Some(MediaPreviewConfigEventContent {
                 media_previews: MediaPreviews::Off,
                 invite_avatars: InviteAvatars::On,
                 ..
-            }
+            })
         );
         assert_pending!(stream);
     }
@@ -3442,7 +3444,6 @@ pub(crate) mod tests {
 
         let (initial_value, _) = client.account().observe_media_preview_config().await.unwrap();
 
-        assert_eq!(initial_value.invite_avatars, InviteAvatars::On);
-        assert_eq!(initial_value.media_previews, MediaPreviews::On);
+        assert!(initial_value.is_none());
     }
 }


### PR DESCRIPTION
The reason is that, while the `default` was quite handy, it prevents clients to perform migrations. This will allow a client to check if the server or the store do have a definition for the account data, and if not decide to perform a migration or present a different default if they so wish.