### PR TITLE
feat(ffi): Add reply_params to GalleryUploadParameters

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -34,6 +34,8 @@ Additions:
   ([#4994](https://github.com/matrix-org/matrix-rust-sdk/pull/4994))
 - Add `Timeline::send_gallery` to send MSC4274-style galleries.
   ([#5163](https://github.com/matrix-org/matrix-rust-sdk/pull/5163))
+- Add `reply_params` to `GalleryUploadParameters` to allow sending galleries as (threaded) replies.
+  ([#5173](https://github.com/matrix-org/matrix-rust-sdk/pull/5173))
 
 Breaking changes:
 

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -1391,7 +1391,7 @@ mod galleries {
     use crate::{
         error::RoomError,
         ruma::{AudioInfo, FileInfo, FormattedBody, ImageInfo, Mentions, VideoInfo},
-        timeline::{build_thumbnail_info, Timeline},
+        timeline::{build_thumbnail_info, ReplyParameters, Timeline},
     };
 
     #[derive(uniffi::Record)]
@@ -1402,6 +1402,8 @@ mod galleries {
         formatted_caption: Option<FormattedBody>,
         /// Optional intentional mentions to be sent with the gallery.
         mentions: Option<Mentions>,
+        /// Optional parameters for sending the media as (threaded) reply.
+        reply_params: Option<ReplyParameters>,
     }
 
     #[derive(uniffi::Enum)]
@@ -1586,7 +1588,8 @@ mod galleries {
             let mut gallery_config = GalleryConfig::new()
                 .caption(params.caption)
                 .formatted_caption(formatted_caption)
-                .mentions(params.mentions.map(Into::into));
+                .mentions(params.mentions.map(Into::into))
+                .reply(params.reply_params.map(|p| p.try_into()).transpose()?);
 
             for item_info in item_infos {
                 gallery_config = gallery_config.add_item(item_info.try_into()?);


### PR DESCRIPTION
Looks like I forgot adding this in https://github.com/matrix-org/matrix-rust-sdk/pull/5163, sorry. Everything below the FFI layer was already prepared for replies.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
