### PR TITLE
ci: Store successful test results in the JUnit file as well

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,3 +10,4 @@ slow-timeout = { period = "60s", terminate-after = 3 }
 
 [profile.ci.junit]
 path = "junit.xml"
+store-success-output = true


### PR DESCRIPTION
This is useful to detect which tests might be the slowest.
