### PR TITLE
fix(sdk): check max_upload_size before attempting to upload any media

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 Breaking changes:
 
+- `Client::upload_avatar` and `Timeline::send_attachment` now may fail if a file too large for the homeserver media
+  config is uploaded.
 - `UploadParameters` replaces field `filename: String` with `source: UploadSource`.
   `UploadSource` is an enum which may take a filename or a filename and bytes, which
   allows a foreign language to read file contents natively and then pass those contents to
@@ -19,6 +21,8 @@ Breaking changes:
 
 Additions:
 
+- `Client::get_max_media_upload_size` to get the max size of a request sent to the homeserver so we can tweak our media
+  uploads by compressing/transcoding the media.
 - Add `ClientBuilder::enable_share_history_on_invite` to enable experimental support for sharing encrypted room history on invite, per [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268).
   ([#5141](https://github.com/matrix-org/matrix-rust-sdk/pull/5141))
 - Support for adding a Sentry layer to the FFI bindings has been added. Only `tracing` statements with

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1553,6 +1553,13 @@ impl Client {
     ) -> Result<Option<MediaPreviewConfig>, ClientError> {
         Ok(self.inner.account().fetch_media_preview_config_event_content().await?.map(Into::into))
     }
+
+    /// Gets the `max_upload_size` value from the homeserver, which controls the
+    /// max size a media upload request can have.
+    pub async fn get_max_media_upload_size(&self) -> Result<u64, ClientError> {
+        let max_upload_size = self.inner.load_or_fetch_max_upload_size().await?;
+        Ok(max_upload_size.into())
+    }
 }
 
 #[matrix_sdk_ffi_macros::export(callback_interface)]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
@@ -134,7 +134,7 @@ async fn test_send_attachment_from_file() {
     }
 
     // Eventually, the media is updated with the final MXC IDs…
-    sleep(Duration::from_secs(2)).await;
+    sleep(Duration::from_secs(4)).await;
 
     {
         assert_let_timeout!(
@@ -234,7 +234,7 @@ async fn test_send_attachment_from_bytes() {
     }
 
     // Eventually, the media is updated with the final MXC IDs…
-    sleep(Duration::from_secs(2)).await;
+    sleep(Duration::from_secs(4)).await;
 
     {
         assert_let_timeout!(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
@@ -62,6 +62,7 @@ async fn test_send_attachment_from_file() {
     let mock = MatrixMockServer::new().await;
     let client = mock.client_builder().build().await;
 
+    mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
 
     let room_id = room_id!("!a98sd12bjh:example.org");
@@ -168,6 +169,7 @@ async fn test_send_attachment_from_bytes() {
     let mock = MatrixMockServer::new().await;
     let client = mock.client_builder().build().await;
 
+    mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
 
     let room_id = room_id!("!a98sd12bjh:example.org");

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Added `SendMediaUploadRequest` wrapper for `SendRequest`, which checks the size of the request to
+  upload making sure it doesn't exceed the `m.upload.size` value that can be fetched through
+  `Client::load_or_fetch_max_upload_size`.
 - Add `ClientBuilder::with_enable_share_history_on_invite` to enable experimental support for sharing encrypted room history on invite, per [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268).
   ([#5141](https://github.com/matrix-org/matrix-rust-sdk/pull/5141))
 - `Room::list_threads()` is a new method to list all the threads in a room.

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -48,6 +48,20 @@ pub struct SendRequest<R> {
 }
 
 impl<R> SendRequest<R> {
+    /// Replace the default `SharedObservable` used for tracking upload
+    /// progress.
+    ///
+    /// Note that any subscribers obtained from
+    /// [`subscribe_to_send_progress`][Self::subscribe_to_send_progress]
+    /// will be invalidated by this.
+    pub fn with_send_progress_observable(
+        mut self,
+        send_progress: SharedObservable<TransmissionProgress>,
+    ) -> Self {
+        self.send_progress = send_progress;
+        self
+    }
+
     /// Use the given [`RequestConfig`] for this send request, instead of the
     /// one provided by default.
     pub fn with_request_config(mut self, request_config: impl Into<Option<RequestConfig>>) -> Self {
@@ -165,7 +179,7 @@ impl SendMediaUploadRequest {
         mut self,
         send_progress: SharedObservable<TransmissionProgress>,
     ) -> Self {
-        self.send_request.send_progress = send_progress;
+        self.send_request = self.send_request.with_send_progress_observable(send_progress);
         self
     }
 

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -19,9 +19,14 @@ use std::{fmt::Debug, future::IntoFuture};
 use eyeball::SharedObservable;
 #[cfg(not(target_family = "wasm"))]
 use eyeball::Subscriber;
+use js_int::UInt;
 use matrix_sdk_common::boxed_into_future;
 use oauth2::{basic::BasicErrorResponseType, RequestTokenError};
-use ruma::api::{client::error::ErrorKind, error::FromHttpResponseError, OutgoingRequest};
+use ruma::api::{
+    client::{error::ErrorKind, media},
+    error::FromHttpResponseError,
+    OutgoingRequest,
+};
 use tracing::{error, trace};
 
 use super::super::Client;
@@ -29,7 +34,8 @@ use crate::{
     authentication::oauth::OAuthError,
     config::RequestConfig,
     error::{HttpError, HttpResult},
-    RefreshTokenError, TransmissionProgress,
+    media::MediaError,
+    Error, RefreshTokenError, TransmissionProgress,
 };
 
 /// `IntoFuture` returned by [`Client::send`].
@@ -42,20 +48,6 @@ pub struct SendRequest<R> {
 }
 
 impl<R> SendRequest<R> {
-    /// Replace the default `SharedObservable` used for tracking upload
-    /// progress.
-    ///
-    /// Note that any subscribers obtained from
-    /// [`subscribe_to_send_progress`][Self::subscribe_to_send_progress]
-    /// will be invalidated by this.
-    pub fn with_send_progress_observable(
-        mut self,
-        send_progress: SharedObservable<TransmissionProgress>,
-    ) -> Self {
-        self.send_progress = send_progress;
-        self
-    }
-
     /// Use the given [`RequestConfig`] for this send request, instead of the
     /// one provided by default.
     pub fn with_request_config(mut self, request_config: impl Into<Option<RequestConfig>>) -> Self {
@@ -146,6 +138,65 @@ where
             }
 
             res
+        })
+    }
+}
+
+/// `IntoFuture` used to send media upload requests. It wraps another
+/// [`SendRequest`], checking its size will be accepted by the homeserver before
+/// uploading.
+#[allow(missing_debug_implementations)]
+pub struct SendMediaUploadRequest {
+    send_request: SendRequest<media::create_content::v3::Request>,
+}
+
+impl SendMediaUploadRequest {
+    pub fn new(request: SendRequest<media::create_content::v3::Request>) -> Self {
+        Self { send_request: request }
+    }
+
+    /// Replace the default `SharedObservable` used for tracking upload
+    /// progress.
+    ///
+    /// Note that any subscribers obtained from
+    /// [`subscribe_to_send_progress`][Self::subscribe_to_send_progress]
+    /// will be invalidated by this.
+    pub fn with_send_progress_observable(
+        mut self,
+        send_progress: SharedObservable<TransmissionProgress>,
+    ) -> Self {
+        self.send_request.send_progress = send_progress;
+        self
+    }
+
+    /// Get a subscriber to observe the progress of sending the request
+    /// body.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn subscribe_to_send_progress(&self) -> Subscriber<TransmissionProgress> {
+        self.send_request.send_progress.subscribe()
+    }
+}
+
+impl IntoFuture for SendMediaUploadRequest {
+    type Output = Result<media::create_content::v3::Response, Error>;
+    boxed_into_future!();
+
+    fn into_future(self) -> Self::IntoFuture {
+        let request_length = self.send_request.request.file.len();
+        let client = self.send_request.client.clone();
+        let send_request = self.send_request;
+
+        Box::pin(async move {
+            let max_upload_size = client.load_or_fetch_max_upload_size().await?;
+            let request_length = UInt::new_wrapping(request_length as u64);
+            if request_length > max_upload_size {
+                return Err(Error::Media(MediaError::MediaTooLargeToUpload {
+                    max: max_upload_size,
+                    current: request_length,
+                }));
+            }
+
+            send_request.into_future().await.map_err(Into::into)
         })
     }
 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -89,6 +89,7 @@ use crate::{
         EventHandlerStore, ObservableEventHandler, SyncEvent,
     },
     http_client::HttpClient,
+    media::MediaError,
     notification_settings::NotificationSettings,
     room_preview::RoomPreview,
     send_queue::SendQueueData,
@@ -336,6 +337,10 @@ pub(crate) struct ClientInner {
     ///
     /// [`SendQueue`]: crate::send_queue::SendQueue
     pub(crate) send_queue_data: Arc<SendQueueData>,
+
+    /// The `max_upload_size` value of the homeserver, it contains the max
+    /// request size you can send.
+    pub(crate) server_max_upload_size: Mutex<OnceCell<UInt>>,
 }
 
 impl ClientInner {
@@ -392,6 +397,7 @@ impl ClientInner {
             verification_state: SharedObservable::new(VerificationState::Unknown),
             #[cfg(feature = "e2e-encryption")]
             enable_share_history_on_invite,
+            server_max_upload_size: Mutex::new(OnceCell::new()),
         };
 
         #[allow(clippy::let_and_return)]
@@ -2558,6 +2564,27 @@ impl Client {
     pub async fn is_user_ignored(&self, user_id: &UserId) -> bool {
         self.base_client().is_user_ignored(user_id).await
     }
+
+    /// Gets the `max_upload_size` value from the homeserver, getting either a
+    /// cached value or with a `/_matrix/client/v1/media/config` request if it's
+    /// missing.
+    pub async fn load_or_fetch_max_upload_size(&self) -> Result<UInt> {
+        let max_upload_size_lock = self.inner.server_max_upload_size.lock().await;
+        if let Some(data) = max_upload_size_lock.get() {
+            return Ok(data.to_owned());
+        }
+
+        let response = self
+            .send(ruma::api::client::authenticated_media::get_media_config::v1::Request::default())
+            .await?;
+
+        match max_upload_size_lock.set(response.upload_size) {
+            Ok(_) => Ok(response.upload_size),
+            Err(error) => {
+                Err(Error::Media(MediaError::FetchMaxUploadSizeFailed(error.to_string())))
+            }
+        }
+    }
 }
 
 /// A weak reference to the inner client, useful when trying to get a handle
@@ -2606,7 +2633,10 @@ pub(crate) mod tests {
     use std::{sync::Arc, time::Duration};
 
     use assert_matches::assert_matches;
+    use assert_matches2::assert_let;
+    use eyeball::SharedObservable;
     use futures_util::{pin_mut, FutureExt};
+    use js_int::{uint, UInt};
     use matrix_sdk_base::{
         store::{MemoryStore, StoreConfig},
         RoomState,
@@ -2641,13 +2671,15 @@ pub(crate) mod tests {
 
     use super::Client;
     use crate::{
-        client::WeakClient,
+        client::{futures::SendMediaUploadRequest, WeakClient},
         config::{RequestConfig, SyncSettings},
+        futures::SendRequest,
+        media::MediaError,
         test_utils::{
             logged_in_client, mocks::MatrixMockServer, no_retry_test_client, set_client_session,
             test_client_builder, test_client_builder_with_server,
         },
-        Error,
+        Error, TransmissionProgress,
     };
 
     #[async_test]
@@ -3462,5 +3494,44 @@ pub(crate) mod tests {
         let (initial_value, _) = client.account().observe_media_preview_config().await.unwrap();
 
         assert!(initial_value.is_none());
+    }
+
+    #[async_test]
+    async fn test_load_or_fetch_max_upload_size() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        assert!(!client.inner.server_max_upload_size.lock().await.initialized());
+
+        server.mock_authenticated_media_config().ok(uint!(2)).mock_once().mount().await;
+        client.load_or_fetch_max_upload_size().await.unwrap();
+
+        assert_eq!(*client.inner.server_max_upload_size.lock().await.get().unwrap(), uint!(2));
+    }
+
+    #[async_test]
+    async fn test_uploading_a_too_large_media_file() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        server.mock_authenticated_media_config().ok(uint!(1)).mock_once().mount().await;
+        client.load_or_fetch_max_upload_size().await.unwrap();
+        assert_eq!(*client.inner.server_max_upload_size.lock().await.get().unwrap(), uint!(1));
+
+        let data = vec![1, 2];
+        let upload_request =
+            ruma::api::client::media::create_content::v3::Request::new(data.clone());
+        let request = SendRequest {
+            client: client.clone(),
+            request: upload_request,
+            config: None,
+            send_progress: SharedObservable::new(TransmissionProgress::default()),
+        };
+        let media_request = SendMediaUploadRequest::new(request);
+
+        let error = media_request.await.err();
+        assert_let!(Some(Error::Media(MediaError::MediaTooLargeToUpload { max, current })) = error);
+        assert_eq!(max, uint!(1));
+        assert_eq!(current, UInt::new_wrapping(data.len() as u64));
     }
 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2568,6 +2568,9 @@ impl Client {
     /// Gets the `max_upload_size` value from the homeserver, getting either a
     /// cached value or with a `/_matrix/client/v1/media/config` request if it's
     /// missing.
+    ///
+    /// Check the spec for more info:
+    /// <https://spec.matrix.org/v1.14/client-server-api/#get_matrixclientv1mediaconfig>
     pub async fn load_or_fetch_max_upload_size(&self) -> Result<UInt> {
         let max_upload_size_lock = self.inner.server_max_upload_size.lock().await;
         if let Some(data) = max_upload_size_lock.get() {

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -3024,4 +3024,11 @@ impl<'a> MockEndpoint<'a, AuthenticatedMediaConfigEndpoint> {
             "m.upload.size": max_upload_size,
         })))
     }
+
+    /// Returns a successful response with a maxed out max upload size.
+    pub fn ok_default(self) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "m.upload.size": UInt::MAX,
+        })))
+    }
 }

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -22,6 +22,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use js_int::UInt;
 use matrix_sdk_base::deserialized_responses::TimelineEvent;
 use matrix_sdk_test::{
     test_json, InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, LeftRoomBuilder,
@@ -1142,6 +1143,15 @@ impl MatrixMockServer {
             "^/_matrix/client/v3/user/.*/rooms/.*/account_data/{data_type}"
         )));
         self.mock_endpoint(mock, RoomAccountDataEndpoint).expect_default_access_token()
+    }
+
+    /// Create a prebuilt mock for the endpoint used to get the media config of
+    /// the homeserver.
+    pub fn mock_authenticated_media_config(
+        &self,
+    ) -> MockEndpoint<'_, AuthenticatedMediaConfigEndpoint> {
+        let mock = Mock::given(method("GET")).and(path("/_matrix/client/v1/media/config"));
+        self.mock_endpoint(mock, AuthenticatedMediaConfigEndpoint).expect_default_access_token()
     }
 }
 
