### PR TITLE
refactor: When mapping FFI event contents, log unsupported event types

### DIFF
--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -244,7 +244,7 @@ impl TryFrom<AnySyncMessageLikeEvent> for MessageLikeEventContent {
                 MessageLikeEventContent::RoomRedaction { redacted_event_id, reason }
             }
             AnySyncMessageLikeEvent::Sticker(_) => MessageLikeEventContent::Sticker,
-            _ => bail!("Unsupported Event Type"),
+            _ => bail!("Unsupported Event Type: {:?}", value.event_type()),
         };
         Ok(content)
     }

--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -135,7 +135,7 @@ impl TryFrom<AnySyncStateEvent> for StateEventContent {
             }
             AnySyncStateEvent::SpaceChild(_) => StateEventContent::SpaceChild,
             AnySyncStateEvent::SpaceParent(_) => StateEventContent::SpaceParent,
-            _ => bail!("Unsupported state event"),
+            _ => bail!("Unsupported state event: {:?}", value.event_type()),
         };
         Ok(event)
     }


### PR DESCRIPTION
At the moment, the error just says `Unsupported Event Type`, which is not that helpful.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
