### PR TITLE
feat(multiverse): add support for threaded timelines

### DIFF
--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -31,7 +31,7 @@ use matrix_sdk_common::locks::Mutex;
 use matrix_sdk_ui::{
     room_list_service::{self, filters::new_filter_non_left},
     sync_service::SyncService,
-    timeline::{RoomExt as _, TimelineItem},
+    timeline::{RoomExt as _, TimelineFocus, TimelineItem},
     Timeline as SdkTimeline,
 };
 use ratatui::{prelude::*, style::palette::tailwind, widgets::*};
@@ -260,7 +260,12 @@ impl App {
                 all_rooms.into_iter().filter(|room| !previous_rooms.contains(room.room_id()))
             {
                 // Initialize the timeline.
-                let Ok(timeline) = room.timeline_builder().build().await else {
+                let Ok(timeline) = room
+                    .timeline_builder()
+                    .with_focus(TimelineFocus::Live { hide_threaded_events: true })
+                    .build()
+                    .await
+                else {
                     error!("error when creating default timeline");
                     continue;
                 };

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::large_enum_variant)]
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     io::{self, stdout, Write},
     path::{Path, PathBuf},
     sync::Arc,
@@ -25,7 +25,7 @@ use matrix_sdk::{
     encryption::{BackupDownloadStrategy, EncryptionSettings},
     reqwest::Url,
     ruma::OwnedRoomId,
-    AuthSession, Client, Room, SqliteCryptoStore, SqliteEventCacheStore, SqliteStateStore,
+    AuthSession, Client, SqliteCryptoStore, SqliteEventCacheStore, SqliteStateStore,
 };
 use matrix_sdk_common::locks::Mutex;
 use matrix_sdk_ui::{
@@ -57,7 +57,6 @@ const ALT_ROW_COLOR: Color = tailwind::SLATE.c900;
 const SELECTED_STYLE_FG: Color = tailwind::BLUE.c300;
 const TEXT_COLOR: Color = tailwind::SLATE.c200;
 
-type UiRooms = Arc<Mutex<HashMap<OwnedRoomId, Room>>>;
 type Timelines = Arc<Mutex<HashMap<OwnedRoomId, Timeline>>>;
 
 #[derive(Debug, Parser)]
@@ -174,7 +173,6 @@ impl App {
 
         let rooms = Rooms::default();
         let room_infos = RoomInfos::default();
-        let ui_rooms = UiRooms::default();
         let timelines = Timelines::default();
 
         let room_list_service = sync_service.room_list_service();
@@ -183,7 +181,6 @@ impl App {
         let listen_task = spawn(Self::listen_task(
             rooms.clone(),
             room_infos.clone(),
-            ui_rooms.clone(),
             timelines.clone(),
             all_rooms,
         ));
@@ -193,15 +190,10 @@ impl App {
         sync_service.start().await;
 
         let status = Status::new();
-        let room_list = RoomList::new(
-            rooms,
-            ui_rooms.clone(),
-            room_infos,
-            sync_service.clone(),
-            status.handle(),
-        );
+        let room_list =
+            RoomList::new(client.clone(), rooms, room_infos, sync_service.clone(), status.handle());
 
-        let room_view = RoomView::new(ui_rooms, timelines.clone(), status.handle());
+        let room_view = RoomView::new(client.clone(), timelines.clone(), status.handle());
 
         Ok(Self {
             sync_service,
@@ -219,7 +211,6 @@ impl App {
     async fn listen_task(
         rooms: Rooms,
         room_infos: RoomInfos,
-        ui_rooms: UiRooms,
         timelines: Timelines,
         all_rooms: room_list_service::RoomList,
     ) {
@@ -227,6 +218,8 @@ impl App {
         entries_controller.set_filter(Box::new(new_filter_non_left()));
 
         pin_mut!(stream);
+
+        let mut previous_rooms = HashSet::new();
 
         while let Some(diffs) = stream.next().await {
             let all_rooms = {
@@ -240,12 +233,6 @@ impl App {
                 // Collect rooms early to release the room entries list lock.
                 (*rooms).clone()
             };
-
-            // Clone the previous set of ui rooms to avoid keeping the ui_rooms lock (which
-            // we couldn't do below, because it's a sync lock, and has to be
-            // sync b/o rendering; and we'd have to cross await points
-            // below).
-            let previous_rooms = ui_rooms.lock().clone();
 
             let mut new_rooms = HashMap::new();
             let mut new_timelines = Vec::new();
@@ -270,7 +257,7 @@ impl App {
 
             // Initialize all the new rooms.
             for room in
-                all_rooms.into_iter().filter(|room| !previous_rooms.contains_key(room.room_id()))
+                all_rooms.into_iter().filter(|room| !previous_rooms.contains(room.room_id()))
             {
                 // Initialize the timeline.
                 let Ok(timeline) = room.timeline_builder().build().await else {
@@ -305,7 +292,8 @@ impl App {
                 new_rooms.insert(room.room_id().to_owned(), room);
             }
 
-            ui_rooms.lock().extend(new_rooms);
+            previous_rooms.extend(new_rooms.into_keys());
+
             timelines.lock().extend(new_timelines);
         }
     }

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -158,7 +158,7 @@ struct App {
     /// Task listening to room list service changes, and spawning timelines.
     listen_task: JoinHandle<()>,
 
-    /// The status widet at the bottom of the screen.
+    /// The status widget at the bottom of the screen.
     status: Status,
 
     state: AppState,

--- a/labs/multiverse/src/widgets/help.rs
+++ b/labs/multiverse/src/widgets/help.rs
@@ -24,11 +24,15 @@ impl Widget for &mut HelpView {
         let rows = vec![
             Row::new(vec![Cell::from("F1"), Cell::from("Open Help")]),
             Row::new(vec![Cell::from("F10"), Cell::from("Open the encryption settings")]),
-            Row::new(vec![Cell::from("ALT-l"), Cell::from("Open the linked chunk details view")]),
-            Row::new(vec![Cell::from("ALT-e"), Cell::from("Open the events details view")]),
-            Row::new(vec![Cell::from("ALT-r"), Cell::from("Open the read receipt details view")]),
+            Row::new(vec![Cell::from("Alt-l"), Cell::from("Open the linked chunk details view")]),
+            Row::new(vec![Cell::from("Alt-e"), Cell::from("Open the events details view")]),
+            Row::new(vec![Cell::from("Alt-r"), Cell::from("Open the read receipt details view")]),
             Row::new(vec![
-                Cell::from("ALT-m"),
+                Cell::from("Alt-t"),
+                Cell::from("Switch the detail view tiling direction"),
+            ]),
+            Row::new(vec![
+                Cell::from("Alt-m"),
                 Cell::from("Mark the currently selected room as read"),
             ]),
             Row::new(vec![Cell::from("Ctrl-q"), Cell::from("Quit Multiverse")]),
@@ -47,6 +51,18 @@ impl Widget for &mut HelpView {
             Row::new(vec![
                 Cell::from("Ctrl-l"),
                 Cell::from("Like the last message in the selected room"),
+            ]),
+            Row::new(vec![
+                Cell::from("Ctrl-n"),
+                Cell::from("Focus on the next item in the timeline view"),
+            ]),
+            Row::new(vec![
+                Cell::from("Ctrl-p"),
+                Cell::from("Focus on the previous item in the timeline view"),
+            ]),
+            Row::new(vec![
+                Cell::from("Ctrl-t"),
+                Cell::from("Open a thread on the focused timeline item"),
             ]),
         ];
         let widths = [Constraint::Length(5), Constraint::Length(5)];

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -231,8 +231,7 @@ impl RoomView {
 
         let status_handle = self.status_handle.clone();
 
-        // Start a new one, request batches of 20 events, stop after 10 timeline items
-        // have been added.
+        // Request to back-paginate 20 events.
         *pagination = Some(spawn(async move {
             if let Err(err) = sdk_timeline.paginate_backwards(20).await {
                 status_handle.set_message(format!("Error during backpagination: {err}"));
@@ -448,6 +447,7 @@ impl Widget for &mut RoomView {
                         Some(middle_area)
                     }
                 }
+
                 Mode::Details { tiling_direction, view } => {
                     let vertical = Layout::new(
                         *tiling_direction,
@@ -462,10 +462,10 @@ impl Widget for &mut RoomView {
                 }
             };
 
-            if let Some(items) =
-                self.timelines.lock().get(room_id).map(|timeline| timeline.items.clone())
-            {
-                if let Some(timeline_area) = timeline_area {
+            if let Some(timeline_area) = timeline_area {
+                if let Some(items) =
+                    self.timelines.lock().get(room_id).map(|timeline| timeline.items.clone())
+                {
                     let items = items.lock();
                     let mut timeline = TimelineView::new(items.deref());
 

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use color_eyre::Result;
 use crossterm::event::{Event, KeyCode, KeyModifiers};
 use imbl::Vector;
 use input::MessageOrCommand;
@@ -337,24 +336,18 @@ impl RoomView {
     }
 
     async fn send_message(&mut self, message: String) {
-        match self.send_message_impl(message).await {
-            Ok(_) => {
-                self.input.clear();
-            }
-            Err(err) => {
-                self.status_handle.set_message(format!("error when sending event: {err}"));
-            }
-        }
-    }
-
-    async fn send_message_impl(&self, message: String) -> Result<()> {
         if let Some(sdk_timeline) = self.get_selected_timeline() {
-            sdk_timeline.send(RoomMessageEventContent::text_plain(message).into()).await?;
+            match sdk_timeline.send(RoomMessageEventContent::text_plain(message).into()).await {
+                Ok(_) => {
+                    self.input.clear();
+                }
+                Err(err) => {
+                    self.status_handle.set_message(format!("error when sending event: {err}"));
+                }
+            }
         } else {
             self.status_handle.set_message("missing timeline for room".to_owned());
-        };
-
-        Ok(())
+        }
     }
 
     /// Mark the currently selected room as read.

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -23,6 +23,7 @@ use matrix_sdk_ui::{
 };
 use ratatui::{prelude::*, widgets::*};
 use tokio::{spawn, sync::OnceCell, task::JoinHandle};
+use tracing::info;
 
 use self::{details::RoomDetails, input::Input, timeline::TimelineView};
 use super::status::StatusHandle;
@@ -137,10 +138,7 @@ impl RoomView {
             return;
         };
 
-        self.status_handle.set_message(format!(
-            "Opening thread for event {root_event_id} in room {}",
-            room.room_id()
-        ));
+        info!("Opening thread view for event {root_event_id} in room {}", room.room_id());
 
         let thread_timeline = Arc::new(OnceCell::new());
         let items = Arc::new(Mutex::new(Default::default()));

--- a/labs/multiverse/src/widgets/room_view/timeline.rs
+++ b/labs/multiverse/src/widgets/room_view/timeline.rs
@@ -173,7 +173,7 @@ fn format_membership_change(membership: &RoomMembershipChange) -> Option<ListIte
             MembershipChange::None
             | MembershipChange::Error
             | MembershipChange::InvitationRevoked
-            | MembershipChange::NotImplemented => "has changed it's membership status",
+            | MembershipChange::NotImplemented => "has changed its membership status",
         };
 
         Some(format!("{display_name} {change}").into())

--- a/labs/multiverse/src/widgets/room_view/timeline.rs
+++ b/labs/multiverse/src/widgets/room_view/timeline.rs
@@ -12,25 +12,55 @@ use crate::{ALT_ROW_COLOR, NORMAL_ROW_COLOR, SELECTED_STYLE_FG, TEXT_COLOR};
 
 pub struct TimelineView<'a> {
     items: &'a Vector<Arc<TimelineItem>>,
+    is_thread: bool,
 }
 
 impl<'a> TimelineView<'a> {
-    pub fn new(items: &'a Vector<Arc<TimelineItem>>) -> Self {
-        Self { items }
+    pub fn new(items: &'a Vector<Arc<TimelineItem>>, is_thread: bool) -> Self {
+        Self { items, is_thread }
+    }
+}
+
+#[derive(Default)]
+pub struct TimelineListState {
+    state: ListState,
+    /// An index from a rendered list item to the original timeline item index
+    /// (since some timeline items may not be rendered).
+    list_index_to_item_index: Vec<usize>,
+}
+
+impl TimelineListState {
+    pub fn select_next(&mut self) {
+        self.state.select_next();
+    }
+    pub fn select_previous(&mut self) {
+        self.state.select_previous();
+    }
+    pub fn unselect(&mut self) {
+        self.state.select(None);
+    }
+    pub fn selected(&self) -> Option<usize> {
+        let rendered_index = self.state.selected()?;
+        self.list_index_to_item_index.get(rendered_index).copied()
     }
 }
 
 impl StatefulWidget for &mut TimelineView<'_> {
-    type State = ListState;
+    type State = TimelineListState;
 
-    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State)
+    fn render(self, area: Rect, buf: &mut Buffer, timeline_list_state: &mut Self::State)
     where
         Self: Sized,
     {
-        let content = self.items.iter().map(format_timeline_item);
+        timeline_list_state.list_index_to_item_index.clear();
+
+        let content = self.items.iter().enumerate().filter_map(|(i, item)| {
+            let result = format_timeline_item(item, self.is_thread)?;
+            timeline_list_state.list_index_to_item_index.push(i);
+            Some(result)
+        });
 
         let list_items = content
-            .flatten()
             .enumerate()
             .map(|(i, line)| {
                 let bg_color = match i % 2 {
@@ -47,26 +77,24 @@ impl StatefulWidget for &mut TimelineView<'_> {
             .highlight_symbol(">")
             .highlight_style(SELECTED_STYLE_FG);
 
-        StatefulWidget::render(list, area, buf, state);
+        StatefulWidget::render(list, area, buf, &mut timeline_list_state.state);
     }
 }
 
-fn format_timeline_item(item: &Arc<TimelineItem>) -> Option<ListItem<'_>> {
+fn format_timeline_item(item: &Arc<TimelineItem>, is_thread: bool) -> Option<ListItem<'_>> {
     let item = match item.kind() {
         TimelineItemKind::Event(ev) => {
-            // TODO: Once the SDK allows you to filter out messages that are part of a
-            // thread, switch to that mechanism instead of manually returning `None` here.
-            if ev.content().thread_root().is_some() {
-                return None;
-            }
-
             let sender = ev.sender();
 
             match ev.content() {
                 TimelineItemContent::MsgLike(MsgLikeContent {
                     kind: MsgLikeKind::Message(message),
                     ..
-                }) => format_text_message(sender, message, ev.content().thread_summary())?,
+                }) => {
+                    let thread_summary =
+                        if is_thread { None } else { ev.content().thread_summary() };
+                    format_text_message(sender, message, thread_summary)?
+                }
 
                 TimelineItemContent::MsgLike(MsgLikeContent {
                     kind: MsgLikeKind::Redacted,


### PR DESCRIPTION
This adds supports for threaded timelines to multiverse, by pressing `Ctrl+T` on a given thread root event. This will be useful for debugging, and understanding how one would use the APIs, for sure. Already noticed #5216 because of this.

Part of #4869.