### PR TITLE
chore(timeline): report day divider invariant violations to sentry

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
@@ -207,8 +207,7 @@ impl DateDividerAdjuster {
 
         // Then check invariants.
         if let Some(report) = self.check_invariants(items, initial_state) {
-            warn!("Errors encountered when checking invariants.");
-            warn!("{report}");
+            error!(sentry = true, %report, "day divider invariants violated");
             #[cfg(any(debug_assertions, test))]
             panic!("There was an error checking date separator invariants");
         }


### PR DESCRIPTION
On this date (heh), the date divider reports include the following information:

- initial timeline items in a shortened format,
- operations to apply,
- final timeline items in the same shortened format,
- errors

The shortened format includes:

- either, for events: "[event id]: server timestamp"
- or for date divider: "--- date divider timestamp"

As such, they don't include any personal information.

The initial timeline items state and set of operations to apply constitutes a fully enclosed test case, so it's nice to report it to Sentry, so we can reuse it almost as is (we'd only need to randomize the event IDs) and fix it in a subsequent commit.