### PR TITLE
refactor: Use native async fn in traits more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,7 +2979,6 @@ name = "matrix-sdk-common"
 version = "0.11.0"
 dependencies = [
  "assert_matches",
- "async-trait",
  "eyeball-im",
  "futures-core",
  "futures-util",

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -2,10 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use async_compat::get_runtime_handle;
 use language_tags::LanguageTag;
-use matrix_sdk::{
-    async_trait,
-    widget::{MessageLikeEventFilter, StateEventFilter, ToDeviceEventFilter},
-};
+use matrix_sdk::widget::{MessageLikeEventFilter, StateEventFilter, ToDeviceEventFilter};
 use ruma::events::MessageLikeEventType;
 use tracing::error;
 
@@ -553,7 +550,6 @@ pub trait WidgetCapabilitiesProvider: Send + Sync {
 
 struct CapabilitiesProviderWrap(Arc<dyn WidgetCapabilitiesProvider>);
 
-#[async_trait]
 impl matrix_sdk::widget::CapabilitiesProvider for CapabilitiesProviderWrap {
     async fn acquire_capabilities(
         &self,

--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -185,8 +185,6 @@ pub type Result<T, E = EventCacheStoreError> = std::result::Result<T, E>;
 #[derive(Clone, Debug)]
 struct LockableEventCacheStore(Arc<DynEventCacheStore>);
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl BackingStore for LockableEventCacheStore {
     type LockError = EventCacheStoreError;
 

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -25,7 +25,6 @@ uniffi = ["dep:uniffi"]
 test-send-sync = []
 
 [dependencies]
-async-trait.workspace = true
 eyeball-im.workspace = true
 futures-core.workspace = true
 futures-util.workspace = true

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -2138,8 +2138,6 @@ impl Deref for Store {
 #[derive(Clone, Debug)]
 pub struct LockableCryptoStore(Arc<dyn CryptoStore<Error = CryptoStoreError>>);
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl matrix_sdk_common::store_locks::BackingStore for LockableCryptoStore {
     type LockError = CryptoStoreError;
 

--- a/crates/matrix-sdk/src/widget/README.md
+++ b/crates/matrix-sdk/src/widget/README.md
@@ -187,7 +187,6 @@ To use this module, two structs are needed:
 #[derive(Clone)]
 struct CapProv {}
 
-#[async_trait]
 impl CapabilitiesProvider for CapProv {
     async fn acquire_capabilities(&self, requested_capabilities: Capabilities) -> Capabilities {
         // Only approve capabilities the user has approved interactively

--- a/crates/matrix-sdk/src/widget/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/capabilities.rs
@@ -15,9 +15,8 @@
 //! Types and traits related to the capabilities that a widget can request from
 //! a client.
 
-use std::fmt;
+use std::{fmt, future::Future};
 
-use async_trait::async_trait;
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use tracing::{debug, warn};
 
@@ -29,12 +28,14 @@ use super::{
 /// Must be implemented by a component that provides functionality of deciding
 /// whether a widget is allowed to use certain capabilities (typically by
 /// providing a prompt to the user).
-#[async_trait]
 pub trait CapabilitiesProvider: Send + Sync + 'static {
     /// Receives a request for given capabilities and returns the actual
     /// capabilities that the clients grants to a given widget (usually by
     /// prompting the user).
-    async fn acquire_capabilities(&self, capabilities: Capabilities) -> Capabilities;
+    fn acquire_capabilities(
+        &self,
+        capabilities: Capabilities,
+    ) -> impl Future<Output = Capabilities> + Send;
 }
 
 /// Capabilities that a widget can request from a client.

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -15,7 +15,6 @@
 use std::{pin::pin, time::Duration};
 
 use assert_matches::assert_matches;
-use async_trait::async_trait;
 use futures_util::FutureExt;
 use matrix_sdk::{
     test_utils::mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
@@ -56,13 +55,13 @@ async fn run_test_driver(
 ) -> (Client, MatrixMockServer, WidgetDriverHandle) {
     struct DummyCapabilitiesProvider;
 
-    #[async_trait]
     impl CapabilitiesProvider for DummyCapabilitiesProvider {
         async fn acquire_capabilities(&self, capabilities: Capabilities) -> Capabilities {
             // Grant all capabilities that the widget asks for
             capabilities
         }
     }
+
     let mock_server = MatrixMockServer::new().await;
     let client = mock_server.client_builder().build().await;
 


### PR DESCRIPTION
The main thing left now are the store traits, unsure how to deal with those. `dynosaur` + `trait_variant` are kind of the modern replacement for `async_trait`, but (a) `trait_variant` seemed to generate invalid code here when I tried it and (b) even with that fixed I think the error type erasure is going to present some extra problems. Maybe it's fine to just keep the current solution for the store traits for now.

<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Jonas Platte <jplatte+matrix@posteo.de>
