### PR TITLE
multiverse: expand user names when inviting

### DIFF
--- a/labs/multiverse/src/widgets/room_view/input.rs
+++ b/labs/multiverse/src/widgets/room_view/input.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use crossterm::event::KeyEvent;
-use matrix_sdk::{ruma::OwnedUserId, Room};
+use matrix_sdk::Room;
 use ratatui::{prelude::*, widgets::*};
 use style::palette::tailwind;
 use tui_textarea::TextArea;
@@ -14,7 +14,7 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
-    Invite { user_id: OwnedUserId },
+    Invite { user_id: String },
 }
 
 pub enum MessageOrCommand {


### PR DESCRIPTION
When the user does an `/invite`, if the target user doesn't start with an `@`, try expanding it as a user on the local server.

This makes it much easier when repeatedly testing inviting!