### PR TITLE
refactor(crypto): Extract a method for handling encrypted to-device events

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -89,13 +89,14 @@ use crate::{
             room::encrypted::{
                 EncryptedEvent, EncryptedToDeviceEvent, RoomEncryptedEventContent,
                 RoomEventEncryptionScheme, SupportedEventEncryptionSchemes,
+                ToDeviceEncryptedEventContent,
             },
             room_key::{MegolmV1AesSha2Content, RoomKeyContent},
             room_key_bundle::RoomKeyBundleContent,
             room_key_withheld::{
                 MegolmV1AesSha2WithheldContent, RoomKeyWithheldContent, RoomKeyWithheldEvent,
             },
-            ToDeviceEvents,
+            ToDeviceEvent, ToDeviceEvents,
         },
         requests::{
             AnyIncomingResponse, KeysQueryRequest, OutgoingRequest, ToDeviceRequest,
@@ -1339,7 +1340,6 @@ impl OlmMachine {
             #[serde(borrow, rename = "org.matrix.msgid")]
             message_id: Option<&'a str>,
         }
-
         #[derive(Deserialize)]
         struct ToDeviceStub<'a> {
             sender: &'a str,
@@ -1368,7 +1368,7 @@ impl OlmMachine {
         &self,
         transaction: &mut StoreTransaction,
         changes: &mut Changes,
-        mut raw_event: Raw<AnyToDeviceEvent>,
+        raw_event: Raw<AnyToDeviceEvent>,
     ) -> Option<ProcessedToDeviceEvent> {
         Self::record_message_id(&raw_event);
 
@@ -1385,87 +1385,100 @@ impl OlmMachine {
 
         match event {
             ToDeviceEvents::RoomEncrypted(e) => {
-                let decrypted = match self.decrypt_to_device_event(transaction, &e, changes).await {
-                    Ok(e) => e,
-                    Err(err) => {
-                        if let OlmError::SessionWedged(sender, curve_key) = err {
-                            if let Err(e) = self
-                                .inner
-                                .session_manager
-                                .mark_device_as_wedged(&sender, curve_key)
-                                .await
-                            {
-                                error!(
-                                    error = ?e,
-                                    "Couldn't mark device from to be unwedged",
-                                );
-                            }
-                        }
-
-                        return Some(ProcessedToDeviceEvent::UnableToDecrypt(raw_event));
-                    }
-                };
-
-                // We ignore all to-device events from dehydrated devices - we should not
-                // receive any
-                match self.to_device_event_is_from_dehydrated_device(&decrypted, &e.sender).await {
-                    Ok(true) => {
-                        warn!(
-                            sender = ?e.sender,
-                            session = ?decrypted.session,
-                            "Received a to-device event from a dehydrated device. This is unexpected: ignoring event"
-                        );
-                        return None;
-                    }
-                    Ok(false) => {}
-                    Err(err) => {
-                        error!(
-                            error = ?err,
-                            "Couldn't check whether event is from dehydrated device",
-                        );
-                    }
-                }
-
-                // New sessions modify the account so we need to save that
-                // one as well.
-                match decrypted.session {
-                    SessionType::New(s) | SessionType::Existing(s) => {
-                        changes.sessions.push(s);
-                    }
-                }
-
-                changes.message_hashes.push(decrypted.message_hash);
-
-                if let Some(group_session) = decrypted.inbound_group_session {
-                    changes.inbound_group_sessions.push(group_session);
-                }
-
-                match decrypted.result.raw_event.deserialize_as() {
-                    Ok(event) => {
-                        self.handle_to_device_event(changes, &event).await;
-
-                        raw_event = event
-                            .serialize_zeroized()
-                            .expect("Zeroizing and reserializing our events should always work")
-                            .cast();
-                    }
-                    Err(e) => {
-                        warn!("Received an invalid encrypted to-device event: {e}");
-                        raw_event = decrypted.result.raw_event;
-                    }
-                }
-
-                Some(ProcessedToDeviceEvent::Decrypted {
-                    raw: raw_event,
-                    encryption_info: decrypted.result.encryption_info,
-                })
+                self.receive_encrypted_to_device_event(transaction, changes, raw_event, e).await
             }
-
             e => {
                 self.handle_to_device_event(changes, &e).await;
                 Some(ProcessedToDeviceEvent::PlainText(raw_event))
             }
         }
+    }
+
+    /// Decrypt the supplied encrypted to-device event (if we can) and handle
+    /// it.
+    ///
+    /// Return the same event, decrypted if possible.
+    ///
+    /// If we can identify that this to-device event came from a dehydrated
+    /// device, this method does not process it, and returns `None`.
+    async fn receive_encrypted_to_device_event(
+        &self,
+        transaction: &mut StoreTransaction,
+        changes: &mut Changes,
+        mut raw_event: Raw<AnyToDeviceEvent>,
+        e: ToDeviceEvent<ToDeviceEncryptedEventContent>,
+    ) -> Option<ProcessedToDeviceEvent> {
+        let decrypted = match self.decrypt_to_device_event(transaction, &e, changes).await {
+            Ok(e) => e,
+            Err(err) => {
+                if let OlmError::SessionWedged(sender, curve_key) = err {
+                    if let Err(e) =
+                        self.inner.session_manager.mark_device_as_wedged(&sender, curve_key).await
+                    {
+                        error!(
+                            error = ?e,
+                            "Couldn't mark device to be unwedged",
+                        );
+                    }
+                }
+
+                return Some(ProcessedToDeviceEvent::UnableToDecrypt(raw_event));
+            }
+        };
+
+        // We ignore all to-device events from dehydrated devices - we should not
+        // receive any
+        match self.to_device_event_is_from_dehydrated_device(&decrypted, &e.sender).await {
+            Ok(true) => {
+                warn!(
+                    sender = ?e.sender,
+                    session = ?decrypted.session,
+                    "Received a to-device event from a dehydrated device. This is unexpected: ignoring event"
+                );
+                return None;
+            }
+            Ok(false) => {}
+            Err(err) => {
+                error!(
+                    error = ?err,
+                    "Couldn't check whether the event is from a dehydrated device",
+                );
+            }
+        }
+
+        // New sessions modify the account so we need to save that
+        // one as well.
+        match decrypted.session {
+            SessionType::New(s) | SessionType::Existing(s) => {
+                changes.sessions.push(s);
+            }
+        }
+
+        changes.message_hashes.push(decrypted.message_hash);
+
+        if let Some(group_session) = decrypted.inbound_group_session {
+            changes.inbound_group_sessions.push(group_session);
+        }
+
+        match decrypted.result.raw_event.deserialize_as() {
+            Ok(event) => {
+                self.handle_to_device_event(changes, &event).await;
+
+                raw_event = event
+                    .serialize_zeroized()
+                    .expect("Zeroizing and reserializing our events should always work")
+                    .cast();
+            }
+            Err(e) => {
+                warn!("Received an invalid encrypted to-device event: {e}");
+                raw_event = decrypted.result.raw_event;
+            }
+        }
+
+        Some(ProcessedToDeviceEvent::Decrypted {
+            raw: raw_event,
+            encryption_info: decrypted.result.encryption_info,
+        })
     }
 
     /// Decide whether a decrypted to-device event was sent from a dehydrated


### PR DESCRIPTION
This is a cut-and-paste of the logic from within a match branch into a separate method: the diff doesn't necessarily make that easy to see but I promise I didn't change anything.

This is purely because I found the existing method too long for me to understand easily, and because I may possibly want to unit test the new method as part of my work.

Preparation for https://github.com/matrix-org/matrix-rust-sdk/issues/4147