### PR TITLE
feat(sdk): Introduce `GenericRoomEventCacheUpdate`, one channel to get update of all rooms

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -22,7 +22,7 @@ use futures_util::{pin_mut, StreamExt};
 use matrix_sdk::{
     crypto::store::types::RoomKeyInfo,
     encryption::backups::BackupState,
-    event_cache::{EventsOrigin, RoomEventCache, RoomEventCacheListener, RoomEventCacheUpdate},
+    event_cache::{EventsOrigin, RoomEventCache, RoomEventCacheSubscriber, RoomEventCacheUpdate},
     executor::spawn,
     send_queue::RoomSendQueueUpdate,
     Room,
@@ -356,7 +356,7 @@ where
 async fn room_event_cache_updates_task(
     room_event_cache: RoomEventCache,
     timeline_controller: TimelineController,
-    mut event_subscriber: RoomEventCacheListener,
+    mut room_event_cache_subscriber: RoomEventCacheSubscriber,
     timeline_focus: TimelineFocus,
 ) {
     trace!("Spawned the event subscriber task.");
@@ -364,7 +364,7 @@ async fn room_event_cache_updates_task(
     loop {
         trace!("Waiting for an event.");
 
-        let update = match event_subscriber.recv().await {
+        let update = match room_event_cache_subscriber.recv().await {
             Ok(up) => up,
             Err(RecvError::Closed) => break,
             Err(RecvError::Lagged(num_skipped)) => {

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -193,13 +193,13 @@ impl EventCache {
             // Force-initialize the sender in the [`RoomEventCacheInner`].
             self.inner.auto_shrink_sender.get_or_init(|| tx);
 
-            let auto_shrink_linked_chunk_tasks =
+            let auto_shrink_linked_chunk_task =
                 spawn(Self::auto_shrink_linked_chunk_task(self.inner.clone(), rx));
 
             Arc::new(EventCacheDropHandles {
                 listen_updates_task,
                 ignore_user_list_update_task,
-                auto_shrink_linked_chunk_task: auto_shrink_linked_chunk_tasks,
+                auto_shrink_linked_chunk_task,
             })
         });
 

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -188,13 +188,15 @@ impl EventCache {
                 client.subscribe_to_ignore_user_list_changes(),
             ));
 
-            let (tx, rx) = mpsc::channel(32);
+            let (auto_shrink_sender, auto_shrink_receiver) = mpsc::channel(32);
 
             // Force-initialize the sender in the [`RoomEventCacheInner`].
-            self.inner.auto_shrink_sender.get_or_init(|| tx);
+            self.inner.auto_shrink_sender.get_or_init(|| auto_shrink_sender);
 
-            let auto_shrink_linked_chunk_task =
-                spawn(Self::auto_shrink_linked_chunk_task(self.inner.clone(), rx));
+            let auto_shrink_linked_chunk_task = spawn(Self::auto_shrink_linked_chunk_task(
+                self.inner.clone(),
+                auto_shrink_receiver,
+            ));
 
             Arc::new(EventCacheDropHandles {
                 listen_updates_task,

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -49,7 +49,7 @@ use ruma::{
     events::AnySyncEphemeralRoomEvent, serde::Raw, OwnedEventId, OwnedRoomId, RoomId, RoomVersionId,
 };
 use tokio::sync::{
-    broadcast::{error::RecvError, Receiver},
+    broadcast::{channel, error::RecvError, Receiver, Sender},
     mpsc, Mutex, RwLock,
 };
 use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument as _, Span};
@@ -155,6 +155,8 @@ impl Debug for EventCache {
 impl EventCache {
     /// Create a new [`EventCache`] for the given client.
     pub(crate) fn new(client: WeakClient, event_cache_store: EventCacheStoreLock) -> Self {
+        let (generic_room_event_cache_update_sender, _) = channel(32);
+
         Self {
             inner: Arc::new(EventCacheInner {
                 client,
@@ -163,6 +165,7 @@ impl EventCache {
                 by_room: Default::default(),
                 drop_handles: Default::default(),
                 auto_shrink_sender: Default::default(),
+                generic_room_event_cache_update_sender,
             }),
         }
     }
@@ -353,6 +356,21 @@ impl EventCache {
     pub async fn clear_all_rooms(&self) -> Result<()> {
         self.inner.clear_all_rooms().await
     }
+
+    /// Subscribe to _generic_ room updates.
+    ///
+    /// If one wants to listen what has changed in a specific room, the
+    /// [`RoomEventCache::subscribe`] is recommended. However, the
+    /// [`RoomEventCacheSubscriber`] type triggers side-effects.
+    ///
+    /// If one wants to get a high-overview, generic, updates for rooms, and
+    /// without side-effects, this method is recommended. For example, it
+    /// doesn't provide a list of new events, but rather a
+    /// [`GenericRoomEventCacheUpdate::TimelineUpdated`] message. Also, dropping
+    /// the receiver of this channel will not trigger any side-effect.
+    pub fn subscribe_to_generic_room_updates(&self) -> Receiver<GenericRoomEventCacheUpdate> {
+        self.inner.generic_room_event_cache_update_sender.subscribe()
+    }
 }
 
 struct EventCacheInner {
@@ -384,6 +402,12 @@ struct EventCacheInner {
     ///
     /// See doc comment of [`EventCache::auto_shrink_linked_chunk_task`].
     auto_shrink_sender: OnceLock<mpsc::Sender<AutoShrinkChannelPayload>>,
+
+    /// A sender for generic room update.
+    ///
+    /// See doc comment of [`GenericRoomEventCacheUpdate`] and
+    /// [`EventCache::subscribe_to_generic_room_updates`].
+    generic_room_event_cache_update_sender: Sender<GenericRoomEventCacheUpdate>,
 }
 
 type AutoShrinkChannelPayload = OwnedRoomId;
@@ -473,7 +497,14 @@ impl EventCacheInner {
         for (room_id, left_room_update) in updates.left {
             let room = self.for_room(&room_id).await?;
 
-            if let Err(err) = room.inner.handle_left_room_update(left_room_update).await {
+            if let Err(err) = room
+                .inner
+                .handle_left_room_update(
+                    left_room_update,
+                    &self.generic_room_event_cache_update_sender,
+                )
+                .await
+            {
                 // Non-fatal error, try to continue to the next room.
                 error!("handling left room update: {err}");
             }
@@ -483,7 +514,14 @@ impl EventCacheInner {
         for (room_id, joined_room_update) in updates.joined {
             let room = self.for_room(&room_id).await?;
 
-            if let Err(err) = room.inner.handle_joined_room_update(joined_room_update).await {
+            if let Err(err) = room
+                .inner
+                .handle_joined_room_update(
+                    joined_room_update,
+                    &self.generic_room_event_cache_update_sender,
+                )
+                .await
+            {
                 // Non-fatal error, try to continue to the next room.
                 error!(%room_id, "handling joined room update: {err}");
             }
@@ -540,6 +578,8 @@ impl EventCacheInner {
                 )
                 .await?;
 
+                let has_at_least_one_event = room_state.events().revents().next().is_some();
+
                 // SAFETY: we must have subscribed before reaching this coed, otherwise
                 // something is very wrong.
                 let auto_shrink_sender =
@@ -553,9 +593,20 @@ impl EventCacheInner {
                     pagination_status,
                     room_id.to_owned(),
                     auto_shrink_sender,
+                    self.generic_room_event_cache_update_sender.clone(),
                 );
 
                 by_room_guard.insert(room_id.to_owned(), room_event_cache.clone());
+
+                // If at least one event has been loaded, it means there is a timeline. Let's
+                // emit a generic update.
+                if has_at_least_one_event {
+                    let _ = self.generic_room_event_cache_update_sender.send(
+                        GenericRoomEventCacheUpdate::TimelineUpdated {
+                            room_id: room_id.to_owned(),
+                        },
+                    );
+                }
 
                 Ok(room_event_cache)
             }
@@ -576,6 +627,21 @@ pub struct BackPaginationOutcome {
     /// if present, is the most "recent" event from the chunk (or
     /// technically, the last one in the topological ordering).
     pub events: Vec<TimelineEvent>,
+}
+
+/// Represents an update of a room. It hides the details of
+/// [`RoomEventCacheUpdate`] by being more generic.
+///
+/// This is used by [`EventCache::subscribe_to_generic_room_updates`]. Please
+/// read it to learn more about the motivation behind this type.
+#[derive(Clone, Debug)]
+pub enum GenericRoomEventCacheUpdate {
+    /// The timeline has been updated, i.e. an event has been added, redacted or
+    /// removed.
+    TimelineUpdated {
+        /// The room ID owning the timeline.
+        room_id: OwnedRoomId,
+    },
 }
 
 /// An update related to events happened in a room.
@@ -628,14 +694,21 @@ pub enum EventsOrigin {
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Not;
+
     use assert_matches::assert_matches;
     use futures_util::FutureExt as _;
-    use matrix_sdk_base::sync::{JoinedRoomUpdate, RoomUpdates, Timeline};
+    use matrix_sdk_base::{
+        linked_chunk::{ChunkIdentifier, LinkedChunkId, Position, Update},
+        sync::{JoinedRoomUpdate, RoomUpdates, Timeline},
+        RoomState,
+    };
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
     use ruma::{event_id, room_id, serde::Raw, user_id};
     use serde_json::json;
+    use tokio::sync::broadcast::channel;
 
-    use super::{EventCacheError, RoomEventCacheUpdate};
+    use super::{EventCacheError, GenericRoomEventCacheUpdate, RoomEventCacheUpdate};
     use crate::test_utils::{assert_event_matches_msg, logged_in_client};
 
     #[async_test]
@@ -658,7 +731,7 @@ mod tests {
     async fn test_uniq_read_marker() {
         let client = logged_in_client(None).await;
         let room_id = room_id!("!galette:saucisse.bzh");
-        client.base_client().get_or_create_room(room_id, matrix_sdk_base::RoomState::Joined);
+        client.base_client().get_or_create_room(room_id, RoomState::Joined);
 
         let event_cache = client.event_cache();
 
@@ -683,10 +756,14 @@ mod tests {
         )
         .unwrap();
         let account_data = vec![read_marker_event; 100];
+        let (generic_update_sender, mut generic_update_receiver) = channel(2);
 
         room_event_cache
             .inner
-            .handle_joined_room_update(JoinedRoomUpdate { account_data, ..Default::default() })
+            .handle_joined_room_update(
+                JoinedRoomUpdate { account_data, ..Default::default() },
+                &generic_update_sender,
+            )
             .await
             .unwrap();
 
@@ -697,6 +774,9 @@ mod tests {
         );
 
         assert!(stream.recv().now_or_never().is_none());
+
+        // None, because an account data doesn't trigger a generic update.
+        assert!(generic_update_receiver.recv().now_or_never().is_none());
     }
 
     #[async_test]
@@ -742,7 +822,7 @@ mod tests {
         event_cache.inner.handle_room_updates(updates).await.unwrap();
 
         // We can find the events in a single room.
-        client.base_client().get_or_create_room(room_id1, matrix_sdk_base::RoomState::Joined);
+        client.base_client().get_or_create_room(room_id1, RoomState::Joined);
         let room1 = client.get_room(room_id1).unwrap();
 
         let (room_event_cache, _drop_handles) = room1.event_cache().await.unwrap();
@@ -769,7 +849,7 @@ mod tests {
         let f = EventFactory::new().room(room_id).sender(user_id!("@ben:saucisse.bzh"));
         let event_id = event_id!("$1");
 
-        client.base_client().get_or_create_room(room_id, matrix_sdk_base::RoomState::Joined);
+        client.base_client().get_or_create_room(room_id, RoomState::Joined);
         let room = client.get_room(room_id).unwrap();
 
         let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
@@ -777,5 +857,177 @@ mod tests {
 
         // Retrieving the event at the room-wide cache works.
         assert!(room_event_cache.event(event_id).await.is_some());
+    }
+
+    #[async_test]
+    async fn test_generic_update_when_loading_rooms() {
+        // Create 2 rooms. One of them has data in the event cache storage.
+        let user = user_id!("@mnt_io:matrix.org");
+        let client = logged_in_client(None).await;
+        let room_id_0 = room_id!("!raclette:patate.ch");
+        let room_id_1 = room_id!("!fondue:patate.ch");
+
+        let event_factory = EventFactory::new().room(room_id_0).sender(user);
+
+        let event_cache = client.event_cache();
+        event_cache.subscribe().unwrap();
+
+        client.base_client().get_or_create_room(room_id_0, RoomState::Joined);
+        client.base_client().get_or_create_room(room_id_1, RoomState::Joined);
+
+        client
+            .event_cache_store()
+            .lock()
+            .await
+            .unwrap()
+            .handle_linked_chunk_updates(
+                LinkedChunkId::Room(room_id_0),
+                vec![
+                    // Non-empty items chunk.
+                    Update::NewItemsChunk {
+                        previous: None,
+                        new: ChunkIdentifier::new(0),
+                        next: None,
+                    },
+                    Update::PushItems {
+                        at: Position::new(ChunkIdentifier::new(0), 0),
+                        items: vec![event_factory
+                            .text_msg("hello")
+                            .sender(user)
+                            .event_id(event_id!("$ev0"))
+                            .into_event()],
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+
+        let mut generic_stream = event_cache.subscribe_to_generic_room_updates();
+
+        // Room 0 has initial data, so it must trigger a generic update.
+        {
+            let _room_event_cache = event_cache.for_room(room_id_0).await.unwrap();
+
+            assert_matches!(
+                generic_stream.recv().await,
+                Ok(GenericRoomEventCacheUpdate::TimelineUpdated { room_id }) => {
+                    assert_eq!(room_id, room_id_0);
+                }
+            );
+        }
+
+        // Room 1 has NO initial data, so nothing should happen.
+        {
+            let _room_event_cache = event_cache.for_room(room_id_1).await.unwrap();
+
+            assert!(generic_stream.recv().now_or_never().is_none());
+        }
+    }
+
+    #[async_test]
+    async fn test_generic_update_when_paginating_room() {
+        // Create 1 room, with 4 chunks in the event cache storage.
+        let user = user_id!("@mnt_io:matrix.org");
+        let client = logged_in_client(None).await;
+        let room_id = room_id!("!raclette:patate.ch");
+
+        let event_factory = EventFactory::new().room(room_id).sender(user);
+
+        let event_cache = client.event_cache();
+        event_cache.subscribe().unwrap();
+
+        client.base_client().get_or_create_room(room_id, RoomState::Joined);
+
+        client
+            .event_cache_store()
+            .lock()
+            .await
+            .unwrap()
+            .handle_linked_chunk_updates(
+                LinkedChunkId::Room(room_id),
+                vec![
+                    // Empty chunk.
+                    Update::NewItemsChunk {
+                        previous: None,
+                        new: ChunkIdentifier::new(0),
+                        next: None,
+                    },
+                    // Empty chunk.
+                    Update::NewItemsChunk {
+                        previous: Some(ChunkIdentifier::new(0)),
+                        new: ChunkIdentifier::new(1),
+                        next: None,
+                    },
+                    // Non-empty items chunk.
+                    Update::NewItemsChunk {
+                        previous: Some(ChunkIdentifier::new(1)),
+                        new: ChunkIdentifier::new(2),
+                        next: None,
+                    },
+                    Update::PushItems {
+                        at: Position::new(ChunkIdentifier::new(2), 0),
+                        items: vec![event_factory
+                            .text_msg("hello")
+                            .sender(user)
+                            .event_id(event_id!("$ev0"))
+                            .into_event()],
+                    },
+                    // Non-empty items chunk.
+                    Update::NewItemsChunk {
+                        previous: Some(ChunkIdentifier::new(2)),
+                        new: ChunkIdentifier::new(3),
+                        next: None,
+                    },
+                    Update::PushItems {
+                        at: Position::new(ChunkIdentifier::new(3), 0),
+                        items: vec![event_factory
+                            .text_msg("world")
+                            .sender(user)
+                            .event_id(event_id!("$ev1"))
+                            .into_event()],
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+
+        let mut generic_stream = event_cache.subscribe_to_generic_room_updates();
+
+        // Room is initialised, it gets one event in the timeline.
+        let (room_event_cache, _) = event_cache.for_room(room_id).await.unwrap();
+
+        assert_matches!(
+            generic_stream.recv().await,
+            Ok(GenericRoomEventCacheUpdate::TimelineUpdated { room_id: expected_room_id }) => {
+                assert_eq!(room_id, expected_room_id);
+            }
+        );
+
+        let pagination = room_event_cache.pagination();
+
+        // Paginate, it gets one new event in the timeline.
+        let pagination_outcome = pagination.run_backwards_once(1).await.unwrap();
+
+        assert_eq!(pagination_outcome.events.len(), 1);
+        assert!(pagination_outcome.reached_start.not());
+        assert_matches!(
+            generic_stream.recv().await,
+            Ok(GenericRoomEventCacheUpdate::TimelineUpdated { room_id: expected_room_id }) => {
+                assert_eq!(room_id, expected_room_id);
+            }
+        );
+
+        // Paginate, it gets zero new event in the timeline.
+        let pagination_outcome = pagination.run_backwards_once(1).await.unwrap();
+
+        assert!(pagination_outcome.events.is_empty());
+        assert!(pagination_outcome.reached_start.not());
+        assert!(generic_stream.recv().now_or_never().is_none());
+
+        // Paginate once more. Just checking our scenario is correct.
+        let pagination_outcome = pagination.run_backwards_once(1).await.unwrap();
+
+        assert!(pagination_outcome.reached_start);
+        assert!(generic_stream.recv().now_or_never().is_none());
     }
 }

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -26,7 +26,10 @@ use super::{
     room::{events::Gap, LoadMoreEventsBackwardsOutcome, RoomEventCacheInner},
     BackPaginationOutcome, EventsOrigin, Result, RoomEventCacheUpdate,
 };
-use crate::{event_cache::EventCacheError, room::MessagesOptions};
+use crate::{
+    event_cache::{EventCacheError, GenericRoomEventCacheUpdate},
+    room::MessagesOptions,
+};
 
 /// Status for the back-pagination on a room event cache.
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -151,6 +154,15 @@ impl RoomPagination {
                 // Notify subscribers that pagination ended.
                 status_observable
                     .set(RoomPaginationStatus::Idle { hit_timeline_start: outcome.reached_start });
+
+                // Send a generic room event cache update.
+                if !outcome.events.is_empty() {
+                    let _ = self.inner.generic_update_sender.send(
+                        GenericRoomEventCacheUpdate::TimelineUpdated {
+                            room_id: self.inner.room_id.clone(),
+                        },
+                    );
+                }
 
                 Ok(Some(outcome))
             }

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1295,8 +1295,8 @@ mod private {
         /// It may send room event cache updates to the given sender, if it
         /// generated any of those.
         ///
-        /// Returns true if a new gap (previous-batch token) has been inserted,
-        /// false otherwise.
+        /// Returns `true` for the first part of the tuple if a new gap
+        /// (previous-batch token) has been inserted, `false` otherwise.
         #[must_use = "Propagate `VectorDiff` updates via `RoomEventCacheUpdate`"]
         pub async fn handle_sync(
             &mut self,

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -68,6 +68,11 @@ impl fmt::Debug for RoomEventCache {
 
 /// Thin wrapper for a room event cache listener, so as to trigger side-effects
 /// when all listeners are gone.
+///
+/// The current side-effect is: auto-shrinking the [`RoomEventCache`] when no
+/// more listeners are active. This is an optimisation to reduce the number of
+/// data held in memory by a [`RoomEventCache`]: when no more listeners are
+/// active, all data are reduced to the minimum.
 #[allow(missing_debug_implementations)]
 pub struct RoomEventCacheListener {
     /// Underlying receiver of the room event cache's updates.
@@ -174,7 +179,7 @@ impl RoomEventCache {
     ///
     /// Use [`RoomEventCache::events`] to get all current events without the
     /// listener/subscriber. Creating, and especially dropping, a
-    /// [`RoomEventCacheListener`] isn't free.
+    /// [`RoomEventCacheListener`] isn't free, as it triggers side-effects.
     pub async fn subscribe(&self) -> (Vec<Event>, RoomEventCacheListener) {
         let state = self.inner.state.read().await;
         let events = state.events().events().map(|(_position, item)| item.clone()).collect();

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -45,8 +45,8 @@ use tokio::sync::{
 use tracing::{instrument, trace, warn};
 
 use super::{
-    AutoShrinkChannelPayload, EventsOrigin, Result, RoomEventCacheUpdate, RoomPagination,
-    RoomPaginationStatus,
+    AutoShrinkChannelPayload, EventsOrigin, GenericRoomEventCacheUpdate, Result,
+    RoomEventCacheUpdate, RoomPagination, RoomPaginationStatus,
 };
 use crate::{client::WeakClient, room::WeakRoom};
 
@@ -154,6 +154,7 @@ impl RoomEventCache {
         pagination_status: SharedObservable<RoomPaginationStatus>,
         room_id: OwnedRoomId,
         auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
+        generic_update_sender: Sender<GenericRoomEventCacheUpdate>,
     ) -> Self {
         Self {
             inner: Arc::new(RoomEventCacheInner::new(
@@ -162,6 +163,7 @@ impl RoomEventCache {
                 pagination_status,
                 room_id,
                 auto_shrink_sender,
+                generic_update_sender,
             )),
         }
     }
@@ -274,7 +276,7 @@ impl RoomEventCache {
 /// The (non-cloneable) details of the `RoomEventCache`.
 pub(super) struct RoomEventCacheInner {
     /// The room id for this room.
-    room_id: OwnedRoomId,
+    pub(super) room_id: OwnedRoomId,
 
     pub weak_room: WeakRoom,
 
@@ -294,6 +296,13 @@ pub(super) struct RoomEventCacheInner {
     /// See doc comment around [`EventCache::auto_shrink_linked_chunk_task`] for
     /// more details.
     auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
+
+    /// A clone of [`EventCacheInner::generic_room_event_cache_update_sender`].
+    ///
+    /// Whilst `EventCacheInner` handles the generic updates from the sync, or
+    /// the storage, it doesn't handle the update from pagination. Having a
+    /// clone here allows to access it from [`RoomPagination`].
+    pub(super) generic_update_sender: Sender<GenericRoomEventCacheUpdate>,
 }
 
 impl RoomEventCacheInner {
@@ -305,6 +314,7 @@ impl RoomEventCacheInner {
         pagination_status: SharedObservable<RoomPaginationStatus>,
         room_id: OwnedRoomId,
         auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
+        generic_update_sender: Sender<GenericRoomEventCacheUpdate>,
     ) -> Self {
         let sender = Sender::new(32);
         let weak_room = WeakRoom::new(client, room_id);
@@ -316,6 +326,7 @@ impl RoomEventCacheInner {
             pagination_batch_token_notifier: Default::default(),
             auto_shrink_sender,
             pagination_status,
+            generic_update_sender,
         }
     }
 
@@ -359,13 +370,19 @@ impl RoomEventCacheInner {
     }
 
     #[instrument(skip_all, fields(room_id = %self.room_id))]
-    pub(super) async fn handle_joined_room_update(&self, updates: JoinedRoomUpdate) -> Result<()> {
-        self.handle_timeline(
-            updates.timeline,
-            updates.ephemeral.clone(),
-            updates.ambiguity_changes,
-        )
-        .await?;
+    pub(super) async fn handle_joined_room_update(
+        &self,
+        updates: JoinedRoomUpdate,
+        generic_room_event_cache_update_sender: &Sender<GenericRoomEventCacheUpdate>,
+    ) -> Result<()> {
+        if self
+            .handle_timeline(updates.timeline, updates.ephemeral.clone(), updates.ambiguity_changes)
+            .await?
+        {
+            let _ = generic_room_event_cache_update_sender.send(
+                GenericRoomEventCacheUpdate::TimelineUpdated { room_id: self.room_id.clone() },
+            );
+        }
 
         self.handle_account_data(updates.account_data);
 
@@ -373,23 +390,37 @@ impl RoomEventCacheInner {
     }
 
     #[instrument(skip_all, fields(room_id = %self.room_id))]
-    pub(super) async fn handle_left_room_update(&self, updates: LeftRoomUpdate) -> Result<()> {
-        self.handle_timeline(updates.timeline, Vec::new(), updates.ambiguity_changes).await?;
+    pub(super) async fn handle_left_room_update(
+        &self,
+        updates: LeftRoomUpdate,
+        generic_room_event_cache_update_sender: &Sender<GenericRoomEventCacheUpdate>,
+    ) -> Result<()> {
+        if self.handle_timeline(updates.timeline, Vec::new(), updates.ambiguity_changes).await? {
+            let _ = generic_room_event_cache_update_sender.send(
+                GenericRoomEventCacheUpdate::TimelineUpdated { room_id: self.room_id.clone() },
+            );
+        }
+
         Ok(())
     }
 
+    /// Handle a [`Timeline`], i.e. new events receivedy by a sync for this
+    /// room.
+    ///
+    /// It returns `Ok(true)` if events have been added, redacted or removed,
+    /// `Ok(false)` otherwise.
     async fn handle_timeline(
         &self,
         timeline: Timeline,
         ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
         ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         if timeline.events.is_empty()
             && timeline.prev_batch.is_none()
             && ephemeral_events.is_empty()
             && ambiguity_changes.is_empty()
         {
-            return Ok(());
+            return Ok(false);
         }
 
         // Add all the events to the backend.
@@ -404,6 +435,8 @@ impl RoomEventCacheInner {
             self.pagination_batch_token_notifier.notify_one();
         }
 
+        let mut events_update_the_timeline = false;
+
         // The order matters here: first send the timeline event diffs, then only the
         // related events (read receipts, etc.).
         if !timeline_event_diffs.is_empty() {
@@ -411,19 +444,22 @@ impl RoomEventCacheInner {
                 diffs: timeline_event_diffs,
                 origin: EventsOrigin::Sync,
             });
+            events_update_the_timeline = true;
         }
 
         if !ephemeral_events.is_empty() {
             let _ = self
                 .sender
                 .send(RoomEventCacheUpdate::AddEphemeralEvents { events: ephemeral_events });
+            events_update_the_timeline = true;
         }
 
         if !ambiguity_changes.is_empty() {
             let _ = self.sender.send(RoomEventCacheUpdate::UpdateMembers { ambiguity_changes });
+            events_update_the_timeline = true;
         }
 
-        Ok(())
+        Ok(events_update_the_timeline)
     }
 }
 
@@ -1799,6 +1835,7 @@ mod timed_tests {
     use assert_matches::assert_matches;
     use assert_matches2::assert_let;
     use eyeball_im::VectorDiff;
+    use futures_util::FutureExt;
     use matrix_sdk_base::{
         event_cache::{
             store::{EventCacheStore as _, MemoryStore},
@@ -1817,8 +1854,9 @@ mod timed_tests {
         events::{AnySyncMessageLikeEvent, AnySyncTimelineEvent},
         room_id, user_id,
     };
-    use tokio::task::yield_now;
+    use tokio::{sync::broadcast::channel, task::yield_now};
 
+    use super::GenericRoomEventCacheUpdate;
     use crate::{
         assert_let_timeout,
         event_cache::{room::LoadMoreEventsBackwardsOutcome, RoomEventCacheUpdate},
@@ -1855,13 +1893,26 @@ mod timed_tests {
             prev_batch: Some("raclette".to_owned()),
             events: vec![f.text_msg("hey yo").sender(*ALICE).into_event()],
         };
+        let (generic_update_sender, mut generic_update_receiver) = channel(2);
 
         room_event_cache
             .inner
-            .handle_joined_room_update(JoinedRoomUpdate { timeline, ..Default::default() })
+            .handle_joined_room_update(
+                JoinedRoomUpdate { timeline, ..Default::default() },
+                &generic_update_sender,
+            )
             .await
             .unwrap();
 
+        // Just checking the generic update is correct.
+        assert_matches!(
+            generic_update_receiver.recv().await,
+            Ok(GenericRoomEventCacheUpdate::TimelineUpdated { room_id: expected_room_id }) => {
+                assert_eq!(expected_room_id, room_id);
+            }
+        );
+
+        // Check the storage.
         let linked_chunk = from_all_chunks::<3, _, _>(
             event_cache_store.load_all_chunks(LinkedChunkId::Room(room_id)).await.unwrap(),
         )
@@ -1921,12 +1972,24 @@ mod timed_tests {
             .into_event();
 
         let timeline = Timeline { limited: false, prev_batch: None, events: vec![ev] };
+        let (generic_update_sender, mut generic_update_receiver) = channel(2);
 
         room_event_cache
             .inner
-            .handle_joined_room_update(JoinedRoomUpdate { timeline, ..Default::default() })
+            .handle_joined_room_update(
+                JoinedRoomUpdate { timeline, ..Default::default() },
+                &generic_update_sender,
+            )
             .await
             .unwrap();
+
+        // Just checking the generic update is correct.
+        assert_matches!(
+            generic_update_receiver.recv().await,
+            Ok(GenericRoomEventCacheUpdate::TimelineUpdated { room_id: expected_room_id }) => {
+                assert_eq!(expected_room_id, room_id);
+            }
+        );
 
         // The in-memory linked chunk keeps the bundled relation.
         {
@@ -2176,10 +2239,22 @@ mod timed_tests {
         // Don't forget to subscribe and like^W enable storage!
         event_cache.subscribe().unwrap();
 
+        // Let's check whether the generic updates are received for the initialisation.
+        let mut generic_stream = event_cache.subscribe_to_generic_room_updates();
+
         client.base_client().get_or_create_room(room_id, matrix_sdk_base::RoomState::Joined);
         let room = client.get_room(room_id).unwrap();
 
         let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
+
+        // The room event cache has been loaded. A generic update must have been
+        // triggered.
+        assert_matches!(
+            generic_stream.recv().await,
+            Ok(GenericRoomEventCacheUpdate::TimelineUpdated { room_id: expected_room_id }) => {
+                assert_eq!(room_id, expected_room_id);
+            }
+        );
 
         let (items, mut stream) = room_event_cache.subscribe().await;
 
@@ -2206,13 +2281,30 @@ mod timed_tests {
 
         assert!(stream.is_empty());
 
+        // A generic update is triggered too.
+        assert_matches!(
+            generic_stream.recv().await,
+            Ok(GenericRoomEventCacheUpdate::TimelineUpdated { room_id: expected_room_id }) => {
+                assert_eq!(expected_room_id, room_id);
+            }
+        );
+
         // A new update with one of these events leads to deduplication.
         let timeline = Timeline { limited: false, prev_batch: None, events: vec![ev2] };
+        let (generic_update_sender, mut generic_update_receiver) = channel(2);
+
         room_event_cache
             .inner
-            .handle_joined_room_update(JoinedRoomUpdate { timeline, ..Default::default() })
+            .handle_joined_room_update(
+                JoinedRoomUpdate { timeline, ..Default::default() },
+                &generic_update_sender,
+            )
             .await
             .unwrap();
+
+        // Just checking the generic update is correct. There is a duplicate event, so
+        // no generic changes whatsoever!
+        assert!(generic_update_receiver.recv().now_or_never().is_none());
 
         // The stream doesn't report these changes *yet*. Use the items vector given
         // when subscribing, to check that the items correspond to their new
@@ -2303,22 +2395,34 @@ mod timed_tests {
         let room = client.get_room(room_id).unwrap();
         let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
 
+        let (generic_update_sender, mut generic_update_receiver) = channel(2);
         let f = EventFactory::new().room(room_id).sender(*ALICE);
 
         // Propagate an update including a limited timeline with one message and a
         // prev-batch token.
         room_event_cache
             .inner
-            .handle_joined_room_update(JoinedRoomUpdate {
-                timeline: Timeline {
-                    limited: true,
-                    prev_batch: Some("raclette".to_owned()),
-                    events: vec![f.text_msg("hey yo").into_event()],
+            .handle_joined_room_update(
+                JoinedRoomUpdate {
+                    timeline: Timeline {
+                        limited: true,
+                        prev_batch: Some("raclette".to_owned()),
+                        events: vec![f.text_msg("hey yo").into_event()],
+                    },
+                    ..Default::default()
                 },
-                ..Default::default()
-            })
+                &generic_update_sender,
+            )
             .await
             .unwrap();
+
+        // Just checking the generic update is correct.
+        assert_matches!(
+            generic_update_receiver.recv().await,
+            Ok(GenericRoomEventCacheUpdate::TimelineUpdated { room_id: expected_room_id }) => {
+                assert_eq!(expected_room_id, room_id);
+            }
+        );
 
         {
             let mut state = room_event_cache.inner.state.write().await;
@@ -2358,20 +2462,33 @@ mod timed_tests {
             assert_eq!(num_events, 1);
         }
 
+        let (generic_update_sender, mut generic_update_receiver) = channel(2);
+
         // Now, propagate an update for another message, but the timeline isn't limited
         // this time.
         room_event_cache
             .inner
-            .handle_joined_room_update(JoinedRoomUpdate {
-                timeline: Timeline {
-                    limited: false,
-                    prev_batch: Some("fondue".to_owned()),
-                    events: vec![f.text_msg("sup").into_event()],
+            .handle_joined_room_update(
+                JoinedRoomUpdate {
+                    timeline: Timeline {
+                        limited: false,
+                        prev_batch: Some("fondue".to_owned()),
+                        events: vec![f.text_msg("sup").into_event()],
+                    },
+                    ..Default::default()
                 },
-                ..Default::default()
-            })
+                &generic_update_sender,
+            )
             .await
             .unwrap();
+
+        // Just checking the generic update is correct.
+        assert_matches!(
+            generic_update_receiver.recv().await,
+            Ok(GenericRoomEventCacheUpdate::TimelineUpdated { room_id: expected_room_id }) => {
+                assert_eq!(expected_room_id, room_id);
+            }
+        );
 
         {
             let state = room_event_cache.inner.state.read().await;


### PR DESCRIPTION
`RoomEventCache::subscribe` is nice to subscribe to every update
happening inside a room in the event cache. However, the returned
`RoomEventCacheSubscriber` has side-effects when dropped (see
auto-shrink to save memory space). In some situation, this is pretty
annoying. for example, if one wants to listen to multiple room updates,
all the room event cache subscribers must be kept in memory, thus
breaking the side-effects. This isn't always the desired output. In
addition, listening to multiple channels/subscribers at the same is
quite complex, as it implies non-trivial async runtime efforts or
complex future types.

To solve this problem, this patch introduces a new
`EventCache::subscribe_to_generic_room_updates` method, which returns a
single `Receiver<GenericRoomEventCacheUpdate>`.

First off, it hides the details of `RoomEventCacheUpdate` (returned by
`RoomEventCacheSubscriber`), which might be desired, but particularly
lighter because events aren't part of the payload.

Second, one no longer needs to subscribe to all rooms. Only one channel
can be listened to get updates for all rooms. It reduces the complexity
on the caller side, plus `Receiver<GenericRoomEventCacheUpdate>` doesn't
have any side-effect.

This patch tests this feature in 4 situations:

1. when a room is created/loaded empty,
2. when a room is loaded and is not empty because data exists in the storage,
3. when a room receives data from the sync,
4. when a room receives data from the pagination.