### PR TITLE
feat(ffi): Expose legacy SSO support infomation

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Features:
+
+- Add `HomeserverLoginDetails::supports_sso_login` for legacy SSO support information.
+  This is primarily for Element X to give a dedicated error message in case
+  it connects a homeserver with only this method available.
+  ([#5222](https://github.com/matrix-org/matrix-rust-sdk/pull/5222))
+
 ### Breaking changes:
 
 - `Client::url_for_oidc` now allows requesting additional scopes for the OAuth2 authorization code grant.

--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -23,6 +23,7 @@ pub struct HomeserverLoginDetails {
     pub(crate) sliding_sync_version: SlidingSyncVersion,
     pub(crate) supports_oidc_login: bool,
     pub(crate) supported_oidc_prompts: Vec<OidcPrompt>,
+    pub(crate) supports_sso_login: bool,
     pub(crate) supports_password_login: bool,
 }
 
@@ -41,6 +42,11 @@ impl HomeserverLoginDetails {
     /// Whether the current homeserver supports login using OIDC.
     pub fn supports_oidc_login(&self) -> bool {
         self.supports_oidc_login
+    }
+
+    /// Whether the current homeserver supports login using legacy SSO.
+    pub fn supports_sso_login(&self) -> bool {
+        self.supports_sso_login
     }
 
     /// The prompts advertised by the authentication issuer for use in the login


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Currently Element X can't distinguish the cases where a homeserver only
supports legacy SSO without OIDC (and password login isn't avaliable),
and other server unreachable scenarios.

This patch exposes legacy SSO support infomation so that Element X side
can give a dedicated error message when it encounters a homeserver that
can only support legacy SSO.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Yorusaka Miyabi <23130178+ShadowRZ@users.noreply.github.com>
