### PR TITLE
Test: Replace `sync_timeline_event!` with `EventFactory` for sticker event in timeline test

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -132,18 +132,13 @@ async fn test_replace_with_initial_events_and_read_marker() {
 async fn test_sticker() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
-    let mut image_info = ImageInfo::new();
-    image_info.height = Some(398u16.into());
-    image_info.width = Some(394u16.into());
-    image_info.size = Some(31037u16.into());
-    image_info.mimetype = Some("image/jpeg".to_owned());
 
     timeline
         .handle_live_event(
             EventFactory::new()
                 .sticker(
                     "Happy sticker",
-                    image_info,
+                    ImageInfo::new(),
                     owned_mxc_uri!("mxc://server.name/JWEIFJgwEIhweiWJE"),
                 )
                 .reply_thread(event_id!("$thread_root"), event_id!("$in_reply_to"))

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -148,7 +148,6 @@ async fn test_sticker() {
                 )
                 .reply_thread(event_id!("$thread_root"), event_id!("$in_reply_to"))
                 .event_id(event_id!("$143273582443PhrSn"))
-                .server_ts(143273582)
                 .sender(user_id!("@alice:server.name"))
                 .into_event(),
         )

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -17,7 +17,6 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use imbl::vector;
-use matrix_sdk::deserialized_responses::TimelineEvent;
 use matrix_sdk_test::{
     async_test,
     event_factory::{EventFactory, PreviousMembership},
@@ -140,7 +139,7 @@ async fn test_sticker() {
     image_info.mimetype = Some("image/jpeg".to_owned());
 
     timeline
-        .handle_live_event(TimelineEvent::new(
+        .handle_live_event(
             EventFactory::new()
                 .sticker(
                     "Happy sticker",
@@ -151,8 +150,8 @@ async fn test_sticker() {
                 .event_id(event_id!("$143273582443PhrSn"))
                 .server_ts(143273582)
                 .sender(user_id!("@alice:server.name"))
-                .into(),
-        ))
+                .into_event(),
+        )
         .await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -434,6 +434,15 @@ impl EventBuilder<RoomCreateEventContent> {
     }
 }
 
+impl EventBuilder<StickerEventContent> {
+    /// Add reply [`Thread`] relation to root event and set replied-to event id.
+    pub fn reply_thread(mut self, root: &EventId, reply_to_event: &EventId) -> Self {
+        self.content.relates_to =
+            Some(Relation::Thread(Thread::reply(root.to_owned(), reply_to_event.to_owned())));
+        self
+    }
+}
+
 impl<E: EventContent> From<EventBuilder<E>> for Raw<AnySyncTimelineEvent>
 where
     E::EventType: Serialize,

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -55,7 +55,9 @@ use ruma::{
             server_acl::RoomServerAclEventContent,
             tombstone::RoomTombstoneEventContent,
             topic::RoomTopicEventContent,
+            ImageInfo,
         },
+        sticker::StickerEventContent,
         typing::TypingEventContent,
         AnyMessageLikeEvent, AnyStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,
         AnyTimelineEvent, BundledMessageLikeRelations, EventContent,
@@ -899,6 +901,16 @@ impl EventFactory {
     ) -> EventBuilder<BeaconEventContent> {
         let geo_uri = format!("geo:{latitude},{longitude};u={uncertainty}");
         self.event(BeaconEventContent::new(beacon_info_event_id, geo_uri, ts))
+    }
+
+    /// Create a new `m.sticker` event.
+    pub fn sticker(
+        &self,
+        body: impl Into<String>,
+        info: ImageInfo,
+        url: OwnedMxcUri,
+    ) -> EventBuilder<StickerEventContent> {
+        self.event(StickerEventContent::new(body.into(), info, url))
     }
 
     /// Set the next server timestamp.


### PR DESCRIPTION
Part of #3716

I'm fairly sure that I've used the correct relation in the sticker event content (a reply to a specific message within a thread?), but please do double-check me on that in particular.

I also removed some information attached to the event that wasn't being used in the test:
- the server timestamp
- the various fields on the `ImageInfo` (it seemed like, in its current state, the test is primarily checking that the event is a sticker event and that the relation to another event is correct, and so the actual image info isn't important) 

The first one likely doesn't matter if it's done or not, but maybe the second one shouldn't be done if it'd make sense to be asserting on the image information - I'm happy to remove that change if desired.

Signed-off-by: Yousef Moazzam <yousefmoazzam@hotmail.co.uk>