### PR TITLE
feat(wasm): Add Wasm platform aware test to export proc-macro

### DIFF
--- a/bindings/matrix-sdk-ffi-macros/src/lib.rs
+++ b/bindings/matrix-sdk-ffi-macros/src/lib.rs
@@ -51,7 +51,12 @@ pub fn export(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let res = match syn::parse(item) {
         Ok(item) => match has_async_fn(item) {
-            true => quote! { #[uniffi::export(async_runtime = "tokio", #attr2)] },
+            true => {
+                quote! {
+                  #[cfg_attr(target_family = "wasm", uniffi::export(#attr2))]
+                  #[cfg_attr(not(target_family = "wasm"), uniffi::export(async_runtime = "tokio", #attr2))]
+                }
+            }
             false => quote! { #[uniffi::export(#attr2)] },
         },
         Err(e) => e.into_compile_error(),


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Change the uniffi export to not use tokio on Wasm platforms.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
