### PR TITLE
feat(wasm): Eliminate some unecessary wasm removals from matrix-sdk crate

### DIFF
--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -174,7 +174,7 @@ use error::{
     OAuthAuthorizationCodeError, OAuthClientRegistrationError, OAuthDiscoveryError,
     OAuthTokenRevocationError, RedirectUriQueryParseError,
 };
-#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
+#[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::types::qr_login::QrCodeData;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::once_cell::sync::OnceCell;
@@ -208,7 +208,7 @@ mod cross_process;
 pub mod error;
 mod http_client;
 mod oidc_discovery;
-#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
+#[cfg(feature = "e2e-encryption")]
 pub mod qrcode;
 pub mod registration;
 #[cfg(all(test, not(target_family = "wasm")))]
@@ -216,7 +216,7 @@ mod tests;
 
 #[cfg(feature = "e2e-encryption")]
 use self::cross_process::{CrossProcessRefreshLockGuard, CrossProcessRefreshManager};
-#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
+#[cfg(feature = "e2e-encryption")]
 use self::qrcode::LoginWithQrCode;
 pub use self::{
     account_management_url::{AccountManagementActionFull, AccountManagementUrlBuilder},
@@ -454,7 +454,7 @@ impl OAuth {
     /// println!("Successfully logged in: {:?} {:?}", client.user_id(), client.device_id());
     /// # anyhow::Ok(()) };
     /// ```
-    #[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
+    #[cfg(feature = "e2e-encryption")]
     pub fn login_with_qr_code<'a>(
         &'a self,
         data: &'a QrCodeData,
@@ -1154,7 +1154,7 @@ impl OAuth {
 
     /// Request codes from the authorization server for logging in with another
     /// device.
-    #[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
+    #[cfg(feature = "e2e-encryption")]
     async fn request_device_authorization(
         &self,
         server_metadata: &AuthorizationServerMetadata,
@@ -1182,7 +1182,7 @@ impl OAuth {
     }
 
     /// Exchange the device code against an access token.
-    #[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
+    #[cfg(feature = "e2e-encryption")]
     async fn exchange_device_code(
         &self,
         server_metadata: &AuthorizationServerMetadata,

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -16,9 +16,7 @@
 
 use std::{fmt::Debug, future::IntoFuture};
 
-use eyeball::SharedObservable;
-#[cfg(not(target_family = "wasm"))]
-use eyeball::Subscriber;
+use eyeball::{SharedObservable, Subscriber};
 use js_int::UInt;
 use matrix_sdk_common::{boxed_into_future, SendOutsideWasm, SyncOutsideWasm};
 use oauth2::{basic::BasicErrorResponseType, RequestTokenError};
@@ -71,7 +69,6 @@ impl<R> SendRequest<R> {
 
     /// Get a subscriber to observe the progress of sending the request
     /// body.
-    #[cfg(not(target_family = "wasm"))]
     pub fn subscribe_to_send_progress(&self) -> Subscriber<TransmissionProgress> {
         self.send_progress.subscribe()
     }

--- a/crates/matrix-sdk/src/encryption/futures.rs
+++ b/crates/matrix-sdk/src/encryption/futures.rs
@@ -19,9 +19,7 @@
 
 use std::{future::IntoFuture, io::Read};
 
-use eyeball::SharedObservable;
-#[cfg(not(target_family = "wasm"))]
-use eyeball::Subscriber;
+use eyeball::{SharedObservable, Subscriber};
 use matrix_sdk_common::boxed_into_future;
 use ruma::events::room::{EncryptedFile, EncryptedFileInit};
 
@@ -66,7 +64,6 @@ impl<'a, R: ?Sized> UploadEncryptedFile<'a, R> {
 
     /// Get a subscriber to observe the progress of sending the request
     /// body.
-    #[cfg(not(target_family = "wasm"))]
     pub fn subscribe_to_send_progress(&self) -> Subscriber<TransmissionProgress> {
         self.send_progress.subscribe()
     }

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -108,7 +108,7 @@ impl UserIdentity {
         Self { inner: identity, client }
     }
 
-    #[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
+    #[cfg(feature = "e2e-encryption")]
     pub(crate) fn underlying_identity(&self) -> CryptoUserIdentity {
         self.inner.clone()
     }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -723,7 +723,6 @@ impl Encryption {
         }
     }
 
-    #[cfg(not(target_family = "wasm"))]
     pub(crate) async fn import_secrets_bundle(
         &self,
         bundle: &matrix_sdk_base::crypto::types::SecretsBundle,
@@ -1691,7 +1690,6 @@ impl Encryption {
     /// **Warning**: Do not use this method if we're already calling
     /// [`Client::send_outgoing_request()`]. This method is intended for
     /// explicitly uploading the device keys before starting a sync.
-    #[cfg(not(target_family = "wasm"))]
     pub(crate) async fn ensure_device_keys_upload(&self) -> Result<()> {
         let olm = self.client.olm_machine().await;
         let olm = olm.as_ref().ok_or(Error::NoOlmMachine)?;

--- a/crates/matrix-sdk/src/room/identity_status_changes.rs
+++ b/crates/matrix-sdk/src/room/identity_status_changes.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Facility to track changes to the identity of members of rooms.
-#![cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
+#![cfg(feature = "e2e-encryption")]
 
 use std::collections::BTreeMap;
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -28,9 +28,9 @@ use eyeball::SharedObservable;
 use futures_core::Stream;
 use futures_util::{future::join_all, stream::FuturesUnordered};
 use http::StatusCode;
-#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
+#[cfg(feature = "e2e-encryption")]
 pub use identity_status_changes::IdentityStatusChanges;
-#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
+#[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::{IdentityStatusChange, RoomIdentityProvider, UserIdentity};
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::{
@@ -47,7 +47,7 @@ use matrix_sdk_base::{
     ComposerDraft, EncryptionState, RoomInfoNotableUpdateReasons, RoomMemberships, SendOutsideWasm,
     StateChanges, StateStoreDataKey, StateStoreDataValue,
 };
-#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
+#[cfg(feature = "e2e-encryption")]
 use matrix_sdk_common::BoxFuture;
 use matrix_sdk_common::{
     deserialized_responses::TimelineEvent,
@@ -583,7 +583,7 @@ impl Room {
     /// Note that if a user who is in pin violation leaves the room, a `Pinned`
     /// update is sent, to indicate that the warning should be removed, even
     /// though the user's identity is not necessarily pinned.
-    #[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
+    #[cfg(feature = "e2e-encryption")]
     pub async fn subscribe_to_identity_status_changes(
         &self,
     ) -> Result<impl Stream<Item = Vec<IdentityStatusChange>>> {
@@ -3709,7 +3709,7 @@ impl Room {
     }
 }
 
-#[cfg(all(feature = "e2e-encryption", not(target_family = "wasm")))]
+#[cfg(feature = "e2e-encryption")]
 impl RoomIdentityProvider for Room {
     fn is_member<'a>(&'a self, user_id: &'a UserId) -> BoxFuture<'a, bool> {
         Box::pin(async { self.get_member(user_id).await.unwrap_or(None).is_some() })
@@ -4019,7 +4019,7 @@ pub struct RoomMemberWithSenderInfo {
     pub sender_info: Option<RoomMember>,
 }
 
-#[cfg(all(test, not(target_family = "wasm")))]
+#[cfg(test)]
 mod tests {
     use matrix_sdk_base::{store::ComposerDraftType, ComposerDraft};
     use matrix_sdk_test::{


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Previously, some elements of eyeball streams + subscriptions did not function on wasm, so there were some platform specific cfg carve-outs in the matrix-sdk crate.  Support for that was added many months ago, making these features related to e2e encryption and streams compilable on wasm32-unknown-unknown platforms again.  

As we work to compile the matrix-sdk-ffi crate on wasm, this functionality will be needed.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
