### PR TITLE
Test: Replace `sync_timeline_event!` with `EventFactory` for events in timeline subscribe tests

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -100,14 +100,9 @@ async fn test_event_filter() {
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let first_event_id = event_id!("$YTQwYl2ply");
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id).add_timeline_event(
-            f.text_msg("hello")
-                .sender(user_id!("@alice:example.org"))
-                .event_id(first_event_id)
-                .server_ts(152037280),
-        ),
-    );
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+        f.text_msg("hello").sender(user_id!("@alice:example.org")).event_id(first_event_id),
+    ));
 
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
@@ -135,12 +130,10 @@ async fn test_event_filter() {
             f.text_html("Test", "<em>Test</em>")
                 .sender(user_id!("@bob:example.org"))
                 .event_id(second_event_id)
-                .server_ts(152038280)
                 .into(),
             f.text_msg(" * hi")
                 .sender(user_id!("@alice:example.org"))
                 .event_id(edit_event_id)
-                .server_ts(159056300)
                 .edit(first_event_id, RoomMessageEventContent::text_plain("hi").into())
                 .into(),
         ]),
@@ -319,8 +312,8 @@ async fn test_profile_updates() {
     let event_2_id = event_id!("$YTQwYl2pl2");
 
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_bulk([
-        f.text_msg("hello").event_id(event_1_id).sender(alice).server_ts(152037280).into(),
-        f.text_msg("hello").event_id(event_2_id).sender(bob).server_ts(152037280).into(),
+        f.text_msg("hello").event_id(event_1_id).sender(alice).into(),
+        f.text_msg("hello").event_id(event_2_id).sender(bob).into(),
     ]));
 
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
@@ -351,9 +344,9 @@ async fn test_profile_updates() {
     let event_5_id = event_id!("$YTQwYl2pl5");
 
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_bulk([
-        f.member(bob).display_name("Member").event_id(event_3_id).server_ts(152037280).into(),
-        f.member(alice).display_name("Alice").event_id(event_4_id).server_ts(152037280).into(),
-        f.text_msg("hello").event_id(event_5_id).sender(alice).server_ts(152037280).into(),
+        f.member(bob).display_name("Member").event_id(event_3_id).into(),
+        f.member(alice).display_name("Alice").event_id(event_4_id).into(),
+        f.text_msg("hello").event_id(event_5_id).sender(alice).into(),
     ]));
 
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
@@ -420,9 +413,10 @@ async fn test_profile_updates() {
     // Change name to be ambiguous.
     let event_6_id = event_id!("$YTQwYl2pl6");
 
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
-        f.member(alice).display_name("Member").event_id(event_6_id).server_ts(152037280),
-    ));
+    sync_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            .add_timeline_event(f.member(alice).display_name("Member").event_id(event_6_id)),
+    );
 
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -131,20 +131,19 @@ async fn test_event_filter() {
     let second_event_id = event_id!("$Ga6Y2l0gKY");
     let edit_event_id = event_id!("$7i9In0gEmB");
     sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(
-                f.text_html("Test", "<em>Test</em>")
-                    .sender(user_id!("@bob:example.org"))
-                    .event_id(second_event_id)
-                    .server_ts(152038280),
-            )
-            .add_timeline_event(
-                f.text_msg(" * hi")
-                    .sender(user_id!("@alice:example.org"))
-                    .event_id(edit_event_id)
-                    .server_ts(159056300)
-                    .edit(first_event_id, RoomMessageEventContent::text_plain("hi").into()),
-            ),
+        JoinedRoomBuilder::new(room_id).add_timeline_bulk([
+            f.text_html("Test", "<em>Test</em>")
+                .sender(user_id!("@bob:example.org"))
+                .event_id(second_event_id)
+                .server_ts(152038280)
+                .into(),
+            f.text_msg(" * hi")
+                .sender(user_id!("@alice:example.org"))
+                .event_id(edit_event_id)
+                .server_ts(159056300)
+                .edit(first_event_id, RoomMessageEventContent::text_plain("hi").into())
+                .into(),
+        ]),
     );
 
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
@@ -319,15 +318,10 @@ async fn test_profile_updates() {
     let event_1_id = event_id!("$YTQwYl2pl1");
     let event_2_id = event_id!("$YTQwYl2pl2");
 
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(
-                f.text_msg("hello").event_id(event_1_id).sender(alice).server_ts(152037280),
-            )
-            .add_timeline_event(
-                f.text_msg("hello").event_id(event_2_id).sender(bob).server_ts(152037280),
-            ),
-    );
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_bulk([
+        f.text_msg("hello").event_id(event_1_id).sender(alice).server_ts(152037280).into(),
+        f.text_msg("hello").event_id(event_2_id).sender(bob).server_ts(152037280).into(),
+    ]));
 
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
@@ -356,18 +350,11 @@ async fn test_profile_updates() {
     let event_4_id = event_id!("$YTQwYl2pl4");
     let event_5_id = event_id!("$YTQwYl2pl5");
 
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(
-                f.member(bob).display_name("Member").event_id(event_3_id).server_ts(152037280),
-            )
-            .add_timeline_event(
-                f.member(alice).display_name("Alice").event_id(event_4_id).server_ts(152037280),
-            )
-            .add_timeline_event(
-                f.text_msg("hello").event_id(event_5_id).sender(alice).server_ts(152037280),
-            ),
-    );
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_bulk([
+        f.member(bob).display_name("Member").event_id(event_3_id).server_ts(152037280).into(),
+        f.member(alice).display_name("Alice").event_id(event_4_id).server_ts(152037280).into(),
+        f.text_msg("hello").event_id(event_5_id).sender(alice).server_ts(152037280).into(),
+    ]));
 
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -20,7 +20,7 @@ use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, sync_timeline_event,
+    async_test, event_factory::EventFactory, mocks::mock_encryption_state,
     GlobalAccountDataTestEvent, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB,
 };
 use matrix_sdk_ui::timeline::{RoomExt, TimelineDetails};


### PR DESCRIPTION
Part of #3716

For the tests which were modified, this additionally:
- removes server timestamp information on events that weren't necessary for the associated test to pass
- for places where multiple events were added at the same time, the code was very slightly tidied by adding them in bulk rather than adding them individually

If it's preferred to do those changes separate to the removal of the `sync_timeline_event!` macro, I'm happy to split them off into a separate PR :slightly_smiling_face:

Signed-off-by: Yousef Moazzam <yousefmoazzam@hotmail.co.uk>