### PR TITLE
feat(wasm): Remove MediaFileHandle from ffi on Wasm platforms

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -710,7 +710,7 @@ impl Client {
 #[matrix_sdk_ffi_macros::export]
 impl Client {
     /// Retrieves a media file from the media source
-    /// 
+    ///
     /// Not available on Wasm platforms, due to lack of accessible file system.
     pub async fn get_media_file(
         &self,


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Remove the MediaFileHandle concept from the matrix-sdk-ffi crate on Wasm platforms.  File handles are not supported in the browser.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
