### PR TITLE
feat(ui): don't mark each thread reply as an actual reply to the previous message, in threaded timelines

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -165,7 +165,7 @@ impl TimelineState {
         let mut date_divider_adjuster = DateDividerAdjuster::new(date_divider_mode);
 
         let (in_reply_to, thread_root) =
-            txn.meta.process_content_relations(&content, None, &txn.items);
+            txn.meta.process_content_relations(&content, None, &txn.items, &txn.timeline_focus);
 
         // TODO merge with other should_add, one way or another?
         let should_add_new_items = match &txn.timeline_focus {

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -626,6 +626,7 @@ impl<'a> TimelineStateTransaction<'a> {
                     &raw,
                     bundled_edit_encryption_info,
                     &self.items,
+                    &self.timeline_focus,
                 );
 
                 let should_add = self.should_add_event_item(

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -345,11 +345,19 @@ impl EventBuilder<RoomMessageEventContent> {
         self
     }
 
-    /// Adds a thread relation to the root event, setting the latest thread
-    /// event id too.
+    /// Adds a thread relation to the root event, setting the reply fallback to
+    /// the latest in-thread event.
     pub fn in_thread(mut self, root: &EventId, latest_thread_event: &EventId) -> Self {
         self.content.relates_to =
             Some(Relation::Thread(Thread::plain(root.to_owned(), latest_thread_event.to_owned())));
+        self
+    }
+
+    /// Adds a thread relation to the root event, that's a non-fallback reply to
+    /// another thread event.
+    pub fn in_thread_reply(mut self, root: &EventId, replied_to: &EventId) -> Self {
+        self.content.relates_to =
+            Some(Relation::Thread(Thread::reply(root.to_owned(), replied_to.to_owned())));
         self
     }
 


### PR DESCRIPTION
This correctly handles the reply fallback behavior:

- the behavior isn't changed for a live timeline,
- when a timeline is thread-focused, we will extract the `replied_to` field if and only if the thread relation is *not* marked as behaving in a fallback manner.

This makes it possible to distinguish actual in-thread replies.

Part of #4833.