### PR TITLE
refactor(sdk): extract a bundled thread's latest event as a `TimelineEvent`

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use assert_matches::assert_matches;
 use matrix_sdk_common::{
     deserialized_responses::{
-        AlgorithmInfo, DecryptedRoomEvent, EncryptionInfo, ThreadSummaryStatus, TimelineEvent,
-        TimelineEventKind, VerificationState,
+        AlgorithmInfo, DecryptedRoomEvent, EncryptionInfo, TimelineEvent, TimelineEventKind,
+        VerificationState,
     },
     linked_chunk::{lazy_loader, ChunkContent, ChunkIdentifier as CId, Position, Update},
 };
@@ -74,15 +74,10 @@ pub fn make_test_event_with_event_id(
     }
     let event = builder.into_raw_timeline().cast();
 
-    TimelineEvent {
-        kind: TimelineEventKind::Decrypted(DecryptedRoomEvent {
-            event,
-            encryption_info,
-            unsigned_encryption_info: None,
-        }),
-        push_actions: Some(vec![Action::Notify]),
-        thread_summary: ThreadSummaryStatus::Unknown,
-    }
+    TimelineEvent::from_decrypted(
+        DecryptedRoomEvent { event, encryption_info, unsigned_encryption_info: None },
+        Some(vec![Action::Notify]),
+    )
 }
 
 /// Check that an event created with [`make_test_event`] contains the expected
