### PR TITLE
feat(ffi): Expose method for sending galleries

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -32,6 +32,8 @@ Additions:
 - Add `Client::observe_account_data_event` and `Client::observe_room_account_data_event` to
   subscribe to global and room account data changes.
   ([#4994](https://github.com/matrix-org/matrix-rust-sdk/pull/4994))
+- Add `Timeline::send_gallery` to send MSC4274-style galleries.
+  ([#5163](https://github.com/matrix-org/matrix-rust-sdk/pull/5163))
 
 Breaking changes:
 

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -17,8 +17,9 @@ release = true
 crate-type = ["cdylib", "staticlib"]
 
 [features]
-default = ["bundled-sqlite", "matrix-sdk-ui/unstable-msc4274"]
+default = ["bundled-sqlite", "unstable-msc4274"]
 bundled-sqlite = ["matrix-sdk/bundled-sqlite"]
+unstable-msc4274 = ["matrix-sdk-ui/unstable-msc4274"]
 
 [dependencies]
 anyhow.workspace = true

--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -387,6 +387,8 @@ pub enum RoomMessageEventMessageType {
     Audio,
     Emote,
     File,
+    #[cfg(feature = "unstable-msc4274")]
+    Gallery,
     Image,
     Location,
     Notice,
@@ -403,6 +405,8 @@ impl From<RumaMessageType> for RoomMessageEventMessageType {
             RumaMessageType::Audio { .. } => Self::Audio,
             RumaMessageType::Emote { .. } => Self::Emote,
             RumaMessageType::File { .. } => Self::File,
+            #[cfg(feature = "unstable-msc4274")]
+            RumaMessageType::Gallery { .. } => Self::Gallery,
             RumaMessageType::Image { .. } => Self::Image,
             RumaMessageType::Location { .. } => Self::Location,
             RumaMessageType::Notice { .. } => Self::Notice,

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -1854,9 +1854,4 @@ mod galleries {
             })
         }
     }
-
-    #[uniffi::export]
-    pub fn formatted_body_from_html(body: String) -> FormattedBody {
-        FormattedBody::from(&RumaFormattedBody::html(body))
-    }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -1200,15 +1200,15 @@ impl TryFrom<PollData> for UnstablePollStartContentBlock {
 
 #[derive(uniffi::Object)]
 pub struct SendAttachmentJoinHandle {
-    join_hdl: Arc<Mutex<JoinHandle<Result<(), RoomError>>>>,
-    abort_hdl: AbortHandle,
+    join_handle: Arc<Mutex<JoinHandle<Result<(), RoomError>>>>,
+    abort_handle: AbortHandle,
 }
 
 impl SendAttachmentJoinHandle {
-    fn new(join_hdl: JoinHandle<Result<(), RoomError>>) -> Arc<Self> {
-        let abort_hdl = join_hdl.abort_handle();
-        let join_hdl = Arc::new(Mutex::new(join_hdl));
-        Arc::new(Self { join_hdl, abort_hdl })
+    fn new(join_handle: JoinHandle<Result<(), RoomError>>) -> Arc<Self> {
+        let abort_handle = join_handle.abort_handle();
+        let join_handle = Arc::new(Mutex::new(join_handle));
+        Arc::new(Self { join_handle, abort_handle })
     }
 }
 
@@ -1218,7 +1218,7 @@ impl SendAttachmentJoinHandle {
     ///
     /// If the sending had been cancelled, will return immediately.
     pub async fn join(&self) -> Result<(), RoomError> {
-        let handle = self.join_hdl.clone();
+        let handle = self.join_handle.clone();
         let mut locked_handle = handle.lock().await;
         let join_result = (&mut *locked_handle).await;
         match join_result {
@@ -1237,7 +1237,7 @@ impl SendAttachmentJoinHandle {
     ///
     /// A subsequent call to [`Self::join`] will return immediately.
     pub fn cancel(&self) {
-        self.abort_hdl.abort();
+        self.abort_handle.abort();
     }
 }
 
@@ -1562,15 +1562,15 @@ mod galleries {
 
     #[derive(uniffi::Object)]
     pub struct SendGalleryJoinHandle {
-        join_hdl: Arc<Mutex<JoinHandle<Result<(), RoomError>>>>,
-        abort_hdl: AbortHandle,
+        join_handle: Arc<Mutex<JoinHandle<Result<(), RoomError>>>>,
+        abort_handle: AbortHandle,
     }
 
     impl SendGalleryJoinHandle {
-        fn new(join_hdl: JoinHandle<Result<(), RoomError>>) -> Arc<Self> {
-            let abort_hdl = join_hdl.abort_handle();
-            let join_hdl = Arc::new(Mutex::new(join_hdl));
-            Arc::new(Self { join_hdl, abort_hdl })
+        fn new(join_handle: JoinHandle<Result<(), RoomError>>) -> Arc<Self> {
+            let abort_handle = join_handle.abort_handle();
+            let join_handle = Arc::new(Mutex::new(join_handle));
+            Arc::new(Self { join_handle, abort_handle })
         }
     }
 
@@ -1580,7 +1580,7 @@ mod galleries {
         ///
         /// If the sending had been cancelled, will return immediately.
         pub async fn join(&self) -> Result<(), RoomError> {
-            let handle = self.join_hdl.clone();
+            let handle = self.join_handle.clone();
             let mut locked_handle = handle.lock().await;
             let join_result = (&mut *locked_handle).await;
             match join_result {
@@ -1599,7 +1599,7 @@ mod galleries {
         ///
         /// A subsequent call to [`Self::join`] will return immediately.
         pub fn cancel(&self) {
-            self.abort_hdl.abort();
+            self.abort_handle.abort();
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/futures.rs
+++ b/crates/matrix-sdk-ui/src/timeline/futures.rs
@@ -100,11 +100,11 @@ pub use galleries::*;
 mod galleries {
     use std::future::IntoFuture;
 
-    use matrix_sdk::attachment::GalleryConfig;
     use matrix_sdk_base::boxed_into_future;
     use tracing::{Instrument as _, Span};
 
     use super::{Error, Timeline};
+    use crate::timeline::GalleryConfig;
 
     pub struct SendGallery<'a> {
         timeline: &'a Timeline,
@@ -127,7 +127,7 @@ mod galleries {
 
             let fut = async move {
                 let send_queue = timeline.room().send_queue();
-                let fut = send_queue.send_gallery(gallery);
+                let fut = send_queue.send_gallery(gallery.try_into()?);
                 fut.await.map_err(|_| Error::FailedSendingAttachment)?;
 
                 Ok(())

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -26,7 +26,7 @@ use futures::SendGallery;
 use futures_core::Stream;
 use imbl::Vector;
 #[cfg(feature = "unstable-msc4274")]
-use matrix_sdk::attachment::GalleryConfig;
+use matrix_sdk::attachment::{AttachmentInfo, Thumbnail};
 use matrix_sdk::{
     attachment::AttachmentConfig,
     deserialized_responses::TimelineEvent,
@@ -51,6 +51,11 @@ use ruma::{
         AnyMessageLikeEventContent, AnySyncTimelineEvent,
     },
     EventId, OwnedEventId, RoomVersionId, UserId,
+};
+#[cfg(feature = "unstable-msc4274")]
+use ruma::{
+    events::{room::message::FormattedBody, Mentions},
+    OwnedTransactionId,
 };
 use subscriber::TimelineWithDropHandle;
 use thiserror::Error;
@@ -828,5 +833,159 @@ where
 {
     fn from(value: P) -> Self {
         Self::File(value.into())
+    }
+}
+
+/// Configuration for sending a gallery.
+#[cfg(feature = "unstable-msc4274")]
+#[derive(Debug, Default)]
+pub struct GalleryConfig {
+    pub(crate) txn_id: Option<OwnedTransactionId>,
+    pub(crate) items: Vec<GalleryItemInfo>,
+    pub(crate) caption: Option<String>,
+    pub(crate) formatted_caption: Option<FormattedBody>,
+    pub(crate) mentions: Option<Mentions>,
+    pub(crate) reply: Option<Reply>,
+}
+
+#[cfg(feature = "unstable-msc4274")]
+impl GalleryConfig {
+    /// Create a new empty `GalleryConfig`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the transaction ID to send.
+    ///
+    /// # Arguments
+    ///
+    /// * `txn_id` - A unique ID that can be attached to a `MessageEvent` held
+    ///   in its unsigned field as `transaction_id`. If not given, one is
+    ///   created for the message.
+    #[must_use]
+    pub fn txn_id(mut self, txn_id: OwnedTransactionId) -> Self {
+        self.txn_id = Some(txn_id);
+        self
+    }
+
+    /// Adds a media item to the gallery.
+    ///
+    /// # Arguments
+    ///
+    /// * `item` - Information about the item to be added.
+    #[must_use]
+    pub fn add_item(mut self, item: GalleryItemInfo) -> Self {
+        self.items.push(item);
+        self
+    }
+
+    /// Set the optional caption.
+    ///
+    /// # Arguments
+    ///
+    /// * `caption` - The optional caption.
+    pub fn caption(mut self, caption: Option<String>) -> Self {
+        self.caption = caption;
+        self
+    }
+
+    /// Set the optional formatted caption.
+    ///
+    /// # Arguments
+    ///
+    /// * `formatted_caption` - The optional formatted caption.
+    pub fn formatted_caption(mut self, formatted_caption: Option<FormattedBody>) -> Self {
+        self.formatted_caption = formatted_caption;
+        self
+    }
+
+    /// Set the mentions of the message.
+    ///
+    /// # Arguments
+    ///
+    /// * `mentions` - The mentions of the message.
+    pub fn mentions(mut self, mentions: Option<Mentions>) -> Self {
+        self.mentions = mentions;
+        self
+    }
+
+    /// Set the reply information of the message.
+    ///
+    /// # Arguments
+    ///
+    /// * `reply` - The reply information of the message.
+    pub fn reply(mut self, reply: Option<Reply>) -> Self {
+        self.reply = reply;
+        self
+    }
+
+    /// Returns the number of media items in the gallery.
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Checks whether the gallery contains any media items or not.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+#[cfg(feature = "unstable-msc4274")]
+impl TryFrom<GalleryConfig> for matrix_sdk::attachment::GalleryConfig {
+    type Error = Error;
+
+    fn try_from(value: GalleryConfig) -> std::result::Result<Self, Self::Error> {
+        let mut config = matrix_sdk::attachment::GalleryConfig::new();
+
+        if let Some(txn_id) = value.txn_id {
+            config = config.txn_id(txn_id);
+        }
+
+        for item in value.items {
+            config = config.add_item(item.try_into()?);
+        }
+
+        config = config.caption(value.caption);
+        config = config.formatted_caption(value.formatted_caption);
+        config = config.mentions(value.mentions);
+        config = config.reply(value.reply);
+
+        Ok(config)
+    }
+}
+
+#[cfg(feature = "unstable-msc4274")]
+#[derive(Debug)]
+/// Metadata for a gallery item
+pub struct GalleryItemInfo {
+    /// The attachment source.
+    pub source: AttachmentSource,
+    /// The mime type.
+    pub content_type: Mime,
+    /// The attachment info.
+    pub attachment_info: AttachmentInfo,
+    /// The caption.
+    pub caption: Option<String>,
+    /// The formatted caption.
+    pub formatted_caption: Option<FormattedBody>,
+    /// The thumbnail.
+    pub thumbnail: Option<Thumbnail>,
+}
+
+#[cfg(feature = "unstable-msc4274")]
+impl TryFrom<GalleryItemInfo> for matrix_sdk::attachment::GalleryItemInfo {
+    type Error = Error;
+
+    fn try_from(value: GalleryItemInfo) -> std::result::Result<Self, Self::Error> {
+        let (data, filename) = value.source.try_into_bytes_and_filename()?;
+        Ok(matrix_sdk::attachment::GalleryItemInfo {
+            filename,
+            content_type: value.content_type,
+            data,
+            attachment_info: value.attachment_info,
+            caption: value.caption,
+            formatted_caption: value.formatted_caption,
+            thumbnail: value.thumbnail,
+        })
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -939,7 +939,7 @@ impl GalleryConfig {
 impl TryFrom<GalleryConfig> for matrix_sdk::attachment::GalleryConfig {
     type Error = Error;
 
-    fn try_from(value: GalleryConfig) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: GalleryConfig) -> Result<Self, Self::Error> {
         let mut config = matrix_sdk::attachment::GalleryConfig::new();
 
         if let Some(txn_id) = value.txn_id {
@@ -981,7 +981,7 @@ pub struct GalleryItemInfo {
 impl TryFrom<GalleryItemInfo> for matrix_sdk::attachment::GalleryItemInfo {
     type Error = Error;
 
-    fn try_from(value: GalleryItemInfo) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: GalleryItemInfo) -> Result<Self, Self::Error> {
         let (data, filename) = value.source.try_into_bytes_and_filename()?;
         Ok(matrix_sdk::attachment::GalleryItemInfo {
             filename,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -837,6 +837,11 @@ where
 }
 
 /// Configuration for sending a gallery.
+///
+/// This duplicates [`matrix_sdk::attachment::GalleryConfig`] but uses an
+/// `AttachmentSource` so that we can delay loading the actual data until we're
+/// inside the SendGallery future. This allows [`Timeline::send_gallery`] to
+/// return early without blocking the caller.
 #[cfg(feature = "unstable-msc4274")]
 #[derive(Debug, Default)]
 pub struct GalleryConfig {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
@@ -19,7 +19,7 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 #[cfg(feature = "unstable-msc4274")]
-use matrix_sdk::attachment::{AttachmentInfo, BaseFileInfo, GalleryConfig, GalleryItemInfo};
+use matrix_sdk::attachment::{AttachmentInfo, BaseFileInfo};
 use matrix_sdk::{
     assert_let_timeout,
     attachment::AttachmentConfig,
@@ -28,6 +28,8 @@ use matrix_sdk::{
 };
 use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE};
 use matrix_sdk_ui::timeline::{AttachmentSource, EventSendState, RoomExt};
+#[cfg(feature = "unstable-msc4274")]
+use matrix_sdk_ui::timeline::{GalleryConfig, GalleryItemInfo};
 #[cfg(feature = "unstable-msc4274")]
 use ruma::events::room::message::GalleryItemType;
 #[cfg(feature = "unstable-msc4274")]
@@ -328,9 +330,8 @@ async fn test_send_gallery_from_bytes() {
     // Queue sending of a gallery.
     let gallery =
         GalleryConfig::new().caption(Some("caption".to_owned())).add_item(GalleryItemInfo {
-            filename: filename.to_owned(),
+            source: AttachmentSource::Data { bytes: data, filename: filename.to_owned() },
             content_type: mime::TEXT_PLAIN,
-            data,
             attachment_info: AttachmentInfo::File(BaseFileInfo { size: None }),
             caption: Some("item caption".to_owned()),
             formatted_caption: None,


### PR DESCRIPTION
Addendum to https://github.com/matrix-org/matrix-rust-sdk/pull/5125 to allow sending galleries from the FFI crate. This is the final PR for galleries (apart from possible enhancements to report the upload status in https://github.com/matrix-org/matrix-rust-sdk/pull/5008).

This is somewhat lengthy again, apologies. Most of the changes are just wrappers and type mapping, however. So I was hoping that it's relatively straightforward to review in bulk. Happy to try and elaborate on the changes or break them up into smaller commits if that helps, however.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)