@@ -3001,5 +3011,17 @@ impl<'a> MockEndpoint<'a, RoomAccountDataEndpoint> {
     /// Returns a successful empty response.
     pub fn ok(self) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+    }
+}
+
+/// A prebuilt mock for `GET /_matrix/client/v1/media/config` request.
+pub struct AuthenticatedMediaConfigEndpoint;
+
+impl<'a> MockEndpoint<'a, AuthenticatedMediaConfigEndpoint> {
+    /// Returns a successful response with the provided max upload size.
+    pub fn ok(self, max_upload_size: UInt) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "m.upload.size": max_upload_size,
+        })))
     }
 }

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -21,6 +21,8 @@ use serde_json::json;
 async fn test_room_attachment_send() {
     let mock = MatrixMockServer::new().await;
 
+    mock.mock_authenticated_media_config().ok_default().mount().await;
+
     let expected_event_id = event_id!("$h29iv0s8:example.com");
 
     mock.mock_room_send()
@@ -63,6 +65,8 @@ async fn test_room_attachment_send() {
 async fn test_room_attachment_send_in_encrypted_room_has_binary_mime_type() {
     let mock = MatrixMockServer::new().await;
 
+    mock.mock_authenticated_media_config().ok_default().mount().await;
+
     let expected_event_id = event_id!("$h29iv0s8:example.com");
 
     mock.mock_room_send().ok(expected_event_id).mock_once().mount().await;
@@ -97,6 +101,8 @@ async fn test_room_attachment_send_in_encrypted_room_has_binary_mime_type() {
 #[async_test]
 async fn test_room_attachment_send_info() {
     let mock = MatrixMockServer::new().await;
+
+    mock.mock_authenticated_media_config().ok_default().mount().await;
 
     let expected_event_id = event_id!("$h29iv0s8:example.com");
     mock.mock_room_send()
@@ -142,6 +148,8 @@ async fn test_room_attachment_send_info() {
 #[async_test]
 async fn test_room_attachment_send_wrong_info() {
     let mock = MatrixMockServer::new().await;
+
+    mock.mock_authenticated_media_config().ok_default().mount().await;
 
     // Note: this mock is NOT called because the height and width are lost, because
     // we're trying to send the attachment as an image, while we provide a
@@ -194,6 +202,8 @@ async fn test_room_attachment_send_wrong_info() {
 #[async_test]
 async fn test_room_attachment_send_info_thumbnail() {
     let mock = MatrixMockServer::new().await;
+
+    mock.mock_authenticated_media_config().ok_default().mount().await;
 
     let media_mxc = owned_mxc_uri!("mxc://example.com/media");
     let thumbnail_mxc = owned_mxc_uri!("mxc://example.com/thumbnail");
@@ -299,6 +309,8 @@ async fn test_room_attachment_send_info_thumbnail() {
 async fn test_room_attachment_send_mentions() {
     let mock = MatrixMockServer::new().await;
 
+    mock.mock_authenticated_media_config().ok_default().mount().await;
+
     let expected_event_id = event_id!("$h29iv0s8:example.com");
 
     mock.mock_room_send()
@@ -343,6 +355,8 @@ async fn test_room_attachment_reply_outside_thread() {
 
     let expected_event_id = event_id!("$h29iv0s8:example.com");
     let replied_to_event_id = event_id!("$foo:bar.com");
+
+    mock.mock_authenticated_media_config().ok_default().mount().await;
 
     mock.mock_room_send()
         .body_matches_partial_json(json!({
@@ -404,6 +418,8 @@ async fn test_room_attachment_start_thread() {
 
     let expected_event_id = event_id!("$h29iv0s8:example.com");
     let replied_to_event_id = event_id!("$foo:bar.com");
+
+    mock.mock_authenticated_media_config().ok_default().mount().await;
 
     mock.mock_room_send()
         .body_matches_partial_json(json!({
@@ -470,6 +486,8 @@ async fn test_room_attachment_reply_on_thread_as_reply() {
     let thread_root_event_id = event_id!("$bar:foo.com");
     let replied_to_event_id = event_id!("$foo:bar.com");
 
+    mock.mock_authenticated_media_config().ok_default().mount().await;
+
     mock.mock_room_send()
         .body_matches_partial_json(json!({
             "m.relates_to": {
@@ -530,6 +548,8 @@ async fn test_room_attachment_reply_on_thread_as_reply() {
 #[async_test]
 async fn test_room_attachment_reply_forwarding_thread() {
     let mock = MatrixMockServer::new().await;
+
+    mock.mock_authenticated_media_config().ok_default().mount().await;
 
     let expected_event_id = event_id!("$h29iv0s8:example.com");
     let thread_root_event_id = event_id!("$bar:foo.com");
@@ -596,6 +616,8 @@ async fn test_room_attachment_reply_forwarding_thread() {
 #[async_test]
 async fn test_room_attachment_send_is_animated() {
     let mock = MatrixMockServer::new().await;
+
+    mock.mock_authenticated_media_config().ok_default().mount().await;
 
     let expected_event_id = event_id!("$h29iv0s8:example.com");
     mock.mock_room_send()

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1838,6 +1838,7 @@ async fn test_media_uploads() {
 
     // ----------------------
     // Prepare endpoints.
+    mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
     mock.mock_room_send().ok(event_id!("$1")).mock_once().mount().await;
 
@@ -2507,6 +2508,7 @@ async fn test_media_upload_retry() {
     assert!(local_echoes.is_empty());
 
     // Prepare endpoints.
+    mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
 
     // Fail for the first three attempts.
@@ -2583,6 +2585,8 @@ async fn test_media_upload_retry_with_520_http_status_code() {
     // Prepare endpoints.
     mock.mock_room_state_encryption().plain().mount().await;
 
+    mock.mock_authenticated_media_config().ok_default().mount().await;
+
     // Fail with a 520 http status code
     mock.mock_upload()
         .expect_mime_type("image/jpeg")
@@ -2622,6 +2626,7 @@ async fn test_unwedging_media_upload() {
     assert!(local_echoes.is_empty());
 
     // Prepare endpoints.
+    mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
 
     // Fail for the first attempt with an error indicating the media's too large,
@@ -2729,6 +2734,7 @@ async fn test_media_event_is_sent_in_order() {
     assert!(local_echoes.is_empty());
 
     // Prepare endpoints.
+    mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
     mock.mock_upload().ok(mxc_uri!("mxc://sdk.rs/media")).mock_once().mount().await;
 
@@ -2859,6 +2865,7 @@ async fn test_cancel_upload_with_thumbnail_active() {
     assert!(local_echoes.is_empty());
 
     // Prepare endpoints.
+    mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
     mock.mock_room_send().ok(event_id!("$msg")).mock_once().mount().await;
 
@@ -2910,6 +2917,7 @@ async fn test_cancel_upload_with_uploaded_thumbnail_and_file_active() {
     assert!(local_echoes.is_empty());
 
     // Prepare endpoints.
+    mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
     mock.mock_room_send().ok(event_id!("$msg")).mock_once().named("send event").mount().await;
 
@@ -2973,6 +2981,7 @@ async fn test_cancel_upload_only_file_with_file_active() {
     assert!(local_echoes.is_empty());
 
     // Prepare endpoints.
+    mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
     mock.mock_room_send().ok(event_id!("$msg")).mock_once().named("send event").mount().await;
 
@@ -3038,6 +3047,7 @@ async fn test_cancel_upload_while_sending_event() {
     assert!(local_echoes.is_empty());
 
     // Prepare endpoints.
+    mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
 
     // File upload will succeed immediately.
@@ -3141,6 +3151,7 @@ async fn test_update_caption_while_sending_media() {
     assert!(local_echoes.is_empty());
 
     // Prepare endpoints.
+    mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
 
     // File upload will take a second.
@@ -3213,6 +3224,8 @@ async fn test_update_caption_while_sending_media() {
 #[async_test]
 async fn test_update_caption_before_event_is_sent() {
     let mock = MatrixMockServer::new().await;
+
+    mock.mock_authenticated_media_config().ok_default().mount().await;
 
     // Mark the room as joined.
     let room_id = room_id!("!a:b.c");
@@ -3327,6 +3340,7 @@ async fn test_add_mention_to_caption_before_media_sent() {
     assert!(local_echoes.is_empty());
 
     // Prepare endpoints.
+    mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
 
     // File upload will take a second.
@@ -3426,6 +3440,7 @@ async fn test_update_caption_while_sending_media_event() {
     assert!(local_echoes.is_empty());
 
     // Prepare endpoints.
+    mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
 
     // File upload will resolve immediately.


### PR DESCRIPTION
## Changes:

- Add `ClientInner::server_max_upload_size` field to hold the max upload size coming from the media config endpoint response.
- Add `Client::load_or_fetch_max_upload_size()` fn that will either load the value from the cached `OnceCell` or fetch it from the homeserver using the media config endpoint, then set it in the cell. This means the value is only valid for the current Client and will have to be re-fetched when the client is restarted.
- Create `SendMediaUploadRequest` wrapper for media upload requests, which will check the size of the file to upload and cancel the upload with an error if the file is larger than the allowed size.
- Expose `ffi::Client::get_max_upload_size()` fn to get this value so we can use it when compressing media in the platform side to check if further compression is needed before trying to upload anything.

Also fixed a few tests related to media upload since they now need to mock the media config endpoint to work.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
