### PR TITLE
feat: add thread support to the room message draft facilities

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -828,18 +828,31 @@ impl Room {
 
     /// Store the given `ComposerDraft` in the state store using the current
     /// room id, as identifier.
-    pub async fn save_composer_draft(&self, draft: ComposerDraft) -> Result<(), ClientError> {
-        Ok(self.inner.save_composer_draft(draft.try_into()?).await?)
+    pub async fn save_composer_draft(
+        &self,
+        draft: ComposerDraft,
+        thread_root: Option<String>,
+    ) -> Result<(), ClientError> {
+        let thread_root = thread_root.map(EventId::parse).transpose()?;
+        Ok(self.inner.save_composer_draft(draft.try_into()?, thread_root.as_deref()).await?)
     }
 
     /// Retrieve the `ComposerDraft` stored in the state store for this room.
-    pub async fn load_composer_draft(&self) -> Result<Option<ComposerDraft>, ClientError> {
-        Ok(self.inner.load_composer_draft().await?.map(Into::into))
+    pub async fn load_composer_draft(
+        &self,
+        thread_root: Option<String>,
+    ) -> Result<Option<ComposerDraft>, ClientError> {
+        let thread_root = thread_root.map(EventId::parse).transpose()?;
+        Ok(self.inner.load_composer_draft(thread_root.as_deref()).await?.map(Into::into))
     }
 
     /// Remove the `ComposerDraft` stored in the state store for this room.
-    pub async fn clear_composer_draft(&self) -> Result<(), ClientError> {
-        Ok(self.inner.clear_composer_draft().await?)
+    pub async fn clear_composer_draft(
+        &self,
+        thread_root: Option<String>,
+    ) -> Result<(), ClientError> {
+        let thread_root = thread_root.map(EventId::parse).transpose()?;
+        Ok(self.inner.clear_composer_draft(thread_root.as_deref()).await?)
     }
 
     /// Edit an event given its event id.

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -1134,7 +1134,7 @@ pub enum StateStoreDataKey<'a> {
     /// To learn more, see [`ComposerDraft`].
     ///
     /// [`ComposerDraft`]: Self::ComposerDraft
-    ComposerDraft(&'a RoomId),
+    ComposerDraft(&'a RoomId, Option<&'a EventId>),
 
     /// A list of knock request ids marked as seen in a room.
     SeenKnockRequests(&'a RoomId),

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -416,8 +416,15 @@ impl IndexeddbStateStore {
             StateStoreDataKey::UtdHookManagerData => {
                 self.encode_key(keys::KV, StateStoreDataKey::UTD_HOOK_MANAGER_DATA)
             }
-            StateStoreDataKey::ComposerDraft(room_id) => {
-                self.encode_key(keys::KV, (StateStoreDataKey::COMPOSER_DRAFT, room_id))
+            StateStoreDataKey::ComposerDraft(room_id, thread_root) => {
+                if let Some(thread_root) = thread_root {
+                    self.encode_key(
+                        keys::KV,
+                        (StateStoreDataKey::COMPOSER_DRAFT, (room_id, thread_root)),
+                    )
+                } else {
+                    self.encode_key(keys::KV, (StateStoreDataKey::COMPOSER_DRAFT, room_id))
+                }
             }
             StateStoreDataKey::SeenKnockRequests(room_id) => {
                 self.encode_key(keys::KV, (StateStoreDataKey::SEEN_KNOCK_REQUESTS, room_id))
@@ -550,7 +557,7 @@ impl_state_store!({
                 .map(|f| self.deserialize_value::<GrowableBloom>(&f))
                 .transpose()?
                 .map(StateStoreDataValue::UtdHookManagerData),
-            StateStoreDataKey::ComposerDraft(_) => value
+            StateStoreDataKey::ComposerDraft(_, _) => value
                 .map(|f| self.deserialize_value::<ComposerDraft>(&f))
                 .transpose()?
                 .map(StateStoreDataValue::ComposerDraft),
@@ -592,7 +599,7 @@ impl_state_store!({
             StateStoreDataKey::UtdHookManagerData => self.serialize_value(
                 &value.into_utd_hook_manager_data().expect("Session data not UtdHookManagerData"),
             ),
-            StateStoreDataKey::ComposerDraft(_) => self.serialize_value(
+            StateStoreDataKey::ComposerDraft(_, _) => self.serialize_value(
                 &value.into_composer_draft().expect("Session data not a composer draft"),
             ),
             StateStoreDataKey::SeenKnockRequests(_) => self.serialize_value(

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -425,8 +425,15 @@ impl SqliteStateStore {
             StateStoreDataKey::UtdHookManagerData => {
                 Cow::Borrowed(StateStoreDataKey::UTD_HOOK_MANAGER_DATA)
             }
-            StateStoreDataKey::ComposerDraft(room_id) => {
-                Cow::Owned(format!("{}:{room_id}", StateStoreDataKey::COMPOSER_DRAFT))
+            StateStoreDataKey::ComposerDraft(room_id, thread_root) => {
+                if let Some(thread_root) = thread_root {
+                    Cow::Owned(format!(
+                        "{}:{room_id}:{thread_root}",
+                        StateStoreDataKey::COMPOSER_DRAFT
+                    ))
+                } else {
+                    Cow::Owned(format!("{}:{room_id}", StateStoreDataKey::COMPOSER_DRAFT))
+                }
             }
             StateStoreDataKey::SeenKnockRequests(room_id) => {
                 Cow::Owned(format!("{}:{room_id}", StateStoreDataKey::SEEN_KNOCK_REQUESTS))
@@ -1037,7 +1044,7 @@ impl StateStore for SqliteStateStore {
                     StateStoreDataKey::UtdHookManagerData => {
                         StateStoreDataValue::UtdHookManagerData(self.deserialize_value(&data)?)
                     }
-                    StateStoreDataKey::ComposerDraft(_) => {
+                    StateStoreDataKey::ComposerDraft(_, _) => {
                         StateStoreDataValue::ComposerDraft(self.deserialize_value(&data)?)
                     }
                     StateStoreDataKey::SeenKnockRequests(_) => {
@@ -1074,7 +1081,7 @@ impl StateStore for SqliteStateStore {
             StateStoreDataKey::UtdHookManagerData => self.serialize_value(
                 &value.into_utd_hook_manager_data().expect("Session data not UtdHookManagerData"),
             )?,
-            StateStoreDataKey::ComposerDraft(_) => self.serialize_value(
+            StateStoreDataKey::ComposerDraft(_, _) => self.serialize_value(
                 &value.into_composer_draft().expect("Session data not a composer draft"),
             )?,
             StateStoreDataKey::SeenKnockRequests(_) => self.serialize_value(


### PR DESCRIPTION
This patch adds optional thread root event id parameters to the drafting functions exposed on the room level allowing unfinished messages to be managed for the main room as well as any inner thread.

Fixes #5223