### PR TITLE
feat(ffi): Add ability to configure indexedb instead of sqlite for wasm platforms

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -18,6 +18,8 @@ Breaking changes:
 - `RoomInfo` replaces its field `is_tombstoned: bool` with `tombstone: Option<RoomTombstoneInfo>`,
   containing the data needed to implement the room migration UI, a message and the replacement room id.
   ([#5027](https://github.com/matrix-org/matrix-rust-sdk/pull/5027))
+- Encapsulate the configuration of the sqlite system into a builder `SqliteSessionBuilder` to allow for 
+  swapping with `IndexedDbSessionBuilder` on Wasm platforms.
 
 Additions:
 

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -14,17 +14,17 @@ publish = false
 release = true
 
 [lib]
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["cdylib", "staticlib", "lib"]
 
 [features]
 default = ["bundled-sqlite", "unstable-msc4274"]
 bundled-sqlite = ["matrix-sdk/bundled-sqlite"]
 unstable-msc4274 = ["matrix-sdk-ui/unstable-msc4274"]
+js = []
 
 [dependencies]
 anyhow.workspace = true
 as_variant.workspace = true
-async-compat = "0.2.4"
 extension-trait = "1.0.1"
 eyeball-im.workspace = true
 futures-util.workspace = true
@@ -36,21 +36,18 @@ matrix-sdk-ui = { workspace = true, features = ["uniffi"] }
 mime = "0.3.16"
 once_cell.workspace = true
 ruma = { workspace = true, features = ["html", "unstable-unspecified", "unstable-msc3488", "compat-unset-avatar", "unstable-msc3245-v1-compat", "unstable-msc4278"] }
-sentry-tracing = "0.36.0"
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing.workspace = true
 tracing-appender = { version = "0.2.2" }
 tracing-core.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-uniffi = { workspace = true, features = ["tokio"] }
 url.workspace = true
 uuid = { version = "1.4.1", features = ["v4"] }
 zeroize.workspace = true
 
-[target.'cfg(not(target_os = "android"))'.dependencies.matrix-sdk]
+[target.'cfg(all(not(target_os = "android"), not(target_family = "wasm")))'.dependencies.matrix-sdk]
 workspace = true
 features = [
     "anyhow",
@@ -64,7 +61,7 @@ features = [
     "uniffi",
 ]
 
-[target.'cfg(not(target_os = "android"))'.dependencies.sentry]
+[target.'cfg(all(not(target_os = "android"), not(target_family = "wasm")))'.dependencies.sentry]
 version = "0.36.0"
 default-features = false
 features = [
@@ -76,6 +73,31 @@ features = [
     "panic",
     "reqwest",
 ]
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+matrix-sdk-ui = { workspace = true, features = ["js", "uniffi"] }
+tokio = { workspace = true, features = ["sync", "macros"] }
+uniffi = { workspace = true, features = [] }
+
+[target.'cfg(target_family = "wasm")'.dependencies.matrix-sdk]
+workspace = true
+features = [
+    "anyhow",
+    "e2e-encryption",
+    "experimental-widgets",
+    "markdown",
+    "rustls-tls",
+    "socks",
+    "indexeddb",
+    "uniffi",
+]
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+async-compat.workspace = true
+matrix-sdk-ui = { workspace = true, features = ["uniffi"] }
+sentry-tracing = "0.36.0"
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+uniffi = { workspace = true, features = ["tokio"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 paranoid-android = "0.2.1"

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["cdylib", "staticlib", "lib"]
 default = ["bundled-sqlite", "unstable-msc4274"]
 bundled-sqlite = ["matrix-sdk/bundled-sqlite"]
 unstable-msc4274 = ["matrix-sdk-ui/unstable-msc4274"]
-js = []
+cross-platform-api = []
 
 [dependencies]
 anyhow.workspace = true
@@ -86,7 +86,7 @@ features = [
     "e2e-encryption",
     "experimental-widgets",
     "markdown",
-    "rustls-tls",
+    "native-tls",
     "socks",
     "indexeddb",
     "uniffi",

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -397,7 +397,7 @@ impl IndexedDbSessionBuilder {
 }
 
 #[derive(Clone)]
-pub enum ClientSessionConfig {
+enum ClientSessionConfig {
     /// Setup the client to use the SQLite store.
     #[cfg_attr(target_family = "wasm", allow(unused))]
     Sqlite(SqliteSessionBuilder),

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -306,7 +306,7 @@ impl SqliteSessionBuilder {
     }
 
     /// Set the passphrase for the stores given to
-    /// [`ClientBuilder::paths`].
+    /// [`SqliteSessionBuilder::paths`].
     pub fn passphrase(self: Arc<Self>, passphrase: Option<String>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.passphrase = Zeroizing::new(passphrase);


### PR DESCRIPTION
Introduces `SqliteSessionBuilder` and `IndexedDbSessionBuilder` to allow for a choice of session store.  Non-wasm platforms will only support sqlite, while Wasm platforms will support indexedb.  In order to maintain a compatible-ffi, these restrictions are handled at runtime rather than compile time.  

We also conditionally remove things related to network features (proxy, ssl validation, etc), that are not available on wasm platforms.

<!-- description of the changes in this PR -->

- [X] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
