### PR TITLE
IndexedDB: Add initial implementation of `EventCacheStore`

### DIFF
--- a/crates/matrix-sdk-indexeddb/CHANGELOG.md
+++ b/crates/matrix-sdk-indexeddb/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+- Add `IndexeddbEventCacheStore` for providing an IndexedDB implementation
+  of the `EventCacheStore`. Expose the type through `IndexeddbEventCacheStoreBuilder`
+  which ensures object stores in IndexedDB are properly initialized.
+
 ## [0.11.0] - 2025-04-11
 
 No notable changes in this release.

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -14,9 +14,10 @@ default-target = "wasm32-unknown-unknown"
 rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [features]
-default = ["e2e-encryption", "state-store"]
+default = ["e2e-encryption", "state-store", "event-cache-store"]
 state-store = ["dep:matrix-sdk-base", "growable-bloom-filter"]
 e2e-encryption = ["dep:matrix-sdk-crypto"]
+event-cache-store = ["e2e-encryption"]
 testing = ["matrix-sdk-crypto?/testing"]
 
 [dependencies]
@@ -55,10 +56,17 @@ matrix-sdk-common = { workspace = true, features = ["js"] }
 matrix-sdk-crypto = { workspace = true, features = ["js", "testing"] }
 matrix-sdk-test.workspace = true
 rand.workspace = true
-tracing-subscriber = { workspace = true, features = ["registry", "tracing-log"] }
+tracing-subscriber = { workspace = true, features = [
+    "registry",
+    "tracing-log",
+] }
 uuid.workspace = true
 wasm-bindgen-test.workspace = true
