### PR TITLE
chore(ci): exclude `matrix-sdk-base` from code coverage testing :(

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,6 @@ jobs:
           RUST_LOG: "info,matrix_sdk=trace"
           HOMESERVER_URL: "http://localhost:8008"
           HOMESERVER_DOMAIN: "synapse"
-          SLIDING_SYNC_PROXY_URL: "http://localhost:8118"
         run: |
           cargo nextest run -p matrix-sdk-integration-testing
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -78,7 +78,6 @@ jobs:
           CARGO_PROFILE_COV_DEBUG: 1
           HOMESERVER_URL: "http://localhost:8008"
           HOMESERVER_DOMAIN: "synapse"
-          SLIDING_SYNC_PROXY_URL: "http://localhost:8118"
 
       # Copied with minimal adjustments, source:
       # https://github.com/google/mdbook-i18n-helpers/blob/2168b9cea1f4f76b55426591a9bcc308a620194f/.github/workflows/test.yml

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -9,7 +9,7 @@ exclude-files = [
 ]
 workspace = true
 # sqlite crypto store is not tested otherwise because it's only activated by
-# matrix-sdk-crypto-ffi, which is excluded from testing below
+# matrix-sdk-crypto-ffi, which is excluded from testing below.
 features = "crypto-store"
 exclude = [
     # bindings
@@ -23,4 +23,6 @@ exclude = [
     # repo automation (ci, codegen)
     "uniffi-bindgen",
     "xtask",
+    # until it doesn't segfault anymore, this is excluded :(
+    "matrix-sdk-base",
 ]

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -4,6 +4,7 @@ verbose = false
 exclude-files = [
     "examples/*",
     "testing/*",
+    "labs/*",
     "**/tests/*",
 ]
 workspace = true


### PR DESCRIPTION
This particular crate is running into segfaults as part of the code coverage job in #5165. I've opened https://github.com/xd009642/tarpaulin/issues/1749 to track the status of this failure upstream, or know if there are workarounds/other solutions we could try. In the meantime, @poljar agreed with me that we ought to disable it.

This will lose us a few points of coverage, but hopefully we can get it back when the upstream issue has been fixed.