### PR TITLE
refactor(event cache): prepare the event cache for storing a linked chunk per thread

### DIFF
--- a/crates/matrix-sdk/src/event_cache/deduplicator.rs
+++ b/crates/matrix-sdk/src/event_cache/deduplicator.rs
@@ -18,100 +18,82 @@
 use std::collections::BTreeSet;
 
 use matrix_sdk_base::{event_cache::store::EventCacheStoreLock, linked_chunk::Position};
-use ruma::{OwnedEventId, OwnedRoomId};
+use ruma::{OwnedEventId, RoomId};
 
 use super::{
     room::events::{Event, RoomEvents},
     EventCacheError,
 };
 
-/// An events deduplication mechanism based on the persistent storage associated
-/// to the event cache.
-///
-/// It will use queries to the persistent storage to figure when events are
-/// duplicates or not, making it entirely stateless.
-pub struct Deduplicator {
-    /// The room this deduplicator applies to.
-    room_id: OwnedRoomId,
-    /// The actual event cache store implementation used to query events.
-    store: EventCacheStoreLock,
-}
+/// Find duplicates in the given collection of events, and return both
+/// valid events (those with an event id) as well as the event ids of
+/// duplicate events along with their position.
+pub async fn filter_duplicate_events(
+    room_id: &RoomId,
+    store: &EventCacheStoreLock,
+    mut events: Vec<Event>,
+    room_events: &RoomEvents,
+) -> Result<DeduplicationOutcome, EventCacheError> {
+    // Remove all events with no ID, or that is duplicated inside `events`, i.e.
+    // `events` contains duplicated events in itself, e.g. `[$e0, $e1, $e0]`, here
+    // `$e0` is duplicated in within `events`.
+    {
+        let mut event_ids = BTreeSet::new();
 
-impl Deduplicator {
-    /// Create a new instance of a [`StoreDeduplicator`].
-    pub fn new(room_id: OwnedRoomId, store: EventCacheStoreLock) -> Self {
-        Self { room_id, store }
-    }
+        events.retain(|event| {
+            let Some(event_id) = event.event_id() else {
+                // No event ID? Bye bye.
+                return false;
+            };
 
-    /// Find duplicates in the given collection of events, and return both
-    /// valid events (those with an event id) as well as the event ids of
-    /// duplicate events along with their position.
-    pub async fn filter_duplicate_events(
-        &self,
-        mut events: Vec<Event>,
-        room_events: &RoomEvents,
-    ) -> Result<DeduplicationOutcome, EventCacheError> {
-        // Remove all events with no ID, or that is duplicated inside `events`, i.e.
-        // `events` contains duplicated events in itself, e.g. `[$e0, $e1, $e0]`, here
-        // `$e0` is duplicated in within `events`.
-        {
-            let mut event_ids = BTreeSet::new();
-
-            events.retain(|event| {
-                let Some(event_id) = event.event_id() else {
-                    // No event ID? Bye bye.
-                    return false;
-                };
-
-                // Already seen this event in `events`? Bye bye.
-                if event_ids.contains(&event_id) {
-                    return false;
-                }
-
-                event_ids.insert(event_id);
-
-                // Let's keep this event!
-                true
-            });
-        }
-
-        let store = self.store.lock().await?;
-
-        // Let the store do its magic ✨
-        let duplicated_event_ids = store
-            .filter_duplicated_events(
-                &self.room_id,
-                events.iter().filter_map(|event| event.event_id()).collect(),
-            )
-            .await?;
-
-        // Separate duplicated events in two collections: ones that are in-memory, ones
-        // that are in the store.
-        let (in_memory_duplicated_event_ids, in_store_duplicated_event_ids) = {
-            // Collect all in-memory chunk identifiers.
-            let in_memory_chunk_identifiers =
-                room_events.chunks().map(|chunk| chunk.identifier()).collect::<Vec<_>>();
-
-            let mut in_memory = vec![];
-            let mut in_store = vec![];
-
-            for (duplicated_event_id, position) in duplicated_event_ids {
-                if in_memory_chunk_identifiers.contains(&position.chunk_identifier()) {
-                    in_memory.push((duplicated_event_id, position));
-                } else {
-                    in_store.push((duplicated_event_id, position));
-                }
+            // Already seen this event in `events`? Bye bye.
+            if event_ids.contains(&event_id) {
+                return false;
             }
 
-            (in_memory, in_store)
-        };
+            event_ids.insert(event_id);
 
-        Ok(DeduplicationOutcome {
-            all_events: events,
-            in_memory_duplicated_event_ids,
-            in_store_duplicated_event_ids,
-        })
+            // Let's keep this event!
+            true
+        });
     }
+
+    let store = store.lock().await?;
+
+    // Let the store do its magic ✨
+    let duplicated_event_ids = store
+        .filter_duplicated_events(
+            room_id,
+            events.iter().filter_map(|event| event.event_id()).collect(),
+        )
+        .await?;
+
+    // Separate duplicated events in two collections: ones that are in-memory, ones
+    // that are in the store.
+    let (in_memory_duplicated_event_ids, in_store_duplicated_event_ids) = {
+        // Collect all in-memory chunk identifiers.
+        let in_memory_chunk_identifiers =
+            room_events.chunks().map(|chunk| chunk.identifier()).collect::<Vec<_>>();
+
+        let mut in_memory = vec![];
+        let mut in_store = vec![];
+
+        for (duplicated_event_id, position) in duplicated_event_ids {
+            if in_memory_chunk_identifiers.contains(&position.chunk_identifier()) {
+                in_memory.push((duplicated_event_id, position));
+            } else {
+                in_store.push((duplicated_event_id, position));
+            }
+        }
+
+        (in_memory, in_store)
+    };
+
+    Ok(DeduplicationOutcome {
+        all_events: events,
+        in_memory_duplicated_event_ids,
+        in_store_duplicated_event_ids,
+    })
 }
 
 pub(super) struct DeduplicationOutcome {
@@ -214,17 +196,17 @@ mod tests {
 
         let event_cache_store = EventCacheStoreLock::new(event_cache_store, "hodor".to_owned());
 
-        let deduplicator = Deduplicator::new(room_id.to_owned(), event_cache_store);
         let mut room_events = RoomEvents::new();
         room_events.push_events([event_2.clone(), event_3.clone()]);
 
-        let outcome = deduplicator
-            .filter_duplicate_events(
-                vec![event_0, event_1, event_2, event_3, event_4],
-                &room_events,
-            )
-            .await
-            .unwrap();
+        let outcome = filter_duplicate_events(
+            room_id,
+            &event_cache_store,
+            vec![event_0, event_1, event_2, event_3, event_4],
+            &room_events,
+        )
+        .await
+        .unwrap();
 
         // The deduplication says 5 events are valid.
         assert_eq!(outcome.all_events.len(), 5);
@@ -321,17 +303,19 @@ mod tests {
         // Wrap the store into its lock.
         let event_cache_store = EventCacheStoreLock::new(event_cache_store, "hodor".to_owned());
 
-        let deduplicator = Deduplicator::new(room_id.to_owned(), event_cache_store);
-
         let room_events = RoomEvents::new();
         let DeduplicationOutcome {
             all_events: events,
             in_memory_duplicated_event_ids,
             in_store_duplicated_event_ids,
-        } = deduplicator
-            .filter_duplicate_events(vec![ev1, ev2, ev3, ev4], &room_events)
-            .await
-            .unwrap();
+        } = filter_duplicate_events(
+            room_id,
+            &event_cache_store,
+            vec![ev1, ev2, ev3, ev4],
+            &room_events,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(events.len(), 3);
         assert_eq!(events[0].event_id().as_deref(), Some(eid1));

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -17,18 +17,14 @@
 use std::{sync::Arc, time::Duration};
 
 use eyeball::{SharedObservable, Subscriber};
-use matrix_sdk_base::{
-    deserialized_responses::TimelineEvent, linked_chunk::ChunkIdentifier, timeout::timeout,
-};
+use matrix_sdk_base::timeout::timeout;
 use matrix_sdk_common::linked_chunk::ChunkContent;
 use ruma::api::Direction;
-use tokio::sync::RwLockWriteGuard;
 use tracing::{debug, instrument, trace};
 
 use super::{
-    deduplicator::DeduplicationOutcome,
     room::{events::Gap, LoadMoreEventsBackwardsOutcome, RoomEventCacheInner},
-    BackPaginationOutcome, EventsOrigin, Result, RoomEventCacheState, RoomEventCacheUpdate,
+    BackPaginationOutcome, EventsOrigin, Result, RoomEventCacheUpdate,
 };
 use crate::{event_cache::EventCacheError, room::MessagesOptions};
 
@@ -278,7 +274,7 @@ impl RoomPagination {
 
         // Make sure the `RoomEvents` isn't updated while we are saving events from
         // backpagination.
-        let state = self.inner.state.write().await;
+        let mut state = self.inner.state.write().await;
 
         // Check that the previous token still exists; otherwise it's a sign that the
         // room's timeline has been cleared.
@@ -302,161 +298,10 @@ impl RoomPagination {
             None
         };
 
-        self.handle_network_pagination_result(state, events, new_gap, prev_gap_chunk_id)
+        state
+            .handle_backpagination(events, new_gap, prev_gap_chunk_id, &self.inner.sender)
             .await
             .map(Some)
-    }
-
-    /// Handle the result of a successful network back-pagination.
-    async fn handle_network_pagination_result(
-        &self,
-        mut state: RwLockWriteGuard<'_, RoomEventCacheState>,
-        events: Vec<TimelineEvent>,
-        new_gap: Option<Gap>,
-        prev_gap_id: Option<ChunkIdentifier>,
-    ) -> Result<BackPaginationOutcome> {
-        // If there's no new previous gap, then we've reached the start of the timeline.
-        let network_reached_start = new_gap.is_none();
-
-        let (
-            DeduplicationOutcome {
-                all_events: mut events,
-                in_memory_duplicated_event_ids,
-                in_store_duplicated_event_ids,
-            },
-            all_duplicates,
-        ) = state.collect_valid_and_duplicated_events(events).await?;
-
-        // If not all the events have been back-paginated, we need to remove the
-        // previous ones, otherwise we can end up with misordered events.
-        //
-        // Consider the following scenario:
-        // - sync returns [D, E, F]
-        // - then sync returns [] with a previous batch token PB1, so the internal
-        //   linked chunk state is [D, E, F, PB1].
-        // - back-paginating with PB1 may return [A, B, C, D, E, F].
-        //
-        // Only inserting the new events when replacing PB1 would result in a timeline
-        // ordering of [D, E, F, A, B, C], which is incorrect. So we do have to remove
-        // all the events, in case this happens (see also #4746).
-
-        let mut event_diffs = if !all_duplicates {
-            // Let's forget all the previous events.
-            state
-                .remove_events(in_memory_duplicated_event_ids, in_store_duplicated_event_ids)
-                .await?
-        } else {
-            // All new events are duplicated, they can all be ignored.
-            events.clear();
-            Default::default()
-        };
-
-        let next_diffs = state
-            .with_events_mut(false, |room_events| {
-            // Reverse the order of the events as `/messages` has been called with `dir=b`
-            // (backwards). The `RoomEvents` API expects the first event to be the oldest.
-            // Let's re-order them for this block.
-            let reversed_events = events
-                .iter()
-                .rev()
-                .cloned()
-                .collect::<Vec<_>>();
-
-            let first_event_pos = room_events.events().next().map(|(item_pos, _)| item_pos);
-
-            // First, insert events.
-            let insert_new_gap_pos = if let Some(gap_id) = prev_gap_id {
-                // There is a prior gap, let's replace it by new events!
-                if all_duplicates {
-                    assert!(reversed_events.is_empty());
-                }
-
-                trace!("replacing previous gap with the back-paginated events");
-
-                // Replace the gap with the events we just deduplicated. This might get rid of the
-                // underlying gap, if the conditions are favorable to us.
-                room_events.replace_gap_at(reversed_events.clone(), gap_id)
-                    .expect("gap_identifier is a valid chunk id we read previously")
-            } else if let Some(pos) = first_event_pos {
-                // No prior gap, but we had some events: assume we need to prepend events
-                // before those.
-                trace!("inserted events before the first known event");
-
-                room_events
-                    .insert_events_at(reversed_events.clone(), pos)
-                    .expect("pos is a valid position we just read above");
-
-                Some(pos)
-            } else {
-                // No prior gap, and no prior events: push the events.
-                trace!("pushing events received from back-pagination");
-
-                room_events.push_events(reversed_events.clone());
-
-                // A new gap may be inserted before the new events, if there are any.
-                room_events.events().next().map(|(item_pos, _)| item_pos)
-            };
-
-            // And insert the new gap if needs be.
-            //
-            // We only do this when at least one new, non-duplicated event, has been added to
-            // the chunk. Otherwise it means we've back-paginated all the known events.
-            if !all_duplicates {
-                if let Some(new_gap) = new_gap {
-                    if let Some(new_pos) = insert_new_gap_pos {
-                        room_events
-                            .insert_gap_at(new_gap, new_pos)
-                            .expect("events_chunk_pos represents a valid chunk position");
-                    } else {
-                        room_events.push_gap(new_gap);
-                    }
-                }
-            } else {
-                debug!("not storing previous batch token, because we deduplicated all new back-paginated events");
-            }
-
-            reversed_events
-        })
-        .await?;
-
-        event_diffs.extend(next_diffs);
-
-        // There could be an inconsistency between the network (which thinks we hit the
-        // start of the timeline) and the disk (which has the initial empty
-        // chunks), so tweak the `reached_start` value so that it reflects the disk
-        // state in priority instead.
-        let reached_start = {
-            // There are no gaps.
-            let has_gaps = state.events().chunks().any(|chunk| chunk.is_gap());
-
-            // The first chunk has no predecessors.
-            let first_chunk_is_definitive_head =
-                state.events().chunks().next().map(|chunk| chunk.is_definitive_head());
-
-            let reached_start =
-                !has_gaps && first_chunk_is_definitive_head.unwrap_or(network_reached_start);
-
-            trace!(
-                ?network_reached_start,
-                ?has_gaps,
-                ?first_chunk_is_definitive_head,
-                ?reached_start,
-                "finished handling network back-pagination"
-            );
-
-            reached_start
-        };
-
-        let backpagination_outcome = BackPaginationOutcome { events, reached_start };
-
-        if !event_diffs.is_empty() {
-            let _ = self.inner.sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
-                diffs: event_diffs,
-                origin: EventsOrigin::Pagination,
-            });
-        }
-
-        Ok(backpagination_outcome)
     }
 
     /// Returns a subscriber to the pagination status used for the

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1203,38 +1203,39 @@ mod private {
             };
 
             // Replace the redacted event by a redacted form, if we knew about it.
-            if let Some((location, mut target_event)) = self.find_event(event_id).await? {
-                // Don't redact already redacted events.
-                if let Ok(deserialized) = target_event.raw().deserialize() {
-                    match deserialized {
-                        AnySyncTimelineEvent::MessageLike(ev) => {
-                            if ev.is_redacted() {
-                                return Ok(());
-                            }
+            let Some((location, mut target_event)) = self.find_event(event_id).await? else {
+                trace!("redacted event is missing from the linked chunk");
+                return Ok(());
+            };
+
+            // Don't redact already redacted events.
+            if let Ok(deserialized) = target_event.raw().deserialize() {
+                match deserialized {
+                    AnySyncTimelineEvent::MessageLike(ev) => {
+                        if ev.is_redacted() {
+                            return Ok(());
                         }
-                        AnySyncTimelineEvent::State(ev) => {
-                            if ev.is_redacted() {
-                                return Ok(());
-                            }
+                    }
+                    AnySyncTimelineEvent::State(ev) => {
+                        if ev.is_redacted() {
+                            return Ok(());
                         }
                     }
                 }
+            }
 
-                if let Some(redacted_event) = apply_redaction(
-                    target_event.raw(),
-                    event.raw().cast_ref::<SyncRoomRedactionEvent>(),
-                    &self.room_version,
-                ) {
-                    // It's safe to cast `redacted_event` here:
-                    // - either the event was an `AnyTimelineEvent` cast to `AnySyncTimelineEvent`
-                    //   when calling .raw(), so it's still one under the hood.
-                    // - or it wasn't, and it's a plain `AnySyncTimelineEvent` in this case.
-                    target_event.replace_raw(redacted_event.cast());
+            if let Some(redacted_event) = apply_redaction(
+                target_event.raw(),
+                event.raw().cast_ref::<SyncRoomRedactionEvent>(),
+                &self.room_version,
+            ) {
+                // It's safe to cast `redacted_event` here:
+                // - either the event was an `AnyTimelineEvent` cast to `AnySyncTimelineEvent`
+                //   when calling .raw(), so it's still one under the hood.
+                // - or it wasn't, and it's a plain `AnySyncTimelineEvent` in this case.
+                target_event.replace_raw(redacted_event.cast());
 
-                    self.replace_event_at(location, target_event).await?;
-                }
-            } else {
-                trace!("redacted event is missing from the linked chunk");
+                self.replace_event_at(location, target_event).await?;
             }
 
             Ok(())

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1329,73 +1329,72 @@ mod private {
                 prev_batch = None;
             }
 
+            if all_duplicates {
+                // No new events and no gap (per the previous check), thus no need to change the
+                // room state. We're done!
+                return Ok(false);
+            }
+
             // During a sync, when a duplicated event is found, the old event is removed and
             // the new event is added.
             //
             // Let's remove the old events that are duplicated.
-            let timeline_event_diffs = if all_duplicates {
-                // No new events, thus no need to change the room events.
-                vec![]
-            } else {
-                // Remove the old duplicated events.
-                //
-                // We don't have to worry the removals can change the position of the
-                // existing events, because we are pushing all _new_
-                // `events` at the back.
-                let mut timeline_event_diffs = self
-                    .remove_events(in_memory_duplicated_event_ids, in_store_duplicated_event_ids)
-                    .await?;
 
-                // Add the previous back-pagination token (if present), followed by the timeline
-                // events themselves.
-                let new_timeline_event_diffs = self
-                    .with_events_mut(true, |room_events| {
-                        // If we only received duplicated events, we don't need to store the gap: if
-                        // there was a gap, we'd have received an unknown event at the tail of
-                        // the room's timeline (unless the server reordered sync events since the
-                        // last time we sync'd).
-                        if let Some(prev_token) = &prev_batch {
-                            // As a tiny optimization: remove the last chunk if it's an empty event
-                            // one, as it's not useful to keep it before a gap.
-                            let prev_chunk_to_remove =
-                                room_events.rchunks().next().and_then(|chunk| {
-                                    (chunk.is_items() && chunk.num_items() == 0)
-                                        .then_some(chunk.identifier())
-                                });
+            // Remove the old duplicated events.
+            //
+            // We don't have to worry the removals can change the position of the
+            // existing events, because we are pushing all _new_
+            // `events` at the back.
+            let mut timeline_event_diffs = self
+                .remove_events(in_memory_duplicated_event_ids, in_store_duplicated_event_ids)
+                .await?;
 
-                            room_events.push_gap(Gap { prev_token: prev_token.clone() });
+            // Add the previous back-pagination token (if present), followed by the timeline
+            // events themselves.
+            let new_timeline_event_diffs = self
+                .with_events_mut(true, |room_events| {
+                    // If we only received duplicated events, we don't need to store the gap: if
+                    // there was a gap, we'd have received an unknown event at the tail of
+                    // the room's timeline (unless the server reordered sync events since the
+                    // last time we sync'd).
+                    if let Some(prev_token) = &prev_batch {
+                        // As a tiny optimization: remove the last chunk if it's an empty event
+                        // one, as it's not useful to keep it before a gap.
+                        let prev_chunk_to_remove = room_events.rchunks().next().and_then(|chunk| {
+                            (chunk.is_items() && chunk.num_items() == 0)
+                                .then_some(chunk.identifier())
+                        });
 
-                            if let Some(prev_chunk_to_remove) = prev_chunk_to_remove {
-                                room_events.remove_empty_chunk_at(prev_chunk_to_remove).expect(
+                        room_events.push_gap(Gap { prev_token: prev_token.clone() });
+
+                        if let Some(prev_chunk_to_remove) = prev_chunk_to_remove {
+                            room_events.remove_empty_chunk_at(prev_chunk_to_remove).expect(
                                 "we just checked the chunk is there, and it's an empty item chunk",
                             );
-                            }
                         }
-
-                        room_events.push_events(events.clone());
-
-                        events.clone()
-                    })
-                    .await?;
-
-                timeline_event_diffs.extend(new_timeline_event_diffs);
-
-                if timeline.limited && prev_batch.is_some() {
-                    // If there was a previous batch token for a limited timeline, unload the chunks
-                    // so it only contains the last one; otherwise, there might be a
-                    // valid gap in between, and observers may not render it (yet).
-                    //
-                    // We must do this *after* the above call to `.with_events_mut`, so the new
-                    // events and gaps are properly persisted to storage.
-                    if let Some(diffs) = self.shrink_to_last_chunk().await? {
-                        // Override the diffs with the new ones, as per `shrink_to_last_chunk`'s API
-                        // contract.
-                        timeline_event_diffs = diffs;
                     }
-                }
 
-                timeline_event_diffs
-            };
+                    room_events.push_events(events.clone());
+
+                    events.clone()
+                })
+                .await?;
+
+            timeline_event_diffs.extend(new_timeline_event_diffs);
+
+            if timeline.limited && prev_batch.is_some() {
+                // If there was a previous batch token for a limited timeline, unload the chunks
+                // so it only contains the last one; otherwise, there might be a
+                // valid gap in between, and observers may not render it (yet).
+                //
+                // We must do this *after* the above call to `.with_events_mut`, so the new
+                // events and gaps are properly persisted to storage.
+                if let Some(diffs) = self.shrink_to_last_chunk().await? {
+                    // Override the diffs with the new ones, as per `shrink_to_last_chunk`'s API
+                    // contract.
+                    timeline_event_diffs = diffs;
+                }
+            }
 
             if !timeline_event_diffs.is_empty() {
                 let _ = sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1054,33 +1054,18 @@ mod private {
             Ok(Some((target, related)))
         }
 
-        /// Gives a temporary mutable handle to the underlying in-memory events,
-        /// and will propagate changes to the storage once done.
-        ///
-        /// Returns the updates to the linked chunk, as vector diffs, so the
-        /// caller may propagate such updates, if needs be.
-        ///
-        /// The function `func` takes a mutable reference to `RoomEvents`. It
-        /// returns a set of events that will be post-processed. At the time of
-        /// writing, all these events are passed to
-        /// `Self::maybe_apply_new_redaction`.
-        #[instrument(skip_all, fields(room_id = %self.room))]
-        async fn with_events_mut<F>(
+        /// Post-process new events, after they have been added to the in-memory
+        /// linked chunk.
+        async fn post_process_new_events(
             &mut self,
-            is_live_sync: bool,
-            func: F,
-        ) -> Result<(), EventCacheError>
-        where
-            F: FnOnce(&mut RoomEvents) -> Vec<TimelineEvent>,
-        {
-            let events_to_post_process = func(&mut self.events);
-
+            events: Vec<TimelineEvent>,
+        ) -> Result<(), EventCacheError> {
             // Update the store before doing the post-processing.
             self.propagate_changes().await?;
 
-            for event in &events_to_post_process {
+            for event in &events {
                 self.maybe_apply_new_redaction(event).await?;
-                self.analyze_thread_root(event, is_live_sync).await?;
+                self.analyze_thread_root(event, true).await?;
             }
 
             Ok(())
@@ -1337,34 +1322,31 @@ mod private {
 
             // Add the previous back-pagination token (if present), followed by the timeline
             // events themselves.
-            self.with_events_mut(true, |room_events| {
-                if let Some(prev_token) = &prev_batch {
-                    // As a tiny optimization: remove the last chunk if it's an empty event
-                    // one, as it's not useful to keep it before a gap.
-                    let prev_chunk_to_remove = room_events.rchunks().next().and_then(|chunk| {
-                        (chunk.is_items() && chunk.num_items() == 0).then_some(chunk.identifier())
-                    });
+            if let Some(prev_token) = &prev_batch {
+                // As a tiny optimization: remove the last chunk if it's an empty event
+                // one, as it's not useful to keep it before a gap.
+                let prev_chunk_to_remove = self.events.rchunks().next().and_then(|chunk| {
+                    (chunk.is_items() && chunk.num_items() == 0).then_some(chunk.identifier())
+                });
 
-                    room_events.push_gap(Gap { prev_token: prev_token.clone() });
+                self.events.push_gap(Gap { prev_token: prev_token.clone() });
 
-                    if let Some(prev_chunk_to_remove) = prev_chunk_to_remove {
-                        room_events.remove_empty_chunk_at(prev_chunk_to_remove).expect(
-                            "we just checked the chunk is there, and it's an empty item chunk",
-                        );
-                    }
+                // If we've never waited for an initial previous-batch token, and we've now
+                // inserted a gap, no need to wait for a previous-batch token later.
+                if !self.waited_for_initial_prev_token && prev_batch.is_some() {
+                    self.waited_for_initial_prev_token = true;
                 }
 
-                room_events.push_events(events.clone());
-
-                events
-            })
-            .await?;
-
-            // If we've never waited for an initial previous-batch token, and we've now
-            // inserted a gap, no need to wait for a previous-batch token later.
-            if !self.waited_for_initial_prev_token && prev_batch.is_some() {
-                self.waited_for_initial_prev_token = true;
+                if let Some(prev_chunk_to_remove) = prev_chunk_to_remove {
+                    self.events
+                        .remove_empty_chunk_at(prev_chunk_to_remove)
+                        .expect("we just checked the chunk is there, and it's an empty item chunk");
+                }
             }
+
+            self.events.push_events(events.clone());
+
+            self.post_process_new_events(events).await?;
 
             if timeline.limited && prev_batch.is_some() {
                 // If there was a previous batch token for a limited timeline, unload the chunks
@@ -1432,67 +1414,64 @@ mod private {
                 new_gap = None;
             };
 
-            self.with_events_mut(false, |room_events| {
-                // Reverse the order of the events as `/messages` has been called with `dir=b`
-                // (backwards). The `RoomEvents` API expects the first event to be the oldest.
-                // Let's re-order them for this block.
-                let reversed_events = events.iter().rev().cloned().collect::<Vec<_>>();
+            // Reverse the order of the events as `/messages` has been called with `dir=b`
+            // (backwards). The `RoomEvents` API expects the first event to be the oldest.
+            // Let's re-order them for this block.
+            let reversed_events = events.iter().rev().cloned().collect::<Vec<_>>();
 
-                let first_event_pos = room_events.events().next().map(|(item_pos, _)| item_pos);
+            let first_event_pos = self.events.events().next().map(|(item_pos, _)| item_pos);
 
-                // First, insert events.
-                let insert_new_gap_pos = if let Some(gap_id) = prev_gap_id {
-                    // There is a prior gap, let's replace it by new events!
-                    if all_duplicates {
-                        assert!(reversed_events.is_empty());
-                    }
-
-                    trace!("replacing previous gap with the back-paginated events");
-
-                    // Replace the gap with the events we just deduplicated. This might get rid of
-                    // the underlying gap, if the conditions are favorable to
-                    // us.
-                    room_events
-                        .replace_gap_at(reversed_events.clone(), gap_id)
-                        .expect("gap_identifier is a valid chunk id we read previously")
-                } else if let Some(pos) = first_event_pos {
-                    // No prior gap, but we had some events: assume we need to prepend events
-                    // before those.
-                    trace!("inserted events before the first known event");
-
-                    room_events
-                        .insert_events_at(reversed_events.clone(), pos)
-                        .expect("pos is a valid position we just read above");
-
-                    Some(pos)
-                } else {
-                    // No prior gap, and no prior events: push the events.
-                    trace!("pushing events received from back-pagination");
-
-                    room_events.push_events(reversed_events.clone());
-
-                    // A new gap may be inserted before the new events, if there are any.
-                    room_events.events().next().map(|(item_pos, _)| item_pos)
-                };
-
-                // And insert the new gap if needs be.
-                //
-                // We only do this when at least one new, non-duplicated event, has been added
-                // to the chunk. Otherwise it means we've back-paginated all the
-                // known events.
-                if let Some(new_gap) = new_gap {
-                    if let Some(new_pos) = insert_new_gap_pos {
-                        room_events
-                            .insert_gap_at(new_gap, new_pos)
-                            .expect("events_chunk_pos represents a valid chunk position");
-                    } else {
-                        room_events.push_gap(new_gap);
-                    }
+            // First, insert events.
+            let insert_new_gap_pos = if let Some(gap_id) = prev_gap_id {
+                // There is a prior gap, let's replace it by new events!
+                if all_duplicates {
+                    assert!(reversed_events.is_empty());
                 }
 
-                reversed_events
-            })
-            .await?;
+                trace!("replacing previous gap with the back-paginated events");
+
+                // Replace the gap with the events we just deduplicated. This might get rid of
+                // the underlying gap, if the conditions are favorable to
+                // us.
+                self.events
+                    .replace_gap_at(reversed_events.clone(), gap_id)
+                    .expect("gap_identifier is a valid chunk id we read previously")
+            } else if let Some(pos) = first_event_pos {
+                // No prior gap, but we had some events: assume we need to prepend events
+                // before those.
+                trace!("inserted events before the first known event");
+
+                self.events
+                    .insert_events_at(reversed_events.clone(), pos)
+                    .expect("pos is a valid position we just read above");
+
+                Some(pos)
+            } else {
+                // No prior gap, and no prior events: push the events.
+                trace!("pushing events received from back-pagination");
+
+                self.events.push_events(reversed_events.clone());
+
+                // A new gap may be inserted before the new events, if there are any.
+                self.events.events().next().map(|(item_pos, _)| item_pos)
+            };
+
+            // And insert the new gap if needs be.
+            //
+            // We only do this when at least one new, non-duplicated event, has been added
+            // to the chunk. Otherwise it means we've back-paginated all the
+            // known events.
+            if let Some(new_gap) = new_gap {
+                if let Some(new_pos) = insert_new_gap_pos {
+                    self.events
+                        .insert_gap_at(new_gap, new_pos)
+                        .expect("events_chunk_pos represents a valid chunk position");
+                } else {
+                    self.events.push_gap(new_gap);
+                }
+            }
+
+            self.post_process_new_events(reversed_events).await?;
 
             // There could be an inconsistency between the network (which thinks we hit the
             // start of the timeline) and the disk (which has the initial empty

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -565,14 +565,11 @@ mod private {
     use tracing::{debug, error, instrument, trace, warn};
 
     use super::{
-        super::{
-            deduplicator::{DeduplicationOutcome, Deduplicator},
-            EventCacheError,
-        },
+        super::{deduplicator::DeduplicationOutcome, EventCacheError},
         events::RoomEvents,
         sort_positions_descending, EventLocation, LoadMoreEventsBackwardsOutcome,
     };
-    use crate::event_cache::RoomPaginationStatus;
+    use crate::event_cache::{deduplicator::filter_duplicate_events, RoomPaginationStatus};
 
     /// State for a single room's event cache.
     ///
@@ -590,9 +587,6 @@ mod private {
 
         /// The events of the room.
         events: RoomEvents,
-
-        /// The events deduplicator instance to help finding duplicates.
-        deduplicator: Deduplicator,
 
         /// Have we ever waited for a previous-batch-token to come from sync, in
         /// the context of pagination? We do this at most once per room,
@@ -647,14 +641,12 @@ mod private {
             };
 
             let events = RoomEvents::with_initial_linked_chunk(linked_chunk);
-            let deduplicator = Deduplicator::new(room_id.clone(), store.clone());
 
             Ok(Self {
                 room: room_id,
                 room_version,
                 store,
                 events,
-                deduplicator,
                 waited_for_initial_prev_token: false,
                 listener_count: Default::default(),
                 pagination_status,
@@ -692,7 +684,7 @@ mod private {
             events: Vec<Event>,
         ) -> Result<(DeduplicationOutcome, bool), EventCacheError> {
             let deduplication_outcome =
-                self.deduplicator.filter_duplicate_events(events, &self.events).await?;
+                filter_duplicate_events(&self.room, &self.store, events, &self.events).await?;
 
             let number_of_events = deduplication_outcome.all_events.len();
             let number_of_deduplicated_events =

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1339,10 +1339,6 @@ mod private {
             // Add the previous back-pagination token (if present), followed by the timeline
             // events themselves.
             self.with_events_mut(true, |room_events| {
-                // If we only received duplicated events, we don't need to store the gap: if
-                // there was a gap, we'd have received an unknown event at the tail of
-                // the room's timeline (unless the server reordered sync events since the
-                // last time we sync'd).
                 if let Some(prev_token) = &prev_batch {
                     // As a tiny optimization: remove the last chunk if it's an empty event
                     // one, as it's not useful to keep it before a gap.

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -590,7 +590,7 @@ mod private {
         /// possibly misplace them. And we should not be missing
         /// events either: the already-known events would have their own
         /// previous-batch token (it might already be consumed).
-        pub async fn collect_valid_and_duplicated_events(
+        async fn collect_valid_and_duplicated_events(
             &mut self,
             events: Vec<Event>,
         ) -> Result<(DeduplicationOutcome, bool), EventCacheError> {
@@ -842,13 +842,12 @@ mod private {
         ///
         /// This method is purposely isolated because it must ensure that
         /// positions are sorted appropriately or it can be disastrous.
-        #[must_use = "Updates as `VectorDiff` must probably be propagated via `RoomEventCacheUpdate`"]
         #[instrument(skip_all)]
-        pub(crate) async fn remove_events(
+        async fn remove_events(
             &mut self,
             in_memory_events: Vec<(OwnedEventId, Position)>,
             in_store_events: Vec<(OwnedEventId, Position)>,
-        ) -> Result<Vec<VectorDiff<TimelineEvent>>, EventCacheError> {
+        ) -> Result<(), EventCacheError> {
             // In-store events.
             if !in_store_events.is_empty() {
                 let mut positions = in_store_events
@@ -870,7 +869,7 @@ mod private {
             // In-memory events.
             if in_memory_events.is_empty() {
                 // Nothing else to do, return early.
-                return Ok(Vec::new());
+                return Ok(());
             }
 
             // `remove_events_by_position` is responsible of sorting positions.
@@ -880,9 +879,7 @@ mod private {
                 )
                 .expect("failed to remove an event");
 
-            self.propagate_changes().await?;
-
-            Ok(self.events.updates_as_vector_diffs())
+            self.propagate_changes().await
         }
 
         /// Propagate changes to the underlying storage.
@@ -891,7 +888,7 @@ mod private {
             self.send_updates_to_store(updates).await
         }
 
-        pub async fn send_updates_to_store(
+        async fn send_updates_to_store(
             &mut self,
             mut updates: Vec<Update<TimelineEvent, Gap>>,
         ) -> Result<(), EventCacheError> {
@@ -982,7 +979,7 @@ mod private {
         ) -> Result<Option<(EventLocation, TimelineEvent)>, EventCacheError> {
             // There are supposedly fewer events loaded in memory than in the store. Let's
             // start by looking up in the `RoomEvents`.
-            for (position, event) in self.events().revents() {
+            for (position, event) in self.events.revents() {
                 if event.event_id().as_deref() == Some(event_id) {
                     return Ok(Some((EventLocation::Memory(position), event.clone())));
                 }
@@ -1060,13 +1057,12 @@ mod private {
         /// returns a set of events that will be post-processed. At the time of
         /// writing, all these events are passed to
         /// `Self::maybe_apply_new_redaction`.
-        #[must_use = "Updates as `VectorDiff` must probably be propagated via `RoomEventCacheUpdate`"]
         #[instrument(skip_all, fields(room_id = %self.room))]
-        pub async fn with_events_mut<F>(
+        async fn with_events_mut<F>(
             &mut self,
             is_live_sync: bool,
             func: F,
-        ) -> Result<Vec<VectorDiff<TimelineEvent>>, EventCacheError>
+        ) -> Result<(), EventCacheError>
         where
             F: FnOnce(&mut RoomEvents) -> Vec<TimelineEvent>,
         {
@@ -1088,9 +1084,7 @@ mod private {
                 self.waited_for_initial_prev_token = true;
             }
 
-            let updates_as_vector_diffs = self.events.updates_as_vector_diffs();
-
-            Ok(updates_as_vector_diffs)
+            Ok(())
         }
 
         /// If the event is a threaded reply, ensure the related thread's root
@@ -1335,52 +1329,43 @@ mod private {
                 return Ok(false);
             }
 
-            // During a sync, when a duplicated event is found, the old event is removed and
-            // the new event is added.
-            //
-            // Let's remove the old events that are duplicated.
-
             // Remove the old duplicated events.
             //
-            // We don't have to worry the removals can change the position of the
-            // existing events, because we are pushing all _new_
-            // `events` at the back.
-            let mut timeline_event_diffs = self
-                .remove_events(in_memory_duplicated_event_ids, in_store_duplicated_event_ids)
+            // We don't have to worry the removals can change the position of the existing
+            // events, because we are pushing all _new_ `events` at the back.
+            self.remove_events(in_memory_duplicated_event_ids, in_store_duplicated_event_ids)
                 .await?;
 
             // Add the previous back-pagination token (if present), followed by the timeline
             // events themselves.
-            let new_timeline_event_diffs = self
-                .with_events_mut(true, |room_events| {
-                    // If we only received duplicated events, we don't need to store the gap: if
-                    // there was a gap, we'd have received an unknown event at the tail of
-                    // the room's timeline (unless the server reordered sync events since the
-                    // last time we sync'd).
-                    if let Some(prev_token) = &prev_batch {
-                        // As a tiny optimization: remove the last chunk if it's an empty event
-                        // one, as it's not useful to keep it before a gap.
-                        let prev_chunk_to_remove = room_events.rchunks().next().and_then(|chunk| {
-                            (chunk.is_items() && chunk.num_items() == 0)
-                                .then_some(chunk.identifier())
-                        });
+            self.with_events_mut(true, |room_events| {
+                // If we only received duplicated events, we don't need to store the gap: if
+                // there was a gap, we'd have received an unknown event at the tail of
+                // the room's timeline (unless the server reordered sync events since the
+                // last time we sync'd).
+                if let Some(prev_token) = &prev_batch {
+                    // As a tiny optimization: remove the last chunk if it's an empty event
+                    // one, as it's not useful to keep it before a gap.
+                    let prev_chunk_to_remove = room_events.rchunks().next().and_then(|chunk| {
+                        (chunk.is_items() && chunk.num_items() == 0).then_some(chunk.identifier())
+                    });
 
-                        room_events.push_gap(Gap { prev_token: prev_token.clone() });
+                    room_events.push_gap(Gap { prev_token: prev_token.clone() });
 
-                        if let Some(prev_chunk_to_remove) = prev_chunk_to_remove {
-                            room_events.remove_empty_chunk_at(prev_chunk_to_remove).expect(
-                                "we just checked the chunk is there, and it's an empty item chunk",
-                            );
-                        }
+                    if let Some(prev_chunk_to_remove) = prev_chunk_to_remove {
+                        room_events.remove_empty_chunk_at(prev_chunk_to_remove).expect(
+                            "we just checked the chunk is there, and it's an empty item chunk",
+                        );
                     }
+                }
 
-                    room_events.push_events(events.clone());
+                room_events.push_events(events.clone());
 
-                    events.clone()
-                })
-                .await?;
+                events
+            })
+            .await?;
 
-            timeline_event_diffs.extend(new_timeline_event_diffs);
+            let mut timeline_event_diffs = None;
 
             if timeline.limited && prev_batch.is_some() {
                 // If there was a previous batch token for a limited timeline, unload the chunks
@@ -1389,12 +1374,13 @@ mod private {
                 //
                 // We must do this *after* the above call to `.with_events_mut`, so the new
                 // events and gaps are properly persisted to storage.
-                if let Some(diffs) = self.shrink_to_last_chunk().await? {
-                    // Override the diffs with the new ones, as per `shrink_to_last_chunk`'s API
-                    // contract.
-                    timeline_event_diffs = diffs;
-                }
+
+                // TODO(bnjbvr): could this method not return diff updates?
+                timeline_event_diffs = self.shrink_to_last_chunk().await?;
             }
+
+            let timeline_event_diffs =
+                timeline_event_diffs.unwrap_or_else(|| self.events.updates_as_vector_diffs());
 
             if !timeline_event_diffs.is_empty() {
                 let _ = sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
@@ -1439,85 +1425,81 @@ mod private {
             // ordering of [D, E, F, A, B, C], which is incorrect. So we do have to remove
             // all the events, in case this happens (see also #4746).
 
-            let mut event_diffs = if !all_duplicates {
+            if !all_duplicates {
                 // Let's forget all the previous events.
                 self.remove_events(in_memory_duplicated_event_ids, in_store_duplicated_event_ids)
-                    .await?
+                    .await?;
             } else {
                 // All new events are duplicated, they can all be ignored.
                 events.clear();
-                Default::default()
             };
 
-            let next_diffs = self
-            .with_events_mut(false, |room_events| {
-            // Reverse the order of the events as `/messages` has been called with `dir=b`
-            // (backwards). The `RoomEvents` API expects the first event to be the oldest.
-            // Let's re-order them for this block.
-            let reversed_events = events
-                .iter()
-                .rev()
-                .cloned()
-                .collect::<Vec<_>>();
+            self.with_events_mut(false, |room_events| {
+                // Reverse the order of the events as `/messages` has been called with `dir=b`
+                // (backwards). The `RoomEvents` API expects the first event to be the oldest.
+                // Let's re-order them for this block.
+                let reversed_events = events
+                    .iter()
+                    .rev()
+                    .cloned()
+                    .collect::<Vec<_>>();
 
-            let first_event_pos = room_events.events().next().map(|(item_pos, _)| item_pos);
+                let first_event_pos = room_events.events().next().map(|(item_pos, _)| item_pos);
 
-            // First, insert events.
-            let insert_new_gap_pos = if let Some(gap_id) = prev_gap_id {
-                // There is a prior gap, let's replace it by new events!
-                if all_duplicates {
-                    assert!(reversed_events.is_empty());
-                }
-
-                trace!("replacing previous gap with the back-paginated events");
-
-                // Replace the gap with the events we just deduplicated. This might get rid of the
-                // underlying gap, if the conditions are favorable to us.
-                room_events.replace_gap_at(reversed_events.clone(), gap_id)
-                    .expect("gap_identifier is a valid chunk id we read previously")
-            } else if let Some(pos) = first_event_pos {
-                // No prior gap, but we had some events: assume we need to prepend events
-                // before those.
-                trace!("inserted events before the first known event");
-
-                room_events
-                    .insert_events_at(reversed_events.clone(), pos)
-                    .expect("pos is a valid position we just read above");
-
-                Some(pos)
-            } else {
-                // No prior gap, and no prior events: push the events.
-                trace!("pushing events received from back-pagination");
-
-                room_events.push_events(reversed_events.clone());
-
-                // A new gap may be inserted before the new events, if there are any.
-                room_events.events().next().map(|(item_pos, _)| item_pos)
-            };
-
-            // And insert the new gap if needs be.
-            //
-            // We only do this when at least one new, non-duplicated event, has been added to
-            // the chunk. Otherwise it means we've back-paginated all the known events.
-            if !all_duplicates {
-                if let Some(new_gap) = new_gap {
-                    if let Some(new_pos) = insert_new_gap_pos {
-                        room_events
-                            .insert_gap_at(new_gap, new_pos)
-                            .expect("events_chunk_pos represents a valid chunk position");
-                    } else {
-                        room_events.push_gap(new_gap);
+                // First, insert events.
+                let insert_new_gap_pos = if let Some(gap_id) = prev_gap_id {
+                    // There is a prior gap, let's replace it by new events!
+                    if all_duplicates {
+                        assert!(reversed_events.is_empty());
                     }
+
+                    trace!("replacing previous gap with the back-paginated events");
+
+                    // Replace the gap with the events we just deduplicated. This might get rid of the
+                    // underlying gap, if the conditions are favorable to us.
+                    room_events.replace_gap_at(reversed_events.clone(), gap_id)
+                        .expect("gap_identifier is a valid chunk id we read previously")
+                } else if let Some(pos) = first_event_pos {
+                    // No prior gap, but we had some events: assume we need to prepend events
+                    // before those.
+                    trace!("inserted events before the first known event");
+
+                    room_events
+                        .insert_events_at(reversed_events.clone(), pos)
+                        .expect("pos is a valid position we just read above");
+
+                    Some(pos)
+                } else {
+                    // No prior gap, and no prior events: push the events.
+                    trace!("pushing events received from back-pagination");
+
+                    room_events.push_events(reversed_events.clone());
+
+                    // A new gap may be inserted before the new events, if there are any.
+                    room_events.events().next().map(|(item_pos, _)| item_pos)
+                };
+
+                // And insert the new gap if needs be.
+                //
+                // We only do this when at least one new, non-duplicated event, has been added to
+                // the chunk. Otherwise it means we've back-paginated all the known events.
+                if !all_duplicates {
+                    if let Some(new_gap) = new_gap {
+                        if let Some(new_pos) = insert_new_gap_pos {
+                            room_events
+                                .insert_gap_at(new_gap, new_pos)
+                                .expect("events_chunk_pos represents a valid chunk position");
+                        } else {
+                            room_events.push_gap(new_gap);
+                        }
+                    }
+                } else {
+                    debug!("not storing previous batch token, because we deduplicated all new back-paginated events");
                 }
-            } else {
-                debug!("not storing previous batch token, because we deduplicated all new back-paginated events");
-            }
 
-            reversed_events
-        })
-        .await?;
-
-            event_diffs.extend(next_diffs);
+                reversed_events
+            })
+            .await?;
 
             // There could be an inconsistency between the network (which thinks we hit the
             // start of the timeline) and the disk (which has the initial empty
@@ -1547,6 +1529,7 @@ mod private {
 
             let backpagination_outcome = BackPaginationOutcome { events, reached_start };
 
+            let event_diffs = self.events.updates_as_vector_diffs();
             if !event_diffs.is_empty() {
                 let _ = sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
                     diffs: event_diffs,

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1083,14 +1083,6 @@ mod private {
                 self.analyze_thread_root(event, is_live_sync).await?;
             }
 
-            // If we've never waited for an initial previous-batch token, and we now have at
-            // least one gap in the chunk, no need to wait for a previous-batch token later.
-            if !self.waited_for_initial_prev_token
-                && self.events.chunks().any(|chunk| chunk.is_gap())
-            {
-                self.waited_for_initial_prev_token = true;
-            }
-
             Ok(())
         }
 
@@ -1367,6 +1359,12 @@ mod private {
                 events
             })
             .await?;
+
+            // If we've never waited for an initial previous-batch token, and we've now
+            // inserted a gap, no need to wait for a previous-batch token later.
+            if !self.waited_for_initial_prev_token && prev_batch.is_some() {
+                self.waited_for_initial_prev_token = true;
+            }
 
             if timeline.limited && prev_batch.is_some() {
                 // If there was a previous batch token for a limited timeline, unload the chunks

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -723,10 +723,7 @@ mod private {
         /// pending diff updates with the result of this function.
         ///
         /// Otherwise, returns `None`.
-        #[must_use = "Updates as `VectorDiff` must probably be propagated via `RoomEventCacheUpdate`"]
-        pub(super) async fn shrink_to_last_chunk(
-            &mut self,
-        ) -> Result<Option<Vec<VectorDiff<TimelineEvent>>>, EventCacheError> {
+        pub(super) async fn shrink_to_last_chunk(&mut self) -> Result<(), EventCacheError> {
             let store_lock = self.store.lock().await?;
 
             // Attempt to load the last chunk.
@@ -754,7 +751,7 @@ mod private {
             // updates the chunk identifier generator.
             if let Err(err) = self.events.replace_with(last_chunk, chunk_identifier_generator) {
                 error!("error when replacing the linked chunk: {err}");
-                return self.reset().await.map(Some);
+                return self.reset_internal().await;
             }
 
             // Let pagination observers know that we may have not reached the start of the
@@ -766,12 +763,7 @@ mod private {
             // representation that we're doing this. Let's drain those store updates.
             let _ = self.events.store_updates().take();
 
-            // However, we want to get updates as `VectorDiff`s, for the external listeners.
-            // Check we're respecting the contract defined in the doc comment.
-            let diffs = self.events.updates_as_vector_diffs();
-            assert!(matches!(diffs[0], VectorDiff::Clear));
-
-            Ok(Some(diffs))
+            Ok(())
         }
 
         /// Automatically shrink the room if there are no listeners, as
@@ -787,10 +779,19 @@ mod private {
             if listener_count == 0 {
                 // If we are the last strong reference to the auto-shrinker, we can shrink the
                 // events data structure to its last chunk.
-                self.shrink_to_last_chunk().await
+                self.shrink_to_last_chunk().await?;
+                Ok(Some(self.events.updates_as_vector_diffs()))
             } else {
                 Ok(None)
             }
+        }
+
+        #[cfg(test)]
+        pub(crate) async fn force_shrink_to_last_chunk(
+            &mut self,
+        ) -> Result<Vec<VectorDiff<TimelineEvent>>, EventCacheError> {
+            self.shrink_to_last_chunk().await?;
+            Ok(self.events.updates_as_vector_diffs())
         }
 
         /// Removes the bundled relations from an event, if they were present.
@@ -944,6 +945,18 @@ mod private {
         /// with the result of this function.
         #[must_use = "Updates as `VectorDiff` must probably be propagated via `RoomEventCacheUpdate`"]
         pub async fn reset(&mut self) -> Result<Vec<VectorDiff<TimelineEvent>>, EventCacheError> {
+            self.reset_internal().await?;
+
+            let diff_updates = self.events.updates_as_vector_diffs();
+
+            // Ensure the contract defined in the doc comment is true:
+            debug_assert_eq!(diff_updates.len(), 1);
+            debug_assert!(matches!(diff_updates[0], VectorDiff::Clear));
+
+            Ok(diff_updates)
+        }
+
+        async fn reset_internal(&mut self) -> Result<(), EventCacheError> {
             self.events.reset();
 
             self.propagate_changes().await?;
@@ -955,13 +968,7 @@ mod private {
             // TODO: likely must cancel any ongoing back-paginations too
             self.pagination_status.set(RoomPaginationStatus::Idle { hit_timeline_start: false });
 
-            let diff_updates = self.events.updates_as_vector_diffs();
-
-            // Ensure the contract defined in the doc comment is true:
-            debug_assert_eq!(diff_updates.len(), 1);
-            debug_assert!(matches!(diff_updates[0], VectorDiff::Clear));
-
-            Ok(diff_updates)
+            Ok(())
         }
 
         /// Returns a read-only reference to the underlying events.
@@ -1361,8 +1368,6 @@ mod private {
             })
             .await?;
 
-            let mut timeline_event_diffs = None;
-
             if timeline.limited && prev_batch.is_some() {
                 // If there was a previous batch token for a limited timeline, unload the chunks
                 // so it only contains the last one; otherwise, there might be a
@@ -1370,14 +1375,10 @@ mod private {
                 //
                 // We must do this *after* the above call to `.with_events_mut`, so the new
                 // events and gaps are properly persisted to storage.
-
-                // TODO(bnjbvr): could this method not return diff updates?
-                timeline_event_diffs = self.shrink_to_last_chunk().await?;
+                self.shrink_to_last_chunk().await?;
             }
 
-            let timeline_event_diffs =
-                timeline_event_diffs.unwrap_or_else(|| self.events.updates_as_vector_diffs());
-
+            let timeline_event_diffs = self.events.updates_as_vector_diffs();
             if !timeline_event_diffs.is_empty() {
                 let _ = sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
                     diffs: timeline_event_diffs,
@@ -2488,10 +2489,9 @@ mod timed_tests {
             .state
             .write()
             .await
-            .shrink_to_last_chunk()
+            .force_shrink_to_last_chunk()
             .await
-            .expect("shrinking should succeed")
-            .unwrap();
+            .expect("shrinking should succeed");
 
         // We receive updates about the changes to the linked chunk.
         assert_eq!(diffs.len(), 2);

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -24,7 +24,7 @@ use std::{
     },
 };
 
-use events::{sort_positions_descending, Gap};
+use events::sort_positions_descending;
 use eyeball::SharedObservable;
 use eyeball_im::VectorDiff;
 use matrix_sdk_base::{
@@ -44,8 +44,8 @@ use tokio::sync::{
 use tracing::{instrument, trace, warn};
 
 use super::{
-    deduplicator::DeduplicationOutcome, AutoShrinkChannelPayload, EventsOrigin, Result,
-    RoomEventCacheUpdate, RoomPagination, RoomPaginationStatus,
+    AutoShrinkChannelPayload, EventsOrigin, Result, RoomEventCacheUpdate, RoomPagination,
+    RoomPaginationStatus,
 };
 use crate::{client::WeakClient, room::WeakRoom};
 
@@ -376,9 +376,8 @@ impl RoomEventCacheInner {
         ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
         ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
     ) -> Result<()> {
-        let mut prev_batch = timeline.prev_batch;
         if timeline.events.is_empty()
-            && prev_batch.is_none()
+            && timeline.prev_batch.is_none()
             && ephemeral_events.is_empty()
             && ambiguity_changes.is_empty()
         {
@@ -388,115 +387,18 @@ impl RoomEventCacheInner {
         // Add all the events to the backend.
         trace!("adding new events");
 
-        let mut state = self.state.write().await;
-
-        let (
-            DeduplicationOutcome {
-                all_events: events,
-                in_memory_duplicated_event_ids,
-                in_store_duplicated_event_ids,
-            },
-            all_duplicates,
-        ) = state.collect_valid_and_duplicated_events(timeline.events).await?;
-
-        // If the timeline isn't limited, and we already knew about some past events,
-        // then this definitely know what the timeline head is (either we know
-        // about all the events persisted in storage, or we have a gap
-        // somewhere). In this case, we can ditch the previous-batch
-        // token, which is an optimization to avoid unnecessary future back-pagination
-        // requests.
-        //
-        // We can also ditch it, if we knew about all the events that came from sync,
-        // viz. they were all deduplicated. In this case, using the
-        // previous-batch token would only result in fetching other events we
-        // knew about. This is slightly incorrect in the presence of
-        // network splits, but this has shown to be Good Enough™.
-        if !timeline.limited && state.events().events().next().is_some() || all_duplicates {
-            prev_batch = None;
-        }
-
-        // During a sync, when a duplicated event is found, the old event is removed and
-        // the new event is added.
-        //
-        // Let's remove the old events that are duplicated.
-        let timeline_event_diffs = if all_duplicates {
-            // No new events, thus no need to change the room events.
-            vec![]
-        } else {
-            // Remove the old duplicated events.
-            //
-            // We don't have to worry the removals can change the position of the
-            // existing events, because we are pushing all _new_
-            // `events` at the back.
-            let mut timeline_event_diffs = state
-                .remove_events(in_memory_duplicated_event_ids, in_store_duplicated_event_ids)
-                .await?;
-
-            // Add the previous back-pagination token (if present), followed by the timeline
-            // events themselves.
-            let new_timeline_event_diffs = state
-                .with_events_mut(true, |room_events| {
-                    // If we only received duplicated events, we don't need to store the gap: if
-                    // there was a gap, we'd have received an unknown event at the tail of
-                    // the room's timeline (unless the server reordered sync events since the last
-                    // time we sync'd).
-                    if let Some(prev_token) = &prev_batch {
-                        // As a tiny optimization: remove the last chunk if it's an empty event
-                        // one, as it's not useful to keep it before a gap.
-                        let prev_chunk_to_remove = room_events.rchunks().next().and_then(|chunk| {
-                            (chunk.is_items() && chunk.num_items() == 0)
-                                .then_some(chunk.identifier())
-                        });
-
-                        room_events.push_gap(Gap { prev_token: prev_token.clone() });
-
-                        if let Some(prev_chunk_to_remove) = prev_chunk_to_remove {
-                            room_events.remove_empty_chunk_at(prev_chunk_to_remove).expect(
-                                "we just checked the chunk is there, and it's an empty item chunk",
-                            );
-                        }
-                    }
-
-                    room_events.push_events(events.clone());
-
-                    events.clone()
-                })
-                .await?;
-
-            timeline_event_diffs.extend(new_timeline_event_diffs);
-
-            if timeline.limited && prev_batch.is_some() {
-                // If there was a previous batch token for a limited timeline, unload the chunks
-                // so it only contains the last one; otherwise, there might be a
-                // valid gap in between, and observers may not render it (yet).
-                //
-                // We must do this *after* the above call to `.with_events_mut`, so the new
-                // events and gaps are properly persisted to storage.
-                if let Some(diffs) = state.shrink_to_last_chunk().await? {
-                    // Override the diffs with the new ones, as per `shrink_to_last_chunk`'s API
-                    // contract.
-                    timeline_event_diffs = diffs;
-                }
-            }
-
-            timeline_event_diffs
-        };
+        let stored_prev_batch_token =
+            self.state.write().await.handle_sync(timeline, &self.sender).await?;
 
         // Now that all events have been added, we can trigger the
         // `pagination_token_notifier`.
-        if prev_batch.is_some() {
+        if stored_prev_batch_token {
             self.pagination_batch_token_notifier.notify_one();
         }
 
-        // The order of `RoomEventCacheUpdate`s is **really** important here.
+        // State sent the timeline diff updates, so we can send updates about the
+        // related events now.
         {
-            if !timeline_event_diffs.is_empty() {
-                let _ = self.sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
-                    diffs: timeline_event_diffs,
-                    origin: EventsOrigin::Sync,
-                });
-            }
-
             if !ephemeral_events.is_empty() {
                 let _ = self
                     .sender
@@ -554,6 +456,7 @@ mod private {
         event_cache::{store::EventCacheStoreLock, Event, Gap},
         linked_chunk::{lazy_loader, ChunkContent, ChunkIdentifierGenerator, Position, Update},
         serde_helpers::extract_thread_root,
+        sync::Timeline,
     };
     use matrix_sdk_common::executor::spawn;
     use ruma::{
@@ -564,6 +467,7 @@ mod private {
         serde::Raw,
         EventId, OwnedEventId, OwnedRoomId, RoomVersionId,
     };
+    use tokio::sync::broadcast::Sender;
     use tracing::{debug, error, instrument, trace, warn};
 
     use super::{
@@ -571,7 +475,9 @@ mod private {
         events::RoomEvents,
         sort_positions_descending, EventLocation, LoadMoreEventsBackwardsOutcome,
     };
-    use crate::event_cache::{deduplicator::filter_duplicate_events, RoomPaginationStatus};
+    use crate::event_cache::{
+        deduplicator::filter_duplicate_events, RoomEventCacheUpdate, RoomPaginationStatus,
+    };
 
     /// State for a single room's event cache.
     ///
@@ -1379,6 +1285,117 @@ mod private {
             .expect("joining failed")?;
 
             Ok(())
+        }
+
+        /// Handle the result of a sync.
+        pub async fn handle_sync(
+            &mut self,
+            mut timeline: Timeline,
+            sender: &Sender<RoomEventCacheUpdate>,
+        ) -> Result<bool, EventCacheError> {
+            let mut prev_batch = timeline.prev_batch.take();
+
+            let (
+                DeduplicationOutcome {
+                    all_events: events,
+                    in_memory_duplicated_event_ids,
+                    in_store_duplicated_event_ids,
+                },
+                all_duplicates,
+            ) = self.collect_valid_and_duplicated_events(timeline.events).await?;
+
+            // If the timeline isn't limited, and we already knew about some past events,
+            // then this definitely know what the timeline head is (either we know
+            // about all the events persisted in storage, or we have a gap
+            // somewhere). In this case, we can ditch the previous-batch
+            // token, which is an optimization to avoid unnecessary future back-pagination
+            // requests.
+            //
+            // We can also ditch it, if we knew about all the events that came from sync,
+            // viz. they were all deduplicated. In this case, using the
+            // previous-batch token would only result in fetching other events we
+            // knew about. This is slightly incorrect in the presence of
+            // network splits, but this has shown to be Good Enough™.
+            if !timeline.limited && self.events.events().next().is_some() || all_duplicates {
+                prev_batch = None;
+            }
+
+            // During a sync, when a duplicated event is found, the old event is removed and
+            // the new event is added.
+            //
+            // Let's remove the old events that are duplicated.
+            let timeline_event_diffs = if all_duplicates {
+                // No new events, thus no need to change the room events.
+                vec![]
+            } else {
+                // Remove the old duplicated events.
+                //
+                // We don't have to worry the removals can change the position of the
+                // existing events, because we are pushing all _new_
+                // `events` at the back.
+                let mut timeline_event_diffs = self
+                    .remove_events(in_memory_duplicated_event_ids, in_store_duplicated_event_ids)
+                    .await?;
+
+                // Add the previous back-pagination token (if present), followed by the timeline
+                // events themselves.
+                let new_timeline_event_diffs = self
+                    .with_events_mut(true, |room_events| {
+                        // If we only received duplicated events, we don't need to store the gap: if
+                        // there was a gap, we'd have received an unknown event at the tail of
+                        // the room's timeline (unless the server reordered sync events since the
+                        // last time we sync'd).
+                        if let Some(prev_token) = &prev_batch {
+                            // As a tiny optimization: remove the last chunk if it's an empty event
+                            // one, as it's not useful to keep it before a gap.
+                            let prev_chunk_to_remove =
+                                room_events.rchunks().next().and_then(|chunk| {
+                                    (chunk.is_items() && chunk.num_items() == 0)
+                                        .then_some(chunk.identifier())
+                                });
+
+                            room_events.push_gap(Gap { prev_token: prev_token.clone() });
+
+                            if let Some(prev_chunk_to_remove) = prev_chunk_to_remove {
+                                room_events.remove_empty_chunk_at(prev_chunk_to_remove).expect(
+                                "we just checked the chunk is there, and it's an empty item chunk",
+                            );
+                            }
+                        }
+
+                        room_events.push_events(events.clone());
+
+                        events.clone()
+                    })
+                    .await?;
+
+                timeline_event_diffs.extend(new_timeline_event_diffs);
+
+                if timeline.limited && prev_batch.is_some() {
+                    // If there was a previous batch token for a limited timeline, unload the chunks
+                    // so it only contains the last one; otherwise, there might be a
+                    // valid gap in between, and observers may not render it (yet).
+                    //
+                    // We must do this *after* the above call to `.with_events_mut`, so the new
+                    // events and gaps are properly persisted to storage.
+                    if let Some(diffs) = self.shrink_to_last_chunk().await? {
+                        // Override the diffs with the new ones, as per `shrink_to_last_chunk`'s API
+                        // contract.
+                        timeline_event_diffs = diffs;
+                    }
+                }
+
+                timeline_event_diffs
+            };
+
+            if !timeline_event_diffs.is_empty() {
+                let _ = sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
+                    diffs: timeline_event_diffs,
+                    origin: crate::event_cache::EventsOrigin::Sync,
+                });
+            }
+
+            Ok(prev_batch.is_some())
         }
     }
 }

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1392,7 +1392,7 @@ mod private {
         pub async fn handle_backpagination(
             &mut self,
             events: Vec<TimelineEvent>,
-            new_gap: Option<Gap>,
+            mut new_gap: Option<Gap>,
             prev_gap_id: Option<ChunkIdentifier>,
             sender: &Sender<RoomEventCacheUpdate>,
         ) -> Result<BackPaginationOutcome, EventCacheError> {
@@ -1429,17 +1429,16 @@ mod private {
             } else {
                 // All new events are duplicated, they can all be ignored.
                 events.clear();
+                // The gap can be ditched too, as it won't be useful to backpaginate any
+                // further.
+                new_gap = None;
             };
 
             self.with_events_mut(false, |room_events| {
                 // Reverse the order of the events as `/messages` has been called with `dir=b`
                 // (backwards). The `RoomEvents` API expects the first event to be the oldest.
                 // Let's re-order them for this block.
-                let reversed_events = events
-                    .iter()
-                    .rev()
-                    .cloned()
-                    .collect::<Vec<_>>();
+                let reversed_events = events.iter().rev().cloned().collect::<Vec<_>>();
 
                 let first_event_pos = room_events.events().next().map(|(item_pos, _)| item_pos);
 
@@ -1452,9 +1451,11 @@ mod private {
 
                     trace!("replacing previous gap with the back-paginated events");
 
-                    // Replace the gap with the events we just deduplicated. This might get rid of the
-                    // underlying gap, if the conditions are favorable to us.
-                    room_events.replace_gap_at(reversed_events.clone(), gap_id)
+                    // Replace the gap with the events we just deduplicated. This might get rid of
+                    // the underlying gap, if the conditions are favorable to
+                    // us.
+                    room_events
+                        .replace_gap_at(reversed_events.clone(), gap_id)
                         .expect("gap_identifier is a valid chunk id we read previously")
                 } else if let Some(pos) = first_event_pos {
                     // No prior gap, but we had some events: assume we need to prepend events
@@ -1478,20 +1479,17 @@ mod private {
 
                 // And insert the new gap if needs be.
                 //
-                // We only do this when at least one new, non-duplicated event, has been added to
-                // the chunk. Otherwise it means we've back-paginated all the known events.
-                if !all_duplicates {
-                    if let Some(new_gap) = new_gap {
-                        if let Some(new_pos) = insert_new_gap_pos {
-                            room_events
-                                .insert_gap_at(new_gap, new_pos)
-                                .expect("events_chunk_pos represents a valid chunk position");
-                        } else {
-                            room_events.push_gap(new_gap);
-                        }
+                // We only do this when at least one new, non-duplicated event, has been added
+                // to the chunk. Otherwise it means we've back-paginated all the
+                // known events.
+                if let Some(new_gap) = new_gap {
+                    if let Some(new_pos) = insert_new_gap_pos {
+                        room_events
+                            .insert_gap_at(new_gap, new_pos)
+                            .expect("events_chunk_pos represents a valid chunk position");
+                    } else {
+                        room_events.push_gap(new_gap);
                     }
-                } else {
-                    debug!("not storing previous batch token, because we deduplicated all new back-paginated events");
                 }
 
                 reversed_events

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -454,7 +454,9 @@ mod private {
             ThreadSummary, ThreadSummaryStatus, TimelineEvent, TimelineEventKind,
         },
         event_cache::{store::EventCacheStoreLock, Event, Gap},
-        linked_chunk::{lazy_loader, ChunkContent, ChunkIdentifierGenerator, Position, Update},
+        linked_chunk::{
+            lazy_loader, ChunkContent, ChunkIdentifier, ChunkIdentifierGenerator, Position, Update,
+        },
         serde_helpers::extract_thread_root,
         sync::Timeline,
     };
@@ -476,7 +478,8 @@ mod private {
         sort_positions_descending, EventLocation, LoadMoreEventsBackwardsOutcome,
     };
     use crate::event_cache::{
-        deduplicator::filter_duplicate_events, RoomEventCacheUpdate, RoomPaginationStatus,
+        deduplicator::filter_duplicate_events, BackPaginationOutcome, EventsOrigin,
+        RoomEventCacheUpdate, RoomPaginationStatus,
     };
 
     /// State for a single room's event cache.
@@ -1288,6 +1291,12 @@ mod private {
         }
 
         /// Handle the result of a sync.
+        ///
+        /// It may send room event cache updates to the given sender, if it
+        /// generated any of those.
+        ///
+        /// Returns true if a new gap (previous-batch token) has been inserted,
+        /// false otherwise.
         pub async fn handle_sync(
             &mut self,
             mut timeline: Timeline,
@@ -1391,11 +1400,162 @@ mod private {
             if !timeline_event_diffs.is_empty() {
                 let _ = sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
                     diffs: timeline_event_diffs,
-                    origin: crate::event_cache::EventsOrigin::Sync,
+                    origin: EventsOrigin::Sync,
                 });
             }
 
             Ok(prev_batch.is_some())
+        }
+
+        pub async fn handle_backpagination(
+            &mut self,
+            events: Vec<TimelineEvent>,
+            new_gap: Option<Gap>,
+            prev_gap_id: Option<ChunkIdentifier>,
+            sender: &Sender<RoomEventCacheUpdate>,
+        ) -> Result<BackPaginationOutcome, EventCacheError> {
+            // If there's no new gap (previous batch token), then we've reached the start of
+            // the timeline.
+            let network_reached_start = new_gap.is_none();
+
+            let (
+                DeduplicationOutcome {
+                    all_events: mut events,
+                    in_memory_duplicated_event_ids,
+                    in_store_duplicated_event_ids,
+                },
+                all_duplicates,
+            ) = self.collect_valid_and_duplicated_events(events).await?;
+
+            // If not all the events have been back-paginated, we need to remove the
+            // previous ones, otherwise we can end up with misordered events.
+            //
+            // Consider the following scenario:
+            // - sync returns [D, E, F]
+            // - then sync returns [] with a previous batch token PB1, so the internal
+            //   linked chunk state is [D, E, F, PB1].
+            // - back-paginating with PB1 may return [A, B, C, D, E, F].
+            //
+            // Only inserting the new events when replacing PB1 would result in a timeline
+            // ordering of [D, E, F, A, B, C], which is incorrect. So we do have to remove
+            // all the events, in case this happens (see also #4746).
+
+            let mut event_diffs = if !all_duplicates {
+                // Let's forget all the previous events.
+                self.remove_events(in_memory_duplicated_event_ids, in_store_duplicated_event_ids)
+                    .await?
+            } else {
+                // All new events are duplicated, they can all be ignored.
+                events.clear();
+                Default::default()
+            };
+
+            let next_diffs = self
+            .with_events_mut(false, |room_events| {
+            // Reverse the order of the events as `/messages` has been called with `dir=b`
+            // (backwards). The `RoomEvents` API expects the first event to be the oldest.
+            // Let's re-order them for this block.
+            let reversed_events = events
+                .iter()
+                .rev()
+                .cloned()
+                .collect::<Vec<_>>();
+
+            let first_event_pos = room_events.events().next().map(|(item_pos, _)| item_pos);
+
+            // First, insert events.
+            let insert_new_gap_pos = if let Some(gap_id) = prev_gap_id {
+                // There is a prior gap, let's replace it by new events!
+                if all_duplicates {
+                    assert!(reversed_events.is_empty());
+                }
+
+                trace!("replacing previous gap with the back-paginated events");
+
+                // Replace the gap with the events we just deduplicated. This might get rid of the
+                // underlying gap, if the conditions are favorable to us.
+                room_events.replace_gap_at(reversed_events.clone(), gap_id)
+                    .expect("gap_identifier is a valid chunk id we read previously")
+            } else if let Some(pos) = first_event_pos {
+                // No prior gap, but we had some events: assume we need to prepend events
+                // before those.
+                trace!("inserted events before the first known event");
+
+                room_events
+                    .insert_events_at(reversed_events.clone(), pos)
+                    .expect("pos is a valid position we just read above");
+
+                Some(pos)
+            } else {
+                // No prior gap, and no prior events: push the events.
+                trace!("pushing events received from back-pagination");
+
+                room_events.push_events(reversed_events.clone());
+
+                // A new gap may be inserted before the new events, if there are any.
+                room_events.events().next().map(|(item_pos, _)| item_pos)
+            };
+
+            // And insert the new gap if needs be.
+            //
+            // We only do this when at least one new, non-duplicated event, has been added to
+            // the chunk. Otherwise it means we've back-paginated all the known events.
+            if !all_duplicates {
+                if let Some(new_gap) = new_gap {
+                    if let Some(new_pos) = insert_new_gap_pos {
+                        room_events
+                            .insert_gap_at(new_gap, new_pos)
+                            .expect("events_chunk_pos represents a valid chunk position");
+                    } else {
+                        room_events.push_gap(new_gap);
+                    }
+                }
+            } else {
+                debug!("not storing previous batch token, because we deduplicated all new back-paginated events");
+            }
+
+            reversed_events
+        })
+        .await?;
+
+            event_diffs.extend(next_diffs);
+
+            // There could be an inconsistency between the network (which thinks we hit the
+            // start of the timeline) and the disk (which has the initial empty
+            // chunks), so tweak the `reached_start` value so that it reflects the disk
+            // state in priority instead.
+            let reached_start = {
+                // There are no gaps.
+                let has_gaps = self.events.chunks().any(|chunk| chunk.is_gap());
+
+                // The first chunk has no predecessors.
+                let first_chunk_is_definitive_head =
+                    self.events.chunks().next().map(|chunk| chunk.is_definitive_head());
+
+                let reached_start =
+                    !has_gaps && first_chunk_is_definitive_head.unwrap_or(network_reached_start);
+
+                trace!(
+                    ?network_reached_start,
+                    ?has_gaps,
+                    ?first_chunk_is_definitive_head,
+                    ?reached_start,
+                    "finished handling network back-pagination"
+                );
+
+                reached_start
+            };
+
+            let backpagination_outcome = BackPaginationOutcome { events, reached_start };
+
+            if !event_diffs.is_empty() {
+                let _ = sender.send(RoomEventCacheUpdate::UpdateTimelineEvents {
+                    diffs: event_diffs,
+                    origin: EventsOrigin::Pagination,
+                });
+            }
+
+            Ok(backpagination_outcome)
         }
     }
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
