### PR TITLE
IndexedDB: Add (de)serialization functionality for `EventCacheStore` backend

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -120,6 +120,8 @@ pub mod v1 {
         pub const EVENTS_POSITION_KEY_PATH: &str = "position";
         pub const EVENTS_RELATION: &str = "events_relation";
         pub const EVENTS_RELATION_KEY_PATH: &str = "relation";
+        pub const EVENTS_RELATION_RELATED_EVENTS: &str = "events_relation_related_event";
+        pub const EVENTS_RELATION_RELATION_TYPES: &str = "events_relation_relation_type";
         pub const GAPS: &str = "gaps";
         pub const GAPS_KEY_PATH: &str = "id";
     }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -109,6 +109,7 @@ pub mod v1 {
 
     pub mod keys {
         pub const CORE: &str = "core";
+        pub const ROOMS: &str = "rooms";
         pub const LINKED_CHUNKS: &str = "linked_chunks";
         pub const LINKED_CHUNKS_KEY_PATH: &str = "id";
         pub const LINKED_CHUNKS_NEXT: &str = "linked_chunks_next";

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License
 
+#![allow(unused)]
+
 mod migrations;
 mod serializer;
 mod types;

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License
 
+mod traits;
 mod types;

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
@@ -12,5 +12,146 @@
 // See the License for the specific language governing permissions and
 // limitations under the License
 
+use gloo_utils::format::JsValueSerdeExt;
+use matrix_sdk_crypto::CryptoStoreError;
+use ruma::RoomId;
+use serde::{de::DeserializeOwned, Serialize};
+use thiserror::Error;
+use wasm_bindgen::JsValue;
+use web_sys::IdbKeyRange;
+
+use crate::{
+    event_cache_store::serializer::traits::{Indexed, IndexedKey, IndexedKeyBounds},
+    serializer::IndexeddbSerializer,
+};
+
 mod traits;
 mod types;
+
+#[derive(Debug, Error)]
+pub enum IndexeddbEventCacheStoreSerializerError {
+    #[error("indexing: {0}")]
+    Indexing(Box<dyn std::error::Error>),
+    #[error("serialization: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+impl From<serde_wasm_bindgen::Error> for IndexeddbEventCacheStoreSerializerError {
+    fn from(e: serde_wasm_bindgen::Error) -> Self {
+        Self::Serialization(serde::de::Error::custom(e.to_string()))
+    }
+}
+
+/// A (de)serializer for an IndexedDB implementation of [`EventCacheStore`][1].
+///
+/// This is primarily a wrapper around [`IndexeddbSerializer`] with a
+/// convenience functions for (de)serializing types specific to the
+/// [`EventCacheStore`][1].
+///
+/// [1]: matrix_sdk_base::event_cache::store::EventCacheStore
+pub struct IndexeddbEventCacheStoreSerializer {
+    inner: IndexeddbSerializer,
+}
+
+impl IndexeddbEventCacheStoreSerializer {
+    pub fn new(inner: IndexeddbSerializer) -> Self {
+        Self { inner }
+    }
+
+    /// Encodes an key for a [`Indexed`] type.
+    ///
+    /// Note that the particular key which is encoded is defined by the type
+    /// `K`.
+    pub fn encode_key<T, K>(&self, room_id: &RoomId, components: &K::KeyComponents) -> K
+    where
+        T: Indexed,
+        K: IndexedKey<T>,
+    {
+        K::encode(room_id, components, &self.inner)
+    }
+
+    /// Encodes a key for a [`Indexed`] type as a [`JsValue`].
+    ///
+    /// Note that the particular key which is encoded is defined by the type
+    /// `K`.
+    pub fn encode_key_as_value<T, K>(
+        &self,
+        room_id: &RoomId,
+        components: &K::KeyComponents,
+    ) -> Result<JsValue, serde_wasm_bindgen::Error>
+    where
+        T: Indexed,
+        K: IndexedKey<T> + Serialize,
+    {
+        serde_wasm_bindgen::to_value(&self.encode_key::<T, K>(room_id, components))
+    }
+
+    /// Encodes the entire key range for an [`Indexed`] type.
+    ///
+    /// Note that the particular key which is encoded is defined by the type
+    /// `K`.
+    pub fn encode_key_range<T, K>(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<IdbKeyRange, serde_wasm_bindgen::Error>
+    where
+        T: Indexed,
+        K: IndexedKeyBounds<T> + Serialize,
+    {
+        let lower = serde_wasm_bindgen::to_value(&K::encode_lower(room_id, &self.inner))?;
+        let upper = serde_wasm_bindgen::to_value(&K::encode_upper(room_id, &self.inner))?;
+        IdbKeyRange::bound(&lower, &upper).map_err(Into::into)
+    }
+
+    /// Encodes a bounded key range for an [`Indexed`] type from `lower` to
+    /// `upper`.
+    ///
+    /// Note that the particular key which is encoded is defined by the type
+    /// `K`.
+    pub fn encode_key_range_from_to<T, K>(
+        &self,
+        room_id: &RoomId,
+        lower: &K::KeyComponents,
+        upper: &K::KeyComponents,
+    ) -> Result<IdbKeyRange, serde_wasm_bindgen::Error>
+    where
+        T: Indexed,
+        K: IndexedKeyBounds<T> + Serialize,
+    {
+        let lower = serde_wasm_bindgen::to_value(&K::encode(room_id, lower, &self.inner))?;
+        let upper = serde_wasm_bindgen::to_value(&K::encode(room_id, upper, &self.inner))?;
+        IdbKeyRange::bound(&lower, &upper).map_err(Into::into)
+    }
+
+    /// Serializes an [`Indexed`] type into a [`JsValue`]
+    pub fn serialize<T>(
+        &self,
+        room_id: &RoomId,
+        t: &T,
+    ) -> Result<JsValue, IndexeddbEventCacheStoreSerializerError>
+    where
+        T: Indexed,
+        T::IndexedType: Serialize,
+        T::Error: std::error::Error + 'static,
+    {
+        let indexed = t
+            .to_indexed(room_id, &self.inner)
+            .map_err(|e| IndexeddbEventCacheStoreSerializerError::Indexing(Box::new(e)))?;
+        serde_wasm_bindgen::to_value(&indexed).map_err(Into::into)
+    }
+
+    /// Deserializes an [`Indexed`] type from a [`JsValue`]
+    pub fn deserialize<T>(
+        &self,
+        value: JsValue,
+    ) -> Result<T, IndexeddbEventCacheStoreSerializerError>
+    where
+        T: Indexed,
+        T::IndexedType: DeserializeOwned,
+        T::Error: std::error::Error + 'static,
+    {
+        let indexed: T::IndexedType = value.into_serde()?;
+        T::from_indexed(indexed, &self.inner)
+            .map_err(|e| IndexeddbEventCacheStoreSerializerError::Indexing(Box::new(e)))
+    }
+}

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -63,3 +63,14 @@ pub trait IndexedKey<T: Indexed> {
         serializer: &IndexeddbSerializer,
     ) -> Self;
 }
+
+/// A trait for constructing the bounds of an [`IndexedKey`].
+///
+/// This is useful when constructing range queries in IndexedDB.
+pub trait IndexedKeyBounds<T: Indexed>: IndexedKey<T> {
+    /// Encodes the lower bound of the key.
+    fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self;
+
+    /// Encodes the upper bound of the key.
+    fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self;
+}

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -1,0 +1,44 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+use ruma::RoomId;
+
+use crate::serializer::IndexeddbSerializer;
+
+/// A conversion trait for preparing high-level types into indexed types
+/// which are better suited for storage in IndexedDB.
+///
+/// Note that the functions below take an [`IndexeddbSerializer`] as an
+/// argument, which provides the necessary context for encryption and
+/// decryption, in the case the high-level type must be encrypted before
+/// storage.
+pub trait Indexed: Sized {
+    /// The indexed type that is used for storage in IndexedDB.
+    type IndexedType;
+    /// The error type that is returned when conversion fails.
+    type Error;
+
+    /// Converts the high-level type into an indexed type.
+    fn to_indexed(
+        &self,
+        room_id: &RoomId,
+        serializer: &IndexeddbSerializer,
+    ) -> Result<Self::IndexedType, Self::Error>;
+
+    /// Converts an indexed type into the high-level type.
+    fn from_indexed(
+        indexed: Self::IndexedType,
+        serializer: &IndexeddbSerializer,
+    ) -> Result<Self, Self::Error>;
+}

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -42,3 +42,24 @@ pub trait Indexed: Sized {
         serializer: &IndexeddbSerializer,
     ) -> Result<Self, Self::Error>;
 }
+
+/// A trait for encoding types which will be used as keys in IndexedDB.
+///
+/// Each implementation represents a key on an [`Indexed`] type.
+pub trait IndexedKey<T: Indexed> {
+    /// Any extra data used to construct the key.
+    type KeyComponents;
+
+    /// Encodes the key components into a type that can be used as a key in
+    /// IndexedDB.
+    ///
+    /// Note that this function takes an [`IndexeddbSerializer`] as an
+    /// argument, which provides the necessary context for encryption and
+    /// decryption, in the case that certain components of the key must be
+    /// encrypted before storage.
+    fn encode(
+        room_id: &RoomId,
+        components: &Self::KeyComponents,
+        serializer: &IndexeddbSerializer,
+    ) -> Self;
+}

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
@@ -173,6 +173,12 @@ pub enum IndexedNextChunkIdKey {
     Some(IndexedChunkIdKey),
 }
 
+impl IndexedNextChunkIdKey {
+    pub fn none(room_id: IndexedRoomId) -> Self {
+        Self::None((room_id,))
+    }
+}
+
 impl IndexedKey<Chunk> for IndexedNextChunkIdKey {
     type KeyComponents = Option<ChunkIdentifier>;
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
@@ -29,17 +29,36 @@
 
 use matrix_sdk_base::linked_chunk::ChunkIdentifier;
 use matrix_sdk_crypto::CryptoStoreError;
-use ruma::RoomId;
+use ruma::{events::relation::RelationType, EventId, OwnedEventId, RoomId};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::{
     event_cache_store::{
         migrations::current::keys,
         serializer::traits::{Indexed, IndexedKey, IndexedKeyBounds},
-        types::Chunk,
+        types::{Chunk, Event, Position},
     },
     serializer::{IndexeddbSerializer, MaybeEncrypted},
 };
+
+/// The first unicode character, and hence the lower bound for IndexedDB keys
+/// (or key components) which are represented as strings.
+///
+/// This value is useful for constructing a key range over all strings when used
+/// in conjunction with [`INDEXED_KEY_UPPER_CHARACTER`].
+const INDEXED_KEY_LOWER_CHARACTER: char = '\u{0000}';
+
+/// The last unicode character in the [Basic Multilingual Plane][1]. This seems
+/// like a reasonable place to set the upper bound for IndexedDB keys (or key
+/// components) which are represented as strings, though one could
+/// theoretically set it to `\u{10FFFF}`.
+///
+/// This value is useful for constructing a key range over all strings when used
+/// in conjunction with [`INDEXED_KEY_LOWER_CHARACTER`].
+///
+/// [1]: https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane
+const INDEXED_KEY_UPPER_CHARACTER: char = '\u{FFFF}';
 
 /// Represents the [`LINKED_CHUNKS`][1] object store.
 ///
@@ -206,6 +225,46 @@ pub struct IndexedEvent {
     pub content: IndexedEventContent,
 }
 
+#[derive(Debug, Error)]
+pub enum IndexedEventError {
+    #[error("no event id")]
+    NoEventId,
+    #[error("crypto store: {0}")]
+    CryptoStore(#[from] CryptoStoreError),
+}
+
+impl Indexed for Event {
+    type IndexedType = IndexedEvent;
+    type Error = IndexedEventError;
+
+    fn to_indexed(
+        &self,
+        room_id: &RoomId,
+        serializer: &IndexeddbSerializer,
+    ) -> Result<Self::IndexedType, Self::Error> {
+        let event_id = self.event_id().ok_or(Self::Error::NoEventId)?;
+        let id = IndexedEventIdKey::encode(room_id, &event_id, serializer);
+        let position = self
+            .position()
+            .map(|position| IndexedEventPositionKey::encode(room_id, &position, serializer));
+        let relation = self.relation().map(|(related_event, relation_type)| {
+            IndexedEventRelationKey::encode(
+                room_id,
+                &(related_event, RelationType::from(relation_type)),
+                serializer,
+            )
+        });
+        Ok(IndexedEvent { id, position, relation, content: serializer.maybe_encrypt_value(self)? })
+    }
+
+    fn from_indexed(
+        indexed: Self::IndexedType,
+        serializer: &IndexeddbSerializer,
+    ) -> Result<Self, Self::Error> {
+        serializer.maybe_decrypt_value(indexed.content).map_err(Into::into)
+    }
+}
+
 /// The value associated with the [primary key](IndexedEvent::id) of the
 /// [`EVENTS`][1] object store, which is constructed from:
 ///
@@ -215,6 +274,30 @@ pub struct IndexedEvent {
 /// [1]: crate::event_cache_store::migrations::v1::create_events_object_store
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IndexedEventIdKey(IndexedRoomId, IndexedEventId);
+
+impl IndexedKey<Event> for IndexedEventIdKey {
+    type KeyComponents = OwnedEventId;
+
+    fn encode(room_id: &RoomId, event_id: &OwnedEventId, serializer: &IndexeddbSerializer) -> Self {
+        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);
+        let event_id = serializer.encode_key_as_string(keys::EVENTS, event_id);
+        Self(room_id, event_id)
+    }
+}
+
+impl IndexedKeyBounds<Event> for IndexedEventIdKey {
+    fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
+        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);
+        let event_id = String::from(INDEXED_KEY_LOWER_CHARACTER);
+        Self(room_id, event_id)
+    }
+
+    fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
+        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);
+        let event_id = String::from(INDEXED_KEY_UPPER_CHARACTER);
+        Self(room_id, event_id)
+    }
+}
 
 pub type IndexedEventId = String;
 
