### PR TITLE
crypto: Only expose type/sender/content for raw decrypted to-device msg

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine/tests/send_encrypted_to_device.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/send_encrypted_to_device.rs
@@ -463,16 +463,7 @@ async fn test_processed_to_device_variants() {
 
     insta::with_settings!({ prepend_module_to_snapshot => false }, {
         assert_json_snapshot!(
-            processed_event.to_raw().deserialize_as::<Value>().unwrap(),
-             {
-                 ".keys.ed25519" => "[sender_ed25519_key]",
-                 r#"["sender_device_keys"].device_id"# => "[ABCDEFGH]",
-                 r#"["sender_device_keys"].keys"# => "++REDACTED++",
-                 r#"["sender_device_keys"].signatures"# => "++REDACTED++",
-                 // Redacted because depending on feature flags
-                 r#"["sender_device_keys"].algorithms"# => "++REDACTED++",
-                 ".recipient_keys.ed25519" => "[recipient_sender_key]",
-            }
+            processed_event.to_raw().deserialize_as::<Value>().unwrap()
         );
     });
 

--- a/crates/matrix-sdk-crypto/src/machine/tests/snapshots/processed_to_device_variants.snap
+++ b/crates/matrix-sdk-crypto/src/machine/tests/snapshots/processed_to_device_variants.snap
@@ -13,20 +13,6 @@ expression: "processed_event.to_raw().deserialize_as::<Value>().unwrap()"
       }
     ]
   },
-  "keys": {
-    "ed25519": "[sender_ed25519_key]"
-  },
-  "recipient": "@bob:example.com",
-  "recipient_keys": {
-    "ed25519": "[recipient_sender_key]"
-  },
   "sender": "@alice:example.org",
-  "sender_device_keys": {
-    "algorithms": "++REDACTED++",
-    "device_id": "[ABCDEFGH]",
-    "keys": "++REDACTED++",
-    "signatures": "++REDACTED++",
-    "user_id": "@alice:example.org"
-  },
   "type": "rtc.call.encryption_keys"
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

The `DecryptionResult#raw_event` is exposing a lot of "internal" crypto related fields as part of the raw json encoded object. 
All these properties are then exposed outside of the crypto crate, in a sort of hidden way because you have to serialize as a Value to get them. For example in the wasm-bindings they will be exposed to the js-sdk and easilly accessible and that could cause the sdk to wrongly use these fields (source of footgun?)

Just like we zeroized content of to-device messages, I think we should also clean-up these crypto fields before exposing them outside?

Before:
```
{
    "type": "my.custom.to.device",
    "content": {
        "call_id": ""
    },
    "keys": {
        "ed25519": "hk5X9uSb0OwhdAFrlcdtzNkE+AmL/85XdPO5v1Ocgg"
    },
    "recipient": "@alice:example.org",
    "recipient_keys": {
        "ed25519": "WgEu0w6T511+R03R4dUQP53d9OQTVJr6F/cYmF3Civs"
    },
    "sender": "@bob:example.org",
    "sender_device_keys": {
        "algorithms": [
            "m.olm.v1.curve25519-aes-sha2",
            "m.megolm.v1.aes-sha2"
        ],
        "device_id": "B0B0B0B0B",
        "keys": {
            "curve25519:B0B0B0B0B": "Bwl3kZjTnxxKNufqMiG1XoJg1VxGQko5asIy6aq4pUk",
            "ed25519:B0B0B0B0B": "hk5X9uSb0OwhdAFrlcdtzNkE+AmLT/85XdPO5v1Ocgg"
        },
        "signatures": {
            "@bob:example.org": {
                "ed25519:B0B0B0B0B": "XvyTR/3piBBCl4Xq4wHjrjhnJdgMMtXvpMh9itG1Nr9GUI80n8bQ32CtHTZCENk77esgUZ4Tkzy0bUGJRMzZAg"
            }
        },
    	"user_id": "@bob:example.org",
    },
}
```

After
```
{
    "type": "my.custom.to.device",
    "content": {
        "call_id": ""
    },
    "sender": "@bob:example.org",
}
```

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
