### PR TITLE
feat(wasm): Enable subscribe_to_send_progress on wasm platforms

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/futures.rs
+++ b/crates/matrix-sdk-ui/src/timeline/futures.rs
@@ -49,7 +49,6 @@ impl<'a> SendAttachment<'a> {
     }
 
     /// Get a subscriber to observe the progress of sending the request body.
-    #[cfg(not(target_family = "wasm"))]
     pub fn subscribe_to_send_progress(&self) -> eyeball::Subscriber<TransmissionProgress> {
         self.send_progress.subscribe()
     }


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Similar to https://github.com/matrix-org/matrix-rust-sdk/pull/5169, subscriptions now support wasm making this cfg carve out unnecessary. 

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
