### PR TITLE
Upgrade to uniffi 29.x to support wasm targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "anymap2"
@@ -212,43 +212,44 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 
 [[package]]
 name = "askama"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
 dependencies = [
  "askama_derive",
- "askama_escape",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "askama_derive"
-version = "0.12.5"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
 dependencies = [
  "askama_parser",
  "basic-toml",
- "mime",
- "mime_guess",
+ "memchr",
  "proc-macro2",
  "quote",
+ "rustc-hash 2.0.0",
  "serde",
+ "serde_derive",
  "syn",
 ]
 
 [[package]]
-name = "askama_escape"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
-
-[[package]]
 name = "askama_parser"
-version = "0.2.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
 dependencies = [
- "nom",
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.10",
 ]
 
 [[package]]
@@ -499,15 +500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,16 +627,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
- "thiserror 1.0.63",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3370,16 +3362,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "515a63dc9666c865e848b043ab52fe9a5c713ae89cde4b5fbaae67cfd614b93a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minicov"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5576,7 +5558,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -5824,17 +5806,18 @@ checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "uniffi"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31bff6daf87277a9014bcdefbc2842b0553392919d1096843c5aad899ca4588"
+version = "0.29.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f#c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f"
 dependencies = [
  "anyhow",
  "camino",
+ "cargo_metadata",
  "clap",
  "uniffi_bindgen",
  "uniffi_build",
  "uniffi_core",
  "uniffi_macros",
+ "uniffi_pipeline",
 ]
 
 [[package]]
@@ -5846,9 +5829,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96061d7e01b185aa405f7c9b134741ab3e50cc6796a47d6fd8ab9a5364b5feed"
+version = "0.29.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f#c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f"
 dependencies = [
  "anyhow",
  "askama",
@@ -5858,21 +5840,22 @@ dependencies = [
  "glob",
  "goblin",
  "heck",
+ "indexmap",
  "once_cell",
- "paste",
  "serde",
+ "tempfile",
  "textwrap",
  "toml 0.5.11",
+ "uniffi_internal_macros",
  "uniffi_meta",
- "uniffi_testing",
+ "uniffi_pipeline",
  "uniffi_udl",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6b86f9b221046af0c533eafe09ece04e2f1ded04ccdc9bba0ec09aec1c52bd"
+version = "0.29.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f#c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f"
 dependencies = [
  "anyhow",
  "camino",
@@ -5880,38 +5863,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_checksum_derive"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
+name = "uniffi_core"
+version = "0.29.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f#c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f"
 dependencies = [
+ "anyhow",
+ "async-compat",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.29.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f#c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "proc-macro2",
  "quote",
  "syn",
 ]
 
 [[package]]
-name = "uniffi_core"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3210d57d6ab6065ab47a2898dacdb7c606fd6a4156196831fa3bf82e34ac58a6"
-dependencies = [
- "anyhow",
- "async-compat",
- "bytes",
- "camino",
- "log",
- "once_cell",
- "paste",
- "static_assertions",
-]
-
-[[package]]
 name = "uniffi_macros"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58691741080935437dc862122e68d7414432a11824ac1137868de46181a0bd2"
+version = "0.29.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f#c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f"
 dependencies = [
- "bincode",
  "camino",
  "fs-err",
  "once_cell",
@@ -5925,39 +5904,35 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7663eacdbd9fbf4a88907ddcfe2e6fa85838eb6dc2418a7d91eebb3786f8e20b"
+version = "0.29.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f#c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f"
 dependencies = [
  "anyhow",
- "bytes",
  "siphasher",
- "uniffi_checksum_derive",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
 ]
 
 [[package]]
-name = "uniffi_testing"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f922465f7566f25f8fe766920205fdfa9a3fcdc209c6bfb7557f0b5bf45b04dd"
+name = "uniffi_pipeline"
+version = "0.29.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f#c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f"
 dependencies = [
  "anyhow",
- "camino",
- "cargo_metadata",
- "fs-err",
- "once_cell",
+ "heck",
+ "indexmap",
+ "tempfile",
+ "uniffi_internal_macros",
 ]
 
 [[package]]
 name = "uniffi_udl"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef408229a3a407fafa4c36dc4f6ece78a6fb258ab28d2b64bddd49c8cb680f6"
+version = "0.29.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f#c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f"
 dependencies = [
  "anyhow",
  "textwrap",
  "uniffi_meta",
- "uniffi_testing",
  "weedle2",
 ]
 
@@ -6280,8 +6255,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f#c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f"
 dependencies = [
  "nom",
 ]
@@ -6589,6 +6563,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6664,11 +6647,14 @@ checksum = "88301b56c26dd9bf5c43d858538f82d6f3f7764767defbc5d34e59459901c41a"
 name = "xtask"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "camino",
+ "cargo_metadata",
  "clap",
  "fs_extra",
  "serde",
  "serde_json",
+ "toml 0.5.11",
  "uniffi_bindgen",
  "xshell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,8 +94,9 @@ tracing = { version = "0.1.40", default-features = false, features = ["std"] }
 tracing-core = "0.1.32"
 tracing-subscriber = "0.3.18"
 unicode-normalization = "0.1.24"
-uniffi = { version = "0.28.0" }
-uniffi_bindgen = { version = "0.28.0" }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f" }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f" }
+uniffi_core = { git = "https://github.com/mozilla/uniffi-rs", rev = "c7f6caa3d1bf20f934346cefd8e82b5093f0dc6f" }
 url = "2.5.4"
 uuid = "1.12.1"
 vodozemac = { version = "0.9.0", features = ["insecure-pk-encryption"] }

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -1,10 +1,12 @@
 namespace matrix_sdk_ffi {};
 
+[Remote]
 dictionary Mentions {
   sequence<string> user_ids;
   boolean room;
 };
 
+[Remote]
 interface RoomMessageEventContentWithoutRelation {
     RoomMessageEventContentWithoutRelation with_mentions(Mentions mentions);
 };

--- a/bindings/matrix-sdk-ffi/uniffi.toml
+++ b/bindings/matrix-sdk-ffi/uniffi.toml
@@ -2,3 +2,13 @@
 package_name = "org.matrix.rustcomponents.sdk"
 cdylib_name = "matrix_sdk_ffi"
 android_cleaner = true
+
+[bindings.typescript]
+[bindings.typescript.customTypes.Date64]
+typeName = "Date"
+intoCustom = """((v: FfiType) => {
+    return new Date(Number(v));
+})({})"""
+fromCustom = """((v: TsType) => {
+    return BigInt(v.getTime());
+})({})"""

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,10 +13,13 @@ name = "xtask"
 test = false
 
 [dependencies]
+anyhow = "1.0.96"
 camino = "1.0.8"
+cargo_metadata = "0.19.2"
 clap = { version = "4.0.18", features = ["derive"] }
 fs_extra = "1"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+toml = "0.5.11"
 uniffi_bindgen.workspace = true
 xshell = "0.2.2"

--- a/xtask/src/config_supplier.rs
+++ b/xtask/src/config_supplier.rs
@@ -1,0 +1,74 @@
+use std::{collections::HashMap, fs};
+
+use anyhow::{bail, Context};
+use camino::Utf8PathBuf;
+use cargo_metadata::Metadata;
+use toml::value::Table;
+use uniffi_bindgen::BindgenCrateConfigSupplier;
+
+#[derive(Debug, Clone, Default)]
+pub struct CrateConfigSupplier {
+    paths: HashMap<String, Utf8PathBuf>,
+}
+
+fn load_toml_file(path: Option<&Utf8PathBuf>) -> anyhow::Result<Option<Table>> {
+    if let Some(path) = path {
+        if path.exists() {
+            let contents = fs::read_to_string(path)?;
+            let table: Table = toml::from_str(&contents)?;
+            Ok(Some(table))
+        } else {
+            Ok(None)
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+impl BindgenCrateConfigSupplier for CrateConfigSupplier {
+    fn get_toml(&self, crate_name: &str) -> anyhow::Result<Option<Table>> {
+        load_toml_file(self.get_toml_path(crate_name).as_ref())
+    }
+
+    fn get_toml_path(&self, crate_name: &str) -> Option<Utf8PathBuf> {
+        self.paths.get(crate_name).map(|p| p.join("uniffi.toml"))
+    }
+
+    fn get_udl(&self, crate_name: &str, udl_name: &str) -> anyhow::Result<String> {
+        let path = self
+            .paths
+            .get(crate_name)
+            .context(format!("No path known to UDL files for '{crate_name}'"))?
+            .join("src")
+            .join(format!("{udl_name}.udl"));
+        if path.exists() {
+            Ok(fs::read_to_string(path)?)
+        } else {
+            bail!(format!("No UDL file found at '{path}'"));
+        }
+    }
+}
+
+impl From<Metadata> for CrateConfigSupplier {
+    fn from(metadata: Metadata) -> Self {
+        let paths: HashMap<String, Utf8PathBuf> = metadata
+            .packages
+            .iter()
+            .flat_map(|p| {
+                p.targets
+                    .iter()
+                    .filter(|t| {
+                        !t.is_bin()
+                            && !t.is_example()
+                            && !t.is_test()
+                            && !t.is_bench()
+                            && !t.is_custom_build()
+                    })
+                    .filter_map(|t| {
+                        p.manifest_path.parent().map(|p| (t.name.replace('-', "_"), p.to_owned()))
+                    })
+            })
+            .collect();
+        Self { paths }
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(unexpected_cfgs)]
 
 mod ci;
+mod config_supplier;
 mod fixup;
 mod kotlin;
 mod release;

--- a/xtask/src/swift.rs
+++ b/xtask/src/swift.rs
@@ -4,11 +4,12 @@ use std::{
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
+use cargo_metadata::MetadataCommand;
 use clap::{Args, Subcommand};
 use uniffi_bindgen::{bindings::SwiftBindingGenerator, library_mode::generate_bindings};
 use xshell::cmd;
 
-use crate::{sh, workspace, Result};
+use crate::{config_supplier::CrateConfigSupplier, sh, workspace, Result};
 
 /// Builds the SDK for Swift as a Static Library or XCFramework.
 #[derive(Args)]
@@ -168,7 +169,24 @@ fn build_library() -> Result<()> {
 }
 
 fn generate_uniffi(library_path: &Utf8Path, ffi_directory: &Utf8Path) -> Result<()> {
-    generate_bindings(library_path, None, &SwiftBindingGenerator, None, ffi_directory, false)?;
+    let manifest_path = std::env::current_dir()?.join("Cargo.toml");
+    println!("manifest path {:?}", manifest_path);
+
+    // Get metadata using cargo_metadata
+    let metadata = MetadataCommand::new().manifest_path(&manifest_path).exec()?;
+
+    // Convert the Metadata into a CrateConfigSupplier using From
+    let config_supplier = CrateConfigSupplier::from(metadata);
+
+    generate_bindings(
+        library_path,
+        None,
+        &SwiftBindingGenerator,
+        &config_supplier,
+        None,
+        ffi_directory,
+        false,
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
Upgrade to what will soon be uniffi 0.29.3 (release is planned for next week).  This mostly concerns an upgrade of the xtask orchestration system, but there were some small changes to the .udl spec that were needed as well.

This will likely produce issues with the complement-crypto package, which seems to still be using uniffi 0.25 to build.
  
- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
