### PR TITLE
SDK: Cache the RTC foci from the well-known file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4449,8 +4449,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d910a9b75cbf0e88f74295997c1a41c3ab7a117879a029c72db815192c167a0d"
+source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
 dependencies = [
  "assign",
  "js_int",
@@ -4466,8 +4465,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc4ff88a70a3d1e7a2c5b51cca7499cb889b42687608ab664b9a216c49314d"
+source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
 dependencies = [
  "as_variant",
  "assign",
@@ -4490,8 +4488,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b75da013b362664c3e161662902e5da3f77e990525681b59c6035bac27e87b4"
+source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
 dependencies = [
  "as_variant",
  "base64",
@@ -4523,8 +4520,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ab3d1b54c32a65194ecc44bc7f7575df50ef4255b139547d7dcc1753dc883d"
+source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4549,8 +4545,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373bc5a30b84574dfce3e75c33d79d6ba9843bf0eee1bf351f904eef9bea001a"
+source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
 dependencies = [
  "http",
  "js_int",
@@ -4564,8 +4559,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865afa2321e34fa836ea4c1d77ce0c2bb40f7d13fe18ee3e795091fd8d173a1d"
+source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4577,8 +4571,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad674b5e5368c53a2c90fde7dac7e30747004aaf7b1827b72874a25fc06d4d8"
+source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
 dependencies = [
  "js_int",
  "thiserror 2.0.11",
@@ -4587,8 +4580,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1182e83ee5cd10121974f163337b16af68a93eedfc7cdbdbd52307ac7e1d743"
+source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ reqwest = { version = "0.12.12", default-features = false }
 rmp-serde = "1.3.0"
 # Be careful to use commits from the https://github.com/ruma/ruma/tree/ruma-0.12
 # branch until a proper release with breaking changes happens.
-ruma = { version = "0.12.3", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -73,11 +73,12 @@ ruma = { version = "0.12.3", features = [
     "unstable-msc3489",
     "unstable-msc4075",
     "unstable-msc4140",
+    "unstable-msc4143",
     "unstable-msc4171",
     "unstable-msc4278",
     "unstable-msc4286",
-    ] }
-ruma-common = "0.15.2"
+] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a" }
 sentry = "0.36.0"
 sentry-tracing = "0.36.0"
 serde = { version = "1.0.217", features = ["rc"] }

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -23,6 +23,11 @@ All notable changes to this project will be documented in this file.
   In the future additional choices (such as session storage, `sqlite` and `indexeddb`) 
   will likely be added as well.
 
+Breaking changes:
+
+- `Client::reset_server_capabilities` has been renamed to `Client::reset_server_info`.
+  ([#5167](https://github.com/matrix-org/matrix-rust-sdk/pull/5167))
+
 ## [0.12.0] - 2025-06-10
 
 Breaking changes:
@@ -39,7 +44,6 @@ Breaking changes:
 - `RoomInfo` replaces its field `is_tombstoned: bool` with `tombstone: Option<RoomTombstoneInfo>`,
   containing the data needed to implement the room migration UI, a message and the replacement room id.
   ([#5027](https://github.com/matrix-org/matrix-rust-sdk/pull/5027))
-- `Client::reset_server_capabilities` has been renamed to `Client::reset_server_info`.
 
 Additions:
 

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -39,6 +39,7 @@ Breaking changes:
 - `RoomInfo` replaces its field `is_tombstoned: bool` with `tombstone: Option<RoomTombstoneInfo>`,
   containing the data needed to implement the room migration UI, a message and the replacement room id.
   ([#5027](https://github.com/matrix-org/matrix-rust-sdk/pull/5027))
+- `Client::reset_server_capabilities` has been renamed to `Client::reset_server_info`.
 
 Additions:
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -19,7 +19,10 @@ use matrix_sdk::{
     },
     ruma::{
         api::client::{
-            discovery::get_authorization_server_metadata::msc2965::Prompt as RumaOidcPrompt,
+            discovery::{
+                discover_homeserver::RtcFocusInfo,
+                get_authorization_server_metadata::msc2965::Prompt as RumaOidcPrompt,
+            },
             push::{EmailPusherData, PusherIds, PusherInit, PusherKind as RumaPusherKind},
             room::{create_room, Visibility},
             session::get_login_types,
@@ -1487,6 +1490,16 @@ impl Client {
     /// Checks if the server supports the report room API.
     pub async fn is_report_room_api_supported(&self) -> Result<bool, ClientError> {
         Ok(self.inner.server_versions().await?.contains(&ruma::api::MatrixVersion::V1_13))
+    }
+
+    /// Checks if the server supports the LiveKit RTC focus for placing calls.
+    pub async fn is_livekit_rtc_supported(&self) -> Result<bool, ClientError> {
+        Ok(self
+            .inner
+            .rtc_foci()
+            .await?
+            .iter()
+            .any(|focus| matches!(focus, RtcFocusInfo::LiveKit(_))))
     }
 
     /// Subscribe to changes in the media preview configuration.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -725,11 +725,11 @@ impl Client {
 
     /// Empty the server version and unstable features cache.
     ///
-    /// Since the SDK caches server capabilities (versions and unstable
-    /// features), it's possible to have a stale entry in the cache. This
-    /// functions makes it possible to force reset it.
-    pub async fn reset_server_capabilities(&self) -> Result<(), ClientError> {
-        Ok(self.inner.reset_server_capabilities().await?)
+    /// Since the SDK caches server info (versions, unstable features,
+    /// well-known etc), it's possible to have a stale entry in the cache.
+    /// This functions makes it possible to force reset it.
+    pub async fn reset_server_info(&self) -> Result<(), ClientError> {
+        Ok(self.inner.reset_server_info().await?)
     }
 }
 

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -52,6 +52,9 @@ No notable changes in this release.
   ([#4897](https://github.com/matrix-org/matrix-rust-sdk/pull/4897))
 - [**breaking**] `RoomInfo::prev_state` has been removed due to being useless.
   ([#5054](https://github.com/matrix-org/matrix-rust-sdk/pull/5054))
+- The cached `ServerCapabilities` has been renamed to `ServerInfo` and additionally contains
+  the well-known response alongside the existing server versions. Despite the old name, it
+  does not contain the server capabilities (yet?!).
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Refactor
+
+- The cached `ServerCapabilities` has been renamed to `ServerInfo` and
+  additionally contains the well-known response alongside the existing server versions.
+  Despite the old name, it does not contain the server capabilities.
+  ([#5167](https://github.com/matrix-org/matrix-rust-sdk/pull/5167))
+
 ## [0.12.0] - 2025-06-10
 
 No notable changes in this release.
@@ -52,9 +59,6 @@ No notable changes in this release.
   ([#4897](https://github.com/matrix-org/matrix-rust-sdk/pull/4897))
 - [**breaking**] `RoomInfo::prev_state` has been removed due to being useless.
   ([#5054](https://github.com/matrix-org/matrix-rust-sdk/pull/5054))
-- The cached `ServerCapabilities` has been renamed to `ServerInfo` and additionally contains
-  the well-known response alongside the existing server versions. Despite the old name, it
-  does not contain the server capabilities (yet?!).
 
 ## [0.10.0] - 2025-02-04
 

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -7,7 +7,10 @@ use assert_matches2::assert_let;
 use growable_bloom_filter::GrowableBloomBuilder;
 use matrix_sdk_test::{event_factory::EventFactory, test_json};
 use ruma::{
-    api::MatrixVersion,
+    api::{
+        client::discovery::discover_homeserver::{HomeserverInfo, RtcFocusInfo},
+        MatrixVersion,
+    },
     event_id,
     events::{
         presence::PresenceEvent,
@@ -34,7 +37,7 @@ use serde_json::{json, value::Value as JsonValue};
 
 use super::{
     send_queue::SentRequestKey, DependentQueuedRequestKind, DisplayName, DynStateStore,
-    RoomLoadSettings, ServerInfo,
+    RoomLoadSettings, ServerInfo, WellKnownResponse,
 };
 use crate::{
     deserialized_responses::MemberEvent,
@@ -477,6 +480,12 @@ impl StateStoreIntegrationTests for DynStateStore {
         let server_info = ServerInfo::new(
             versions.iter().map(|version| version.to_string()).collect(),
             [("org.matrix.experimental".to_owned(), true)].into(),
+            Some(WellKnownResponse {
+                homeserver: HomeserverInfo::new("matrix.example.com".to_owned()),
+                identity_server: None,
+                tile_server: None,
+                rtc_foci: vec![RtcFocusInfo::livekit("livekit.example.com".to_owned())],
+            }),
         );
 
         self.set_kv_data(

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -37,7 +37,7 @@ use tracing::{debug, instrument, warn};
 
 use super::{
     send_queue::{ChildTransactionId, QueuedRequest, SentRequestKey},
-    traits::{ComposerDraft, ServerCapabilities},
+    traits::{ComposerDraft, ServerInfo},
     DependentQueuedRequest, DependentQueuedRequestKind, QueuedRequestKind, Result, RoomInfo,
     RoomLoadSettings, StateChanges, StateStore, StoreError,
 };
@@ -54,7 +54,7 @@ struct MemoryStoreInner {
     composer_drafts: HashMap<(OwnedRoomId, Option<OwnedEventId>), ComposerDraft>,
     user_avatar_url: HashMap<OwnedUserId, OwnedMxcUri>,
     sync_token: Option<String>,
-    server_capabilities: Option<ServerCapabilities>,
+    server_info: Option<ServerInfo>,
     filters: HashMap<String, String>,
     utd_hook_manager_data: Option<GrowableBloom>,
     account_data: HashMap<GlobalAccountDataEventType, Raw<AnyGlobalAccountDataEvent>>,
@@ -149,8 +149,8 @@ impl StateStore for MemoryStore {
             StateStoreDataKey::SyncToken => {
                 inner.sync_token.clone().map(StateStoreDataValue::SyncToken)
             }
-            StateStoreDataKey::ServerCapabilities => {
-                inner.server_capabilities.clone().map(StateStoreDataValue::ServerCapabilities)
+            StateStoreDataKey::ServerInfo => {
+                inner.server_info.clone().map(StateStoreDataValue::ServerInfo)
             }
             StateStoreDataKey::Filter(filter_name) => {
                 inner.filters.get(filter_name).cloned().map(StateStoreDataValue::Filter)
@@ -222,11 +222,9 @@ impl StateStore for MemoryStore {
                     value.into_composer_draft().expect("Session data not a composer draft"),
                 );
             }
-            StateStoreDataKey::ServerCapabilities => {
-                inner.server_capabilities = Some(
-                    value
-                        .into_server_capabilities()
-                        .expect("Session data not containing server capabilities"),
+            StateStoreDataKey::ServerInfo => {
+                inner.server_info = Some(
+                    value.into_server_info().expect("Session data not containing server info"),
                 );
             }
             StateStoreDataKey::SeenKnockRequests(room_id) => {
@@ -246,7 +244,7 @@ impl StateStore for MemoryStore {
         let mut inner = self.inner.write().unwrap();
         match key {
             StateStoreDataKey::SyncToken => inner.sync_token = None,
-            StateStoreDataKey::ServerCapabilities => inner.server_capabilities = None,
+            StateStoreDataKey::ServerInfo => inner.server_info = None,
             StateStoreDataKey::Filter(filter_name) => {
                 inner.filters.remove(filter_name);
             }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -82,7 +82,7 @@ pub use self::{
     },
     traits::{
         ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, ServerInfo, StateStore,
-        StateStoreDataKey, StateStoreDataValue, StateStoreExt,
+        StateStoreDataKey, StateStoreDataValue, StateStoreExt, WellKnownResponse,
     },
 };
 

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -81,8 +81,8 @@ pub use self::{
         SentMediaInfo, SentRequestKey, SerializableEventContent,
     },
     traits::{
-        ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, ServerCapabilities,
-        StateStore, StateStoreDataKey, StateStoreDataValue, StateStoreExt,
+        ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, ServerInfo, StateStore,
+        StateStoreDataKey, StateStoreDataValue, StateStoreExt,
     },
 };
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -24,7 +24,7 @@ use async_trait::async_trait;
 use growable_bloom_filter::GrowableBloom;
 use matrix_sdk_common::AsyncTraitDeps;
 use ruma::{
-    api::MatrixVersion,
+    api::{client::discovery::get_supported_versions, MatrixVersion},
     events::{
         presence::PresenceEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
@@ -950,12 +950,11 @@ where
     }
 }
 
-/// Server capabilities returned by the /client/versions endpoint.
+/// Useful server info such as data returned by the /client/versions and
+/// .well-known/client/matrix endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ServerCapabilities {
+pub struct ServerInfo {
     /// Versions supported by the remote server.
-    ///
-    /// This contains [`MatrixVersion`]s converted to strings.
     pub versions: Vec<String>,
 
     /// List of unstable features and their enablement status.
@@ -966,33 +965,36 @@ pub struct ServerCapabilities {
     last_fetch_ts: f64,
 }
 
-impl ServerCapabilities {
+impl ServerInfo {
     /// The number of milliseconds after which the data is considered stale.
     pub const STALE_THRESHOLD: f64 = (1000 * 60 * 60 * 24 * 7) as _; // seven days
 
-    /// Encode server capabilities into this serializable struct.
-    pub fn new(versions: &[MatrixVersion], unstable_features: BTreeMap<String, bool>) -> Self {
-        Self {
-            versions: versions.iter().map(|item| item.to_string()).collect(),
-            unstable_features,
-            last_fetch_ts: now_timestamp_ms(),
-        }
+    /// Encode server info into this serializable struct.
+    pub fn new(versions: Vec<String>, unstable_features: BTreeMap<String, bool>) -> Self {
+        Self { versions, unstable_features, last_fetch_ts: now_timestamp_ms() }
     }
 
-    /// Decode server capabilities from this serializable struct.
+    /// Decode server info from this serializable struct.
     ///
     /// May return `None` if the data is considered stale, after
     /// [`Self::STALE_THRESHOLD`] milliseconds since the last time we stored
     /// it.
-    pub fn maybe_decode(&self) -> Option<(Vec<MatrixVersion>, BTreeMap<String, bool>)> {
+    pub fn maybe_decode(&self) -> Option<Self> {
         if now_timestamp_ms() - self.last_fetch_ts >= Self::STALE_THRESHOLD {
             None
         } else {
-            Some((
-                self.versions.iter().filter_map(|item| item.parse().ok()).collect(),
-                self.unstable_features.clone(),
-            ))
+            Some(self.clone())
         }
+    }
+
+    /// Extracts known Matrix versions from the un-typed list of strings.
+    ///
+    /// Note: Matrix versions that Ruma cannot parse, or does not know about,
+    /// are discarded.
+    pub fn known_versions(&self) -> Vec<MatrixVersion> {
+        get_supported_versions::Response::new(self.versions.clone())
+            .known_versions()
+            .collect::<Vec<_>>()
     }
 }
 
@@ -1011,8 +1013,8 @@ pub enum StateStoreDataValue {
     /// The sync token.
     SyncToken(String),
 
-    /// The server capabilities.
-    ServerCapabilities(ServerCapabilities),
+    /// The server info (versions, well-known etc).
+    ServerInfo(ServerInfo),
 
     /// A filter with the given ID.
     Filter(String),
@@ -1097,9 +1099,9 @@ impl StateStoreDataValue {
         as_variant!(self, Self::ComposerDraft)
     }
 
-    /// Get this value if it is the server capabilities metadata.
-    pub fn into_server_capabilities(self) -> Option<ServerCapabilities> {
-        as_variant!(self, Self::ServerCapabilities)
+    /// Get this value if it is the server info metadata.
+    pub fn into_server_info(self) -> Option<ServerInfo> {
+        as_variant!(self, Self::ServerInfo)
     }
 
     /// Get this value if it is the data for the ignored join requests.
@@ -1114,8 +1116,8 @@ pub enum StateStoreDataKey<'a> {
     /// The sync token.
     SyncToken,
 
-    /// The server capabilities,
-    ServerCapabilities,
+    /// The server info,
+    ServerInfo,
 
     /// A filter with the given name.
     Filter(&'a str),
@@ -1143,9 +1145,9 @@ pub enum StateStoreDataKey<'a> {
 impl StateStoreDataKey<'_> {
     /// Key to use for the [`SyncToken`][Self::SyncToken] variant.
     pub const SYNC_TOKEN: &'static str = "sync_token";
-    /// Key to use for the [`ServerCapabilities`][Self::ServerCapabilities]
+    /// Key to use for the [`ServerInfo`][Self::ServerInfo]
     /// variant.
-    pub const SERVER_CAPABILITIES: &'static str = "server_capabilities";
+    pub const SERVER_INFO: &'static str = "server_capabilities"; // Note: this is the old name, kept for backwards compatibility.
     /// Key prefix to use for the [`Filter`][Self::Filter] variant.
     pub const FILTER: &'static str = "filter";
     /// Key prefix to use for the [`UserAvatarUrl`][Self::UserAvatarUrl]
@@ -1171,21 +1173,21 @@ impl StateStoreDataKey<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::{now_timestamp_ms, ServerCapabilities};
+    use super::{now_timestamp_ms, ServerInfo};
 
     #[test]
-    fn test_stale_server_capabilities() {
-        let mut caps = ServerCapabilities {
+    fn test_stale_server_info() {
+        let mut server_info = ServerInfo {
             versions: Default::default(),
             unstable_features: Default::default(),
-            last_fetch_ts: now_timestamp_ms() - ServerCapabilities::STALE_THRESHOLD - 1.0,
+            last_fetch_ts: now_timestamp_ms() - ServerInfo::STALE_THRESHOLD - 1.0,
         };
 
         // Definitely stale.
-        assert!(caps.maybe_decode().is_none());
+        assert!(server_info.maybe_decode().is_none());
 
         // Definitely not stale.
-        caps.last_fetch_ts = now_timestamp_ms() - 1.0;
-        assert!(caps.maybe_decode().is_some());
+        server_info.last_fetch_ts = now_timestamp_ms() - 1.0;
+        assert!(server_info.maybe_decode().is_some());
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -27,7 +27,7 @@ use matrix_sdk_base::{
     store::{
         ChildTransactionId, ComposerDraft, DependentQueuedRequest, DependentQueuedRequestKind,
         QueuedRequest, QueuedRequestKind, RoomLoadSettings, SentRequestKey,
-        SerializableEventContent, ServerCapabilities, StateChanges, StateStore, StoreError,
+        SerializableEventContent, ServerInfo, StateChanges, StateStore, StoreError,
     },
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, StateStoreDataKey, StateStoreDataValue,
 };
@@ -400,10 +400,9 @@ impl IndexeddbStateStore {
             StateStoreDataKey::SyncToken => {
                 self.encode_key(StateStoreDataKey::SYNC_TOKEN, StateStoreDataKey::SYNC_TOKEN)
             }
-            StateStoreDataKey::ServerCapabilities => self.encode_key(
-                StateStoreDataKey::SERVER_CAPABILITIES,
-                StateStoreDataKey::SERVER_CAPABILITIES,
-            ),
+            StateStoreDataKey::ServerInfo => {
+                self.encode_key(StateStoreDataKey::SERVER_INFO, StateStoreDataKey::SERVER_INFO)
+            }
             StateStoreDataKey::Filter(filter_name) => {
                 self.encode_key(StateStoreDataKey::FILTER, (StateStoreDataKey::FILTER, filter_name))
             }
@@ -537,10 +536,10 @@ impl_state_store!({
                 .map(|f| self.deserialize_value::<String>(&f))
                 .transpose()?
                 .map(StateStoreDataValue::SyncToken),
-            StateStoreDataKey::ServerCapabilities => value
-                .map(|f| self.deserialize_value::<ServerCapabilities>(&f))
+            StateStoreDataKey::ServerInfo => value
+                .map(|f| self.deserialize_value::<ServerInfo>(&f))
                 .transpose()?
-                .map(StateStoreDataValue::ServerCapabilities),
+                .map(StateStoreDataValue::ServerInfo),
             StateStoreDataKey::Filter(_) => value
                 .map(|f| self.deserialize_value::<String>(&f))
                 .transpose()?
@@ -580,10 +579,8 @@ impl_state_store!({
         let serialized_value = match key {
             StateStoreDataKey::SyncToken => self
                 .serialize_value(&value.into_sync_token().expect("Session data not a sync token")),
-            StateStoreDataKey::ServerCapabilities => self.serialize_value(
-                &value
-                    .into_server_capabilities()
-                    .expect("Session data not containing server capabilities"),
+            StateStoreDataKey::ServerInfo => self.serialize_value(
+                &value.into_server_info().expect("Session data not containing server info"),
             ),
             StateStoreDataKey::Filter(_) => {
                 self.serialize_value(&value.into_filter().expect("Session data not a filter"))

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -410,9 +410,7 @@ impl SqliteStateStore {
     fn encode_state_store_data_key(&self, key: StateStoreDataKey<'_>) -> Key {
         let key_s = match key {
             StateStoreDataKey::SyncToken => Cow::Borrowed(StateStoreDataKey::SYNC_TOKEN),
-            StateStoreDataKey::ServerCapabilities => {
-                Cow::Borrowed(StateStoreDataKey::SERVER_CAPABILITIES)
-            }
+            StateStoreDataKey::ServerInfo => Cow::Borrowed(StateStoreDataKey::SERVER_INFO),
             StateStoreDataKey::Filter(f) => {
                 Cow::Owned(format!("{}:{f}", StateStoreDataKey::FILTER))
             }
@@ -1029,8 +1027,8 @@ impl StateStore for SqliteStateStore {
                     StateStoreDataKey::SyncToken => {
                         StateStoreDataValue::SyncToken(self.deserialize_value(&data)?)
                     }
-                    StateStoreDataKey::ServerCapabilities => {
-                        StateStoreDataValue::ServerCapabilities(self.deserialize_value(&data)?)
+                    StateStoreDataKey::ServerInfo => {
+                        StateStoreDataValue::ServerInfo(self.deserialize_value(&data)?)
                     }
                     StateStoreDataKey::Filter(_) => {
                         StateStoreDataValue::Filter(self.deserialize_value(&data)?)
@@ -1064,10 +1062,8 @@ impl StateStore for SqliteStateStore {
             StateStoreDataKey::SyncToken => self.serialize_value(
                 &value.into_sync_token().expect("Session data not a sync token"),
             )?,
-            StateStoreDataKey::ServerCapabilities => self.serialize_value(
-                &value
-                    .into_server_capabilities()
-                    .expect("Session data not containing server capabilities"),
+            StateStoreDataKey::ServerInfo => self.serialize_value(
+                &value.into_server_info().expect("Session data not containing server info"),
             )?,
             StateStoreDataKey::Filter(_) => {
                 self.serialize_value(&value.into_filter().expect("Session data not a filter"))?

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -189,7 +189,7 @@ impl SyncTaskSupervisor {
                 //
                 // Still, as a precaution, we're going to sleep here for a while in the Error
                 // case.
-                match client.fetch_server_capabilities(Some(request_config)).await {
+                match client.fetch_server_versions(Some(request_config)).await {
                     Ok(_) => break,
                     Err(_) => sleep(Duration::from_millis(100)).await,
                 }

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+- `ClientServerCapabilities` has been renamed to `ClientServerInfo`. Alongside this,
+  `Client::reset_server_info` is now `Client::reset_server_info` and `Client::fetch_server_capabilities`
+  is now `Client::fetch_server_versions`, returning the server versions response directly.
+  ([#5167](https://github.com/matrix-org/matrix-rust-sdk/pull/5167))
 - `Client::add_event_handler`: Set `Option<EncryptionInfo>` in `EventHandlerData` for to-device messages.
   If the to-device message was encrypted, the `EncryptionInfo` will be set. If it is `None` the message was sent in clear.
   ([#5099](https://github.com/matrix-org/matrix-rust-sdk/pull/5099))
@@ -78,9 +82,6 @@ All notable changes to this project will be documented in this file.
   ([#5047](https://github.com/matrix-org/matrix-rust-sdk/pull/5047))
 - `Room::set_unread_flag()` is now a no-op if the unread flag already has the wanted value.
   ([#5055](https://github.com/matrix-org/matrix-rust-sdk/pull/5055))
-- `ClientServerCapabilities` has been renamed to `ClientServerInfo`. Alongside this,
-  `Client::reset_server_info` is now `Client::reset_server_info` and `Client::fetch_server_capabilities`
-  is now `Client::fetch_server_versions`, returning the server versions response directly.
 
 ## [0.11.0] - 2025-04-11
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -78,6 +78,9 @@ All notable changes to this project will be documented in this file.
   ([#5047](https://github.com/matrix-org/matrix-rust-sdk/pull/5047))
 - `Room::set_unread_flag()` is now a no-op if the unread flag already has the wanted value.
   ([#5055](https://github.com/matrix-org/matrix-rust-sdk/pull/5055))
+- `ClientServerCapabilities` has been renamed to `ClientServerInfo`. Alongside this,
+  `Client::reset_server_info` is now `Client::reset_server_info` and `Client::fetch_server_capabilities`
+  is now `Client::fetch_server_versions`, returning the server versions response directly.
 
 ## [0.11.0] - 2025-04-11
 

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -516,7 +516,7 @@ async fn test_insecure_clients() -> anyhow::Result<()> {
     let server = MatrixMockServer::new().await;
     let server_url = server.server().uri();
 
-    server.mock_well_known().ok().expect(1).named("well_known").mount().await;
+    server.mock_well_known().ok().expect(1..).named("well_known").mount().await;
     server.mock_versions().ok().expect(1..).named("versions").mount().await;
 
     let oauth_server = server.oauth();

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -40,7 +40,7 @@ use crate::encryption::EncryptionSettings;
 use crate::http_client::HttpSettings;
 use crate::{
     authentication::{oauth::OAuthCtx, AuthCtx},
-    client::ClientServerCapabilities,
+    client::ClientServerInfo,
     config::RequestConfig,
     error::RumaApiError,
     http_client::HttpClient,
@@ -560,10 +560,8 @@ impl ClientBuilder {
         // Enable the send queue by default.
         let send_queue = Arc::new(SendQueueData::new(true));
 
-        let server_capabilities = ClientServerCapabilities {
-            server_versions: self.server_versions,
-            unstable_features: None,
-        };
+        let server_info =
+            ClientServerInfo { server_versions: self.server_versions, unstable_features: None };
 
         let event_cache = OnceCell::new();
         let inner = ClientInner::new(
@@ -573,7 +571,7 @@ impl ClientBuilder {
             sliding_sync_version,
             http_client,
             base_client,
-            server_capabilities,
+            server_info,
             self.respect_login_well_known,
             event_cache,
             send_queue,

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -40,7 +40,10 @@ use crate::encryption::EncryptionSettings;
 use crate::http_client::HttpSettings;
 use crate::{
     authentication::{oauth::OAuthCtx, AuthCtx},
-    client::ClientServerInfo,
+    client::{
+        CachedValue::{Cached, NotSet},
+        ClientServerInfo,
+    },
     config::RequestConfig,
     error::RumaApiError,
     http_client::HttpClient,
@@ -561,9 +564,12 @@ impl ClientBuilder {
         let send_queue = Arc::new(SendQueueData::new(true));
 
         let server_info = ClientServerInfo {
-            server_versions: self.server_versions,
-            unstable_features: None,
-            well_known: Some(well_known.map(Into::into)),
+            server_versions: match self.server_versions {
+                Some(versions) => Cached(versions),
+                None => NotSet,
+            },
+            unstable_features: NotSet,
+            well_known: Cached(well_known.map(Into::into)),
         };
 
         let event_cache = OnceCell::new();

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -563,7 +563,7 @@ impl ClientBuilder {
         let server_info = ClientServerInfo {
             server_versions: self.server_versions,
             unstable_features: None,
-            well_known: well_known.map(Into::into),
+            well_known: Some(well_known.map(Into::into)),
         };
 
         let event_cache = OnceCell::new();

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -525,7 +525,7 @@ impl ClientBuilder {
         let http_client = HttpClient::new(inner_http_client.clone(), self.request_config);
 
         #[allow(unused_variables)]
-        let HomeserverDiscoveryResult { server, homeserver, supported_versions } =
+        let HomeserverDiscoveryResult { server, homeserver, supported_versions, well_known } =
             homeserver_cfg.discover(&http_client).await?;
 
         let sliding_sync_version = {
@@ -560,8 +560,11 @@ impl ClientBuilder {
         // Enable the send queue by default.
         let send_queue = Arc::new(SendQueueData::new(true));
 
-        let server_info =
-            ClientServerInfo { server_versions: self.server_versions, unstable_features: None };
+        let server_info = ClientServerInfo {
+            server_versions: self.server_versions,
+            unstable_features: None,
+            well_known: well_known.map(Into::into),
+        };
 
         let event_cache = OnceCell::new();
         let inner = ClientInner::new(

--- a/crates/matrix-sdk/src/client/caches.rs
+++ b/crates/matrix-sdk/src/client/caches.rs
@@ -16,13 +16,13 @@ use matrix_sdk_base::ttl_cache::TtlCache;
 use ruma::api::client::discovery::get_authorization_server_metadata::msc2965::AuthorizationServerMetadata;
 use tokio::sync::RwLock;
 
-use super::ClientServerCapabilities;
+use super::ClientServerInfo;
 
 /// A collection of in-memory data that the `Client` might want to cache to
 /// avoid hitting the homeserver every time users request the data.
 pub(crate) struct ClientCaches {
-    /// Server capabilities, either prefilled during building or fetched from
-    /// the server.
-    pub(super) server_capabilities: RwLock<ClientServerCapabilities>,
+    /// Server info, either prefilled during building or fetched from the
+    /// server.
+    pub(super) server_info: RwLock<ClientServerInfo>,
     pub(crate) server_metadata: tokio::sync::Mutex<TtlCache<String, AuthorizationServerMetadata>>,
 }

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -410,7 +410,7 @@ async fn test_get_media_file_with_auth_matrix_stable_feature() {
 async fn test_async_media_upload() {
     let (client, server) = logged_in_client_with_server().await;
 
-    client.reset_server_capabilities().await.unwrap();
+    client.reset_server_info().await.unwrap();
 
     // Declare Matrix version v1.7.
     Mock::given(method("GET"))

--- a/testing/matrix-sdk-test/src/test_json/api_responses.rs
+++ b/testing/matrix-sdk-test/src/test_json/api_responses.rs
@@ -359,7 +359,13 @@ pub static WELL_KNOWN: Lazy<JsonValue> = Lazy::new(|| {
     json!({
         "m.homeserver": {
             "base_url": "HOMESERVER_URL"
-        }
+        },
+        "m.rtc_foci": [
+            {
+                "type": "livekit",
+                "livekit_service_url": "https://livekit.example.com",
+            }
+        ]
     })
 });
 


### PR DESCRIPTION
This PR makes the following changes:

- Refactor `ServerCapabilities` into `ServerInfo`
    - It had nothing to do with `/capabilities` and was confusing.
- Include the `/.well-known/matrix/client` response in the `ServerInfo` cache.
- Add `Client::rtc_foci` which uses the cached well-known.
- Add `Client::is_livekit_rtc_supported` to the FFI using the cache RTC foci.

Requires https://github.com/ruma/ruma/pull/2091 before merging