### PR TITLE
Stop using tokio::runtime::Handle directly

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/dehydrated_devices.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/dehydrated_devices.rs
@@ -1,5 +1,6 @@
 use std::{mem::ManuallyDrop, sync::Arc};
 
+use matrix_sdk_common::executor::Handle;
 use matrix_sdk_crypto::{
     dehydrated_devices::{
         DehydratedDevice as InnerDehydratedDevice, DehydratedDevices as InnerDehydratedDevices,
@@ -9,7 +10,6 @@ use matrix_sdk_crypto::{
 };
 use ruma::{api::client::dehydrated_device, events::AnyToDeviceEvent, serde::Raw, OwnedDeviceId};
 use serde_json::json;
-use tokio::runtime::Handle;
 
 use crate::{CryptoStoreError, DehydratedDeviceKey};
 

--- a/bindings/matrix-sdk-crypto-ffi/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/verification.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use futures_util::{Stream, StreamExt};
+use matrix_sdk_common::executor::Handle;
 use matrix_sdk_crypto::{
     matrix_sdk_qrcode::QrVerificationData, CancelInfo as RustCancelInfo, QrVerification as InnerQr,
     QrVerificationState, Sas as InnerSas, SasState as RustSasState,
@@ -8,7 +9,6 @@ use matrix_sdk_crypto::{
     VerificationRequestState as RustVerificationRequestState,
 };
 use ruma::events::key::verification::VerificationMethod;
-use tokio::runtime::Handle;
 use vodozemac::{base64_decode, base64_encode};
 
 use crate::{CryptoStoreError, OutgoingVerificationRequest, SignatureUploadRequest};

--- a/labs/multiverse/src/widgets/room_view/details/events.rs
+++ b/labs/multiverse/src/widgets/room_view/details/events.rs
@@ -1,10 +1,10 @@
 use itertools::Itertools;
 use matrix_sdk::Room;
+use matrix_sdk_common::executor::Handle;
 use ratatui::{
     prelude::*,
     widgets::{Paragraph, Wrap},
 };
-use tokio::runtime::Handle;
 
 use crate::TEXT_COLOR;
 

--- a/labs/multiverse/src/widgets/room_view/details/linked_chunk.rs
+++ b/labs/multiverse/src/widgets/room_view/details/linked_chunk.rs
@@ -1,9 +1,9 @@
 use matrix_sdk::Room;
+use matrix_sdk_common::executor::Handle;
 use ratatui::{
     prelude::*,
     widgets::{Paragraph, Wrap},
 };
-use tokio::runtime::Handle;
 
 use crate::TEXT_COLOR;
 


### PR DESCRIPTION
Use our platform aware export from matrix-sdk-common instead.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
