### PR TITLE
Enable subscribe_to_send_progress for Wasm

### DIFF
--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -182,7 +182,6 @@ impl SendMediaUploadRequest {
 
     /// Get a subscriber to observe the progress of sending the request
     /// body.
-    #[cfg(not(target_family = "wasm"))]
     pub fn subscribe_to_send_progress(&self) -> Subscriber<TransmissionProgress> {
         self.send_request.send_progress.subscribe()
     }


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Missing one carve out for Wasm platforms that is now fine

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
