### PR TITLE
feat(threads): add a `ThreadSummary` to `TimelineEvent` and maintain it over time

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use assert_matches::assert_matches;
 use matrix_sdk_common::{
     deserialized_responses::{
-        AlgorithmInfo, DecryptedRoomEvent, EncryptionInfo, TimelineEvent, TimelineEventKind,
-        VerificationState,
+        AlgorithmInfo, DecryptedRoomEvent, EncryptionInfo, ThreadSummaryStatus, TimelineEvent,
+        TimelineEventKind, VerificationState,
     },
     linked_chunk::{lazy_loader, ChunkContent, ChunkIdentifier as CId, Position, Update},
 };
@@ -81,6 +81,7 @@ pub fn make_test_event_with_event_id(
             unsigned_encryption_info: None,
         }),
         push_actions: Some(vec![Action::Notify]),
+        thread_summary: ThreadSummaryStatus::Unknown,
     }
 }
 

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -654,8 +654,9 @@ mod tests {
                                     "event_id": "$1"
                                 }
                             }
-                        }
-                    },
+                        },
+                        "thread_summary": "None",
+                    }
                 }
             })
         );

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1241,6 +1241,7 @@ mod tests {
             "latest_event": {
                 "event": {
                     "kind": {"PlainText": {"event": {"sender": "@u:i.uk"}}},
+                    "thread_summary": "None"
                 },
             },
             "base_info": {

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -392,6 +392,15 @@ impl ThreadSummaryStatus {
     fn is_unknown(&self) -> bool {
         matches!(self, ThreadSummaryStatus::Unknown)
     }
+
+    /// Transforms the [`ThreadSummaryStatus`] into an optional thread summary,
+    /// for cases where we don't care about distinguishing unknown and none.
+    pub fn summary(&self) -> Option<&ThreadSummary> {
+        match self {
+            ThreadSummaryStatus::Unknown | ThreadSummaryStatus::None => None,
+            ThreadSummaryStatus::Some(thread_summary) => Some(thread_summary),
+        }
+    }
 }
 
 /// Represents a Matrix room event that has been returned from `/sync`,

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -1052,6 +1052,7 @@ mod tests {
         UnableToDecryptReason, UnsignedDecryptionResult, UnsignedEventLocation, VerificationLevel,
         VerificationState, WithheldCode,
     };
+    use crate::deserialized_responses::{ThreadSummary, ThreadSummaryStatus};
 
     fn example_event() -> serde_json::Value {
         json!({

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -466,7 +466,7 @@ impl TimelineEvent {
         self.kind.encryption_info()
     }
 
-    /// Takes ownership of this `TimelineEvent`, returning the (potentially
+    /// Takes ownership of this [`TimelineEvent`], returning the (potentially
     /// decrypted) Matrix event within.
     pub fn into_raw(self) -> Raw<AnySyncTimelineEvent> {
         self.kind.into_raw()

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -386,9 +386,15 @@ pub struct TimelineEvent {
 
     /// The push actions associated with this event.
     ///
-    /// If it's set to `None`, then it means we couldn't compute those actions.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// If it's set to `None`, then it means we couldn't compute those actions,
+    /// or that they could be computed but there were none.
+    #[serde(skip_serializing_if = "skip_serialize_push_actions")]
     pub push_actions: Option<Vec<Action>>,
+}
+
+// Don't serialize push actions if they're `None` or an empty vec.
+fn skip_serialize_push_actions(push_actions: &Option<Vec<Action>>) -> bool {
+    push_actions.as_ref().is_none_or(|v| v.is_empty())
 }
 
 // See https://github.com/matrix-org/matrix-rust-sdk/pull/3749#issuecomment-2312939823.

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -417,18 +417,6 @@ impl TimelineEvent {
         Self { kind: TimelineEventKind::PlainText { event }, push_actions: None }
     }
 
-    /// Create a new [`TimelineEvent`] from the given raw event and push
-    /// actions.
-    ///
-    /// This is a convenience constructor for a plaintext event, for example
-    /// inside a test.
-    pub fn new_with_push_actions(
-        event: Raw<AnySyncTimelineEvent>,
-        push_actions: Vec<Action>,
-    ) -> Self {
-        Self { kind: TimelineEventKind::PlainText { event }, push_actions: Some(push_actions) }
-    }
-
     /// Create a new [`TimelineEvent`] to represent the given decryption
     /// failure.
     pub fn new_utd_event(event: Raw<AnySyncTimelineEvent>, utd_info: UnableToDecryptInfo) -> Self {

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -28,6 +28,7 @@ pub mod failures_cache;
 pub mod linked_chunk;
 pub mod locks;
 pub mod ring_buffer;
+pub mod serde_helpers;
 pub mod sleep;
 pub mod store_locks;
 pub mod timeout;

--- a/crates/matrix-sdk-common/src/serde_helpers.rs
+++ b/crates/matrix-sdk-common/src/serde_helpers.rs
@@ -1,0 +1,140 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A collection of serde helpers to avoid having to deserialize an entire event
+//! to access some fields.
+
+use ruma::{events::AnySyncTimelineEvent, serde::Raw, OwnedEventId};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+enum RelationsType {
+    #[serde(rename = "m.thread")]
+    Thread,
+}
+
+#[derive(Deserialize)]
+struct RelatesTo {
+    #[serde(rename = "rel_type")]
+    rel_type: RelationsType,
+    #[serde(rename = "event_id")]
+    event_id: Option<OwnedEventId>,
+}
+
+#[allow(missing_debug_implementations)]
+#[derive(Deserialize)]
+struct SimplifiedContent {
+    #[serde(rename = "m.relates_to")]
+    relates_to: Option<RelatesTo>,
+}
+
+/// Try to extract the thread root from a timeline event, if provided.
+///
+/// The thread root is the field located at `content`.`m.relates_to`.`event_id`,
+/// if the field at `content`.`m.relates_to`.`rel_type` is `m.thread`.
+///
+/// Returns `None` if we couldn't find a thread root, or if there was an issue
+/// during deserialization.
+pub fn extract_thread_root(event: &Raw<AnySyncTimelineEvent>) -> Option<OwnedEventId> {
+    let relates_to = event.get_field::<SimplifiedContent>("content").ok().flatten()?.relates_to?;
+    match relates_to.rel_type {
+        RelationsType::Thread => relates_to.event_id,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use ruma::{event_id, serde::Raw};
+    use serde_json::json;
+
+    use super::extract_thread_root;
+
+    #[test]
+    fn test_extract_thread_root() {
+        // No event factory in this crate :( There would be a dependency cycle with the
+        // `matrix-sdk-test` crate if we tried to use it here.
+
+        // We can extract the thread root from a regular message that contains one.
+        let thread_root = event_id!("$thread_root_event_id:example.com");
+        let event = Raw::new(&json!({
+            "event_id": "$eid:example.com",
+            "type": "m.room.message",
+            "sender": "@alice:example.com",
+            "origin_server_ts": 42,
+            "content": {
+                "body": "Hello, world!",
+                "m.relates_to": {
+                    "rel_type": "m.thread",
+                    "event_id": thread_root,
+                }
+            }
+        }))
+        .unwrap()
+        .cast();
+
+        let observed_thread_root = extract_thread_root(&event);
+        assert_eq!(observed_thread_root.as_deref(), Some(thread_root));
+
+        // If the event doesn't have a content for some reason (redacted), it returns
+        // None.
+        let event = Raw::new(&json!({
+            "event_id": "$eid:example.com",
+            "type": "m.room.message",
+            "sender": "@alice:example.com",
+            "origin_server_ts": 42,
+        }))
+        .unwrap()
+        .cast();
+
+        let observed_thread_root = extract_thread_root(&event);
+        assert_matches!(observed_thread_root, None);
+
+        // If the event has a content but with no `m.relates_to` field, it returns None.
+        let event = Raw::new(&json!({
+            "event_id": "$eid:example.com",
+            "type": "m.room.message",
+            "sender": "@alice:example.com",
+            "origin_server_ts": 42,
+            "content": {
+                "body": "Hello, world!",
+            }
+        }))
+        .unwrap()
+        .cast();
+
+        let observed_thread_root = extract_thread_root(&event);
+        assert_matches!(observed_thread_root, None);
+
+        // If the event has a relation, but it's not a thread reply, it returns None.
+        let event = Raw::new(&json!({
+            "event_id": "$eid:example.com",
+            "type": "m.room.message",
+            "sender": "@alice:example.com",
+            "origin_server_ts": 42,
+            "content": {
+                "body": "Hello, world!",
+                "m.relates_to": {
+                    "rel_type": "m.reference",
+                    "event_id": "$referenced_event_id:example.com",
+                }
+            }
+        }))
+        .unwrap()
+        .cast();
+
+        let observed_thread_root = extract_thread_root(&event);
+        assert_matches!(observed_thread_root, None);
+    }
+}

--- a/crates/matrix-sdk-common/src/snapshots/snapshot_test_sync_timeline_event.snap
+++ b/crates/matrix-sdk-common/src/snapshots/snapshot_test_sync_timeline_event.snap
@@ -44,5 +44,8 @@ expression: "serde_json::to_value(&room_event).unwrap()"
         }
       }
     }
+  },
+  "thread_summary": {
+    "Some": {}
   }
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -554,7 +554,8 @@ impl<'a> TimelineStateTransaction<'a> {
         settings: &TimelineSettings,
         date_divider_adjuster: &mut DateDividerAdjuster,
     ) -> RemovedItem {
-        let TimelineEvent { push_actions, kind } = event;
+        // TODO: do something with the thread summary!
+        let TimelineEvent { push_actions, kind, thread_summary: _thread_summary } = event;
 
         let encryption_info = kind.encryption_info().cloned();
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -37,7 +37,7 @@ use super::{
 };
 use crate::timeline::{
     event_handler::{FailedToParseEvent, RemovedItem, TimelineAction},
-    VirtualTimelineItem,
+    ThreadSummary, TimelineDetails, VirtualTimelineItem,
 };
 
 pub(in crate::timeline) struct TimelineStateTransaction<'a> {
@@ -203,6 +203,7 @@ impl<'a> TimelineStateTransaction<'a> {
             deserialized,
             event.raw(),
             room_data_provider,
+            None,
             None,
             None,
             &self.items,
@@ -555,7 +556,12 @@ impl<'a> TimelineStateTransaction<'a> {
         date_divider_adjuster: &mut DateDividerAdjuster,
     ) -> RemovedItem {
         // TODO: do something with the thread summary!
-        let TimelineEvent { push_actions, kind, thread_summary: _thread_summary } = event;
+        let TimelineEvent { push_actions, kind, thread_summary } = event;
+
+        let thread_summary = thread_summary.summary().map(|_common_summary| {
+            // TODO: later, fill the latest event in the thread summary!
+            ThreadSummary { latest_event: TimelineDetails::Unavailable }
+        });
 
         let encryption_info = kind.encryption_info().cloned();
 
@@ -584,6 +590,7 @@ impl<'a> TimelineStateTransaction<'a> {
                         event,
                         &raw,
                         room_data_provider,
+                        thread_summary,
                         utd_info,
                         bundled_edit_encryption_info,
                         &self.items,

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -192,6 +192,7 @@ impl TimelineAction {
     ///
     /// The return value may be `None` if handling the event (be it a new item
     /// or an aggregation) is not supported for this event type.
+    #[allow(clippy::too_many_arguments)]
     pub async fn from_event<P: RoomDataProvider>(
         event: AnySyncTimelineEvent,
         raw_event: &Raw<AnySyncTimelineEvent>,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -121,11 +121,15 @@ impl RepliedToEvent {
 
         debug!(event_type = %event.event_type(), "got deserialized event");
 
+        // We don't need to fill the thread information of an embedded reply.
+        let thread_summary = None;
+
         let sender = event.sender().to_owned();
         let action = TimelineAction::from_event(
             event,
             &raw_event,
             room_data_provider,
+            thread_summary,
             unable_to_decrypt_info,
             bundled_edit_encryption_info,
             timeline_items,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -693,7 +693,7 @@ impl<T> TimelineDetails<T> {
         }
     }
 
-    pub(crate) fn is_unavailable(&self) -> bool {
+    pub fn is_unavailable(&self) -> bool {
         matches!(self, Self::Unavailable)
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -804,7 +804,7 @@ mod tests {
                 member::RoomMemberEventContent,
                 message::{MessageFormat, MessageType},
             },
-            AnySyncStateEvent, BundledMessageLikeRelations,
+            AnySyncStateEvent,
         },
         room_id,
         serde::Raw,
@@ -918,23 +918,19 @@ mod tests {
 
         let original_event_id = event_id!("$original");
 
-        let mut relations = BundledMessageLikeRelations::new();
-        relations.replace = Some(Box::new(
-            f.text_html(" * Updated!", " * <b>Updated!</b>")
-                .edit(
-                    original_event_id,
-                    MessageType::text_html("Updated!", "<b>Updated!</b>").into(),
-                )
-                .event_id(event_id!("$edit"))
-                .sender(user_id)
-                .into_raw_sync(),
-        ));
-
         let event = f
             .text_html("**My M**", "<b>My M</b>")
             .sender(user_id)
             .event_id(original_event_id)
-            .bundled_relations(relations)
+            .with_bundled_edit(
+                f.text_html(" * Updated!", " * <b>Updated!</b>")
+                    .edit(
+                        original_event_id,
+                        MessageType::text_html("Updated!", "<b>Updated!</b>").into(),
+                    )
+                    .event_id(event_id!("$edit"))
+                    .sender(user_id),
+            )
             .server_ts(42)
             .into_event();
 
@@ -971,18 +967,6 @@ mod tests {
 
         let original_event_id = event_id!("$original");
 
-        let mut relations = BundledMessageLikeRelations::new();
-        relations.replace = Some(Box::new(
-            f.poll_edit(
-                original_event_id,
-                "It's one banana, Michael, how much could it cost?",
-                vec!["1 dollar", "10 dollars", "100 dollars"],
-            )
-            .event_id(event_id!("$edit"))
-            .sender(user_id)
-            .into_raw_sync(),
-        ));
-
         let event = f
             .poll_start(
                 "It's one avocado, Michael, how much could it cost? 10 dollars?",
@@ -990,7 +974,15 @@ mod tests {
                 vec!["1 dollar", "10 dollars", "100 dollars"],
             )
             .event_id(original_event_id)
-            .bundled_relations(relations)
+            .with_bundled_edit(
+                f.poll_edit(
+                    original_event_id,
+                    "It's one banana, Michael, how much could it cost?",
+                    vec!["1 dollar", "10 dollars", "100 dollars"],
+                )
+                .event_id(event_id!("$edit"))
+                .sender(user_id),
+            )
             .sender(user_id)
             .into_event();
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -23,10 +23,7 @@ use matrix_sdk_base::deserialized_responses::{DecryptedRoomEvent, TimelineEvent}
 use matrix_sdk_test::{async_test, ALICE, BOB};
 use ruma::{
     event_id,
-    events::{
-        room::message::{MessageType, RedactedRoomMessageEventContent},
-        BundledMessageLikeRelations,
-    },
+    events::room::message::{MessageType, RedactedRoomMessageEventContent},
     room_id,
 };
 use stream_assert::{assert_next_matches, assert_pending};
@@ -114,30 +111,26 @@ async fn test_aggregated_sanitized() {
 
     let f = &timeline.factory;
 
-    let mut relations = BundledMessageLikeRelations::new();
-    relations.replace = Some(Box::new(
-        f.text_html(
-            "* !!edited!! **better** message",
-            "* <edited/> <strong>better</strong> message",
-        )
-        .edit(
-            original_event_id,
-            MessageType::text_html(
-                "!!edited!! **better** message",
-                "<edited/> <strong>better</strong> message",
-            )
-            .into(),
-        )
-        .event_id(edit_event_id)
-        .sender(*ALICE)
-        .into_raw_sync(),
-    ));
-
     let ev = f
         .text_html("**original** message", "<strong>original</strong> message")
         .sender(*ALICE)
         .event_id(original_event_id)
-        .bundled_relations(relations);
+        .with_bundled_edit(
+            f.text_html(
+                "* !!edited!! **better** message",
+                "* <edited/> <strong>better</strong> message",
+            )
+            .edit(
+                original_event_id,
+                MessageType::text_html(
+                    "!!edited!! **better** message",
+                    "<edited/> <strong>better</strong> message",
+                )
+                .into(),
+            )
+            .event_id(edit_event_id)
+            .sender(*ALICE),
+        );
 
     timeline.handle_live_event(ev).await;
 
@@ -252,20 +245,12 @@ async fn test_relations_edit_overrides_pending_edit_msg() {
     assert_pending!(stream);
 
     // Now we receive the original event, with a bundled relations group.
-    let mut relations = BundledMessageLikeRelations::new();
-    relations.replace = Some(Box::new(
+    let ev = f.text_msg("original").sender(*ALICE).event_id(original_event_id).with_bundled_edit(
         f.text_msg("* edit 2")
             .edit(original_event_id, MessageType::text_plain("edit 2").into())
             .event_id(edit2_event_id)
-            .sender(*ALICE)
-            .into_raw_sync(),
-    ));
-
-    let ev = f
-        .text_msg("original")
-        .sender(*ALICE)
-        .event_id(original_event_id)
-        .bundled_relations(relations);
+            .sender(*ALICE),
+    );
 
     timeline.handle_live_event(ev).await;
 
@@ -318,18 +303,6 @@ async fn test_relations_edit_overrides_pending_edit_poll() {
     assert_pending!(stream);
 
     // Now we receive the original event, with a bundled relations group.
-    let mut relations = BundledMessageLikeRelations::new();
-    relations.replace = Some(Box::new(
-        f.poll_edit(
-            original_event_id,
-            "Can the real slim shady please stand up?",
-            vec!["Excuse me?", "Please stand up 🎵", "Please stand up 🎶"],
-        )
-        .sender(*ALICE)
-        .event_id(edit2_event_id)
-        .into(),
-    ));
-
     let ev = f
         .poll_start(
             "Can the fake slim shady please stand down?\nExcuse me?",
@@ -338,7 +311,15 @@ async fn test_relations_edit_overrides_pending_edit_poll() {
         )
         .sender(*ALICE)
         .event_id(original_event_id)
-        .bundled_relations(relations);
+        .with_bundled_edit(
+            f.poll_edit(
+                original_event_id,
+                "Can the real slim shady please stand up?",
+                vec!["Excuse me?", "Please stand up 🎵", "Please stand up 🎶"],
+            )
+            .sender(*ALICE)
+            .event_id(edit2_event_id),
+        );
 
     timeline.handle_live_event(ev).await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -19,8 +19,8 @@ use matrix_sdk::{
     assert_let_timeout,
     test_utils::mocks::{MatrixMockServer, RoomRelationsResponseTemplate},
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE};
-use matrix_sdk_ui::timeline::{RoomExt as _, TimelineBuilder, TimelineFocus};
+use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE, BOB};
+use matrix_sdk_ui::timeline::{RoomExt as _, TimelineBuilder, TimelineDetails, TimelineFocus};
 use ruma::{event_id, events::AnyTimelineEvent, owned_event_id, room_id, serde::Raw, user_id};
 use stream_assert::assert_pending;
 
@@ -196,7 +196,7 @@ async fn test_thread_backpagination() {
 }
 
 #[async_test]
-async fn test_thread_summary() {
+async fn test_extract_bundled_thread_summary() {
     // A sync event that includes a bundled thread summary receives a
     // `ThreadSummary` in the associated timeline content.
     let server = MatrixMockServer::new().await;
@@ -239,4 +239,88 @@ async fn test_thread_summary() {
 
     assert_let!(VectorDiff::PushFront { value } = &timeline_updates[1]);
     assert!(value.is_date_divider());
+}
+
+#[async_test]
+async fn test_new_thread_reply_causes_thread_summary() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!a:b.c");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    let timeline = room.timeline().await.unwrap();
+
+    let (initial_items, mut stream) = timeline.subscribe().await;
+    assert!(initial_items.is_empty());
+
+    // Start with a simple message, with no bundled thread info.
+    let f = EventFactory::new().room(room_id).sender(&ALICE);
+    let thread_event_id = event_id!("$thread_root");
+
+    let event = f.text_msg("thready thread mcthreadface").event_id(thread_event_id);
+
+    server.sync_room(&client, JoinedRoomBuilder::new(room_id).add_timeline_event(event)).await;
+
+    assert_let_timeout!(Some(timeline_updates) = stream.next());
+    // Message + day divider.
+    assert_eq!(timeline_updates.len(), 2);
+
+    // Sanity check the timeline diffs.
+    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);
+    let event_item = value.as_event().unwrap();
+    assert_eq!(event_item.event_id().unwrap(), thread_event_id);
+    assert!(event_item.content().thread_summary().is_none());
+
+    assert_let!(VectorDiff::PushFront { value } = &timeline_updates[1]);
+    assert!(value.is_date_divider());
+
+    // When I receive a threaded reply to this event,
+    let reply_event_id = event_id!("$thread_reply");
+    let event = f
+        .sender(&BOB)
+        .text_msg("thread reply")
+        .in_thread(thread_event_id, thread_event_id)
+        .event_id(reply_event_id);
+
+    server.sync_room(&client, JoinedRoomBuilder::new(room_id).add_timeline_event(event)).await;
+
+    // The timeline sees the reply.
+    //
+    // TODO: maybe we should include the thread summaries if and only if the live
+    // timeline is configured to exclude thread replies, aka, it requires
+    // thread-focused timelines to consult the thread replies.
+    assert_let_timeout!(Some(timeline_updates) = stream.next());
+    assert_eq!(timeline_updates.len(), 3);
+
+    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);
+    let event_item = value.as_event().unwrap();
+    assert_eq!(event_item.event_id().unwrap(), reply_event_id);
+    assert!(event_item.content().thread_summary().is_none());
+    assert_eq!(event_item.content().thread_root().as_deref(), Some(thread_event_id));
+    // First, the replied-to event (thread root) doesn't have any thread summary
+    // info.
+    let replied_to_details = value.as_event().unwrap().content().in_reply_to().unwrap().event;
+    assert_let!(TimelineDetails::Ready(replied_to_event) = replied_to_details);
+    assert!(replied_to_event.content().thread_summary().is_none());
+
+    // Since the replied-to item (the thread root) has been updated, all replies get
+    // updated too, including the item we just pushed.
+    assert_let!(VectorDiff::Set { index: 2, value } = &timeline_updates[1]);
+    let event_item = value.as_event().unwrap();
+    assert_eq!(event_item.event_id().unwrap(), reply_event_id);
+    let replied_to_details = value.as_event().unwrap().content().in_reply_to().unwrap().event;
+    assert_let!(TimelineDetails::Ready(replied_to_event) = replied_to_details);
+    // Spoiling a bit here…
+    assert!(replied_to_event.content().thread_summary().is_some());
+
+    // And finally, the thread root event receives a thread summary.
+    assert_let!(VectorDiff::Set { index: 1, value } = &timeline_updates[2]);
+    let event_item = value.as_event().unwrap();
+    assert_eq!(event_item.event_id().unwrap(), thread_event_id);
+    assert!(event_item.content().thread_root().is_none());
+
+    assert_let!(Some(summary) = event_item.content().thread_summary());
+    // Soon™, Stefan, soon™.
+    assert!(summary.latest_event.is_unavailable());
 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -21,13 +21,7 @@ use matrix_sdk::{
 };
 use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE};
 use matrix_sdk_ui::timeline::{RoomExt as _, TimelineBuilder, TimelineFocus};
-use ruma::{
-    event_id,
-    events::{relation::BundledThread, AnyTimelineEvent, BundledMessageLikeRelations},
-    owned_event_id, room_id,
-    serde::Raw,
-    uint, user_id,
-};
+use ruma::{event_id, events::AnyTimelineEvent, owned_event_id, room_id, serde::Raw, user_id};
 use stream_assert::assert_pending;
 
 #[async_test]
@@ -220,14 +214,13 @@ async fn test_thread_summary() {
     let thread_event_id = event_id!("$thread_root");
     let latest_event_id = event_id!("$latest_event");
 
-    let latest_thread_event = f.text_msg("the last one!").event_id(latest_event_id).into_raw();
-
-    let mut relations = BundledMessageLikeRelations::new();
-    relations.thread = Some(Box::new(BundledThread::new(latest_thread_event, uint!(42), false)));
-
     let event = f
         .text_msg("thready thread mcthreadface")
-        .bundled_relations(relations)
+        .with_bundled_thread_summary(
+            f.text_msg("the last one!").event_id(latest_event_id).into_raw(),
+            42,
+            false,
+        )
         .event_id(thread_event_id);
 
     server.sync_room(&client, JoinedRoomBuilder::new(room_id).add_timeline_event(event)).await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -15,10 +15,19 @@
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt as _;
-use matrix_sdk::test_utils::mocks::{MatrixMockServer, RoomRelationsResponseTemplate};
-use matrix_sdk_test::{async_test, event_factory::EventFactory};
-use matrix_sdk_ui::timeline::{TimelineBuilder, TimelineFocus};
-use ruma::{event_id, events::AnyTimelineEvent, owned_event_id, room_id, serde::Raw, user_id};
+use matrix_sdk::{
+    assert_let_timeout,
+    test_utils::mocks::{MatrixMockServer, RoomRelationsResponseTemplate},
+};
+use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE};
+use matrix_sdk_ui::timeline::{RoomExt as _, TimelineBuilder, TimelineFocus};
+use ruma::{
+    event_id,
+    events::{relation::BundledThread, AnyTimelineEvent, BundledMessageLikeRelations},
+    owned_event_id, room_id,
+    serde::Raw,
+    uint, user_id,
+};
 use stream_assert::assert_pending;
 
 #[async_test]
@@ -151,8 +160,6 @@ async fn test_thread_backpagination() {
     // events and the thread root
     assert_eq!(timeline_updates.len(), 5);
 
-    println!("Stefan: {timeline_updates:?}");
-
     // Check the timeline diffs
     assert_let!(VectorDiff::PushFront { value } = &timeline_updates[0]);
     assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$2"));
@@ -192,4 +199,51 @@ async fn test_thread_backpagination() {
         items[5].as_event().unwrap().content().as_message().unwrap().body(),
         "Threaded event 4"
     );
+}
+
+#[async_test]
+async fn test_thread_summary() {
+    // A sync event that includes a bundled thread summary receives a
+    // `ThreadSummary` in the associated timeline content.
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!a:b.c");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    let timeline = room.timeline().await.unwrap();
+
+    let (initial_items, mut stream) = timeline.subscribe().await;
+    assert!(initial_items.is_empty());
+
+    let f = EventFactory::new().room(room_id).sender(&ALICE);
+    let thread_event_id = event_id!("$thread_root");
+    let latest_event_id = event_id!("$latest_event");
+
+    let latest_thread_event = f.text_msg("the last one!").event_id(latest_event_id).into_raw();
+
+    let mut relations = BundledMessageLikeRelations::new();
+    relations.thread = Some(Box::new(BundledThread::new(latest_thread_event, uint!(42), false)));
+
+    let event = f
+        .text_msg("thready thread mcthreadface")
+        .bundled_relations(relations)
+        .event_id(thread_event_id);
+
+    server.sync_room(&client, JoinedRoomBuilder::new(room_id).add_timeline_event(event)).await;
+
+    assert_let_timeout!(Some(timeline_updates) = stream.next());
+    // Message + day divider.
+    assert_eq!(timeline_updates.len(), 2);
+
+    // Check the timeline diffs.
+    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);
+    let event_item = value.as_event().unwrap();
+    assert_eq!(event_item.event_id().unwrap(), thread_event_id);
+    assert_let!(Some(summary) = event_item.content().thread_summary());
+    // Soon™, Stefan, soon™.
+    assert!(summary.latest_event.is_unavailable());
+
+    assert_let!(VectorDiff::PushFront { value } = &timeline_updates[1]);
+    assert!(value.is_date_divider());
 }

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1611,7 +1611,6 @@ mod tests {
     #[async_test]
     async fn test_write_to_storage_strips_bundled_relations() {
         use matrix_sdk_base::linked_chunk::lazy_loader::from_all_chunks;
-        use ruma::events::BundledMessageLikeRelations;
 
         let room_id = room_id!("!galette:saucisse.bzh");
         let f = EventFactory::new().room(room_id).sender(user_id!("@ben:saucisse.bzh"));
@@ -1636,10 +1635,11 @@ mod tests {
         let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
 
         // Propagate an update for a message with bundled relations.
-        let mut relations = BundledMessageLikeRelations::new();
-        relations.replace =
-            Some(Box::new(f.text_msg("Hello, Kind Sir").sender(*ALICE).into_raw_sync()));
-        let ev = f.text_msg("hey yo").sender(*ALICE).bundled_relations(relations).into_event();
+        let ev = f
+            .text_msg("hey yo")
+            .sender(*ALICE)
+            .with_bundled_edit(f.text_msg("Hello, Kind Sir").sender(*ALICE))
+            .into_event();
 
         let timeline = Timeline { limited: false, prev_batch: None, events: vec![ev] };
 

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -37,7 +37,7 @@ use ruma::{
         },
         reaction::ReactionEventContent,
         receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
-        relation::{Annotation, InReplyTo, Replacement, Thread},
+        relation::{Annotation, BundledThread, InReplyTo, Replacement, Thread},
         room::{
             avatar::{self, RoomAvatarEventContent},
             canonical_alias::RoomCanonicalAliasEventContent,
@@ -57,9 +57,9 @@ use ruma::{
             topic::RoomTopicEventContent,
         },
         typing::TypingEventContent,
-        AnyStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent,
-        BundledMessageLikeRelations, EventContent, RedactedMessageLikeEventContent,
-        RedactedStateEventContent, StateEventContent,
+        AnyMessageLikeEvent, AnyStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,
+        AnyTimelineEvent, BundledMessageLikeRelations, EventContent,
+        RedactedMessageLikeEventContent, RedactedStateEventContent, StateEventContent,
     },
     serde::Raw,
     server_name, EventId, Int, MilliSecondsSinceUnixEpoch, MxcUri, OwnedEventId, OwnedMxcUri,
@@ -193,18 +193,35 @@ where
         self
     }
 
-    /// Adds bundled relations to this event.
-    ///
-    /// Ideally, we'd type-check that an event passed as a relation is the same
-    /// type as this one, but it's not trivial to do so because this builder
-    /// is only generic on the event's *content*, not the event type itself;
-    /// doing so would require many changes, and this is testing code after
-    /// all.
-    pub fn bundled_relations(
+    /// Create a bundled thread summary in the unsigned bundled relations of
+    /// this event.
+    pub fn with_bundled_thread_summary(
         mut self,
-        relations: BundledMessageLikeRelations<Raw<AnySyncTimelineEvent>>,
+        latest_event: Raw<AnyMessageLikeEvent>,
+        count: usize,
+        current_user_participated: bool,
     ) -> Self {
-        self.unsigned.get_or_insert_with(Default::default).relations = Some(relations);
+        let relations = self
+            .unsigned
+            .get_or_insert_with(Default::default)
+            .relations
+            .get_or_insert_with(BundledMessageLikeRelations::new);
+        relations.thread = Some(Box::new(BundledThread::new(
+            latest_event,
+            UInt::try_from(count).unwrap(),
+            current_user_participated,
+        )));
+        self
+    }
+
+    /// Create a bundled edit in the unsigned bundled relations of this event.
+    pub fn with_bundled_edit(mut self, replacement: impl Into<Raw<AnySyncTimelineEvent>>) -> Self {
+        let relations = self
+            .unsigned
+            .get_or_insert_with(Default::default)
+            .relations
+            .get_or_insert_with(BundledMessageLikeRelations::new);
+        relations.replace = Some(Box::new(replacement.into()));
         self
     }
 


### PR DESCRIPTION
This adds the following functionality:

- we add a new `ThreadSummary` data structure (empty at the moment; it will be filled later), and add it as a field of `TimelineEvent`
- when a thread root event contains a bundled thread summary, we translate it into a `ThreadSummary` on the carrying event.
- event cache: when an event is a threaded reply, we identify the thread root and attach a `ThreadSummary` to it
- we forward this new `ThreadSummary` into the timeline's `ThreadSummary`

This allows a main timeline to identify which events are thread roots, by querying whether they have a (timeline) `ThreadSummary` with `event_item.content().thread_summary().is_some()`. If that's the case, then it means the item can lead to the opening of a thread.

Subsequent PRs will introduce Interesting Fields™ in the common ThreadSummary. Note related to the persistent storage: as I haven't migrated any event stored on disk (to fill their thread summary if needs be), the thread summaries will be incorrect until we either perform such a migration, or clear the event cache.

Part of #5036.