### PR TITLE
Feat ffi room tombstone

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -1,14 +1,13 @@
 use std::collections::HashMap;
 
 use matrix_sdk::{EncryptionState, RoomState};
-use ruma::events::room::tombstone::RoomTombstoneEventContent;
 use tracing::warn;
 
 use crate::{
     client::JoinRule,
     error::ClientError,
     notification_settings::RoomNotificationMode,
-    room::{Membership, RoomHero, RoomHistoryVisibility},
+    room::{Membership, RoomHero, RoomHistoryVisibility, SuccessorRoom},
     room_member::RoomMember,
 };
 
@@ -28,7 +27,7 @@ pub struct RoomInfo {
     is_public: bool,
     is_space: bool,
     /// If present, it means the room has been archived/upgraded.
-    tombstone: Option<RoomTombstoneInfo>,
+    successor_room: Option<SuccessorRoom>,
     is_favourite: bool,
     canonical_alias: Option<String>,
     alternative_aliases: Vec<String>,
@@ -96,7 +95,7 @@ impl RoomInfo {
             is_direct: room.is_direct().await?,
             is_public: room.is_public(),
             is_space: room.is_space(),
-            tombstone: room.tombstone_content().map(Into::into),
+            successor_room: room.successor_room().map(Into::into),
             is_favourite: room.is_favourite(),
             canonical_alias: room.canonical_alias().map(Into::into),
             alternative_aliases: room.alt_aliases().into_iter().map(Into::into).collect(),
@@ -137,19 +136,5 @@ impl RoomInfo {
             join_rule: join_rule.ok(),
             history_visibility: room.history_visibility_or_default().try_into()?,
         })
-    }
-}
-
-/// Contains the `m.room.tombstone` state of the room, with a message about the
-/// room upgrade and the id of the newly created room to replace this one.
-#[derive(uniffi::Record)]
-pub struct RoomTombstoneInfo {
-    body: String,
-    replacement_room_id: String,
-}
-
-impl From<ruma::events::room::tombstone::RoomTombstoneEventContent> for RoomTombstoneInfo {
-    fn from(value: RoomTombstoneEventContent) -> Self {
-        Self { body: value.body, replacement_room_id: value.replacement_room.to_string() }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -14,10 +14,10 @@ use matrix_sdk::{
 };
 use matrix_sdk_ui::{
     room_list_service::filters::{
-        new_filter_all, new_filter_any, new_filter_category, new_filter_favourite,
-        new_filter_fuzzy_match_room_name, new_filter_invite, new_filter_joined,
-        new_filter_non_left, new_filter_none, new_filter_normalized_match_room_name,
-        new_filter_unread, BoxedFilterFn, RoomCategory,
+        new_filter_all, new_filter_any, new_filter_category, new_filter_deduplicate_versions,
+        new_filter_favourite, new_filter_fuzzy_match_room_name, new_filter_invite,
+        new_filter_joined, new_filter_non_left, new_filter_none,
+        new_filter_normalized_match_room_name, new_filter_unread, BoxedFilterFn, RoomCategory,
     },
     unable_to_decrypt_hook::UtdHookManager,
 };
@@ -457,6 +457,7 @@ pub enum RoomListEntriesDynamicFilterKind {
     None,
     NormalizedMatchRoomName { pattern: String },
     FuzzyMatchRoomName { pattern: String },
+    DeduplicateVersions,
 }
 
 #[derive(uniffi::Enum)]
@@ -498,6 +499,7 @@ impl From<RoomListEntriesDynamicFilterKind> for BoxedFilterFn {
             Kind::FuzzyMatchRoomName { pattern } => {
                 Box::new(new_filter_fuzzy_match_room_name(&pattern))
             }
+            Kind::DeduplicateVersions => Box::new(new_filter_deduplicate_versions()),
         }
     }
 }

--- a/crates/matrix-sdk-base/src/room/tombstone.rs
+++ b/crates/matrix-sdk-base/src/room/tombstone.rs
@@ -99,7 +99,6 @@ pub struct SuccessorRoom {
 /// To know the predecessor of a room, the [`m.room.create`] state event must
 /// have been received.
 ///
-/// [`m.room.tombstone`]: https://spec.matrix.org/v1.14/client-server-api/#mroomtombstone
 /// [`m.room.create`]: https://spec.matrix.org/v1.14/client-server-api/#mroomcreate
 #[derive(Debug)]
 pub struct PredecessorRoom {

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -25,10 +25,10 @@ pub use matrix_sdk_base::crypto;
 pub use matrix_sdk_base::{
     deserialized_responses,
     store::{self, DynStateStore, MemoryStore, StateStoreExt},
-    ComposerDraft, ComposerDraftType, EncryptionState, QueueWedgeError, Room as BaseRoom,
-    RoomCreateWithCreatorEventContent, RoomDisplayName, RoomHero, RoomInfo,
+    ComposerDraft, ComposerDraftType, EncryptionState, PredecessorRoom, QueueWedgeError,
+    Room as BaseRoom, RoomCreateWithCreatorEventContent, RoomDisplayName, RoomHero, RoomInfo,
     RoomMember as BaseRoomMember, RoomMemberships, RoomState, SessionMeta, StateChanges,
-    StateStore, StoreError,
+    StateStore, StoreError, SuccessorRoom,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;


### PR DESCRIPTION
These patches add support for `SuccessorRoom`, `PredecessorRoom` and the new `DeduplicateVersions` room list filter.
This is porting the following new features to our FFI bindings:

- https://github.com/matrix-org/matrix-rust-sdk/pull/5070
- https://github.com/matrix-org/matrix-rust-sdk/pull/5084

---

- Address https://github.com/matrix-org/matrix-rust-sdk/issues/5050