### PR TITLE
feat(event cache): save a bundled thread's latest event into the event cache

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -690,9 +690,9 @@ impl Timeline {
             Ok(Some(replied_to)) => Ok(Arc::new(InReplyToDetails::new(
                 event_id_str,
                 EmbeddedEventDetails::Ready {
-                    content: replied_to.content().clone().into(),
-                    sender: replied_to.sender().to_string(),
-                    sender_profile: replied_to.sender_profile().into(),
+                    content: replied_to.content.clone().into(),
+                    sender: replied_to.sender.to_string(),
+                    sender_profile: (&replied_to.sender_profile).into(),
                 },
             ))),
 
@@ -1144,6 +1144,7 @@ pub enum ProfileDetails {
     Error { message: String },
 }
 
+// TODO try to !use &
 impl From<&TimelineDetails<Profile>> for ProfileDetails {
     fn from(details: &TimelineDetails<Profile>) -> Self {
         match details {

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -36,7 +36,7 @@ use matrix_sdk_ui::timeline::{
     TimelineUniqueId as SdkTimelineUniqueId,
 };
 use mime::Mime;
-use reply::{InReplyToDetails, RepliedToEventDetails};
+use reply::{EmbeddedEventDetails, InReplyToDetails};
 use ruma::{
     events::{
         location::{AssetType as RumaAssetType, LocationContent, ZoomLevel},
@@ -689,7 +689,7 @@ impl Timeline {
         match replied_to {
             Ok(Some(replied_to)) => Ok(Arc::new(InReplyToDetails::new(
                 event_id_str,
-                RepliedToEventDetails::Ready {
+                EmbeddedEventDetails::Ready {
                     content: replied_to.content().clone().into(),
                     sender: replied_to.sender().to_string(),
                     sender_profile: replied_to.sender_profile().into(),
@@ -698,12 +698,12 @@ impl Timeline {
 
             Ok(None) => Ok(Arc::new(InReplyToDetails::new(
                 event_id_str,
-                RepliedToEventDetails::Error { message: "unsupported event".to_owned() },
+                EmbeddedEventDetails::Error { message: "unsupported event".to_owned() },
             ))),
 
             Err(e) => Ok(Arc::new(InReplyToDetails::new(
                 event_id_str,
-                RepliedToEventDetails::Error { message: e.to_string() },
+                EmbeddedEventDetails::Error { message: e.to_string() },
             ))),
         }
     }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -692,7 +692,7 @@ impl Timeline {
                 EmbeddedEventDetails::Ready {
                     content: replied_to.content.clone().into(),
                     sender: replied_to.sender.to_string(),
-                    sender_profile: (&replied_to.sender_profile).into(),
+                    sender_profile: replied_to.sender_profile.into(),
                 },
             ))),
 
@@ -1103,7 +1103,7 @@ impl From<matrix_sdk_ui::timeline::EventTimelineItem> for EventTimelineItem {
             is_remote: !item.is_local_echo(),
             event_or_transaction_id: item.identifier().into(),
             sender: item.sender().to_string(),
-            sender_profile: item.sender_profile().into(),
+            sender_profile: item.sender_profile().clone().into(),
             is_own: item.is_own(),
             is_editable: item.is_editable(),
             content: item.content().clone().into(),
@@ -1144,14 +1144,13 @@ pub enum ProfileDetails {
     Error { message: String },
 }
 
-// TODO try to !use &
-impl From<&TimelineDetails<Profile>> for ProfileDetails {
-    fn from(details: &TimelineDetails<Profile>) -> Self {
+impl From<TimelineDetails<Profile>> for ProfileDetails {
+    fn from(details: TimelineDetails<Profile>) -> Self {
         match details {
             TimelineDetails::Unavailable => Self::Unavailable,
             TimelineDetails::Pending => Self::Pending,
             TimelineDetails::Ready(profile) => Self::Ready {
-                display_name: profile.display_name.clone(),
+                display_name: profile.display_name,
                 display_name_ambiguous: profile.display_name_ambiguous,
                 avatar_url: profile.avatar_url.as_ref().map(ToString::to_string),
             },

--- a/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
@@ -15,17 +15,16 @@
 use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::crypto::types::events::UtdCause;
-use matrix_sdk_ui::timeline::TimelineDetails;
 use ruma::events::{room::MediaSource as RumaMediaSource, EventContent};
 
 use super::{
-    content::{Reaction, TimelineItemContent},
-    reply::InReplyToDetails,
+    content::Reaction,
+    reply::{EmbeddedEventDetails, InReplyToDetails},
 };
 use crate::{
     error::ClientError,
     ruma::{ImageInfo, MediaSource, MediaSourceExt, Mentions, MessageType, PollKind},
-    timeline::{content::ReactionSenderData, ProfileDetails},
+    timeline::content::ReactionSenderData,
     utils::Timestamp,
 };
 
@@ -241,42 +240,22 @@ pub struct PollAnswer {
 
 #[derive(Clone, uniffi::Object)]
 pub struct ThreadSummary {
-    pub latest_event: ThreadSummaryLatestEventDetails,
+    pub latest_event: EmbeddedEventDetails,
     pub num_replies: usize,
 }
 
 #[matrix_sdk_ffi_macros::export]
 impl ThreadSummary {
-    pub fn latest_event(&self) -> ThreadSummaryLatestEventDetails {
+    pub fn latest_event(&self) -> EmbeddedEventDetails {
         self.latest_event.clone()
     }
 }
 
-#[derive(Clone, uniffi::Enum)]
-#[allow(clippy::large_enum_variant)]
-// TODO: unify with the FFI replied-to-event-details
-pub enum ThreadSummaryLatestEventDetails {
-    Unavailable,
-    Pending,
-    Ready { sender: String, sender_profile: ProfileDetails, content: TimelineItemContent },
-    Error { message: String },
-}
-
 impl From<matrix_sdk_ui::timeline::ThreadSummary> for ThreadSummary {
     fn from(value: matrix_sdk_ui::timeline::ThreadSummary) -> Self {
-        let latest_event = match value.latest_event {
-            TimelineDetails::Unavailable => ThreadSummaryLatestEventDetails::Unavailable,
-            TimelineDetails::Pending => ThreadSummaryLatestEventDetails::Pending,
-            TimelineDetails::Ready(event) => ThreadSummaryLatestEventDetails::Ready {
-                content: event.content.into(),
-                sender: event.sender.to_string(),
-                sender_profile: (&event.sender_profile).into(),
-            },
-            TimelineDetails::Error(message) => {
-                ThreadSummaryLatestEventDetails::Error { message: message.to_string() }
-            }
-        };
-
-        Self { latest_event, num_replies: value.num_replies }
+        Self {
+            latest_event: EmbeddedEventDetails::from(value.latest_event),
+            num_replies: value.num_replies,
+        }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
@@ -254,6 +254,7 @@ impl ThreadSummary {
 
 #[derive(Clone, uniffi::Enum)]
 #[allow(clippy::large_enum_variant)]
+// TODO: unify with the FFI replied-to-event-details
 pub enum ThreadSummaryLatestEventDetails {
     Unavailable,
     Pending,

--- a/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
@@ -242,6 +242,7 @@ pub struct PollAnswer {
 #[derive(Clone, uniffi::Object)]
 pub struct ThreadSummary {
     pub latest_event: ThreadSummaryLatestEventDetails,
+    pub num_replies: usize,
 }
 
 #[matrix_sdk_ffi_macros::export]
@@ -275,6 +276,6 @@ impl From<matrix_sdk_ui::timeline::ThreadSummary> for ThreadSummary {
             }
         };
 
-        Self { latest_event }
+        Self { latest_event, num_replies: value.num_replies }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/reply.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/reply.rs
@@ -59,14 +59,11 @@ impl From<TimelineDetails<Box<EmbeddedEvent>>> for EmbeddedEventDetails {
         match event {
             TimelineDetails::Unavailable => EmbeddedEventDetails::Unavailable,
             TimelineDetails::Pending => EmbeddedEventDetails::Pending,
-            TimelineDetails::Ready(event) => {
-                let sender_profile = event.sender_profile().into();
-                EmbeddedEventDetails::Ready {
-                    content: event.content.into(),
-                    sender: event.sender.to_string(),
-                    sender_profile,
-                }
-            }
+            TimelineDetails::Ready(event) => EmbeddedEventDetails::Ready {
+                content: event.content.into(),
+                sender: event.sender.to_string(),
+                sender_profile: (&event.sender_profile).into(),
+            },
             TimelineDetails::Error(err) => EmbeddedEventDetails::Error { message: err.to_string() },
         }
     }

--- a/bindings/matrix-sdk-ffi/src/timeline/reply.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/reply.rs
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use matrix_sdk_ui::timeline::TimelineDetails;
+use matrix_sdk_ui::timeline::{EmbeddedEvent, TimelineDetails};
 
 use super::{content::TimelineItemContent, ProfileDetails};
 
 #[derive(Clone, uniffi::Object)]
 pub struct InReplyToDetails {
     event_id: String,
-    event: RepliedToEventDetails,
+    event: EmbeddedEventDetails,
 }
 
 impl InReplyToDetails {
-    pub(crate) fn new(event_id: String, event: RepliedToEventDetails) -> Self {
+    pub(crate) fn new(event_id: String, event: EmbeddedEventDetails) -> Self {
         Self { event_id, event }
     }
 }
@@ -34,36 +34,40 @@ impl InReplyToDetails {
         self.event_id.clone()
     }
 
-    pub fn event(&self) -> RepliedToEventDetails {
+    pub fn event(&self) -> EmbeddedEventDetails {
         self.event.clone()
     }
 }
 
 impl From<matrix_sdk_ui::timeline::InReplyToDetails> for InReplyToDetails {
     fn from(inner: matrix_sdk_ui::timeline::InReplyToDetails) -> Self {
-        let event_id = inner.event_id.to_string();
-        let event = match &inner.event {
-            TimelineDetails::Unavailable => RepliedToEventDetails::Unavailable,
-            TimelineDetails::Pending => RepliedToEventDetails::Pending,
-            TimelineDetails::Ready(event) => RepliedToEventDetails::Ready {
-                content: event.content().clone().into(),
-                sender: event.sender().to_string(),
-                sender_profile: event.sender_profile().into(),
-            },
-            TimelineDetails::Error(err) => {
-                RepliedToEventDetails::Error { message: err.to_string() }
-            }
-        };
-
-        Self { event_id, event }
+        Self { event_id: inner.event_id.to_string(), event: inner.event.into() }
     }
 }
 
 #[derive(Clone, uniffi::Enum)]
 #[allow(clippy::large_enum_variant)]
-pub enum RepliedToEventDetails {
+pub enum EmbeddedEventDetails {
     Unavailable,
     Pending,
     Ready { content: TimelineItemContent, sender: String, sender_profile: ProfileDetails },
     Error { message: String },
+}
+
+impl From<TimelineDetails<Box<EmbeddedEvent>>> for EmbeddedEventDetails {
+    fn from(event: TimelineDetails<Box<EmbeddedEvent>>) -> Self {
+        match event {
+            TimelineDetails::Unavailable => EmbeddedEventDetails::Unavailable,
+            TimelineDetails::Pending => EmbeddedEventDetails::Pending,
+            TimelineDetails::Ready(event) => {
+                let sender_profile = event.sender_profile().into();
+                EmbeddedEventDetails::Ready {
+                    content: event.content.into(),
+                    sender: event.sender.to_string(),
+                    sender_profile,
+                }
+            }
+            TimelineDetails::Error(err) => EmbeddedEventDetails::Error { message: err.to_string() },
+        }
+    }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/reply.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/reply.rs
@@ -62,7 +62,7 @@ impl From<TimelineDetails<Box<EmbeddedEvent>>> for EmbeddedEventDetails {
             TimelineDetails::Ready(event) => EmbeddedEventDetails::Ready {
                 content: event.content.into(),
                 sender: event.sender.to_string(),
-                sender_profile: (&event.sender_profile).into(),
+                sender_profile: event.sender_profile.into(),
             },
             TimelineDetails::Error(err) => EmbeddedEventDetails::Error { message: err.to_string() },
         }

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -124,6 +124,11 @@ pub trait EventCacheStore: AsyncTraitDeps {
 
     /// Find all the events that relate to a given event.
     ///
+    /// Note: it doesn't process relations recursively: for instance, if
+    /// requesting only thread events, it will NOT return the aggregated
+    /// events affecting the returned events. It is the responsibility of
+    /// the caller to do so, if needed.
+    ///
     /// An additional filter can be provided to only retrieve related events for
     /// a certain relationship.
     async fn find_event_relations(

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -370,7 +370,7 @@ impl<'de> Deserialize<'de> for EncryptionInfo {
 /// - the number of replies to the thread,
 /// - the full event of the latest reply to the thread,
 /// - whether the user participated or not to this thread.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ThreadSummary {
     /// The number of replies to the thread.
     ///
@@ -381,7 +381,7 @@ pub struct ThreadSummary {
 }
 
 /// The status of a thread summary.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub enum ThreadSummaryStatus {
     /// We don't know if the event has a thread summary.
     #[default]

--- a/crates/matrix-sdk-common/src/serde_helpers.rs
+++ b/crates/matrix-sdk-common/src/serde_helpers.rs
@@ -16,7 +16,7 @@
 //! to access some fields.
 
 use ruma::{
-    events::{relation::BundledThread, AnySyncTimelineEvent},
+    events::{relation::BundledThread, AnyMessageLikeEvent, AnySyncTimelineEvent},
     serde::Raw,
     OwnedEventId, UInt,
 };
@@ -89,6 +89,18 @@ pub fn extract_bundled_thread_summary(event: &Raw<AnySyncTimelineEvent>) -> Thre
         }
         Ok(_) => ThreadSummaryStatus::None,
         Err(_) => ThreadSummaryStatus::Unknown,
+    }
+}
+
+/// Try to extract a bundled thread's latest event, if available.
+pub fn extract_bundled_latest_thread_event(
+    event: &Raw<AnySyncTimelineEvent>,
+) -> Option<Raw<AnyMessageLikeEvent>> {
+    match event.get_field::<Unsigned>("unsigned") {
+        Ok(Some(Unsigned { relations: Some(Relations { thread: Some(bundled_thread) }) })) => {
+            Some(bundled_thread.latest_event)
+        }
+        Ok(_) | Err(_) => None,
     }
 }
 

--- a/crates/matrix-sdk-common/src/serde_helpers.rs
+++ b/crates/matrix-sdk-common/src/serde_helpers.rs
@@ -18,7 +18,7 @@
 use ruma::{
     events::{relation::BundledThread, AnySyncTimelineEvent},
     serde::Raw,
-    OwnedEventId,
+    OwnedEventId, UInt,
 };
 use serde::Deserialize;
 
@@ -77,9 +77,12 @@ struct Unsigned {
 pub fn extract_bundled_thread_summary(event: &Raw<AnySyncTimelineEvent>) -> ThreadSummaryStatus {
     match event.get_field::<Unsigned>("unsigned") {
         Ok(Some(Unsigned { relations: Some(Relations { thread: Some(bundled_thread) }) })) => {
-            // Currently, we don't do anything with the bundled thread, but later we will!
-            let _ = bundled_thread;
-            ThreadSummaryStatus::Some(ThreadSummary {})
+            // Take the count from the bundled thread summary, if available. If it can't be
+            // converted to a `u64`, we use `UInt::MAX` as a fallback, as this is unlikely
+            // to happen to have that many events in real-world threads.
+            let count = bundled_thread.count.try_into().unwrap_or(UInt::MAX.try_into().unwrap());
+
+            ThreadSummaryStatus::Some(ThreadSummary { num_replies: count })
         }
         Ok(_) => ThreadSummaryStatus::None,
         Err(_) => ThreadSummaryStatus::Unknown,

--- a/crates/matrix-sdk-common/src/serde_helpers.rs
+++ b/crates/matrix-sdk-common/src/serde_helpers.rs
@@ -82,7 +82,10 @@ pub fn extract_bundled_thread_summary(event: &Raw<AnySyncTimelineEvent>) -> Thre
             // to happen to have that many events in real-world threads.
             let count = bundled_thread.count.try_into().unwrap_or(UInt::MAX.try_into().unwrap());
 
-            ThreadSummaryStatus::Some(ThreadSummary { num_replies: count })
+            let latest_reply =
+                bundled_thread.latest_event.get_field::<OwnedEventId>("event_id").ok().flatten();
+
+            ThreadSummaryStatus::Some(ThreadSummary { num_replies: count, latest_reply })
         }
         Ok(_) => ThreadSummaryStatus::None,
         Err(_) => ThreadSummaryStatus::Unknown,

--- a/crates/matrix-sdk-common/src/snapshots/snapshot_test_sync_timeline_event.snap
+++ b/crates/matrix-sdk-common/src/snapshots/snapshot_test_sync_timeline_event.snap
@@ -46,6 +46,8 @@ expression: "serde_json::to_value(&room_event).unwrap()"
     }
   },
   "thread_summary": {
-    "Some": {}
+    "Some": {
+      "num_replies": 2
+    }
   }
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -558,9 +558,9 @@ impl<'a> TimelineStateTransaction<'a> {
         // TODO: do something with the thread summary!
         let TimelineEvent { push_actions, kind, thread_summary } = event;
 
-        let thread_summary = thread_summary.summary().map(|_common_summary| {
-            // TODO: later, fill the latest event in the thread summary!
-            ThreadSummary { latest_event: TimelineDetails::Unavailable }
+        let thread_summary = thread_summary.summary().map(|summary| ThreadSummary {
+            latest_event: TimelineDetails::Unavailable,
+            num_replies: summary.num_replies,
         });
 
         let encryption_info = kind.encryption_info().cloned();

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -56,8 +56,8 @@ use super::{
         TimelineEventItemId,
     },
     traits::RoomDataProvider,
-    EncryptedMessage, EventTimelineItem, InReplyToDetails, MsgLikeContent, MsgLikeKind, OtherState,
-    ReactionStatus, RepliedToEvent, Sticker, ThreadSummary, TimelineDetails, TimelineItem,
+    EmbeddedEvent, EncryptedMessage, EventTimelineItem, InReplyToDetails, MsgLikeContent,
+    MsgLikeKind, OtherState, ReactionStatus, Sticker, ThreadSummary, TimelineDetails, TimelineItem,
     TimelineItemContent,
 };
 use crate::timeline::controller::aggregations::PendingEdit;
@@ -1205,7 +1205,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             trace!(reply_event_id = ?event_item.identifier(), "Updating response to updated event");
             let in_reply_to = InReplyToDetails {
                 event_id: in_reply_to.event_id.clone(),
-                event: TimelineDetails::Ready(Box::new(RepliedToEvent::from_timeline_item(
+                event: TimelineDetails::Ready(Box::new(EmbeddedEvent::from_timeline_item(
                     new_item,
                 ))),
             };

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -71,9 +71,9 @@ pub(in crate::timeline) use self::message::{
 };
 pub use self::{
     message::Message,
-    msg_like::{MsgLikeContent, MsgLikeKind, ThreadSummary, ThreadSummaryLatestEvent},
+    msg_like::{MsgLikeContent, MsgLikeKind, ThreadSummary},
     polls::{PollResult, PollState},
-    reply::{InReplyToDetails, RepliedToEvent},
+    reply::{EmbeddedEvent, InReplyToDetails},
 };
 use super::ReactionsByKeyBySender;
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/msg_like.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/msg_like.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use as_variant::as_variant;
-use ruma::{OwnedEventId, OwnedUserId};
+use ruma::OwnedEventId;
 
-use super::{EncryptedMessage, InReplyToDetails, Message, PollState, Sticker, TimelineItemContent};
-use crate::timeline::{Profile, ReactionsByKeyBySender, TimelineDetails};
+use super::{EmbeddedEvent, EncryptedMessage, InReplyToDetails, Message, PollState, Sticker};
+use crate::timeline::{ReactionsByKeyBySender, TimelineDetails};
 
 #[derive(Clone, Debug)]
 pub enum MsgLikeKind {
@@ -38,7 +38,7 @@ pub enum MsgLikeKind {
 
 #[derive(Clone, Debug)]
 pub struct ThreadSummary {
-    pub latest_event: TimelineDetails<Box<ThreadSummaryLatestEvent>>,
+    pub latest_event: TimelineDetails<Box<EmbeddedEvent>>,
 
     /// The number of events in the thread, except for the thread root.
     ///
@@ -48,13 +48,6 @@ pub struct ThreadSummary {
     /// thread-focused timeline with the same timeline filter may result in
     /// *fewer* events than this number.
     pub num_replies: usize,
-}
-
-#[derive(Clone, Debug)]
-pub struct ThreadSummaryLatestEvent {
-    pub content: TimelineItemContent,
-    pub sender: OwnedUserId,
-    pub sender_profile: TimelineDetails<Profile>,
 }
 
 /// A special kind of [`super::TimelineItemContent`] that groups together

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/msg_like.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/msg_like.rs
@@ -39,6 +39,15 @@ pub enum MsgLikeKind {
 #[derive(Clone, Debug)]
 pub struct ThreadSummary {
     pub latest_event: TimelineDetails<Box<ThreadSummaryLatestEvent>>,
+
+    /// The number of events in the thread, except for the thread root.
+    ///
+    /// This can be zero if all the events in the thread have been redacted.
+    ///
+    /// Note: this doesn't interact with the timeline filter; so opening a
+    /// thread-focused timeline with the same timeline filter may result in
+    /// *fewer* events than this number.
+    pub num_replies: usize,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -40,7 +40,7 @@ pub struct InReplyToDetails {
     /// unavailable.
     ///
     /// [`Timeline::fetch_details_for_event`]: crate::Timeline::fetch_details_for_event
-    pub event: TimelineDetails<Box<RepliedToEvent>>,
+    pub event: TimelineDetails<Box<EmbeddedEvent>>,
 }
 
 impl InReplyToDetails {
@@ -52,21 +52,26 @@ impl InReplyToDetails {
             .iter()
             .filter_map(|it| it.as_event())
             .find(|it| it.event_id() == Some(&*event_id))
-            .map(|item| Box::new(RepliedToEvent::from_timeline_item(item)));
+            .map(|item| Box::new(EmbeddedEvent::from_timeline_item(item)));
 
         InReplyToDetails { event_id, event: TimelineDetails::from_initial_value(event) }
     }
 }
 
-/// An event that is replied to.
+/// An event that is embedded in another event, such as a replied-to event, or a
+/// thread latest event.
 #[derive(Clone, Debug)]
-pub struct RepliedToEvent {
-    content: TimelineItemContent,
-    sender: OwnedUserId,
-    sender_profile: TimelineDetails<Profile>,
+pub struct EmbeddedEvent {
+    /// The content of the embedded item.
+    pub content: TimelineItemContent,
+    /// The user ID of the sender of the related embedded event.
+    pub sender: OwnedUserId,
+    /// The profile of the sender of the related embedded event.
+    pub sender_profile: TimelineDetails<Profile>,
 }
 
-impl RepliedToEvent {
+impl EmbeddedEvent {
+    // TODO: remove public getters
     /// Get the message of this event.
     pub fn content(&self) -> &TimelineItemContent {
         &self.content
@@ -82,7 +87,7 @@ impl RepliedToEvent {
         &self.sender_profile
     }
 
-    /// Create a [`RepliedToEvent`] from a loaded event timeline item.
+    /// Create a [`EmbeddedEvent`] from a loaded event timeline item.
     pub fn from_timeline_item(timeline_item: &EventTimelineItem) -> Self {
         Self {
             content: timeline_item.content.clone(),

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use imbl::Vector;
 use matrix_sdk::deserialized_responses::{TimelineEvent, UnsignedEventLocation};
-use ruma::{OwnedEventId, OwnedUserId, UserId};
+use ruma::{OwnedEventId, OwnedUserId};
 use tracing::{debug, instrument, warn};
 
 use super::TimelineItemContent;
@@ -71,22 +71,6 @@ pub struct EmbeddedEvent {
 }
 
 impl EmbeddedEvent {
-    // TODO: remove public getters
-    /// Get the message of this event.
-    pub fn content(&self) -> &TimelineItemContent {
-        &self.content
-    }
-
-    /// Get the sender of this event.
-    pub fn sender(&self) -> &UserId {
-        &self.sender
-    }
-
-    /// Get the profile of the sender.
-    pub fn sender_profile(&self) -> &TimelineDetails<Profile> {
-        &self.sender_profile
-    }
-
     /// Create a [`EmbeddedEvent`] from a loaded event timeline item.
     pub fn from_timeline_item(timeline_item: &EventTimelineItem) -> Self {
         Self {

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -51,10 +51,10 @@ pub(super) use self::{
 };
 pub use self::{
     content::{
-        AnyOtherFullStateEventContent, EncryptedMessage, InReplyToDetails, MemberProfileChange,
-        MembershipChange, Message, MsgLikeContent, MsgLikeKind, OtherState, PollResult, PollState,
-        RepliedToEvent, RoomMembershipChange, RoomPinnedEventsChange, Sticker, ThreadSummary,
-        ThreadSummaryLatestEvent, TimelineItemContent,
+        AnyOtherFullStateEventContent, EmbeddedEvent, EncryptedMessage, InReplyToDetails,
+        MemberProfileChange, MembershipChange, Message, MsgLikeContent, MsgLikeKind, OtherState,
+        PollResult, PollState, RoomMembershipChange, RoomPinnedEventsChange, Sticker,
+        ThreadSummary, TimelineItemContent,
     },
     local::EventSendState,
 };

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -81,12 +81,12 @@ pub use self::{
     controller::default_event_filter,
     error::*,
     event_item::{
-        AnyOtherFullStateEventContent, EncryptedMessage, EventItemOrigin, EventSendState,
-        EventTimelineItem, InReplyToDetails, MemberProfileChange, MembershipChange, Message,
-        MsgLikeContent, MsgLikeKind, OtherState, PollResult, PollState, Profile, ReactionInfo,
-        ReactionStatus, ReactionsByKeyBySender, RepliedToEvent, RoomMembershipChange,
-        RoomPinnedEventsChange, Sticker, ThreadSummary, ThreadSummaryLatestEvent, TimelineDetails,
-        TimelineEventItemId, TimelineItemContent,
+        AnyOtherFullStateEventContent, EmbeddedEvent, EncryptedMessage, EventItemOrigin,
+        EventSendState, EventTimelineItem, InReplyToDetails, MemberProfileChange, MembershipChange,
+        Message, MsgLikeContent, MsgLikeKind, OtherState, PollResult, PollState, Profile,
+        ReactionInfo, ReactionStatus, ReactionsByKeyBySender, RoomMembershipChange,
+        RoomPinnedEventsChange, Sticker, ThreadSummary, TimelineDetails, TimelineEventItemId,
+        TimelineItemContent,
     },
     event_type_filter::TimelineEventTypeFilter,
     item::{TimelineItem, TimelineItemKind, TimelineUniqueId},
@@ -697,7 +697,7 @@ impl Timeline {
     pub async fn make_replied_to(
         &self,
         event: TimelineEvent,
-    ) -> Result<Option<RepliedToEvent>, Error> {
+    ) -> Result<Option<EmbeddedEvent>, Error> {
         self.controller.make_replied_to(event).await
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -428,7 +428,7 @@ async fn test_reply() {
     let in_reply_to = in_reply_to.clone().unwrap();
     assert_eq!(in_reply_to.event_id, first_event_id);
     assert_let!(TimelineDetails::Ready(replied_to_event) = &in_reply_to.event);
-    assert_eq!(replied_to_event.sender(), *ALICE);
+    assert_eq!(replied_to_event.sender, *ALICE);
 }
 
 #[async_test]
@@ -470,7 +470,7 @@ async fn test_thread() {
     let in_reply_to = in_reply_to.clone().unwrap();
     assert_eq!(in_reply_to.event_id, first_event_id);
     assert_let!(TimelineDetails::Ready(replied_to_event) = &in_reply_to.event);
-    assert_eq!(replied_to_event.sender(), *ALICE);
+    assert_eq!(replied_to_event.sender, *ALICE);
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -873,7 +873,7 @@ async fn test_retry_decryption_updates_response() {
         assert_eq!(reply_details.event_id, original_event_id);
 
         let replied_to = as_variant!(&reply_details.event, TimelineDetails::Ready).unwrap();
-        assert!(replied_to.content().is_unable_to_decrypt());
+        assert!(replied_to.content.is_unable_to_decrypt());
     }
 
     // Import a room key backup.
@@ -908,7 +908,7 @@ async fn test_retry_decryption_updates_response() {
         assert_eq!(reply_details.event_id, original_event_id);
 
         let replied_to = as_variant!(&reply_details.event, TimelineDetails::Ready).unwrap();
-        assert_eq!(replied_to.content().as_message().unwrap().body(), "It's a secret to everybody");
+        assert_eq!(replied_to.content.as_message().unwrap().body(), "It's a secret to everybody");
     }
 
     // The event itself is decrypted.

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -437,4 +437,8 @@ impl RoomDataProvider for TestRoomDataProvider {
     ) -> Result<Relations, matrix_sdk::Error> {
         unimplemented!();
     }
+
+    async fn load_event<'a>(&'a self, _event_id: &'a EventId) -> matrix_sdk::Result<TimelineEvent> {
+        unimplemented!();
+    }
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -80,7 +80,7 @@ async fn test_redact_replied_to_event() {
     let msglike = second_item.content().as_msglike().unwrap();
     let in_reply_to = msglike.in_reply_to.clone().unwrap();
     assert_let!(TimelineDetails::Ready(replied_to_event) = &in_reply_to.event);
-    assert!(replied_to_event.content().is_message());
+    assert!(replied_to_event.content.is_message());
 
     timeline.handle_live_event(f.redaction(first_item.event_id().unwrap()).sender(&ALICE)).await;
 
@@ -94,7 +94,7 @@ async fn test_redact_replied_to_event() {
     let msglike = second_item_again.content().as_msglike().unwrap();
     let in_reply_to = msglike.in_reply_to.clone().unwrap();
     assert_let!(TimelineDetails::Ready(replied_to_event) = &in_reply_to.event);
-    assert!(replied_to_event.content().is_redacted());
+    assert!(replied_to_event.content.is_redacted());
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -145,6 +145,12 @@ pub(super) trait RoomDataProvider:
     ) -> impl Future<Output = Option<Arc<EncryptionInfo>>> + SendOutsideWasm;
 
     async fn relations(&self, event_id: OwnedEventId, opts: RelationsOptions) -> Result<Relations>;
+
+    /// Loads an event from the cache or network.
+    fn load_event<'a>(
+        &'a self,
+        event_id: &'a EventId,
+    ) -> impl Future<Output = Result<TimelineEvent>> + SendOutsideWasm + 'a;
 }
 
 impl RoomDataProvider for Room {
@@ -293,6 +299,10 @@ impl RoomDataProvider for Room {
 
     async fn relations(&self, event_id: OwnedEventId, opts: RelationsOptions) -> Result<Relations> {
         self.relations(event_id, opts).await
+    }
+
+    async fn load_event<'a>(&'a self, event_id: &'a EventId) -> Result<TimelineEvent> {
+        self.load_or_fetch_event(event_id, None).await
     }
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -462,7 +462,7 @@ async fn test_edit_to_replied_updates_reply() {
         assert_eq!(in_reply_to.event_id, eid1);
 
         assert_let!(TimelineDetails::Ready(replied_to) = &in_reply_to.event);
-        assert_eq!(replied_to.content().as_message().unwrap().body(), "bonjour");
+        assert_eq!(replied_to.content.as_message().unwrap().body(), "bonjour");
     });
 
     assert_next_matches!(timeline_stream, VectorDiff::PushBack { value: reply_item } => {
@@ -474,7 +474,7 @@ async fn test_edit_to_replied_updates_reply() {
         assert_eq!(in_reply_to.event_id, eid1);
 
         assert_let!(TimelineDetails::Ready(replied_to) = &in_reply_to.event);
-        assert_eq!(replied_to.content().as_message().unwrap().body(), "bonjour");
+        assert_eq!(replied_to.content.as_message().unwrap().body(), "bonjour");
     });
 
     server.mock_room_send().ok(event_id!("$edit_event")).mock_once().mount().await;
@@ -509,7 +509,7 @@ async fn test_edit_to_replied_updates_reply() {
         let in_reply_to = msglike.in_reply_to.clone().unwrap();
         assert_eq!(in_reply_to.event_id, eid1);
         assert_let!(TimelineDetails::Ready(replied_to) = &in_reply_to.event);
-        assert_eq!(replied_to.content().as_message().unwrap().body(), "hello world");
+        assert_eq!(replied_to.content.as_message().unwrap().body(), "hello world");
     });
 
     assert_next_matches!(timeline_stream, VectorDiff::Set { index: 2, value } => {
@@ -521,7 +521,7 @@ async fn test_edit_to_replied_updates_reply() {
         let in_reply_to = msglike.in_reply_to.clone().unwrap();
         assert_eq!(in_reply_to.event_id, eid1);
         assert_let!(TimelineDetails::Ready(replied_to) = &in_reply_to.event);
-        assert_eq!(replied_to.content().as_message().unwrap().body(), "hello world");
+        assert_eq!(replied_to.content.as_message().unwrap().body(), "hello world");
     });
 
     sleep(Duration::from_millis(200)).await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -349,9 +349,9 @@ async fn test_fetch_details_utd() {
         // The replied-to event is available, and is a UTD.
         let in_reply_to = in_reply_to.clone().unwrap();
         assert_let!(TimelineDetails::Ready(replied_to) = &in_reply_to.event);
-        assert_eq!(replied_to.sender(), *ALICE);
+        assert_eq!(replied_to.sender, *ALICE);
         assert_matches!(
-            replied_to.content(),
+            replied_to.content,
             TimelineItemContent::MsgLike(MsgLikeContent {
                 kind: MsgLikeKind::UnableToDecrypt(_),
                 ..
@@ -461,8 +461,8 @@ async fn test_fetch_details_poll() {
         // The replied-to event is available, and is the poll.
         let in_reply_to = in_reply_to.clone().unwrap();
         assert_let!(TimelineDetails::Ready(replied_to) = &in_reply_to.event);
-        assert_eq!(replied_to.sender(), *ALICE);
-        assert_let!(Some(poll_state) = replied_to.content().as_poll());
+        assert_eq!(replied_to.sender, *ALICE);
+        assert_let!(Some(poll_state) = replied_to.content.as_poll());
         assert_eq!(
             poll_state.fallback_text().unwrap(),
             "What is the best color? A. Red, B. Blue, C. Green"
@@ -572,8 +572,8 @@ async fn test_fetch_details_sticker() {
         // The replied-to event is available, and is a sticker.
         let in_reply_to = in_reply_to.clone().unwrap();
         assert_let!(TimelineDetails::Ready(replied_to) = &in_reply_to.event);
-        assert_eq!(replied_to.sender(), *ALICE);
-        assert_let!(Some(sticker) = replied_to.content().as_sticker());
+        assert_eq!(replied_to.sender, *ALICE);
+        assert_let!(Some(sticker) = replied_to.content.as_sticker());
         assert_eq!(sticker.content().body, "sticker!");
         assert_matches!(&sticker.content().source, StickerMediaSource::Plain(src) => {
             assert_eq!(*src, media_src);
@@ -894,7 +894,7 @@ async fn test_send_reply_to_threaded() {
     assert_eq!(in_reply_to.event_id, event_id_1);
 
     assert_let!(TimelineDetails::Ready(replied_to_event) = &in_reply_to.event);
-    assert_eq!(replied_to_event.sender(), *BOB);
+    assert_eq!(replied_to_event.sender, *BOB);
 
     // Wait for remote echo.
     let diff = timeout(timeline_stream.next(), Duration::from_secs(1)).await.unwrap().unwrap();
@@ -910,7 +910,7 @@ async fn test_send_reply_to_threaded() {
     assert_eq!(in_reply_to.event_id, event_id_1);
 
     assert_let!(TimelineDetails::Ready(replied_to_event) = &in_reply_to.event);
-    assert_eq!(replied_to_event.sender(), *BOB);
+    assert_eq!(replied_to_event.sender, *BOB);
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -312,7 +312,7 @@ async fn test_new_thread_reply_causes_thread_summary() {
     // info.
     let replied_to_details = value.as_event().unwrap().content().in_reply_to().unwrap().event;
     assert_let!(TimelineDetails::Ready(replied_to_event) = replied_to_details);
-    assert!(replied_to_event.content().thread_summary().is_none());
+    assert!(replied_to_event.content.thread_summary().is_none());
 
     // Since the replied-to item (the thread root) has been updated, all replies get
     // updated too, including the item we just pushed.
@@ -322,7 +322,7 @@ async fn test_new_thread_reply_causes_thread_summary() {
     let replied_to_details = value.as_event().unwrap().content().in_reply_to().unwrap().event;
     assert_let!(TimelineDetails::Ready(replied_to_event) = replied_to_details);
     // Spoiling a bit here…
-    assert!(replied_to_event.content().thread_summary().is_some());
+    assert!(replied_to_event.content.thread_summary().is_some());
 
     // And finally, the thread root event receives a thread summary.
     assert_let!(VectorDiff::Set { index: 1, value } = &timeline_updates[2]);
@@ -378,7 +378,7 @@ async fn test_new_thread_reply_causes_thread_summary() {
     let replied_to_details = value.as_event().unwrap().content().in_reply_to().unwrap().event;
     assert_let!(TimelineDetails::Ready(replied_to_event) = replied_to_details);
     // Spoiling a bit here…
-    assert_eq!(replied_to_event.content().thread_summary().unwrap().num_replies, 2);
+    assert_eq!(replied_to_event.content.thread_summary().unwrap().num_replies, 2);
 
     // Then, we receive an update for the thread root itself, which now has an
     // up-to-date thread summary.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -220,11 +220,6 @@ async fn test_extract_bundled_thread_summary() {
         .with_bundled_thread_summary(latest_event.raw().cast_ref().clone(), 42, false)
         .event_id(thread_event_id);
 
-    // Set up the /event for the latest thread event.
-    // FIXME(bnjbvr): shouldn't be necessary, the event cache could save the bundled
-    // latest event instead.
-    server.mock_room_event().match_event_id().ok(latest_event).mock_once().mount().await;
-
     server.sync_room(&client, JoinedRoomBuilder::new(room_id).add_timeline_event(event)).await;
 
     assert_let_timeout!(Some(timeline_updates) = stream.next());

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -352,7 +352,7 @@ impl RoomPagination {
         };
 
         let next_diffs = state
-            .with_events_mut(|room_events| {
+            .with_events_mut(false, |room_events| {
             // Reverse the order of the events as `/messages` has been called with `dir=b`
             // (backwards). The `RoomEvents` API expects the first event to be the oldest.
             // Let's re-order them for this block.

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1224,8 +1224,17 @@ mod private {
                 related_thread_events.len()
             };
 
-            target_event.thread_summary = ThreadSummaryStatus::Some(ThreadSummary { num_replies });
+            let new_summary = ThreadSummary { num_replies };
 
+            if let ThreadSummaryStatus::Some(existing) = &target_event.thread_summary {
+                if existing == &new_summary {
+                    trace!("thread summary is already up-to-date");
+                    return Ok(());
+                }
+            }
+
+            // Cause an update to observers.
+            target_event.thread_summary = ThreadSummaryStatus::Some(new_summary);
             self.replace_event_at(location, target_event).await?;
 
             Ok(())

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1302,6 +1302,9 @@ mod private {
                             self.events
                                 .replace_event_at(position, copy)
                                 .expect("should have been a valid position of an item");
+                            // We just changed the in-memory representation; synchronize this with
+                            // the store.
+                            self.propagate_changes().await?;
                         }
                         EventLocation::Store => self.save_event([copy]).await?,
                     }


### PR DESCRIPTION
Builds on top of #5153, only the last commit is relevant; drafting for now.

The hardship is that we're building a `TimelineEvent` out of the `Raw<AnyMessageLikeEvent>` included in the bundled thread summary, and as such we need to include the encryption information, which is… tricky and error-prone. I wonder if there's a way to do something simpler there.