### PR TITLE
feat(ffi): pass live events to threaded timelines and allow sending locations in them

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -587,7 +587,8 @@ impl Timeline {
         description: Option<String>,
         zoom_level: Option<u8>,
         asset_type: Option<AssetType>,
-    ) {
+        reply_params: Option<ReplyParameters>,
+    ) -> Result<(), ClientError> {
         let mut location_event_message_content =
             LocationMessageEventContent::new(body, geo_uri.clone());
 
@@ -604,8 +605,13 @@ impl Timeline {
         let room_message_event_content = RoomMessageEventContentWithoutRelation::new(
             MessageType::Location(location_event_message_content),
         );
-        // Errors are logged in `Self::send` already.
-        let _ = self.send(Arc::new(room_message_event_content)).await;
+
+        if let Some(reply_params) = reply_params {
+            self.send_reply(Arc::new(room_message_event_content), reply_params).await
+        } else {
+            self.send(Arc::new(room_message_event_content)).await?;
+            Ok(())
+        }
     }
 
     /// Toggle a reaction on an event.

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -172,8 +172,6 @@ impl TimelineBuilder {
         let (room_event_cache, event_cache_drop) = room.event_cache().await?;
         let (_, event_subscriber) = room_event_cache.subscribe().await;
 
-        let is_live = matches!(focus, TimelineFocus::Live { .. });
-        let is_pinned_events = matches!(focus, TimelineFocus::PinnedEvents { .. });
         let is_room_encrypted = room
             .latest_encryption_state()
             .await
@@ -192,7 +190,7 @@ impl TimelineBuilder {
 
         let has_events = controller.init_focus(&room_event_cache).await?;
 
-        let pinned_events_join_handle = if is_pinned_events {
+        let pinned_events_join_handle = if matches!(focus, TimelineFocus::PinnedEvents { .. }) {
             Some(spawn(pinned_events_task(room.pinned_event_ids_stream(), controller.clone())))
         } else {
             None
@@ -219,7 +217,7 @@ impl TimelineBuilder {
                 room_event_cache.clone(),
                 controller.clone(),
                 event_subscriber,
-                is_live,
+                focus.clone(),
             )
             .instrument(span)
         });
@@ -359,7 +357,7 @@ async fn room_event_cache_updates_task(
     room_event_cache: RoomEventCache,
     timeline_controller: TimelineController,
     mut event_subscriber: RoomEventCacheListener,
-    is_live: bool,
+    timeline_focus: TimelineFocus,
 ) {
     trace!("Spawned the event subscriber task.");
 
@@ -404,7 +402,10 @@ async fn room_event_cache_updates_task(
 
                 let has_diffs = !diffs.is_empty();
 
-                if is_live {
+                if matches!(
+                    timeline_focus,
+                    TimelineFocus::Live { .. } | TimelineFocus::Thread { .. }
+                ) {
                     timeline_controller.handle_remote_events_with_diffs(diffs, origin).await;
                 } else {
                     // Only handle the remote aggregation for a non-live timeline.


### PR DESCRIPTION
This PR makes 2 changes:

1) exposes `ReplyParameters` on `send_location` on the FFI layer so that locations can be sent as replies, or, more importantly, within threads.
2) Updates the definition of what a "live" timeline is on the builder level so that events coming down from /sync are forwarded to threaded timelines.