### PR TITLE
refactor: Use inline format arguments more

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -29,7 +29,7 @@ pub fn receive_all_members_benchmark(c: &mut Criterion) {
     let f = EventFactory::new().room(&room_id);
     let mut member_events: Vec<Raw<RoomMemberEvent>> = Vec::with_capacity(MEMBERS_IN_ROOM);
     for i in 0..MEMBERS_IN_ROOM {
-        let user_id = OwnedUserId::try_from(format!("@user_{}:matrix.org", i)).unwrap();
+        let user_id = OwnedUserId::try_from(format!("@user_{i}:matrix.org")).unwrap();
         let event = f
             .member(&user_id)
             .membership(MembershipState::Join)

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2338,7 +2338,7 @@ impl TryFrom<RumaJoinRule> for JoinRule {
             }
             RumaJoinRule::Invite => Ok(JoinRule::Invite),
             RumaJoinRule::_Custom(_) => Ok(JoinRule::Custom { repr: value.as_str().to_owned() }),
-            _ => Err(format!("Unknown JoinRule: {:?}", value)),
+            _ => Err(format!("Unknown JoinRule: {value:?}")),
         }
     }
 }
@@ -2355,7 +2355,7 @@ impl TryFrom<RumaAllowRule> for AllowRule {
                     .map_err(|e| format!("Couldn't serialize custom AllowRule: {e:?}"))?;
                 Ok(Self::Custom { json })
             }
