### PR TITLE
refactor(ci): Don't rerun most CI jobs when un-drafting a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,11 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/detect-long-path.yml
+++ b/.github/workflows/detect-long-path.yml
@@ -7,11 +7,6 @@ on:
   workflow_dispatch:
   pull_request: # focus on the changed files in current PR
     branches: [main]
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -6,11 +6,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
 
 jobs:
   msrv:


### PR DESCRIPTION
This only makes sense to do for workflows that branch off of github.event.pull_request.draft, which only bindings_ci.yml does at this point in time.

Signed-off-by: Jonas Platte <jplatte+matrix@posteo.de>
