### PR TITLE
feat(wasm): Address use of errors and panic::resume_unwind for wasm targets

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -634,7 +634,7 @@ impl Timeline {
         self.inner
             .fetch_details_for_event(event_id)
             .await
-            .map_err(|_| ClientError::from_str("Fetching event details".to_owned(), None))?;
+            .map_err(|e| ClientError::from_str(e, Some("Fetching event details".to_owned())))?;
         Ok(())
     }
 


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Address use of anyhow's error context + use of panic::resume_unwind on wasm targets.
- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