@@ -229,6 +312,36 @@ pub type IndexedEventId = String;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IndexedEventPositionKey(IndexedRoomId, IndexedChunkId, IndexedEventPositionIndex);
 
+impl IndexedKey<Event> for IndexedEventPositionKey {
+    type KeyComponents = Position;
+
+    fn encode(room_id: &RoomId, position: &Position, serializer: &IndexeddbSerializer) -> Self {
+        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);
+        Self(room_id, position.chunk_identifier, position.index)
+    }
+}
+
+impl IndexedKeyBounds<Event> for IndexedEventPositionKey {
+    fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
+        <Self as IndexedKey<Event>>::encode(
+            room_id,
+            &Position { chunk_identifier: 0, index: 0 },
+            serializer,
+        )
+    }
+
+    fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
+        <Self as IndexedKey<Event>>::encode(
+            room_id,
+            &Position {
+                chunk_identifier: js_sys::Number::MAX_SAFE_INTEGER as u64,
+                index: js_sys::Number::MAX_SAFE_INTEGER as usize,
+            },
+            serializer,
+        )
+    }
+}
+
 pub type IndexedEventPositionIndex = usize;
 
 /// The value associated with the [`relation`](IndexedEvent::relation) index of
@@ -241,6 +354,39 @@ pub type IndexedEventPositionIndex = usize;
 /// [1]: crate::event_cache_store::migrations::v1::create_events_object_store
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IndexedEventRelationKey(IndexedRoomId, IndexedEventId, IndexedRelationType);
+
+impl IndexedKey<Event> for IndexedEventRelationKey {
+    type KeyComponents = (OwnedEventId, RelationType);
+
+    fn encode(
+        room_id: &RoomId,
+        (related_event_id, relation_type): &(OwnedEventId, RelationType),
+        serializer: &IndexeddbSerializer,
+    ) -> Self {
+        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);
+        let related_event_id =
+            serializer.encode_key_as_string(keys::EVENTS_RELATION_RELATED_EVENTS, related_event_id);
+        let relation_type = serializer
+            .encode_key_as_string(keys::EVENTS_RELATION_RELATION_TYPES, relation_type.to_string());
+        Self(room_id, related_event_id, relation_type)
+    }
+}
+
+impl IndexedKeyBounds<Event> for IndexedEventRelationKey {
+    fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
+        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);
+        let related_event_id = String::from(INDEXED_KEY_LOWER_CHARACTER);
+        let relation_type = String::from(INDEXED_KEY_LOWER_CHARACTER);
+        Self(room_id, related_event_id, relation_type)
+    }
+
+    fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
+        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);
+        let related_event_id = String::from(INDEXED_KEY_UPPER_CHARACTER);
+        let relation_type = String::from(INDEXED_KEY_UPPER_CHARACTER);
+        Self(room_id, related_event_id, relation_type)
+    }
+}
 
 /// A representation of the relationship between two events (see
 /// [`RelationType`](ruma::events::relation::RelationType))

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
 use matrix_sdk_base::{
     deserialized_responses::TimelineEvent, event_cache::store::extract_event_relation,
     linked_chunk::ChunkIdentifier,

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -145,6 +145,8 @@ impl From<matrix_sdk_base::linked_chunk::Position> for Position {
 /// which can be stored in IndexedDB.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Gap {
+    /// The identifier of the chunk containing this gap.
+    pub chunk_identifier: u64,
     /// The token to use in the query, extracted from a previous "from" /
     /// "end" field of a `/messages` response.
     pub prev_token: String,


### PR DESCRIPTION
## Background

This pull request is part of a series of pull requests to add an IndexedDB implementation of the `EventCacheStore` (see #4617, #4996, #5090, #5138). This particular pull request provides (de)serialization functionality for the types defined in #5138.

## Changes

This change add a few traits to aid in (de)serialization and implements those traits on a relevant types. Furthermore, there is a `struct` for conveniently calling into those (de)serialization traits - i.e., `IndexeddbEventCacheStoreSerializer`.

### `trait`s and `impl`s

- `Indexed` - converts high-level types to/from indexed types
    - `impl`s:
        - `Chunk` ↔ `IndexedChunk`
        - `Event` ↔ `IndexedEvent`
        - `Gap` ↔ `IndexedGap`
- `IndexedKey` - encodes a key for an indexed type
    - `impl`s:
        - `Chunk`
            - `IndexedChunkIdKey`
            - `IndexedNextChunkIdKey`
        - `Event`
            - `IndexedEventIdKey`
            - `IndexedEventPositionKey`
            - `IndexedEventRelationKey`
        - `Gap`
            - `IndexedGapIdKey`   
- `IndexedKeyBounds` - encodes the lower and upper keys for an indexed type
    - `impl`s:
        - `Chunk`
            - `IndexedChunkIdKey`
            - `IndexedNextChunkIdKey`
        - `Event`
            - `IndexedEventIdKey`
            - `IndexedEventPositionKey`
            - `IndexedEventRelationKey`
        - `Gap`
            - `IndexedGapIdKey` 

## Future Work

- Add convenient query functions that wrap (de)serialization logic
- Add implementation of `EventCacheStore` which uses query functions mentioned above

---

- [ ] Public API changes documented in changelogs (optional)


Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
