### PR TITLE
feat(crypto): Support EncryptionInfo for olm encrypted messages when using `add_event_handler`

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -495,7 +495,7 @@ impl BaseClient {
         #[cfg(feature = "e2e-encryption")]
         let to_device = {
             let processors::e2ee::to_device::Output {
-                decrypted_to_device_events: to_device,
+                processed_to_device_events: to_device,
                 room_key_updates,
             } = processors::e2ee::to_device::from_sync_v2(&response, olm_machine.as_ref()).await?;
 

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
@@ -14,7 +14,9 @@
 
 use std::collections::BTreeMap;
 
-use matrix_sdk_crypto::{store::RoomKeyInfo, EncryptionSyncChanges, OlmMachine};
+use matrix_sdk_crypto::{
+    store::RoomKeyInfo, types::ProcessedToDeviceEvent, EncryptionSyncChanges, OlmMachine,
+};
 use ruma::{
     api::client::sync::sync_events::{v3, v5, DeviceLists},
     events::AnyToDeviceEvent,
@@ -93,28 +95,31 @@ async fn process(
         let (events, room_key_updates) =
             olm_machine.receive_sync_changes(encryption_sync_changes).await?;
 
-        let events = events
-            .iter()
-            // TODO: There is loss of information here, after calling `to_raw` it is not
-            // possible to make the difference between a successfully decrypted event and a plain
-            // text event. This information needs to be propagated to top layer at some point if
-            // clients relies on custom encrypted to device events.
-            .map(|p| p.to_raw())
-            .collect();
-
-        Output { decrypted_to_device_events: events, room_key_updates: Some(room_key_updates) }
+        Output { processed_to_device_events: events, room_key_updates: Some(room_key_updates) }
     } else {
-        // If we have no `OlmMachine`, just return the events that were passed in.
+        // If we have no `OlmMachine`, just return the clear events that were passed in.
+        // The encrypted ones are dropped as they are un-usable.
         // This should not happen unless we forget to set things up by calling
         // `Self::activate()`.
         Output {
-            decrypted_to_device_events: encryption_sync_changes.to_device_events,
+            processed_to_device_events: encryption_sync_changes
+                .to_device_events
+                .into_iter()
+                .filter(|raw| {
+                    if let Ok(Some(event_type)) = raw.get_field::<String>("type") {
+                        event_type != "m.room.encrypted"
+                    } else {
+                        false // Exclude events with no type or encrypted
+                    }
+                })
+                .map(ProcessedToDeviceEvent::PlainText)
+                .collect(),
             room_key_updates: None,
         }
     })
 }
 
 pub struct Output {
-    pub decrypted_to_device_events: Vec<Raw<AnyToDeviceEvent>>,
+    pub processed_to_device_events: Vec<ProcessedToDeviceEvent>,
     pub room_key_updates: Option<Vec<RoomKeyInfo>>,
 }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -15,9 +15,8 @@
 //! Extend `BaseClient` with capabilities to handle MSC4186.
 
 use matrix_sdk_common::deserialized_responses::TimelineEvent;
+use matrix_sdk_crypto::types::ProcessedToDeviceEvent;
 use ruma::{api::client::sync::sync_events::v5 as http, OwnedRoomId};
-#[cfg(feature = "e2e-encryption")]
-use ruma::{events::AnyToDeviceEvent, serde::Raw};
 use tracing::{instrument, trace};
 
 use super::BaseClient;
@@ -44,7 +43,7 @@ impl BaseClient {
         &self,
         to_device: Option<&http::response::ToDevice>,
         e2ee: &http::response::E2EE,
-    ) -> Result<Option<Vec<Raw<AnyToDeviceEvent>>>> {
+    ) -> Result<Option<Vec<ProcessedToDeviceEvent>>> {
         if to_device.is_none() && e2ee.is_empty() {
             return Ok(None);
         }
@@ -62,7 +61,7 @@ impl BaseClient {
 
         let mut context = processors::Context::default();
 
-        let processors::e2ee::to_device::Output { decrypted_to_device_events, room_key_updates } =
+        let processors::e2ee::to_device::Output { processed_to_device_events, room_key_updates } =
             processors::e2ee::to_device::from_msc4186(to_device, e2ee, olm_machine.as_ref())
                 .await?;
 
@@ -89,7 +88,7 @@ impl BaseClient {
         )
         .await?;
 
-        Ok(Some(decrypted_to_device_events))
+        Ok(Some(processed_to_device_events))
     }
 
     /// Process a response from a sliding sync call.

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -17,6 +17,7 @@
 use std::{collections::BTreeMap, fmt};
 
 use matrix_sdk_common::{debug::DebugRawEvent, deserialized_responses::TimelineEvent};
+use matrix_sdk_crypto::types::ProcessedToDeviceEvent;
 pub use ruma::api::client::sync::sync_events::v3::{
     InvitedRoom as InvitedRoomUpdate, KnockedRoom as KnockedRoomUpdate,
 };
@@ -24,7 +25,7 @@ use ruma::{
     api::client::sync::sync_events::UnreadNotificationsCount as RumaUnreadNotificationsCount,
     events::{
         presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
-        AnySyncEphemeralRoomEvent, AnySyncStateEvent, AnyToDeviceEvent,
+        AnySyncEphemeralRoomEvent, AnySyncStateEvent,
     },
     push::Action,
     serde::Raw,
@@ -50,7 +51,7 @@ pub struct SyncResponse {
     /// The global private data created by this user.
     pub account_data: Vec<Raw<AnyGlobalAccountDataEvent>>,
     /// Messages sent directly between devices.
-    pub to_device: Vec<Raw<AnyToDeviceEvent>>,
+    pub to_device: Vec<ProcessedToDeviceEvent>,
     /// New notifications per room.
     pub notifications: BTreeMap<OwnedRoomId, Vec<Notification>>,
 }
@@ -61,7 +62,12 @@ impl fmt::Debug for SyncResponse {
         f.debug_struct("SyncResponse")
             .field("rooms", &self.rooms)
             .field("account_data", &DebugListOfRawEventsNoId(&self.account_data))
-            .field("to_device", &DebugListOfRawEventsNoId(&self.to_device))
+            .field(
+                "to_device",
+                &DebugListOfRawEventsNoId(
+                    self.to_device.iter().map(|p| p.to_raw()).collect::<Vec<_>>().as_slice(),
+                ),
+            )
             .field("notifications", &self.notifications)
             .finish_non_exhaustive()
     }

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -52,8 +52,6 @@ use ruma::{
 };
 use serde_json::{value::to_raw_value, Value};
 use tokio::sync::Mutex;
-#[cfg(feature = "experimental-send-custom-to-device")]
-use tracing::trace;
 use tracing::{
     debug, error,
     field::{debug, display},

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1786,7 +1786,7 @@ impl Encryption {
 
         // TODO: parallelize that? it's already grouping 250 devices per chunk.
         for request in requests {
-            let request = RumaToDeviceRequest::new_raw(
+            let ruma_request = RumaToDeviceRequest::new_raw(
                 request.event_type.clone(),
                 request.txn_id.clone(),
                 request.messages.clone(),
@@ -1794,7 +1794,7 @@ impl Encryption {
 
             let send_result = self
                 .client
-                .send_inner(request, Some(RequestConfig::short_retry()), Default::default())
+                .send_inner(ruma_request, Some(RequestConfig::short_retry()), Default::default())
                 .await;
 
             // If the sending failed we need to collect the failures to report them

--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -60,7 +60,7 @@ use serde_json::value::RawValue as RawJsonValue;
 use tracing::{debug, error, field::debug, instrument, warn};
 
 use self::maps::EventHandlerMaps;
-use crate::{Client, Room};
+use crate::{crypto::types::ProcessedToDeviceEvent, Client, Room};
 
 mod context;
 mod maps;
@@ -344,6 +344,38 @@ impl Client {
         for raw_event in events {
             let event_type = raw_event.deserialize_as::<ExtractType<'_>>()?.event_type;
             self.call_event_handlers(room, raw_event.json(), kind, &event_type, None, &[]).await;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn handle_sync_to_device_events(
+        &self,
+        events: &[ProcessedToDeviceEvent],
+    ) -> serde_json::Result<()> {
+        #[derive(Deserialize)]
+        struct ExtractType<'a> {
+            #[serde(borrow, rename = "type")]
+            event_type: Cow<'a, str>,
+        }
+
+        for processed_to_device in events {
+            let (raw_event, encryption_info) = match processed_to_device {
+                ProcessedToDeviceEvent::Decrypted { raw, encryption_info } => {
+                    (raw, Some(encryption_info))
+                }
+                other => (&other.to_raw(), None),
+            };
+            let event_type = raw_event.deserialize_as::<ExtractType<'_>>()?.event_type;
+            self.call_event_handlers(
+                None,
+                raw_event.json(),
+                HandlerKind::ToDevice,
+                &event_type,
+                encryption_info,
+                &[],
+            )
+            .await;
         }
 
         Ok(())
@@ -687,6 +719,11 @@ mod tests {
         },
     };
 
+    use assert_matches2::{assert_let, assert_matches};
+    use matrix_sdk_common::{
+        deserialized_responses::{AlgorithmInfo, EncryptionInfo},
+        locks::Mutex,
+    };
     use matrix_sdk_test::{StateTestEvent, StrippedStateTestEvent, SyncResponseBuilder};
     use once_cell::sync::Lazy;
     use ruma::{
@@ -698,7 +735,7 @@ mod tests {
                 power_levels::OriginalSyncRoomPowerLevelsEvent,
             },
             typing::SyncTypingEvent,
-            AnySyncStateEvent, AnySyncTimelineEvent,
+            AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
         },
         room_id,
         serde::Raw,
@@ -812,6 +849,49 @@ mod tests {
         assert_eq!(power_levels_count.load(SeqCst), 1);
         assert_eq!(invited_member_count.load(SeqCst), 1);
 
+        Ok(())
+    }
+
+    #[async_test]
+    #[allow(dependency_on_unit_never_type_fallback)]
+    async fn test_add_to_device_event_handler() -> crate::Result<()> {
+        let client = logged_in_client(None).await;
+
+        let captured_event: Arc<Mutex<Option<AnyToDeviceEvent>>> = Arc::new(Mutex::new(None));
+        let captured_info: Arc<Mutex<Option<EncryptionInfo>>> = Arc::new(Mutex::new(None));
+
+        client.add_event_handler({
+            let captured = captured_event.clone();
+            let captured_info = captured_info.clone();
+            move |ev: AnyToDeviceEvent, encryption_info: Option<EncryptionInfo>| {
+                let mut captured_lock = captured.lock();
+                *captured_lock = Some(ev);
+                let mut captured_info_lock = captured_info.lock();
+                *captured_info_lock = encryption_info;
+                future::ready(())
+            }
+        });
+
+        let response = SyncResponseBuilder::default()
+            .add_to_device_event(json!({
+              "sender": "@alice:example.com",
+              "type": "m.custom.to.device.type",
+              "content": {
+                "a": "test",
+              }
+            }))
+            .build_sync_response();
+        client.process_sync(response).await?;
+
+        let captured = captured_event.lock().clone();
+        assert_let!(Some(received_event) = captured);
+        assert_eq!(received_event.event_type().to_string(), "m.custom.to.device.type");
+        let info = captured_info.lock().clone();
+        assert_let!(Some(encryption_info) = info);
+        assert_matches!(
+            encryption_info.algorithm_info,
+            AlgorithmInfo::OlmV1Curve25519AesSha2 { .. }
+        );
         Ok(())
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -1,15 +1,11 @@
 use std::collections::BTreeSet;
 
 use matrix_sdk_base::{sync::SyncResponse, RequestedRequiredStates};
-use ruma::{
-    api::client::{discovery::get_supported_versions, sync::sync_events::v5 as http},
-    events::AnyToDeviceEvent,
-    serde::Raw,
-};
+use ruma::api::client::{discovery::get_supported_versions, sync::sync_events::v5 as http};
 use tracing::error;
 
 use super::{SlidingSync, SlidingSyncBuilder};
-use crate::{Client, Result};
+use crate::{crypto::types::ProcessedToDeviceEvent, Client, Result};
 
 /// A sliding sync version.
 #[derive(Clone, Debug)]
@@ -154,7 +150,7 @@ impl Client {
 #[must_use]
 pub(crate) struct SlidingSyncResponseProcessor {
     client: Client,
-    to_device_events: Vec<Raw<AnyToDeviceEvent>>,
+    to_device_events: Vec<ProcessedToDeviceEvent>,
     response: Option<SyncResponse>,
 }
 

--- a/crates/matrix-sdk/tests/integration/encryption/to_device.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/to_device.rs
@@ -1,19 +1,35 @@
 #![cfg(feature = "experimental-send-custom-to-device")]
 
+use std::{future, sync::Arc, time::Duration};
+
+use assert_matches2::{assert_let, assert_matches};
 use matrix_sdk::{
-    authentication::matrix::MatrixSession, config::RequestConfig,
-    test_utils::client::mock_session_tokens, Client,
+    authentication::matrix::MatrixSession,
+    config::{RequestConfig, SyncSettings},
+    test_utils::client::mock_session_tokens,
+    Client,
 };
 use matrix_sdk_base::SessionMeta;
+use matrix_sdk_common::{
+    deserialized_responses::{AlgorithmInfo, EncryptionInfo},
+    locks::Mutex,
+};
 use matrix_sdk_test::{async_test, test_json, SyncResponseBuilder};
-use ruma::{api::MatrixVersion, owned_device_id, owned_user_id, serde::Raw};
-use serde_json::json;
+use ruma::{
+    api::{client::to_device::send_event_to_device::v3::Messages, MatrixVersion},
+    events::AnyToDeviceEvent,
+    owned_device_id, owned_user_id,
+    serde::Raw,
+    MilliSecondsSinceUnixEpoch, OwnedUserId,
+};
+use serde_json::{json, Value};
+use tracing::info;
 use wiremock::{
     matchers::{method, path, path_regex},
-    Mock, ResponseTemplate,
+    Mock, Request, ResponseTemplate,
 };
 
-use crate::mock_sync_scoped;
+use crate::{mock_sync, mock_sync_scoped};
 
 async fn set_up_alice_and_bob_for_encryption(
     server: &mut crate::encryption::verification::MockedServer,
@@ -65,6 +81,14 @@ async fn set_up_alice_and_bob_for_encryption(
         alice_olm.update_tracked_users([bob_user_id.as_ref()]).await.unwrap();
     }
 
+    // let bob be aware of Alice keys in order to be able to decrypt custom to
+    // device
+    {
+        let bob_olm = bob.olm_machine_for_testing().await;
+        let bob_olm = bob_olm.as_ref().unwrap();
+        bob_olm.update_tracked_users([alice_user_id.as_ref()]).await.unwrap();
+    }
+
     // Have Alice and Bob upload their signed device keys.
     {
         let mut sync_response_builder = SyncResponseBuilder::new();
@@ -78,11 +102,11 @@ async fn set_up_alice_and_bob_for_encryption(
         bob.sync_once(Default::default()).await.unwrap();
     }
 
-    // Run a sync so we do send outgoing requests, including the /keys/query for
-    // getting bob's identity.
-    let mut sync_response_builder = SyncResponseBuilder::new();
-
     {
+        // Run a sync so we do send outgoing requests, including the /keys/query for
+        // getting bob's identity.
+        let mut sync_response_builder = SyncResponseBuilder::new();
+
         let _scope = mock_sync_scoped(
             &server.server,
             sync_response_builder.build_json_sync_response(),
@@ -92,7 +116,7 @@ async fn set_up_alice_and_bob_for_encryption(
         alice
             .sync_once(Default::default())
             .await
-            .expect("We should be able to sync so we get theinitial set of devices");
+            .expect("We should be able to sync so we get the initial set of devices");
     }
 
     (alice, bob)
@@ -199,6 +223,121 @@ async fn test_encrypt_and_send_to_device_report_failures_server() {
     let failure = result.first().unwrap();
     assert_eq!(bob_user_id.to_owned(), failure.0);
     assert_eq!(bob_device_id.to_owned(), failure.1);
+}
+
+// A simple mock to capture an encrypted to device message via `sendToDevice`.
+// Expect the request payload to be for an encrypted event and to only have one
+// message.
+fn mock_send_encrypted_to_device_responder(
+    sender: OwnedUserId,
+    to_device: Arc<Mutex<Option<Value>>>,
+) -> impl Fn(&Request) -> ResponseTemplate {
+    move |req: &Request| {
+        #[derive(Debug, serde::Deserialize)]
+        struct Parameters {
+            messages: Messages,
+        }
+
+        let params: Parameters = req.body_json().unwrap();
+
+        let (_, device_to_content) = params.messages.first_key_value().unwrap();
+        let content = device_to_content.first_key_value().unwrap().1;
+
+        let event = json!({
+            "origin_server_ts": MilliSecondsSinceUnixEpoch::now(),
+            "sender": sender,
+            "type": "m.room.encrypted",
+            "content": content,
+        });
+
+        let mut lock = to_device.lock();
+        *lock = Some(event);
+
+        ResponseTemplate::new(200).set_body_json(&*test_json::EMPTY)
+    }
+}
+
+#[async_test]
+async fn test_to_device_event_handler_olm_encryption_info() {
+    // ===========
+    // Happy path, will encrypt and send
+    // ============
+    let mut server = crate::encryption::verification::MockedServer::new().await;
+
+    let (alice, bob) = set_up_alice_and_bob_for_encryption(&mut server).await;
+    let bob_user_id = bob.user_id().unwrap();
+    let bob_device_id = bob.device_id().unwrap();
+
+    // From the point of view of Alice, Bob now has a device.
+    let alice_bob_device = alice
+        .encryption()
+        .get_device(bob_user_id, bob_device_id)
+        .await
+        .unwrap()
+        .expect("alice sees bob's device");
+
+    let content_raw = Raw::new(&json!({
+        "keys": [
+            {
+                "index": 0,
+                "key": "rQuVUQs2sHV8Z2rjhmW+aQ=="
+            }
+        ],
+        "device_id": "VYTOIDPHBO",
+        "call_id": "",
+        "sent_ts": 1000
+    }))
+    .unwrap()
+    .cast();
+
+    let captured_event: Arc<Mutex<Option<Value>>> = Arc::new(Mutex::new(None));
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/sendToDevice/m.room.encrypted/.*"))
+        .respond_with(mock_send_encrypted_to_device_responder(
+            alice.user_id().unwrap().to_owned(),
+            captured_event.clone(),
+        ))
+        // Should be called once
+        .expect(1)
+        .named("send_to_device")
+        .mount(&server.server)
+        .await;
+
+    alice
+        .encryption()
+        .encrypt_and_send_raw_to_device(vec![&alice_bob_device], "call.keys", content_raw)
+        .await
+        .unwrap();
+
+    let captured_processed_event: Arc<Mutex<Option<AnyToDeviceEvent>>> = Arc::new(Mutex::new(None));
+    let captured_info: Arc<Mutex<Option<EncryptionInfo>>> = Arc::new(Mutex::new(None));
+
+    bob.add_event_handler({
+        let captured = captured_processed_event.clone();
+        let captured_info = captured_info.clone();
+        move |ev: AnyToDeviceEvent, encryption_info: Option<EncryptionInfo>| {
+            let mut captured_lock = captured.lock();
+            *captured_lock = Some(ev);
+            let mut captured_info_lock = captured_info.lock();
+            *captured_info_lock = encryption_info;
+            future::ready(())
+        }
+    });
+
+    // feed back the event to bob client
+    let mut sync_response_builder = SyncResponseBuilder::new();
+    let lock = captured_event.lock();
+    sync_response_builder.add_to_device_event(lock.clone().unwrap());
+
+    mock_sync(&server.server, sync_response_builder.build_json_sync_response(), None).await;
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let _response = bob.sync_once(sync_settings.clone()).await.unwrap();
+
+    let captured = captured_processed_event.lock().clone();
+    assert_eq!(captured.is_some(), true);
+    let info = captured_info.lock().clone();
+    assert_let!(Some(encryption_info) = info);
+    assert_matches!(encryption_info.algorithm_info, AlgorithmInfo::OlmV1Curve25519AesSha2 { .. });
 }
 
 #[async_test]

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
@@ -9,7 +9,7 @@ use assert_matches2::assert_let;
 use assign::assign;
 use matrix_sdk::{
     assert_next_eq_with_timeout,
-    crypto::{format_emojis, SasState, UserDevices},
+    crypto::{format_emojis, types::ProcessedToDeviceEvent, SasState, UserDevices},
     encryption::{
         backups::BackupState,
         recovery::{Recovery, RecoveryState},
@@ -1297,6 +1297,7 @@ async fn test_history_share_on_invite() -> Result<()> {
     // Bob should have received a to-device event with the payload
     assert_eq!(bob_response.to_device.len(), 1);
     let to_device_event = &bob_response.to_device[0];
+    assert_let!(ProcessedToDeviceEvent::Decrypted { raw: to_device_event, .. } = to_device_event);
     assert_eq!(
         to_device_event.get_field::<String>("type").unwrap().unwrap(),
         "io.element.msc4268.room_key_bundle"


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Make it possible to make a difference between a plaintext and a successfully decrypted to-device message. 
There is now a new variant of `EncryptionInfo` that will be passed to the to-device event handlers.


Based on https://github.com/matrix-org/matrix-rust-sdk/pull/5074


- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
