### PR TITLE
Add Wasm version of AsyncRuntimeDropped

### DIFF
--- a/bindings/matrix-sdk-ffi/src/utils.rs
+++ b/bindings/matrix-sdk-ffi/src/utils.rs
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{mem::ManuallyDrop, ops::Deref};
-
 use ruma::{MilliSecondsSinceUnixEpoch, UInt};
 use tracing::warn;
-
-use crate::runtime::get_runtime_handle;
 
 #[derive(Debug, Clone)]
 pub struct Timestamp(u64);
@@ -36,45 +32,94 @@ pub(crate) fn u64_to_uint(u: u64) -> UInt {
         UInt::MAX
     })
 }
+#[cfg(target_family = "wasm")]
+mod sys {
+    use std::ops::Deref;
 
-/// Tiny wrappers for data types that must be dropped in the context of an async
-/// runtime.
-///
-/// This is useful whenever such a data type may transitively call some
-/// runtime's `block_on` function in their `Drop` impl (since we lack async drop
-/// at the moment), like done in some `deadpool` drop impls.
-pub(crate) struct AsyncRuntimeDropped<T>(ManuallyDrop<T>);
+    /// Tiny wrappers for data types that must be dropped in the context of an
+    /// async runtime.
+    ///
+    /// This is useful whenever such a data type may transitively call some
+    /// runtime's `block_on` function in their `Drop` impl (since we lack async
+    /// drop at the moment), like done in some `deadpool` drop impls.
+    pub struct AsyncRuntimeDropped<T>(T);
 
-impl<T> AsyncRuntimeDropped<T> {
-    /// Create a new wrapper for this type that will be dropped under an async
-    /// runtime.
-    pub fn new(val: T) -> Self {
-        Self(ManuallyDrop::new(val))
+    impl<T> AsyncRuntimeDropped<T> {
+        /// Create a new wrapper for this type.
+        pub fn new(val: T) -> Self {
+            Self(val)
+        }
     }
-}
 
-impl<T> Drop for AsyncRuntimeDropped<T> {
-    fn drop(&mut self) {
-        let _guard = get_runtime_handle().enter();
-        // SAFETY: self.inner is never used again, which is the only requirement
-        //         for ManuallyDrop::drop to be used safely.
-        unsafe {
-            ManuallyDrop::drop(&mut self.0);
+    impl<T> Drop for AsyncRuntimeDropped<T> {
+        fn drop(&mut self) {
+            // No special handling is needed for wasm32 since it doesn't require
+            // async runtime context.
+        }
+    }
+
+    // What is an `AsyncRuntimeDropped<T>`, if not a `T` in disguise?
+    impl<T> Deref for AsyncRuntimeDropped<T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl<T: Clone> Clone for AsyncRuntimeDropped<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
         }
     }
 }
 
-// What is an `AsyncRuntimeDropped<T>`, if not a `T` in disguise?
-impl<T> Deref for AsyncRuntimeDropped<T> {
-    type Target = T;
+#[cfg(not(target_family = "wasm"))]
+mod sys {
+    use std::{mem::ManuallyDrop, ops::Deref};
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    use crate::runtime::get_runtime_handle;
+    /// Tiny wrappers for data types that must be dropped in the context of an
+    /// async runtime.
+    ///
+    /// This is useful whenever such a data type may transitively call some
+    /// runtime's `block_on` function in their `Drop` impl (since we lack async
+    /// drop at the moment), like done in some `deadpool` drop impls.
+    pub struct AsyncRuntimeDropped<T>(ManuallyDrop<T>);
+
+    impl<T> AsyncRuntimeDropped<T> {
+        /// Create a new wrapper for this type that will be dropped under an
+        /// async runtime.
+        pub fn new(val: T) -> Self {
+            Self(ManuallyDrop::new(val))
+        }
+    }
+
+    impl<T> Drop for AsyncRuntimeDropped<T> {
+        fn drop(&mut self) {
+            let _guard = get_runtime_handle().enter();
+            // SAFETY: self.inner is never used again, which is the only requirement
+            //         for ManuallyDrop::drop to be used safely.
+            unsafe {
+                ManuallyDrop::drop(&mut self.0);
+            }
+        }
+    }
+
+    // What is an `AsyncRuntimeDropped<T>`, if not a `T` in disguise?
+    impl<T> Deref for AsyncRuntimeDropped<T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl<T: Clone> Clone for AsyncRuntimeDropped<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
     }
 }
 
-impl<T: Clone> Clone for AsyncRuntimeDropped<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
+pub(crate) use sys::*;


### PR DESCRIPTION
<!-- description of the changes in this PR -->
The stock implementation of AsyncRuntimeDropped makes use of ManuallyDropped which is not usable on Wasm.  Introduce a Wasm specific version of this struct.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
