### PR TITLE
chore: Add CVE-2025-48937 reference to the CHANGELOG

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Security Fixes
 - Check the sender of an event matches owner of session, preventing sender
   spoofing by homeserver owners.
-  [13c1d20](https://github.com/matrix-org/matrix-rust-sdk/commit/13c1d2048286bbabf5e7bc6b015aafee98f04d55) (High, [GHSA-x958-rvg6-956w](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-x958-rvg6-956w)).
+  [13c1d20](https://github.com/matrix-org/matrix-rust-sdk/commit/13c1d2048286bbabf5e7bc6b015aafee98f04d55) (High, [CVE-2025-48937](https://www.cve.org/CVERecord?id=CVE-2025-48937), [GHSA-x958-rvg6-956w](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-x958-rvg6-956w)).
 
 ### Bug Fixes
 - Remove a wildcard enum variant import which breaks compilation if used with


### PR DESCRIPTION
Signed-off-by: `Denis Kasak <dkasak@termina.org.uk>`
