### PR TITLE
feat(ffi): Subscribe to a room's `RoomInfo` through `Client`

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -21,6 +21,9 @@ Breaking changes:
 
 Additions:
 
+- `Client::subscribe_to_room_info` allows clients to subscribe to room info updates in rooms which may not be known yet. 
+  This is useful when displaying a room preview for an unknown room, so when we receive any membership change for it, 
+  we can automatically update the UI.
 - `Client::get_max_media_upload_size` to get the max size of a request sent to the homeserver so we can tweak our media
   uploads by compressing/transcoding the media.
 - Add `ClientBuilder::enable_share_history_on_invite` to enable experimental support for sharing encrypted room history on invite, per [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268).

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -37,6 +37,7 @@ use matrix_sdk::{
     },
     sliding_sync::Version as SdkSlidingSyncVersion,
     store::RoomLoadSettings as SdkRoomLoadSettings,
+    sync::RoomUpdate,
     AuthApi, AuthSession, Client as MatrixClient, SessionChange, SessionTokens,
     STATE_STORE_DATABASE_NAME,
 };
@@ -93,8 +94,9 @@ use crate::{
     encryption::Encryption,
     notification::NotificationClient,
     notification_settings::NotificationSettings,
-    room::RoomHistoryVisibility,
+    room::{RoomHistoryVisibility, RoomInfoListener},
     room_directory_search::RoomDirectorySearch,
+    room_info::RoomInfo,
     room_preview::RoomPreview,
     ruma::{
         AccountDataEvent, AccountDataEventType, AuthData, InviteAvatars, MediaPreviewConfig,
@@ -1560,6 +1562,47 @@ impl Client {
     pub async fn get_max_media_upload_size(&self) -> Result<u64, ClientError> {
         let max_upload_size = self.inner.load_or_fetch_max_upload_size().await?;
         Ok(max_upload_size.into())
+    }
+
+    /// Subscribe to [`RoomInfo`] updates given a provided [`RoomId`].
+    ///
+    /// This works even for rooms we haven't received yet, so we can subscribe
+    /// to this and wait until we receive updates from them when sync responses
+    /// are processed.
+    ///
+    /// Note this method should be used sparingly since using callback
+    /// interfaces is expensive, as well as keeping them alive for a long
+    /// time. Usages of this method should be short-lived and dropped as
+    /// soon as possible.
+    pub async fn subscribe_to_room_info(
+        &self,
+        room_id: String,
+        listener: Box<dyn RoomInfoListener>,
+    ) -> Result<Arc<TaskHandle>, ClientError> {
+        let room_id = RoomId::parse(room_id)?;
+        let receiver = self.inner.subscribe_to_room_updates(&room_id);
+
+        // Emit the initial event, if present
+        if let Some(room) = self.inner.get_room(&room_id) {
+            if let Ok(room_info) = RoomInfo::new(&room).await {
+                listener.call(room_info);
+            }
+        }
+
+        Ok(Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
+            pin_mut!(receiver);
+            while let Ok(room_update) = receiver.recv().await {
+                let room = match room_update {
+                    RoomUpdate::Invited { room, .. } => room,
+                    RoomUpdate::Joined { room, .. } => room,
+                    RoomUpdate::Knocked { room, .. } => room,
+                    RoomUpdate::Left { room, .. } => room,
+                };
+                if let Ok(room_info) = RoomInfo::new(&room).await {
+                    listener.call(room_info);
+                }
+            }
+        }))))
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -1764,7 +1764,7 @@ pub use galleries::*;
 mod galleries {
     use ruma::{
         events::room::message::{
-            FormattedBody as RumaFormattedBody, GalleryItemType as RumaGalleryItemType,
+            GalleryItemType as RumaGalleryItemType,
             GalleryMessageEventContent as RumaGalleryMessageEventContent,
         },
         serde::JsonObject,


### PR DESCRIPTION
This helps in the case we want to observe the membership state changes - or some other info - for a room that's still not known so we can't just use `Client::get_room` to fetch it.

<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
