### PR TITLE
feat(widget): Receive custom to-device messages in widgets in e2ee rooms

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -1440,6 +1440,11 @@ impl OlmMachine {
                     Ok(event) => {
                         self.handle_to_device_event(changes, &event).await;
 
+                        // TODO: we should have access to some decryption settings here
+                        // (TrustRequirement) and use it (at least for
+                        // custom to-devices) to manually reject the decryption.
+                        // Similar to check_sender_trust_requirement for room events
+
                         raw_event = event
                             .serialize_zeroized()
                             .expect("Zeroizing and reserializing our events should always work")

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -240,7 +240,6 @@ impl MatrixDriver {
                     return;
                 };
 
-                // Or should I use room.encryption_settings()?
                 let room_encrypted = room.latest_encryption_state().await
                     .map(|s| s.is_encrypted())
                     // Default consider encrypted

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -38,10 +38,12 @@ use ruma::{
 };
 use serde_json::{value::RawValue as RawJsonValue, Value};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
-use tracing::error;
+use tracing::{error, trace, warn};
 
 use super::{machine::SendEventResponse, StateKeySelector};
-use crate::{event_handler::EventHandlerDropGuard, room::MessagesOptions, Error, Result, Room};
+use crate::{
+    event_handler::EventHandlerDropGuard, room::MessagesOptions, Client, Error, Result, Room,
+};
 
 /// Thin wrapper around a [`Room`] that provides functionality relevant for
 /// widgets.
@@ -214,24 +216,90 @@ impl MatrixDriver {
         EventReceiver { rx, _drop_guards: vec![drop_guard_msg_like, drop_guard_state] }
     }
 
-    /// Starts forwarding new room events. Once the returned `EventReceiver`
-    /// is dropped, forwarding will be stopped.
+    /// Starts forwarding new to-device messages. Once the returned
+    /// `EventReceiver` is dropped, forwarding will be stopped.
     pub(crate) fn to_device_events(&self) -> EventReceiver<Raw<AnyToDeviceEvent>> {
         let (tx, rx) = unbounded_channel();
 
+        let room_id = self.room.room_id().to_owned();
         let to_device_handle = self.room.client().add_event_handler(
-            // TODO: encryption support for to-device is not yet supported. Needs an Olm
-            // EncryptionInfo. The widgetAPI expects a boolean `encrypted` to be added
-            // (!) to the raw content to know if the to-device message was encrypted or
-            // not (as per MSC3819).
-            move |raw: Raw<AnyToDeviceEvent>, _: Option<EncryptionInfo>| {
-                let _ = tx.send(raw);
-                async {}
+
+            async move |raw: Raw<AnyToDeviceEvent>, encryption_info: Option<EncryptionInfo>, client: Client| {
+
+                // Some to-device traffic is used by the sdk for internal machinery.
+                // They should not be exposed to widgets.
+                if Self::should_filter_message_to_widget(&raw) {
+                    trace!("Internal or UTD to-device message filtered out by widget driver.");
+                    return;
+                }
+
+                // Encryption can be enabled after the widget has been instantiated,
+                // we want to keep track of the latest status
+                let Some(room) = client.get_room(&room_id) else {
+                    warn!("Room {} not found in client.", room_id);
+                    return;
+                };
+
+                // Or should I use room.encryption_settings()?
+                let room_encrypted = room.latest_encryption_state().await
+                    .map(|s| s.is_encrypted())
+                    // Default consider encrypted
+                    .unwrap_or(true);
+                if room_encrypted {
+                    // The room is encrypted so the to-device traffic should be too.
+                    if encryption_info.is_none() {
+                        warn!(
+                            ?room_id,
+                            "Received to-device event in clear for a widget in an e2e room, dropping."
+                        );
+                        return;
+                    };
+
+                    // There no per-room specific decryption setting, so we can just send to the
+                    // widget
+                    let _ = tx.send(raw);
+                } else {
+                    // forward to the widget
+                    // It is ok to send an encrypted to-device message even if the room is clear.
+                    let _ = tx.send(raw);
+                }
             },
         );
 
         let drop_guard = self.room.client().event_handler_drop_guard(to_device_handle);
         EventReceiver { rx, _drop_guards: vec![drop_guard] }
+    }
+
+    fn should_filter_message_to_widget(raw_message: &Raw<AnyToDeviceEvent>) -> bool {
+        let Ok(Some(event_type)) = raw_message.get_field::<String>("type") else {
+            return true;
+        };
+
+        if event_type == "m.room.encrypted" {
+            // Unable to decrypt,
+            return true;
+        }
+
+        // Filter out all the internal crypto related traffic.
+        // The SDK has already zeroized the critical data, but let's not leak any
+        // information
+        matches!(
+            event_type.as_str(),
+            "m.dummy"
+                | "m.room_key"
+                | "m.room_key_request"
+                | "m.forwarded_room_key"
+                | "m.key.verification.request"
+                | "m.key.verification.ready"
+                | "m.key.verification.start"
+                | "m.key.verification.cancel"
+                | "m.key.verification.accept"
+                | "m.key.verification.key"
+                | "m.key.verification.mac"
+                | "m.key.verification.done"
+                | "m.secret.request"
+                | "m.secret.send"
+        )
     }
 
     /// It will ignore all devices where errors occurred or where the device is

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -53,6 +53,7 @@ static ROOM_ID: Lazy<OwnedRoomId> = Lazy::new(|| owned_room_id!("!a98sd12bjh:exa
 
 async fn run_test_driver(
     init_on_content_load: bool,
+    is_room_e2ee: bool,
 ) -> (Client, MatrixMockServer, WidgetDriverHandle) {
     struct DummyCapabilitiesProvider;
 
@@ -67,7 +68,12 @@ async fn run_test_driver(
     let client = mock_server.client_builder().build().await;
 
     let room = mock_server.sync_joined_room(&client, &ROOM_ID).await;
-    mock_server.mock_room_state_encryption().plain().mount().await;
+
+    if is_room_e2ee {
+        mock_server.mock_room_state_encryption().encrypted().mount().await;
+    } else {
+        mock_server.mock_room_state_encryption().plain().mount().await;
+    }
 
     let (driver, handle) = WidgetDriver::new(
         WidgetSettings::new(WIDGET_ID.to_owned(), init_on_content_load, "https://foo.bar/widget")
@@ -129,7 +135,7 @@ async fn send_response(
 
 #[async_test]
 async fn test_negotiate_capabilities_immediately() {
-    let (_, _, driver_handle) = run_test_driver(false).await;
+    let (_, _, driver_handle) = run_test_driver(false, false).await;
 
     let caps = json!(["org.matrix.msc2762.receive.event:m.room.message"]);
 
@@ -183,7 +189,7 @@ async fn test_negotiate_capabilities_immediately() {
 
 #[async_test]
 async fn test_read_messages() {
-    let (_, mock_server, driver_handle) = run_test_driver(true).await;
+    let (_, mock_server, driver_handle) = run_test_driver(true, false).await;
 
     {
         // Tell the driver that we're ready for communication
@@ -269,7 +275,7 @@ async fn test_read_messages() {
 
 #[async_test]
 async fn test_read_messages_with_msgtype_capabilities() {
-    let (_, mock_server, driver_handle) = run_test_driver(true).await;
+    let (_, mock_server, driver_handle) = run_test_driver(true, false).await;
 
     {
         // Tell the driver that we're ready for communication
@@ -334,7 +340,7 @@ async fn test_read_messages_with_msgtype_capabilities() {
 
 #[async_test]
 async fn test_read_room_members() {
-    let (_, mock_server, driver_handle) = run_test_driver(false).await;
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
 
     negotiate_capabilities(
         &driver_handle,
@@ -372,7 +378,7 @@ async fn test_read_room_members() {
 
 #[async_test]
 async fn test_receive_live_events() {
-    let (client, mock_server, driver_handle) = run_test_driver(false).await;
+    let (client, mock_server, driver_handle) = run_test_driver(false, true).await;
 
     negotiate_capabilities(
         &driver_handle,
@@ -483,7 +489,7 @@ async fn test_receive_live_events() {
 
 #[async_test]
 async fn test_send_room_message() {
-    let (_, mock_server, driver_handle) = run_test_driver(false).await;
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
 
     negotiate_capabilities(&driver_handle, json!(["org.matrix.msc2762.send.event:m.room.message"]))
         .await;
@@ -520,7 +526,7 @@ async fn test_send_room_message() {
 
 #[async_test]
 async fn test_send_room_name() {
-    let (_, mock_server, driver_handle) = run_test_driver(false).await;
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
 
     negotiate_capabilities(
         &driver_handle,
@@ -560,7 +566,7 @@ async fn test_send_room_name() {
 
 #[async_test]
 async fn test_send_delayed_message_event() {
-    let (_, mock_server, driver_handle) = run_test_driver(false).await;
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
 
     negotiate_capabilities(
         &driver_handle,
@@ -606,7 +612,7 @@ async fn test_send_delayed_message_event() {
 
 #[async_test]
 async fn test_send_delayed_state_event() {
-    let (_, mock_server, driver_handle) = run_test_driver(false).await;
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
 
     negotiate_capabilities(
         &driver_handle,
@@ -653,7 +659,7 @@ async fn test_send_delayed_state_event() {
 
 #[async_test]
 async fn test_fail_sending_delay_rate_limit() {
-    let (_, mock_server, driver_handle) = run_test_driver(false).await;
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
 
     negotiate_capabilities(
         &driver_handle,
@@ -712,7 +718,7 @@ async fn test_fail_sending_delay_rate_limit() {
 
 #[async_test]
 async fn test_try_send_delayed_state_event_without_permission() {
-    let (_, _mock_server, driver_handle) = run_test_driver(false).await;
+    let (_, _mock_server, driver_handle) = run_test_driver(false, false).await;
 
     negotiate_capabilities(
         &driver_handle,
@@ -748,7 +754,7 @@ async fn test_try_send_delayed_state_event_without_permission() {
 
 #[async_test]
 async fn test_update_delayed_event() {
-    let (_, mock_server, driver_handle) = run_test_driver(false).await;
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
 
     negotiate_capabilities(&driver_handle, json!(["org.matrix.msc4157.update_delayed_event",]))
         .await;
@@ -781,7 +787,7 @@ async fn test_update_delayed_event() {
 
 #[async_test]
 async fn test_try_update_delayed_event_without_permission() {
-    let (_, _mock_server, driver_handle) = run_test_driver(false).await;
+    let (_, _mock_server, driver_handle) = run_test_driver(false, false).await;
 
     negotiate_capabilities(&driver_handle, json!([])).await;
 
@@ -809,7 +815,7 @@ async fn test_try_update_delayed_event_without_permission() {
 
 #[async_test]
 async fn test_try_update_delayed_event_without_permission_negotiate() {
-    let (_, _mock_server, driver_handle) = run_test_driver(false).await;
+    let (_, _mock_server, driver_handle) = run_test_driver(false, false).await;
 
     send_request(
         &driver_handle,
@@ -839,7 +845,7 @@ async fn test_try_update_delayed_event_without_permission_negotiate() {
 
 #[async_test]
 async fn test_send_redaction() {
-    let (_, mock_server, driver_handle) = run_test_driver(false).await;
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
 
     negotiate_capabilities(
         &driver_handle,
@@ -881,7 +887,7 @@ async fn send_to_device_test_helper(
     expected_response: JsonValue,
     calls: u64,
 ) -> JsonValue {
-    let (_, mock_server, driver_handle) = run_test_driver(false).await;
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
 
     negotiate_capabilities(
         &driver_handle,

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -488,6 +488,38 @@ async fn test_receive_live_events() {
 }
 
 #[async_test]
+async fn test_block_clear_to_device_in_e2ee_room() {
+    let (client, mock_server, driver_handle) = run_test_driver(false, true).await;
+
+    negotiate_capabilities(
+        &driver_handle,
+        json!(["org.matrix.msc3819.receive.to_device:my.custom.to.device"]),
+    )
+    .await;
+
+    // No messages from the driver yet
+    assert_matches!(recv_message(&driver_handle).now_or_never(), None);
+
+    mock_server
+        .mock_sync()
+        .ok_and_run(&client, |sync_builder| {
+            sync_builder.add_to_device_event(json!({
+                    "sender": "@alice:example.com",
+                    "type": "my.custom.to.device",
+                    "content": {
+                      "a": "test",
+                    }
+                  }
+            ));
+        })
+        .await;
+
+    // The message should be filtered out because it is not encrypted and the room
+    // is encrypted
+    assert_matches!(recv_message(&driver_handle).now_or_never(), None);
+}
+
+#[async_test]
 async fn test_send_room_message() {
     let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
 


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Proper support for receiving to-device messages for widgets

If the widget is in an e2ee room, clear to-device traffic will be excluded.
Also filter out internal to-device messages that widgets should not be aware off

Draft for now because depends on 
 - https://github.com/matrix-org/matrix-rust-sdk/pull/5099
 - and https://github.com/matrix-org/matrix-rust-sdk/pull/5074

I want to add more test, but for that I'd like to have this [PR for new common mock helpers](https://github.com/matrix-org/matrix-rust-sdk/pull/5005) to be merged.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
