### PR TITLE
timeline: Thread filtering

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/configuration.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/configuration.rs
@@ -63,10 +63,28 @@ impl From<FilterTimelineEventType> for TimelineEventType {
 
 #[derive(uniffi::Enum)]
 pub enum TimelineFocus {
-    Live { hide_threaded_events: bool },
-    Event { event_id: String, num_context_events: u16, hide_threaded_events: bool },
-    Thread { root_event_id: String, num_events: u16 },
-    PinnedEvents { max_events_to_load: u16, max_concurrent_requests: u16 },
+    Live {
+        /// Whether to hide in-thread replies from the live timeline.
+        hide_threaded_events: bool,
+    },
+    Event {
+        /// The initial event to focus on. This is usually the target of a
+        /// permalink.
+        event_id: String,
+        /// The number of context events to load around the focused event.
+        num_context_events: u16,
+        /// Whether to hide in-thread replies from the live timeline.
+        hide_threaded_events: bool,
+    },
+    Thread {
+        /// The thread root event ID to focus on.
+        root_event_id: String,
+        num_events: u16,
+    },
+    PinnedEvents {
+        max_events_to_load: u16,
+        max_concurrent_requests: u16,
+    },
 }
 
 impl TryFrom<TimelineFocus> for matrix_sdk_ui::timeline::TimelineFocus {

--- a/bindings/matrix-sdk-ffi/src/timeline/configuration.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/configuration.rs
@@ -63,8 +63,8 @@ impl From<FilterTimelineEventType> for TimelineEventType {
 
 #[derive(uniffi::Enum)]
 pub enum TimelineFocus {
-    Live,
-    Event { event_id: String, num_context_events: u16 },
+    Live { hide_threaded_events: bool },
+    Event { event_id: String, num_context_events: u16, hide_threaded_events: bool },
     Thread { root_event_id: String, num_events: u16 },
     PinnedEvents { max_events_to_load: u16, max_concurrent_requests: u16 },
 }
@@ -76,15 +76,19 @@ impl TryFrom<TimelineFocus> for matrix_sdk_ui::timeline::TimelineFocus {
         value: TimelineFocus,
     ) -> Result<matrix_sdk_ui::timeline::TimelineFocus, Self::Error> {
         match value {
-            TimelineFocus::Live => Ok(Self::Live),
-            TimelineFocus::Event { event_id, num_context_events } => {
+            TimelineFocus::Live { hide_threaded_events } => Ok(Self::Live { hide_threaded_events }),
+            TimelineFocus::Event { event_id, num_context_events, hide_threaded_events } => {
                 let parsed_event_id =
                     EventId::parse(&event_id).map_err(|err| FocusEventError::InvalidEventId {
                         event_id: event_id.clone(),
                         err: err.to_string(),
                     })?;
 
-                Ok(Self::Event { target: parsed_event_id, num_context_events })
+                Ok(Self::Event {
+                    target: parsed_event_id,
+                    num_context_events,
+                    hide_threaded_events,
+                })
             }
             TimelineFocus::Thread { root_event_id, num_events } => {
                 let parsed_root_event_id = EventId::parse(&root_event_id).map_err(|err| {

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -62,7 +62,7 @@ impl TimelineBuilder {
             room: room.clone(),
             settings: TimelineSettings::default(),
             unable_to_decrypt_hook: None,
-            focus: TimelineFocus::Live,
+            focus: TimelineFocus::Live { hide_threaded_events: false },
             internal_id_prefix: None,
         }
     }
@@ -168,7 +168,7 @@ impl TimelineBuilder {
         let (room_event_cache, event_cache_drop) = room.event_cache().await?;
         let (_, event_subscriber) = room_event_cache.subscribe().await;
 
-        let is_live = matches!(focus, TimelineFocus::Live);
+        let is_live = matches!(focus, TimelineFocus::Live { .. });
         let is_pinned_events = matches!(focus, TimelineFocus::PinnedEvents { .. });
         let is_room_encrypted = room
             .latest_encryption_state()

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -17,15 +17,44 @@ use std::{
     sync::Arc,
 };
 
-use ruma::{EventId, OwnedEventId, OwnedUserId, RoomVersionId};
+use imbl::Vector;
+use matrix_sdk::deserialized_responses::EncryptionInfo;
+use ruma::{
+    events::{
+        poll::unstable_start::UnstablePollStartEventContent, relation::Replacement,
+        room::message::RelationWithoutReplacement, AnyMessageLikeEventContent,
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, BundledMessageLikeRelations,
+    },
+    serde::Raw,
+    EventId, OwnedEventId, OwnedUserId, RoomVersionId,
+};
 use tracing::trace;
 
 use super::{
     super::{subscriber::skip::SkipCount, TimelineItem, TimelineItemKind, TimelineUniqueId},
     read_receipts::ReadReceipts,
-    Aggregations, AllRemoteEvents, ObservableItemsTransaction,
+    Aggregation, AggregationKind, Aggregations, AllRemoteEvents, ObservableItemsTransaction,
+    PendingEdit, PendingEditKind,
 };
-use crate::unable_to_decrypt_hook::UtdHookManager;
+use crate::{
+    timeline::{
+        event_item::{
+            extract_bundled_edit_event_json, extract_poll_edit_content,
+            extract_room_msg_edit_content,
+        },
+        InReplyToDetails, TimelineEventItemId,
+    },
+    unable_to_decrypt_hook::UtdHookManager,
+};
+
+/// All parameters to [`TimelineAction::from_content`] that only apply if an
+/// event is a remote echo.
+pub struct RemoteEventContext<'a> {
+    pub event_id: &'a EventId,
+    pub raw_event: &'a Raw<AnySyncTimelineEvent>,
+    pub relations: BundledMessageLikeRelations<AnySyncMessageLikeEvent>,
+    pub bundled_edit_encryption_info: Option<Arc<EncryptionInfo>>,
+}
 
 #[derive(Clone, Debug)]
 pub(in crate::timeline) struct TimelineMetadata {
@@ -276,6 +305,140 @@ impl TimelineMetadata {
                     self.has_up_to_date_read_marker_item = false;
                 }
             }
+        }
+    }
+
+    pub(crate) fn process_content_relations(
+        &mut self,
+        content: &AnyMessageLikeEventContent,
+        remote_ctx: Option<RemoteEventContext<'_>>,
+        timeline_items: &Vector<Arc<TimelineItem>>,
+    ) -> (Option<InReplyToDetails>, Option<OwnedEventId>) {
+        match content {
+            AnyMessageLikeEventContent::Sticker(content) => {
+                let (in_reply_to, thread_root) = Self::extract_reply_and_thread_root(
+                    content.relates_to.clone().and_then(|rel| rel.try_into().ok()),
+                    timeline_items,
+                );
+
+                if let Some(event_id) = remote_ctx.map(|ctx| ctx.event_id) {
+                    self.mark_response(event_id, in_reply_to.as_ref());
+                }
+
+                (in_reply_to, thread_root)
+            }
+
+            AnyMessageLikeEventContent::UnstablePollStart(UnstablePollStartEventContent::New(
+                c,
+            )) => {
+                let (in_reply_to, thread_root) =
+                    Self::extract_reply_and_thread_root(c.relates_to.clone(), timeline_items);
+
+                // Record the bundled edit in the aggregations set, if any.
+                if let Some(ctx) = remote_ctx {
+                    if let Some(new_content) = extract_poll_edit_content(ctx.relations) {
+                        // It is replacing the current event.
+                        if let Some(edit_event_id) =
+                            ctx.raw_event.get_field::<OwnedEventId>("event_id").ok().flatten()
+                        {
+                            let edit_json = extract_bundled_edit_event_json(ctx.raw_event);
+                            let aggregation = Aggregation::new(
+                                TimelineEventItemId::EventId(edit_event_id),
+                                AggregationKind::Edit(PendingEdit {
+                                    kind: PendingEditKind::Poll(Replacement::new(
+                                        ctx.event_id.to_owned(),
+                                        new_content,
+                                    )),
+                                    edit_json,
+                                    encryption_info: ctx.bundled_edit_encryption_info,
+                                }),
+                            );
+                            self.aggregations.add(
+                                TimelineEventItemId::EventId(ctx.event_id.to_owned()),
+                                aggregation,
+                            );
+                        }
+                    }
+
+                    self.mark_response(ctx.event_id, in_reply_to.as_ref());
+                }
+
+                (in_reply_to, thread_root)
+            }
+
+            AnyMessageLikeEventContent::RoomMessage(msg) => {
+                let (in_reply_to, thread_root) = Self::extract_reply_and_thread_root(
+                    msg.relates_to.clone().and_then(|rel| rel.try_into().ok()),
+                    timeline_items,
+                );
+
+                // Record the bundled edit in the aggregations set, if any.
+                if let Some(ctx) = remote_ctx {
+                    if let Some(new_content) = extract_room_msg_edit_content(ctx.relations) {
+                        // It is replacing the current event.
+                        if let Some(edit_event_id) =
+                            ctx.raw_event.get_field::<OwnedEventId>("event_id").ok().flatten()
+                        {
+                            let edit_json = extract_bundled_edit_event_json(ctx.raw_event);
+                            let aggregation = Aggregation::new(
+                                TimelineEventItemId::EventId(edit_event_id),
+                                AggregationKind::Edit(PendingEdit {
+                                    kind: PendingEditKind::RoomMessage(Replacement::new(
+                                        ctx.event_id.to_owned(),
+                                        new_content,
+                                    )),
+                                    edit_json,
+                                    encryption_info: ctx.bundled_edit_encryption_info,
+                                }),
+                            );
+                            self.aggregations.add(
+                                TimelineEventItemId::EventId(ctx.event_id.to_owned()),
+                                aggregation,
+                            );
+                        }
+                    }
+
+                    self.mark_response(ctx.event_id, in_reply_to.as_ref());
+                }
+
+                (in_reply_to, thread_root)
+            }
+
+            _ => (None, None),
+        }
+    }
+
+    fn extract_reply_and_thread_root(
+        relates_to: Option<RelationWithoutReplacement>,
+        timeline_items: &Vector<Arc<TimelineItem>>,
+    ) -> (Option<InReplyToDetails>, Option<OwnedEventId>) {
+        let mut thread_root = None;
+
+        let in_reply_to = relates_to.and_then(|relation| match relation {
+            RelationWithoutReplacement::Reply { in_reply_to } => {
+                Some(InReplyToDetails::new(in_reply_to.event_id, timeline_items))
+            }
+            RelationWithoutReplacement::Thread(thread) => {
+                thread_root = Some(thread.event_id);
+                thread
+                    .in_reply_to
+                    .map(|in_reply_to| InReplyToDetails::new(in_reply_to.event_id, timeline_items))
+            }
+            _ => None,
+        });
+
+        (in_reply_to, thread_root)
+    }
+
+    fn mark_response(&mut self, event_id: &EventId, in_reply_to: Option<&InReplyToDetails>) {
+        // If this message is a reply to another message, add an entry in the
+        // inverted mapping.
+        if let Some(replied_to_event_id) = in_reply_to.as_ref().map(|details| &details.event_id) {
+            // This is a reply! Add an entry.
+            self.replies
+                .entry(replied_to_event_id.to_owned())
+                .or_default()
+                .insert(event_id.to_owned());
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -308,6 +308,32 @@ impl TimelineMetadata {
         }
     }
 
+    pub(crate) fn process_event_relations(
+        &mut self,
+        event: AnySyncTimelineEvent,
+        raw_event: &Raw<AnySyncTimelineEvent>,
+        bundled_edit_encryption_info: Option<Arc<EncryptionInfo>>,
+        timeline_items: &Vector<Arc<TimelineItem>>,
+    ) -> (Option<InReplyToDetails>, Option<OwnedEventId>) {
+        match event {
+            AnySyncTimelineEvent::MessageLike(ev) => match ev.original_content() {
+                Some(content) => {
+                    let remote_ctx = Some(RemoteEventContext {
+                        event_id: ev.event_id(),
+                        raw_event,
+                        relations: ev.relations(),
+                        bundled_edit_encryption_info,
+                    });
+
+                    self.process_content_relations(&content, remote_ctx, timeline_items)
+                }
+
+                None => (None, None),
+            },
+            _ => (None, None),
+        }
+    }
+
     pub(crate) fn process_content_relations(
         &mut self,
         content: &AnyMessageLikeEventContent,

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -54,7 +54,7 @@ use tokio::sync::{RwLock, RwLockWriteGuard};
 use tracing::{debug, error, field::debug, info, instrument, trace, warn};
 
 pub(super) use self::{
-    metadata::{RelativePosition, RemoteEventContext, TimelineMetadata},
+    metadata::{RelativePosition, TimelineMetadata},
     observable_items::{
         AllRemoteEvents, ObservableItems, ObservableItemsEntry, ObservableItemsTransaction,
         ObservableItemsTransactionEntry,

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -54,7 +54,7 @@ use tokio::sync::{RwLock, RwLockWriteGuard};
 use tracing::{debug, error, field::debug, info, instrument, trace, warn};
 
 pub(super) use self::{
-    metadata::{RelativePosition, TimelineMetadata},
+    metadata::{RelativePosition, RemoteEventContext, TimelineMetadata},
     observable_items::{
         AllRemoteEvents, ObservableItems, ObservableItemsEntry, ObservableItemsTransaction,
         ObservableItemsTransactionEntry,

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1349,15 +1349,9 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
     ) -> Result<Option<EmbeddedEvent>, Error> {
         // Reborrow, to avoid that the automatic deref borrows the entire guard (and we
         // can't borrow both items and meta).
-        let state = &mut *self.state.write().await;
+        let state = &*self.state.write().await;
 
-        EmbeddedEvent::try_from_timeline_event(
-            event,
-            &self.room_data_provider,
-            &state.items,
-            &mut state.meta,
-        )
-        .await
+        EmbeddedEvent::try_from_timeline_event(event, &self.room_data_provider, &state.meta).await
     }
 }
 
@@ -1587,15 +1581,10 @@ async fn fetch_replied_to_event(
     trace!("Fetching replied-to event");
     let res = match room.load_or_fetch_event(in_reply_to, None).await {
         Ok(timeline_event) => {
-            let state = &mut *state_lock.write().await;
+            let state = &*state_lock.write().await;
 
-            let replied_to_item = EmbeddedEvent::try_from_timeline_event(
-                timeline_event,
-                room,
-                &state.items,
-                &mut state.meta,
-            )
-            .await?;
+            let replied_to_item =
+                EmbeddedEvent::try_from_timeline_event(timeline_event, room, &state.meta).await?;
 
             if let Some(item) = replied_to_item {
                 TimelineDetails::Ready(Box::new(item))

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -181,11 +181,11 @@ impl Default for TimelineSettings {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(super) enum TimelineFocusKind {
     Live,
     Event,
-    Thread,
+    Thread { root_event_id: OwnedEventId },
     PinnedEvents,
 }
 
@@ -291,10 +291,13 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
 
             TimelineFocus::Thread { root_event_id, num_events } => (
                 TimelineFocusData::Thread {
-                    loader: ThreadedEventsLoader::new(room_data_provider.clone(), root_event_id),
+                    loader: ThreadedEventsLoader::new(
+                        room_data_provider.clone(),
+                        root_event_id.clone(),
+                    ),
                     num_events,
                 },
-                TimelineFocusKind::Thread,
+                TimelineFocusKind::Thread { root_event_id },
             ),
 
             TimelineFocus::PinnedEvents { max_events_to_load, max_concurrent_requests } => (

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -183,8 +183,8 @@ impl Default for TimelineSettings {
 
 #[derive(Debug, Clone)]
 pub(super) enum TimelineFocusKind {
-    Live,
-    Event,
+    Live { hide_threaded_events: bool },
+    Event { hide_threaded_events: bool },
     Thread { root_event_id: OwnedEventId },
     PinnedEvents,
 }
@@ -279,13 +279,15 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
         is_room_encrypted: bool,
     ) -> Self {
         let (focus_data, focus_kind) = match focus {
-            TimelineFocus::Live => (TimelineFocusData::Live, TimelineFocusKind::Live),
+            TimelineFocus::Live { hide_threaded_events } => {
+                (TimelineFocusData::Live, TimelineFocusKind::Live { hide_threaded_events })
+            }
 
-            TimelineFocus::Event { target, num_context_events } => {
+            TimelineFocus::Event { target, num_context_events, hide_threaded_events } => {
                 let paginator = Paginator::new(room_data_provider.clone());
                 (
                     TimelineFocusData::Event { paginator, event_id: target, num_context_events },
-                    TimelineFocusKind::Event,
+                    TimelineFocusKind::Event { hide_threaded_events },
                 )
             }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1352,10 +1352,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
         &self,
         event: TimelineEvent,
     ) -> Result<Option<EmbeddedEvent>, Error> {
-        // Reborrow, to avoid that the automatic deref borrows the entire guard (and we
-        // can't borrow both items and meta).
-        let state = &*self.state.write().await;
-
+        let state = self.state.read().await;
         EmbeddedEvent::try_from_timeline_event(event, &self.room_data_provider, &state.meta).await
     }
 }
@@ -1586,7 +1583,7 @@ async fn fetch_replied_to_event(
     trace!("Fetching replied-to event");
     let res = match room.load_or_fetch_event(in_reply_to, None).await {
         Ok(timeline_event) => {
-            let state = &*state_lock.write().await;
+            let state = state_lock.read().await;
 
             let replied_to_item =
                 EmbeddedEvent::try_from_timeline_event(timeline_event, room, &state.meta).await?;

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -199,13 +199,15 @@ impl TimelineState {
         thread_root: &Option<OwnedEventId>,
     ) -> bool {
         match &timeline_focus {
-            TimelineFocusKind::Live => thread_root.is_none(),
+            TimelineFocusKind::Live { hide_threaded_events } => {
+                thread_root.is_none() || thread_root.is_some() && !hide_threaded_events
+            }
 
             TimelineFocusKind::Thread { root_event_id } => {
                 thread_root.as_ref().is_some_and(|r| r == root_event_id)
             }
 
-            TimelineFocusKind::Event | TimelineFocusKind::PinnedEvents => false,
+            TimelineFocusKind::Event { .. } | TimelineFocusKind::PinnedEvents => false,
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -182,8 +182,11 @@ impl TimelineState {
 
         let mut date_divider_adjuster = DateDividerAdjuster::new(date_divider_mode);
 
+        let (in_reply_to, thread_root) =
+            txn.meta.process_content_relations(&content, None, &txn.items);
+
         if let Some(timeline_action) =
-            TimelineAction::from_content(content, None, &txn.items, &mut txn.meta)
+            TimelineAction::from_content(content, in_reply_to, thread_root, None)
         {
             TimelineEventHandler::new(&mut txn, ctx)
                 .handle_event(&mut date_divider_adjuster, timeline_action)

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -162,9 +162,8 @@ impl TimelineState {
     ) {
         // Only add new items if the timeline is live.
         let should_add_new_items = match self.timeline_focus {
-            TimelineFocusKind::Live => true,
+            TimelineFocusKind::Live | TimelineFocusKind::Thread { .. } => true,
             TimelineFocusKind::Event | TimelineFocusKind::PinnedEvents => false,
-            TimelineFocusKind::Thread => false,
         };
 
         let ctx = TimelineEventContext {
@@ -297,6 +296,6 @@ impl TimelineState {
     }
 
     pub(super) fn transaction(&mut self) -> TimelineStateTransaction<'_> {
-        TimelineStateTransaction::new(&mut self.items, &mut self.meta, self.timeline_focus)
+        TimelineStateTransaction::new(&mut self.items, &mut self.meta, self.timeline_focus.clone())
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -206,10 +206,10 @@ impl<'a> TimelineStateTransaction<'a> {
             event.raw(),
             room_data_provider,
             None,
+            &self.meta,
             None,
             None,
-            &self.items,
-            &mut self.meta,
+            None,
         )
         .await
         {
@@ -619,6 +619,13 @@ impl<'a> TimelineStateTransaction<'a> {
         {
             // Classical path: the event is valid, can be deserialized, everything is alright.
             Ok(event) => {
+                let (in_reply_to, thread_root) = self.meta.process_event_relations(
+                    event.clone(),
+                    &raw,
+                    bundled_edit_encryption_info,
+                    &self.items,
+                );
+
                 let should_add =
                     self.should_add_event_item(room_data_provider, settings, &event, position);
                 (
@@ -630,11 +637,11 @@ impl<'a> TimelineStateTransaction<'a> {
                         event,
                         &raw,
                         room_data_provider,
-                        thread_summary,
                         utd_info,
-                        bundled_edit_encryption_info,
-                        &self.items,
-                        &mut self.meta,
+                        &self.meta,
+                        in_reply_to,
+                        thread_root,
+                        thread_summary,
                     )
                     .await,
                     should_add,

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -408,8 +408,8 @@ impl<'a> TimelineStateTransaction<'a> {
                 room_data_provider.is_pinned_event(event.event_id())
             }
 
-            TimelineFocusKind::Event => {
-                if thread_root.is_some() {
+            TimelineFocusKind::Event { hide_threaded_events } => {
+                if thread_root.is_some() && *hide_threaded_events {
                     return false;
                 }
 
@@ -433,7 +433,9 @@ impl<'a> TimelineStateTransaction<'a> {
                 }
             }
 
-            TimelineFocusKind::Live => thread_root.is_none(),
+            TimelineFocusKind::Live { hide_threaded_events } => {
+                thread_root.is_none() || thread_root.is_some() && !hide_threaded_events
+            }
 
             TimelineFocusKind::Thread { root_event_id } => {
                 event.event_id() == root_event_id

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -561,19 +561,14 @@ impl<'a> TimelineStateTransaction<'a> {
             })
             .ok()?;
 
-        EmbeddedEvent::try_from_timeline_event(
-            event,
-            room_data_provider,
-            &self.items,
-            &mut self.meta,
-        )
-        .await
-        .inspect_err(|err| {
-            warn!("Failed to extract thread latest event into a timeline item content: {err}");
-        })
-        .ok()
-        .flatten()
-        .map(Box::new)
+        EmbeddedEvent::try_from_timeline_event(event, room_data_provider, &self.meta)
+            .await
+            .inspect_err(|err| {
+                warn!("Failed to extract thread latest event into a timeline item content: {err}");
+            })
+            .ok()
+            .flatten()
+            .map(Box::new)
     }
 
     /// Handle a remote event.

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -433,9 +433,7 @@ impl<'a> TimelineStateTransaction<'a> {
                 }
             }
 
-            TimelineFocusKind::Live => {
-                return thread_root.is_none();
-            }
+            TimelineFocusKind::Live => thread_root.is_none(),
 
             TimelineFocusKind::Thread { root_event_id } => {
                 event.event_id() == root_event_id

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -113,16 +113,23 @@ impl EmbeddedEvent {
         // We don't need to fill the thread information of an embedded reply.
         let thread_summary = None;
 
+        let (in_reply_to, thread_root) = meta.process_event_relations(
+            event.clone(),
+            &raw_event,
+            bundled_edit_encryption_info,
+            timeline_items,
+        );
+
         let sender = event.sender().to_owned();
         let action = TimelineAction::from_event(
             event,
             &raw_event,
             room_data_provider,
-            thread_summary,
             unable_to_decrypt_info,
-            bundled_edit_encryption_info,
-            timeline_items,
             meta,
+            in_reply_to,
+            thread_root,
+            thread_summary,
         )
         .await;
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -121,10 +121,10 @@ pub struct Timeline {
 pub enum TimelineFocus {
     /// Focus on live events, i.e. receive events from sync and append them in
     /// real-time.
-    Live,
+    Live { hide_threaded_events: bool },
 
     /// Focus on a specific event, e.g. after clicking a permalink.
-    Event { target: OwnedEventId, num_context_events: u16 },
+    Event { target: OwnedEventId, num_context_events: u16, hide_threaded_events: bool },
 
     /// Focus on a specific thread
     Thread { root_event_id: OwnedEventId, num_events: u16 },
@@ -136,7 +136,7 @@ pub enum TimelineFocus {
 impl TimelineFocus {
     pub(super) fn debug_string(&self) -> String {
         match self {
-            TimelineFocus::Live => "live".to_owned(),
+            TimelineFocus::Live { .. } => "live".to_owned(),
             TimelineFocus::Event { target, .. } => format!("permalink:{target}"),
             TimelineFocus::Thread { root_event_id, .. } => format!("thread:{root_event_id}"),
             TimelineFocus::PinnedEvents { .. } => "pinned-events".to_owned(),

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -121,13 +121,31 @@ pub struct Timeline {
 pub enum TimelineFocus {
     /// Focus on live events, i.e. receive events from sync and append them in
     /// real-time.
-    Live { hide_threaded_events: bool },
+    Live {
+        /// Whether to hide in-thread replies from the live timeline.
+        ///
+        /// This should be set to true when the client can create
+        /// [`Self::Thread`]-focused timelines from the thread roots themselves.
+        hide_threaded_events: bool,
+    },
 
     /// Focus on a specific event, e.g. after clicking a permalink.
-    Event { target: OwnedEventId, num_context_events: u16, hide_threaded_events: bool },
+    Event {
+        target: OwnedEventId,
+        num_context_events: u16,
+        /// Whether to hide in-thread replies from the live timeline.
+        ///
+        /// This should be set to true when the client can create
+        /// [`Self::Thread`]-focused timelines from the thread roots themselves.
+        hide_threaded_events: bool,
+    },
 
     /// Focus on a specific thread
-    Thread { root_event_id: OwnedEventId, num_events: u16 },
+    Thread {
+        root_event_id: OwnedEventId,
+        /// Number of initial events to load on the first /relations request.
+        num_events: u16,
+    },
 
     /// Only show pinned events.
     PinnedEvents { max_events_to_load: u16, max_concurrent_requests: u16 },

--- a/crates/matrix-sdk-ui/src/timeline/subscriber.rs
+++ b/crates/matrix-sdk-ui/src/timeline/subscriber.rs
@@ -249,7 +249,7 @@ pub mod skip {
         /// Update the skip count if and only if the timeline has a live focus
         /// ([`TimelineFocusKind::Live`]).
         pub fn update(&self, count: usize, focus_kind: &TimelineFocusKind) {
-            if matches!(focus_kind, TimelineFocusKind::Live) {
+            if matches!(focus_kind, TimelineFocusKind::Live { .. }) {
                 self.count.set_if_not_eq(count);
             }
         }

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -123,7 +123,7 @@ impl TestTimelineBuilder {
     fn build(self) -> TestTimeline {
         let mut controller = TimelineController::new(
             self.provider.unwrap_or_default(),
-            TimelineFocus::Live,
+            TimelineFocus::Live { hide_threaded_events: false },
             self.internal_id_prefix,
             self.utd_hook,
             self.is_room_encrypted,

--- a/crates/matrix-sdk-ui/src/timeline/threaded_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/threaded_events_loader.rs
@@ -21,7 +21,7 @@ use matrix_sdk::{
     },
     room::{IncludeRelations, RelationsOptions},
 };
-use ruma::{api::Direction, events::relation::RelationType, OwnedEventId, UInt};
+use ruma::{api::Direction, OwnedEventId, UInt};
 
 use super::traits::RoomDataProvider;
 
@@ -57,7 +57,7 @@ impl<P: RoomDataProvider> ThreadedEventsLoader<P> {
             from: token,
             dir: Direction::Backward,
             limit: Some(num_events),
-            include_relations: IncludeRelations::RelationsOfType(RelationType::Thread),
+            include_relations: IncludeRelations::AllRelations,
             recurse: true,
         };
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -74,6 +74,7 @@ async fn test_new_focused() {
         .with_focus(TimelineFocus::Event {
             target: target_event.to_owned(),
             num_context_events: 20,
+            hide_threaded_events: false,
         })
         .build()
         .await
@@ -222,6 +223,7 @@ async fn test_live_aggregations_are_reflected_on_focused_timelines() {
         .with_focus(TimelineFocus::Event {
             target: target_event.to_owned(),
             num_context_events: 20,
+            hide_threaded_events: false,
         })
         .build()
         .await
@@ -304,6 +306,7 @@ async fn test_focused_timeline_local_echoes() {
         .with_focus(TimelineFocus::Event {
             target: target_event.to_owned(),
             num_context_events: 20,
+            hide_threaded_events: false,
         })
         .build()
         .await
@@ -383,6 +386,7 @@ async fn test_focused_timeline_doesnt_show_local_echoes() {
         .with_focus(TimelineFocus::Event {
             target: target_event.to_owned(),
             num_context_events: 20,
+            hide_threaded_events: false,
         })
         .build()
         .await

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use assert_matches2::assert_let;
+use std::ops::Not as _;
+
+use assert_matches2::{assert_let, assert_matches};
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt as _;
 use matrix_sdk::{
@@ -99,28 +101,29 @@ async fn test_thread_backpagination() {
     let batch1 = vec![
         factory
             .text_msg("Threaded event 4")
-            .event_id(event_id!("$3"))
-            .in_thread(&thread_root_event_id, event_id!("$latest"))
+            .event_id(event_id!("$4"))
+            .in_thread(&thread_root_event_id, event_id!("$3"))
             .into_raw_sync()
             .cast(),
         factory
             .text_msg("Threaded event 3")
-            .event_id(event_id!("$4"))
-            .in_thread(&thread_root_event_id, event_id!("$latest"))
+            .event_id(event_id!("$3"))
+            .in_thread(&thread_root_event_id, event_id!("$2"))
             .into_raw_sync()
             .cast(),
     ];
+
     let batch2 = vec![
         factory
             .text_msg("Threaded event 2")
             .event_id(event_id!("$2"))
-            .in_thread(&thread_root_event_id, event_id!("$latest"))
+            .in_thread(&thread_root_event_id, event_id!("$1"))
             .into_raw_sync()
             .cast(),
         factory
             .text_msg("Threaded event 1")
             .event_id(event_id!("$1"))
-            .in_thread(&thread_root_event_id, event_id!("$latest"))
+            .in_thread(&thread_root_event_id, event_id!("$root"))
             .into_raw_sync()
             .cast(),
     ];
@@ -176,10 +179,14 @@ async fn test_thread_backpagination() {
 
     // Check the timeline diffs
     assert_let!(VectorDiff::PushFront { value } = &timeline_updates[0]);
-    assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$2"));
+    let event_item = value.as_event().unwrap();
+    assert_eq!(event_item.event_id().unwrap(), event_id!("$2"));
+    assert_eq!(event_item.content().in_reply_to().unwrap().event_id, event_id!("$1"));
 
     assert_let!(VectorDiff::PushFront { value } = &timeline_updates[1]);
-    assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$1"));
+    let event_item = value.as_event().unwrap();
+    assert_eq!(event_item.event_id().unwrap(), event_id!("$1"));
+    assert_eq!(event_item.content().in_reply_to().unwrap().event_id, event_id!("$root"));
 
     assert_let!(VectorDiff::PushFront { value } = &timeline_updates[2]);
     assert_eq!(value.as_event().unwrap().event_id().unwrap(), event_id!("$root"));
@@ -187,6 +194,7 @@ async fn test_thread_backpagination() {
     assert_let!(VectorDiff::PushFront { value } = &timeline_updates[3]);
     assert!(value.is_date_divider());
 
+    // Remove the other day divider.
     assert_let!(VectorDiff::Remove { index: 4 } = &timeline_updates[4]);
 
     // Check the final items
@@ -200,7 +208,6 @@ async fn test_thread_backpagination() {
         items[2].as_event().unwrap().content().as_message().unwrap().body(),
         "Threaded event 1"
     );
-
     assert_eq!(
         items[3].as_event().unwrap().content().as_message().unwrap().body(),
         "Threaded event 2"
@@ -465,29 +472,66 @@ async fn test_thread_filtering() {
                         .text_msg("Within thread")
                         .sender(sender_id)
                         .event_id(event_id!("$threaded_event"))
-                        .in_thread(&thread_root_event_id, event_id!("$first_reply_in_thread")),
+                        .in_thread(&thread_root_event_id, &thread_root_event_id),
                 ),
         )
         .await;
 
-    filtered_timeline_stream.next().await;
+    // A live timeline hiding in-thread events should only contain the date
+    // separator and the thread root.
+    {
+        assert_let_timeout!(Some(timeline_updates) = filtered_timeline_stream.next());
+        assert_eq!(timeline_updates.len(), 3);
 
-    let items = timeline.items().await;
+        assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);
+        let event_item = value.as_event().unwrap();
+        assert_eq!(event_item.content().as_message().unwrap().body(), "Thread root");
+        assert_matches!(event_item.content().thread_summary(), None);
 
-    // A thread filtered timeline should only contain the date separator and the
-    // thread root.
-    assert!(items[0].is_date_divider());
-    assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "Thread root");
+        // The item gets a thread summary.
+        assert_let!(VectorDiff::Set { index: 0, value } = &timeline_updates[1]);
+        assert_matches!(value.as_event().unwrap().content().thread_summary(), Some(_));
 
-    timeline_stream.next().await;
+        assert_let!(VectorDiff::PushFront { value } = &timeline_updates[2]);
+        assert!(value.is_date_divider());
 
-    let items = timeline.items().await;
+        assert_pending!(filtered_timeline_stream);
+    }
 
-    // A non-thread filtered timeline should contain all the items.
-    assert!(items[0].is_date_divider());
-    assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "Thread root");
-    assert_eq!(
-        items[2].as_event().unwrap().content().as_message().unwrap().body(),
-        "Within thread"
-    );
+    // A non-filtered live timeline should contain all the items.
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
+    assert_eq!(timeline_updates.len(), 6);
+
+    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);
+    let event_item = value.as_event().unwrap();
+    assert_eq!(event_item.content().as_message().unwrap().body(), "Thread root");
+    assert_matches!(event_item.content().thread_summary(), None);
+    assert!(event_item.read_receipts().is_empty().not());
+
+    // The read receipt from the author moves to the second item.
+    assert_let!(VectorDiff::Set { index: 0, value } = &timeline_updates[1]);
+    let event_item = value.as_event().unwrap();
+    assert_matches!(event_item.content().thread_summary(), None);
+    assert!(event_item.read_receipts().is_empty());
+
+    // The threaded event is pushed to the timeline.
+    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[2]);
+    assert_eq!(value.as_event().unwrap().content().as_message().unwrap().body(), "Within thread");
+
+    // The thread summary gets updated:
+
+    // The thread event is a reply (because of the reply fallback), and since its
+    // replied-to timeline item has been updated, it also gets updated.
+    assert_let!(VectorDiff::Set { index: 1, value } = &timeline_updates[3]);
+    assert_eq!(value.as_event().unwrap().content().as_message().unwrap().body(), "Within thread");
+
+    // Then the thread summary is updated on the thread root.
+    assert_let!(VectorDiff::Set { index: 0, value } = &timeline_updates[4]);
+    assert_matches!(value.as_event().unwrap().content().thread_summary(), Some(_));
+
+    assert_let!(VectorDiff::PushFront { value } = &timeline_updates[5]);
+    assert!(value.is_date_divider());
+
+    // That's all, folks!
+    assert_pending!(timeline_stream);
 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -97,12 +97,32 @@ async fn test_thread_backpagination() {
         .await;
 
     let batch1 = vec![
-        factory.text_msg("Threaded event 4").event_id(event_id!("$3")).into_raw_sync().cast(),
-        factory.text_msg("Threaded event 3").event_id(event_id!("$4")).into_raw_sync().cast(),
+        factory
+            .text_msg("Threaded event 4")
+            .event_id(event_id!("$3"))
+            .in_thread(&thread_root_event_id, event_id!("$latest"))
+            .into_raw_sync()
+            .cast(),
+        factory
+            .text_msg("Threaded event 3")
+            .event_id(event_id!("$4"))
+            .in_thread(&thread_root_event_id, event_id!("$latest"))
+            .into_raw_sync()
+            .cast(),
     ];
     let batch2 = vec![
-        factory.text_msg("Threaded event 2").event_id(event_id!("$2")).into_raw_sync().cast(),
-        factory.text_msg("Threaded event 1").event_id(event_id!("$1")).into_raw_sync().cast(),
+        factory
+            .text_msg("Threaded event 2")
+            .event_id(event_id!("$2"))
+            .in_thread(&thread_root_event_id, event_id!("$latest"))
+            .into_raw_sync()
+            .cast(),
+        factory
+            .text_msg("Threaded event 1")
+            .event_id(event_id!("$1"))
+            .in_thread(&thread_root_event_id, event_id!("$latest"))
+            .into_raw_sync()
+            .cast(),
     ];
 
     server
@@ -398,4 +418,76 @@ async fn test_new_thread_reply_causes_thread_summary() {
 
     // The number of replies has been updated.
     assert_eq!(summary.num_replies, 2);
+}
+
+#[async_test]
+async fn test_thread_filtering() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!a:b.c");
+    let sender_id = user_id!("@alice:b.c");
+    let thread_root_event_id = owned_event_id!("$root");
+
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    let filtered_timeline = room
+        .timeline_builder()
+        .with_focus(TimelineFocus::Live { hide_threaded_events: true })
+        .build()
+        .await
+        .unwrap();
+
+    let (_, mut filtered_timeline_stream) = filtered_timeline.subscribe().await;
+
+    let timeline = room
+        .timeline_builder()
+        .with_focus(TimelineFocus::Live { hide_threaded_events: false })
+        .build()
+        .await
+        .unwrap();
+
+    let (_, mut timeline_stream) = timeline.subscribe().await;
+
+    let factory = EventFactory::new();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    factory
+                        .text_msg("Thread root")
+                        .sender(sender_id)
+                        .event_id(&thread_root_event_id),
+                )
+                .add_timeline_event(
+                    factory
+                        .text_msg("Within thread")
+                        .sender(sender_id)
+                        .event_id(event_id!("$threaded_event"))
+                        .in_thread(&thread_root_event_id, event_id!("$first_reply_in_thread")),
+                ),
+        )
+        .await;
+
+    filtered_timeline_stream.next().await;
+
+    let items = timeline.items().await;
+
+    // A thread filtered timeline should only contain the date separator and the
+    // thread root.
+    assert!(items[0].is_date_divider());
+    assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "Thread root");
+
+    timeline_stream.next().await;
+
+    let items = timeline.items().await;
+
+    // A non-thread filtered timeline should contain all the items.
+    assert!(items[0].is_date_divider());
+    assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "Thread root");
+    assert_eq!(
+        items[2].as_event().unwrap().content().as_message().unwrap().body(),
+        "Within thread"
+    );
 }


### PR DESCRIPTION
This set of patches introduces options for filtering out threaded messages from the main timelines. In order to do so it:
* moves relation processing from `TimelineAction` to `TimelineMetadata` so that they're available beforehand and can be used in `TimelineStateTransaction::handle_remote_event` and `TimelineState::handle_local_event`
* uses the thread root in the `TimelineStateTransaction::should_add_event_item` and the newly introduced `TimelineState::should_add_event_item`
* adds new `hide_threaded_events` associated values to the `Live` and `Event` focuses so that the old behavior can be kept until clients migrate 

Relates to https://github.com/element-hq/element-meta/issues/2771 and https://github.com/matrix-org/matrix-rust-sdk/issues/4833 