### PR TITLE
feat(wasm): Replace async_trait with wasm aware cfg conditional

### DIFF
--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -553,7 +553,8 @@ pub trait WidgetCapabilitiesProvider: Send + Sync {
 
 struct CapabilitiesProviderWrap(Arc<dyn WidgetCapabilitiesProvider>);
 
-#[async_trait]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl matrix_sdk::widget::CapabilitiesProvider for CapabilitiesProviderWrap {
     async fn acquire_capabilities(
         &self,

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -1297,7 +1297,8 @@ mod integration_tests {
     }
 
     /// Forwards all methods to the underlying [MemoryStore].
-    #[async_trait]
+    #[cfg_attr(target_family = "wasm", async_trait(?Send))]
+    #[cfg_attr(not(target_family = "wasm"), async_trait)]
     impl CryptoStore for PersistentMemoryStore {
         type Error = <MemoryStore as CryptoStore>::Error;
 

--- a/crates/matrix-sdk/src/widget/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/capabilities.rs
@@ -29,7 +29,8 @@ use super::{
 /// Must be implemented by a component that provides functionality of deciding
 /// whether a widget is allowed to use certain capabilities (typically by
 /// providing a prompt to the user).
-#[async_trait]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait CapabilitiesProvider: Send + Sync + 'static {
     /// Receives a request for given capabilities and returns the actual
     /// capabilities that the clients grants to a given widget (usually by

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -58,7 +58,8 @@ async fn run_test_driver(
 ) -> (Client, MatrixMockServer, WidgetDriverHandle) {
     struct DummyCapabilitiesProvider;
 
-    #[async_trait]
+    #[cfg_attr(target_family = "wasm", async_trait(?Send))]
+    #[cfg_attr(not(target_family = "wasm"), async_trait)]
     impl CapabilitiesProvider for DummyCapabilitiesProvider {
         async fn acquire_capabilities(&self, capabilities: Capabilities) -> Capabilities {
             // Grant all capabilities that the widget asks for


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Change the use of async_trait to remove required Send for wasm family of platforms.
- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
