### PR TITLE
feat(wasm): Add Wasm aware async_trait proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,7 +2875,6 @@ dependencies = [
  "assert_matches2",
  "async-channel",
  "async-stream",
- "async-trait",
  "axum",
  "backon",
  "bytes",
@@ -2946,7 +2945,6 @@ dependencies = [
  "assert_matches",
  "assert_matches2",
  "assign",
- "async-trait",
  "bitflags 2.8.0",
  "decancer",
  "eyeball",
@@ -2979,6 +2977,7 @@ name = "matrix-sdk-common"
 version = "0.11.0"
 dependencies = [
  "assert_matches",
+ "async-trait",
  "eyeball-im",
  "futures-core",
  "futures-util",
@@ -2987,6 +2986,7 @@ dependencies = [
  "imbl",
  "insta",
  "js-sys",
+ "matrix-sdk-macros",
  "matrix-sdk-test-macros",
  "proptest",
  "ruma",
@@ -3013,7 +3013,6 @@ dependencies = [
  "as_variant",
  "assert_matches",
  "assert_matches2",
- "async-trait",
  "bs58",
  "byteorder",
  "cfg-if",
@@ -3138,7 +3137,6 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "assert_matches2",
- "async-trait",
  "base64",
  "getrandom 0.2.15",
  "gloo-utils",
@@ -3200,6 +3198,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrix-sdk-macros"
+version = "0.11.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "matrix-sdk-qrcode"
 version = "0.11.0"
 dependencies = [
@@ -3217,7 +3223,6 @@ version = "0.11.0"
 dependencies = [
  "as_variant",
  "assert_matches",
- "async-trait",
  "deadpool-sqlite",
  "glob",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ matrix-sdk-common = { path = "crates/matrix-sdk-common", version = "0.11.0" }
 matrix-sdk-crypto = { path = "crates/matrix-sdk-crypto", version = "0.11.0" }
 matrix-sdk-ffi-macros = { path = "bindings/matrix-sdk-ffi-macros", version = "0.7.0" }
 matrix-sdk-indexeddb = { path = "crates/matrix-sdk-indexeddb", version = "0.11.0", default-features = false }
+matrix-sdk-macros = { path = "crates/matrix-sdk-macros", version = "0.11.0" }
 matrix-sdk-qrcode = { path = "crates/matrix-sdk-qrcode", version = "0.11.0" }
 matrix-sdk-sqlite = { path = "crates/matrix-sdk-sqlite", version = "0.11.0", default-features = false }
 matrix-sdk-store-encryption = { path = "crates/matrix-sdk-store-encryption", version = "0.11.0" }

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -56,7 +56,6 @@ unstable-msc4274 = []
 as_variant.workspace = true
 assert_matches = { workspace = true, optional = true }
 assert_matches2 = { workspace = true, optional = true }
-async-trait.workspace = true
 bitflags = { workspace = true, features = ["serde"] }
 decancer = "3.3.0"
 eyeball = { workspace = true, features = ["async-lock"] }

--- a/crates/matrix-sdk-base/src/event_cache/store/media/media_service.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/media/media_service.rs
@@ -14,8 +14,8 @@
 
 use std::{fmt, sync::Arc};
 
-use async_trait::async_trait;
 use matrix_sdk_common::{
+    async_trait,
     executor::{spawn, JoinHandle},
     locks::Mutex,
     AsyncTraitDeps, SendOutsideWasm, SyncOutsideWasm,
@@ -356,8 +356,7 @@ where
 /// [`MediaRetentionPolicy`] by wrapping this in a [`MediaService`], and to
 /// simplify the implementation of tests by being able to have complete control
 /// over the `SystemTime`s provided to the store.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 pub trait EventCacheStoreMedia: AsyncTraitDeps + Clone {
     /// The error type used by this media cache store.
     type Error: fmt::Debug + fmt::Display + Into<EventCacheStoreError>;
@@ -534,8 +533,7 @@ mod tests {
         sync::{Arc, MutexGuard},
     };
 
-    use async_trait::async_trait;
-    use matrix_sdk_common::locks::Mutex;
+    use matrix_sdk_common::{async_trait, locks::Mutex};
     use matrix_sdk_test::async_test;
     use ruma::{
         events::room::MediaSource,

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -18,8 +18,8 @@ use std::{
     sync::{Arc, RwLock as StdRwLock},
 };
 
-use async_trait::async_trait;
 use matrix_sdk_common::{
+    async_trait,
     linked_chunk::{
         relational::RelationalLinkedChunk, ChunkIdentifier, ChunkIdentifierGenerator, Position,
         RawChunk, Update,
@@ -110,8 +110,7 @@ impl MemoryStore {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 impl EventCacheStore for MemoryStore {
     type Error = EventCacheStoreError;
 
@@ -364,8 +363,7 @@ impl EventCacheStore for MemoryStore {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 impl EventCacheStoreMedia for MemoryStore {
     type Error = EventCacheStoreError;
 

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -14,8 +14,8 @@
 
 use std::{fmt, sync::Arc};
 
-use async_trait::async_trait;
 use matrix_sdk_common::{
+    async_trait,
     linked_chunk::{ChunkIdentifier, ChunkIdentifierGenerator, Position, RawChunk, Update},
     AsyncTraitDeps,
 };
@@ -37,8 +37,7 @@ pub const DEFAULT_CHUNK_CAPACITY: usize = 128;
 
 /// An abstract trait that can be used to implement different store backends
 /// for the event cache of the SDK.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 pub trait EventCacheStore: AsyncTraitDeps {
     /// The error type used by this event cache store.
     type Error: fmt::Debug + Into<EventCacheStoreError>;
@@ -277,8 +276,7 @@ impl<T: fmt::Debug> fmt::Debug for EraseEventCacheStoreError<T> {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
     type Error = EventCacheStoreError;
 

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -17,8 +17,8 @@ use std::{
     sync::RwLock,
 };
 
-use async_trait::async_trait;
 use growable_bloom_filter::GrowableBloom;
+use matrix_sdk_common::async_trait;
 use ruma::{
     canonical_json::{redact, RedactedBecause},
     events::{
@@ -138,8 +138,7 @@ impl MemoryStore {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 impl StateStore for MemoryStore {
     type Error = StoreError;
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -20,9 +20,8 @@ use std::{
 };
 
 use as_variant::as_variant;
-use async_trait::async_trait;
 use growable_bloom_filter::GrowableBloom;
-use matrix_sdk_common::AsyncTraitDeps;
+use matrix_sdk_common::{async_trait, AsyncTraitDeps};
 use ruma::{
     api::MatrixVersion,
     events::{
@@ -54,8 +53,7 @@ use crate::{
 
 /// An abstract state store trait that can be used to implement different stores
 /// for the SDK.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 pub trait StateStore: AsyncTraitDeps {
     /// The error type used by this state store.
     type Error: fmt::Debug + Into<StoreError> + From<serde_json::Error>;
@@ -485,8 +483,7 @@ impl<T: fmt::Debug> fmt::Debug for EraseStateStoreError<T> {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 impl<T: StateStore> StateStore for EraseStateStoreError<T> {
     type Error = StoreError;
 
@@ -770,8 +767,7 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
 }
 
 /// Convenience functionality for state stores.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 pub trait StateStoreExt: StateStore {
     /// Get a specific state event of statically-known type.
     ///
@@ -909,8 +905,7 @@ pub trait StateStoreExt: StateStore {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 impl<T: StateStore + ?Sized> StateStoreExt for T {}
 
 /// A type-erased [`StateStore`].

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -25,10 +25,12 @@ uniffi = ["dep:uniffi"]
 test-send-sync = []
 
 [dependencies]
+async-trait.workspace = true
 eyeball-im.workspace = true
 futures-core.workspace = true
 futures-util.workspace = true
 imbl.workspace = true
+matrix-sdk-macros.workspace = true
 ruma.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -72,10 +72,32 @@ pub trait SyncOutsideWasm {}
 impl<T> SyncOutsideWasm for T {}
 
 /// Super trait that is used for our store traits, this trait will differ if
-/// it's used on WASM. WASM targets will not require `Send` and `Sync` to have
+/// it's used on Wasm. Wasm targets will not require `Send` and `Sync` to have
 /// implemented, while other targets will.
 pub trait AsyncTraitDeps: std::fmt::Debug + SendOutsideWasm + SyncOutsideWasm {}
 impl<T: std::fmt::Debug + SendOutsideWasm + SyncOutsideWasm> AsyncTraitDeps for T {}
+
+// Re-export async_trait implementation with an alias
+pub use async_trait::async_trait as async_trait_impl;
+
+// Helper "macros" for the async_trait proc macro - these are actually just
+// identifiers
+#[macro_export]
+macro_rules! __matrix_sdk_async_trait_wasm {
+    () => {
+        $crate::async_trait_impl(?Send)
+    };
+}
+
+#[macro_export]
+macro_rules! __matrix_sdk_async_trait_non_wasm {
+    () => {
+        $crate::async_trait_impl
+    };
+}
+
+// Re-export the async_trait proc macro
+pub use matrix_sdk_macros::async_trait;
 
 // TODO: Remove in favor of impl Trait once allowed in associated types
 #[macro_export]

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -39,7 +39,6 @@ testing = ["matrix-sdk-test"]
 aes = "0.8.4"
 aquamarine.workspace = true
 as_variant.workspace = true
-async-trait.workspace = true
 bs58 = { version = "0.5.1" }
 byteorder.workspace = true
 cfg-if = "1.0.0"

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -18,9 +18,8 @@ use std::{
     sync::Arc,
 };
 
-use async_trait::async_trait;
 use matrix_sdk_common::{
-    locks::RwLock as StdRwLock, store_locks::memory_store_helper::try_take_leased_lock,
+    async_trait, locks::RwLock as StdRwLock, store_locks::memory_store_helper::try_take_leased_lock,
 };
 use ruma::{
     events::secret::request::SecretName, time::Instant, DeviceId, OwnedDeviceId, OwnedRoomId,
@@ -183,8 +182,7 @@ impl MemoryStore {
 
 type Result<T> = std::result::Result<T, Infallible>;
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 impl CryptoStore for MemoryStore {
     type Error = Infallible;
 
@@ -1231,7 +1229,7 @@ mod integration_tests {
         sync::{Arc, Mutex, OnceLock},
     };
 
-    use async_trait::async_trait;
+    use matrix_sdk_common::async_trait;
     use ruma::{
         events::secret::request::SecretName, DeviceId, OwnedDeviceId, RoomId, TransactionId, UserId,
     };

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -14,8 +14,7 @@
 
 use std::{collections::HashMap, fmt, sync::Arc};
 
-use async_trait::async_trait;
-use matrix_sdk_common::AsyncTraitDeps;
+use matrix_sdk_common::{async_trait, AsyncTraitDeps};
 use ruma::{
     events::secret::request::SecretName, DeviceId, OwnedDeviceId, RoomId, TransactionId, UserId,
 };
@@ -38,8 +37,7 @@ use crate::{
 
 /// Represents a store that the `OlmMachine` uses to store E2EE data (such as
 /// cryptographic keys).
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 pub trait CryptoStore: AsyncTraitDeps {
     /// The error type used by this crypto store.
     type Error: fmt::Debug + Into<CryptoStoreError>;
@@ -386,8 +384,7 @@ impl<T: fmt::Debug> fmt::Debug for EraseCryptoStoreError<T> {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
     type Error = CryptoStoreError;
 

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -21,7 +21,6 @@ testing = ["matrix-sdk-crypto?/testing"]
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 base64.workspace = true
 gloo-utils = { version = "0.2.0", features = ["serde"] }
 growable-bloom-filter = { workspace = true, optional = true }
@@ -29,6 +28,7 @@ hkdf.workspace = true
 indexed_db_futures = "0.5.0"
 js-sys.workspace = true
 matrix-sdk-base = { workspace = true, features = ["js"], optional = true }
+matrix-sdk-common.workspace = true
 matrix-sdk-crypto = { workspace = true, features = ["js"], optional = true }
 matrix-sdk-store-encryption.workspace = true
 ruma.workspace = true

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -17,11 +17,11 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use async_trait::async_trait;
 use gloo_utils::format::JsValueSerdeExt;
 use hkdf::Hkdf;
 use indexed_db_futures::prelude::*;
 use js_sys::Array;
+use matrix_sdk_common::async_trait;
 use matrix_sdk_crypto::{
     olm::{
         Curve25519PublicKey, InboundGroupSession, OlmMessageHash, OutboundGroupSession,

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -18,7 +18,6 @@ use std::{
 };
 
 use anyhow::anyhow;
-use async_trait::async_trait;
 use gloo_utils::format::JsValueSerdeExt;
 use growable_bloom_filter::GrowableBloom;
 use indexed_db_futures::prelude::*;
@@ -31,6 +30,7 @@ use matrix_sdk_base::{
     },
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, StateStoreDataKey, StateStoreDataValue,
 };
+use matrix_sdk_common::async_trait;
 use matrix_sdk_store_encryption::{Error as EncryptionError, StoreCipher};
 use ruma::{
     canonical_json::{redact, RedactedBecause},

--- a/crates/matrix-sdk-macros/Cargo.toml
+++ b/crates/matrix-sdk-macros/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "matrix-sdk-macros"
+version = "0.11.0"
+edition = "2021"
+authors = ["Damir Jelić <poljar@termina.org.uk>"]
+description = "Procedural macros for the matrix-rust-sdk"
+homepage = "https://github.com/matrix-org/matrix-rust-sdk"
+repository = "https://github.com/matrix-org/matrix-rust-sdk"
+license = "Apache-2.0"
+rust-version.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.86"
+quote = "1.0.18"
+
+[lints]
+workspace = true

--- a/crates/matrix-sdk-macros/src/lib.rs
+++ b/crates/matrix-sdk-macros/src/lib.rs
@@ -1,0 +1,26 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+
+/// A wrapper around `async_trait` that automatically handles Wasm
+/// compatibility.
+///
+/// On Wasm targets, this expands to `#[async_trait(?Send)]` since Wasm is
+/// single-threaded. On other targets, this expands to `#[async_trait]` with
+/// Send bounds.
+///
+/// This should not be used directly, it is intended to be re-exported by
+/// the `matrix-sdk-common` crate for use in external crates that depend on it.
+#[proc_macro_attribute]
+pub fn async_trait(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let item = TokenStream2::from(item);
+
+    // Use the matrix_sdk_common re-export for external crates
+    let expanded = quote! {
+        #[cfg_attr(target_family = "wasm", ::matrix_sdk_common::async_trait_impl(?Send))]
+        #[cfg_attr(not(target_family = "wasm"), ::matrix_sdk_common::async_trait_impl)]
+        #item
+    };
+
+    TokenStream::from(expanded)
+}

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -21,10 +21,10 @@ state-store = ["dep:matrix-sdk-base"]
 
 [dependencies]
 as_variant.workspace = true
-async-trait.workspace = true
 deadpool-sqlite = "0.10.0"
 itertools.workspace = true
 matrix-sdk-base = { workspace = true, optional = true }
+matrix-sdk-common.workspace = true
 matrix-sdk-crypto = { workspace = true, optional = true }
 matrix-sdk-store-encryption.workspace = true
 num_cpus = "1.16.0"
@@ -42,7 +42,6 @@ vodozemac.workspace = true
 assert_matches.workspace = true
 glob = "0.3.2"
 matrix-sdk-base = { workspace = true, features = ["testing"] }
-matrix-sdk-common.workspace = true
 matrix-sdk-crypto = { workspace = true, features = ["testing"] }
 matrix-sdk-test.workspace = true
 once_cell.workspace = true

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -20,8 +20,8 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use async_trait::async_trait;
 use deadpool_sqlite::{Object as SqliteAsyncConn, Pool as SqlitePool, Runtime};
+use matrix_sdk_common::async_trait;
 use matrix_sdk_crypto::{
     olm::{
         InboundGroupSession, OutboundGroupSession, PickledInboundGroupSession,

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -16,7 +16,6 @@
 
 use std::{borrow::Cow, fmt, iter::once, path::Path, sync::Arc};
 
-use async_trait::async_trait;
 use deadpool_sqlite::{Object as SqliteAsyncConn, Pool as SqlitePool, Runtime};
 use matrix_sdk_base::{
     deserialized_responses::TimelineEvent,
@@ -36,6 +35,7 @@ use matrix_sdk_base::{
     },
     media::{MediaRequestParameters, UniqueKey},
 };
+use matrix_sdk_common::async_trait;
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{
     events::relation::RelationType, time::SystemTime, EventId, MilliSecondsSinceUnixEpoch, MxcUri,
@@ -1237,8 +1237,7 @@ impl EventCacheStore for SqliteEventCacheStore {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 impl EventCacheStoreMedia for SqliteEventCacheStore {
     type Error = Error;
 

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -6,7 +6,6 @@ use std::{
     sync::Arc,
 };
 
-use async_trait::async_trait;
 use deadpool_sqlite::{Object as SqliteAsyncConn, Pool as SqlitePool, Runtime};
 use matrix_sdk_base::{
     deserialized_responses::{DisplayName, RawAnySyncOrStrippedState, SyncOrStrippedState},
@@ -18,6 +17,7 @@ use matrix_sdk_base::{
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, RoomState, StateChanges, StateStore,
     StateStoreDataKey, StateStoreDataValue,
 };
+use matrix_sdk_common::async_trait;
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{
     canonical_json::{redact, RedactedBecause},

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -15,9 +15,9 @@
 use core::fmt;
 use std::{borrow::Borrow, cmp::min, iter, ops::Deref};
 
-use async_trait::async_trait;
 use deadpool_sqlite::Object as SqliteAsyncConn;
 use itertools::Itertools;
+use matrix_sdk_common::async_trait;
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::time::SystemTime;
 use rusqlite::{limits::Limit, OptionalExtension, Params, Row, Statement, Transaction};

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -71,7 +71,6 @@ as_variant.workspace = true
 assert_matches2 = { workspace = true, optional = true }
 async-channel = "2.3.1"
 async-stream.workspace = true
-async-trait.workspace = true
 axum = { version = "0.8.1", optional = true }
 bytes = "1.9.0"
 bytesize = "2.0.1"

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -18,7 +18,6 @@
 #![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-pub use async_trait::async_trait;
 pub use bytes;
 #[cfg(feature = "e2e-encryption")]
 pub use matrix_sdk_base::crypto;
@@ -30,7 +29,7 @@ pub use matrix_sdk_base::{
     RoomMember as BaseRoomMember, RoomMemberships, RoomState, SessionMeta, StateChanges,
     StateStore, StoreError, SuccessorRoom,
 };
-pub use matrix_sdk_common::*;
+pub use matrix_sdk_common::{async_trait, *};
 pub use reqwest;
 
 mod account;

--- a/crates/matrix-sdk/src/widget/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/capabilities.rs
@@ -17,7 +17,7 @@
 
 use std::fmt;
 
-use async_trait::async_trait;
+use matrix_sdk_common::async_trait;
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use tracing::{debug, warn};
 

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -15,9 +15,9 @@
 use std::{pin::pin, time::Duration};
 
 use assert_matches::assert_matches;
-use async_trait::async_trait;
 use futures_util::FutureExt;
 use matrix_sdk::{
+    async_trait,
     test_utils::mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
     widget::{
         Capabilities, CapabilitiesProvider, WidgetDriver, WidgetDriverHandle, WidgetSettings,


### PR DESCRIPTION
Create a new proc-macro to eliminate conditional cfgs wherever async_trait is defined. Convert existing use of conditional wasm cfg to use this macro, as well as other call site thats were using async_trait::async_trait directly

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