@@ -92,7 +87,7 @@ pub fn make_test_event_with_event_id(
 #[track_caller]
 pub fn check_test_event(event: &TimelineEvent, text: &str) {
     // Check push actions.
-    let actions = event.push_actions.as_ref().unwrap();
+    let actions = event.push_actions().unwrap();
     assert_eq!(actions.len(), 1);
     assert_matches!(&actions[0], Action::Notify);
 

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -629,7 +629,7 @@ mod tests {
             latest_event: LatestEvent,
         }
 
-        let event = TimelineEvent::new(
+        let event = TimelineEvent::from_plaintext(
             Raw::from_json_string(json!({ "event_id": "$1" }).to_string()).unwrap(),
         );
 

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -209,7 +209,7 @@ impl RoomReadReceipts {
         let mut has_notify = false;
         let mut has_mention = false;
 
-        let Some(actions) = event.push_actions.as_ref() else {
+        let Some(actions) = event.push_actions() else {
             return;
         };
 
@@ -711,7 +711,7 @@ mod tests {
                 .sender(user_id)
                 .event_id(event_id!("$ida"))
                 .into_event();
-            ev.push_actions = Some(push_actions);
+            ev.set_push_actions(push_actions);
             ev
         }
 

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
@@ -39,7 +39,8 @@ pub async fn sync_timeline_event(
     Ok(Some(
         match olm.try_decrypt_room_event(event.cast_ref(), room_id, &decryption_settings).await? {
             RoomEventDecryptionResult::Decrypted(decrypted) => {
-                let timeline_event = TimelineEvent::from(decrypted);
+                // Note: the push actions are set by the caller.
+                let timeline_event = TimelineEvent::from_decrypted(decrypted, None);
 
                 if let Ok(sync_timeline_event) = timeline_event.raw().deserialize() {
                     verification::process_if_relevant(&sync_timeline_event, e2ee, room_id).await?;

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
@@ -49,7 +49,7 @@ pub async fn sync_timeline_event(
                 timeline_event
             }
             RoomEventDecryptionResult::UnableToDecrypt(utd_info) => {
-                TimelineEvent::new_utd_event(event.clone(), utd_info)
+                TimelineEvent::from_utd(event.clone(), utd_info)
             }
         },
     ))

--- a/crates/matrix-sdk-base/src/response_processors/latest_event.rs
+++ b/crates/matrix-sdk-base/src/response_processors/latest_event.rs
@@ -118,7 +118,8 @@ async fn decrypt_sync_room_event(
         .await?
     {
         RoomEventDecryptionResult::Decrypted(decrypted) => {
-            let event: TimelineEvent = decrypted.into();
+            // We're fine not setting the push actions for the latest event.
+            let event = TimelineEvent::from_decrypted(decrypted, None);
 
             if let Ok(sync_timeline_event) = event.raw().deserialize() {
                 verification::process_if_relevant(&sync_timeline_event, e2ee.clone(), room_id)

--- a/crates/matrix-sdk-base/src/response_processors/latest_event.rs
+++ b/crates/matrix-sdk-base/src/response_processors/latest_event.rs
@@ -130,7 +130,7 @@ async fn decrypt_sync_room_event(
         }
 
         RoomEventDecryptionResult::UnableToDecrypt(utd_info) => {
-            TimelineEvent::new_utd_event(event.clone(), utd_info)
+            TimelineEvent::from_utd(event.clone(), utd_info)
         }
     };
 

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -197,7 +197,7 @@ pub mod builder {
 ///
 /// Updates the context data from `context.state_changes` or `room_info`.
 fn update_push_room_context(
-    context: &mut Context,
+    context: &Context,
     push_rules: &mut PushConditionRoomCtx,
     user_id: &UserId,
     room_info: &RoomInfo,
@@ -235,7 +235,7 @@ fn update_push_room_context(
 /// Returns `None` if some data couldn't be found. This should only happen
 /// in brand new rooms, while we process its state.
 pub async fn get_push_room_context(
-    context: &mut Context,
+    context: &Context,
     room: &Room,
     room_info: &RoomInfo,
     state_store: &BaseStateStore,

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -146,7 +146,7 @@ pub async fn build<'notification, 'e2ee>(
                         Action::should_notify,
                     );
 
-                    timeline_event.push_actions = Some(actions.to_owned());
+                    timeline_event.set_push_actions(actions.to_owned());
                 }
             }
             Err(error) => {

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -61,7 +61,7 @@ pub async fn build<'notification, 'e2ee>(
     for raw_event in timeline_inputs.raw_events {
         // Start by assuming we have a plaintext event. We'll replace it with a
         // decrypted or UTD event below if necessary.
-        let mut timeline_event = TimelineEvent::new(raw_event);
+        let mut timeline_event = TimelineEvent::from_plaintext(raw_event);
 
         // Do some special stuff on the `timeline_event` before collecting it.
         match timeline_event.raw().deserialize() {

--- a/crates/matrix-sdk-base/src/room/latest_event.rs
+++ b/crates/matrix-sdk-base/src/room/latest_event.rs
@@ -279,7 +279,7 @@ mod tests_with_e2e_encryption {
     }
 
     fn make_latest_event(event_id: &str) -> Box<LatestEvent> {
-        Box::new(LatestEvent::new(TimelineEvent::new(
+        Box::new(LatestEvent::new(TimelineEvent::from_plaintext(
             Raw::from_json_string(json!({ "event_id": event_id }).to_string()).unwrap(),
         )))
     }

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1204,7 +1204,7 @@ mod tests {
             last_prev_batch: Some("pb".to_owned()),
             sync_info: SyncInfo::FullySynced,
             encryption_state_synced: true,
-            latest_event: Some(Box::new(LatestEvent::new(TimelineEvent::new(
+            latest_event: Some(Box::new(LatestEvent::new(TimelineEvent::from_plaintext(
                 Raw::from_json_string(json!({"sender": "@u:i.uk"}).to_string()).unwrap(),
             )))),
             base_info: Box::new(

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -2514,7 +2514,7 @@ mod tests {
 
     #[cfg(feature = "e2e-encryption")]
     fn make_event(event_type: &str, id: &str) -> TimelineEvent {
-        TimelineEvent::new(make_raw_event(event_type, id))
+        TimelineEvent::from_plaintext(make_raw_event(event_type, id))
     }
 
     #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -2519,7 +2519,7 @@ mod tests {
 
     #[cfg(feature = "e2e-encryption")]
     fn make_encrypted_event(id: &str) -> TimelineEvent {
-        TimelineEvent::new_utd_event(
+        TimelineEvent::from_utd(
             Raw::from_json_string(
                 json!({
                     "type": "m.room.encrypted",

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -26,6 +26,7 @@ use ruma::{
     DeviceKeyAlgorithm, OwnedDeviceId, OwnedEventId, OwnedUserId,
 };
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 #[cfg(target_family = "wasm")]
 use wasm_bindgen::prelude::*;
 
@@ -454,6 +455,13 @@ pub struct TimelineEvent {
     /// If the event is part of a thread, a thread summary.
     #[serde(default, skip_serializing_if = "ThreadSummaryStatus::is_unknown")]
     pub thread_summary: ThreadSummaryStatus,
+
+    /// The bundled latest thread event, if it was provided in the unsigned
+    /// relations of this event.
+    ///
+    /// Not serialized.
+    #[serde(skip)]
+    pub bundled_latest_thread_event: Option<Box<TimelineEvent>>,
 }
 
 // Don't serialize push actions if they're `None` or an empty vec.
@@ -484,8 +492,11 @@ impl TimelineEvent {
     /// This is a convenience constructor for a plaintext event when you don't
     /// need to set `push_action`, for example inside a test.
     pub fn from_plaintext(event: Raw<AnySyncTimelineEvent>) -> Self {
-        let thread_summary = extract_bundled_thread_summary(&event);
-        Self { kind: TimelineEventKind::PlainText { event }, push_actions: None, thread_summary }
+        let (thread_summary, latest_thread_event) = extract_bundled_thread_summary(&event);
+        let kind = TimelineEventKind::PlainText { event };
+        let bundled_latest_thread_event =
+            Self::from_bundled_latest_event(&kind, latest_thread_event);
+        Self { kind, push_actions: None, thread_summary, bundled_latest_thread_event }
     }
 
     /// Create a new [`TimelineEvent`] from a decrypted event.
@@ -493,18 +504,96 @@ impl TimelineEvent {
         decrypted: DecryptedRoomEvent,
         push_actions: Option<Vec<Action>>,
     ) -> Self {
-        let thread_summary = extract_bundled_thread_summary(decrypted.event.cast_ref());
-        Self { kind: TimelineEventKind::Decrypted(decrypted), push_actions, thread_summary }
+        let (thread_summary, latest_thread_event) =
+            extract_bundled_thread_summary(decrypted.event.cast_ref());
+        let kind = TimelineEventKind::Decrypted(decrypted);
+        let bundled_latest_thread_event =
+            Self::from_bundled_latest_event(&kind, latest_thread_event);
+        Self { kind, push_actions, thread_summary, bundled_latest_thread_event }
     }
 
     /// Create a new [`TimelineEvent`] to represent the given decryption
     /// failure.
     pub fn from_utd(event: Raw<AnySyncTimelineEvent>, utd_info: UnableToDecryptInfo) -> Self {
-        let thread_summary = extract_bundled_thread_summary(&event);
-        Self {
-            kind: TimelineEventKind::UnableToDecrypt { event, utd_info },
-            push_actions: None,
-            thread_summary,
+        let (thread_summary, latest_thread_event) = extract_bundled_thread_summary(&event);
+        let kind = TimelineEventKind::UnableToDecrypt { event, utd_info };
+        let bundled_latest_thread_event =
+            Self::from_bundled_latest_event(&kind, latest_thread_event);
+        Self { kind, push_actions: None, thread_summary, bundled_latest_thread_event }
+    }
+
+    /// Try to create a new [`TimelineEvent`] for the bundled latest thread
+    /// event, if available, and if we have enough information about the
+    /// encryption status for it.
+    fn from_bundled_latest_event(
+        this: &TimelineEventKind,
+        latest_event: Option<Raw<AnyMessageLikeEvent>>,
+    ) -> Option<Box<Self>> {
+        let latest_event = latest_event?;
+
+        match this {
+            TimelineEventKind::Decrypted(decrypted) => {
+                if let Some(unsigned_decryption_result) =
+                    decrypted.unsigned_encryption_info.as_ref().and_then(|unsigned_map| {
+                        unsigned_map.get(&UnsignedEventLocation::RelationsThreadLatestEvent)
+                    })
+                {
+                    match unsigned_decryption_result {
+                        UnsignedDecryptionResult::Decrypted(encryption_info) => {
+                            // The bundled event was encrypted, and we could decrypt it: pass that
+                            // information around.
+                            return Some(Box::new(TimelineEvent::from_decrypted(
+                                DecryptedRoomEvent {
+                                    event: latest_event,
+                                    encryption_info: encryption_info.clone(),
+                                    // A bundled latest event is never a thread root. It could have
+                                    // a replacement event, but we don't carry this information
+                                    // around.
+                                    unsigned_encryption_info: None,
+                                },
+                                None,
+                            )));
+                        }
+
+                        UnsignedDecryptionResult::UnableToDecrypt(utd_info) => {
+                            // The bundled event was a UTD; store that information.
+                            return Some(Box::new(TimelineEvent::from_utd(
+                                latest_event.cast(),
+                                utd_info.clone(),
+                            )));
+                        }
+                    }
+                }
+            }
+
+            TimelineEventKind::UnableToDecrypt { .. } | TimelineEventKind::PlainText { .. } => {
+                // Figure based on the event type below.
+            }
+        }
+
+        let deserialized = match latest_event.deserialize() {
+            Ok(ev) => ev,
+            Err(err) => {
+                warn!("couldn't deserialize bundled latest thread event: {err}");
+                return None;
+            }
+        };
+
+        match deserialized {
+            AnyMessageLikeEvent::RoomEncrypted(_) => {
+                // The bundled latest thread event is encrypted, but we didn't have any
+                // information about it in the unsigned map. Provide some dummy
+                // UTD info, since we can't really do much better.
+                Some(Box::new(TimelineEvent::from_utd(
+                    latest_event.cast(),
+                    UnableToDecryptInfo {
+                        session_id: None,
+                        reason: UnableToDecryptReason::Unknown,
+                    },
+                )))
+            }
+
+            _ => Some(Box::new(TimelineEvent::from_plaintext(latest_event.cast()))),
         }
     }
 
@@ -588,18 +677,12 @@ impl<'de> Deserialize<'de> for TimelineEvent {
         }
         // Otherwise, it's V1
         else {
-            let mut v1: SyncTimelineEventDeserializationHelperV1 =
+            let v1: SyncTimelineEventDeserializationHelperV1 =
                 serde_json::from_value(Value::Object(value)).map_err(|e| {
                     serde::de::Error::custom(format!(
                         "Unable to deserialize V1-format TimelineEvent: {e}",
                     ))
                 })?;
-
-            // Try to figure whether there's a thread summary, if it was not already known.
-            if v1.thread_summary.is_unknown() {
-                v1.thread_summary = extract_bundled_thread_summary(v1.kind.raw());
-            }
-
             Ok(v1.into())
         }
     }
@@ -998,7 +1081,13 @@ struct SyncTimelineEventDeserializationHelperV1 {
 impl From<SyncTimelineEventDeserializationHelperV1> for TimelineEvent {
     fn from(value: SyncTimelineEventDeserializationHelperV1) -> Self {
         let SyncTimelineEventDeserializationHelperV1 { kind, push_actions, thread_summary } = value;
-        TimelineEvent { kind, push_actions: Some(push_actions), thread_summary }
+        TimelineEvent {
+            kind,
+            push_actions: Some(push_actions),
+            thread_summary,
+            // Bundled latest thread event is not persisted.
+            bundled_latest_thread_event: None,
+        }
     }
 }
 
@@ -1056,6 +1145,8 @@ impl From<SyncTimelineEventDeserializationHelperV0> for TimelineEvent {
             push_actions: Some(push_actions),
             // No serialized events had a thread summary at this version of the struct.
             thread_summary: ThreadSummaryStatus::Unknown,
+            // Bundled latest thread event is not persisted.
+            bundled_latest_thread_event: None,
         }
     }
 }
@@ -1236,6 +1327,7 @@ mod tests {
             }),
             push_actions: Default::default(),
             thread_summary: ThreadSummaryStatus::Unknown,
+            bundled_latest_thread_event: None,
         };
 
         let serialized = serde_json::to_value(&room_event).unwrap();
@@ -1410,10 +1502,7 @@ mod tests {
 
         let timeline_event: TimelineEvent =
             serde_json::from_value(serialized_timeline_item).unwrap();
-        assert_matches!(timeline_event.thread_summary, ThreadSummaryStatus::Some(ThreadSummary { num_replies, latest_reply }) => {
-            assert_eq!(num_replies, 2);
-            assert_eq!(latest_reply.as_deref(), Some(event_id!("$latest_event:example.com")));
-        });
+        assert_matches!(timeline_event.thread_summary, ThreadSummaryStatus::Unknown);
     }
 
     #[test]
@@ -1682,6 +1771,7 @@ mod tests {
                 num_replies: 2,
                 latest_reply: None,
             }),
+            bundled_latest_thread_event: None,
         };
 
         with_settings!({ sort_maps => true, prepend_module_to_snapshot => false }, {

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -483,7 +483,7 @@ impl TimelineEvent {
     ///
     /// This is a convenience constructor for a plaintext event when you don't
     /// need to set `push_action`, for example inside a test.
-    pub fn new(event: Raw<AnySyncTimelineEvent>) -> Self {
+    pub fn from_plaintext(event: Raw<AnySyncTimelineEvent>) -> Self {
         let thread_summary = extract_bundled_thread_summary(&event);
         Self { kind: TimelineEventKind::PlainText { event }, push_actions: None, thread_summary }
     }
@@ -1095,7 +1095,7 @@ mod tests {
 
     #[test]
     fn sync_timeline_debug_content() {
-        let room_event = TimelineEvent::new(Raw::new(&example_event()).unwrap().cast());
+        let room_event = TimelineEvent::from_plaintext(Raw::new(&example_event()).unwrap().cast());
         let debug_s = format!("{room_event:?}");
         assert!(
             !debug_s.contains("secret"),
@@ -1392,7 +1392,7 @@ mod tests {
 
         // When creating a timeline event from a raw event, the thread summary is always
         // extracted, if available.
-        let timeline_event = TimelineEvent::new(raw);
+        let timeline_event = TimelineEvent::from_plaintext(raw);
         assert_matches!(timeline_event.thread_summary, ThreadSummaryStatus::Some(ThreadSummary { num_replies, latest_reply }) => {
             assert_eq!(num_replies, 2);
             assert_eq!(latest_reply.as_deref(), Some(event_id!("$latest_event:example.com")));

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -499,7 +499,7 @@ impl TimelineEvent {
 
     /// Create a new [`TimelineEvent`] to represent the given decryption
     /// failure.
-    pub fn new_utd_event(event: Raw<AnySyncTimelineEvent>, utd_info: UnableToDecryptInfo) -> Self {
+    pub fn from_utd(event: Raw<AnySyncTimelineEvent>, utd_info: UnableToDecryptInfo) -> Self {
         let thread_summary = extract_bundled_thread_summary(&event);
         Self {
             kind: TimelineEventKind::UnableToDecrypt { event, utd_info },

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -492,11 +492,7 @@ impl TimelineEvent {
     /// This is a convenience constructor for a plaintext event when you don't
     /// need to set `push_action`, for example inside a test.
     pub fn from_plaintext(event: Raw<AnySyncTimelineEvent>) -> Self {
-        let (thread_summary, latest_thread_event) = extract_bundled_thread_summary(&event);
-        let kind = TimelineEventKind::PlainText { event };
-        let bundled_latest_thread_event =
-            Self::from_bundled_latest_event(&kind, latest_thread_event);
-        Self { kind, push_actions: None, thread_summary, bundled_latest_thread_event }
+        Self::new(TimelineEventKind::PlainText { event }, None)
     }
 
     /// Create a new [`TimelineEvent`] from a decrypted event.
@@ -504,22 +500,22 @@ impl TimelineEvent {
         decrypted: DecryptedRoomEvent,
         push_actions: Option<Vec<Action>>,
     ) -> Self {
-        let (thread_summary, latest_thread_event) =
-            extract_bundled_thread_summary(decrypted.event.cast_ref());
-        let kind = TimelineEventKind::Decrypted(decrypted);
-        let bundled_latest_thread_event =
-            Self::from_bundled_latest_event(&kind, latest_thread_event);
-        Self { kind, push_actions, thread_summary, bundled_latest_thread_event }
+        Self::new(TimelineEventKind::Decrypted(decrypted), push_actions)
     }
 
     /// Create a new [`TimelineEvent`] to represent the given decryption
     /// failure.
     pub fn from_utd(event: Raw<AnySyncTimelineEvent>, utd_info: UnableToDecryptInfo) -> Self {
-        let (thread_summary, latest_thread_event) = extract_bundled_thread_summary(&event);
-        let kind = TimelineEventKind::UnableToDecrypt { event, utd_info };
+        Self::new(TimelineEventKind::UnableToDecrypt { event, utd_info }, None)
+    }
+
+    /// Internal only: helps extracting a thread summary and latest thread event
+    /// when creating a new [`TimelineEvent`].
+    fn new(kind: TimelineEventKind, push_actions: Option<Vec<Action>>) -> Self {
+        let (thread_summary, latest_thread_event) = extract_bundled_thread_summary(kind.raw());
         let bundled_latest_thread_event =
             Self::from_bundled_latest_event(&kind, latest_thread_event);
-        Self { kind, push_actions: None, thread_summary, bundled_latest_thread_event }
+        Self { kind, push_actions, thread_summary, bundled_latest_thread_event }
     }
 
     /// Try to create a new [`TimelineEvent`] for the bundled latest thread

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -559,15 +559,6 @@ impl TimelineEvent {
     }
 }
 
-// Note: it's the responsibility of the caller to fill the `push_actions` field,
-// if necessary.
-impl From<DecryptedRoomEvent> for TimelineEvent {
-    fn from(decrypted: DecryptedRoomEvent) -> Self {
-        let thread_summary = extract_bundled_thread_summary(decrypted.event.cast_ref());
-        Self { kind: TimelineEventKind::Decrypted(decrypted), push_actions: None, thread_summary }
-    }
-}
-
 impl<'de> Deserialize<'de> for TimelineEvent {
     /// Custom deserializer for [`TimelineEvent`], to support older formats.
     ///

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -889,7 +889,7 @@ mod tests {
             .unwrap();
 
         // When we construct a timeline event from it
-        let event = TimelineEvent::new(raw_event.cast());
+        let event = TimelineEvent::from_plaintext(raw_event.cast());
         let timeline_item =
             EventTimelineItem::from_latest_event(client, room_id, LatestEvent::new(event))
                 .await

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -171,12 +171,14 @@ async fn test_edit_updates_encryption_info() {
         verification_state: VerificationState::Verified,
     });
 
-    let original_event: TimelineEvent = DecryptedRoomEvent {
-        event: original_event.cast(),
-        encryption_info: encryption_info.clone(),
-        unsigned_encryption_info: None,
-    }
-    .into();
+    let original_event = TimelineEvent::from_decrypted(
+        DecryptedRoomEvent {
+            event: original_event.cast(),
+            encryption_info: encryption_info.clone(),
+            unsigned_encryption_info: None,
+        },
+        None,
+    );
 
     timeline.handle_live_event(original_event).await;
 
@@ -200,12 +202,14 @@ async fn test_edit_updates_encryption_info() {
         .into_raw_timeline();
     Arc::make_mut(&mut encryption_info).verification_state =
         VerificationState::Unverified(VerificationLevel::UnverifiedIdentity);
-    let edit_event: TimelineEvent = DecryptedRoomEvent {
-        event: edit_event.cast(),
-        encryption_info: encryption_info.clone(),
-        unsigned_encryption_info: None,
-    }
-    .into();
+    let edit_event = TimelineEvent::from_decrypted(
+        DecryptedRoomEvent {
+            event: edit_event.cast(),
+            encryption_info: encryption_info.clone(),
+            unsigned_encryption_info: None,
+        },
+        None,
+    );
 
     timeline.handle_live_event(edit_event).await;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -626,22 +626,28 @@ async fn test_retry_fetching_encryption_info() {
 
     // But right now the timeline contains 2 events whose info says "unverified"
     // One is linked to SESSION_ID, the other is linked to some other session.
-    let timeline_event_this_session = TimelineEvent::from(DecryptedRoomEvent {
-        event: f.text_msg("foo").sender(sender).room(room_id).into_raw(),
-        encryption_info: make_encryption_info(
-            SESSION_ID,
-            VerificationState::Unverified(VerificationLevel::UnsignedDevice),
-        ),
-        unsigned_encryption_info: None,
-    });
-    let timeline_event_other_session = TimelineEvent::from(DecryptedRoomEvent {
-        event: f.text_msg("foo").sender(sender).room(room_id).into_raw(),
-        encryption_info: make_encryption_info(
-            "other_session_id",
-            VerificationState::Unverified(VerificationLevel::UnsignedDevice),
-        ),
-        unsigned_encryption_info: None,
-    });
+    let timeline_event_this_session = TimelineEvent::from_decrypted(
+        DecryptedRoomEvent {
+            event: f.text_msg("foo").sender(sender).room(room_id).into_raw(),
+            encryption_info: make_encryption_info(
+                SESSION_ID,
+                VerificationState::Unverified(VerificationLevel::UnsignedDevice),
+            ),
+            unsigned_encryption_info: None,
+        },
+        None,
+    );
+    let timeline_event_other_session = TimelineEvent::from_decrypted(
+        DecryptedRoomEvent {
+            event: f.text_msg("foo").sender(sender).room(room_id).into_raw(),
+            encryption_info: make_encryption_info(
+                "other_session_id",
+                VerificationState::Unverified(VerificationLevel::UnsignedDevice),
+            ),
+            unsigned_encryption_info: None,
+        },
+        None,
+    );
     timeline.handle_live_event(timeline_event_this_session).await;
     timeline.handle_live_event(timeline_event_other_session).await;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -947,7 +947,7 @@ fn utd_event_with_unsigned(unsigned: serde_json::Value) -> TimelineEvent {
         .unwrap(),
     );
 
-    TimelineEvent::new_utd_event(
+    TimelineEvent::from_utd(
         raw,
         matrix_sdk::deserialized_responses::UnableToDecryptInfo {
             session_id: Some("SESSION_ID".into()),

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -146,7 +146,7 @@ async fn test_hide_failed_to_parse() {
     // m.room.message events must have a msgtype and body in content, so this
     // event with an empty content object should fail to deserialize.
     timeline
-        .handle_live_event(TimelineEvent::new(sync_timeline_event!({
+        .handle_live_event(TimelineEvent::from_plaintext(sync_timeline_event!({
             "content": {},
             "event_id": "$eeG0HA0FAZ37wP8kXlNkxx3I",
             "origin_server_ts": 10,
@@ -158,7 +158,7 @@ async fn test_hide_failed_to_parse() {
     // Similar to above, the m.room.member state event must also not have an
     // empty content object.
     timeline
-        .handle_live_event(TimelineEvent::new(sync_timeline_event!({
+        .handle_live_event(TimelineEvent::from_plaintext(sync_timeline_event!({
             "content": {},
             "event_id": "$d5G0HA0FAZ37wP8kXlNkxx3I",
             "origin_server_ts": 2179,

--- a/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
@@ -60,7 +60,7 @@ async fn test_invalid_event_content() {
     // m.room.message events must have a msgtype and body in content, so this
     // event with an empty content object should fail to deserialize.
     timeline
-        .handle_live_event(TimelineEvent::new(sync_timeline_event!({
+        .handle_live_event(TimelineEvent::from_plaintext(sync_timeline_event!({
             "content": {},
             "event_id": "$eeG0HA0FAZ37wP8kXlNkxx3I",
             "origin_server_ts": 10,
@@ -79,7 +79,7 @@ async fn test_invalid_event_content() {
     // Similar to above, the m.room.member state event must also not have an
     // empty content object.
     timeline
-        .handle_live_event(TimelineEvent::new(sync_timeline_event!({
+        .handle_live_event(TimelineEvent::from_plaintext(sync_timeline_event!({
             "content": {},
             "event_id": "$d5G0HA0FAZ37wP8kXlNkxx3I",
             "origin_server_ts": 2179,
@@ -107,7 +107,7 @@ async fn test_invalid_event() {
     // This event is missing the sender field which the homeserver must add to
     // all timeline events. Because the event is malformed, it will be ignored.
     timeline
-        .handle_live_event(TimelineEvent::new(sync_timeline_event!({
+        .handle_live_event(TimelineEvent::from_plaintext(sync_timeline_event!({
             "content": {
                 "body": "hello world",
                 "msgtype": "m.text"

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -186,7 +186,7 @@ impl TestTimeline {
     }
 
     async fn handle_back_paginated_event(&self, event: Raw<AnyTimelineEvent>) {
-        let timeline_event = TimelineEvent::new(event.cast());
+        let timeline_event = TimelineEvent::from_plaintext(event.cast());
         self.controller
             .handle_remote_events_with_diffs(
                 vec![VectorDiff::PushFront { value: timeline_event }],

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -346,7 +346,7 @@ impl Decryptor for (matrix_sdk_base::crypto::OlmMachine, ruma::OwnedRoomId) {
                 Ok(TimelineEvent::from_decrypted(decrypted, push_actions))
             }
             RoomEventDecryptionResult::UnableToDecrypt(utd_info) => {
-                Ok(TimelineEvent::new_utd_event(raw.clone(), utd_info))
+                Ok(TimelineEvent::from_utd(raw.clone(), utd_info))
             }
         }
     }

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -337,23 +337,17 @@ impl Decryptor for (matrix_sdk_base::crypto::OlmMachine, ruma::OwnedRoomId) {
         let decryption_settings =
             DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
 
-        let mut timeline_event = match olm_machine
+        match olm_machine
             .try_decrypt_room_event(raw.cast_ref(), room_id, &decryption_settings)
             .await?
         {
             RoomEventDecryptionResult::Decrypted(decrypted) => {
-                TimelineEvent::from_decrypted(decrypted, None)
+                let push_actions = push_ctx.map(|push_ctx| push_ctx.for_event(&decrypted.event));
+                Ok(TimelineEvent::from_decrypted(decrypted, push_actions))
             }
             RoomEventDecryptionResult::UnableToDecrypt(utd_info) => {
-                TimelineEvent::new_utd_event(raw.clone(), utd_info)
+                Ok(TimelineEvent::new_utd_event(raw.clone(), utd_info))
             }
-        };
-
-        // Fill the push actions here, to mimic what `Room::decrypt_event` does.
-        if let Some(push_ctx) = push_ctx {
-            timeline_event.set_push_actions(push_ctx.for_event(timeline_event.raw()));
         }
-
-        Ok(timeline_event)
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -348,7 +348,9 @@ impl Decryptor for (matrix_sdk_base::crypto::OlmMachine, ruma::OwnedRoomId) {
         };
 
         // Fill the push actions here, to mimic what `Room::decrypt_event` does.
-        timeline_event.push_actions = push_ctx.map(|ctx| ctx.for_event(timeline_event.raw()));
+        if let Some(push_ctx) = push_ctx {
+            timeline_event.set_push_actions(push_ctx.for_event(timeline_event.raw()));
+        }
 
         Ok(timeline_event)
     }

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -341,7 +341,9 @@ impl Decryptor for (matrix_sdk_base::crypto::OlmMachine, ruma::OwnedRoomId) {
             .try_decrypt_room_event(raw.cast_ref(), room_id, &decryption_settings)
             .await?
         {
-            RoomEventDecryptionResult::Decrypted(decrypted) => decrypted.into(),
+            RoomEventDecryptionResult::Decrypted(decrypted) => {
+                TimelineEvent::from_decrypted(decrypted, None)
+            }
             RoomEventDecryptionResult::UnableToDecrypt(utd_info) => {
                 TimelineEvent::new_utd_event(raw.clone(), utd_info)
             }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -659,7 +659,7 @@ async fn mock_events_endpoint(
             .mock_room_event()
             .room(room_id.to_owned())
             .match_event_id()
-            .ok(TimelineEvent::new(event.cast()))
+            .ok(TimelineEvent::from_plaintext(event.cast()))
             .mount()
             .await;
     }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -213,17 +213,15 @@ async fn test_extract_bundled_thread_summary() {
     let f = EventFactory::new().room(room_id).sender(&ALICE);
     let thread_event_id = event_id!("$thread_root");
     let latest_event_id = event_id!("$latest_event");
-    let latest_event = f.text_msg("the last one!").event_id(latest_event_id).into_event();
 
     let event = f
         .text_msg("thready thread mcthreadface")
-        .with_bundled_thread_summary(latest_event.raw().cast_ref().clone(), 42, false)
+        .with_bundled_thread_summary(
+            f.text_msg("the last one!").event_id(latest_event_id).into_raw(),
+            42,
+            false,
+        )
         .event_id(thread_event_id);
-
-    // Set up the /event for the latest thread event.
-    // FIXME(bnjbvr): shouldn't be necessary, the event cache could save the bundled
-    // latest event instead.
-    server.mock_room_event().match_event_id().ok(latest_event).mock_once().mount().await;
 
     server.sync_room(&client, JoinedRoomBuilder::new(room_id).add_timeline_event(event)).await;
 

--- a/crates/matrix-sdk/src/event_cache/deduplicator.rs
+++ b/crates/matrix-sdk/src/event_cache/deduplicator.rs
@@ -286,7 +286,7 @@ mod tests {
         let ev2 = f.text_msg("how's it going").sender(*BOB).event_id(eid2).into_event();
         let ev3 = f.text_msg("wassup").sender(*ALICE).event_id(eid3).into_event();
         // An invalid event (doesn't have an event id.).
-        let ev4 = TimelineEvent::new(Raw::from_json_string("{}".to_owned()).unwrap());
+        let ev4 = TimelineEvent::from_plaintext(Raw::from_json_string("{}".to_owned()).unwrap());
 
         // Prefill the store with ev1 and ev2.
         event_cache_store

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1172,9 +1172,15 @@ mod private {
             // Update the store before doing the post-processing.
             self.propagate_changes().await?;
 
-            for event in &events_to_post_process {
-                self.maybe_apply_new_redaction(event).await?;
-                self.analyze_thread_root(event, is_live_sync).await?;
+            for event in events_to_post_process {
+                self.maybe_apply_new_redaction(&event).await?;
+
+                self.analyze_thread_root(&event, is_live_sync).await?;
+
+                // Save a bundled thread event, if there was one.
+                if let Some(bundled_thread) = event.bundled_latest_thread_event {
+                    self.save_event([*bundled_thread]).await?;
+                }
             }
 
             // If we've never waited for an initial previous-batch token, and we now have at

--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -408,7 +408,7 @@ impl Client {
 
             let raw_event = item.raw().json();
             let encryption_info = item.encryption_info().map(|i| &**i);
-            let push_actions = item.push_actions.as_deref().unwrap_or(&[]);
+            let push_actions = item.push_actions().unwrap_or(&[]);
 
             // Event handlers for possibly-redacted timeline events
             self.call_event_handlers(

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1501,11 +1501,15 @@ impl Room {
         let decryption_settings = DecryptionSettings {
             sender_device_trust_requirement: self.client.base_client().decryption_trust_requirement,
         };
+
         let mut event: TimelineEvent = match machine
             .try_decrypt_room_event(event.cast_ref(), self.inner.room_id(), &decryption_settings)
             .await?
         {
-            RoomEventDecryptionResult::Decrypted(decrypted) => decrypted.into(),
+            RoomEventDecryptionResult::Decrypted(decrypted) => {
+                // Note: the push actions are set just afterwards.
+                TimelineEvent::from_decrypted(decrypted, None)
+            }
             RoomEventDecryptionResult::UnableToDecrypt(utd_info) => {
                 self.client
                     .encryption()

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1515,7 +1515,7 @@ impl Room {
                     .encryption()
                     .backups()
                     .maybe_download_room_key(self.room_id().to_owned(), event.clone());
-                Ok(TimelineEvent::new_utd_event(event.clone().cast(), utd_info))
+                Ok(TimelineEvent::from_utd(event.clone().cast(), utd_info))
             }
         }
     }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -610,7 +610,7 @@ impl Room {
             }
         }
 
-        let mut event = TimelineEvent::new(event.cast());
+        let mut event = TimelineEvent::from_plaintext(event.cast());
         if let Some(push_ctx) = push_ctx {
             event.set_push_actions(push_ctx.for_event(event.raw()));
         }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -611,7 +611,9 @@ impl Room {
         }
 
         let mut event = TimelineEvent::new(event.cast());
-        event.push_actions = push_ctx.map(|ctx| ctx.for_event(event.raw()));
+        if let Some(push_ctx) = push_ctx {
+            event.set_push_actions(push_ctx.for_event(event.raw()));
+        }
 
         event
     }
@@ -1513,7 +1515,10 @@ impl Room {
             }
         };
 
-        event.push_actions = push_ctx.map(|ctx| ctx.for_event(event.raw()));
+        if let Some(push_ctx) = push_ctx {
+            event.set_push_actions(push_ctx.for_event(event.raw()));
+        }
+
         Ok(event)
     }
 

--- a/crates/matrix-sdk/src/room/reply.rs
+++ b/crates/matrix-sdk/src/room/reply.rs
@@ -336,7 +336,7 @@ mod tests {
 
         cache.events.insert(
             event_id.to_owned(),
-            TimelineEvent::new(
+            TimelineEvent::from_plaintext(
                 Raw::<AnySyncTimelineEvent>::from_json_string(
                     json!({
                         "content": {

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -649,7 +649,7 @@ async fn test_event() {
     );
     assert_eq!(event.event_id(), event_id);
 
-    let push_actions = timeline_event.push_actions.unwrap();
+    let push_actions = timeline_event.push_actions().unwrap();
     assert!(push_actions.iter().any(|a| a.is_highlight()));
     assert!(push_actions.iter().any(|a| a.should_notify()));
 

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -316,7 +316,7 @@ where
     }
 
     pub fn into_event(self) -> TimelineEvent {
-        TimelineEvent::new(self.into_raw_sync())
+        TimelineEvent::from_plaintext(self.into_raw_sync())
     }
 }
 

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -327,7 +327,7 @@ impl EventBuilder<RoomEncryptedEventContent> {
         let session_id = as_variant!(&self.content.scheme, EncryptedEventScheme::MegolmV1AesSha2)
             .map(|content| content.session_id.clone());
 
-        TimelineEvent::new_utd_event(
+        TimelineEvent::from_utd(
             self.into(),
             UnableToDecryptInfo {
                 session_id,


### PR DESCRIPTION
A few refactorings first around the `TimelineEvent` creation, which was a bit scattered and messy. Then, this patch makes it possible to extract a bundled thread's latest event as a `TimelineEvent`, and store it temporarily in the `TimelineEvent`; it's not persisted, since it's information that could in theory be recovered, and our only use case right now is saving it (the first time we observe it via sync/pagination) in the event cache, so it's sufficient and efficient to do it like this.

This is a followup to #5153, so part of #4869 and #5036.