### PR TITLE
chore(sqlite): revert the busy_timeout pragmas

### DIFF
--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -179,15 +179,6 @@ impl SqliteEventCacheStore {
     async fn acquire(&self) -> Result<SqliteAsyncConn> {
         let connection = self.pool.get().await?;
 
-        // Specify a busy timeout so that operations are automatically retried, in case
-        // the database was marked as locked, which can happen under very
-        // peculiar circumstances in WAL mode.
-        //
-        // The timeout value is in milliseconds.
-        //
-        // See also https://www.sqlite.org/wal.html#sometimes_queries_return_sqlite_busy_in_wal_mode.
-        connection.execute_batch("PRAGMA busy_timeout = 2000;").await?;
-
         // Per https://www.sqlite.org/foreignkeys.html#fk_enable, foreign key
         // support must be enabled on a per-connection basis. Execute it every
         // time we try to get a connection, since we can't guarantee a previous

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -447,18 +447,7 @@ impl SqliteStateStore {
     }
 
     async fn acquire(&self) -> Result<SqliteAsyncConn> {
-        let conn = self.pool.get().await?;
-
-        // Specify a busy timeout so that operations are automatically retried, in case
-        // the database was marked as locked, which can happen under very
-        // peculiar circumstances in WAL mode.
-        //
-        // The timeout value is in milliseconds.
-        //
-        // See also https://www.sqlite.org/wal.html#sometimes_queries_return_sqlite_busy_in_wal_mode.
-        conn.execute_batch("PRAGMA busy_timeout = 2000;").await?;
-
-        Ok(conn)
+        Ok(self.pool.get().await?)
     }
 
     fn remove_maybe_stripped_room_data(


### PR DESCRIPTION
Internal Sentry reports tell us that enabling the busy_timeout seems to have *increased* the number of "database is busy" errors, instead of lowering those. As a result, we're going to disable the pragmas in all the places where we enabled it before, and observe how the number of "database is busy" errors evolves.