### PR TITLE
multiverse: write logs to session dir

### DIFF
--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -99,7 +99,8 @@ fn popup_area(area: Rect, percent_x: u16, percent_y: u16) -> Rect {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let file_writer = tracing_appender::rolling::hourly("/tmp/", "logs-");
+    let cli = Cli::parse();
+    let file_writer = tracing_appender::rolling::hourly(&cli.session_path, "logs-");
 
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
@@ -109,7 +110,6 @@ async fn main() -> Result<()> {
 
     color_eyre::install()?;
 
-    let cli = Cli::parse();
     let client = configure_client(cli).await?;
 
     let event_cache = client.event_cache();


### PR DESCRIPTION
Rather than always writing the logs to `/tmp`, write them to the session
directory. The session directory defaults to `/tmp` so by default this will do
the same as before, but if you override the session path on the commandline,
the logs will get stored alongside the stores and caches.

This is particularly useful when running two instances of multiverse, and you
want them to put their logs in different places.