### PR TITLE
feat(timeline): Expose method to send galleries in matrix-sdk-ui

### DIFF
--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -22,6 +22,9 @@ uniffi = ["dep:uniffi", "matrix-sdk/uniffi", "matrix-sdk-base/uniffi"]
 # Add support for encrypted extensible events.
 unstable-msc3956 = ["ruma/unstable-msc3956"]
 
+# Add support for inline media galleries via msgtypes
+unstable-msc4274 = ["matrix-sdk/unstable-msc4274"]
+
 [dependencies]
 as_variant.workspace = true
 async-rx.workspace = true

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -237,6 +237,7 @@ pub fn default_event_filter(event: &AnySyncTimelineEvent, room_version: &RoomVer
                                 MessageType::Audio(_)
                                     | MessageType::Emote(_)
                                     | MessageType::File(_)
+                                    | MessageType::Gallery(_)
                                     | MessageType::Image(_)
                                     | MessageType::Location(_)
                                     | MessageType::Notice(_)

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -369,6 +369,7 @@ impl EventTimelineItem {
                             | MessageType::Emote(_)
                             | MessageType::Audio(_)
                             | MessageType::File(_)
+                            | MessageType::Gallery(_)
                             | MessageType::Image(_)
                             | MessageType::Video(_)
                     )

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -21,8 +21,12 @@ use std::{fs, path::PathBuf, sync::Arc};
 use algorithms::rfind_event_by_item_id;
 use event_item::TimelineItemHandle;
 use eyeball_im::VectorDiff;
+#[cfg(feature = "unstable-msc4274")]
+use futures::SendGallery;
 use futures_core::Stream;
 use imbl::Vector;
+#[cfg(feature = "unstable-msc4274")]
+use matrix_sdk::attachment::GalleryConfig;
 use matrix_sdk::{
     attachment::AttachmentConfig,
     deserialized_responses::TimelineEvent,
@@ -414,6 +418,28 @@ impl Timeline {
         config: AttachmentConfig,
     ) -> SendAttachment<'_> {
         SendAttachment::new(self, source.into(), mime_type, config)
+    }
+
+    /// Sends a media gallery to the room.
+    ///
+    /// If the encryption feature is enabled, this method will transparently
+    /// encrypt the room message if the room is encrypted.
+    ///
+    /// The attachments and their optional thumbnails are stored in the media
+    /// cache and can be retrieved at any time, by calling
+    /// [`Media::get_media_content()`] with the `MediaSource` that can be found
+    /// in the corresponding `TimelineEventItem`, and using a
+    /// `MediaFormat::File`.
+    ///
+    /// # Arguments
+    /// * `gallery` - A configuration object containing details about the
+    ///   gallery like files, thumbnails, etc.
+    ///
+    /// [`Media::get_media_content()`]: matrix_sdk::Media::get_media_content
+    #[cfg(feature = "unstable-msc4274")]
+    #[instrument(skip_all)]
+    pub fn send_gallery(&self, gallery: GalleryConfig) -> SendGallery<'_> {
+        SendGallery::new(self, gallery)
     }
 
     /// Redact an event given its [`TimelineEventItemId`] and an optional


### PR DESCRIPTION
This was broken out of https://github.com/matrix-org/matrix-rust-sdk/pull/4838 and is a step towards implementing https://github.com/matrix-org/matrix-spec-proposals/pull/4274. Building upon https://github.com/matrix-org/matrix-rust-sdk/pull/4977, a new method `Timeline::send_gallery` in matrix-sdk-ui for sending galleries.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
