### PR TITLE
fix(sdk): Continue leaving a room if server replies with 403

### DIFF
--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -126,7 +126,7 @@ use serde::de::DeserializeOwned;
 use thiserror::Error;
 use tokio::{join, sync::broadcast};
 use tokio_stream::StreamExt;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 use self::futures::{SendAttachment, SendMessageLikeEvent, SendRawMessageLikeEvent};
 pub use self::{
@@ -235,6 +235,7 @@ impl Room {
     ///
     /// Only invited and joined rooms can be left.
     #[doc(alias = "reject_invitation")]
+    #[instrument(skip_all, fields(room_id = ?self.inner.room_id()))]
     pub async fn leave(&self) -> Result<()> {
         let state = self.state();
         if state == RoomState::Left {
@@ -249,7 +250,30 @@ impl Room {
         let should_forget = matches!(self.state(), RoomState::Invited);
 
         let request = leave_room::v3::Request::new(self.inner.room_id().to_owned());
-        self.client.send(request).await?;
+        let response = self.client.send(request).await;
+
+        // The server can return with an error that is acceptable to ignore. Let's find
+        // which one.
+        if let Err(error) = response {
+            error!(?error, "Failed to leave the room");
+
+            #[allow(clippy::collapsible_match)]
+            let ignore_error = if let Some(error) = error.client_api_error_kind() {
+                match error {
+                    // The user is trying to leave a room but doesn't have permissions to do so.
+                    // Let's consider the user has left the room.
+                    ErrorKind::Forbidden { .. } => true,
+                    _ => false,
+                }
+            } else {
+                false
+            };
+
+            if !ignore_error {
+                return Err(error.into());
+            }
+        }
+
         self.client.base_client().room_left(self.room_id()).await?;
 
         if should_forget {

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -2705,6 +2705,14 @@ impl<'a> MockEndpoint<'a, RoomLeaveEndpoint> {
             "room_id": room_id,
         })))
     }
+
+    /// Returns a `M_FORBIDDEN` response.
+    pub fn forbidden(self) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(403).set_body_json(json!({
+            "errcode": "M_FORBIDDEN",
+            "error": "sowwy",
+        })))
+    }
 }
 
 /// A prebuilt mock for the room forget endpoint.


### PR DESCRIPTION
This patch updates `Room::leave` to not early return when the server returns a 403 error code on `/leave`. Indeed, if the user doesn't have the permissions to leave a room, it's impossible for they to leave it. Let's consider it's fine to ignore this particular error and continue the process of leaving the room.