### PR TITLE
fix(timeline): properly fill the event id of a bundled edit

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
@@ -83,6 +83,10 @@ pub(in crate::timeline) struct PendingEdit {
 
     /// The encryption info for this edit.
     pub encryption_info: Option<Arc<EncryptionInfo>>,
+
+    /// If provided, this is the identifier of a remote event item that included
+    /// this bundled edit.
+    pub bundled_item_owner: Option<OwnedEventId>,
 }
 
 /// Which kind of aggregation (related event) is this?
@@ -598,7 +602,12 @@ fn resolve_edits(
 
                 TimelineEventItemId::EventId(event_id) => {
                     if let Some(best_edit_pos) = &mut best_edit_pos {
-                        let pos = items.position_by_event_id(event_id);
+                        // Find the position of the timeline owning the edit: either the bundled
+                        // item owner if this was a bundled edit, or the edit event itself.
+                        let pos = items.position_by_event_id(
+                            pending_edit.bundled_item_owner.as_ref().unwrap_or(event_id),
+                        );
+
                         if let Some(pos) = pos {
                             // If the edit is more recent (higher index) than the previous best
                             // edit we knew about, use this one.
@@ -642,7 +651,7 @@ fn resolve_edits(
 /// Returns true if the edit was applied, false otherwise (because the edit and
 /// original timeline item types didn't match, for instance).
 fn edit_item(item: &mut Cow<'_, EventTimelineItem>, edit: PendingEdit) -> bool {
-    let PendingEdit { kind: edit_kind, edit_json, encryption_info } = edit;
+    let PendingEdit { kind: edit_kind, edit_json, encryption_info, bundled_item_owner: _ } = edit;
 
     if let Some(event_json) = &edit_json {
         let Some(edit_sender) = event_json.get_field::<OwnedUserId>("sender").ok().flatten() else {

--- a/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
@@ -638,6 +638,9 @@ fn resolve_edits(
 }
 
 /// Apply the selected edit to the given EventTimelineItem.
+///
+/// Returns true if the edit was applied, false otherwise (because the edit and
+/// original timeline item types didn't match, for instance).
 fn edit_item(item: &mut Cow<'_, EventTimelineItem>, edit: PendingEdit) -> bool {
     let PendingEdit { kind: edit_kind, edit_json, encryption_info } = edit;
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -364,28 +364,26 @@ impl TimelineMetadata {
 
                 // Record the bundled edit in the aggregations set, if any.
                 if let Some(ctx) = remote_ctx {
-                    if let Some(new_content) = extract_poll_edit_content(ctx.relations) {
-                        // It is replacing the current event.
-                        if let Some(edit_event_id) =
-                            ctx.raw_event.get_field::<OwnedEventId>("event_id").ok().flatten()
-                        {
-                            let edit_json = extract_bundled_edit_event_json(ctx.raw_event);
-                            let aggregation = Aggregation::new(
-                                TimelineEventItemId::EventId(edit_event_id),
-                                AggregationKind::Edit(PendingEdit {
-                                    kind: PendingEditKind::Poll(Replacement::new(
-                                        ctx.event_id.to_owned(),
-                                        new_content,
-                                    )),
-                                    edit_json,
-                                    encryption_info: ctx.bundled_edit_encryption_info,
-                                }),
-                            );
-                            self.aggregations.add(
-                                TimelineEventItemId::EventId(ctx.event_id.to_owned()),
-                                aggregation,
-                            );
-                        }
+                    // Extract a potentially bundled edit.
+                    if let Some((edit_event_id, new_content)) =
+                        extract_poll_edit_content(ctx.relations)
+                    {
+                        let edit_json = extract_bundled_edit_event_json(ctx.raw_event);
+                        let aggregation = Aggregation::new(
+                            TimelineEventItemId::EventId(edit_event_id),
+                            AggregationKind::Edit(PendingEdit {
+                                kind: PendingEditKind::Poll(Replacement::new(
+                                    ctx.event_id.to_owned(),
+                                    new_content,
+                                )),
+                                edit_json,
+                                encryption_info: ctx.bundled_edit_encryption_info,
+                            }),
+                        );
+                        self.aggregations.add(
+                            TimelineEventItemId::EventId(ctx.event_id.to_owned()),
+                            aggregation,
+                        );
                     }
 
                     self.mark_response(ctx.event_id, in_reply_to.as_ref());
@@ -402,28 +400,26 @@ impl TimelineMetadata {
 
                 // Record the bundled edit in the aggregations set, if any.
                 if let Some(ctx) = remote_ctx {
-                    if let Some(new_content) = extract_room_msg_edit_content(ctx.relations) {
-                        // It is replacing the current event.
-                        if let Some(edit_event_id) =
-                            ctx.raw_event.get_field::<OwnedEventId>("event_id").ok().flatten()
-                        {
-                            let edit_json = extract_bundled_edit_event_json(ctx.raw_event);
-                            let aggregation = Aggregation::new(
-                                TimelineEventItemId::EventId(edit_event_id),
-                                AggregationKind::Edit(PendingEdit {
-                                    kind: PendingEditKind::RoomMessage(Replacement::new(
-                                        ctx.event_id.to_owned(),
-                                        new_content,
-                                    )),
-                                    edit_json,
-                                    encryption_info: ctx.bundled_edit_encryption_info,
-                                }),
-                            );
-                            self.aggregations.add(
-                                TimelineEventItemId::EventId(ctx.event_id.to_owned()),
-                                aggregation,
-                            );
-                        }
+                    // Extract a potentially bundled edit.
+                    if let Some((edit_event_id, new_content)) =
+                        extract_room_msg_edit_content(ctx.relations)
+                    {
+                        let edit_json = extract_bundled_edit_event_json(ctx.raw_event);
+                        let aggregation = Aggregation::new(
+                            TimelineEventItemId::EventId(edit_event_id),
+                            AggregationKind::Edit(PendingEdit {
+                                kind: PendingEditKind::RoomMessage(Replacement::new(
+                                    ctx.event_id.to_owned(),
+                                    new_content,
+                                )),
+                                edit_json,
+                                encryption_info: ctx.bundled_edit_encryption_info,
+                            }),
+                        );
+                        self.aggregations.add(
+                            TimelineEventItemId::EventId(ctx.event_id.to_owned()),
+                            aggregation,
+                        );
                     }
 
                     self.mark_response(ctx.event_id, in_reply_to.as_ref());

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -378,6 +378,7 @@ impl TimelineMetadata {
                                 )),
                                 edit_json,
                                 encryption_info: ctx.bundled_edit_encryption_info,
+                                bundled_item_owner: Some(ctx.event_id.to_owned()),
                             }),
                         );
                         self.aggregations.add(
@@ -414,6 +415,7 @@ impl TimelineMetadata {
                                 )),
                                 edit_json,
                                 encryption_info: ctx.bundled_edit_encryption_info,
+                                bundled_item_owner: Some(ctx.event_id.to_owned()),
                             }),
                         );
                         self.aggregations.add(

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -574,6 +574,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 kind: edit_kind,
                 edit_json: self.ctx.flow.raw_event().cloned(),
                 encryption_info,
+                bundled_item_owner: None,
             }),
         );
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -29,6 +29,7 @@ use ruma::{
     },
     html::RemoveReplyFallback,
     serde::Raw,
+    OwnedEventId,
 };
 use tracing::{error, trace};
 
@@ -110,10 +111,10 @@ pub(crate) fn extract_bundled_edit_event_json(
 }
 
 /// Extracts a replacement for a room message, if present in the bundled
-/// relations.
+/// relations , along with the event ID of the replacement event.
 pub(crate) fn extract_room_msg_edit_content(
     relations: BundledMessageLikeRelations<AnySyncMessageLikeEvent>,
-) -> Option<RoomMessageEventContentWithoutRelation> {
+) -> Option<(OwnedEventId, RoomMessageEventContentWithoutRelation)> {
     match *relations.replace? {
         AnySyncMessageLikeEvent::RoomMessage(SyncRoomMessageEvent::Original(ev)) => match ev
             .content
@@ -121,7 +122,7 @@ pub(crate) fn extract_room_msg_edit_content(
         {
             Some(Relation::Replacement(re)) => {
                 trace!("found a bundled edit event in a room message");
-                Some(re.new_content)
+                Some((ev.event_id, re.new_content))
             }
             _ => {
                 error!("got m.room.message event with an edit without a valid m.replace relation");
@@ -139,16 +140,16 @@ pub(crate) fn extract_room_msg_edit_content(
 }
 
 /// Extracts a replacement for a room message, if present in the bundled
-/// relations.
+/// relations, along with the event ID of the replacement event.
 pub(crate) fn extract_poll_edit_content(
     relations: BundledMessageLikeRelations<AnySyncMessageLikeEvent>,
-) -> Option<NewUnstablePollStartEventContentWithoutRelation> {
+) -> Option<(OwnedEventId, NewUnstablePollStartEventContentWithoutRelation)> {
     match *relations.replace? {
         AnySyncMessageLikeEvent::UnstablePollStart(SyncUnstablePollStartEvent::Original(ev)) => {
             match ev.content {
                 UnstablePollStartEventContent::Replacement(re) => {
                     trace!("found a bundled edit event in a poll");
-                    Some(re.relates_to.new_content)
+                    Some((ev.event_id, re.relates_to.new_content))
                 }
                 _ => {
                     error!("got new poll start event in a bundled edit");


### PR DESCRIPTION
Spotted during review of #5140, this would in theory make a redaction of a bundled edit effectless. I haven't included a test, because I think it's such an edge case, but the first commit did change behavior in such a way that `timeline::tests::edit::test_relations_edit_overrides_pending_edit_msg` started failing (because it couldn't find the owning item anymore — since the edit event id didn't have its own event in the events array, as it's bundled). The second commit "fixes" it back by tweaking the "find best edit" algorithm: try to find the event that owned the bundled edit, if it was such a bundled edit; otherwise, try to find the item based on its actual event id (as we did before this PR).