-            _ => Err(format!("Invalid AllowRule: {:?}", value)),
+            _ => Err(format!("Invalid AllowRule: {value:?}")),
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -290,7 +290,7 @@ impl TryFrom<SdkTweak> for Tweak {
             SdkTweak::Highlight(highlight) => Self::Highlight { value: highlight },
             SdkTweak::Custom { name, value } => {
                 let json_string = serde_json::to_string(&value)
-                    .map_err(|e| format!("Failed to serialize custom tweak value: {}", e))?;
+                    .map_err(|e| format!("Failed to serialize custom tweak value: {e}"))?;
 
                 Self::Custom { name, value: json_string }
             }
@@ -308,9 +308,9 @@ impl TryFrom<Tweak> for SdkTweak {
             Tweak::Highlight { value } => Self::Highlight(value),
             Tweak::Custom { name, value } => {
                 let json_value: serde_json::Value = serde_json::from_str(&value)
-                    .map_err(|e| format!("Failed to deserialize custom tweak value: {}", e))?;
+                    .map_err(|e| format!("Failed to deserialize custom tweak value: {e}"))?;
                 let value = serde_json::from_value(json_value)
-                    .map_err(|e| format!("Failed to convert JSON value: {}", e))?;
+                    .map_err(|e| format!("Failed to convert JSON value: {e}"))?;
 
                 Self::Custom { name, value }
             }
@@ -334,7 +334,7 @@ impl TryFrom<SdkAction> for Action {
         Ok(match value {
             SdkAction::Notify => Self::Notify,
             SdkAction::SetTweak(tweak) => Self::SetTweak {
-                value: tweak.try_into().map_err(|e| format!("Failed to convert tweak: {}", e))?,
+                value: tweak.try_into().map_err(|e| format!("Failed to convert tweak: {e}"))?,
             },
             _ => return Err("Unsupported action type".to_owned()),
         })
@@ -348,7 +348,7 @@ impl TryFrom<Action> for SdkAction {
         Ok(match value {
             Action::Notify => Self::Notify,
             Action::SetTweak { value } => Self::SetTweak(
-                value.try_into().map_err(|e| format!("Failed to convert tweak: {}", e))?,
+                value.try_into().map_err(|e| format!("Failed to convert tweak: {e}"))?,
             ),
         })
     }

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -182,10 +182,10 @@ impl From<&RumaMatrixId> for MatrixId {
                         event_id: event_id.to_string(),
                     }
                 } else {
-                    panic!("Unexpected MatrixId type: {:?}", room_id_or_alias)
+                    panic!("Unexpected MatrixId type: {room_id_or_alias:?}")
                 }
             }
-            _ => panic!("Unexpected MatrixId type: {:?}", value),
+            _ => panic!("Unexpected MatrixId type: {value:?}"),
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -647,8 +647,7 @@ mod tests {
         let cap_assert = |capability: &str| {
             assert!(
                 permission_array.contains(&capability.to_owned()),
-                "The \"{}\" capability was missing from the element call capability list.",
-                capability
+                "The \"{capability}\" capability was missing from the element call capability list."
             );
         };
 

--- a/crates/matrix-sdk-base/src/room/display_name.rs
+++ b/crates/matrix-sdk-base/src/room/display_name.rs
@@ -472,7 +472,7 @@ fn compute_display_name_from_heroes(
     heroes.sort_unstable();
 
     let names = if num_heroes == 0 && num_joined_invited > 1 {
-        format!("{} people", num_joined_invited)
+        format!("{num_joined_invited} people")
     } else if num_heroes >= num_joined_invited_except_self {
         heroes.join(", ")
     } else if num_heroes < num_joined_invited_except_self && num_joined_invited > 1 {

--- a/crates/matrix-sdk-base/src/room/state.rs
+++ b/crates/matrix-sdk-base/src/room/state.rs
@@ -49,7 +49,7 @@ impl From<&MembershipState> for RoomState {
             MembershipState::Join => Self::Joined,
             MembershipState::Knock => Self::Knocked,
             MembershipState::Leave => Self::Left,
-            _ => panic!("Unexpected MembershipState: {}", membership_state),
+            _ => panic!("Unexpected MembershipState: {membership_state}"),
         }
     }
 }

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -1739,7 +1739,7 @@ mod tests {
             let olm_sessions =
                 database.get_sessions(id).await.expect("Should have some olm sessions");
 
-            println!("### Session id: {:?}", id);
+            println!("### Session id: {id:?}");
             assert_eq!(olm_sessions.map_or(0, |v| v.len()), count);
         }
 

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -1111,8 +1111,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                 };
 
                 let query = format!(
-                    "SELECT content FROM events WHERE relates_to = ? AND room_id = ? {}",
-                    filter_query
+                    "SELECT content FROM events WHERE relates_to = ? AND room_id = ? {filter_query}"
                 );
 
                 // Collect related events.

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -87,7 +87,7 @@ async fn test_live_sanitized() {
     let new_html_content = "<edited/> <strong>better</strong> message";
     timeline
         .handle_live_event(
-            f.text_html(format!("* {}", new_plain_content), format!("* {}", new_html_content))
+            f.text_html(format!("* {new_plain_content}"), format!("* {new_html_content}"))
                 .sender(&ALICE)
                 .edit(
                     first_event_id,

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -688,7 +688,7 @@ impl PinnedEventsSync {
             .into_iter()
             .map(|id| match EventId::parse(id) {
                 Ok(id) => id,
-                Err(_) => panic!("Invalid event id: {}", id),
+                Err(_) => panic!("Invalid event id: {id}"),
             })
             .collect();
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -151,7 +151,7 @@ async fn test_thread_backpagination() {
     // events and the thread root
     assert_eq!(timeline_updates.len(), 5);
 
-    println!("Stefan: {:?}", timeline_updates);
+    println!("Stefan: {timeline_updates:?}");
 
     // Check the timeline diffs
     assert_let!(VectorDiff::PushFront { value } = &timeline_updates[0]);

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -17,7 +17,7 @@ use crate::{sliding_sync::SlidingSyncListCachePolicy, Client, Result};
 /// Be careful: as this is used as a storage key; changing it requires migrating
 /// data!
 pub(super) fn format_storage_key_prefix(id: &str, user_id: &UserId) -> String {
-    format!("sliding_sync_store::{}::{}", id, user_id)
+    format!("sliding_sync_store::{id}::{user_id}")
 }
 
 /// Be careful: as this is used as a storage key; changing it requires migrating

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -2862,20 +2862,17 @@ impl<'a> MockEndpoint<'a, RoomRelationsEndpoint> {
         match self.endpoint.spec.take() {
             Some(IncludeRelations::RelationsOfType(rel_type)) => {
                 self.mock = self.mock.and(path_regex(format!(
-                    r"^/_matrix/client/v1/rooms/.*/relations/{}/{}$",
-                    event_spec, rel_type
+                    r"^/_matrix/client/v1/rooms/.*/relations/{event_spec}/{rel_type}$"
                 )));
             }
             Some(IncludeRelations::RelationsOfTypeAndEventType(rel_type, event_type)) => {
                 self.mock = self.mock.and(path_regex(format!(
-                    r"^/_matrix/client/v1/rooms/.*/relations/{}/{}/{}$",
-                    event_spec, rel_type, event_type
+                    r"^/_matrix/client/v1/rooms/.*/relations/{event_spec}/{rel_type}/{event_type}$"
                 )));
             }
             _ => {
                 self.mock = self.mock.and(path_regex(format!(
-                    r"^/_matrix/client/v1/rooms/.*/relations/{}",
-                    event_spec,
+                    r"^/_matrix/client/v1/rooms/.*/relations/{event_spec}",
                 )));
             }
         }

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -174,14 +174,13 @@ impl WidgetMachine {
                     return Vec::new();
                 };
 
-                capabilities
-                    .allow_reading(&event_raw)
-                    .then(|| {
-                        self.send_to_widget_request(NotifyNewMatrixEvent(event_raw))
-                            .map(|(_request, action)| vec![action])
-                            .unwrap_or_default()
-                    })
-                    .unwrap_or_default()
+                if capabilities.allow_reading(&event_raw) {
+                    self.send_to_widget_request(NotifyNewMatrixEvent(event_raw))
+                        .map(|(_request, action)| vec![action])
+                        .unwrap_or_default()
+                } else {
+                    vec![]
+                }
             }
             IncomingMessage::ToDeviceReceived(to_device_raw) => {
                 let CapabilitiesState::Negotiated(capabilities) = &self.capabilities else {
@@ -189,14 +188,13 @@ impl WidgetMachine {
                     return Vec::new();
                 };
 
-                capabilities
-                    .allow_reading(&to_device_raw)
-                    .then(|| {
-                        self.send_to_widget_request(NotifyNewToDeviceMessage(to_device_raw))
-                            .map(|(_request, action)| vec![action])
-                            .unwrap_or_default()
-                    })
-                    .unwrap_or_default()
+                if capabilities.allow_reading(&to_device_raw) {
+                    self.send_to_widget_request(NotifyNewToDeviceMessage(to_device_raw))
+                        .map(|(_request, action)| vec![action])
+                        .unwrap_or_default()
+                } else {
+                    vec![]
+                }
             }
         }
     }

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -271,7 +271,7 @@ impl WidgetSettings {
 
         // All the params will be set inside the fragment (to keep the traffic to the
         // server minimal and most importantly don't send the passwords).
-        raw_url.set_fragment(Some(&format!("?{}", query)));
+        raw_url.set_fragment(Some(&format!("?{query}")));
 
         // for EC we always want init on content load to be true.
         Ok(Self { widget_id: props.widget_id, init_on_content_load: true, raw_url })
@@ -510,9 +510,7 @@ mod tests {
             for e in expected_elements {
                 assert!(
                     query_set.contains(&e),
-                    "The query elements: \n{:?}\nDid not contain: \n{:?}",
-                    query_set,
-                    e
+                    "The query elements: \n{query_set:?}\nDid not contain: \n{e:?}"
                 );
             }
         }
@@ -530,9 +528,7 @@ mod tests {
             let expected_elements = ("perParticipantE2EE".to_owned(), "false".to_owned());
             assert!(
                 query_set.contains(&expected_elements),
-                "The url query elements for an unencrypted call: \n{:?}\nDid not contain: \n{:?}",
-                query_set,
-                expected_elements
+                "The url query elements for an unencrypted call: \n{query_set:?}\nDid not contain: \n{expected_elements:?}"
             );
         }
         {
@@ -550,9 +546,7 @@ mod tests {
             for e in expected_elements {
                 assert!(
                     query_set.contains(&e),
-                    "The query elements: \n{:?}\nDid not contain: \n{:?}",
-                    query_set,
-                    e
+                    "The query elements: \n{query_set:?}\nDid not contain: \n{e:?}"
                 );
             }
         }
@@ -574,9 +568,7 @@ mod tests {
             let query_set = get_query_sets(&Url::parse(&url).unwrap()).unwrap().1;
             assert!(
                 query_set.contains(&controlled_media_element),
-                "The query elements: \n{:?}\nDid not contain: \n{:?}",
-                query_set,
-                controlled_media_element
+                "The query elements: \n{query_set:?}\nDid not contain: \n{controlled_media_element:?}"
             );
         }
     }
@@ -595,9 +587,7 @@ mod tests {
             for e in expected_unset_elements {
                 assert!(
                     !query_set.iter().any(|x| x.0 == e),
-                    "The query elements: \n{:?}\nShould not have contained: \n{:?}",
-                    query_set,
-                    e
+                    "The query elements: \n{query_set:?}\nShould not have contained: \n{e:?}"
                 );
             }
         }
@@ -615,9 +605,7 @@ mod tests {
             let expected_elements = ("intent".to_owned(), "join_existing".to_owned());
             assert!(
                 query_set.contains(&expected_elements),
-                "The url query elements for an unencrypted call: \n{:?}\nDid not contain: \n{:?}",
-                query_set,
-                expected_elements
+                "The url query elements for an unencrypted call: \n{query_set:?}\nDid not contain: \n{expected_elements:?}"
             );
 
             let expected_unset_elements = ["skipLobby".to_owned()];
@@ -625,9 +613,7 @@ mod tests {
             for e in expected_unset_elements {
                 assert!(
                     !query_set.iter().any(|x| x.0 == e),
-                    "The query elements: \n{:?}\nShould not have contained: \n{:?}",
-                    query_set,
-                    e
+                    "The query elements: \n{query_set:?}\nShould not have contained: \n{e:?}"
                 );
             }
         }
@@ -651,9 +637,7 @@ mod tests {
             for e in expected_elements {
                 assert!(
                     query_set.contains(&e),
-                    "The query elements: \n{:?}\nDid not contain: \n{:?}",
-                    query_set,
-                    e
+                    "The query elements: \n{query_set:?}\nDid not contain: \n{e:?}"
                 );
             }
         }

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -1557,7 +1557,7 @@ async fn mock_get_event(
         }
     });
     Mock::given(method("GET"))
-        .and(path(format!("_matrix/client/r0/rooms/{}/event/{}", room_id, event_id)))
+        .and(path(format!("_matrix/client/r0/rooms/{room_id}/event/{event_id}")))
         .and(header("authorization", "Bearer 1234"))
         .respond_with(ResponseTemplate::new(200).set_body_json(event_json))
         .expect(2)

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -102,7 +102,7 @@ async fn send_request(
         "action": action,
         "data": data,
     });
-    println!("Json string sent from the widget {}", json_string);
+    println!("Json string sent from the widget {json_string}");
     let sent = driver_handle.send(json_string).await;
     assert!(sent);
 }
@@ -772,7 +772,7 @@ async fn test_update_delayed_event() {
     .await;
     // Receive the response
     let response = recv_message(&driver_handle).await;
-    print!("{:?}", response);
+    print!("{response:?}");
     assert_eq!(response["api"], "fromWidget");
     assert_eq!(response["action"], "org.matrix.msc4157.update_delayed_event");
     let empty_response = response["response"].clone();
@@ -797,7 +797,7 @@ async fn test_try_update_delayed_event_without_permission() {
     .await;
     // Receive the response
     let response = recv_message(&driver_handle).await;
-    print!("{:?}", response);
+    print!("{response:?}");
     assert_eq!(response["api"], "fromWidget");
     assert_eq!(response["action"], "org.matrix.msc4157.update_delayed_event");
     let error_response = response["response"]["error"]["message"].clone();

--- a/labs/multiverse/src/widgets/room_list.rs
+++ b/labs/multiverse/src/widgets/room_list.rs
@@ -197,7 +197,7 @@ impl Widget for &mut RoomList {
                         room_id.to_string()
                     };
 
-                    format!("#{i}{dm_marker} {}", room_name)
+                    format!("#{i}{dm_marker} {room_name}")
                 };
 
                 let line = Line::styled(line, TEXT_COLOR);

--- a/labs/multiverse/src/widgets/room_view/timeline.rs
+++ b/labs/multiverse/src/widgets/room_view/timeline.rs
@@ -45,12 +45,12 @@ impl Widget for &mut TimelineView<'_> {
                         TimelineItemContent::MsgLike(MsgLikeContent {
                             kind: MsgLikeKind::Redacted,
                             ..
-                        }) => content.push(format!("{}: -- redacted --", sender)),
+                        }) => content.push(format!("{sender}: -- redacted --")),
 
                         TimelineItemContent::MsgLike(MsgLikeContent {
                             kind: MsgLikeKind::UnableToDecrypt(_),
                             ..
-                        }) => content.push(format!("{}: (UTD)", sender)),
+                        }) => content.push(format!("{sender}: (UTD)")),
 
                         TimelineItemContent::MembershipChange(m) => {
                             if let Some(change) = m.change() {

--- a/testing/matrix-sdk-integration-testing/src/tests/room_directory_search.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room_directory_search.rs
@@ -37,7 +37,7 @@ async fn test_room_directory_search_filter() -> Result<()> {
     for index in 0..25 {
         let mut request: CreateRoomRequest = CreateRoomRequest::new();
         request.visibility = Visibility::Public;
-        let name = format!("{}_{}", search_string, index);
+        let name = format!("{search_string}_{index}");
         warn!("room name: {}", name);
         request.name = Some(name);
         alice.create_room(request).await?;

--- a/testing/matrix-sdk-integration-testing/src/tests/room_privacy.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room_privacy.rs
@@ -172,7 +172,7 @@ async fn test_removing_published_room_alias() -> anyhow::Result<()> {
 
     // We'll add a room alias to it
     let random_id: u128 = random();
-    let local_part_room_alias = format!("a-room-alias-{}", random_id);
+    let local_part_room_alias = format!("a-room-alias-{random_id}");
     let raw_room_alias = format!("#{local_part_room_alias}:{server_name}");
     let room_alias = RoomAliasId::parse(raw_room_alias).expect("The room alias should be valid");
 


### PR DESCRIPTION
Automated with cargo clippy --fix --workspace --all-targets.

I missed a bunch of things in the last clippy PR because I was running a nightly toolchain that ICE'd on some workspace crates. These are from beta clippy.

There's a single clippy warning left, but addressing that in a good way is a large-ish and potentially controversial change so I'll put it in a separate PR.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Jonas Platte <jplatte+matrix@posteo.de>