### PR TITLE
feat(widget): Send custom to-device messages in widgets in e2ee rooms

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2671,6 +2671,7 @@ impl Client {
 #[cfg(any(feature = "testing", test))]
 impl Client {
     /// Test helper to mark users as tracked by the crypto layer.
+    #[cfg(feature = "e2e-encryption")]
     pub async fn update_tracked_users_for_testing(
         &self,
         user_ids: impl IntoIterator<Item = &UserId>,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2668,6 +2668,19 @@ impl Client {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
+impl Client {
+    /// Test helper to mark users as tracked by the crypto layer.
+    pub async fn update_tracked_users_for_testing(
+        &self,
+        user_ids: impl IntoIterator<Item = &UserId>,
+    ) {
+        let olm = self.olm_machine().await;
+        let olm = olm.as_ref().unwrap();
+        olm.update_tracked_users(user_ids).await.unwrap();
+    }
+}
+
 /// A weak reference to the inner client, useful when trying to get a handle
 /// on the owning client.
 #[derive(Clone)]

--- a/crates/matrix-sdk/src/test_utils/mocks/encryption.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/encryption.rs
@@ -180,8 +180,6 @@ impl MatrixMockServer {
 
     /// Creates a new device and returns a new client for it.
     /// The new and old clients will be aware of each other.
-    /// If possible, the new client will import the secret bundle from the
-    /// initial client
     ///
     /// # Arguments
     ///
@@ -206,19 +204,6 @@ impl MatrixMockServer {
 
         let new_client =
             self.client_builder_for_crypto_end_to_end(&user_id, &new_device_id).build().await;
-
-        // sync the keys
-        self.mock_sync().ok_and_run(&new_client, |_| {}).await;
-
-        {
-            // If cross-signing is enabled, import the secret bundle from the old device.
-            let olm = existing_client.olm_machine_for_testing().await;
-            let olm = olm.as_ref().unwrap();
-            let bundle = olm.store().export_secrets_bundle().await;
-            if let Ok(bundle) = bundle {
-                new_client.encryption().import_secrets_bundle(&bundle).await.unwrap();
-            }
-        }
 
         // sync the keys
         self.mock_sync().ok_and_run(&new_client, |_| {}).await;

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -296,9 +296,6 @@ pub(crate) struct SendToDeviceRequest {
     /// The type of the to-device message.
     #[serde(rename = "type")]
     pub(crate) event_type: String,
-    /// If the to-device message should be encrypted or not.
-    /// TODO: As per MSC 3819 should default to true
-    pub(crate) encrypted: bool,
     /// The messages to be sent.
     /// They are organized in a map of user ID -> device ID -> content like the
     /// cs api request.

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -17,22 +17,19 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
 use ruma::{
-    api::client::{
-        account::request_openid_token, delayed_events::update_delayed_event,
-        to_device::send_event_to_device,
-    },
+    api::client::{account::request_openid_token, delayed_events::update_delayed_event},
     events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEventContent},
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
     OwnedUserId,
 };
-use serde::{de, Deserialize};
+use serde::Deserialize;
 use serde_json::value::RawValue as RawJsonValue;
 use tracing::error;
 
 use super::{
     from_widget::SendEventResponse, incoming::MatrixDriverResponse, Action,
-    MatrixDriverRequestMeta, WidgetMachine,
+    MatrixDriverRequestMeta, SendToDeviceEventResponse, WidgetMachine,
 };
 use crate::widget::{Capabilities, StateKeySelector};
 
@@ -310,18 +307,7 @@ impl From<SendToDeviceRequest> for MatrixDriverRequestData {
 }
 
 impl MatrixDriverRequest for SendToDeviceRequest {
-    type Response = send_event_to_device::v3::Response;
-}
-
-impl TryInto<send_event_to_device::v3::Response> for MatrixDriverResponse {
-    type Error = de::value::Error;
-
-    fn try_into(self) -> Result<send_event_to_device::v3::Response, Self::Error> {
-        match self {
-            MatrixDriverResponse::ToDeviceSent(response) => Ok(response),
-            _ => Err(de::Error::custom("bug in MatrixDriver, received wrong event response")),
-        }
-    }
+    type Response = SendToDeviceEventResponse;
 }
 
 /// Ask the client to send a UpdateDelayedEventRequest with the given `delay_id`

--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -254,11 +254,13 @@ impl From<update_delayed_event::unstable::Response> for UpdateDelayedEventRespon
     }
 }
 
-/// Send to device request response.
+/// Response for a send-to-device request.
+/// The failure map contains recipients that didn't receive the content due to:
+/// - Recipient devices not being found
+/// - Encryption failures (e.g., missing one-time keys)
+/// - Network/Server errors during sending
 #[derive(Serialize, Debug, Default)]
 pub(crate) struct SendToDeviceEventResponse {
-    /// It is possible that sending to some device failed (failed to encrypt or
-    /// failed to send)
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub failures: BTreeMap<String, Vec<String>>,
 }

--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -259,8 +259,8 @@ impl From<update_delayed_event::unstable::Response> for UpdateDelayedEventRespon
 pub(crate) struct SendToDeviceEventResponse {
     /// It is possible that sending to some device failed (failed to encrypt or
     /// failed to send)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub failures: Option<BTreeMap<String, Vec<String>>>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub failures: BTreeMap<String, Vec<String>>,
 }
 
 impl FromMatrixDriverResponse for SendToDeviceEventResponse {

--- a/crates/matrix-sdk/src/widget/machine/incoming.rs
+++ b/crates/matrix-sdk/src/widget/machine/incoming.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use ruma::{
-    api::client::{account::request_openid_token, delayed_events, to_device::send_event_to_device},
+    api::client::{account::request_openid_token, delayed_events},
     events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEvent},
     serde::Raw,
 };
@@ -26,6 +26,7 @@ use super::MatrixDriverRequestData;
 use super::{
     from_widget::{FromWidgetRequest, SendEventResponse},
     to_widget::ToWidgetResponse,
+    SendToDeviceEventResponse,
 };
 use crate::widget::Capabilities;
 
@@ -82,7 +83,7 @@ pub(crate) enum MatrixDriverResponse {
     /// A response to a [`MatrixDriverRequestData::SendEvent`] command.
     EventSent(SendEventResponse),
     /// A response to a `Action::SendToDevice` command.
-    ToDeviceSent(send_event_to_device::v3::Response),
+    ToDeviceSent(SendToDeviceEventResponse),
     /// Client updated a delayed event.
     /// A response to a [`MatrixDriverRequestData::UpdateDelayedEvent`] command.
     DelayedEventUpdated(delayed_events::update_delayed_event::unstable::Response),

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -17,7 +17,7 @@
 use std::time::Duration;
 
 use driver_req::{ReadStateRequest, UpdateDelayedEventRequest};
-use from_widget::{SendToDeviceEventResponse, UpdateDelayedEventResponse};
+use from_widget::UpdateDelayedEventResponse;
 use indexmap::IndexMap;
 use ruma::{
     events::{AnyStateEvent, AnyTimelineEvent},
@@ -66,7 +66,7 @@ mod to_widget;
 
 pub(crate) use self::{
     driver_req::{MatrixDriverRequestData, SendEventRequest, SendToDeviceRequest},
-    from_widget::SendEventResponse,
+    from_widget::{SendEventResponse, SendToDeviceEventResponse},
     incoming::{IncomingMessage, MatrixDriverResponse},
 };
 
@@ -531,9 +531,7 @@ impl WidgetMachine {
         request.add_response_handler(|result, _| {
             vec![Self::send_from_widget_response(
                 raw_request,
-                result
-                    .map(|_| SendToDeviceEventResponse {})
-                    .map_err(FromWidgetErrorResponse::from_error),
+                result.map_err(FromWidgetErrorResponse::from_error),
             )]
         });
         Some(action)

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -443,16 +443,14 @@ impl MatrixDriver {
                 .contains(&DeviceIdOrAllDevices::AllDevices)
             {
                 // If the user wants to send to all devices, there's nothing to filter and no
-                // need to inspect other entries in the user's device list.nd in the
-                // store?
+                // need to inspect other entries in the user's device list.
                 let devices: Vec<_> = user_devices.devices().collect();
                 // TODO: What to do if the user has no devices?
                 if devices.is_empty() {
                     warn!("Recipient list contains `AllDevices` but no devices found for user {user_id}.")
                 }
                 // TODO: What if the `recipient_device_ids` has both
-                // `AllDevices` and other devices but one of the
-                // other devices is not found
+                // `AllDevices` and other devices but one of the  other devices is not found.
                 if recipient_device_ids.len() > 1 {
                     warn!(
                         "The recipient_device_ids list for {user_id} contains both `AllDevices` and explicit `DeviceId` entries. Only consider `AllDevices`",

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -439,9 +439,7 @@ impl MatrixDriver {
         for (user_id, recipient_device_ids) in user_to_list_of_device_id_or_all {
             let user_devices = client.encryption().get_user_devices(&user_id).await?;
 
-            let user_devices = if recipient_device_ids
-                .contains(&DeviceIdOrAllDevices::AllDevices)
-            {
+            let user_devices = if recipient_device_ids.contains(&DeviceIdOrAllDevices::AllDevices) {
                 // If the user wants to send to all devices, there's nothing to filter and no
                 // need to inspect other entries in the user's device list.
                 let devices: Vec<_> = user_devices.devices().collect();

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -322,7 +322,6 @@ impl MatrixDriver {
     pub(crate) async fn send_to_device(
         &self,
         event_type: ToDeviceEventType,
-        encrypted: bool,
         messages: BTreeMap<
             OwnedUserId,
             BTreeMap<DeviceIdOrAllDevices, Raw<AnyToDeviceEventContent>>,
@@ -330,13 +329,7 @@ impl MatrixDriver {
     ) -> Result<send_event_to_device::v3::Response> {
         let client = self.room.client();
 
-        let request = if encrypted {
-            return Err(Error::UnknownError(
-                "Sending encrypted to-device events is not supported by the widget driver.".into(),
-            ));
-        } else {
-            RumaToDeviceRequest::new_raw(event_type, TransactionId::new(), messages)
-        };
+        let request =  RumaToDeviceRequest::new_raw(event_type, TransactionId::new(), messages);
 
         let response = client.send(request).await;
 

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -46,8 +46,8 @@ use tracing::{error, trace, warn};
 
 use super::{machine::SendEventResponse, StateKeySelector};
 use crate::{
-    encryption::identities::Device, event_handler::EventHandlerDropGuard, room::MessagesOptions,
-    sync::RoomUpdate, widget::machine::SendToDeviceEventResponse, Client, Error, Result, Room,
+    event_handler::EventHandlerDropGuard, room::MessagesOptions, sync::RoomUpdate,
+    widget::machine::SendToDeviceEventResponse, Client, Error, Result, Room,
 };
 
 /// Thin wrapper around a [`Room`] that provides functionality relevant for
@@ -434,12 +434,12 @@ impl MatrixDriver {
         failures: &mut BTreeMap<OwnedUserId, Vec<OwnedDeviceId>>,
     ) -> Result<()> {
         let client = self.room.client();
-        let mut recipient_devices = Vec::<Device>::new();
+        let mut recipient_devices = Vec::<_>::new();
 
         for (user_id, recipient_device_ids) in user_to_list_of_device_id_or_all {
             let user_devices = client.encryption().get_user_devices(&user_id).await?;
 
-            let user_devices: Vec<Device> = if recipient_device_ids
+            let user_devices = if recipient_device_ids
                 .contains(&DeviceIdOrAllDevices::AllDevices)
             {
                 // If the user wants to send to all devices, there's nothing to filter and no

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -359,7 +359,6 @@ impl MatrixDriver {
         if Self::is_internal_type(&event_type.to_string()) {
             warn!("Widget tried to send internal to-device message <{}>, ignoring", event_type);
             // Silently return a success response, the widget will not receive the message
-            // TODO! this will later be blocked at negotiation level
             return Ok(Default::default());
         }
 
@@ -409,18 +408,12 @@ impl MatrixDriver {
                 .await?
             }
 
-            let failures = if failures.is_empty() {
-                None
-            } else {
-                Some(
-                    failures
-                        .into_iter()
-                        .map(|(u, list_of_devices)| {
-                            (u.into(), list_of_devices.into_iter().map(|d| d.into()).collect())
-                        })
-                        .collect(),
-                )
-            };
+            let failures = failures
+                .into_iter()
+                .map(|(u, list_of_devices)| {
+                    (u.into(), list_of_devices.into_iter().map(|d| d.into()).collect())
+                })
+                .collect();
 
             let response = SendToDeviceEventResponse { failures };
             Ok(response)

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -445,11 +445,20 @@ impl MatrixDriver {
                 // If the user wants to send to all devices, there's nothing to filter and no
                 // need to inspect other entries in the user's device list.nd in the
                 // store?
-                user_devices.devices().collect()
+                let devices: Vec<_> = user_devices.devices().collect();
                 // TODO: What to do if the user has no devices?
+                if devices.is_empty() {
+                    warn!("Recipient list contains `AllDevices` but no devices found for user {user_id}.")
+                }
                 // TODO: What if the `recipient_device_ids` has both
                 // `AllDevices` and other devices but one of the
-                // other devices is not fou
+                // other devices is not found
+                if recipient_device_ids.len() > 1 {
+                    warn!(
+                        "The recipient_device_ids list for {user_id} contains both `AllDevices` and explicit `DeviceId` entries. Only consider `AllDevices`",
+                    );
+                }
+                devices
             } else {
                 // If the user wants to send to only some devices, filter out any devices that
                 // aren't part of the recipient_device_ids list.

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -246,7 +246,6 @@ impl WidgetDriver {
                         matrix_driver
                             .send_to_device(
                                 send_to_device_request.event_type.into(),
-                                send_to_device_request.encrypted,
                                 send_to_device_request.messages,
                             )
                             .await

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -1334,9 +1334,9 @@ async fn test_send_encrypted_to_device_event() {
 
     send_request(&driver_handle, request_id, "send_to_device", data).await;
 
-    let event_as_sent_by_alice = event_as_sent_by_alice.await;
+    let event_as_sent_by_alice = event_as_sent_by_alice.await.deserialize().unwrap();
     drop(guard);
-    assert_eq!(event_as_sent_by_alice["type"], "m.room.encrypted");
+    assert_eq!(event_as_sent_by_alice.algorithm().as_str(), "m.olm.v1.curve25519-aes-sha2");
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1494,9 +1494,9 @@ async fn test_send_encrypted_to_device_event_partial_error() {
     send_request(&driver_handle, request_id, "send_to_device", data).await;
 
     // It was sent to bob even though other recipients failed
-    let event_as_sent_by_alice = event_as_sent_by_alice.await;
+    let event_as_sent_by_alice = event_as_sent_by_alice.await.deserialize().unwrap();
     drop(guard);
-    assert_eq!(event_as_sent_by_alice["type"], "m.room.encrypted");
+    assert_eq!(event_as_sent_by_alice.algorithm().as_str(), "m.olm.v1.curve25519-aes-sha2");
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;


### PR DESCRIPTION
<!-- description of the changes in this PR -->


Adds the capability for widgets to send encrytped to-device messages properly.

It is getting rid of the old encrypted boolean that was used by widget to request encryption. As said by the base MSC
for widget send/receive messages: Widgets should not be aware of encryption.
If the widget is in an encrytped room then to-device traffic will be encrypted.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/4859

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