-web-sys = { workspace = true, features = ["IdbKeyRange", "Window", "Performance"] }
+web-sys = { workspace = true, features = [
+    "IdbKeyRange",
+    "Window",
+    "Performance",
+] }
 
 [lints]
 workspace = true

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/builder.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/builder.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use matrix_sdk_store_encryption::StoreCipher;
+
+use crate::{
+    event_cache_store::{migrations::open_and_upgrade_db, IndexeddbEventCacheStore, Result},
+    serializer::IndexeddbSerializer,
+};
+
+/// Builder for [`IndexeddbEventCacheStore`]
+pub struct IndexeddbEventCacheStoreBuilder {
+    name: Option<String>,
+    store_cipher: Option<Arc<StoreCipher>>,
+}
+
+impl IndexeddbEventCacheStoreBuilder {
+    pub fn new() -> Self {
+        Self { name: None, store_cipher: None }
+    }
+
+    pub fn name(mut self, name: String) -> Self {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn store_cipher(mut self, store_cipher: Arc<StoreCipher>) -> Self {
+        self.store_cipher = Some(store_cipher);
+        self
+    }
+
+    pub async fn build(self) -> Result<IndexeddbEventCacheStore> {
+        let name = self.name.unwrap_or_else(|| "event_cache".to_owned());
+
+        let serializer = IndexeddbSerializer::new(self.store_cipher.clone());
+        let inner = open_and_upgrade_db(&name).await?;
+
+        let store = IndexeddbEventCacheStore { inner, store_cipher: self.store_cipher, serializer };
+        Ok(store)
+    }
+}
+
+impl Default for IndexeddbEventCacheStoreBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/builder.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/builder.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use matrix_sdk_base::event_cache::store::MemoryStore;
 use matrix_sdk_store_encryption::StoreCipher;
 
 use crate::{
@@ -34,7 +35,12 @@ impl IndexeddbEventCacheStoreBuilder {
         let serializer = IndexeddbSerializer::new(self.store_cipher.clone());
         let inner = open_and_upgrade_db(&name).await?;
 
-        let store = IndexeddbEventCacheStore { inner, store_cipher: self.store_cipher, serializer };
+        let store = IndexeddbEventCacheStore {
+            inner,
+            store_cipher: self.store_cipher,
+            serializer,
+            media_store: MemoryStore::new(),
+        };
         Ok(store)
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/builder.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/builder.rs
@@ -31,14 +31,9 @@ impl IndexeddbEventCacheStoreBuilder {
 
     pub async fn build(self) -> Result<IndexeddbEventCacheStore> {
         let name = self.name.unwrap_or_else(|| "event_cache".to_owned());
-
-        let serializer = IndexeddbSerializer::new(self.store_cipher.clone());
-        let inner = open_and_upgrade_db(&name).await?;
-
         let store = IndexeddbEventCacheStore {
-            inner,
-            store_cipher: self.store_cipher,
-            serializer,
+            inner: open_and_upgrade_db(&name).await?,
+            serializer: IndexeddbSerializer::new(self.store_cipher),
             media_store: MemoryStore::new(),
         };
         Ok(store)

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -1,0 +1,58 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+use indexed_db_futures::{
+    idb_object_store::IdbObjectStoreParameters,
+    request::{IdbOpenDbRequestLike, OpenDbRequest},
+    IdbDatabase, IdbKeyPath, IdbVersionChangeEvent,
+};
+use wasm_bindgen::JsValue;
+use web_sys::DomException;
+
+use crate::event_cache_store::keys;
+
+const CURRENT_DB_VERSION: u32 = 2;
+
+pub async fn open_and_upgrade_db(name: &str) -> Result<IdbDatabase, DomException> {
+    let mut db = IdbDatabase::open(name)?.await?;
+    let old_version = db.version() as u32;
+    if old_version == 1 {
+        db = setup_db(db, CURRENT_DB_VERSION).await?;
+    }
+    Ok(db)
+}
+
+async fn setup_db(db: IdbDatabase, version: u32) -> Result<IdbDatabase, DomException> {
+    let name = db.name();
+    db.close();
+
+    let db = {
+        let mut request: OpenDbRequest = IdbDatabase::open_u32(&name, version)?;
+        request.set_on_upgrade_needed(Some(
+            move |events: &IdbVersionChangeEvent| -> Result<(), JsValue> {
+                events.db().create_object_store(keys::CORE)?;
+
+                let mut params = IdbObjectStoreParameters::new();
+                params.key_path(Some(&IdbKeyPath::from("id")));
+                events.db().create_object_store_with_params(keys::LINKED_CHUNKS, &params)?;
+                events.db().create_object_store_with_params(keys::EVENTS, &params)?;
+                events.db().create_object_store_with_params(keys::GAPS, &params)?;
+                Ok(())
+            },
+        ));
+        request.await?
+    };
+
+    Ok(db)
+}

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -232,6 +232,7 @@ struct TimelineEventForCache {
     id: String,
     content: TimelineEvent,
     room_id: String,
+    chunk_id: u64,
     position: usize,
 }
 
@@ -560,6 +561,7 @@ impl_event_cache_store! {
                             id: id.clone(),
                             content: event,
                             room_id: room_id.to_string(),
+                            chunk_id,
                             position: index,
                         };
 
@@ -584,6 +586,7 @@ impl_event_cache_store! {
                         id: event_id.clone(),
                         content: item,
                         room_id: room_id.to_string(),
+                        chunk_id,
                         position: index,
                     };
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -54,6 +54,17 @@ pub struct IndexeddbEventCacheStore {
     pub serializer: IndexeddbSerializer,
 }
 
+#[cfg(not(tarpaulin_include))]
+impl std::fmt::Debug for IndexeddbEventCacheStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IndexeddbEventCacheStore")
+            .field("inner", &self.inner)
+            .field("store_cipher", &self.store_cipher.as_ref().map(|_| "<StoreCipher>"))
+            .field("serializer", &self.serializer)
+            .finish()
+    }
+}
+
 impl IndexeddbEventCacheStore {
     pub fn builder() -> IndexeddbEventCacheStoreBuilder {
         IndexeddbEventCacheStoreBuilder::new()

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -1,0 +1,61 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+mod builder;
+mod migrations;
+
+use std::sync::Arc;
+
+pub use builder::IndexeddbEventCacheStoreBuilder;
+use indexed_db_futures::IdbDatabase;
+use matrix_sdk_store_encryption::StoreCipher;
+
+use crate::serializer::IndexeddbSerializer;
+
+mod keys {
+    pub const CORE: &str = "core";
+    pub const EVENTS: &str = "events";
+    pub const LINKED_CHUNKS: &str = "linked_chunks";
+    pub const GAPS: &str = "gaps";
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IndexeddbEventCacheStoreError {
+    #[error("DomException {name} ({code}): {message}")]
+    DomException { name: String, message: String, code: u16 },
+}
+
+impl From<web_sys::DomException> for IndexeddbEventCacheStoreError {
+    fn from(frm: web_sys::DomException) -> IndexeddbEventCacheStoreError {
+        IndexeddbEventCacheStoreError::DomException {
+            name: frm.name(),
+            message: frm.message(),
+            code: frm.code(),
+        }
+    }
+}
+
+type Result<T, E = IndexeddbEventCacheStoreError> = std::result::Result<T, E>;
+
+pub struct IndexeddbEventCacheStore {
+    pub inner: IdbDatabase,
+    pub store_cipher: Option<Arc<StoreCipher>>,
+    pub serializer: IndexeddbSerializer,
+}
+
+impl IndexeddbEventCacheStore {
+    pub fn builder() -> IndexeddbEventCacheStoreBuilder {
+        IndexeddbEventCacheStoreBuilder::new()
+    }
+}

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -958,10 +958,47 @@ impl_event_cache_store! {
     /// position if there are any.
     async fn filter_duplicated_events(
         &self,
-        _room_id: &RoomId,
-        _events: Vec<OwnedEventId>,
+        room_id: &RoomId,
+        events: Vec<OwnedEventId>,
     ) -> Result<Vec<(OwnedEventId, Position)>, IndexeddbEventCacheStoreError> {
-        std::future::ready(Err(IndexeddbEventCacheStoreError::Unsupported)).await
+        if events.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let tx = self.inner.transaction_on_multi_with_mode(
+            &[keys::EVENTS],
+            IdbTransactionMode::Readwrite,
+        )?;
+
+        let store = tx.object_store(keys::EVENTS)?;
+
+        // TODO: This is very inefficient, as we are reading and
+        // deserializing every event in the room in order to pick
+        // out a single one. The problem is that the current
+        // schema doesn't easily allow us to find an event without
+        // knowing which chunk it is in. To improve this, we will
+        // need to add another index to our event store.
+        let lower = self.encode_key(vec![
+            (keys::ROOMS, room_id.as_ref(), true),
+        ]);
+        let upper = self.encode_upper_key(vec![
+            (keys::ROOMS, room_id.as_ref(), true),
+        ]);
+        let key_range =
+            IdbKeyRange::bound(&lower.into(), &upper.into()).unwrap();
+
+        let mut result = Vec::new();
+        let values = store.get_all_with_key(&key_range)?.await?;
+        for value in values {
+            let event: TimelineEventForCache = self.deserialize_value_with_id(value)?;
+            if let Some(event_id) = event.content.event_id() {
+                if events.contains(&event_id) {
+                    let position = Position::new(ChunkIdentifier::new(event.chunk_id), event.position);
+                    result.push((event_id, position))
+                }
+            }
+        }
+        Ok(result)
     }
 
     /// Find an event by its ID.

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 pub use builder::IndexeddbEventCacheStoreBuilder;
 use indexed_db_futures::IdbDatabase;
+use matrix_sdk_base::event_cache::store::EventCacheStoreError;
 use matrix_sdk_store_encryption::StoreCipher;
 
 use crate::serializer::IndexeddbSerializer;
@@ -42,6 +43,14 @@ impl From<web_sys::DomException> for IndexeddbEventCacheStoreError {
             name: frm.name(),
             message: frm.message(),
             code: frm.code(),
+        }
+    }
+}
+
+impl From<IndexeddbEventCacheStoreError> for EventCacheStoreError {
+    fn from(e: IndexeddbEventCacheStoreError) -> Self {
+        match e {
+            IndexeddbEventCacheStoreError::DomException { .. } => EventCacheStoreError::backend(e),
         }
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -1152,16 +1152,18 @@ impl_event_cache_store! {
                 }
             }
         }
-        let chunk_id_string = position
-            .as_ref()
-            .map(|inner| inner.chunk_id.to_string())
-            .unwrap_or_else(|| Self::KEY_LOWER_CHARACTER.into());
-
-        let id = self.encode_key(vec![
-            (keys::ROOMS, room_id.as_ref(), true),
-            (keys::LINKED_CHUNKS, chunk_id_string.as_ref(), false),
-            (keys::EVENTS, event_id.as_str(), true),
-        ]);
+        let id = match position {
+            Some(ref position) => self.encode_key(vec![
+                (keys::ROOMS, room_id.as_ref(), true),
+                (keys::LINKED_CHUNKS, &position.chunk_id.to_string(), false),
+                (keys::EVENTS, &position.index.to_string(), false),
+            ]),
+            None => self.encode_key(vec![
+                (keys::ROOMS, room_id.as_ref(), true),
+                (keys::LINKED_CHUNKS, &String::from(Self::KEY_LOWER_CHARACTER), false),
+                (keys::EVENTS, event_id.as_str(), true),
+            ])
+        };
         let value = self.serialize_value_with_id(
             &id,
             &TimelineEventForCache {

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -21,6 +21,7 @@ use async_trait::async_trait;
 pub use builder::IndexeddbEventCacheStoreBuilder;
 use indexed_db_futures::IdbDatabase;
 use matrix_sdk_base::{
+    deserialized_responses::TimelineEvent,
     event_cache::{
         store::{
             media::{IgnoreMediaRetentionPolicy, MediaRetentionPolicy},
@@ -33,6 +34,7 @@ use matrix_sdk_base::{
 };
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{events::relation::RelationType, EventId, MxcUri, OwnedEventId, RoomId};
+use serde::{Deserialize, Serialize};
 
 use crate::serializer::IndexeddbSerializer;
 
@@ -135,6 +137,41 @@ impl IndexeddbEventCacheStore {
         key.push(Self::KEY_UPPER_CHARACTER);
         key
     }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+struct ChunkForCache {
+    id: String,
+    raw_id: u64,
+    previous: Option<String>,
+    raw_previous: Option<u64>,
+    next: Option<String>,
+    raw_next: Option<u64>,
+    type_str: String,
+}
+
+#[allow(dead_code)]
+impl ChunkForCache {
+    /// Used to set field `type_str` to represent a chunk that contains events
+    const CHUNK_TYPE_EVENT_TYPE_STRING: &str = "E";
+    /// Used to set field `type_str` to represent a chunk that is a gap
+    const CHUNK_TYPE_GAP_TYPE_STRING: &str = "G";
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+struct GapForCache {
+    prev_token: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+struct TimelineEventForCache {
+    id: String,
+    content: TimelineEvent,
+    room_id: String,
+    position: usize,
 }
 
 // Small hack to have the following macro invocation act as the appropriate

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -1050,7 +1050,7 @@ impl_event_cache_store! {
         let values = events.get_all_with_key(&events_key_range)?.await?;
         for value in values {
             let event: TimelineEventForCache = self.deserialize_value_with_id(value)?;
-            if event.id == *event_id {
+            if event.content.event_id().is_some_and(|inner| inner == *event_id) {
                 return Ok(Some(event.content))
             }
         }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -15,7 +15,7 @@
 mod builder;
 mod migrations;
 
-use std::{future::IntoFuture, sync::Arc};
+use std::future::IntoFuture;
 
 use async_trait::async_trait;
 pub use builder::IndexeddbEventCacheStoreBuilder;
@@ -34,7 +34,6 @@ use matrix_sdk_base::{
     media::MediaRequestParameters,
 };
 use matrix_sdk_crypto::CryptoStoreError;
-use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{
     events::relation::RelationType, EventId, MilliSecondsSinceUnixEpoch, MxcUri, OwnedEventId,
     RoomId,
@@ -107,23 +106,11 @@ impl From<IndexeddbEventCacheStoreError> for EventCacheStoreError {
 
 type Result<T, E = IndexeddbEventCacheStoreError> = std::result::Result<T, E>;
 
+#[derive(Debug)]
 pub struct IndexeddbEventCacheStore {
     inner: IdbDatabase,
-    store_cipher: Option<Arc<StoreCipher>>,
     serializer: IndexeddbSerializer,
     media_store: MemoryStore,
-}
-
-#[cfg(not(tarpaulin_include))]
-impl std::fmt::Debug for IndexeddbEventCacheStore {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IndexeddbEventCacheStore")
-            .field("inner", &self.inner)
-            .field("store_cipher", &self.store_cipher.as_ref().map(|_| "<StoreCipher>"))
-            .field("serializer", &self.serializer)
-            .field("memory_store", &self.media_store)
-            .finish()
-    }
 }
 
 /// A type that wraps a (de)serialized value `value` and associates it

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -964,10 +964,39 @@ impl_event_cache_store! {
     /// Find an event by its ID.
     async fn find_event(
         &self,
-        _room_id: &RoomId,
-        _event_id: &EventId,
+        room_id: &RoomId,
+        event_id: &EventId,
     ) -> Result<Option<Event>, IndexeddbEventCacheStoreError> {
-        std::future::ready(Err(IndexeddbEventCacheStoreError::Unsupported)).await
+        let tx = self.inner.transaction_on_multi_with_mode(
+            &[keys::EVENTS],
+            IdbTransactionMode::Readwrite,
+        )?;
+
+        let events = tx.object_store(keys::EVENTS)?;
+
+        // TODO: This is very inefficient, as we are reading and
+        // deserializing every event in the room in order to pick
+        // out a single one. The problem is that the current
+        // schema doesn't easily allow us to find an event without
+        // knowing which chunk it is in. To improve this, we will
+        // need to add another index to our event store.
+        let lower = self.encode_key(vec![
+            (keys::ROOMS, room_id.as_ref(), true),
+        ]);
+        let upper = self.encode_upper_key(vec![
+            (keys::ROOMS, room_id.as_ref(), true),
+        ]);
+        let events_key_range =
+            IdbKeyRange::bound(&lower.into(), &upper.into()).unwrap();
+
+        let values = events.get_all_with_key(&events_key_range)?.await?;
+        for value in values {
+            let event: TimelineEventForCache = self.deserialize_value_with_id(value)?;
+            if event.id == *event_id {
+                return Ok(Some(event.content))
+            }
+        }
+        Ok(None)
     }
 
     /// Find all the events that relate to a given event.

--- a/crates/matrix-sdk-indexeddb/src/lib.rs
+++ b/crates/matrix-sdk-indexeddb/src/lib.rs
@@ -6,6 +6,8 @@ use thiserror::Error;
 
 #[cfg(feature = "e2e-encryption")]
 mod crypto_store;
+#[cfg(feature = "event-cache-store")]
+mod event_cache_store;
 mod safe_encode;
 #[cfg(feature = "e2e-encryption")]
 mod serialize_bool_for_indexeddb;
@@ -16,6 +18,10 @@ mod state_store;
 
 #[cfg(feature = "e2e-encryption")]
 pub use crypto_store::{IndexeddbCryptoStore, IndexeddbCryptoStoreError};
+#[cfg(feature = "event-cache-store")]
+pub use event_cache_store::{
+    IndexeddbEventCacheStore, IndexeddbEventCacheStoreBuilder, IndexeddbEventCacheStoreError,
+};
 #[cfg(feature = "state-store")]
 pub use state_store::{
     IndexeddbStateStore, IndexeddbStateStoreBuilder, IndexeddbStateStoreError,

--- a/crates/matrix-sdk-indexeddb/src/serializer.rs
+++ b/crates/matrix-sdk-indexeddb/src/serializer.rs
@@ -39,6 +39,15 @@ pub struct IndexeddbSerializer {
     store_cipher: Option<Arc<StoreCipher>>,
 }
 
+#[cfg(not(tarpaulin_include))]
+impl std::fmt::Debug for IndexeddbSerializer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IndexeddbSerializer")
+            .field("store_cipher", &self.store_cipher.as_ref().map(|_| "<StoreCipher>"))
+            .finish()
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum IndexeddbSerializerError {
     #[error(transparent)]


### PR DESCRIPTION
## Background

This pull request provides an initial implementation of the `EventCacheStore` and is mostly taken from the work completed in #4617, with a few additions and modifications to accommodate more recent updates to the trait.

Given that #4617 was a rather large pull request, this is part of a series of pull requests which will break that work into smaller, more manageable changes (see #4996). **_Notably, to minimize changes, this pull request omits the implementation of `EventCacheStoreMedia` and simply uses a nested `MemoryStore` for media queries for the time being._**

## Changes

This change is focused on integrating the implementation of `EventCacheStore` from #4617, while using a nested `MemoryStore` for media queries. Additionally, since the original implementation was written before the latest version of the `EventCacheStore`, I have added implementations of new functions.

There are virtually no changes to existing code, except for the addition of a new feature - `event-cache-store` - to the `matrix-sdk-indexeddb` crate. Most other changes occur in entirely new files.

## Caveats

Given that the original implementation from #4617 was written before some of the more recent additions to the `EventCacheStore` trait, I had to retrofit implementations for a number of functions which are rather inefficient. I have left them inefficient, however, in order to keep this pull request small, as the changes are a bit involved. 

I plan to improve them in a follow-up pull request.

### Finding the Last Chunk

Loading the last chunk in a list - i.e., `EventCacheStore::load_last_chunk` - currently reads in and deserializes all chunks in a room and looks for any that have no `next` value. This is a rather inefficient process and could be greatly improved by adding another index on the `LINKED_CHUNKS` object store.

### Querying Events by ID

The following functions read and deserialize all events in a room in order to perform their operations.

- `EventCacheStore::filter_duplicated_events`
- `EventCacheStore::find_event`
- `EventCacheStore::find_event_relations`
- `EventCacheStore::save_event`

These operations could also be greatly improved by the addition of a few new indices on the `EVENTS` object store.

## Future Work

- Add an index to the `LINKED_CHUNKS` object store in order to improve chunk-related queries.
- Add indices to the `EVENTS` object store in order to improve event-related queries.
- Add an `EventCacheStoreMedia` implementation in order to have persistent media storage.

---

- [x] Public API changes documented in changelogs (optional)


Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
