### PR TITLE
chore: Switch to latest rustfmt style edition

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -8,3 +8,4 @@ format_code_in_doc_comments = true
 doc_comment_code_block_width = 80
 # Workaround for https://github.com/rust-lang/rust.vim/issues/464
 edition = "2021"
+style_edition = "2024"

--- a/benchmarks/benches/crypto_bench.rs
+++ b/benchmarks/benches/crypto_bench.rs
@@ -1,15 +1,16 @@
 use std::{ops::Deref, sync::Arc};
 
-use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use matrix_sdk_crypto::{EncryptionSettings, OlmMachine};
 use matrix_sdk_sqlite::SqliteCryptoStore;
 use matrix_sdk_test::ruma_response_from_json;
 use ruma::{
+    DeviceId, OwnedUserId, TransactionId, UserId,
     api::client::{
         keys::{claim_keys, get_keys},
         to_device::send_event_to_device::v3::Response as ToDeviceResponse,
     },
-    device_id, room_id, user_id, DeviceId, OwnedUserId, TransactionId, UserId,
+    device_id, room_id, user_id,
 };
 use serde_json::Value;
 use tokio::runtime::Builder;

--- a/benchmarks/benches/linked_chunk.rs
+++ b/benchmarks/benches/linked_chunk.rs
@@ -1,16 +1,16 @@
 use std::{sync::Arc, time::Duration};
 
-use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use matrix_sdk::{
-    linked_chunk::{lazy_loader, LinkedChunk, LinkedChunkId, Update},
     SqliteEventCacheStore,
+    linked_chunk::{LinkedChunk, LinkedChunkId, Update, lazy_loader},
 };
 use matrix_sdk_base::event_cache::{
-    store::{DynEventCacheStore, IntoEventCacheStore, MemoryStore, DEFAULT_CHUNK_CAPACITY},
     Event, Gap,
+    store::{DEFAULT_CHUNK_CAPACITY, DynEventCacheStore, IntoEventCacheStore, MemoryStore},
 };
-use matrix_sdk_test::{event_factory::EventFactory, ALICE};
-use ruma::{room_id, EventId};
+use matrix_sdk_test::{ALICE, event_factory::EventFactory};
+use ruma::{EventId, room_id};
 use tempfile::tempdir;
 use tokio::runtime::Builder;
 

--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -1,20 +1,21 @@
 use std::time::Duration;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use matrix_sdk::{store::RoomLoadSettings, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_base::{
-    store::StoreConfig, BaseClient, RoomInfo, RoomState, SessionMeta, StateChanges, StateStore,
+    BaseClient, RoomInfo, RoomState, SessionMeta, StateChanges, StateStore, store::StoreConfig,
 };
 use matrix_sdk_sqlite::SqliteStateStore;
-use matrix_sdk_test::{event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent};
+use matrix_sdk_test::{JoinedRoomBuilder, StateTestEvent, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{TimelineBuilder, TimelineFocus};
 use ruma::{
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId,
     api::client::membership::get_member_events,
     device_id,
     events::room::member::{MembershipState, RoomMemberEvent},
     mxc_uri, owned_room_id, owned_user_id,
     serde::Raw,
-    user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId,
+    user_id,
 };
 use serde_json::json;
 use tokio::runtime::Builder;

--- a/benchmarks/benches/store_bench.rs
+++ b/benchmarks/benches/store_bench.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use matrix_sdk::{
-    authentication::matrix::MatrixSession, config::StoreConfig, Client, RoomInfo, RoomState,
-    SessionTokens, StateChanges,
+    Client, RoomInfo, RoomState, SessionTokens, StateChanges,
+    authentication::matrix::MatrixSession, config::StoreConfig,
 };
-use matrix_sdk_base::{store::MemoryStore, SessionMeta, StateStore as _};
+use matrix_sdk_base::{SessionMeta, StateStore as _, store::MemoryStore};
 use matrix_sdk_sqlite::SqliteStateStore;
-use ruma::{device_id, user_id, RoomId};
+use ruma::{RoomId, device_id, user_id};
 use tokio::runtime::Builder;
 
 fn criterion() -> Criterion {

--- a/benchmarks/benches/timeline.rs
+++ b/benchmarks/benches/timeline.rs
@@ -1,10 +1,10 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use matrix_sdk::test_utils::mocks::MatrixMockServer;
-use matrix_sdk_test::{event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent};
+use matrix_sdk_test::{JoinedRoomBuilder, StateTestEvent, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::TimelineBuilder;
 use ruma::{
-    events::room::message::RoomMessageEventContentWithoutRelation, owned_room_id, owned_user_id,
-    EventId,
+    EventId, events::room::message::RoomMessageEventContentWithoutRelation, owned_room_id,
+    owned_user_id,
 };
 use tokio::runtime::Builder;
 

--- a/bindings/matrix-sdk-crypto-ffi/src/backup_recovery_key.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/backup_recovery_key.rs
@@ -3,10 +3,10 @@ use std::{collections::HashMap, iter, ops::DerefMut, sync::Arc};
 use hmac::Hmac;
 use matrix_sdk_crypto::{
     backups::DecryptionError,
-    store::{types::BackupDecryptionKey, CryptoStoreError as InnerStoreError},
+    store::{CryptoStoreError as InnerStoreError, types::BackupDecryptionKey},
 };
 use pbkdf2::pbkdf2;
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use rand::{Rng, distributions::Alphanumeric, thread_rng};
 use sha2::Sha512;
 use thiserror::Error;
 use zeroize::Zeroize;

--- a/bindings/matrix-sdk-crypto-ffi/src/dehydrated_devices.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/dehydrated_devices.rs
@@ -8,7 +8,7 @@ use matrix_sdk_crypto::{
     },
     store::types::DehydratedDeviceKey as InnerDehydratedDeviceKey,
 };
-use ruma::{api::client::dehydrated_device, events::AnyToDeviceEvent, serde::Raw, OwnedDeviceId};
+use ruma::{OwnedDeviceId, api::client::dehydrated_device, events::AnyToDeviceEvent, serde::Raw};
 use serde_json::json;
 
 use crate::{CryptoStoreError, DehydratedDeviceKey};
@@ -222,7 +222,7 @@ impl From<dehydrated_device::put_dehydrated_device::unstable::Request>
 
 #[cfg(test)]
 mod tests {
-    use crate::{dehydrated_devices::DehydrationError, DehydratedDeviceKey};
+    use crate::{DehydratedDeviceKey, dehydrated_devices::DehydrationError};
 
     #[test]
     fn test_creating_dehydrated_key() {

--- a/bindings/matrix-sdk-crypto-ffi/src/error.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/error.rs
@@ -1,9 +1,9 @@
 #![allow(missing_docs)]
 
 use matrix_sdk_crypto::{
-    store::{CryptoStoreError as InnerStoreError, DehydrationError as InnerDehydrationError},
     KeyExportError, MegolmError, OlmError, SecretImportError as RustSecretImportError,
     SignatureError as InnerSignatureError,
+    store::{CryptoStoreError as InnerStoreError, DehydrationError as InnerDehydrationError},
 };
 use matrix_sdk_sqlite::OpenStoreError;
 use ruma::{IdParseError, OwnedUserId};

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -31,22 +31,22 @@ pub use error::{
     CryptoStoreError, DecryptionError, KeyImportError, SecretImportError, SignatureError,
 };
 use js_int::UInt;
-pub use logger::{set_logger, Logger};
+pub use logger::{Logger, set_logger};
 pub use machine::{KeyRequestPair, OlmMachine, SignatureVerification};
 use matrix_sdk_common::deserialized_responses::{ShieldState as RustShieldState, ShieldStateCode};
 use matrix_sdk_crypto::{
+    CollectStrategy, EncryptionSettings as RustEncryptionSettings,
     olm::{IdentityKeys, InboundGroupSession, SenderData, Session},
     store::{
+        CryptoStore,
         types::{
             Changes, DehydratedDeviceKey as InnerDehydratedDeviceKey, PendingChanges,
             RoomSettings as RustRoomSettings,
         },
-        CryptoStore,
     },
     types::{
         DeviceKey, DeviceKeys, EventEncryptionAlgorithm as RustEventEncryptionAlgorithm, SigningKey,
     },
-    CollectStrategy, EncryptionSettings as RustEncryptionSettings,
 };
 use matrix_sdk_sqlite::SqliteCryptoStore;
 pub use responses::{
@@ -54,9 +54,9 @@ pub use responses::{
     Request, RequestType, SignatureUploadRequest, UploadSigningKeysRequest,
 };
 use ruma::{
-    events::room::history_visibility::HistoryVisibility as RustHistoryVisibility,
     DeviceKeyAlgorithm, DeviceKeyId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedUserId,
     RoomId, SecondsSinceUnixEpoch, UserId,
+    events::room::history_visibility::HistoryVisibility as RustHistoryVisibility,
 };
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Runtime;
@@ -1034,11 +1034,11 @@ uniffi::setup_scaffolding!();
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
     use tempfile::tempdir;
 
     use super::MigrationData;
-    use crate::{migrate, EventEncryptionAlgorithm, OlmMachine, RoomSettings};
+    use crate::{EventEncryptionAlgorithm, OlmMachine, RoomSettings, migrate};
 
     #[test]
     fn android_migration() -> Result<()> {

--- a/bindings/matrix-sdk-crypto-ffi/src/logger.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/logger.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use tracing_subscriber::{fmt::MakeWriter, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::MakeWriter};
 
 /// Trait that can be used to forward Rust logs over FFI to a language specific
 /// logger.

--- a/bindings/matrix-sdk-crypto-ffi/src/responses.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/responses.rs
@@ -4,14 +4,15 @@ use std::collections::HashMap;
 
 use http::Response;
 use matrix_sdk_crypto::{
+    CrossSigningBootstrapRequests,
     types::requests::{
         AnyIncomingResponse, KeysBackupRequest, OutgoingRequest,
         OutgoingVerificationRequest as SdkVerificationRequest, RoomMessageRequest, ToDeviceRequest,
         UploadSigningKeysRequest as RustUploadSigningKeysRequest,
     },
-    CrossSigningBootstrapRequests,
 };
 use ruma::{
+    OwnedTransactionId, UserId,
     api::client::{
         backup::add_backup_keys::v3::Response as KeysBackupResponse,
         keys::{
@@ -28,7 +29,6 @@ use ruma::{
     },
     assign,
     events::EventContent,
-    OwnedTransactionId, UserId,
 };
 use serde_json::json;
 

--- a/bindings/matrix-sdk-crypto-ffi/src/users.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/users.rs
@@ -1,4 +1,4 @@
-use matrix_sdk_crypto::{types::CrossSigningKey, UserIdentity as SdkUserIdentity};
+use matrix_sdk_crypto::{UserIdentity as SdkUserIdentity, types::CrossSigningKey};
 
 use crate::CryptoStoreError;
 

--- a/bindings/matrix-sdk-crypto-ffi/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/verification.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 use futures_util::{Stream, StreamExt};
 use matrix_sdk_common::executor::Handle;
 use matrix_sdk_crypto::{
-    matrix_sdk_qrcode::QrVerificationData, CancelInfo as RustCancelInfo, QrVerification as InnerQr,
-    QrVerificationState, Sas as InnerSas, SasState as RustSasState,
-    Verification as InnerVerification, VerificationRequest as InnerVerificationRequest,
+    CancelInfo as RustCancelInfo, QrVerification as InnerQr, QrVerificationState, Sas as InnerSas,
+    SasState as RustSasState, Verification as InnerVerification,
+    VerificationRequest as InnerVerificationRequest,
     VerificationRequestState as RustVerificationRequestState,
+    matrix_sdk_qrcode::QrVerificationData,
 };
 use ruma::events::key::verification::VerificationMethod;
 use vodozemac::{base64_decode, base64_encode};

--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -5,12 +5,12 @@ use std::{
 };
 
 use matrix_sdk::{
+    Error,
     authentication::oauth::{
+        ClientId, ClientRegistrationData, OAuthError as SdkOAuthError,
         error::OAuthAuthorizationCodeError,
         registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
-        ClientId, ClientRegistrationData, OAuthError as SdkOAuthError,
     },
-    Error,
 };
 use ruma::serde::Raw;
 use url::Url;

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -6,9 +6,11 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, Context as _};
+use anyhow::{Context as _, anyhow};
 use futures_util::pin_mut;
 use matrix_sdk::{
+    AuthApi, AuthSession, Client as MatrixClient, STATE_STORE_DATABASE_NAME, SessionChange,
+    SessionTokens,
     authentication::oauth::{
         AccountManagementActionFull, ClientId, OAuthAuthorizationData, OAuthSession,
     },
@@ -18,29 +20,27 @@ use matrix_sdk::{
         MediaRetentionPolicy, MediaThumbnailSettings,
     },
     ruma::{
+        EventEncryptionAlgorithm, RoomId, TransactionId, UInt, UserId,
         api::client::{
             discovery::get_authorization_server_metadata::msc2965::Prompt as RumaOidcPrompt,
             push::{EmailPusherData, PusherIds, PusherInit, PusherKind as RumaPusherKind},
-            room::{create_room, Visibility},
+            room::{Visibility, create_room},
             session::get_login_types,
             user_directory::search_users,
         },
         events::{
+            AnyInitialStateEvent, InitialStateEvent,
             room::{
                 avatar::RoomAvatarEventContent, encryption::RoomEncryptionEventContent,
                 message::MessageType,
             },
-            AnyInitialStateEvent, InitialStateEvent,
         },
         serde::Raw,
-        EventEncryptionAlgorithm, RoomId, TransactionId, UInt, UserId,
     },
     sliding_sync::Version as SdkSlidingSyncVersion,
     store::RoomLoadSettings as SdkRoomLoadSettings,
-    AuthApi, AuthSession, Client as MatrixClient, SessionChange, SessionTokens,
-    STATE_STORE_DATABASE_NAME,
 };
-use matrix_sdk_common::{stream::StreamExt, SendOutsideWasm, SyncOutsideWasm};
+use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm, stream::StreamExt};
 use matrix_sdk_ui::{
     notification_client::{
         NotificationClient as MatrixNotificationClient,
@@ -50,8 +50,12 @@ use matrix_sdk_ui::{
 };
 use mime::Mime;
 use ruma::{
+    OwnedServerName, RoomAliasId, RoomOrAliasId, ServerName,
     api::client::{alias::get_alias, error::ErrorKind, uiaa::UserIdentifier},
     events::{
+        GlobalAccountDataEvent as RumaGlobalAccountDataEvent,
+        GlobalAccountDataEventType as RumaGlobalAccountDataEventType,
+        RoomAccountDataEvent as RumaRoomAccountDataEvent,
         direct::DirectEventContent,
         fully_read::FullyReadEventContent,
         identity_server::IdentityServerEventContent,
@@ -71,21 +75,18 @@ use ruma::{
             default_key::SecretStorageDefaultKeyEventContent, key::SecretStorageKeyEventContent,
         },
         tag::TagEventContent,
-        GlobalAccountDataEvent as RumaGlobalAccountDataEvent,
-        GlobalAccountDataEventType as RumaGlobalAccountDataEventType,
-        RoomAccountDataEvent as RumaRoomAccountDataEvent,
     },
     push::{HttpPusherData as RumaHttpPusherData, PushFormat as RumaPushFormat},
-    OwnedServerName, RoomAliasId, RoomOrAliasId, ServerName,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, error};
 use url::Url;
 
 use super::{room::Room, session_verification::SessionVerificationController};
 use crate::{
+    ClientError,
     authentication::{HomeserverLoginDetails, OidcConfiguration, OidcError, SsoError, SsoHandler},
     client,
     encryption::Encryption,
@@ -104,7 +105,6 @@ use crate::{
     task_handle::TaskHandle,
     utd::{UnableToDecryptDelegate, UtdHook},
     utils::AsyncRuntimeDropped,
-    ClientError,
 };
 
 #[derive(Clone, uniffi::Record)]

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -2,10 +2,12 @@ use std::{fs, num::NonZeroUsize, path::Path, sync::Arc, time::Duration};
 
 use futures_util::StreamExt;
 use matrix_sdk::{
+    Client as MatrixClient, ClientBuildError as MatrixClientBuildError, HttpError, IdParseError,
+    RumaApiError, SqliteStoreConfig,
     authentication::oauth::qrcode::{self, DeviceCodeErrorResponseType, LoginFailureReason},
     crypto::{
-        types::qr_login::{LoginQrCodeDecodeError, QrCodeModeData},
         CollectStrategy, TrustRequirement,
+        types::qr_login::{LoginQrCodeDecodeError, QrCodeModeData},
     },
     encryption::{BackupDownloadStrategy, EncryptionSettings},
     event_cache::EventCacheError,
@@ -15,8 +17,6 @@ use matrix_sdk::{
         Error as MatrixSlidingSyncError, VersionBuilder as MatrixSlidingSyncVersionBuilder,
         VersionBuilderError,
     },
-    Client as MatrixClient, ClientBuildError as MatrixClientBuildError, HttpError, IdParseError,
-    RumaApiError, SqliteStoreConfig,
 };
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
 use ruma::api::error::{DeserializationError, FromHttpResponseError};

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -1,19 +1,19 @@
 use std::{collections::HashMap, error::Error, fmt, fmt::Display};
 
 use matrix_sdk::{
+    HttpError, IdParseError, NotificationSettingsError as SdkNotificationSettingsError,
+    QueueWedgeError as SdkQueueWedgeError, StoreError,
     authentication::oauth::OAuthError,
-    encryption::{identities::RequestVerificationError, CryptoStoreError},
+    encryption::{CryptoStoreError, identities::RequestVerificationError},
     event_cache::EventCacheError,
     reqwest,
     room::edit::EditError,
     send_queue::RoomSendQueueError,
-    HttpError, IdParseError, NotificationSettingsError as SdkNotificationSettingsError,
-    QueueWedgeError as SdkQueueWedgeError, StoreError,
 };
 use matrix_sdk_ui::{encryption_sync_service, notification_client, sync_service, timeline};
 use ruma::{
-    api::client::error::{ErrorBody, ErrorKind as RumaApiErrorKind, RetryAfter},
     MilliSecondsSinceUnixEpoch,
+    api::client::error::{ErrorBody, ErrorKind as RumaApiErrorKind, RetryAfter},
 };
 use tracing::warn;
 use uniffi::UnexpectedUniFFICallbackError;

--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -1,26 +1,26 @@
 use std::ops::Deref;
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use matrix_sdk::IdParseError;
 use matrix_sdk_ui::timeline::TimelineEventItemId;
 use ruma::{
+    EventId,
     events::{
+        AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent,
+        MessageLikeEventContent as RumaMessageLikeEventContent, RedactContent,
+        RedactedStateEventContent, StaticStateEventContent, SyncMessageLikeEvent, SyncStateEvent,
         room::{
             message::{MessageType as RumaMessageType, Relation},
             redaction::SyncRoomRedactionEvent,
         },
-        AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent,
-        MessageLikeEventContent as RumaMessageLikeEventContent, RedactContent,
-        RedactedStateEventContent, StaticStateEventContent, SyncMessageLikeEvent, SyncStateEvent,
     },
-    EventId,
 };
 
 use crate::{
+    ClientError,
     room_member::MembershipState,
     ruma::{MessageType, NotifyType},
     utils::Timestamp,
-    ClientError,
 };
 
 #[derive(uniffi::Object)]

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![allow(unused_qualifications, clippy::new_without_default)]
 #![allow(clippy::empty_line_after_doc_comments)] // Needed because uniffi macros contain empty
-                                                 // lines after docs.
+// lines after docs.
 
 mod authentication;
 mod chunk_iterator;

--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -126,11 +126,7 @@ impl NotificationClient {
         let item =
             self.inner.get_notification(&room_id, &event_id).await.map_err(ClientError::from)?;
 
-        if let Some(item) = item {
-            Ok(Some(NotificationItem::from_inner(item)))
-        } else {
-            Ok(None)
-        }
+        if let Some(item) = item { Ok(Some(NotificationItem::from_inner(item))) } else { Ok(None) }
     }
 
     /// Get several notification items in a single batch.

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -1,22 +1,22 @@
 use std::sync::{Arc, RwLock};
 
 use matrix_sdk::{
+    Client as MatrixClient,
     event_handler::EventHandlerHandle,
     notification_settings::{
         NotificationSettings as SdkNotificationSettings,
         RoomNotificationMode as SdkRoomNotificationMode,
     },
     ruma::events::push_rules::PushRulesEvent,
-    Client as MatrixClient,
 };
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
 use ruma::{
+    Int, RoomId, UInt,
     push::{
         Action as SdkAction, ComparisonOperator as SdkComparisonOperator, PredefinedOverrideRuleId,
         PredefinedUnderrideRuleId, PushCondition as SdkPushCondition, RoomMemberCountIs,
         RuleKind as SdkRuleKind, ScalarJsonValue as SdkJsonValue, Tweak as SdkTweak,
     },
-    Int, RoomId, UInt,
 };
 use tokio::sync::RwLock as AsyncRwLock;
 

--- a/bindings/matrix-sdk-ffi/src/platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform.rs
@@ -1,20 +1,19 @@
-use std::sync::{atomic::AtomicBool, Arc, OnceLock};
+use std::sync::{Arc, OnceLock, atomic::AtomicBool};
 
 use tracing::warn;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_core::Subscriber;
 use tracing_subscriber::{
+    Layer,
     field::RecordFields,
     fmt::{
-        self,
+        self, FormatEvent, FormatFields, FormattedFields,
         format::{DefaultFields, Writer},
         time::FormatTime,
-        FormatEvent, FormatFields, FormattedFields,
     },
     layer::SubscriberExt as _,
     registry::LookupSpan,
     util::SubscriberInitExt as _,
-    Layer,
 };
 
 use crate::{error::ClientError, tracing::LogLevel};

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -3,29 +3,29 @@
 use std::{fmt::Debug, mem::MaybeUninit, ptr::addr_of_mut, sync::Arc, time::Duration};
 
 use eyeball_im::VectorDiff;
-use futures_util::{pin_mut, StreamExt};
+use futures_util::{StreamExt, pin_mut};
 use matrix_sdk::{
-    ruma::{
-        api::client::sync::sync_events::UnreadNotificationsCount as RumaUnreadNotificationsCount,
-        RoomId,
-    },
     Room as SdkRoom,
+    ruma::{
+        RoomId,
+        api::client::sync::sync_events::UnreadNotificationsCount as RumaUnreadNotificationsCount,
+    },
 };
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
 use matrix_sdk_ui::{
     room_list_service::filters::{
-        new_filter_all, new_filter_any, new_filter_category, new_filter_deduplicate_versions,
-        new_filter_favourite, new_filter_fuzzy_match_room_name, new_filter_invite,
-        new_filter_joined, new_filter_non_left, new_filter_none,
-        new_filter_normalized_match_room_name, new_filter_unread, BoxedFilterFn, RoomCategory,
+        BoxedFilterFn, RoomCategory, new_filter_all, new_filter_any, new_filter_category,
+        new_filter_deduplicate_versions, new_filter_favourite, new_filter_fuzzy_match_room_name,
+        new_filter_invite, new_filter_joined, new_filter_non_left, new_filter_none,
+        new_filter_normalized_match_room_name, new_filter_unread,
     },
     unable_to_decrypt_hook::UtdHookManager,
 };
 
 use crate::{
+    TaskHandle,
     room::{Membership, Room},
     runtime::get_runtime_handle,
-    TaskHandle,
 };
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
@@ -42,7 +42,9 @@ pub enum RoomListError {
     InvalidRoomId { error: String },
     #[error("Event cache ran into an error: {error}")]
     EventCache { error: String },
-    #[error("The requested room doesn't match the membership requirements {expected:?}, observed {actual:?}")]
+    #[error(
+        "The requested room doesn't match the membership requirements {expected:?}, observed {actual:?}"
+    )]
     IncorrectRoomMembership { expected: Vec<Membership>, actual: Membership },
 }
 

--- a/bindings/matrix-sdk-ffi/src/room_preview.rs
+++ b/bindings/matrix-sdk-ffi/src/room_preview.rs
@@ -1,5 +1,5 @@
 use anyhow::Context as _;
-use matrix_sdk::{room_preview::RoomPreview as SdkRoomPreview, Client};
+use matrix_sdk::{Client, room_preview::RoomPreview as SdkRoomPreview};
 use ruma::{room::RoomType as RumaRoomType, space::SpaceRoomJoinRule};
 use tracing::warn;
 

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -21,8 +21,13 @@ use std::{
 use extension_trait::extension_trait;
 use matrix_sdk::attachment::{BaseAudioInfo, BaseFileInfo, BaseImageInfo, BaseVideoInfo};
 use ruma::{
-    assign,
+    KeyDerivationAlgorithm as RumaKeyDerivationAlgorithm, MatrixToUri, MatrixUri as RumaMatrixUri,
+    OwnedRoomId, OwnedUserId, UInt, UserId, assign,
     events::{
+        GlobalAccountDataEvent as RumaGlobalAccountDataEvent,
+        GlobalAccountDataEventType as RumaGlobalAccountDataEventType,
+        RoomAccountDataEvent as RumaRoomAccountDataEvent,
+        RoomAccountDataEventType as RumaRoomAccountDataEventType,
         call::notify::NotifyType as RumaNotifyType,
         direct::DirectEventContent,
         fully_read::FullyReadEventContent,
@@ -37,6 +42,8 @@ use ruma::{
         poll::start::PollKind as RumaPollKind,
         push_rules::PushRulesEventContent,
         room::{
+            ImageInfo as RumaImageInfo, MediaSource as RumaMediaSource,
+            ThumbnailInfo as RumaThumbnailInfo,
             message::{
                 AudioInfo as RumaAudioInfo,
                 AudioMessageEventContent as RumaAudioMessageEventContent,
@@ -54,8 +61,6 @@ use ruma::{
                 VideoInfo as RumaVideoInfo,
                 VideoMessageEventContent as RumaVideoMessageEventContent,
             },
-            ImageInfo as RumaImageInfo, MediaSource as RumaMediaSource,
-            ThumbnailInfo as RumaThumbnailInfo,
         },
         secret_storage::{
             default_key::SecretStorageDefaultKeyEventContent,
@@ -70,10 +75,6 @@ use ruma::{
             TagEventContent, TagInfo as RumaTagInfo, TagName as RumaTagName,
             UserTagName as RumaUserTagName,
         },
-        GlobalAccountDataEvent as RumaGlobalAccountDataEvent,
-        GlobalAccountDataEventType as RumaGlobalAccountDataEventType,
-        RoomAccountDataEvent as RumaRoomAccountDataEvent,
-        RoomAccountDataEventType as RumaRoomAccountDataEventType,
     },
     matrix_uri::MatrixId as RumaMatrixId,
     push::{
@@ -81,8 +82,6 @@ use ruma::{
         Ruleset as RumaRuleset, SimplePushRule as RumaSimplePushRule,
     },
     serde::JsonObject,
-    KeyDerivationAlgorithm as RumaKeyDerivationAlgorithm, MatrixToUri, MatrixUri as RumaMatrixUri,
-    OwnedRoomId, OwnedUserId, UInt, UserId,
 };
 use tracing::info;
 
@@ -389,11 +388,7 @@ pub enum MessageType {
 ///   is its own field.
 /// - if a media only has a filename, then body is the filename.
 fn get_body_and_filename(filename: String, caption: Option<String>) -> (String, Option<String>) {
-    if let Some(caption) = caption {
-        (caption, Some(filename))
-    } else {
-        (filename, None)
-    }
+    if let Some(caption) = caption { (caption, Some(filename)) } else { (filename, None) }
 }
 
 impl TryFrom<MessageType> for RumaMessageType {

--- a/bindings/matrix-sdk-ffi/src/runtime.rs
+++ b/bindings/matrix-sdk-ffi/src/runtime.rs
@@ -39,7 +39,7 @@ mod sys {
 mod sys {
     use std::future::Future;
 
-    use matrix_sdk_common::executor::{spawn, JoinHandle};
+    use matrix_sdk_common::executor::{JoinHandle, spawn};
 
     /// A dummy guard that does nothing when dropped.
     /// This is used for the Wasm implementation to match

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -2,13 +2,13 @@ use std::sync::{Arc, RwLock};
 
 use futures_util::StreamExt;
 use matrix_sdk::{
+    Account,
     encryption::{
+        Encryption,
         identities::UserIdentity,
         verification::{SasState, SasVerification, VerificationRequest, VerificationRequestState},
-        Encryption,
     },
     ruma::events::key::verification::VerificationMethod,
-    Account,
 };
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
 use ruma::UserId;
@@ -235,7 +235,9 @@ impl SessionVerificationController {
         if sender != self.user_identity.user_id() {
             if let Some(status) = self.encryption.cross_signing_status().await {
                 if !status.is_complete() {
-                    warn!("Cannot verify other users until our own device's cross-signing status is complete: {status:?}");
+                    warn!(
+                        "Cannot verify other users until our own device's cross-signing status is complete: {status:?}"
+                    );
                     return;
                 }
             }

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -26,8 +26,8 @@ use matrix_sdk_ui::{
 };
 
 use crate::{
-    error::ClientError, helpers::unwrap_or_clone_arc, room_list::RoomListService,
-    runtime::get_runtime_handle, TaskHandle,
+    TaskHandle, error::ClientError, helpers::unwrap_or_clone_arc, room_list::RoomListService,
+    runtime::get_runtime_handle,
 };
 
 #[derive(uniffi::Enum)]

--- a/bindings/matrix-sdk-ffi/src/timeline/configuration.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/configuration.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use matrix_sdk_ui::timeline::event_type_filter::TimelineEventTypeFilter as InnerTimelineEventTypeFilter;
 use ruma::{
-    events::{AnySyncTimelineEvent, TimelineEventType},
     EventId,
+    events::{AnySyncTimelineEvent, TimelineEventType},
 };
 
 use super::FocusEventError;

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -17,7 +17,7 @@ use std::{collections::HashMap, fmt::Write as _, fs, panic, sync::Arc};
 use anyhow::{Context, Result};
 use as_variant::as_variant;
 use eyeball_im::VectorDiff;
-use futures_util::{pin_mut, StreamExt as _};
+use futures_util::{StreamExt as _, pin_mut};
 use matrix_sdk::{
     attachment::{
         AttachmentConfig, AttachmentInfo, BaseAudioInfo, BaseFileInfo, BaseImageInfo,
@@ -38,7 +38,9 @@ use matrix_sdk_ui::timeline::{
 use mime::Mime;
 use reply::{EmbeddedEventDetails, InReplyToDetails};
 use ruma::{
+    EventId, UInt,
     events::{
+        AnyMessageLikeEventContent,
         location::{AssetType as RumaAssetType, LocationContent, ZoomLevel},
         poll::{
             unstable_end::UnstablePollEndEventContent,
@@ -53,9 +55,7 @@ use ruma::{
             LocationMessageEventContent, MessageType, ReplyWithinThread,
             RoomMessageEventContentWithoutRelation,
         },
-        AnyMessageLikeEventContent,
     },
-    EventId, UInt,
 };
 use tokio::sync::Mutex;
 use tracing::{error, warn};
@@ -561,7 +561,9 @@ impl Timeline {
                 let event_id = match event_or_transaction_id {
                     EventOrTransactionId::EventId { event_id } => EventId::parse(event_id)?,
                     EventOrTransactionId::TransactionId { .. } => {
-                        warn!("trying to apply an edit to a local echo that doesn't exist in this timeline, aborting");
+                        warn!(
+                            "trying to apply an edit to a local echo that doesn't exist in this timeline, aborting"
+                        );
                         return Ok(());
                     }
                 };
@@ -1396,7 +1398,7 @@ mod galleries {
     use crate::{
         error::RoomError,
         ruma::{AudioInfo, FileInfo, FormattedBody, ImageInfo, Mentions, VideoInfo},
-        timeline::{build_thumbnail_info, ReplyParameters, Timeline},
+        timeline::{ReplyParameters, Timeline, build_thumbnail_info},
     };
 
     #[derive(uniffi::Record)]

--- a/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
@@ -15,7 +15,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::crypto::types::events::UtdCause;
-use ruma::events::{room::MediaSource as RumaMediaSource, EventContent};
+use ruma::events::{EventContent, room::MediaSource as RumaMediaSource};
 
 use super::{
     content::Reaction,

--- a/bindings/matrix-sdk-ffi/src/timeline/reply.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/reply.rs
@@ -14,7 +14,7 @@
 
 use matrix_sdk_ui::timeline::{EmbeddedEvent, TimelineDetails};
 
-use super::{content::TimelineItemContent, ProfileDetails};
+use super::{ProfileDetails, content::TimelineItemContent};
 
 #[derive(Clone, uniffi::Object)]
 pub struct InReplyToDetails {

--- a/bindings/matrix-sdk-ffi/src/tracing.rs
+++ b/bindings/matrix-sdk-ffi/src/tracing.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use once_cell::sync::OnceCell;
-use tracing::{callsite::DefaultCallsite, field::FieldSet, Callsite};
+use tracing::{Callsite, callsite::DefaultCallsite, field::FieldSet};
 use tracing_core::{identify_callsite, metadata::Kind as MetadataKind};
 
 /// Log an event.

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -656,9 +656,15 @@ mod tests {
         cap_assert("org.matrix.msc2762.receive.event:org.matrix.rageshake_request");
         cap_assert("org.matrix.msc2762.receive.event:io.element.call.encryption_keys");
         cap_assert("org.matrix.msc2762.receive.state_event:m.room.create");
-        cap_assert("org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#@my_user:my_domain.org");
-        cap_assert("org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#@my_user:my_domain.org_ABCDEFGHI");
-        cap_assert("org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#_@my_user:my_domain.org_ABCDEFGHI");
+        cap_assert(
+            "org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#@my_user:my_domain.org",
+        );
+        cap_assert(
+            "org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#@my_user:my_domain.org_ABCDEFGHI",
+        );
+        cap_assert(
+            "org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#_@my_user:my_domain.org_ABCDEFGHI",
+        );
         cap_assert("org.matrix.msc2762.send.event:org.matrix.rageshake_request");
         cap_assert("org.matrix.msc2762.send.event:io.element.call.encryption_keys");
     }

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -20,17 +20,17 @@ pub use matrix_sdk_common::deserialized_responses::*;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use ruma::{
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, UInt, UserId,
     events::{
+        AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, EventContentFromType,
+        PossiblyRedactedStateEventContent, RedactContent, RedactedStateEventContent,
+        StateEventContent, StaticStateEventContent, StrippedStateEvent, SyncStateEvent,
         room::{
             member::{MembershipState, RoomMemberEvent, RoomMemberEventContent},
             power_levels::{RoomPowerLevels, RoomPowerLevelsEventContent},
         },
-        AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, EventContentFromType,
-        PossiblyRedactedStateEventContent, RedactContent, RedactedStateEventContent,
-        StateEventContent, StaticStateEventContent, StrippedStateEvent, SyncStateEvent,
     },
     serde::Raw,
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, UInt, UserId,
 };
 use serde::Serialize;
 use unicode_normalization::UnicodeNormalization;

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -23,25 +23,26 @@ use matrix_sdk_common::{
         VerificationState,
     },
     linked_chunk::{
-        lazy_loader, ChunkContent, ChunkIdentifier as CId, LinkedChunkId, Position, Update,
+        ChunkContent, ChunkIdentifier as CId, LinkedChunkId, Position, Update, lazy_loader,
     },
 };
-use matrix_sdk_test::{event_factory::EventFactory, ALICE, DEFAULT_TEST_ROOM_ID};
+use matrix_sdk_test::{ALICE, DEFAULT_TEST_ROOM_ID, event_factory::EventFactory};
 use ruma::{
+    EventId, RoomId,
     api::client::media::get_content_thumbnail::v3::Method,
     event_id,
     events::{
         relation::RelationType,
-        room::{message::RoomMessageEventContentWithoutRelation, MediaSource},
+        room::{MediaSource, message::RoomMessageEventContentWithoutRelation},
     },
     mxc_uri,
     push::Action,
-    room_id, uint, EventId, RoomId,
+    room_id, uint,
 };
 
-use super::{media::IgnoreMediaRetentionPolicy, DynEventCacheStore};
+use super::{DynEventCacheStore, media::IgnoreMediaRetentionPolicy};
 use crate::{
-    event_cache::{store::DEFAULT_CHUNK_CAPACITY, Gap},
+    event_cache::{Gap, store::DEFAULT_CHUNK_CAPACITY},
     media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings},
 };
 
@@ -691,31 +692,39 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         .unwrap();
 
         // Sanity check: both linked chunks can be reloaded.
-        assert!(lazy_loader::from_all_chunks::<3, _, _>(
-            self.load_all_chunks(linked_chunk_id0).await.unwrap()
-        )
-        .unwrap()
-        .is_some());
-        assert!(lazy_loader::from_all_chunks::<3, _, _>(
-            self.load_all_chunks(linked_chunk_id1).await.unwrap()
-        )
-        .unwrap()
-        .is_some());
+        assert!(
+            lazy_loader::from_all_chunks::<3, _, _>(
+                self.load_all_chunks(linked_chunk_id0).await.unwrap()
+            )
+            .unwrap()
+            .is_some()
+        );
+        assert!(
+            lazy_loader::from_all_chunks::<3, _, _>(
+                self.load_all_chunks(linked_chunk_id1).await.unwrap()
+            )
+            .unwrap()
+            .is_some()
+        );
 
         // Clear the chunks.
         self.clear_all_linked_chunks().await.unwrap();
 
         // Both rooms now have no linked chunk.
-        assert!(lazy_loader::from_all_chunks::<3, _, _>(
-            self.load_all_chunks(linked_chunk_id0).await.unwrap()
-        )
-        .unwrap()
-        .is_none());
-        assert!(lazy_loader::from_all_chunks::<3, _, _>(
-            self.load_all_chunks(linked_chunk_id1).await.unwrap()
-        )
-        .unwrap()
-        .is_none());
+        assert!(
+            lazy_loader::from_all_chunks::<3, _, _>(
+                self.load_all_chunks(linked_chunk_id0).await.unwrap()
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            lazy_loader::from_all_chunks::<3, _, _>(
+                self.load_all_chunks(linked_chunk_id1).await.unwrap()
+            )
+            .unwrap()
+            .is_none()
+        );
     }
 
     async fn test_remove_room(&self) {
@@ -899,19 +908,21 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert_eq!(event.event_id(), event_comte.event_id());
 
         // Now let's try to find an event that exists, but not in the expected room.
-        assert!(self
-            .find_event(room_id, event_gruyere.event_id().unwrap().as_ref())
-            .await
-            .expect("failed to query for finding an event")
-            .is_none());
+        assert!(
+            self.find_event(room_id, event_gruyere.event_id().unwrap().as_ref())
+                .await
+                .expect("failed to query for finding an event")
+                .is_none()
+        );
 
         // Clearing the rooms also clears the event's storage.
         self.clear_all_linked_chunks().await.expect("failed to clear all rooms chunks");
-        assert!(self
-            .find_event(room_id, event_comte.event_id().unwrap().as_ref())
-            .await
-            .expect("failed to query for finding an event")
-            .is_none());
+        assert!(
+            self.find_event(room_id, event_comte.event_id().unwrap().as_ref())
+                .await
+                .expect("failed to query for finding an event")
+                .is_none()
+        );
     }
 
     async fn test_find_event_relations(&self) {
@@ -1018,16 +1029,18 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert_eq!(event.event_id(), event_gruyere.event_id());
 
         // But they won't be returned when searching in the wrong room.
-        assert!(self
-            .find_event(another_room_id, event_comte.event_id().unwrap().as_ref())
-            .await
-            .expect("failed to query for finding an event")
-            .is_none());
-        assert!(self
-            .find_event(room_id, event_gruyere.event_id().unwrap().as_ref())
-            .await
-            .expect("failed to query for finding an event")
-            .is_none());
+        assert!(
+            self.find_event(another_room_id, event_comte.event_id().unwrap().as_ref())
+                .await
+                .expect("failed to query for finding an event")
+                .is_none()
+        );
+        assert!(
+            self.find_event(room_id, event_gruyere.event_id().unwrap().as_ref())
+                .await
+                .expect("failed to query for finding an event")
+                .is_none()
+        );
     }
 }
 
@@ -1050,8 +1063,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 /// mod tests {
 ///     use super::{EventCacheStore, EventCacheStoreResult, MyStore};
 ///
-///     async fn get_event_cache_store(
-///     ) -> EventCacheStoreResult<impl EventCacheStore> {
+///     async fn get_event_cache_store()
+///     -> EventCacheStoreResult<impl EventCacheStore> {
 ///         Ok(MyStore::new())
 ///     }
 ///

--- a/crates/matrix-sdk-base/src/event_cache/store/media/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/media/integration_tests.rs
@@ -22,7 +22,7 @@ use ruma::{
 };
 
 use super::{
-    media_service::IgnoreMediaRetentionPolicy, EventCacheStoreMedia, MediaRetentionPolicy,
+    EventCacheStoreMedia, MediaRetentionPolicy, media_service::IgnoreMediaRetentionPolicy,
 };
 use crate::media::{MediaFormat, MediaRequestParameters};
 

--- a/crates/matrix-sdk-base/src/event_cache/store/media/media_service.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/media/media_service.rs
@@ -16,11 +16,11 @@ use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
 use matrix_sdk_common::{
-    executor::{spawn, JoinHandle},
-    locks::Mutex,
     AsyncTraitDeps, SendOutsideWasm, SyncOutsideWasm,
+    executor::{JoinHandle, spawn},
+    locks::Mutex,
 };
-use ruma::{time::SystemTime, MxcUri};
+use ruma::{MxcUri, time::SystemTime};
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::error;
 
@@ -538,15 +538,15 @@ mod tests {
     use matrix_sdk_common::locks::Mutex;
     use matrix_sdk_test::async_test;
     use ruma::{
+        MxcUri, OwnedMxcUri,
         events::room::MediaSource,
         mxc_uri,
         time::{Duration, SystemTime},
-        MxcUri, OwnedMxcUri,
     };
 
     use super::{EventCacheStoreMedia, IgnoreMediaRetentionPolicy, MediaService, TimeProvider};
     use crate::{
-        event_cache::store::{media::MediaRetentionPolicy, EventCacheStoreError},
+        event_cache::store::{EventCacheStoreError, media::MediaRetentionPolicy},
         media::{MediaFormat, MediaRequestParameters, UniqueKey},
     };
 

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -21,23 +21,22 @@ use std::{
 use async_trait::async_trait;
 use matrix_sdk_common::{
     linked_chunk::{
-        relational::RelationalLinkedChunk, ChunkIdentifier, ChunkIdentifierGenerator,
-        LinkedChunkId, Position, RawChunk, Update,
+        ChunkIdentifier, ChunkIdentifierGenerator, LinkedChunkId, Position, RawChunk, Update,
+        relational::RelationalLinkedChunk,
     },
     ring_buffer::RingBuffer,
     store_locks::memory_store_helper::try_take_leased_lock,
 };
 use ruma::{
+    EventId, MxcUri, OwnedEventId, OwnedMxcUri, RoomId,
     events::relation::RelationType,
     time::{Instant, SystemTime},
-    EventId, MxcUri, OwnedEventId, OwnedMxcUri, RoomId,
 };
 use tracing::error;
 
 use super::{
-    compute_filters_string, extract_event_relation,
+    EventCacheStore, EventCacheStoreError, Result, compute_filters_string, extract_event_relation,
     media::{EventCacheStoreMedia, IgnoreMediaRetentionPolicy, MediaRetentionPolicy, MediaService},
-    EventCacheStore, EventCacheStoreError, Result,
 };
 use crate::{
     event_cache::{Event, Gap},

--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -33,9 +33,9 @@ use matrix_sdk_common::store_locks::{
 };
 pub use matrix_sdk_store_encryption::Error as StoreEncryptionError;
 use ruma::{
-    events::{relation::RelationType, AnySyncTimelineEvent},
-    serde::Raw,
     OwnedEventId,
+    events::{AnySyncTimelineEvent, relation::RelationType},
+    serde::Raw,
 };
 use tracing::trace;
 
@@ -43,7 +43,7 @@ use tracing::trace;
 pub use self::integration_tests::EventCacheStoreIntegrationTests;
 pub use self::{
     memory_store::MemoryStore,
-    traits::{DynEventCacheStore, EventCacheStore, IntoEventCacheStore, DEFAULT_CHUNK_CAPACITY},
+    traits::{DEFAULT_CHUNK_CAPACITY, DynEventCacheStore, EventCacheStore, IntoEventCacheStore},
 };
 
 /// The high-level public type to represent an `EventCacheStore` lock.
@@ -255,11 +255,7 @@ pub fn compute_filters_string(filters: Option<&[RelationType]>) -> Option<Vec<St
         filter
             .iter()
             .map(|f| {
-                if *f == RelationType::Replacement {
-                    "m.replace".to_owned()
-                } else {
-                    f.to_string()
-                }
+                if *f == RelationType::Replacement { "m.replace".to_owned() } else { f.to_string() }
             })
             .collect()
     })

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -16,16 +16,16 @@ use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
 use matrix_sdk_common::{
+    AsyncTraitDeps,
     linked_chunk::{
         ChunkIdentifier, ChunkIdentifierGenerator, LinkedChunkId, Position, RawChunk, Update,
     },
-    AsyncTraitDeps,
 };
-use ruma::{events::relation::RelationType, EventId, MxcUri, OwnedEventId, RoomId};
+use ruma::{EventId, MxcUri, OwnedEventId, RoomId, events::relation::RelationType};
 
 use super::{
-    media::{IgnoreMediaRetentionPolicy, MediaRetentionPolicy},
     EventCacheStoreError,
+    media::{IgnoreMediaRetentionPolicy, MediaRetentionPolicy},
 };
 use crate::{
     event_cache::{Event, Gap},
@@ -224,7 +224,7 @@ pub trait EventCacheStore: AsyncTraitDeps {
     ///
     /// * `uri` - The `MxcUri` of the media file.
     async fn get_media_content_for_uri(&self, uri: &MxcUri)
-        -> Result<Option<Vec<u8>>, Self::Error>;
+    -> Result<Option<Vec<u8>>, Self::Error>;
 
     /// Remove all the media files' content associated to an `MxcUri` from the
     /// media store.

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -2,9 +2,12 @@
 //! use as a [crate::Room::latest_event].
 
 use matrix_sdk_common::deserialized_responses::TimelineEvent;
+use ruma::{MxcUri, OwnedEventId};
 #[cfg(feature = "e2e-encryption")]
 use ruma::{
+    UserId,
     events::{
+        AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent,
         call::{invite::SyncCallInviteEvent, notify::SyncCallNotifyEvent},
         poll::unstable_start::SyncUnstablePollStartEvent,
         relation::RelationType,
@@ -14,11 +17,8 @@ use ruma::{
             power_levels::RoomPowerLevels,
         },
         sticker::SyncStickerEvent,
-        AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent,
     },
-    UserId,
 };
-use ruma::{MxcUri, OwnedEventId};
 use serde::{Deserialize, Serialize};
 
 use crate::MinimalRoomMemberEvent;
@@ -227,9 +227,9 @@ impl<'de> Deserialize<'de> for LatestEvent {
             Err(err) => variant_errors.push(err),
         }
 
-        Err(serde::de::Error::custom(
-            format!("data did not match any variant of serialized LatestEvent (using serde_json). Observed errors: {variant_errors:?}")
-        ))
+        Err(serde::de::Error::custom(format!(
+            "data did not match any variant of serialized LatestEvent (using serde_json). Observed errors: {variant_errors:?}"
+        )))
     }
 }
 
@@ -310,13 +310,18 @@ mod tests {
     use ruma::serde::Raw;
     #[cfg(feature = "e2e-encryption")]
     use ruma::{
+        MilliSecondsSinceUnixEpoch, UInt, VoipVersionId,
         events::{
+            AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent, EmptyStateKey,
+            Mentions, MessageLikeUnsigned, OriginalSyncMessageLikeEvent, OriginalSyncStateEvent,
+            RedactedSyncMessageLikeEvent, RedactedUnsigned, StateUnsigned, SyncMessageLikeEvent,
+            UnsignedRoomRedactionEvent,
             call::{
+                SessionDescription,
                 invite::{CallInviteEventContent, SyncCallInviteEvent},
                 notify::{
                     ApplicationType, CallNotifyEventContent, NotifyType, SyncCallNotifyEvent,
                 },
-                SessionDescription,
             },
             poll::{
                 unstable_response::{
@@ -329,6 +334,7 @@ mod tests {
             },
             relation::Replacement,
             room::{
+                ImageInfo, MediaSource,
                 encrypted::{
                     EncryptedEventScheme, OlmV1Curve25519AesSha2Content, RoomEncryptedEventContent,
                     SyncRoomEncryptedEvent,
@@ -338,22 +344,16 @@ mod tests {
                     Relation, RoomMessageEventContent, SyncRoomMessageEvent,
                 },
                 topic::{RoomTopicEventContent, SyncRoomTopicEvent},
-                ImageInfo, MediaSource,
             },
             sticker::{StickerEventContent, SyncStickerEvent},
-            AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent, EmptyStateKey,
-            Mentions, MessageLikeUnsigned, OriginalSyncMessageLikeEvent, OriginalSyncStateEvent,
-            RedactedSyncMessageLikeEvent, RedactedUnsigned, StateUnsigned, SyncMessageLikeEvent,
-            UnsignedRoomRedactionEvent,
         },
-        owned_event_id, owned_mxc_uri, owned_user_id, MilliSecondsSinceUnixEpoch, UInt,
-        VoipVersionId,
+        owned_event_id, owned_mxc_uri, owned_user_id,
     };
     use serde_json::json;
 
     use super::LatestEvent;
     #[cfg(feature = "e2e-encryption")]
-    use super::{is_suitable_for_latest_event, PossibleLatestEvent};
+    use super::{PossibleLatestEvent, is_suitable_for_latest_event};
 
     #[cfg(feature = "e2e-encryption")]
     #[test]

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -55,9 +55,9 @@ pub use http;
 pub use matrix_sdk_crypto as crypto;
 pub use once_cell;
 pub use room::{
-    apply_redaction, EncryptionState, PredecessorRoom, Room, RoomCreateWithCreatorEventContent,
-    RoomDisplayName, RoomHero, RoomInfo, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons,
-    RoomMember, RoomMembersUpdate, RoomMemberships, RoomState, RoomStateFilter, SuccessorRoom,
+    EncryptionState, PredecessorRoom, Room, RoomCreateWithCreatorEventContent, RoomDisplayName,
+    RoomHero, RoomInfo, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons, RoomMember,
+    RoomMembersUpdate, RoomMemberships, RoomState, RoomStateFilter, SuccessorRoom, apply_redaction,
 };
 pub use store::{
     ComposerDraft, ComposerDraftType, QueueWedgeError, StateChanges, StateStore, StateStoreDataKey,

--- a/crates/matrix-sdk-base/src/media.rs
+++ b/crates/matrix-sdk-base/src/media.rs
@@ -1,18 +1,18 @@
 //! Common types for [media content](https://matrix.org/docs/spec/client_server/r0.6.1#id66).
 
 use ruma::{
+    MxcUri, UInt,
     api::client::media::get_content_thumbnail::v3::Method,
     events::{
         room::{
+            MediaSource,
             message::{
                 AudioMessageEventContent, FileMessageEventContent, ImageMessageEventContent,
                 LocationMessageEventContent, VideoMessageEventContent,
             },
-            MediaSource,
         },
         sticker::StickerEventContent,
     },
-    MxcUri, UInt,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -124,15 +124,15 @@ use std::{
 
 use matrix_sdk_common::{deserialized_responses::TimelineEvent, ring_buffer::RingBuffer};
 use ruma::{
+    EventId, OwnedEventId, OwnedUserId, RoomId, UserId,
     events::{
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, OriginalSyncMessageLikeEvent,
+        SyncMessageLikeEvent,
         poll::{start::PollStartEventContent, unstable_start::UnstablePollStartEventContent},
         receipt::{ReceiptEventContent, ReceiptThread, ReceiptType},
         room::message::Relation,
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent, OriginalSyncMessageLikeEvent,
-        SyncMessageLikeEvent,
     },
     serde::Raw,
-    EventId, OwnedEventId, OwnedUserId, RoomId, UserId,
 };
 use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument, trace, warn};
@@ -608,18 +608,18 @@ mod tests {
     use matrix_sdk_common::{deserialized_responses::TimelineEvent, ring_buffer::RingBuffer};
     use matrix_sdk_test::event_factory::EventFactory;
     use ruma::{
-        event_id,
+        EventId, UserId, event_id,
         events::{
             receipt::{ReceiptThread, ReceiptType},
             room::{member::MembershipState, message::MessageType},
         },
         owned_event_id, owned_user_id,
         push::Action,
-        room_id, user_id, EventId, UserId,
+        room_id, user_id,
     };
 
     use super::compute_unread_counts;
-    use crate::read_receipts::{marks_as_unread, ReceiptSelector, RoomReadReceipts};
+    use crate::read_receipts::{ReceiptSelector, RoomReadReceipts, marks_as_unread};
 
     #[test]
     fn test_room_message_marks_as_unread() {
@@ -800,9 +800,9 @@ mod tests {
             num_mentions: 37,
             ..Default::default()
         };
-        assert!(receipts
-            .find_and_process_events(ev0, user_id, &[make_event(event_id!("$1"))],)
-            .not());
+        assert!(
+            receipts.find_and_process_events(ev0, user_id, &[make_event(event_id!("$1"))],).not()
+        );
         assert_eq!(receipts.num_unread, 42);
         assert_eq!(receipts.num_notifications, 13);
         assert_eq!(receipts.num_mentions, 37);
@@ -829,17 +829,19 @@ mod tests {
             num_mentions: 37,
             ..Default::default()
         };
-        assert!(receipts
-            .find_and_process_events(
-                ev0,
-                user_id,
-                &[
-                    make_event(event_id!("$1")),
-                    make_event(event_id!("$2")),
-                    make_event(event_id!("$3"))
-                ],
-            )
-            .not());
+        assert!(
+            receipts
+                .find_and_process_events(
+                    ev0,
+                    user_id,
+                    &[
+                        make_event(event_id!("$1")),
+                        make_event(event_id!("$2")),
+                        make_event(event_id!("$3"))
+                    ],
+                )
+                .not()
+        );
         assert_eq!(receipts.num_unread, 42);
         assert_eq!(receipts.num_notifications, 13);
         assert_eq!(receipts.num_mentions, 37);

--- a/crates/matrix-sdk-base/src/response_processors/account_data/global.rs
+++ b/crates/matrix-sdk-base/src/response_processors/account_data/global.rs
@@ -18,16 +18,16 @@ use std::{
 };
 
 use ruma::{
+    RoomId,
     events::{
-        direct::OwnedDirectUserIdentifier, AnyGlobalAccountDataEvent, GlobalAccountDataEventType,
+        AnyGlobalAccountDataEvent, GlobalAccountDataEventType, direct::OwnedDirectUserIdentifier,
     },
     serde::Raw,
-    RoomId,
 };
 use tracing::{debug, instrument, trace, warn};
 
 use super::super::Context;
-use crate::{store::BaseStateStore, RoomInfo, StateChanges};
+use crate::{RoomInfo, StateChanges, store::BaseStateStore};
 
 /// Create the [`Global`] account data processor.
 pub fn global(events: &[Raw<AnyGlobalAccountDataEvent>]) -> Global {

--- a/crates/matrix-sdk-base/src/response_processors/account_data/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/account_data/mod.rs
@@ -15,5 +15,5 @@
 mod global;
 mod room;
 
-pub use global::{global, Global};
+pub use global::{Global, global};
 pub use room::for_room;

--- a/crates/matrix-sdk-base/src/response_processors/account_data/room.rs
+++ b/crates/matrix-sdk-base/src/response_processors/account_data/room.rs
@@ -13,16 +13,16 @@
 // limitations under the License.
 
 use ruma::{
-    events::{marked_unread::MarkedUnreadEventContent, AnyRoomAccountDataEvent},
-    serde::Raw,
     RoomId,
+    events::{AnyRoomAccountDataEvent, marked_unread::MarkedUnreadEventContent},
+    serde::Raw,
 };
 use tracing::{instrument, warn};
 
 use super::super::{Context, RoomInfoNotableUpdates};
 use crate::{
-    room::AccountDataSource, store::BaseStateStore, RoomInfo, RoomInfoNotableUpdateReasons,
-    StateChanges,
+    RoomInfo, RoomInfoNotableUpdateReasons, StateChanges, room::AccountDataSource,
+    store::BaseStateStore,
 };
 
 #[instrument(skip_all, fields(?room_id))]

--- a/crates/matrix-sdk-base/src/response_processors/changes.rs
+++ b/crates/matrix-sdk-base/src/response_processors/changes.rs
@@ -14,15 +14,15 @@
 
 use eyeball::SharedObservable;
 use ruma::{
-    events::{ignored_user_list::IgnoredUserListEvent, GlobalAccountDataEventType},
+    events::{GlobalAccountDataEventType, ignored_user_list::IgnoredUserListEvent},
     serde::Raw,
 };
 use tracing::{error, instrument, trace};
 
 use super::Context;
 use crate::{
-    store::{BaseStateStore, StateStoreExt as _},
     Result,
+    store::{BaseStateStore, StateStoreExt as _},
 };
 
 /// Save the [`StateChanges`] from the [`Context`] inside the [`BaseStateStore`]

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
@@ -14,7 +14,7 @@
 
 use matrix_sdk_common::deserialized_responses::TimelineEvent;
 use matrix_sdk_crypto::{DecryptionSettings, RoomEventDecryptionResult};
-use ruma::{events::AnySyncTimelineEvent, serde::Raw, RoomId};
+use ruma::{RoomId, events::AnySyncTimelineEvent, serde::Raw};
 
 use super::{super::verification, E2EE};
 use crate::Result;

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
@@ -15,12 +15,12 @@
 use std::collections::BTreeMap;
 
 use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
-use matrix_sdk_crypto::{store::types::RoomKeyInfo, EncryptionSyncChanges, OlmMachine};
+use matrix_sdk_crypto::{EncryptionSyncChanges, OlmMachine, store::types::RoomKeyInfo};
 use ruma::{
-    api::client::sync::sync_events::{v3, v5, DeviceLists},
+    OneTimeKeyAlgorithm, UInt,
+    api::client::sync::sync_events::{DeviceLists, v3, v5},
     events::AnyToDeviceEvent,
     serde::Raw,
-    OneTimeKeyAlgorithm, UInt,
 };
 
 use crate::Result;

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/tracked_users.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/tracked_users.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeSet;
 use matrix_sdk_crypto::OlmMachine;
 use ruma::{OwnedUserId, RoomId};
 
-use crate::{store::BaseStateStore, EncryptionState, Result, RoomMemberships};
+use crate::{EncryptionState, Result, RoomMemberships, store::BaseStateStore};
 
 /// Update tracked users, if the room is encrypted.
 pub async fn update(

--- a/crates/matrix-sdk-base/src/response_processors/ephemeral_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/ephemeral_events.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ruma::{events::AnySyncEphemeralRoomEvent, serde::Raw, RoomId};
+use ruma::{RoomId, events::AnySyncEphemeralRoomEvent, serde::Raw};
 use tracing::info;
 
 use super::Context;

--- a/crates/matrix-sdk-base/src/response_processors/latest_event.rs
+++ b/crates/matrix-sdk-base/src/response_processors/latest_event.rs
@@ -14,12 +14,12 @@
 
 use matrix_sdk_common::deserialized_responses::TimelineEvent;
 use matrix_sdk_crypto::{DecryptionSettings, RoomEventDecryptionResult};
-use ruma::{events::AnySyncTimelineEvent, serde::Raw, RoomId};
+use ruma::{RoomId, events::AnySyncTimelineEvent, serde::Raw};
 
-use super::{e2ee::E2EE, verification, Context};
+use super::{Context, e2ee::E2EE, verification};
 use crate::{
-    latest_event::{is_suitable_for_latest_event, LatestEvent, PossibleLatestEvent},
     Result, Room,
+    latest_event::{LatestEvent, PossibleLatestEvent, is_suitable_for_latest_event},
 };
 
 /// Decrypt any [`Room::latest_encrypted_events`] for a particular set of
@@ -140,11 +140,11 @@ async fn decrypt_sync_room_event(
 #[cfg(test)]
 mod tests {
     use matrix_sdk_test::{
-        async_test, event_factory::EventFactory, JoinedRoomBuilder, SyncResponseBuilder,
+        JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
     };
     use ruma::{event_id, events::room::member::MembershipState, room_id, user_id};
 
-    use super::{decrypt_from_rooms, Context, E2EE};
+    use super::{Context, E2EE, decrypt_from_rooms};
     use crate::{room::RoomInfoNotableUpdateReasons, test_utils::logged_in_base_client};
 
     #[async_test]
@@ -195,11 +195,13 @@ mod tests {
         assert!(room.latest_encrypted_events().is_empty());
         assert!(room.latest_event().is_none());
         assert!(context.state_changes.room_infos.is_empty());
-        assert!(!context
-            .room_info_notable_updates
-            .get(room_id)
-            .copied()
-            .unwrap_or_default()
-            .contains(RoomInfoNotableUpdateReasons::LATEST_EVENT));
+        assert!(
+            !context
+                .room_info_notable_updates
+                .get(room_id)
+                .copied()
+                .unwrap_or_default()
+                .contains(RoomInfoNotableUpdateReasons::LATEST_EVENT)
+        );
     }
 }

--- a/crates/matrix-sdk-base/src/response_processors/notification.rs
+++ b/crates/matrix-sdk-base/src/response_processors/notification.rs
@@ -15,9 +15,9 @@
 use std::collections::BTreeMap;
 
 use ruma::{
+    OwnedRoomId, RoomId,
     push::{Action, PushConditionRoomCtx, Ruleset},
     serde::Raw,
-    OwnedRoomId, RoomId,
 };
 
 use crate::{

--- a/crates/matrix-sdk-base/src/response_processors/profiles.rs
+++ b/crates/matrix-sdk-base/src/response_processors/profiles.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use ruma::{
-    events::{
-        room::member::{MembershipState, RoomMemberEventContent},
-        SyncStateEvent,
-    },
     RoomId,
+    events::{
+        SyncStateEvent,
+        room::member::{MembershipState, RoomMemberEventContent},
+    },
 };
 
 use super::Context;

--- a/crates/matrix-sdk-base/src/response_processors/room/display_name.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/display_name.rs
@@ -14,8 +14,8 @@
 
 use super::super::Context;
 use crate::{
-    room::UpdatedRoomDisplayName, store::BaseStateStore, sync::RoomUpdates,
-    RoomInfoNotableUpdateReasons,
+    RoomInfoNotableUpdateReasons, room::UpdatedRoomDisplayName, store::BaseStateStore,
+    sync::RoomUpdates,
 };
 
 pub async fn update_for_rooms(

--- a/crates/matrix-sdk-base/src/response_processors/room/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/mod.rs
@@ -15,7 +15,7 @@
 use ruma::RoomId;
 use tokio::sync::broadcast::Sender;
 
-use crate::{store::ambiguity_map::AmbiguityCache, RequestedRequiredStates, RoomInfoNotableUpdate};
+use crate::{RequestedRequiredStates, RoomInfoNotableUpdate, store::ambiguity_map::AmbiguityCache};
 
 pub mod display_name;
 pub mod msc4186;

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
@@ -15,19 +15,19 @@
 use std::collections::BTreeMap;
 
 use ruma::{
-    api::client::sync::sync_events::v5 as http,
-    events::{receipt::ReceiptEventContent, AnySyncEphemeralRoomEvent, SyncEphemeralRoomEvent},
-    serde::Raw,
     OwnedRoomId, RoomId,
+    api::client::sync::sync_events::v5 as http,
+    events::{AnySyncEphemeralRoomEvent, SyncEphemeralRoomEvent, receipt::ReceiptEventContent},
+    serde::Raw,
 };
 
 use super::super::super::{
-    account_data::for_room as account_data_for_room, ephemeral_events::dispatch_receipt, Context,
+    Context, account_data::for_room as account_data_for_room, ephemeral_events::dispatch_receipt,
 };
 use crate::{
+    RoomState,
     store::BaseStateStore,
     sync::{JoinedRoomUpdate, RoomUpdates},
-    RoomState,
 };
 
 /// Dispatch the ephemeral events in the `extensions.typing` part of the

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -23,33 +23,33 @@ use matrix_sdk_common::deserialized_responses::TimelineEvent;
 #[cfg(feature = "e2e-encryption")]
 use ruma::events::StateEventType;
 use ruma::{
+    JsOption, OwnedRoomId, RoomId, UserId,
     api::client::sync::sync_events::{
         v3::{InviteState, InvitedRoom, KnockState, KnockedRoom},
         v5 as http,
     },
     assign,
     events::{
-        room::member::{MembershipState, RoomMemberEventContent},
         AnyRoomAccountDataEvent, AnyStrippedStateEvent, AnySyncStateEvent,
+        room::member::{MembershipState, RoomMemberEventContent},
     },
     serde::Raw,
-    JsOption, OwnedRoomId, RoomId, UserId,
 };
 use tokio::sync::broadcast::Sender;
 
 #[cfg(feature = "e2e-encryption")]
 use super::super::e2ee;
 use super::{
-    super::{notification, state_events, timeline, Context},
+    super::{Context, notification, state_events, timeline},
     RoomCreationData,
 };
 #[cfg(feature = "e2e-encryption")]
 use crate::StateChanges;
 use crate::{
-    store::BaseStateStore,
-    sync::{InvitedRoomUpdate, JoinedRoomUpdate, KnockedRoomUpdate, LeftRoomUpdate},
     Result, Room, RoomHero, RoomInfo, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons,
     RoomState,
+    store::BaseStateStore,
+    sync::{InvitedRoomUpdate, JoinedRoomUpdate, KnockedRoomUpdate, LeftRoomUpdate},
 };
 
 /// Represent any kind of room updates.
@@ -434,7 +434,7 @@ pub(crate) async fn cache_latest_events(
 
     use crate::{
         deserialized_responses::DisplayName,
-        latest_event::{is_suitable_for_latest_event, LatestEvent, PossibleLatestEvent},
+        latest_event::{LatestEvent, PossibleLatestEvent, is_suitable_for_latest_event},
         store::ambiguity_map::is_display_name_ambiguous,
     };
 

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -15,20 +15,20 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use ruma::{
-    api::client::sync::sync_events::v3::{InvitedRoom, JoinedRoom, KnockedRoom, LeftRoom},
     OwnedRoomId, OwnedUserId, RoomId,
+    api::client::sync::sync_events::v3::{InvitedRoom, JoinedRoom, KnockedRoom, LeftRoom},
 };
 use tokio::sync::broadcast::Sender;
 
 #[cfg(feature = "e2e-encryption")]
 use super::super::e2ee;
 use super::{
-    super::{account_data, ephemeral_events, notification, state_events, timeline, Context},
+    super::{Context, account_data, ephemeral_events, notification, state_events, timeline},
     RoomCreationData,
 };
 use crate::{
-    sync::{InvitedRoomUpdate, JoinedRoomUpdate, KnockedRoomUpdate, LeftRoomUpdate},
     Result, RoomInfoNotableUpdate, RoomState,
+    sync::{InvitedRoomUpdate, JoinedRoomUpdate, KnockedRoomUpdate, LeftRoomUpdate},
 };
 
 /// Process updates of a joined room.

--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -15,12 +15,12 @@
 use std::collections::BTreeSet;
 
 use ruma::{
+    RoomId,
     events::{
-        room::{create::RoomCreateEventContent, tombstone::RoomTombstoneEventContent},
         AnySyncStateEvent, SyncStateEvent,
+        room::{create::RoomCreateEventContent, tombstone::RoomTombstoneEventContent},
     },
     serde::Raw,
-    RoomId,
 };
 use serde::Deserialize;
 use tracing::warn;
@@ -33,18 +33,18 @@ pub mod sync {
     use std::{collections::BTreeSet, iter};
 
     use ruma::{
-        events::{
-            room::member::{MembershipState, RoomMemberEventContent},
-            AnySyncTimelineEvent, SyncStateEvent,
-        },
         OwnedUserId, RoomId, UserId,
+        events::{
+            AnySyncTimelineEvent, SyncStateEvent,
+            room::member::{MembershipState, RoomMemberEventContent},
+        },
     };
     use tracing::{error, instrument};
 
     use super::{super::profiles, AnySyncStateEvent, Context, Raw};
     use crate::{
-        store::{ambiguity_map::AmbiguityCache, BaseStateStore, Result as StoreResult},
         RoomInfo,
+        store::{BaseStateStore, Result as StoreResult, ambiguity_map::AmbiguityCache},
     };
 
     /// Collect [`AnySyncStateEvent`] to [`AnySyncStateEvent`].
@@ -411,10 +411,10 @@ pub fn is_tombstone_event_valid(
 #[cfg(test)]
 mod tests {
     use matrix_sdk_test::{
-        async_test, event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent,
-        SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
+        DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder, async_test,
+        event_factory::EventFactory,
     };
-    use ruma::{event_id, room_id, user_id, RoomVersionId};
+    use ruma::{RoomVersionId, event_id, room_id, user_id};
 
     use crate::test_utils::logged_in_base_client;
 

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -16,25 +16,25 @@ use matrix_sdk_common::deserialized_responses::TimelineEvent;
 #[cfg(feature = "e2e-encryption")]
 use ruma::events::SyncMessageLikeEvent;
 use ruma::{
+    RoomVersionId, UInt, UserId,
     events::{
+        AnyStrippedStateEvent, AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent,
+        StateEventType,
         room::power_levels::{
             RoomPowerLevelsEvent, RoomPowerLevelsEventContent, StrippedRoomPowerLevelsEvent,
         },
-        AnyStrippedStateEvent, AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent,
-        StateEventType,
     },
     push::{Action, PushConditionRoomCtx},
-    RoomVersionId, UInt, UserId,
 };
 use tracing::{instrument, trace, warn};
 
+use super::{Context, notification};
 #[cfg(feature = "e2e-encryption")]
 use super::{e2ee, verification};
-use super::{notification, Context};
 use crate::{
+    Result, Room, RoomInfo,
     store::{BaseStateStore, StateStoreExt as _},
     sync::Timeline,
-    Result, Room, RoomInfo,
 };
 
 /// Process a set of sync timeline event, and create a [`Timeline`].

--- a/crates/matrix-sdk-base/src/response_processors/verification.rs
+++ b/crates/matrix-sdk-base/src/response_processors/verification.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use ruma::{
-    events::{
-        room::message::MessageType, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
-        SyncMessageLikeEvent,
-    },
     RoomId,
+    events::{
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent,
+        room::message::MessageType,
+    },
 };
 
 use super::e2ee::E2EE;

--- a/crates/matrix-sdk-base/src/room/call.rs
+++ b/crates/matrix-sdk-base/src/room/call.rs
@@ -43,18 +43,18 @@ mod tests {
     use assign::assign;
     use matrix_sdk_test::{ALICE, BOB, CAROL};
     use ruma::{
-        device_id, event_id,
+        DeviceId, EventId, MilliSecondsSinceUnixEpoch, OwnedUserId, UserId, device_id, event_id,
         events::{
+            AnySyncStateEvent, StateUnsigned, SyncStateEvent,
             call::member::{
                 ActiveFocus, ActiveLivekitFocus, Application, CallApplicationContent,
                 CallMemberEventContent, CallMemberStateKey, Focus, LegacyMembershipData,
                 LegacyMembershipDataInit, LivekitFocus, OriginalSyncCallMemberEvent,
             },
-            AnySyncStateEvent, StateUnsigned, SyncStateEvent,
         },
         room_id,
         time::SystemTime,
-        user_id, DeviceId, EventId, MilliSecondsSinceUnixEpoch, OwnedUserId, UserId,
+        user_id,
     };
     use similar_asserts::assert_eq;
 

--- a/crates/matrix-sdk-base/src/room/create.rs
+++ b/crates/matrix-sdk-base/src/room/create.rs
@@ -13,14 +13,13 @@
 // limitations under the License.
 
 use ruma::{
-    assign,
+    OwnedUserId, RoomVersionId, assign,
     events::{
+        EmptyStateKey, RedactContent, RedactedStateEventContent,
         macros::EventContent,
         room::create::{PreviousRoom, RoomCreateEventContent},
-        EmptyStateKey, RedactContent, RedactedStateEventContent,
     },
     room::RoomType,
-    OwnedUserId, RoomVersionId,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/matrix-sdk-base/src/room/display_name.rs
+++ b/crates/matrix-sdk-base/src/room/display_name.rs
@@ -17,17 +17,17 @@ use std::fmt;
 use as_variant::as_variant;
 use regex::Regex;
 use ruma::{
-    events::{member_hints::MemberHintsEventContent, SyncStateEvent},
     OwnedMxcUri, OwnedUserId, UserId,
+    events::{SyncStateEvent, member_hints::MemberHintsEventContent},
 };
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace, warn};
 
 use super::{Room, RoomMemberships};
 use crate::{
+    RoomMember, RoomState,
     deserialized_responses::SyncOrStrippedState,
     store::{Result as StoreResult, StateStoreExt},
-    RoomMember, RoomState,
 };
 
 impl Room {
@@ -485,11 +485,7 @@ fn compute_display_name_from_heroes(
 
     // User is alone.
     if num_joined_invited <= 1 {
-        if names.is_empty() {
-            RoomDisplayName::Empty
-        } else {
-            RoomDisplayName::EmptyWas(names)
-        }
+        if names.is_empty() { RoomDisplayName::Empty } else { RoomDisplayName::EmptyWas(names) }
     } else {
         RoomDisplayName::Calculated(names)
     }
@@ -513,26 +509,27 @@ mod tests {
 
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
     use ruma::{
+        UserId,
         api::client::sync::sync_events::v3::RoomSummary as RumaSummary,
         assign,
         events::{
+            StateEventType,
             room::{
                 canonical_alias::RoomCanonicalAliasEventContent,
                 member::{MembershipState, RoomMemberEventContent, StrippedRoomMemberEvent},
                 name::RoomNameEventContent,
             },
-            StateEventType,
         },
         room_alias_id, room_id,
         serde::Raw,
-        user_id, UserId,
+        user_id,
     };
     use serde_json::json;
 
-    use super::{compute_display_name_from_heroes, Room, RoomDisplayName};
+    use super::{Room, RoomDisplayName, compute_display_name_from_heroes};
     use crate::{
-        store::MemoryStore, MinimalStateEvent, OriginalMinimalStateEvent, RoomState, StateChanges,
-        StateStore,
+        MinimalStateEvent, OriginalMinimalStateEvent, RoomState, StateChanges, StateStore,
+        store::MemoryStore,
     };
 
     fn make_room_test_helper(room_type: RoomState) -> (Arc<MemoryStore>, Room) {

--- a/crates/matrix-sdk-base/src/room/encryption.rs
+++ b/crates/matrix-sdk-base/src/room/encryption.rs
@@ -68,17 +68,18 @@ mod tests {
     use assert_matches::assert_matches;
     use matrix_sdk_test::ALICE;
     use ruma::{
+        EventEncryptionAlgorithm, MilliSecondsSinceUnixEpoch, OwnedEventId,
         events::{
-            room::encryption::{OriginalSyncRoomEncryptionEvent, RoomEncryptionEventContent},
             AnySyncStateEvent, EmptyStateKey, StateUnsigned, SyncStateEvent,
+            room::encryption::{OriginalSyncRoomEncryptionEvent, RoomEncryptionEventContent},
         },
         room_id,
         time::SystemTime,
-        user_id, EventEncryptionAlgorithm, MilliSecondsSinceUnixEpoch, OwnedEventId,
+        user_id,
     };
 
     use super::{EncryptionState, Room};
-    use crate::{store::MemoryStore, RoomState};
+    use crate::{RoomState, store::MemoryStore};
 
     fn make_room_test_helper(room_type: RoomState) -> (Arc<MemoryStore>, Room) {
         let store = Arc::new(MemoryStore::new());

--- a/crates/matrix-sdk-base/src/room/knock.rs
+++ b/crates/matrix-sdk-base/src/room/knock.rs
@@ -16,19 +16,19 @@ use std::collections::BTreeMap;
 
 use eyeball::{AsyncLock, ObservableWriteGuard};
 use ruma::{
-    events::{
-        room::member::{MembershipState, RoomMemberEventContent},
-        StateEventType, SyncStateEvent,
-    },
     OwnedEventId, OwnedUserId,
+    events::{
+        StateEventType, SyncStateEvent,
+        room::member::{MembershipState, RoomMemberEventContent},
+    },
 };
 use tracing::warn;
 
 use super::Room;
 use crate::{
+    StateStoreDataKey, StateStoreDataValue, StoreError,
     deserialized_responses::{MemberEvent, RawMemberEvent, SyncOrStrippedState},
     store::{Result as StoreResult, StateStoreExt},
-    StateStoreDataKey, StateStoreDataValue, StoreError,
 };
 
 impl Room {
@@ -51,7 +51,10 @@ impl Room {
                     if event.content.membership == MembershipState::Knock {
                         event_to_user_ids.push((event.event_id, event.state_key))
                     } else {
-                        warn!("Could not mark knock event as seen: event {} for user {} is not in Knock membership state.", event.event_id, event.state_key);
+                        warn!(
+                            "Could not mark knock event as seen: event {} for user {} is not in Knock membership state.",
+                            event.event_id, event.state_key
+                        );
                     }
                 }
                 _ => warn!(

--- a/crates/matrix-sdk-base/src/room/latest_event.rs
+++ b/crates/matrix-sdk-base/src/room/latest_event.rs
@@ -16,7 +16,7 @@
 use std::{collections::BTreeMap, num::NonZeroUsize};
 
 #[cfg(feature = "e2e-encryption")]
-use ruma::{events::AnySyncTimelineEvent, serde::Raw, OwnedRoomId};
+use ruma::{OwnedRoomId, events::AnySyncTimelineEvent, serde::Raw};
 
 use super::Room;
 #[cfg(feature = "e2e-encryption")]
@@ -88,11 +88,11 @@ mod tests_with_e2e_encryption {
     use serde_json::json;
 
     use crate::{
+        BaseClient, Room, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons, RoomState,
+        SessionMeta, StateChanges,
         latest_event::LatestEvent,
         response_processors as processors,
         store::{MemoryStore, RoomLoadSettings, StoreConfig},
-        BaseClient, Room, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons, RoomState,
-        SessionMeta, StateChanges,
     };
 
     fn make_room_test_helper(room_type: RoomState) -> (Arc<MemoryStore>, Room) {

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -20,24 +20,24 @@ use std::{
 
 use bitflags::bitflags;
 use ruma::{
+    MxcUri, OwnedUserId, UserId,
     events::{
+        MessageLikeEventType, StateEventType,
         ignored_user_list::IgnoredUserListEventContent,
         presence::PresenceEvent,
         room::{
             member::{MembershipState, RoomMemberEventContent},
             power_levels::{PowerLevelAction, RoomPowerLevels, RoomPowerLevelsEventContent},
         },
-        MessageLikeEventType, StateEventType,
     },
-    MxcUri, OwnedUserId, UserId,
 };
 use tracing::debug;
 
 use super::Room;
 use crate::{
-    deserialized_responses::{DisplayName, MemberEvent, SyncOrStrippedState},
-    store::{ambiguity_map::is_display_name_ambiguous, Result as StoreResult, StateStoreExt},
     MinimalRoomMemberEvent,
+    deserialized_responses::{DisplayName, MemberEvent, SyncOrStrippedState},
+    store::{Result as StoreResult, StateStoreExt, ambiguity_map::is_display_name_ambiguous},
 };
 
 impl Room {
@@ -270,11 +270,7 @@ impl RoomMember {
     /// This returns either the display name or the local part of the user id if
     /// the member didn't set a display name.
     pub fn name(&self) -> &str {
-        if let Some(d) = self.display_name() {
-            d
-        } else {
-            self.user_id().localpart()
-        }
+        if let Some(d) = self.display_name() { d } else { self.user_id().localpart() }
     }
 
     /// Get the avatar url of the member, if there is one.

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -44,11 +44,10 @@ use matrix_sdk_common::ring_buffer::RingBuffer;
 pub use members::{RoomMember, RoomMembersUpdate, RoomMemberships};
 pub(crate) use room_info::SyncInfo;
 pub use room_info::{
-    apply_redaction, BaseRoomInfo, RoomInfo, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons,
+    BaseRoomInfo, RoomInfo, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons, apply_redaction,
 };
-#[cfg(feature = "e2e-encryption")]
-use ruma::{events::AnySyncTimelineEvent, serde::Raw};
 use ruma::{
+    EventId, OwnedEventId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, RoomId, UserId,
     events::{
         direct::OwnedDirectUserIdentifier,
         receipt::{Receipt, ReceiptThread, ReceiptType},
@@ -61,8 +60,9 @@ use ruma::{
         },
     },
     room::RoomType,
-    EventId, OwnedEventId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, RoomId, UserId,
 };
+#[cfg(feature = "e2e-encryption")]
+use ruma::{events::AnySyncTimelineEvent, serde::Raw};
 use serde::{Deserialize, Serialize};
 pub use state::{RoomState, RoomStateFilter};
 pub(crate) use tags::RoomNotableTags;
@@ -71,12 +71,12 @@ pub use tombstone::{PredecessorRoom, SuccessorRoom};
 use tracing::{info, instrument, warn};
 
 use crate::{
+    Error, MinimalStateEvent,
     deserialized_responses::MemberEvent,
     notification_settings::RoomNotificationMode,
     read_receipts::RoomReadReceipts,
     store::{DynStateStore, Result as StoreResult, StateStoreExt},
     sync::UnreadNotificationsCount,
-    Error, MinimalStateEvent,
 };
 
 /// The underlying room data structure collecting state for joined, left and

--- a/crates/matrix-sdk-base/src/room/tags.rs
+++ b/crates/matrix-sdk-base/src/room/tags.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use bitflags::bitflags;
-use ruma::events::{tag::Tags, AnyRoomAccountDataEvent, RoomAccountDataEventType};
+use ruma::events::{AnyRoomAccountDataEvent, RoomAccountDataEventType, tag::Tags};
 use serde::{Deserialize, Serialize};
 
 use super::Room;
@@ -82,9 +82,8 @@ mod tests {
 
     use super::{super::BaseRoomInfo, RoomNotableTags};
     use crate::{
-        response_processors as processors,
+        BaseClient, RoomState, SessionMeta, response_processors as processors,
         store::{RoomLoadSettings, StoreConfig},
-        BaseClient, RoomState, SessionMeta,
     };
 
     #[async_test]

--- a/crates/matrix-sdk-base/src/room/tombstone.rs
+++ b/crates/matrix-sdk-base/src/room/tombstone.rs
@@ -14,7 +14,7 @@
 
 use std::ops::Not;
 
-use ruma::{events::room::tombstone::RoomTombstoneEventContent, OwnedEventId, OwnedRoomId};
+use ruma::{OwnedEventId, OwnedRoomId, events::room::tombstone::RoomTombstoneEventContent};
 
 use super::Room;
 
@@ -115,11 +115,11 @@ mod tests {
 
     use assert_matches::assert_matches;
     use matrix_sdk_test::{
-        async_test, event_factory::EventFactory, JoinedRoomBuilder, SyncResponseBuilder,
+        JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
     };
-    use ruma::{event_id, room_id, user_id, RoomVersionId};
+    use ruma::{RoomVersionId, event_id, room_id, user_id};
 
-    use crate::{test_utils::logged_in_base_client, RoomState};
+    use crate::{RoomState, test_utils::logged_in_base_client};
 
     #[async_test]
     async fn test_no_successor_room() {

--- a/crates/matrix-sdk-base/src/store/ambiguity_map.rs
+++ b/crates/matrix-sdk-base/src/store/ambiguity_map.rs
@@ -18,11 +18,11 @@ use std::{
 };
 
 use ruma::{
-    events::{
-        room::member::{MembershipState, SyncRoomMemberEvent},
-        StateEventType,
-    },
     OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UserId,
+    events::{
+        StateEventType,
+        room::member::{MembershipState, SyncRoomMemberEvent},
+    },
 };
 use tracing::{instrument, trace};
 
@@ -45,11 +45,7 @@ impl DisplayNameUsers {
     fn remove(&mut self, user_id: &UserId) -> Option<OwnedUserId> {
         self.users.remove(user_id);
 
-        if self.user_count() == 1 {
-            self.users.iter().next().cloned()
-        } else {
-            None
-        }
+        if self.user_count() == 1 { self.users.iter().next().cloned() } else { None }
     }
 
     /// Add the given [`UserId`] from the map, marking that the [`UserId`]
@@ -313,7 +309,7 @@ impl AmbiguityCache {
 #[cfg(test)]
 mod test {
     use matrix_sdk_test::async_test;
-    use ruma::{room_id, server_name, user_id, EventId};
+    use ruma::{EventId, room_id, server_name, user_id};
     use serde_json::json;
 
     use super::*;

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -20,31 +20,31 @@ use std::{
 use async_trait::async_trait;
 use growable_bloom_filter::GrowableBloom;
 use ruma::{
-    canonical_json::{redact, RedactedBecause},
+    CanonicalJsonObject, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri,
+    OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId, TransactionId, UserId,
+    canonical_json::{RedactedBecause, redact},
     events::{
+        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
+        AnySyncStateEvent, GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
         presence::PresenceEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::member::{MembershipState, StrippedRoomMemberEvent, SyncRoomMemberEvent},
-        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncStateEvent, GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
     },
     serde::Raw,
     time::Instant,
-    CanonicalJsonObject, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri,
-    OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId, TransactionId, UserId,
 };
 use tracing::{debug, instrument, warn};
 
 use super::{
-    send_queue::{ChildTransactionId, QueuedRequest, SentRequestKey},
-    traits::{ComposerDraft, ServerCapabilities},
     DependentQueuedRequest, DependentQueuedRequestKind, QueuedRequestKind, Result, RoomInfo,
     RoomLoadSettings, StateChanges, StateStore, StoreError,
+    send_queue::{ChildTransactionId, QueuedRequest, SentRequestKey},
+    traits::{ComposerDraft, ServerCapabilities},
 };
 use crate::{
+    MinimalRoomMemberEvent, RoomMemberships, StateStoreDataKey, StateStoreDataValue,
     deserialized_responses::{DisplayName, RawAnySyncOrStrippedState},
     store::QueueWedgeError,
-    MinimalRoomMemberEvent, RoomMemberships, StateStoreDataKey, StateStoreDataValue,
 };
 
 #[derive(Debug, Default)]

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -21,7 +21,9 @@ use std::{
 
 use matrix_sdk_common::deserialized_responses::TimelineEvent;
 use ruma::{
+    OwnedRoomId, OwnedUserId, RoomId,
     events::{
+        EmptyStateKey, EventContent, RedactContent, StateEventContent, StateEventType,
         direct::OwnedDirectUserIdentifier,
         room::{
             avatar::RoomAvatarEventContent,
@@ -35,18 +37,16 @@ use ruma::{
             tombstone::RoomTombstoneEventContent,
             topic::RoomTopicEventContent,
         },
-        EmptyStateKey, EventContent, RedactContent, StateEventContent, StateEventType,
     },
-    OwnedRoomId, OwnedUserId, RoomId,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    MinimalStateEvent, OriginalMinimalStateEvent, RoomInfo, RoomState,
     deserialized_responses::SyncOrStrippedState,
     latest_event::LatestEvent,
     room::{BaseRoomInfo, RoomSummary, SyncInfo},
     sync::UnreadNotificationsCount,
-    MinimalStateEvent, OriginalMinimalStateEvent, RoomInfo, RoomState,
 };
 
 /// [`RoomInfo`] version 1.

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -44,24 +44,24 @@ use matrix_sdk_crypto::store::{DynCryptoStore, IntoCryptoStore};
 pub use matrix_sdk_store_encryption::Error as StoreEncryptionError;
 use observable_map::ObservableMap;
 use ruma::{
+    EventId, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UserId,
     events::{
+        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
+        AnySyncStateEvent, GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
         presence::PresenceEvent,
         receipt::ReceiptEventContent,
         room::{member::StrippedRoomMemberEvent, redaction::SyncRoomRedactionEvent},
-        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncStateEvent, GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
     },
     serde::Raw,
-    EventId, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UserId,
 };
-use tokio::sync::{broadcast, Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, broadcast};
 use tracing::warn;
 
 use crate::{
+    MinimalRoomMemberEvent, Room, RoomStateFilter, SendOutsideWasm, SessionMeta, SyncOutsideWasm,
     deserialized_responses::DisplayName,
     event_cache::store as event_cache_store,
     room::{RoomInfo, RoomInfoNotableUpdate, RoomState},
-    MinimalRoomMemberEvent, Room, RoomStateFilter, SendOutsideWasm, SessionMeta, SyncOutsideWasm,
 };
 
 pub(crate) mod ambiguity_map;

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -18,13 +18,13 @@ use std::{collections::BTreeMap, fmt, ops::Deref};
 
 use as_variant::as_variant;
 use ruma::{
-    events::{
-        room::{message::RoomMessageEventContent, MediaSource},
-        AnyMessageLikeEventContent, EventContent as _, RawExt as _,
-    },
-    serde::Raw,
     MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedEventId, OwnedTransactionId, OwnedUserId,
     TransactionId, UInt,
+    events::{
+        AnyMessageLikeEventContent, EventContent as _, RawExt as _,
+        room::{MediaSource, message::RoomMessageEventContent},
+    },
+    serde::Raw,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -24,32 +24,32 @@ use async_trait::async_trait;
 use growable_bloom_filter::GrowableBloom;
 use matrix_sdk_common::AsyncTraitDeps;
 use ruma::{
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomId,
+    OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
     api::MatrixVersion,
     events::{
-        presence::PresenceEvent,
-        receipt::{Receipt, ReceiptThread, ReceiptType},
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, EmptyStateKey, GlobalAccountDataEvent,
         GlobalAccountDataEventContent, GlobalAccountDataEventType, RedactContent,
         RedactedStateEventContent, RoomAccountDataEvent, RoomAccountDataEventContent,
         RoomAccountDataEventType, StateEventType, StaticEventContent, StaticStateEventContent,
+        presence::PresenceEvent,
+        receipt::{Receipt, ReceiptThread, ReceiptType},
     },
     serde::Raw,
     time::SystemTime,
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomId,
-    OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
 };
 use serde::{Deserialize, Serialize};
 
 use super::{
-    send_queue::SentRequestKey, ChildTransactionId, DependentQueuedRequest,
-    DependentQueuedRequestKind, QueueWedgeError, QueuedRequest, QueuedRequestKind,
-    RoomLoadSettings, StateChanges, StoreError,
+    ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind, QueueWedgeError,
+    QueuedRequest, QueuedRequestKind, RoomLoadSettings, StateChanges, StoreError,
+    send_queue::SentRequestKey,
 };
 use crate::{
+    MinimalRoomMemberEvent, RoomInfo, RoomMemberships,
     deserialized_responses::{
         DisplayName, RawAnySyncOrStrippedState, RawMemberEvent, RawSyncOrStrippedState,
     },
-    MinimalRoomMemberEvent, RoomInfo, RoomMemberships,
 };
 
 /// An abstract state store trait that can be used to implement different stores
@@ -1171,7 +1171,7 @@ impl StateStoreDataKey<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::{now_timestamp_ms, ServerCapabilities};
+    use super::{ServerCapabilities, now_timestamp_ms};
 
     #[test]
     fn test_stale_server_capabilities() {

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -24,14 +24,14 @@ pub use ruma::api::client::sync::sync_events::v3::{
     InvitedRoom as InvitedRoomUpdate, KnockedRoom as KnockedRoomUpdate,
 };
 use ruma::{
+    OwnedEventId, OwnedRoomId,
     api::client::sync::sync_events::UnreadNotificationsCount as RumaUnreadNotificationsCount,
     events::{
-        presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
-        AnySyncEphemeralRoomEvent, AnySyncStateEvent,
+        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncEphemeralRoomEvent,
+        AnySyncStateEvent, presence::PresenceEvent,
     },
     push::Action,
     serde::Raw,
-    OwnedEventId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/matrix-sdk-base/src/test_utils.rs
+++ b/crates/matrix-sdk-base/src/test_utils.rs
@@ -16,11 +16,11 @@
 
 #![allow(dead_code)]
 
-use ruma::{owned_user_id, UserId};
+use ruma::{UserId, owned_user_id};
 
 use crate::{
-    store::{RoomLoadSettings, StoreConfig},
     BaseClient, SessionMeta,
+    store::{RoomLoadSettings, StoreConfig},
 };
 
 /// Create a [`BaseClient`] with the given user id, if provided, or an hardcoded

--- a/crates/matrix-sdk-base/src/utils.rs
+++ b/crates/matrix-sdk-base/src/utils.rs
@@ -1,6 +1,8 @@
 use ruma::{
-    assign,
+    EventId, OwnedEventId, RoomVersionId, assign,
     events::{
+        RedactContent, RedactedStateEventContent, StateEventContent, StaticStateEventContent,
+        SyncStateEvent,
         room::{
             avatar::{RoomAvatarEventContent, StrippedRoomAvatarEvent},
             canonical_alias::{RoomCanonicalAliasEventContent, StrippedRoomCanonicalAliasEvent},
@@ -21,12 +23,9 @@ use ruma::{
             },
             topic::{RedactedRoomTopicEventContent, RoomTopicEventContent, StrippedRoomTopicEvent},
         },
-        RedactContent, RedactedStateEventContent, StateEventContent, StaticStateEventContent,
-        SyncStateEvent,
     },
-    EventId, OwnedEventId, RoomVersionId,
 };
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::room::RoomCreateWithCreatorEventContent;
 

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -17,13 +17,13 @@ use std::{collections::BTreeMap, fmt, sync::Arc};
 #[cfg(doc)]
 use ruma::events::AnyTimelineEvent;
 use ruma::{
+    DeviceKeyAlgorithm, OwnedDeviceId, OwnedEventId, OwnedUserId,
     events::{AnyMessageLikeEvent, AnySyncTimelineEvent, AnyToDeviceEvent},
     push::Action,
     serde::{
         AsRefStr, AsStrAsRefStr, DebugAsRefStr, DeserializeFromCowStr, FromString, JsonObject, Raw,
         SerializeAsRefStr,
     },
-    DeviceKeyAlgorithm, OwnedDeviceId, OwnedEventId, OwnedUserId,
 };
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -42,8 +42,7 @@ const VERIFICATION_VIOLATION: &str =
     "Encrypted by a previously-verified user who is no longer verified.";
 const UNSIGNED_DEVICE: &str = "Encrypted by a device not verified by its owner.";
 const UNKNOWN_DEVICE: &str = "Encrypted by an unknown or deleted device.";
-const MISMATCHED_SENDER: &str =
-    "The sender of the event does not match the owner of the device that created the Megolm session.";
+const MISMATCHED_SENDER: &str = "The sender of the event does not match the owner of the device that created the Megolm session.";
 pub const SENT_IN_CLEAR: &str = "Not encrypted.";
 
 /// Represents the state of verification for a decrypted message sent by a
@@ -1220,8 +1219,8 @@ mod tests {
     use assert_matches2::assert_let;
     use insta::{assert_json_snapshot, with_settings};
     use ruma::{
-        device_id, event_id, events::room::message::RoomMessageEventContent, serde::Raw, user_id,
-        DeviceKeyAlgorithm,
+        DeviceKeyAlgorithm, device_id, event_id, events::room::message::RoomMessageEventContent,
+        serde::Raw, user_id,
     };
     use serde::Deserialize;
     use serde_json::json;

--- a/crates/matrix-sdk-common/src/executor.rs
+++ b/crates/matrix-sdk-common/src/executor.rs
@@ -23,7 +23,7 @@
 mod sys {
     pub use tokio::{
         runtime::{Handle, Runtime},
-        task::{spawn, AbortHandle, JoinError, JoinHandle},
+        task::{AbortHandle, JoinError, JoinHandle, spawn},
     };
 }
 
@@ -37,8 +37,8 @@ mod sys {
 
     pub use futures_util::future::AbortHandle;
     use futures_util::{
-        future::{Abortable, RemoteHandle},
         FutureExt,
+        future::{Abortable, RemoteHandle},
     };
 
     /// A Wasm specific version of `tokio::task::JoinError` designed to work

--- a/crates/matrix-sdk-common/src/js_tracing.rs
+++ b/crates/matrix-sdk-common/src/js_tracing.rs
@@ -23,11 +23,11 @@ use std::{
     sync::atomic::{AtomicU32, Ordering},
 };
 
-use tracing::{field::Field, level_filters::LevelFilter, Event, Level, Metadata};
+use tracing::{Event, Level, Metadata, field::Field, level_filters::LevelFilter};
 use tracing_subscriber::{
     fmt::{
-        format::{DefaultFields, Writer},
         FmtContext, FormatEvent, FormatFields, FormattedFields, MakeWriter, Subscriber,
+        format::{DefaultFields, Writer},
     },
     registry::LookupSpan,
 };

--- a/crates/matrix-sdk-common/src/linked_chunk/as_vector.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/as_vector.rs
@@ -22,8 +22,8 @@ use std::{
 use eyeball_im::VectorDiff;
 
 use super::{
-    updates::{ReaderToken, Update, UpdatesInner},
     ChunkContent, ChunkIdentifier, Iter, Position,
+    updates::{ReaderToken, Update, UpdatesInner},
 };
 
 /// A type alias to represent a chunk's length. This is purely for commodity.
@@ -470,7 +470,7 @@ mod tests {
     use std::fmt::Debug;
 
     use assert_matches::assert_matches;
-    use imbl::{vector, Vector};
+    use imbl::{Vector, vector};
 
     use super::{
         super::{Chunk, ChunkIdentifierGenerator, LinkedChunk, Update},

--- a/crates/matrix-sdk-common/src/linked_chunk/lazy_loader.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/lazy_loader.rs
@@ -371,9 +371,9 @@ mod tests {
     use assert_matches::assert_matches;
 
     use super::{
-        super::Position, from_all_chunks, from_last_chunk, insert_new_first_chunk, replace_with,
-        ChunkContent, ChunkIdentifier, ChunkIdentifierGenerator, LazyLoaderError, LinkedChunk,
-        RawChunk, Update,
+        super::Position, ChunkContent, ChunkIdentifier, ChunkIdentifierGenerator, LazyLoaderError,
+        LinkedChunk, RawChunk, Update, from_all_chunks, from_last_chunk, insert_new_first_chunk,
+        replace_with,
     };
 
     #[test]

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -486,7 +486,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
         let chunk = match &mut chunk.content {
             ChunkContent::Gap(..) => {
-                return Err(Error::ChunkIsAGap { identifier: chunk_identifier })
+                return Err(Error::ChunkIsAGap { identifier: chunk_identifier });
             }
 
             ChunkContent::Items(current_items) => {
@@ -574,7 +574,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
             let can_unlink_chunk = match &mut chunk.content {
                 ChunkContent::Gap(..) => {
-                    return Err(Error::ChunkIsAGap { identifier: chunk_identifier })
+                    return Err(Error::ChunkIsAGap { identifier: chunk_identifier });
                 }
 
                 ChunkContent::Items(current_items) => {
@@ -644,7 +644,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
         match &mut chunk.content {
             ChunkContent::Gap(..) => {
-                return Err(Error::ChunkIsAGap { identifier: chunk_identifier })
+                return Err(Error::ChunkIsAGap { identifier: chunk_identifier });
             }
 
             ChunkContent::Items(current_items) => {
@@ -1158,7 +1158,9 @@ impl ChunkIdentifierGenerator {
         // Check for overflows.
         // unlikely — TODO: call `std::intrinsics::unlikely` once it's stable.
         if previous == u64::MAX {
-            panic!("No more chunk identifiers available. Congrats, you did it. 2^64 identifiers have been consumed.")
+            panic!(
+                "No more chunk identifiers available. Congrats, you did it. 2^64 identifiers have been consumed."
+            )
         }
 
         ChunkIdentifier(previous + 1)
@@ -1725,7 +1727,7 @@ pub struct RawChunk<Item, Gap> {
 mod tests {
     use std::{
         ops::Not,
-        sync::{atomic::Ordering, Arc},
+        sync::{Arc, atomic::Ordering},
     };
 
     use assert_matches::assert_matches;

--- a/crates/matrix-sdk-common/src/ring_buffer.rs
+++ b/crates/matrix-sdk-common/src/ring_buffer.rs
@@ -14,8 +14,8 @@
 
 use std::{
     collections::{
-        vec_deque::{Drain, Iter, IterMut},
         VecDeque,
+        vec_deque::{Drain, Iter, IterMut},
     },
     num::NonZeroUsize,
     ops::RangeBounds,

--- a/crates/matrix-sdk-common/src/serde_helpers.rs
+++ b/crates/matrix-sdk-common/src/serde_helpers.rs
@@ -16,9 +16,9 @@
 //! to access some fields.
 
 use ruma::{
-    events::{relation::BundledThread, AnyMessageLikeEvent, AnySyncTimelineEvent},
-    serde::Raw,
     OwnedEventId, UInt,
+    events::{AnyMessageLikeEvent, AnySyncTimelineEvent, relation::BundledThread},
+    serde::Raw,
 };
 use serde::Deserialize;
 

--- a/crates/matrix-sdk-common/src/store_locks.rs
+++ b/crates/matrix-sdk-common/src/store_locks.rs
@@ -41,8 +41,8 @@ use std::{
     error::Error,
     future::Future,
     sync::{
-        atomic::{self, AtomicU32},
         Arc,
+        atomic::{self, AtomicU32},
     },
     time::Duration,
 };
@@ -51,9 +51,9 @@ use tokio::sync::Mutex;
 use tracing::{debug, error, instrument, trace};
 
 use crate::{
-    executor::{spawn, JoinHandle},
-    sleep::sleep,
     SendOutsideWasm,
+    executor::{JoinHandle, spawn},
+    sleep::sleep,
 };
 
 /// Backing store for a cross-process lock.
@@ -356,7 +356,7 @@ pub enum LockStoreError {
 mod tests {
     use std::{
         collections::HashMap,
-        sync::{atomic, Arc, RwLock},
+        sync::{Arc, RwLock, atomic},
         time::Instant,
     };
 
@@ -364,12 +364,12 @@ mod tests {
     use matrix_sdk_test_macros::async_test;
     use tokio::{
         spawn,
-        time::{sleep, Duration},
+        time::{Duration, sleep},
     };
 
     use super::{
-        memory_store_helper::try_take_leased_lock, BackingStore, CrossProcessStoreLock,
-        CrossProcessStoreLockGuard, LockStoreError, EXTEND_LEASE_EVERY_MS,
+        BackingStore, CrossProcessStoreLock, CrossProcessStoreLockGuard, EXTEND_LEASE_EVERY_MS,
+        LockStoreError, memory_store_helper::try_take_leased_lock,
     };
 
     #[derive(Clone, Default)]
@@ -516,7 +516,7 @@ mod tests {
 /// Some code that is shared by almost all `MemoryStore` implementations out
 /// there.
 pub mod memory_store_helper {
-    use std::collections::{hash_map::Entry, HashMap};
+    use std::collections::{HashMap, hash_map::Entry};
 
     use ruma::time::{Duration, Instant};
 

--- a/crates/matrix-sdk-common/src/stream.rs
+++ b/crates/matrix-sdk-common/src/stream.rs
@@ -22,7 +22,7 @@
 #[cfg(not(target_family = "wasm"))]
 mod sys {
     // On native platforms, just re-export everything from futures_util
-    pub use futures_util::{stream::BoxStream, StreamExt};
+    pub use futures_util::{StreamExt, stream::BoxStream};
 }
 
 #[cfg(target_family = "wasm")]

--- a/crates/matrix-sdk-common/src/timeout.rs
+++ b/crates/matrix-sdk-common/src/timeout.rs
@@ -16,7 +16,7 @@ use std::{error::Error, fmt, time::Duration};
 
 use futures_core::Future;
 #[cfg(target_family = "wasm")]
-use futures_util::future::{select, Either};
+use futures_util::future::{Either, select};
 #[cfg(target_family = "wasm")]
 use gloo_timers::future::TimeoutFuture;
 #[cfg(not(target_family = "wasm"))]

--- a/crates/matrix-sdk-common/src/tracing_timer.rs
+++ b/crates/matrix-sdk-common/src/tracing_timer.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use ruma::time::Instant;
-use tracing::{callsite::DefaultCallsite, Callsite as _};
+use tracing::{Callsite as _, callsite::DefaultCallsite};
 
 /// A named RAII that will show on `Drop` how long its covered section took to
 /// execute.
@@ -124,7 +124,7 @@ mod tests {
     #[cfg(not(target_family = "wasm"))]
     #[matrix_sdk_test_macros::async_test]
     async fn test_timer_name() {
-        use tracing::{span, Level};
+        use tracing::{Level, span};
 
         tracing::warn!("Starting test...");
 

--- a/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
@@ -19,7 +19,7 @@ use ruma::{
     api::client::backup::{EncryptedSessionDataInit, KeyBackupData, KeyBackupDataInit},
     serde::Base64,
 };
-use vodozemac::{pk_encryption::PkEncryption, Curve25519PublicKey};
+use vodozemac::{Curve25519PublicKey, pk_encryption::PkEncryption};
 use zeroize::Zeroizing;
 
 use super::decryption::DecodeError;

--- a/crates/matrix-sdk-crypto/src/backups/keys/decryption.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/decryption.rs
@@ -20,8 +20,8 @@ use std::{
 use ruma::api::client::backup::EncryptedSessionData;
 use thiserror::Error;
 use vodozemac::{
-    pk_encryption::{Message, PkDecryption},
     Curve25519PublicKey, Curve25519SecretKey,
+    pk_encryption::{Message, PkDecryption},
 };
 use zeroize::{Zeroize, Zeroizing};
 

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -29,20 +29,20 @@ use std::{
 };
 
 use ruma::{
-    api::client::backup::RoomKeyBackup, serde::Raw, DeviceId, DeviceKeyAlgorithm, OwnedDeviceId,
-    OwnedRoomId, OwnedTransactionId, RoomId, TransactionId,
+    DeviceId, DeviceKeyAlgorithm, OwnedDeviceId, OwnedRoomId, OwnedTransactionId, RoomId,
+    TransactionId, api::client::backup::RoomKeyBackup, serde::Raw,
 };
 use tokio::sync::RwLock;
 use tracing::{debug, info, instrument, trace, warn};
 
 use crate::{
+    CryptoStoreError, Device, RoomKeyImportResult, SignatureError,
     olm::{BackedUpRoomKey, ExportedRoomKey, InboundGroupSession, SignedJsonObject},
     store::{
-        types::{BackupDecryptionKey, BackupKeys, Changes, RoomKeyCounts},
         Store,
+        types::{BackupDecryptionKey, BackupKeys, Changes, RoomKeyCounts},
     },
-    types::{requests::KeysBackupRequest, MegolmV1AuthData, RoomKeyBackupInfo, Signatures},
-    CryptoStoreError, Device, RoomKeyImportResult, SignatureError,
+    types::{MegolmV1AuthData, RoomKeyBackupInfo, Signatures, requests::KeysBackupRequest},
 };
 
 mod keys;
@@ -641,18 +641,18 @@ mod tests {
 
     use assert_matches2::assert_let;
     use matrix_sdk_test::async_test;
-    use ruma::{device_id, room_id, user_id, CanonicalJsonValue, DeviceId, RoomId, UserId};
+    use ruma::{CanonicalJsonValue, DeviceId, RoomId, UserId, device_id, room_id, user_id};
     use serde_json::json;
 
     use super::BackupMachine;
     use crate::{
+        OlmError, OlmMachine,
         olm::BackedUpRoomKey,
         store::{
-            types::{BackupDecryptionKey, Changes},
             CryptoStore, MemoryStore,
+            types::{BackupDecryptionKey, Changes},
         },
         types::RoomKeyBackupInfo,
-        OlmError, OlmMachine,
     };
 
     fn room_key() -> BackedUpRoomKey {

--- a/crates/matrix-sdk-crypto/src/ciphers.rs
+++ b/crates/matrix-sdk-crypto/src/ciphers.rs
@@ -13,17 +13,17 @@
 // limitations under the License.
 
 use aes::{
-    cipher::{generic_array::GenericArray, IvSizeUser, KeyIvInit, KeySizeUser, StreamCipher},
     Aes256,
+    cipher::{IvSizeUser, KeyIvInit, KeySizeUser, StreamCipher, generic_array::GenericArray},
 };
 use ctr::Ctr128BE;
 use hkdf::Hkdf;
 use hmac::{
-    digest::{FixedOutput, MacError},
     Hmac, Mac as _,
+    digest::{FixedOutput, MacError},
 };
 use pbkdf2::pbkdf2;
-use rand::{thread_rng, RngCore};
+use rand::{RngCore, thread_rng};
 use sha2::{Sha256, Sha512};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 

--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -44,23 +44,23 @@
 use std::sync::Arc;
 
 use ruma::{
-    api::client::dehydrated_device::{put_dehydrated_device, DehydratedDeviceData},
+    DeviceId,
+    api::client::dehydrated_device::{DehydratedDeviceData, put_dehydrated_device},
     assign,
     events::AnyToDeviceEvent,
     serde::Raw,
-    DeviceId,
 };
 use thiserror::Error;
 use tracing::{instrument, trace};
 use vodozemac::{DehydratedDeviceError, LibolmPickleError};
 
 use crate::{
+    Account, CryptoStoreError, EncryptionSyncChanges, OlmError, OlmMachine, SignatureError,
     store::{
-        types::{Changes, DehydratedDeviceKey, RoomKeyInfo},
         CryptoStoreWrapper, MemoryStore, Store,
+        types::{Changes, DehydratedDeviceKey, RoomKeyInfo},
     },
     verification::VerificationMachine,
-    Account, CryptoStoreError, EncryptionSyncChanges, OlmError, OlmMachine, SignatureError,
 };
 
 /// Error type for device dehydration issues.
@@ -401,6 +401,7 @@ mod tests {
     use js_option::JsOption;
     use matrix_sdk_test::async_test;
     use ruma::{
+        DeviceId, RoomId, TransactionId, UserId,
         api::client::{
             dehydrated_device::put_dehydrated_device,
             keys::get_keys::v3::Response as KeysQueryResponse,
@@ -410,10 +411,11 @@ mod tests {
         events::AnyToDeviceEvent,
         room_id,
         serde::Raw,
-        user_id, DeviceId, RoomId, TransactionId, UserId,
+        user_id,
     };
 
     use crate::{
+        EncryptionSettings, OlmMachine,
         dehydrated_devices::DehydratedDevice,
         machine::{
             test_helpers::{create_session, get_prepared_machine_test_helper},
@@ -421,9 +423,8 @@ mod tests {
         },
         olm::OutboundGroupSession,
         store::types::DehydratedDeviceKey,
-        types::{events::ToDeviceEvent, DeviceKeys as DeviceKeysType},
+        types::{DeviceKeys as DeviceKeysType, events::ToDeviceEvent},
         utilities::json_convert,
-        EncryptionSettings, OlmMachine,
     };
 
     fn pickle_key() -> DehydratedDeviceKey {

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -16,15 +16,15 @@ use std::collections::BTreeMap;
 
 use matrix_sdk_common::deserialized_responses::{VerificationLevel, WithheldCode};
 use ruma::{CanonicalJsonError, IdParseError, OwnedDeviceId, OwnedRoomId, OwnedUserId};
-use serde::{ser::SerializeMap, Serializer};
+use serde::{Serializer, ser::SerializeMap};
 use serde_json::Error as SerdeError;
 use thiserror::Error;
 use vodozemac::{Curve25519PublicKey, Ed25519PublicKey};
 
 use super::store::CryptoStoreError;
-use crate::{olm::SessionExportError, types::SignedKey};
 #[cfg(doc)]
 use crate::{CollectStrategy, Device, LocalTrust, OtherUserIdentity};
+use crate::{olm::SessionExportError, types::SignedKey};
 
 pub type OlmResult<T> = Result<T, OlmError>;
 pub type MegolmResult<T> = Result<T, MegolmError>;

--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -18,10 +18,10 @@ use std::{
 };
 
 use aes::{
-    cipher::{generic_array::GenericArray, KeyIvInit, StreamCipher},
     Aes256,
+    cipher::{KeyIvInit, StreamCipher, generic_array::GenericArray},
 };
-use rand::{thread_rng, RngCore};
+use rand::{RngCore, thread_rng};
 use ruma::{
     events::room::{EncryptedFile, JsonWebKey, JsonWebKeyInit},
     serde::Base64,

--- a/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
@@ -15,7 +15,7 @@
 use std::io::{Cursor, Read, Seek, SeekFrom};
 
 use byteorder::{BigEndian, ReadBytesExt};
-use rand::{thread_rng, RngCore};
+use rand::{RngCore, thread_rng};
 use serde_json::Error as SerdeError;
 use thiserror::Error;
 use vodozemac::{base64_decode, base64_encode};
@@ -243,8 +243,8 @@ mod tests {
         encrypt_room_key_export,
     };
     use crate::{
-        error::OlmResult, machine::test_helpers::get_prepared_machine_test_helper,
-        RoomKeyImportResult,
+        RoomKeyImportResult, error::OlmResult,
+        machine::test_helpers::get_prepared_machine_test_helper,
     };
 
     const PASSPHRASE: &str = "1234";

--- a/crates/matrix-sdk-crypto/src/file_encryption/mod.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/mod.rs
@@ -4,4 +4,4 @@ mod key_export;
 pub use attachments::{
     AttachmentDecryptor, AttachmentEncryptor, DecryptorError, MediaEncryptionInfo,
 };
-pub use key_export::{decrypt_room_key_export, encrypt_room_key_export, KeyExportError};
+pub use key_export::{KeyExportError, decrypt_room_key_export, encrypt_room_key_export};

--- a/crates/matrix-sdk-crypto/src/gossiping/mod.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/mod.rs
@@ -22,21 +22,22 @@ use std::{
 pub(crate) use machine::GossipMachine;
 use matrix_sdk_common::locks::RwLock as StdRwLock;
 use ruma::{
+    DeviceId, OwnedDeviceId, OwnedTransactionId, OwnedUserId, TransactionId, UserId,
     events::{
+        AnyToDeviceEventContent, ToDeviceEventType,
         room_key_request::{Action, ToDeviceRoomKeyRequestEventContent},
         secret::request::{
             RequestAction, SecretName, ToDeviceSecretRequestEvent as SecretRequestEvent,
             ToDeviceSecretRequestEventContent as SecretRequestEventContent,
         },
-        AnyToDeviceEventContent, ToDeviceEventType,
     },
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
-    DeviceId, OwnedDeviceId, OwnedTransactionId, OwnedUserId, TransactionId, UserId,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    Device,
     types::{
         events::{
             olm_v1::DecryptedSecretSendEvent,
@@ -44,7 +45,6 @@ use crate::{
         },
         requests::{OutgoingRequest, ToDeviceRequest},
     },
-    Device,
 };
 
 /// Struct containing a `m.secret.send` event and its acompanying info.

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -16,48 +16,48 @@ use std::{
     collections::{BTreeMap, HashMap},
     ops::Deref,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
 };
 
 use matrix_sdk_common::locks::RwLock;
 use ruma::{
-    api::client::keys::upload_signatures::v3::Request as SignatureUploadRequest,
-    events::{key::verification::VerificationMethod, AnyToDeviceEventContent},
-    serde::Raw,
     DeviceId, DeviceKeyAlgorithm, DeviceKeyId, MilliSecondsSinceUnixEpoch, OwnedDeviceId,
     OwnedDeviceKeyId, UInt, UserId,
+    api::client::keys::upload_signatures::v3::Request as SignatureUploadRequest,
+    events::{AnyToDeviceEventContent, key::verification::VerificationMethod},
+    serde::Raw,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{instrument, trace};
-use vodozemac::{olm::SessionConfig, Curve25519PublicKey, Ed25519PublicKey};
+use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, olm::SessionConfig};
 
 use super::{atomic_bool_deserializer, atomic_bool_serializer};
 #[cfg(any(test, feature = "testing", doc))]
 use crate::OlmMachine;
 use crate::{
+    Account, Sas, VerificationRequest,
     error::{MismatchedIdentityKeysError, OlmError, OlmResult, SignatureError},
     identities::{OwnUserIdentityData, UserIdentityData},
     olm::{
         InboundGroupSession, OutboundGroupSession, Session, ShareInfo, SignedJsonObject, VerifyJson,
     },
     store::{
+        CryptoStoreWrapper, Result as StoreResult,
         caches::SequenceNumber,
         types::{Changes, DeviceChanges},
-        CryptoStoreWrapper, Result as StoreResult,
     },
     types::{
+        DeviceKey, DeviceKeys, EventEncryptionAlgorithm, Signatures, SignedKey,
         events::{
-            forwarded_room_key::ForwardedRoomKeyContent,
-            room::encrypted::ToDeviceEncryptedEventContent, EventType,
+            EventType, forwarded_room_key::ForwardedRoomKeyContent,
+            room::encrypted::ToDeviceEncryptedEventContent,
         },
         requests::{OutgoingVerificationRequest, ToDeviceRequest},
-        DeviceKey, DeviceKeys, EventEncryptionAlgorithm, Signatures, SignedKey,
     },
     verification::VerificationMachine,
-    Account, Sas, VerificationRequest,
 };
 
 pub enum MaybeEncryptedRoomKey {
@@ -1045,12 +1045,12 @@ pub(crate) mod testing {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use ruma::{user_id, MilliSecondsSinceUnixEpoch};
+    use ruma::{MilliSecondsSinceUnixEpoch, user_id};
     use serde_json::json;
     use vodozemac::{Curve25519PublicKey, Ed25519PublicKey};
 
     use super::testing::{device_keys, get_device};
-    use crate::{identities::LocalTrust, DeviceData};
+    use crate::{DeviceData, identities::LocalTrust};
 
     #[test]
     fn create_a_device() {

--- a/crates/matrix-sdk-crypto/src/identities/mod.rs
+++ b/crates/matrix-sdk-crypto/src/identities/mod.rs
@@ -46,8 +46,8 @@ pub(crate) mod room_identity_state;
 pub(crate) mod user;
 
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc,
+    atomic::{AtomicBool, Ordering},
 };
 
 pub use device::{Device, DeviceData, LocalTrust, UserDevices};

--- a/crates/matrix-sdk-crypto/src/identities/room_identity_state.rs
+++ b/crates/matrix-sdk-crypto/src/identities/room_identity_state.rs
@@ -16,11 +16,11 @@ use std::{collections::HashMap, ops::Deref};
 
 use matrix_sdk_common::BoxFuture;
 use ruma::{
-    events::{
-        room::member::{MembershipState, SyncRoomMemberEvent},
-        SyncStateEvent,
-    },
     OwnedUserId, UserId,
+    events::{
+        SyncStateEvent,
+        room::member::{MembershipState, SyncRoomMemberEvent},
+    },
 };
 
 use super::UserIdentity;
@@ -333,23 +333,22 @@ mod tests {
     use matrix_sdk_common::BoxFuture;
     use matrix_sdk_test::async_test;
     use ruma::{
-        device_id,
+        MilliSecondsSinceUnixEpoch, OwnedUserId, UInt, UserId, device_id,
         events::{
+            OriginalSyncStateEvent,
             room::member::{
                 MembershipState, RoomMemberEventContent, RoomMemberUnsigned, SyncRoomMemberEvent,
             },
-            OriginalSyncStateEvent,
         },
-        owned_event_id, owned_user_id, user_id, MilliSecondsSinceUnixEpoch, OwnedUserId, UInt,
-        UserId,
+        owned_event_id, owned_user_id, user_id,
     };
 
     use super::{IdentityState, RoomIdentityChange, RoomIdentityProvider, RoomIdentityState};
     use crate::{
-        identities::user::testing::own_identity_wrapped,
-        store::{types::IdentityUpdates, Store},
         IdentityStatusChange, OtherUserIdentity, OtherUserIdentityData, OwnUserIdentityData,
         UserIdentity,
+        identities::user::testing::own_identity_wrapped,
+        store::{Store, types::IdentityUpdates},
     };
 
     #[async_test]
@@ -1112,10 +1111,10 @@ mod tests {
         use tokio::sync::Mutex;
 
         use crate::{
+            Account,
             olm::PrivateCrossSigningIdentity,
             store::{CryptoStoreWrapper, MemoryStore},
             verification::VerificationMachine,
-            Account,
         };
 
         let device_id = owned_device_id!("DEV123");
@@ -1152,10 +1151,10 @@ mod tests {
         use tokio::sync::Mutex;
 
         use crate::{
+            Account,
             olm::PrivateCrossSigningIdentity,
             store::{CryptoStoreWrapper, MemoryStore},
             verification::VerificationMachine,
-            Account,
         };
 
         let device_id = owned_device_id!("DEV123");

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -16,35 +16,35 @@ use std::{
     collections::HashMap,
     ops::{Deref, DerefMut},
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
 };
 
 use as_variant::as_variant;
 use matrix_sdk_common::locks::RwLock;
 use ruma::{
+    DeviceId, EventId, OwnedDeviceId, OwnedUserId, RoomId, UserId,
     api::client::keys::upload_signatures::v3::Request as SignatureUploadRequest,
     events::{
         key::verification::VerificationMethod, room::message::KeyVerificationRequestEventContent,
     },
-    DeviceId, EventId, OwnedDeviceId, OwnedUserId, RoomId, UserId,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use tracing::{error, info};
 
 use crate::{
+    CryptoStoreError, DeviceData, VerificationRequest,
     error::SignatureError,
     store::{
-        types::{Changes, IdentityChanges},
         Store,
+        types::{Changes, IdentityChanges},
     },
     types::{
-        requests::OutgoingVerificationRequest, MasterPubkey, SelfSigningPubkey, UserSigningPubkey,
+        MasterPubkey, SelfSigningPubkey, UserSigningPubkey, requests::OutgoingVerificationRequest,
     },
     verification::VerificationMachine,
-    CryptoStoreError, DeviceData, VerificationRequest,
 };
 
 /// Enum over the different user identity types we can have.
@@ -1211,11 +1211,12 @@ where
 pub(crate) mod testing {
     use matrix_sdk_test::ruma_response_from_json;
     use ruma::{
+        UserId,
         api::client::keys::{
             get_keys::v3::Response as KeyQueryResponse,
             upload_signatures::v3::Request as SignatureUploadRequest,
         },
-        user_id, UserId,
+        user_id,
     };
     use serde_json::json;
 
@@ -1224,8 +1225,8 @@ pub(crate) mod testing {
     use crate::{identities::manager::testing::other_user_id, olm::PrivateCrossSigningIdentity};
     use crate::{
         identities::{
-            manager::testing::{other_key_query, own_key_query},
             DeviceData,
+            manager::testing::{other_key_query, own_key_query},
         },
         store::Store,
         types::CrossSigningKey,
@@ -1413,29 +1414,29 @@ pub(crate) mod tests {
 
     use assert_matches::assert_matches;
     use matrix_sdk_test::{async_test, test_json};
-    use ruma::{device_id, user_id, TransactionId};
-    use serde_json::{json, Value};
+    use ruma::{TransactionId, device_id, user_id};
+    use serde_json::{Value, json};
     use tokio::sync::Mutex;
 
     use super::{
-        testing::{device, get_other_identity, get_own_identity},
         OtherUserIdentityDataSerializerV2, OwnUserIdentityData, OwnUserIdentityVerifiedState,
         UserIdentityData,
+        testing::{device, get_other_identity, get_own_identity},
     };
     use crate::{
+        CrossSigningKeyExport, OlmMachine, OtherUserIdentityData,
         identities::{
+            Device,
             manager::testing::own_key_query,
             user::{
-                testing::simulate_key_query_response_for_verification,
                 OtherUserIdentityDataSerializer,
+                testing::simulate_key_query_response_for_verification,
             },
-            Device,
         },
         olm::{Account, PrivateCrossSigningIdentity},
         store::{CryptoStoreWrapper, MemoryStore},
         types::{CrossSigningKey, MasterPubkey, SelfSigningPubkey, Signatures, UserSigningPubkey},
         verification::VerificationMachine,
-        CrossSigningKeyExport, OlmMachine, OtherUserIdentityData,
     };
 
     #[test]

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -82,8 +82,8 @@ pub use error::{
     SetRoomSettingsError, SignatureError,
 };
 pub use file_encryption::{
-    decrypt_room_key_export, encrypt_room_key_export, AttachmentDecryptor, AttachmentEncryptor,
-    DecryptorError, KeyExportError, MediaEncryptionInfo,
+    AttachmentDecryptor, AttachmentEncryptor, DecryptorError, KeyExportError, MediaEncryptionInfo,
+    decrypt_room_key_export, encrypt_room_key_export,
 };
 pub use gossiping::{GossipRequest, GossippedSecret};
 pub use identities::{
@@ -98,12 +98,12 @@ pub use olm::{Account, CrossSigningStatus, EncryptionSettings, Session};
 use serde::{Deserialize, Serialize};
 pub use session_manager::CollectStrategy;
 pub use store::{
-    types::{CrossSigningKeyExport, TrackedUser},
     CryptoStoreError, SecretImportError, SecretInfo,
+    types::{CrossSigningKeyExport, TrackedUser},
 };
 pub use verification::{
-    format_emojis, AcceptSettings, AcceptedProtocols, CancelInfo, Emoji, EmojiShortAuthString, Sas,
-    SasState, Verification, VerificationRequest, VerificationRequestState,
+    AcceptSettings, AcceptedProtocols, CancelInfo, Emoji, EmojiShortAuthString, Sas, SasState,
+    Verification, VerificationRequest, VerificationRequestState, format_emojis,
 };
 #[cfg(feature = "qrcode")]
 pub use verification::{QrVerification, QrVerificationState, ScanError};

--- a/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
+++ b/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
@@ -21,6 +21,7 @@ use as_variant::as_variant;
 use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
 use matrix_sdk_test::{ruma_response_from_json, test_json};
 use ruma::{
+    DeviceId, OwnedOneTimeKeyId, TransactionId, UserId,
     api::client::keys::{
         claim_keys,
         get_keys::{self, v3::Response as KeysQueryResponse},
@@ -31,24 +32,24 @@ use ruma::{
     events::dummy::ToDeviceDummyEventContent,
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
-    user_id, DeviceId, OwnedOneTimeKeyId, TransactionId, UserId,
+    user_id,
 };
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
 use crate::{
+    Account, CrossSigningBootstrapRequests, Device, DeviceData, EncryptionSyncChanges, OlmMachine,
+    OtherUserIdentityData,
     machine::tests,
     olm::PrivateCrossSigningIdentity,
-    store::{types::Changes, CryptoStoreWrapper, MemoryStore},
+    store::{CryptoStoreWrapper, MemoryStore, types::Changes},
     types::{
+        DeviceKeys,
         events::ToDeviceEvent,
         requests::{AnyOutgoingRequest, ToDeviceRequest},
-        DeviceKeys,
     },
     utilities::json_convert,
     verification::VerificationMachine,
-    Account, CrossSigningBootstrapRequests, Device, DeviceData, EncryptionSyncChanges, OlmMachine,
-    OtherUserIdentityData,
 };
 
 /// These keys need to be periodically uploaded to the server.

--- a/crates/matrix-sdk-crypto/src/machine/tests/megolm_sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/megolm_sender_data.rs
@@ -19,12 +19,13 @@ use futures_core::Stream;
 use futures_util::{FutureExt, StreamExt};
 use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
 use matrix_sdk_test::async_test;
-use ruma::{room_id, user_id, RoomId, TransactionId, UserId};
+use ruma::{RoomId, TransactionId, UserId, room_id, user_id};
 use serde::Serialize;
 use serde_json::json;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
 use crate::{
+    DeviceData, EncryptionSettings, EncryptionSyncChanges, OlmMachine, Session,
     machine::{
         test_helpers::{
             bootstrap_requests_to_keys_query_response,
@@ -34,8 +35,7 @@ use crate::{
     },
     olm::{InboundGroupSession, SenderData},
     store::types::RoomKeyInfo,
-    types::events::{room::encrypted::ToDeviceEncryptedEventContent, EventType, ToDeviceEvent},
-    DeviceData, EncryptionSettings, EncryptionSyncChanges, OlmMachine, Session,
+    types::events::{EventType, ToDeviceEvent, room::encrypted::ToDeviceEncryptedEventContent},
 };
 
 /// Test the behaviour when a megolm session is received from an unknown device,

--- a/crates/matrix-sdk-crypto/src/machine/tests/olm_encryption.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/olm_encryption.rs
@@ -21,14 +21,15 @@ use assert_matches2::assert_let;
 use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
 use matrix_sdk_test::async_test;
 use ruma::{
-    device_id,
-    events::{dummy::ToDeviceDummyEventContent, AnyToDeviceEvent},
-    user_id, DeviceKeyAlgorithm, DeviceKeyId, SecondsSinceUnixEpoch,
+    DeviceKeyAlgorithm, DeviceKeyId, SecondsSinceUnixEpoch, device_id,
+    events::{AnyToDeviceEvent, dummy::ToDeviceDummyEventContent},
+    user_id,
 };
 use serde_json::json;
 use vodozemac::Ed25519SecretKey;
 
 use crate::{
+    DeviceData, OlmMachine,
     machine::{
         test_helpers::{
             create_session, get_machine_pair, get_machine_pair_with_session,
@@ -39,8 +40,7 @@ use crate::{
     },
     olm::utility::SignJson,
     store::types::Changes,
-    types::{events::ToDeviceEvent, DeviceKeys},
-    DeviceData, OlmMachine,
+    types::{DeviceKeys, events::ToDeviceEvent},
 };
 
 #[async_test]

--- a/crates/matrix-sdk-crypto/src/machine/tests/room_settings.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/room_settings.rs
@@ -5,8 +5,8 @@ use matrix_sdk_test::async_test;
 use ruma::room_id;
 
 use crate::{
-    machine::tests, store::types::RoomSettings, types::EventEncryptionAlgorithm, OlmMachine,
-    SetRoomSettingsError,
+    OlmMachine, SetRoomSettingsError, machine::tests, store::types::RoomSettings,
+    types::EventEncryptionAlgorithm,
 };
 
 #[async_test]

--- a/crates/matrix-sdk-crypto/src/machine/tests/send_encrypted_to_device.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/send_encrypted_to_device.rs
@@ -19,9 +19,10 @@ use matrix_sdk_common::deserialized_responses::{
 };
 use matrix_sdk_test::async_test;
 use ruma::{events::AnyToDeviceEvent, serde::Raw, to_device::DeviceIdOrAllDevices};
-use serde_json::{json, value::to_raw_value, Value};
+use serde_json::{Value, json, value::to_raw_value};
 
 use crate::{
+    DeviceData, EncryptionSyncChanges, LocalTrust, OlmError, OlmMachine,
     machine::{
         test_helpers::{
             build_session_for_pair, get_machine_pair, get_machine_pair_with_session,
@@ -36,7 +37,6 @@ use crate::{
     },
     utilities::json_convert,
     verification::tests::bob_id,
-    DeviceData, EncryptionSyncChanges, LocalTrust, OlmError, OlmMachine,
 };
 
 #[async_test]
@@ -71,9 +71,11 @@ async fn test_send_encrypted_to_device() {
     assert!(messages.get(bob.user_id()).is_some());
     let target_devices = messages.get(bob.user_id()).unwrap();
     assert_eq!(1, target_devices.len());
-    assert!(target_devices
-        .get(&DeviceIdOrAllDevices::DeviceId(tests::bob_device_id().to_owned()))
-        .is_some());
+    assert!(
+        target_devices
+            .get(&DeviceIdOrAllDevices::DeviceId(tests::bob_device_id().to_owned()))
+            .is_some()
+    );
 
     let event = ToDeviceEvent::new(
         alice.user_id().to_owned(),

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -28,6 +28,9 @@ use matrix_sdk_common::deserialized_responses::{
 #[cfg(test)]
 use ruma::api::client::dehydrated_device::DehydratedDeviceV1;
 use ruma::{
+    DeviceId, DeviceKeyAlgorithm, DeviceKeyId, MilliSecondsSinceUnixEpoch, OneTimeKeyAlgorithm,
+    OneTimeKeyId, OwnedDeviceId, OwnedDeviceKeyId, OwnedOneTimeKeyId, OwnedUserId, RoomId,
+    SecondsSinceUnixEpoch, UInt, UserId,
     api::client::{
         dehydrated_device::{DehydratedDeviceData, DehydratedDeviceV2},
         keys::{
@@ -35,45 +38,43 @@ use ruma::{
             upload_signatures::v3::{Request as SignatureUploadRequest, SignedKeys},
         },
     },
-    events::{room::history_visibility::HistoryVisibility, AnyToDeviceEvent},
+    events::{AnyToDeviceEvent, room::history_visibility::HistoryVisibility},
     serde::Raw,
-    DeviceId, DeviceKeyAlgorithm, DeviceKeyId, MilliSecondsSinceUnixEpoch, OneTimeKeyAlgorithm,
-    OneTimeKeyId, OwnedDeviceId, OwnedDeviceKeyId, OwnedOneTimeKeyId, OwnedUserId, RoomId,
-    SecondsSinceUnixEpoch, UInt, UserId,
 };
-use serde::{de::Error, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error};
 use serde_json::{
-    value::{to_raw_value, RawValue as RawJsonValue},
     Value,
+    value::{RawValue as RawJsonValue, to_raw_value},
 };
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
-use tracing::{debug, field::debug, info, instrument, trace, warn, Span};
+use tracing::{Span, debug, field::debug, info, instrument, trace, warn};
 use vodozemac::{
-    base64_encode,
+    Curve25519PublicKey, Ed25519Signature, KeyId, PickleError, base64_encode,
     olm::{
         Account as InnerAccount, AccountPickle, IdentityKeys, OlmMessage,
         OneTimeKeyGenerationResult, PreKeyMessage, SessionConfig,
     },
-    Curve25519PublicKey, Ed25519Signature, KeyId, PickleError,
 };
 
 use super::{
-    utility::SignJson, EncryptionSettings, InboundGroupSession, OutboundGroupSession,
-    PrivateCrossSigningIdentity, Session, SessionCreationError as MegolmSessionCreationError,
+    EncryptionSettings, InboundGroupSession, OutboundGroupSession, PrivateCrossSigningIdentity,
+    Session, SessionCreationError as MegolmSessionCreationError, utility::SignJson,
 };
 #[cfg(feature = "experimental-algorithms")]
 use crate::types::events::room::encrypted::OlmV2Curve25519AesSha2Content;
 use crate::{
+    Device, OlmError, SignatureError,
     dehydrated_devices::DehydrationError,
     error::{EventError, OlmResult, SessionCreationError},
     identities::DeviceData,
     olm::SenderData,
     store::{
-        types::{Changes, DeviceChanges},
         Store,
+        types::{Changes, DeviceChanges},
     },
     types::{
+        CrossSigningKey, DeviceKeys, EventEncryptionAlgorithm, MasterPubkey, OneTimeKey, SignedKey,
         events::{
             olm_v1::AnyDecryptedOlmEvent,
             room::encrypted::{
@@ -82,9 +83,7 @@ use crate::{
             },
         },
         requests::UploadSigningKeysRequest,
-        CrossSigningKey, DeviceKeys, EventEncryptionAlgorithm, MasterPubkey, OneTimeKey, SignedKey,
     },
-    Device, OlmError, SignatureError,
 };
 
 #[derive(Debug)]
@@ -880,11 +879,7 @@ impl Account {
     pub fn signed_fallback_keys(&self) -> FallbackKeys {
         let fallback_key = self.fallback_key();
 
-        if fallback_key.is_empty() {
-            BTreeMap::new()
-        } else {
-            self.signed_keys(fallback_key, true)
-        }
+        if fallback_key.is_empty() { BTreeMap::new() } else { self.signed_keys(fallback_key, true) }
     }
 
     fn signed_keys(
@@ -1713,16 +1708,16 @@ mod tests {
     use anyhow::Result;
     use matrix_sdk_test::async_test;
     use ruma::{
-        device_id, events::room::history_visibility::HistoryVisibility, room_id, user_id, DeviceId,
-        MilliSecondsSinceUnixEpoch, OneTimeKeyAlgorithm, OneTimeKeyId, UserId,
+        DeviceId, MilliSecondsSinceUnixEpoch, OneTimeKeyAlgorithm, OneTimeKeyId, UserId, device_id,
+        events::room::history_visibility::HistoryVisibility, room_id, user_id,
     };
     use serde_json::json;
 
     use super::Account;
     use crate::{
-        olm::{account::shared_history_from_history_visibility, SignedJsonObject},
-        types::{DeviceKeys, SignedKey},
         DeviceData, EncryptionSettings,
+        olm::{SignedJsonObject, account::shared_history_from_history_visibility},
+        types::{DeviceKeys, SignedKey},
     };
 
     fn user_id() -> &'static UserId {

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -17,23 +17,23 @@ use std::{
     fmt,
     ops::Deref,
     sync::{
-        atomic::{AtomicBool, Ordering::SeqCst},
         Arc,
+        atomic::{AtomicBool, Ordering::SeqCst},
     },
 };
 
 use ruma::{
-    events::room::history_visibility::HistoryVisibility, serde::JsonObject, DeviceKeyAlgorithm,
-    OwnedRoomId, RoomId,
+    DeviceKeyAlgorithm, OwnedRoomId, RoomId, events::room::history_visibility::HistoryVisibility,
+    serde::JsonObject,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use vodozemac::{
+    Curve25519PublicKey, Ed25519PublicKey, PickleError,
     megolm::{
         DecryptedMessage, DecryptionError, InboundGroupSession as InnerSession,
         InboundGroupSessionPickle, MegolmMessage, SessionConfig, SessionOrdering,
     },
-    Curve25519PublicKey, Ed25519PublicKey, PickleError,
 };
 
 use super::{
@@ -45,7 +45,7 @@ use crate::types::events::room_key::RoomKeyContent;
 use crate::{
     error::{EventError, MegolmResult},
     types::{
-        deserialize_curve_key,
+        EventEncryptionAlgorithm, SigningKeys, deserialize_curve_key,
         events::{
             forwarded_room_key::{
                 ForwardedMegolmV1AesSha2Content, ForwardedMegolmV2AesSha2Content,
@@ -56,7 +56,7 @@ use crate::{
             room_key,
         },
         room_history::HistoricRoomKey,
-        serialize_curve_key, EventEncryptionAlgorithm, SigningKeys,
+        serialize_curve_key,
     },
 };
 // TODO: add creation times to the inbound group sessions so we can export
@@ -829,20 +829,20 @@ mod tests {
     use insta::assert_json_snapshot;
     use matrix_sdk_test::async_test;
     use ruma::{
-        device_id, events::room::history_visibility::HistoryVisibility, owned_room_id, room_id,
-        user_id, DeviceId, UserId,
+        DeviceId, UserId, device_id, events::room::history_visibility::HistoryVisibility,
+        owned_room_id, room_id, user_id,
     };
     use serde_json::json;
     use similar_asserts::assert_eq;
     use vodozemac::{
-        megolm::{SessionKey, SessionOrdering},
         Curve25519PublicKey, Ed25519PublicKey,
+        megolm::{SessionKey, SessionOrdering},
     };
 
     use crate::{
-        olm::{BackedUpRoomKey, ExportedRoomKey, InboundGroupSession, KnownSenderData, SenderData},
-        types::{events::room_key, EventEncryptionAlgorithm},
         Account,
+        olm::{BackedUpRoomKey, ExportedRoomKey, InboundGroupSession, KnownSenderData, SenderData},
+        types::{EventEncryptionAlgorithm, events::room_key},
     };
 
     fn alice_id() -> &'static UserId {

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -28,15 +28,15 @@ pub use outbound::{
 pub use sender_data::{KnownSenderData, SenderData, SenderDataType};
 use thiserror::Error;
 pub use vodozemac::megolm::{ExportedSessionKey, SessionKey};
-use vodozemac::{megolm::SessionKeyDecodeError, Curve25519PublicKey};
+use vodozemac::{Curve25519PublicKey, megolm::SessionKeyDecodeError};
 
 #[cfg(feature = "experimental-algorithms")]
 use crate::types::events::forwarded_room_key::ForwardedMegolmV2AesSha2Content;
 use crate::types::{
-    deserialize_curve_key, deserialize_curve_key_vec,
+    EventEncryptionAlgorithm, RoomKeyExport, SigningKey, SigningKeys, deserialize_curve_key,
+    deserialize_curve_key_vec,
     events::forwarded_room_key::{ForwardedMegolmV1AesSha2Content, ForwardedRoomKeyContent},
-    serialize_curve_key, serialize_curve_key_vec, EventEncryptionAlgorithm, RoomKeyExport,
-    SigningKey, SigningKeys,
+    serialize_curve_key, serialize_curve_key_vec,
 };
 
 /// An error type for the creation of group sessions.

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -15,13 +15,13 @@
 use std::{cmp::Ordering, fmt};
 
 use ruma::{DeviceId, OwnedDeviceId, OwnedUserId, UserId};
-use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de, de::Visitor};
 use tracing::error;
 use vodozemac::Ed25519PublicKey;
 
 use crate::{
-    types::{serialize_ed25519_key, DeviceKeys},
     Device,
+    types::{DeviceKeys, serialize_ed25519_key},
 };
 
 /// Information about the sender of a megolm session where we know the
@@ -426,20 +426,20 @@ mod tests {
     use insta::assert_json_snapshot;
     use matrix_sdk_test::async_test;
     use ruma::{
-        device_id, owned_device_id, owned_user_id, user_id, DeviceKeyAlgorithm, DeviceKeyId,
+        DeviceKeyAlgorithm, DeviceKeyId, device_id, owned_device_id, owned_user_id, user_id,
     };
     use serde_json::json;
-    use vodozemac::{base64_decode, Curve25519PublicKey, Ed25519PublicKey};
+    use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, base64_decode};
 
     use super::SenderData;
     use crate::{
+        Account,
         machine::test_helpers::{
             create_signed_device_of_unverified_user, create_signed_device_of_verified_user,
             create_unsigned_device,
         },
         olm::{KnownSenderData, PickledInboundGroupSession, PrivateCrossSigningIdentity},
         types::{DeviceKey, DeviceKeys, EventEncryptionAlgorithm, Signatures},
-        Account,
     };
 
     #[test]
@@ -706,8 +706,7 @@ mod tests {
         // This export usse a more efficient serialization format for bytes. This was
         // exported when the `KnownSenderData` master_key was serialized as an byte
         // array instead of a base64 encoded string.
-        const SERIALIZED_B64: &str =
-            "iaZwaWNrbGWEr2luaXRpYWxfcmF0Y2hldIKlaW5uZXLcAIABYMzfSnBRzMlPKF1uKjYbzLtkzNJ4RcylzN0HzP\
+        const SERIALIZED_B64: &str = "iaZwaWNrbGWEr2luaXRpYWxfcmF0Y2hldIKlaW5uZXLcAIABYMzfSnBRzMlPKF1uKjYbzLtkzNJ4RcylzN0HzP\
              9DzON1Tm05zO7M2MzFQsy9Acz9zPnMqDvM4syQzNrMzxF5KzbM4sy9zPUbBWfM7m4/zJzM18zDzMESKgfMkE7M\
              yszIHszqWjYyQURbzKTMkx7M58zANsy+AGPM2A8tbcyFYczge8ykzMFdbVxJMMyAzN8azJEXGsy8zPJazMMaP8\
              ziDszmWwfM+My2ajLMr8y+eczTRm9TFadjb3VudGVyAKtzaWduaW5nX2tlecQgefpCr6Duu7QUWzKIeMOFmxv/\

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
@@ -17,8 +17,8 @@ use vodozemac::Curve25519PublicKey;
 
 use super::{InboundGroupSession, SenderData};
 use crate::{
-    error::MismatchedIdentityKeysError, store::Store, types::events::olm_v1::DecryptedRoomKeyEvent,
     CryptoStoreError, Device, DeviceData, MegolmError, OlmError, SignatureError,
+    error::MismatchedIdentityKeysError, store::Store, types::events::olm_v1::DecryptedRoomKeyEvent,
 };
 
 /// Temporary struct that is used to look up [`SenderData`] based on the
@@ -330,31 +330,31 @@ mod tests {
 
     use assert_matches2::assert_let;
     use matrix_sdk_test::async_test;
-    use ruma::{device_id, room_id, user_id, DeviceId, OwnedUserId, RoomId, UserId};
+    use ruma::{DeviceId, OwnedUserId, RoomId, UserId, device_id, room_id, user_id};
     use tokio::sync::Mutex;
-    use vodozemac::{megolm::SessionKey, Curve25519PublicKey, Ed25519PublicKey};
+    use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, megolm::SessionKey};
 
     use super::SenderDataFinder;
     use crate::{
+        Account, Device, OtherUserIdentityData, OwnUserIdentityData, UserIdentityData,
         error::MismatchedIdentityKeysError,
         machine::test_helpers::{
             create_signed_device_of_unverified_user, create_unsigned_device,
             sign_user_identity_data,
         },
         olm::{
-            group_sessions::sender_data_finder::SessionDeviceKeysCheckError, InboundGroupSession,
-            KnownSenderData, PrivateCrossSigningIdentity, SenderData,
+            InboundGroupSession, KnownSenderData, PrivateCrossSigningIdentity, SenderData,
+            group_sessions::sender_data_finder::SessionDeviceKeysCheckError,
         },
-        store::{types::Changes, CryptoStoreWrapper, MemoryStore, Store},
+        store::{CryptoStoreWrapper, MemoryStore, Store, types::Changes},
         types::{
+            EventEncryptionAlgorithm,
             events::{
                 olm_v1::DecryptedRoomKeyEvent,
                 room_key::{MegolmV1AesSha2Content, RoomKeyContent},
             },
-            EventEncryptionAlgorithm,
         },
         verification::VerificationMachine,
-        Account, Device, OtherUserIdentityData, OwnUserIdentityData, UserIdentityData,
     };
 
     impl<'a> SenderDataFinder<'a> {

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -25,36 +25,36 @@ pub(crate) mod utility;
 
 pub use account::{Account, OlmMessageHash, PickledAccount, StaticAccountData};
 pub(crate) use account::{OlmDecryptionInfo, SessionType};
-pub(crate) use group_sessions::{
-    sender_data_finder::{self, SenderDataFinder},
-    ShareState,
-};
 pub use group_sessions::{
     BackedUpRoomKey, EncryptionSettings, ExportedRoomKey, InboundGroupSession, KnownSenderData,
     OutboundGroupSession, PickledInboundGroupSession, PickledOutboundGroupSession, SenderData,
     SenderDataType, SessionCreationError, SessionExportError, SessionKey, ShareInfo,
 };
+pub(crate) use group_sessions::{
+    ShareState,
+    sender_data_finder::{self, SenderDataFinder},
+};
 pub use session::{PickledSession, Session};
 pub use signing::{CrossSigningStatus, PickledCrossSigningIdentity, PrivateCrossSigningIdentity};
 pub(crate) use utility::{SignedJsonObject, VerifyJson};
-pub use vodozemac::{olm::IdentityKeys, Curve25519PublicKey};
+pub use vodozemac::{Curve25519PublicKey, olm::IdentityKeys};
 
 #[cfg(test)]
 pub(crate) mod tests {
     use assert_matches::assert_matches;
     use matrix_sdk_test::{async_test, message_like_event_content};
     use ruma::{
-        device_id, event_id,
+        DeviceId, UserId, device_id, event_id,
         events::{
+            AnyMessageLikeEvent, AnyTimelineEvent, MessageLikeEvent,
             relation::Replacement,
             room::message::{Relation, RoomMessageEventContent},
-            AnyMessageLikeEvent, AnyTimelineEvent, MessageLikeEvent,
         },
         room_id,
         serde::Raw,
-        user_id, DeviceId, UserId,
+        user_id,
     };
-    use serde_json::{from_value, json, Value};
+    use serde_json::{Value, from_value, json};
     use vodozemac::olm::{OlmMessage, SessionConfig};
 
     use crate::{

--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -14,29 +14,29 @@
 
 use std::{fmt, sync::Arc};
 
-use ruma::{serde::Raw, SecondsSinceUnixEpoch};
+use ruma::{SecondsSinceUnixEpoch, serde::Raw};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::Mutex;
-use tracing::{debug, Span};
+use tracing::{Span, debug};
 use vodozemac::{
-    olm::{DecryptionError, OlmMessage, Session as InnerSession, SessionConfig, SessionPickle},
     Curve25519PublicKey,
+    olm::{DecryptionError, OlmMessage, Session as InnerSession, SessionConfig, SessionPickle},
 };
 
 #[cfg(feature = "experimental-algorithms")]
 use crate::types::events::room::encrypted::OlmV2Curve25519AesSha2Content;
 use crate::{
+    DeviceData,
     error::{EventError, OlmResult, SessionUnpickleError},
     types::{
+        DeviceKeys, EventEncryptionAlgorithm,
         events::{
+            EventType,
             olm_v1::{DecryptedOlmV1Event, OlmV1Keys},
             room::encrypted::{OlmV1Curve25519AesSha2Content, ToDeviceEncryptedEventContent},
-            EventType,
         },
-        DeviceKeys, EventEncryptionAlgorithm,
     },
-    DeviceData,
 };
 
 /// Cryptographic session that enables secure communication between two

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -15,15 +15,15 @@
 mod pk_signing;
 
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc,
+    atomic::{AtomicBool, Ordering},
 };
 
 pub use pk_signing::{MasterSigning, PickledSignings, SelfSigning, SigningError, UserSigning};
 use ruma::{
+    DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceId, OwnedDeviceKeyId, OwnedUserId, UserId,
     api::client::keys::upload_signatures::v3::{Request as SignatureUploadRequest, SignedKeys},
     events::secret::request::SecretName,
-    DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceId, OwnedDeviceKeyId, OwnedUserId, UserId,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
@@ -31,13 +31,13 @@ use vodozemac::Ed25519Signature;
 
 use super::StaticAccountData;
 use crate::{
+    Account, DeviceData, OtherUserIdentityData, OwnUserIdentity, OwnUserIdentityData,
     error::SignatureError,
     store::SecretImportError,
     types::{
-        requests::UploadSigningKeysRequest, DeviceKeys, MasterPubkey, SelfSigningPubkey,
-        UserSigningPubkey,
+        DeviceKeys, MasterPubkey, SelfSigningPubkey, UserSigningPubkey,
+        requests::UploadSigningKeysRequest,
     },
-    Account, DeviceData, OtherUserIdentityData, OwnUserIdentity, OwnUserIdentityData,
 };
 
 /// Private cross signing identity.
@@ -637,10 +637,10 @@ mod tests {
     use std::sync::Arc;
 
     use matrix_sdk_test::async_test;
-    use ruma::{device_id, user_id, CanonicalJsonValue, DeviceKeyAlgorithm, DeviceKeyId, UserId};
+    use ruma::{CanonicalJsonValue, DeviceKeyAlgorithm, DeviceKeyId, UserId, device_id, user_id};
     use serde_json::json;
 
-    use super::{pk_signing::Signing, PrivateCrossSigningIdentity};
+    use super::{PrivateCrossSigningIdentity, pk_signing::Signing};
     use crate::{
         identities::{DeviceData, OtherUserIdentityData},
         olm::{Account, SignedJsonObject, VerifyJson},

--- a/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ruma::{encryption::KeyUsage, DeviceKeyAlgorithm, DeviceKeyId, OwnedUserId};
+use ruma::{DeviceKeyAlgorithm, DeviceKeyId, OwnedUserId, encryption::KeyUsage};
 use serde::{Deserialize, Serialize};
 use serde_json::{Error as JsonError, Value};
 use thiserror::Error;
@@ -20,13 +20,13 @@ use vodozemac::{DecodeError, Ed25519PublicKey, Ed25519SecretKey, Ed25519Signatur
 use zeroize::Zeroize;
 
 use crate::{
+    OtherUserIdentityData,
     error::SignatureError,
     olm::utility::SignJson,
     types::{
         CrossSigningKey, DeviceKeys, MasterPubkey, SelfSigningPubkey, Signatures, SigningKeys,
         UserSigningPubkey,
     },
-    OtherUserIdentityData,
 };
 
 /// Error type reporting failures in the signing operations.

--- a/crates/matrix-sdk-crypto/src/olm/utility.rs
+++ b/crates/matrix-sdk-crypto/src/olm/utility.rs
@@ -15,7 +15,7 @@
 use ruma::{CanonicalJsonValue, DeviceKeyAlgorithm, DeviceKeyId, UserId};
 use serde::Serialize;
 use serde_json::Value;
-use vodozemac::{olm::Account, Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature};
+use vodozemac::{Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature, olm::Account};
 
 use crate::{
     error::SignatureError,
@@ -200,7 +200,7 @@ impl SignedJsonObject for crate::types::MegolmV1AuthData {
 
 #[cfg(test)]
 mod tests {
-    use ruma::{device_id, user_id, DeviceKeyAlgorithm, DeviceKeyId};
+    use ruma::{DeviceKeyAlgorithm, DeviceKeyId, device_id, user_id};
     use serde_json::json;
     use vodozemac::Ed25519PublicKey;
 

--- a/crates/matrix-sdk-crypto/src/secret_storage.rs
+++ b/crates/matrix-sdk-crypto/src/secret_storage.rs
@@ -19,15 +19,18 @@
 
 use std::fmt;
 
-pub use hmac::digest::MacError;
 use hmac::Hmac;
+pub use hmac::digest::MacError;
 use pbkdf2::pbkdf2;
 use rand::{
+    RngCore,
     distributions::{Alphanumeric, DistString},
-    thread_rng, RngCore,
+    thread_rng,
 };
 use ruma::{
+    UInt,
     events::{
+        EventContent, GlobalAccountDataEventType,
         secret::request::SecretName,
         secret_storage::{
             key::{
@@ -36,10 +39,8 @@ use ruma::{
             },
             secret::SecretEncryptedData,
         },
-        EventContent, GlobalAccountDataEventType,
     },
     serde::Base64,
-    UInt,
 };
 use serde::de::Error;
 use sha2::Sha512;
@@ -78,11 +79,15 @@ pub enum DecodeError {
     Mac(#[from] MacError),
     /// The MAC of the secret storage key for the MAC check has an incorrect
     /// length.
-    #[error("The MAC of for the secret storage MAC check has an incorrect length, expected: {0}, got: {1}")]
+    #[error(
+        "The MAC of for the secret storage MAC check has an incorrect length, expected: {0}, got: {1}"
+    )]
     MacLength(usize, usize),
     /// The IV of the secret storage key for the MAC check has an incorrect
     /// length.
-    #[error("The IV of for the secret storage key MAC check has an incorrect length, expected: {0}, got: {1}")]
+    #[error(
+        "The IV of for the secret storage key MAC check has an incorrect length, expected: {0}, got: {1}"
+    )]
     IvLength(usize, usize),
     /// The secret storage key is using an unsupported secret encryption
     /// algorithm. Currently only the [`m.secret_storage.v1.aes-hmac-sha2`]
@@ -624,11 +629,13 @@ mod test {
         let content = to_raw_value(key.event_content())
             .expect("We should be able to serialize the secret storage key event content");
 
-        let content =
-            SecretStorageKeyEventContent::from_parts(&key.event_type().to_string(), &content)
-                .expect(
-                "We should be able to parse our, just serialized, secret storage key event content",
-            );
+        let content = SecretStorageKeyEventContent::from_parts(
+            &key.event_type().to_string(),
+            &content,
+        )
+        .expect(
+            "We should be able to parse our, just serialized, secret storage key event content",
+        );
 
         let key = SecretStorageKey::from_account_data(passphrase, content)
             .expect("We should be able to restore our secret storage key");
@@ -655,11 +662,13 @@ mod test {
         let content = to_raw_value(key.event_content())
             .expect("We should be able to serialize the secret storage key event content");
 
-        let content =
-            SecretStorageKeyEventContent::from_parts(&key.event_type().to_string(), &content)
-                .expect(
-                "We should be able to parse our, just serialized, secret storage key event content",
-            );
+        let content = SecretStorageKeyEventContent::from_parts(
+            &key.event_type().to_string(),
+            &content,
+        )
+        .expect(
+            "We should be able to parse our, just serialized, secret storage key event content",
+        );
 
         let base58_key = key.to_base58();
 
@@ -732,11 +741,13 @@ mod test {
         let content = to_raw_value(key.event_content())
             .expect("We should be able to serialize the secret storage key event content");
 
-        let content =
-            SecretStorageKeyEventContent::from_parts(&key.event_type().to_string(), &content)
-                .expect(
-                "We should be able to parse our, just serialized, secret storage key event content",
-            );
+        let content = SecretStorageKeyEventContent::from_parts(
+            &key.event_type().to_string(),
+            &content,
+        )
+        .expect(
+            "We should be able to parse our, just serialized, secret storage key event content",
+        );
 
         assert_matches!(
             SecretStorageKey::from_account_data("It's a secret to nobody", content.to_owned()),

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -24,14 +24,14 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument, trace};
 
 use super::OutboundGroupSession;
+#[cfg(doc)]
+use crate::{Device, UserIdentity};
 use crate::{
+    DeviceData, EncryptionSettings, LocalTrust, OlmError, OwnUserIdentityData, UserIdentityData,
     error::{OlmResult, SessionRecipientCollectionError},
     olm::ShareInfo,
     store::Store,
-    DeviceData, EncryptionSettings, LocalTrust, OlmError, OwnUserIdentityData, UserIdentityData,
 };
-#[cfg(doc)]
-use crate::{Device, UserIdentity};
 
 /// Strategy to collect the devices that should receive room keys for the
 /// current discussion.
@@ -304,12 +304,12 @@ pub(crate) async fn collect_recipients_for_share_strategy(
                 None => {
                     return Err(OlmError::SessionRecipientCollectionError(
                         SessionRecipientCollectionError::CrossSigningNotSetup,
-                    ))
+                    ));
                 }
                 Some(identity) if !identity.is_verified() => {
                     return Err(OlmError::SessionRecipientCollectionError(
                         SessionRecipientCollectionError::SendingFromUnverifiedDevice,
-                    ))
+                    ));
                 }
                 Some(_) => (),
             }
@@ -724,22 +724,22 @@ mod tests {
         },
     };
     use ruma::{
-        device_id,
+        TransactionId, device_id,
         events::{dummy::ToDeviceDummyEventContent, room::history_visibility::HistoryVisibility},
-        room_id, TransactionId,
+        room_id,
     };
     use serde_json::json;
 
     use crate::{
+        CrossSigningKeyExport, EncryptionSettings, LocalTrust, OlmError, OlmMachine,
         error::SessionRecipientCollectionError,
         olm::{OutboundGroupSession, ShareInfo},
         session_manager::{
-            group_sessions::share_strategy::collect_session_recipients, CollectStrategy,
+            CollectStrategy, group_sessions::share_strategy::collect_session_recipients,
         },
         store::caches::SequenceNumber,
         testing::simulate_key_query_response_for_verification,
         types::requests::ToDeviceRequest,
-        CrossSigningKeyExport, EncryptionSettings, LocalTrust, OlmError, OlmMachine,
     };
 
     /// Returns an `OlmMachine` set up for the test user in
@@ -1192,11 +1192,9 @@ mod tests {
         // and he should have an unsigned device.
         let bob_identity =
             machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap().other().unwrap();
-        assert!(bob_identity
-            .own_identity
-            .as_ref()
-            .unwrap()
-            .is_identity_signed(&bob_identity.inner));
+        assert!(
+            bob_identity.own_identity.as_ref().unwrap().is_identity_signed(&bob_identity.inner)
+        );
         assert!(!bob_identity.is_verified());
 
         let bob_unsigned_device = machine
@@ -1333,7 +1331,7 @@ mod tests {
                 KeyQueryResponseTemplateDeviceOptions,
             },
         };
-        use ruma::{device_id, user_id, DeviceId, TransactionId, UserId};
+        use ruma::{DeviceId, TransactionId, UserId, device_id, user_id};
         use vodozemac::{Curve25519PublicKey, Ed25519SecretKey};
 
         use super::{
@@ -1342,10 +1340,10 @@ mod tests {
             test_machine,
         };
         use crate::{
-            session_manager::group_sessions::{
-                share_strategy::collect_session_recipients, CollectRecipientsResult,
-            },
             EncryptionSettings, OlmMachine,
+            session_manager::group_sessions::{
+                CollectRecipientsResult, share_strategy::collect_session_recipients,
+            },
         };
 
         #[async_test]
@@ -1354,8 +1352,8 @@ mod tests {
         }
 
         #[async_test]
-        async fn test_error_on_verification_problem_strategy_should_share_with_verified_dehydrated_device(
-        ) {
+        async fn test_error_on_verification_problem_strategy_should_share_with_verified_dehydrated_device()
+         {
             should_share_with_verified_dehydrated_device(
                 &error_on_verification_problem_encryption_settings(),
             )
@@ -1409,8 +1407,8 @@ mod tests {
         }
 
         #[async_test]
-        async fn test_error_on_verification_problem_strategy_should_not_share_with_unverified_dehydrated_device(
-        ) {
+        async fn test_error_on_verification_problem_strategy_should_not_share_with_unverified_dehydrated_device()
+         {
             should_not_share_with_unverified_dehydrated_device(
                 &error_on_verification_problem_encryption_settings(),
             )
@@ -1469,8 +1467,8 @@ mod tests {
         }
 
         #[async_test]
-        async fn test_error_on_verification_problem_strategy_should_share_with_verified_device_of_pin_violation_user(
-        ) {
+        async fn test_error_on_verification_problem_strategy_should_share_with_verified_device_of_pin_violation_user()
+         {
             should_share_with_verified_device_of_pin_violation_user(
                 &error_on_verification_problem_encryption_settings(),
             )
@@ -1478,8 +1476,8 @@ mod tests {
         }
 
         #[async_test]
-        async fn test_identity_based_strategy_should_share_with_verified_device_of_pin_violation_user(
-        ) {
+        async fn test_identity_based_strategy_should_share_with_verified_device_of_pin_violation_user()
+         {
             should_share_with_verified_device_of_pin_violation_user(
                 &identity_based_strategy_settings(),
             )
@@ -1527,8 +1525,8 @@ mod tests {
         }
 
         #[async_test]
-        async fn test_all_devices_strategy_should_not_share_with_dehydrated_device_of_verification_violation_user(
-        ) {
+        async fn test_all_devices_strategy_should_not_share_with_dehydrated_device_of_verification_violation_user()
+         {
             should_not_share_with_dehydrated_device_of_verification_violation_user(
                 &all_devices_strategy_settings(),
             )
@@ -1562,8 +1560,8 @@ mod tests {
         }
 
         #[async_test]
-        async fn test_error_on_verification_problem_strategy_should_give_error_for_dehydrated_device_of_verification_violation_user(
-        ) {
+        async fn test_error_on_verification_problem_strategy_should_give_error_for_dehydrated_device_of_verification_violation_user()
+         {
             should_give_error_for_dehydrated_device_of_verification_violation_user(
                 &error_on_verification_problem_encryption_settings(),
             )
@@ -1571,8 +1569,8 @@ mod tests {
         }
 
         #[async_test]
-        async fn test_identity_based_strategy_should_give_error_for_dehydrated_device_of_verification_violation_user(
-        ) {
+        async fn test_identity_based_strategy_should_give_error_for_dehydrated_device_of_verification_violation_user()
+         {
             // This hits the same codepath as
             // `test_share_identity_strategy_report_verification_violation`, but
             // we test dehydrated devices here specifically, for completeness.

--- a/crates/matrix-sdk-crypto/src/store/caches.rs
+++ b/crates/matrix-sdk-crypto/src/store/caches.rs
@@ -22,8 +22,8 @@ use std::{
     fmt::Display,
     ops::Deref,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Weak,
+        atomic::{AtomicBool, Ordering},
     },
 };
 
@@ -31,10 +31,10 @@ use matrix_sdk_common::locks::RwLock as StdRwLock;
 use ruma::{DeviceId, OwnedDeviceId, OwnedUserId, UserId};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, MutexGuard, OwnedRwLockReadGuard, RwLock};
-use tracing::{field::display, instrument, trace, Span};
+use tracing::{Span, field::display, instrument, trace};
 
 use super::{CryptoStoreError, CryptoStoreWrapper};
-use crate::{identities::DeviceData, olm::Session, Account};
+use crate::{Account, identities::DeviceData, olm::Session};
 
 /// In-memory store for Olm Sessions.
 #[derive(Debug, Default, Clone)]

--- a/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
+++ b/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
@@ -5,18 +5,18 @@ use futures_util::StreamExt;
 use matrix_sdk_common::store_locks::CrossProcessStoreLock;
 use ruma::{DeviceId, OwnedDeviceId, OwnedUserId, UserId};
 use tokio::sync::{
-    broadcast::{self},
     Mutex,
+    broadcast::{self},
 };
-use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
+use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 use tracing::{debug, trace, warn};
 
-use super::{caches::SessionStore, DeviceChanges, IdentityChanges, LockableCryptoStore};
+use super::{DeviceChanges, IdentityChanges, LockableCryptoStore, caches::SessionStore};
 use crate::{
+    CryptoStoreError, GossippedSecret, OwnUserIdentityData, Session, UserIdentityData,
     olm::InboundGroupSession,
     store,
     store::{Changes, DynCryptoStore, IntoCryptoStore, RoomKeyInfo, RoomKeyWithheldInfo},
-    CryptoStoreError, GossippedSecret, OwnUserIdentityData, Session, UserIdentityData,
 };
 
 /// A wrapper for crypto store implementations that adds update notifiers.
@@ -178,7 +178,9 @@ impl CryptoStoreWrapper {
                 let own_identity_is_verified = own_identity_after.is_verified();
 
                 if !own_identity_was_verified_before_change && own_identity_is_verified {
-                    debug!("Own identity is now verified, check all known identities for verification status changes");
+                    debug!(
+                        "Own identity is now verified, check all known identities for verification status changes"
+                    );
                     // We need to review all the other identities to see if they are verified now
                     // and mark them as such
                     self.check_all_identities_and_update_was_previously_verified_flag_if_needed(

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -23,20 +23,20 @@ use matrix_sdk_common::{
     locks::RwLock as StdRwLock, store_locks::memory_store_helper::try_take_leased_lock,
 };
 use ruma::{
-    events::secret::request::SecretName, time::Instant, DeviceId, OwnedDeviceId, OwnedRoomId,
-    OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
+    DeviceId, OwnedDeviceId, OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, TransactionId,
+    UserId, events::secret::request::SecretName, time::Instant,
 };
 use tokio::sync::{Mutex, RwLock};
 use tracing::warn;
 use vodozemac::Curve25519PublicKey;
 
 use super::{
+    Account, CryptoStore, InboundGroupSession, Session,
     caches::DeviceStore,
     types::{
         BackupKeys, Changes, DehydratedDeviceKey, PendingChanges, RoomKeyCounts, RoomSettings,
         StoredRoomKeyBundleData, TrackedUser,
     },
-    Account, CryptoStore, InboundGroupSession, Session,
 };
 use crate::{
     gossiping::{GossipRequest, GossippedSecret, SecretInfo},
@@ -747,22 +747,22 @@ mod tests {
     use std::collections::HashMap;
 
     use matrix_sdk_test::async_test;
-    use ruma::{room_id, user_id, RoomId};
+    use ruma::{RoomId, room_id, user_id};
     use vodozemac::{Curve25519PublicKey, Ed25519PublicKey};
 
     use super::SessionId;
     use crate::{
+        DeviceData,
         identities::device::testing::get_device,
         olm::{
-            tests::get_account_and_session_test_helper, Account, InboundGroupSession,
-            OlmMessageHash, PrivateCrossSigningIdentity, SenderData,
+            Account, InboundGroupSession, OlmMessageHash, PrivateCrossSigningIdentity, SenderData,
+            tests::get_account_and_session_test_helper,
         },
         store::{
+            CryptoStore,
             memorystore::MemoryStore,
             types::{Changes, DeviceChanges, PendingChanges},
-            CryptoStore,
         },
-        DeviceData,
     };
 
     #[async_test]
@@ -1239,26 +1239,26 @@ mod integration_tests {
 
     use async_trait::async_trait;
     use ruma::{
-        events::secret::request::SecretName, DeviceId, OwnedDeviceId, RoomId, TransactionId, UserId,
+        DeviceId, OwnedDeviceId, RoomId, TransactionId, UserId, events::secret::request::SecretName,
     };
     use vodozemac::Curve25519PublicKey;
 
     use super::MemoryStore;
     use crate::{
+        Account, DeviceData, GossipRequest, GossippedSecret, SecretInfo, Session, UserIdentityData,
         cryptostore_integration_tests, cryptostore_integration_tests_time,
         olm::{
             InboundGroupSession, OlmMessageHash, OutboundGroupSession, PrivateCrossSigningIdentity,
             SenderDataType, StaticAccountData,
         },
         store::{
+            CryptoStore,
             types::{
                 BackupKeys, Changes, DehydratedDeviceKey, PendingChanges, RoomKeyCounts,
                 RoomSettings, StoredRoomKeyBundleData, TrackedUser,
             },
-            CryptoStore,
         },
         types::events::room_key_withheld::RoomKeyWithheldEvent,
-        Account, DeviceData, GossipRequest, GossippedSecret, SecretInfo, Session, UserIdentityData,
     };
 
     /// Holds on to a MemoryStore during a test, and moves it back into STORES

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -17,26 +17,26 @@ use std::{collections::HashMap, fmt, sync::Arc};
 use async_trait::async_trait;
 use matrix_sdk_common::AsyncTraitDeps;
 use ruma::{
-    events::secret::request::SecretName, DeviceId, OwnedDeviceId, RoomId, TransactionId, UserId,
+    DeviceId, OwnedDeviceId, RoomId, TransactionId, UserId, events::secret::request::SecretName,
 };
 use vodozemac::Curve25519PublicKey;
 
 use super::{
+    CryptoStoreError, Result,
     types::{
         BackupKeys, Changes, DehydratedDeviceKey, PendingChanges, RoomKeyCounts, RoomSettings,
         StoredRoomKeyBundleData, TrackedUser,
     },
-    CryptoStoreError, Result,
 };
 #[cfg(doc)]
 use crate::olm::SenderData;
 use crate::{
+    Account, DeviceData, GossipRequest, GossippedSecret, SecretInfo, UserIdentityData,
     olm::{
         InboundGroupSession, OlmMessageHash, OutboundGroupSession, PrivateCrossSigningIdentity,
         SenderDataType, Session,
     },
     types::events::room_key_withheld::RoomKeyWithheldEvent,
-    Account, DeviceData, GossipRequest, GossippedSecret, SecretInfo, UserIdentityData,
 };
 
 /// Represents a store that the `OlmMachine` uses to store E2EE data (such as

--- a/crates/matrix-sdk-crypto/src/store/types.rs
+++ b/crates/matrix-sdk-crypto/src/store/types.rs
@@ -21,20 +21,20 @@ use std::{
 
 use ruma::{OwnedDeviceId, OwnedRoomId, OwnedUserId};
 use serde::{Deserialize, Serialize};
-use vodozemac::{base64_encode, Curve25519PublicKey};
+use vodozemac::{Curve25519PublicKey, base64_encode};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use super::{DehydrationError, GossipRequest};
 use crate::{
+    Account, Device, DeviceData, GossippedSecret, Session, UserIdentity, UserIdentityData,
     olm::{
         InboundGroupSession, OlmMessageHash, OutboundGroupSession, PrivateCrossSigningIdentity,
         SenderData,
     },
     types::{
-        events::{room_key_bundle::RoomKeyBundleContent, room_key_withheld::RoomKeyWithheldEvent},
         EventEncryptionAlgorithm,
+        events::{room_key_bundle::RoomKeyBundleContent, room_key_withheld::RoomKeyWithheldEvent},
     },
-    Account, Device, DeviceData, GossippedSecret, Session, UserIdentity, UserIdentityData,
 };
 
 /// Aggregated changes to be saved in the database.

--- a/crates/matrix-sdk-crypto/src/types/backup.rs
+++ b/crates/matrix-sdk-crypto/src/types/backup.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use vodozemac::Curve25519PublicKey;
 
-use super::{deserialize_curve_key, serialize_curve_key, Signatures};
+use super::{Signatures, deserialize_curve_key, serialize_curve_key};
 
 /// Auth data for the `m.megolm_backup.v1.curve25519-aes-sha2` backup algorithm
 /// as defined in the [spec].
@@ -112,8 +112,8 @@ mod tests {
 
     use assert_matches::assert_matches;
     use insta::{assert_json_snapshot, with_settings};
-    use ruma::{user_id, DeviceKeyAlgorithm, KeyId};
-    use serde_json::{json, Value};
+    use ruma::{DeviceKeyAlgorithm, KeyId, user_id};
+    use serde_json::{Value, json};
     use vodozemac::{Curve25519PublicKey, Ed25519Signature};
 
     use super::RoomKeyBackupInfo;

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/common.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/common.rs
@@ -23,11 +23,11 @@ use std::collections::BTreeMap;
 
 use as_variant::as_variant;
 use ruma::{
-    encryption::KeyUsage, serde::Raw, DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId,
-    OwnedUserId, UserId,
+    DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, OwnedUserId, UserId, encryption::KeyUsage,
+    serde::Raw,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::{value::to_raw_value, Value};
+use serde_json::{Value, value::to_raw_value};
 use vodozemac::{Ed25519PublicKey, KeyError};
 
 use super::{SelfSigningPubkey, UserSigningPubkey};

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/master.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/master.rs
@@ -14,15 +14,15 @@
 
 use std::collections::btree_map::Iter;
 
-use ruma::{encryption::KeyUsage, DeviceKeyId, OwnedDeviceKeyId, UserId};
+use ruma::{DeviceKeyId, OwnedDeviceKeyId, UserId, encryption::KeyUsage};
 use serde::{Deserialize, Serialize};
 use vodozemac::Ed25519PublicKey;
 
 use super::{CrossSigningKey, CrossSigningSubKeys, SigningKey};
 use crate::{
+    SignatureError,
     olm::VerifyJson,
     types::{Signatures, SigningKeys},
-    SignatureError,
 };
 
 /// Wrapper for a cross signing key marking it as the master key.

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/mod.rs
@@ -60,7 +60,7 @@ impl_partial_eq!(UserSigningPubkey);
 #[cfg(test)]
 mod tests {
     use matrix_sdk_test::async_test;
-    use ruma::{encryption::KeyUsage, user_id, DeviceKeyId};
+    use ruma::{DeviceKeyId, encryption::KeyUsage, user_id};
     use serde_json::json;
     use vodozemac::Ed25519Signature;
 

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/self_signing.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/self_signing.rs
@@ -1,14 +1,14 @@
 use std::collections::btree_map::Iter;
 
-use ruma::{encryption::KeyUsage, OwnedDeviceKeyId, UserId};
+use ruma::{OwnedDeviceKeyId, UserId, encryption::KeyUsage};
 use serde::{Deserialize, Serialize};
 use vodozemac::Ed25519PublicKey;
 
 use super::{CrossSigningKey, SigningKey};
 use crate::{
+    DeviceData, SignatureError,
     olm::VerifyJson,
     types::{DeviceKeys, SigningKeys},
-    DeviceData, SignatureError,
 };
 
 /// Wrapper for a cross signing key marking it as a self signing key.

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/user_signing.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/user_signing.rs
@@ -1,11 +1,11 @@
 use std::collections::btree_map::Iter;
 
-use ruma::{encryption::KeyUsage, OwnedDeviceKeyId, UserId};
+use ruma::{OwnedDeviceKeyId, UserId, encryption::KeyUsage};
 use serde::{Deserialize, Serialize};
 use vodozemac::Ed25519PublicKey;
 
 use super::{CrossSigningKey, MasterPubkey, SigningKey};
-use crate::{olm::VerifyJson, types::SigningKeys, SignatureError};
+use crate::{SignatureError, olm::VerifyJson, types::SigningKeys};
 
 /// Wrapper for a cross signing key marking it as a user signing key.
 ///

--- a/crates/matrix-sdk-crypto/src/types/device_keys.rs
+++ b/crates/matrix-sdk-crypto/src/types/device_keys.rs
@@ -22,10 +22,10 @@ use std::collections::BTreeMap;
 
 use js_option::JsOption;
 use ruma::{
-    serde::Raw, DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceId, OwnedDeviceKeyId, OwnedUserId,
+    DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceId, OwnedDeviceKeyId, OwnedUserId, serde::Raw,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::{value::to_raw_value, Value};
+use serde_json::{Value, value::to_raw_value};
 use vodozemac::{Curve25519PublicKey, Ed25519PublicKey};
 
 use super::{EventEncryptionAlgorithm, Signatures};
@@ -114,24 +114,14 @@ impl DeviceKeys {
 
     /// Get the Curve25519 key of the given device.
     pub fn curve25519_key(&self) -> Option<Curve25519PublicKey> {
-        self.get_key(DeviceKeyAlgorithm::Curve25519).and_then(|k| {
-            if let DeviceKey::Curve25519(k) = k {
-                Some(*k)
-            } else {
-                None
-            }
-        })
+        self.get_key(DeviceKeyAlgorithm::Curve25519)
+            .and_then(|k| if let DeviceKey::Curve25519(k) = k { Some(*k) } else { None })
     }
 
     /// Get the Ed25519 key of the given device.
     pub fn ed25519_key(&self) -> Option<Ed25519PublicKey> {
-        self.get_key(DeviceKeyAlgorithm::Ed25519).and_then(|k| {
-            if let DeviceKey::Ed25519(k) = k {
-                Some(*k)
-            } else {
-                None
-            }
-        })
+        self.get_key(DeviceKeyAlgorithm::Ed25519)
+            .and_then(|k| if let DeviceKey::Ed25519(k) = k { Some(*k) } else { None })
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/types/events/dummy.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/dummy.rs
@@ -45,7 +45,7 @@ impl EventType for DummyEventContent {
 
 #[cfg(test)]
 pub(super) mod tests {
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     use super::DummyEvent;
 

--- a/crates/matrix-sdk-crypto/src/types/events/forwarded_room_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/forwarded_room_key.rs
@@ -19,14 +19,14 @@ use std::collections::BTreeMap;
 use ruma::{DeviceKeyAlgorithm, OwnedRoomId};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use vodozemac::{megolm::ExportedSessionKey, Curve25519PublicKey, Ed25519PublicKey};
+use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, megolm::ExportedSessionKey};
 
 use super::{EventType, ToDeviceEvent};
 #[cfg(doc)]
 use crate::olm::InboundGroupSession;
 use crate::types::{
-    deserialize_curve_key, deserialize_curve_key_vec, deserialize_ed25519_key, serialize_curve_key,
-    serialize_curve_key_vec, serialize_ed25519_key, EventEncryptionAlgorithm, SigningKeys,
+    EventEncryptionAlgorithm, SigningKeys, deserialize_curve_key, deserialize_curve_key_vec,
+    deserialize_ed25519_key, serialize_curve_key, serialize_curve_key_vec, serialize_ed25519_key,
 };
 
 /// The `m.forwarded_room_key` to-device event.

--- a/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
@@ -23,17 +23,17 @@ use serde_json::value::RawValue;
 use vodozemac::Ed25519PublicKey;
 
 use super::{
+    EventType,
     dummy::DummyEventContent,
     forwarded_room_key::ForwardedRoomKeyContent,
     room_key::RoomKeyContent,
     room_key_request::{self, SupportedKeyInfo},
     secret_send::SecretSendContent,
-    EventType,
 };
 use crate::types::{
-    deserialize_ed25519_key,
+    DeviceKeys, deserialize_ed25519_key,
     events::{from_str, room_key_bundle::RoomKeyBundleContent},
-    serialize_ed25519_key, DeviceKeys,
+    serialize_ed25519_key,
 };
 
 /// An `m.dummy` event that was decrypted using the
@@ -344,15 +344,15 @@ mod tests {
 
     use assert_matches::assert_matches;
     use insta::{assert_json_snapshot, with_settings};
-    use ruma::{device_id, owned_user_id, KeyId};
-    use serde_json::{json, Value};
+    use ruma::{KeyId, device_id, owned_user_id};
+    use serde_json::{Value, json};
     use similar_asserts::assert_eq;
     use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, Ed25519Signature};
 
     use super::AnyDecryptedOlmEvent;
     use crate::types::{
-        events::olm_v1::DecryptedRoomKeyEvent, DeviceKey, DeviceKeys, EventEncryptionAlgorithm,
-        Signatures,
+        DeviceKey, DeviceKeys, EventEncryptionAlgorithm, Signatures,
+        events::olm_v1::DecryptedRoomKeyEvent,
     };
 
     const ED25519_KEY: &str = "aOfOnlaeMb5GW1TxkZ8pXnblkGMgAvps+lAukrdYaZk";

--- a/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
@@ -19,16 +19,16 @@ use std::collections::BTreeMap;
 use ruma::{OwnedDeviceId, RoomId};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use vodozemac::{megolm::MegolmMessage, olm::OlmMessage, Curve25519PublicKey};
+use vodozemac::{Curve25519PublicKey, megolm::MegolmMessage, olm::OlmMessage};
 
 use super::Event;
 use crate::types::{
-    deserialize_curve_key,
+    EventEncryptionAlgorithm, deserialize_curve_key,
     events::{
-        room_key_request::{self, SupportedKeyInfo},
         EventType, ToDeviceEvent,
+        room_key_request::{self, SupportedKeyInfo},
     },
-    serialize_curve_key, EventEncryptionAlgorithm,
+    serialize_curve_key,
 };
 
 /// An m.room.encrypted room event.
@@ -422,7 +422,7 @@ scheme_serialization!(
 pub(crate) mod tests {
     use assert_matches::assert_matches;
     use assert_matches2::assert_let;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
     use vodozemac::Curve25519PublicKey;
 
     use super::{

--- a/crates/matrix-sdk-crypto/src/types/events/room_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key.rs
@@ -16,9 +16,9 @@
 
 use std::collections::BTreeMap;
 
-use ruma::{serde::Raw, OwnedRoomId, RoomId};
+use ruma::{OwnedRoomId, RoomId, serde::Raw};
 use serde::{Deserialize, Serialize};
-use serde_json::{value::to_raw_value, Value};
+use serde_json::{Value, value::to_raw_value};
 use vodozemac::megolm::SessionKey;
 
 use super::{EventType, ToDeviceEvent};
@@ -223,7 +223,7 @@ impl Serialize for RoomKeyContent {
 #[cfg(test)]
 pub(super) mod tests {
     use assert_matches::assert_matches;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
     use similar_asserts::assert_eq;
 
     use super::RoomKeyEvent;

--- a/crates/matrix-sdk-crypto/src/types/events/room_key_request.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key_request.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 use vodozemac::Curve25519PublicKey;
 
 use super::{EventType, ToDeviceEvent};
-use crate::types::{deserialize_curve_key, serialize_curve_key, EventEncryptionAlgorithm};
+use crate::types::{EventEncryptionAlgorithm, deserialize_curve_key, serialize_curve_key};
 
 /// The `m.room_key_request` to-device event.
 pub type RoomKeyRequestEvent = ToDeviceEvent<RoomKeyRequestContent>;
@@ -287,7 +287,7 @@ impl TryFrom<RequestedKeyInfoHelper> for RequestedKeyInfo {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     use super::{Action, RequestedKeyInfo, RoomKeyRequestEvent};
 

--- a/crates/matrix-sdk-crypto/src/types/events/room_key_withheld.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key_withheld.rs
@@ -23,7 +23,7 @@ use serde_json::Value;
 use vodozemac::Curve25519PublicKey;
 
 use super::{EventType, ToDeviceEvent};
-use crate::types::{deserialize_curve_key, serialize_curve_key, EventEncryptionAlgorithm};
+use crate::types::{EventEncryptionAlgorithm, deserialize_curve_key, serialize_curve_key};
 
 /// The `m.room_key_request` to-device event.
 pub type RoomKeyWithheldEvent = ToDeviceEvent<RoomKeyWithheldContent>;
@@ -428,13 +428,13 @@ pub(super) mod tests {
     use assert_matches2::assert_let;
     use matrix_sdk_common::deserialized_responses::WithheldCode;
     use ruma::{device_id, room_id, serde::Raw, to_device::DeviceIdOrAllDevices, user_id};
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
     use vodozemac::Curve25519PublicKey;
 
     use super::RoomKeyWithheldEvent;
     use crate::types::{
-        events::room_key_withheld::{MegolmV1AesSha2WithheldContent, RoomKeyWithheldContent},
         EventEncryptionAlgorithm,
+        events::room_key_withheld::{MegolmV1AesSha2WithheldContent, RoomKeyWithheldContent},
     };
 
     pub fn json(code: &WithheldCode) -> Value {

--- a/crates/matrix-sdk-crypto/src/types/events/secret_send.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/secret_send.rs
@@ -16,7 +16,7 @@
 
 use std::collections::BTreeMap;
 
-use ruma::{events::secret::request::SecretName, OwnedTransactionId};
+use ruma::{OwnedTransactionId, events::secret::request::SecretName};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use zeroize::Zeroize;
@@ -81,7 +81,7 @@ impl EventType for SecretSendContent {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     use super::SecretSendEvent;
 

--- a/crates/matrix-sdk-crypto/src/types/events/to_device.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/to_device.rs
@@ -15,7 +15,9 @@
 use std::{collections::BTreeMap, fmt::Debug};
 
 use ruma::{
+    OwnedUserId, UserId,
     events::{
+        EventContent, ToDeviceEventType,
         key::verification::{
             accept::ToDeviceKeyVerificationAcceptEvent, cancel::ToDeviceKeyVerificationCancelEvent,
             done::ToDeviceKeyVerificationDoneEvent, key::ToDeviceKeyVerificationKeyEvent,
@@ -23,19 +25,18 @@ use ruma::{
             request::ToDeviceKeyVerificationRequestEvent, start::ToDeviceKeyVerificationStartEvent,
         },
         secret::request::{SecretName, ToDeviceSecretRequestEvent},
-        EventContent, ToDeviceEventType,
     },
     serde::Raw,
-    OwnedUserId, UserId,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{
-    value::{to_raw_value, RawValue},
     Value,
+    value::{RawValue, to_raw_value},
 };
 use zeroize::Zeroize;
 
 use super::{
+    EventType,
     dummy::DummyEvent,
     forwarded_room_key::{ForwardedRoomKeyContent, ForwardedRoomKeyEvent},
     room::encrypted::EncryptedToDeviceEvent,
@@ -43,7 +44,6 @@ use super::{
     room_key_request::RoomKeyRequestEvent,
     room_key_withheld::RoomKeyWithheldEvent,
     secret_send::SecretSendEvent,
-    EventType,
 };
 use crate::types::events::from_str;
 
@@ -407,7 +407,7 @@ impl Serialize for ToDeviceEvents {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
     use similar_asserts::assert_eq;
 
     use super::ToDeviceEvents;

--- a/crates/matrix-sdk-crypto/src/types/events/utd_cause.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/utd_cause.rs
@@ -15,7 +15,7 @@
 use matrix_sdk_common::deserialized_responses::{
     UnableToDecryptInfo, UnableToDecryptReason, VerificationLevel, WithheldCode,
 };
-use ruma::{events::AnySyncTimelineEvent, serde::Raw, MilliSecondsSinceUnixEpoch};
+use ruma::{MilliSecondsSinceUnixEpoch, events::AnySyncTimelineEvent, serde::Raw};
 use serde::Deserialize;
 
 /// Our best guess at the reason why an event can't be decrypted.
@@ -242,10 +242,10 @@ mod tests {
     use matrix_sdk_common::deserialized_responses::{
         DeviceLinkProblem, UnableToDecryptInfo, UnableToDecryptReason, VerificationLevel,
     };
-    use ruma::{events::AnySyncTimelineEvent, serde::Raw, MilliSecondsSinceUnixEpoch};
+    use ruma::{MilliSecondsSinceUnixEpoch, events::AnySyncTimelineEvent, serde::Raw};
     use serde_json::{json, value::to_raw_value};
 
-    use crate::types::events::{utd_cause::CryptoContextInfo, UtdCause};
+    use crate::types::events::{UtdCause, utd_cause::CryptoContextInfo};
 
     const EVENT_TIME: usize = 5555;
     const BEFORE_EVENT_TIME: usize = 1111;

--- a/crates/matrix-sdk-crypto/src/types/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/mod.rs
@@ -28,16 +28,16 @@
 use std::{
     borrow::Borrow,
     collections::{
-        btree_map::{IntoIter, Iter},
         BTreeMap,
+        btree_map::{IntoIter, Iter},
     },
 };
 
 use as_variant::as_variant;
 use matrix_sdk_common::deserialized_responses::PrivOwnedStr;
 use ruma::{
-    serde::StringEnum, DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, OwnedUserId, RoomId,
-    UserId,
+    DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, OwnedUserId, RoomId, UserId,
+    serde::StringEnum,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, Ed25519Signature, KeyError};

--- a/crates/matrix-sdk-crypto/src/types/one_time_keys.rs
+++ b/crates/matrix-sdk-crypto/src/types/one_time_keys.rs
@@ -20,12 +20,12 @@
 
 use std::collections::BTreeMap;
 
-use ruma::{serde::Raw, OneTimeKeyAlgorithm};
+use ruma::{OneTimeKeyAlgorithm, serde::Raw};
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::{value::to_raw_value, Value};
+use serde_json::{Value, value::to_raw_value};
 use vodozemac::Curve25519PublicKey;
 
-use super::{deserialize_curve_key, serialize_curve_key, Signatures};
+use super::{Signatures, deserialize_curve_key, serialize_curve_key};
 
 /// A key for the SignedCurve25519 algorithm
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -133,7 +133,7 @@ impl OneTimeKey {
 
 #[cfg(test)]
 mod tests {
-    use ruma::{device_id, user_id, DeviceKeyAlgorithm, DeviceKeyId};
+    use ruma::{DeviceKeyAlgorithm, DeviceKeyId, device_id, user_id};
     use serde_json::json;
     use vodozemac::{Curve25519PublicKey, Ed25519Signature};
 

--- a/crates/matrix-sdk-crypto/src/types/qr_login.rs
+++ b/crates/matrix-sdk-crypto/src/types/qr_login.rs
@@ -24,7 +24,7 @@ use std::{
 use byteorder::{BigEndian, ReadBytesExt};
 use thiserror::Error;
 use url::Url;
-use vodozemac::{base64_decode, base64_encode, Curve25519PublicKey};
+use vodozemac::{Curve25519PublicKey, base64_decode, base64_encode};
 
 /// The version of the QR code data, currently only one version is specified.
 const VERSION: u8 = 0x02;
@@ -299,8 +299,7 @@ mod test {
     ];
 
     // Test vector for the QR code data in base64 format, self-generated.
-    const QR_CODE_DATA_BASE64: &str =
-        "TUFUUklYAgS0yzZ1QVpQ1jlnoxWX3d5jrWRFfELxjS2gN7pz9y+3PABaaHR0\
+    const QR_CODE_DATA_BASE64: &str = "TUFUUklYAgS0yzZ1QVpQ1jlnoxWX3d5jrWRFfELxjS2gN7pz9y+3PABaaHR0\
          cHM6Ly9zeW5hcHNlLW9pZGMubGFiLmVsZW1lbnQuZGV2L19zeW5hcHNlL2Ns\
          aWVudC9yZW5kZXp2b3VzLzAxSFg5SzAwUTFINktQRDQ3RUc0RzFUM1hHACVo\
          dHRwczovL3N5bmFwc2Utb2lkYy5sYWIuZWxlbWVudC5kZXYv";

--- a/crates/matrix-sdk-crypto/src/types/requests/enums.rs
+++ b/crates/matrix-sdk-crypto/src/types/requests/enums.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use ruma::{
+    TransactionId,
     api::client::{
         backup::add_backup_keys::v3::Response as KeysBackupResponse,
         keys::{
@@ -29,7 +30,6 @@ use ruma::{
         message::send_message_event::v3::Response as RoomMessageResponse,
         to_device::send_event_to_device::v3::Response as ToDeviceResponse,
     },
-    TransactionId,
 };
 
 use super::{

--- a/crates/matrix-sdk-crypto/src/types/requests/keys_backup.rs
+++ b/crates/matrix-sdk-crypto/src/types/requests/keys_backup.rs
@@ -14,7 +14,7 @@
 
 use std::collections::BTreeMap;
 
-use ruma::{api::client::backup::RoomKeyBackup, OwnedRoomId};
+use ruma::{OwnedRoomId, api::client::backup::RoomKeyBackup};
 
 /// A request that will back up a batch of room keys to the server.
 #[derive(Clone, Debug)]

--- a/crates/matrix-sdk-crypto/src/types/requests/room_message.rs
+++ b/crates/matrix-sdk-crypto/src/types/requests/room_message.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ruma::{events::AnyMessageLikeEventContent, OwnedRoomId, OwnedTransactionId};
+use ruma::{OwnedRoomId, OwnedTransactionId, events::AnyMessageLikeEventContent};
 
 /// Customized owned request type for sending out room messages.
 #[derive(Clone, Debug)]

--- a/crates/matrix-sdk-crypto/src/types/requests/to_device.rs
+++ b/crates/matrix-sdk-crypto/src/types/requests/to_device.rs
@@ -15,10 +15,10 @@
 use std::{collections::BTreeMap, iter};
 
 use ruma::{
+    OwnedDeviceId, OwnedTransactionId, OwnedUserId, TransactionId, UserId,
     events::{AnyToDeviceEventContent, EventContent, ToDeviceEventType},
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
-    OwnedDeviceId, OwnedTransactionId, OwnedUserId, TransactionId, UserId,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/matrix-sdk-crypto/src/types/room_history.rs
+++ b/crates/matrix-sdk-crypto/src/types/room_history.rs
@@ -22,14 +22,14 @@ use std::fmt::Debug;
 
 use ruma::{DeviceKeyAlgorithm, OwnedRoomId};
 use serde::{Deserialize, Serialize};
-use vodozemac::{megolm::ExportedSessionKey, Curve25519PublicKey};
+use vodozemac::{Curve25519PublicKey, megolm::ExportedSessionKey};
 
 use super::RoomKeyExport;
 use crate::{
     olm::ExportedRoomKey,
     types::{
-        deserialize_curve_key, events::room_key_withheld::RoomKeyWithheldContent,
-        serialize_curve_key, EventEncryptionAlgorithm, SigningKeys,
+        EventEncryptionAlgorithm, SigningKeys, deserialize_curve_key,
+        events::room_key_withheld::RoomKeyWithheldContent, serialize_curve_key,
     },
 };
 #[cfg(doc)]
@@ -138,12 +138,12 @@ impl From<ExportedRoomKey> for HistoricRoomKey {
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;
-    use ruma::{owned_room_id, DeviceKeyAlgorithm};
+    use ruma::{DeviceKeyAlgorithm, owned_room_id};
     use vodozemac::{
-        megolm::ExportedSessionKey, Curve25519PublicKey, Curve25519SecretKey, Ed25519SecretKey,
+        Curve25519PublicKey, Curve25519SecretKey, Ed25519SecretKey, megolm::ExportedSessionKey,
     };
 
-    use crate::types::{room_history::HistoricRoomKey, EventEncryptionAlgorithm};
+    use crate::types::{EventEncryptionAlgorithm, room_history::HistoricRoomKey};
 
     #[test]
     fn test_historic_room_key_debug() {

--- a/crates/matrix-sdk-crypto/src/utilities.rs
+++ b/crates/matrix-sdk-crypto/src/utilities.rs
@@ -16,8 +16,8 @@ use std::num::NonZeroU8;
 
 use ruma::MilliSecondsSinceUnixEpoch;
 use time::{
-    format_description::well_known::{iso8601, Iso8601},
     OffsetDateTime,
+    format_description::well_known::{Iso8601, iso8601},
 };
 
 #[cfg(test)]

--- a/crates/matrix-sdk-crypto/src/verification/cache.rs
+++ b/crates/matrix-sdk-crypto/src/verification/cache.rs
@@ -21,12 +21,12 @@ use ruma::{DeviceId, OwnedTransactionId, OwnedUserId, TransactionId, UserId};
 use tracing::debug;
 use tracing::{trace, warn};
 
-use super::{event_enums::OutgoingContent, FlowId, Sas, Verification};
+use super::{FlowId, Sas, Verification, event_enums::OutgoingContent};
+#[cfg(feature = "qrcode")]
+use crate::QrVerification;
 use crate::types::requests::{
     OutgoingRequest, OutgoingVerificationRequest, RoomMessageRequest, ToDeviceRequest,
 };
-#[cfg(feature = "qrcode")]
-use crate::QrVerification;
 
 #[derive(Clone, Debug, Default)]
 pub struct VerificationCache {

--- a/crates/matrix-sdk-crypto/src/verification/event_enums.rs
+++ b/crates/matrix-sdk-crypto/src/verification/event_enums.rs
@@ -16,8 +16,11 @@ use std::collections::BTreeMap;
 
 use as_variant::as_variant;
 use ruma::{
+    CanonicalJsonValue, DeviceId, MilliSecondsSinceUnixEpoch, OwnedRoomId, UserId,
     events::{
+        AnyMessageLikeEvent, AnyMessageLikeEventContent, AnyToDeviceEventContent, MessageLikeEvent,
         key::verification::{
+            VerificationMethod,
             accept::{
                 AcceptMethod, KeyVerificationAcceptEventContent,
                 ToDeviceKeyVerificationAcceptEventContent,
@@ -35,13 +38,10 @@ use ruma::{
                 KeyVerificationStartEventContent, StartMethod,
                 ToDeviceKeyVerificationStartEventContent,
             },
-            VerificationMethod,
         },
         room::message::{KeyVerificationRequestEventContent, MessageType},
-        AnyMessageLikeEvent, AnyMessageLikeEventContent, AnyToDeviceEventContent, MessageLikeEvent,
     },
     serde::Base64,
-    CanonicalJsonValue, DeviceId, MilliSecondsSinceUnixEpoch, OwnedRoomId, UserId,
 };
 
 use super::FlowId;

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -16,31 +16,32 @@ use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk_common::locks::RwLock as StdRwLock;
 use ruma::{
+    DeviceId, EventId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedUserId, RoomId,
+    SecondsSinceUnixEpoch, TransactionId, UInt, UserId,
     events::{
-        key::verification::VerificationMethod, AnyToDeviceEvent, AnyToDeviceEventContent,
-        ToDeviceEvent,
+        AnyToDeviceEvent, AnyToDeviceEventContent, ToDeviceEvent,
+        key::verification::VerificationMethod,
     },
     serde::Raw,
-    uint, DeviceId, EventId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedUserId, RoomId,
-    SecondsSinceUnixEpoch, TransactionId, UInt, UserId,
+    uint,
 };
 use tokio::sync::Mutex;
-use tracing::{debug, info, instrument, trace, warn, Span};
+use tracing::{Span, debug, info, instrument, trace, warn};
 
 use super::{
+    FlowId, Verification, VerificationResult, VerificationStore,
     cache::{RequestInfo, VerificationCache},
     event_enums::{AnyEvent, AnyVerificationContent, OutgoingContent},
     requests::VerificationRequest,
     sas::Sas,
-    FlowId, Verification, VerificationResult, VerificationStore,
 };
 use crate::{
+    DeviceData, OtherUserIdentityData,
     olm::{PrivateCrossSigningIdentity, StaticAccountData},
     store::{CryptoStoreError, CryptoStoreWrapper},
     types::requests::{
         OutgoingRequest, OutgoingVerificationRequest, RoomMessageRequest, ToDeviceRequest,
     },
-    DeviceData, OtherUserIdentityData,
 };
 
 #[derive(Clone, Debug)]
@@ -367,7 +368,9 @@ impl VerificationMachine {
                 let Some(device_data) =
                     self.store.get_device(event.sender(), r.from_device()).await?
                 else {
-                    warn!("Could not retrieve the device data for the incoming verification request, ignoring it");
+                    warn!(
+                        "Could not retrieve the device data for the incoming verification request, ignoring it"
+                    );
                     return Ok(());
                 };
 
@@ -539,15 +542,15 @@ mod tests {
 
     use super::{Sas, VerificationMachine};
     use crate::{
+        Account, VerificationRequest,
         olm::PrivateCrossSigningIdentity,
         store::{CryptoStoreWrapper, MemoryStore},
         verification::{
+            FlowId, VerificationStore,
             cache::VerificationCache,
             event_enums::{AcceptContent, KeyContent, MacContent, OutgoingContent},
             tests::{alice_device_id, alice_id, setup_stores, wrap_any_to_device_content},
-            FlowId, VerificationStore,
         },
-        Account, VerificationRequest,
     };
 
     async fn verification_machine() -> (VerificationMachine, VerificationStore) {

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -33,29 +33,29 @@ use ruma::events::key::verification::done::{
     KeyVerificationDoneEventContent, ToDeviceKeyVerificationDoneEventContent,
 };
 use ruma::{
+    DeviceId, EventId, OwnedDeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId, RoomId,
+    UserId,
     api::client::keys::upload_signatures::v3::Request as SignatureUploadRequest,
     events::{
+        AnyMessageLikeEventContent, AnyToDeviceEventContent,
         key::verification::cancel::{
             CancelCode, KeyVerificationCancelEventContent,
             ToDeviceKeyVerificationCancelEventContent,
         },
         relation::Reference,
-        AnyMessageLikeEventContent, AnyToDeviceEventContent,
     },
-    DeviceId, EventId, OwnedDeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId, RoomId,
-    UserId,
 };
 pub use sas::{AcceptSettings, AcceptedProtocols, EmojiShortAuthString, Sas, SasState};
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
 use crate::{
+    CryptoStoreError, DeviceData, LocalTrust, OwnUserIdentityData, UserIdentityData,
     error::SignatureError,
     gossiping::{GossipMachine, GossipRequest},
     olm::{PrivateCrossSigningIdentity, StaticAccountData},
-    store::{types::Changes, CryptoStoreWrapper},
-    types::{requests::OutgoingVerificationRequest, Signatures},
-    CryptoStoreError, DeviceData, LocalTrust, OwnUserIdentityData, UserIdentityData,
+    store::{CryptoStoreWrapper, types::Changes},
+    types::{Signatures, requests::OutgoingVerificationRequest},
 };
 
 #[derive(Clone, Debug)]
@@ -738,24 +738,24 @@ pub(crate) mod tests {
     use std::sync::Arc;
 
     use ruma::{
-        device_id,
+        DeviceId, UserId, device_id,
         events::{AnyToDeviceEventContent, ToDeviceEvent},
-        user_id, DeviceId, UserId,
+        user_id,
     };
     use tokio::sync::Mutex;
 
-    use super::{event_enums::OutgoingContent, VerificationStore};
+    use super::{VerificationStore, event_enums::OutgoingContent};
     use crate::{
+        Account, DeviceData, OtherUserIdentityData, OwnUserIdentityData,
         olm::PrivateCrossSigningIdentity,
         store::{
-            types::{Changes, IdentityChanges},
             CryptoStore, CryptoStoreWrapper, MemoryStore,
+            types::{Changes, IdentityChanges},
         },
         types::{
             events::ToDeviceEvents,
             requests::{AnyOutgoingRequest, OutgoingRequest, OutgoingVerificationRequest},
         },
-        Account, DeviceData, OtherUserIdentityData, OwnUserIdentityData,
     };
 
     pub(crate) fn request_to_event(

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -19,13 +19,15 @@ use eyeball::{ObservableWriteGuard, SharedObservable};
 use futures_core::Stream;
 use futures_util::StreamExt;
 use matrix_sdk_qrcode::{
-    qrcode::QrCode, EncodingError, QrVerificationData, SelfVerificationData,
-    SelfVerificationNoMasterKey, VerificationData,
+    EncodingError, QrVerificationData, SelfVerificationData, SelfVerificationNoMasterKey,
+    VerificationData, qrcode::QrCode,
 };
-use rand::{thread_rng, RngCore};
+use rand::{RngCore, thread_rng};
 use ruma::{
+    DeviceId, OwnedDeviceId, OwnedUserId, RoomId, TransactionId, UserId,
     api::client::keys::upload_signatures::v3::Request as SignatureUploadRequest,
     events::{
+        AnyMessageLikeEventContent, AnyToDeviceEventContent,
         key::verification::{
             cancel::CancelCode,
             done::{KeyVerificationDoneEventContent, ToDeviceKeyVerificationDoneEventContent},
@@ -35,24 +37,22 @@ use ruma::{
             },
         },
         relation::Reference,
-        AnyMessageLikeEventContent, AnyToDeviceEventContent,
     },
     serde::Base64,
-    DeviceId, OwnedDeviceId, OwnedUserId, RoomId, TransactionId, UserId,
 };
 use thiserror::Error;
 use tracing::{debug, trace};
 use vodozemac::Ed25519PublicKey;
 
 use super::{
-    event_enums::{CancelContent, DoneContent, OutgoingContent, OwnedStartContent, StartContent},
-    requests::RequestHandle,
     CancelInfo, Cancelled, Done, FlowId, IdentitiesBeingVerified, VerificationResult,
     VerificationStore,
+    event_enums::{CancelContent, DoneContent, OutgoingContent, OwnedStartContent, StartContent},
+    requests::RequestHandle,
 };
 use crate::{
-    types::requests::{OutgoingVerificationRequest, RoomMessageRequest, ToDeviceRequest},
     CryptoStoreError, DeviceData, UserIdentityData,
+    types::requests::{OutgoingVerificationRequest, RoomMessageRequest, ToDeviceRequest},
 };
 
 const SECRET_SIZE: usize = 16;
@@ -893,17 +893,17 @@ mod tests {
     use assert_matches::assert_matches;
     use matrix_sdk_qrcode::QrVerificationData;
     use matrix_sdk_test::async_test;
-    use ruma::{device_id, event_id, room_id, user_id, DeviceId, UserId};
+    use ruma::{DeviceId, UserId, device_id, event_id, room_id, user_id};
     use tokio::sync::Mutex;
 
     use crate::{
-        olm::{Account, PrivateCrossSigningIdentity},
-        store::{types::Changes, CryptoStoreWrapper, MemoryStore},
-        verification::{
-            event_enums::{DoneContent, OutgoingContent, StartContent},
-            FlowId, VerificationStore,
-        },
         DeviceData, QrVerification, QrVerificationState,
+        olm::{Account, PrivateCrossSigningIdentity},
+        store::{CryptoStoreWrapper, MemoryStore, types::Changes},
+        verification::{
+            FlowId, VerificationStore,
+            event_enums::{DoneContent, OutgoingContent, StartContent},
+        },
     };
 
     fn user_id() -> &'static UserId {

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -21,22 +21,22 @@ use futures_util::StreamExt;
 #[cfg(feature = "qrcode")]
 use matrix_sdk_qrcode::QrVerificationData;
 use ruma::{
+    DeviceId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedUserId, RoomId, TransactionId,
+    UserId,
     events::{
+        AnyMessageLikeEventContent, AnyToDeviceEventContent,
         key::verification::{
+            VerificationMethod,
             cancel::CancelCode,
             ready::{KeyVerificationReadyEventContent, ToDeviceKeyVerificationReadyEventContent},
             request::ToDeviceKeyVerificationRequestEventContent,
             start::StartMethod,
-            VerificationMethod,
         },
         relation::Reference,
         room::message::KeyVerificationRequestEventContent,
-        AnyMessageLikeEventContent, AnyToDeviceEventContent,
     },
     time::Instant,
     to_device::DeviceIdOrAllDevices,
-    DeviceId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedUserId, RoomId, TransactionId,
-    UserId,
 };
 #[cfg(feature = "qrcode")]
 use tracing::debug;
@@ -45,16 +45,16 @@ use tracing::{info, trace, warn};
 #[cfg(feature = "qrcode")]
 use super::qrcode::{QrVerification, QrVerificationState, ScanError};
 use super::{
+    CancelInfo, Cancelled, FlowId, Verification, VerificationStore,
     cache::VerificationCache,
     event_enums::{
         CancelContent, DoneContent, OutgoingContent, ReadyContent, RequestContent, StartContent,
     },
-    CancelInfo, Cancelled, FlowId, Verification, VerificationStore,
 };
 use crate::{
+    CryptoStoreError, DeviceData, Sas,
     olm::StaticAccountData,
     types::requests::{OutgoingVerificationRequest, RoomMessageRequest, ToDeviceRequest},
-    CryptoStoreError, DeviceData, Sas,
 };
 
 const SUPPORTED_METHODS: &[VerificationMethod] = &[
@@ -973,7 +973,7 @@ impl InnerRequest {
                 s.clone().into_canceled(cancelled_by_us, cancel_code)
             }
             InnerRequest::Passive(_) | InnerRequest::Done(_) | InnerRequest::Cancelled(_) => {
-                return None
+                return None;
             }
         });
 
@@ -1390,11 +1390,15 @@ async fn receive_start<T: Clone>(
                                 ),
                                 (Ordering::Greater, _) | (Ordering::Equal, Ordering::Greater)
                             ) {
-                                info!("Started a new SAS verification, replacing an already started one.");
+                                info!(
+                                    "Started a new SAS verification, replacing an already started one."
+                                );
                                 request_state.verification_cache.replace_sas(new.to_owned());
                                 Ok(Some(state.to_transitioned(request_state, new.into())))
                             } else {
-                                info!("Ignored incoming SAS verification from lexicographically larger user/device ID.");
+                                info!(
+                                    "Ignored incoming SAS verification from lexicographically larger user/device ID."
+                                );
                                 Ok(None)
                             }
                         }
@@ -1629,22 +1633,22 @@ mod tests {
     use matrix_sdk_qrcode::QrVerificationData;
     use matrix_sdk_test::async_test;
     use ruma::{
-        event_id, events::key::verification::VerificationMethod, room_id,
-        to_device::DeviceIdOrAllDevices, UserId,
+        UserId, event_id, events::key::verification::VerificationMethod, room_id,
+        to_device::DeviceIdOrAllDevices,
     };
 
     use super::VerificationRequest;
     use crate::{
+        DeviceData, VerificationRequestState,
         types::requests::OutgoingVerificationRequest,
         verification::{
+            FlowId, Verification, VerificationStore,
             cache::VerificationCache,
             event_enums::{
                 CancelContent, OutgoingContent, ReadyContent, RequestContent, StartContent,
             },
             tests::{alice_id, bob_id, setup_stores},
-            FlowId, Verification, VerificationStore,
         },
-        DeviceData, VerificationRequestState,
     };
 
     #[async_test]

--- a/crates/matrix-sdk-crypto/src/verification/sas/helpers.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/helpers.rs
@@ -15,27 +15,27 @@
 use std::collections::BTreeMap;
 
 use ruma::{
+    DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, UserId,
     events::{
+        AnyMessageLikeEventContent, AnyToDeviceEventContent,
         key::verification::{
             cancel::CancelCode,
             mac::{KeyVerificationMacEventContent, ToDeviceKeyVerificationMacEventContent},
         },
         relation::Reference,
-        AnyMessageLikeEventContent, AnyToDeviceEventContent,
     },
     serde::Base64,
-    DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, UserId,
 };
 use sha2::{Digest, Sha256};
 use tracing::{trace, warn};
-use vodozemac::{sas::EstablishedSas, Curve25519PublicKey};
+use vodozemac::{Curve25519PublicKey, sas::EstablishedSas};
 
-use super::{sas_state::SupportedMacMethod, FlowId, OutgoingContent};
+use super::{FlowId, OutgoingContent, sas_state::SupportedMacMethod};
 use crate::{
+    Emoji, OwnUserIdentityData,
     identities::{DeviceData, UserIdentityData},
     olm::StaticAccountData,
     verification::event_enums::{MacContent, StartContent},
-    Emoji, OwnUserIdentityData,
 };
 
 #[derive(Clone, Debug)]

--- a/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
@@ -18,27 +18,27 @@ use as_variant::as_variant;
 #[cfg(test)]
 use ruma::time::Instant;
 use ruma::{
-    events::key::verification::{cancel::CancelCode, ShortAuthenticationString},
     TransactionId, UserId,
+    events::key::verification::{ShortAuthenticationString, cancel::CancelCode},
 };
 use tracing::trace;
 
 use super::{
+    FlowId,
     sas_state::{
         Accepted, Confirmed, Created, Done, KeyReceived, KeySent, KeysExchanged, MacReceived,
         SasState, Started, WaitingForDone, WeAccepted,
     },
-    FlowId,
 };
 use crate::{
+    OwnUserIdentityData,
     identities::{DeviceData, UserIdentityData},
     olm::StaticAccountData,
     verification::{
+        Cancelled, Emoji,
         cache::RequestInfo,
         event_enums::{AnyVerificationContent, OutgoingContent, OwnedAcceptContent, StartContent},
-        Cancelled, Emoji,
     },
-    OwnUserIdentityData,
 };
 
 #[derive(Clone, Debug)]

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -24,28 +24,28 @@ use futures_core::Stream;
 use futures_util::StreamExt;
 use inner_sas::InnerSas;
 use ruma::{
+    DeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId, RoomId, TransactionId, UserId,
     api::client::keys::upload_signatures::v3::Request as SignatureUploadRequest,
     events::{
-        key::verification::{cancel::CancelCode, start::SasV1Content, ShortAuthenticationString},
         AnyMessageLikeEventContent, AnyToDeviceEventContent,
+        key::verification::{ShortAuthenticationString, cancel::CancelCode, start::SasV1Content},
     },
-    DeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId, RoomId, TransactionId, UserId,
 };
 pub use sas_state::AcceptedProtocols;
 use tracing::{debug, error, trace};
 
 use super::{
+    CancelInfo, FlowId, IdentitiesBeingVerified, VerificationResult,
     cache::RequestInfo,
     event_enums::{AnyVerificationContent, OutgoingContent, OwnedAcceptContent, StartContent},
     requests::RequestHandle,
-    CancelInfo, FlowId, IdentitiesBeingVerified, VerificationResult,
 };
 use crate::{
+    Emoji,
     identities::{DeviceData, UserIdentityData},
     olm::StaticAccountData,
     store::CryptoStoreError,
     types::requests::{OutgoingVerificationRequest, RoomMessageRequest, ToDeviceRequest},
-    Emoji,
 };
 
 /// Short authentication string object.
@@ -871,21 +871,21 @@ mod tests {
     use assert_matches2::assert_let;
     use matrix_sdk_test::async_test;
     use ruma::{
-        device_id,
-        events::key::verification::{accept::AcceptMethod, ShortAuthenticationString},
-        user_id, DeviceId, TransactionId, UserId,
+        DeviceId, TransactionId, UserId, device_id,
+        events::key::verification::{ShortAuthenticationString, accept::AcceptMethod},
+        user_id,
     };
     use tokio::sync::Mutex;
 
     use super::Sas;
     use crate::{
+        Account, DeviceData, SasState,
         olm::PrivateCrossSigningIdentity,
         store::{CryptoStoreWrapper, MemoryStore},
         verification::{
-            event_enums::{AcceptContent, KeyContent, MacContent, OutgoingContent, StartContent},
             VerificationStore,
+            event_enums::{AcceptContent, KeyContent, MacContent, OutgoingContent, StartContent},
         },
-        Account, DeviceData, SasState,
     };
 
     fn alice_id() -> &'static UserId {

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
@@ -18,7 +18,7 @@ use indexed_db_futures::{prelude::*, web_sys::DomException};
 use tracing::info;
 use wasm_bindgen::JsValue;
 
-use crate::{crypto_store::Result, serializer::IndexeddbSerializer, IndexeddbCryptoStoreError};
+use crate::{IndexeddbCryptoStoreError, crypto_store::Result, serializer::IndexeddbSerializer};
 
 mod old_keys;
 mod v0_to_v5;
@@ -248,15 +248,15 @@ mod tests {
     };
     use matrix_sdk_store_encryption::StoreCipher;
     use matrix_sdk_test::async_test;
-    use ruma::{room_id, OwnedRoomId, RoomId};
+    use ruma::{OwnedRoomId, RoomId, room_id};
     use serde::Serialize;
     use tracing_subscriber::util::SubscriberInitExt;
     use web_sys::console;
 
     use super::{v0_to_v5, v7::InboundGroupSessionIndexedDbObject2};
     use crate::{
-        crypto_store::{keys, migrations::*, InboundGroupSessionIndexedDbObject},
         IndexeddbCryptoStore,
+        crypto_store::{InboundGroupSessionIndexedDbObject, keys, migrations::*},
     };
 
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
@@ -607,10 +607,12 @@ mod tests {
             ))
         );
         assert_eq!(idb_object.sender_data_type, Some(session.sender_data_type() as u8));
-        assert!(raw_store
-            .index_names()
-            .find(|idx| idx == "inbound_group_session_sender_key_sender_data_type_idx")
-            .is_some());
+        assert!(
+            raw_store
+                .index_names()
+                .find(|idx| idx == "inbound_group_session_sender_key_sender_data_type_idx")
+                .is_some()
+        );
 
         db.close();
     }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v0_to_v5.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v0_to_v5.rs
@@ -19,9 +19,8 @@ use indexed_db_futures::IdbDatabase;
 use web_sys::DomException;
 
 use crate::crypto_store::{
-    keys,
+    Result, keys,
     migrations::{add_nonunique_index, add_unique_index, do_schema_upgrade, old_keys},
-    Result,
 };
 
 /// Perform schema migrations as needed, up to schema version 5.

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v10_to_v11.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v10_to_v11.rs
@@ -22,7 +22,7 @@ use web_sys::{DomException, IdbTransactionMode};
 use crate::{
     crypto_store::{
         keys,
-        migrations::{do_schema_upgrade, old_keys, MigrationDb},
+        migrations::{MigrationDb, do_schema_upgrade, old_keys},
     },
     serializer::IndexeddbSerializer,
 };

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs
@@ -18,7 +18,7 @@
 use indexed_db_futures::IdbKeyPath;
 use web_sys::DomException;
 
-use crate::crypto_store::{keys, migrations::do_schema_upgrade, Result};
+use crate::crypto_store::{Result, keys, migrations::do_schema_upgrade};
 
 /// Perform the schema upgrade v11 to v12, adding an index on
 /// `(curve_key, sender_data_type, session_id)` to `inbound_group_sessions3`.

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v5_to_v7.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v5_to_v7.rs
@@ -25,13 +25,12 @@ use tracing::{debug, info};
 use web_sys::{DomException, IdbTransactionMode};
 
 use crate::{
+    IndexeddbCryptoStoreError,
     crypto_store::{
-        keys,
-        migrations::{add_nonunique_index, do_schema_upgrade, old_keys, v7, MigrationDb},
-        Result,
+        Result, keys,
+        migrations::{MigrationDb, add_nonunique_index, do_schema_upgrade, old_keys, v7},
     },
     serializer::IndexeddbSerializer,
-    IndexeddbCryptoStoreError,
 };
 
 /// Perform the schema upgrade v5 to v6, creating `inbound_group_sessions2`.

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v7_to_v8.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v7_to_v8.rs
@@ -21,12 +21,12 @@ use tracing::{debug, info};
 use web_sys::{DomException, IdbTransactionMode};
 
 use crate::{
+    IndexeddbCryptoStoreError,
     crypto_store::{
-        migrations::{do_schema_upgrade, old_keys, v7, MigrationDb},
         Result,
+        migrations::{MigrationDb, do_schema_upgrade, old_keys, v7},
     },
     serializer::IndexeddbSerializer,
-    IndexeddbCryptoStoreError,
 };
 
 /// In the migration v5 to v7, we incorrectly copied the keys in
@@ -101,7 +101,9 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
             }
 
             if !cursor.continue_cursor()?.await? {
-                debug!("Migrated {row_count} sessions: {updated} keys updated and {deleted} obsolete entries deleted.");
+                debug!(
+                    "Migrated {row_count} sessions: {updated} keys updated and {deleted} obsolete entries deleted."
+                );
                 break;
             }
         }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
@@ -21,16 +21,15 @@ use tracing::{debug, info};
 use web_sys::{DomException, IdbTransactionMode};
 
 use crate::{
+    IndexeddbCryptoStoreError,
     crypto_store::{
-        keys,
+        InboundGroupSessionIndexedDbObject, Result, keys,
         migrations::{
-            add_nonunique_index, do_schema_upgrade, old_keys,
-            v7::InboundGroupSessionIndexedDbObject2, MigrationDb,
+            MigrationDb, add_nonunique_index, do_schema_upgrade, old_keys,
+            v7::InboundGroupSessionIndexedDbObject2,
         },
-        InboundGroupSessionIndexedDbObject, Result,
     },
     serializer::IndexeddbSerializer,
-    IndexeddbCryptoStoreError,
 };
 
 /// Perform the schema upgrade v8 to v9, creating `inbound_group_sessions3`.

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -13,8 +13,8 @@
 // limitations under the License
 
 use indexed_db_futures::{
-    idb_object_store::IdbObjectStoreParameters, request::IdbOpenDbRequestLike, IdbDatabase,
-    IdbVersionChangeEvent,
+    IdbDatabase, IdbVersionChangeEvent, idb_object_store::IdbObjectStoreParameters,
+    request::IdbOpenDbRequestLike,
 };
 use thiserror::Error;
 use wasm_bindgen::JsValue;

--- a/crates/matrix-sdk-indexeddb/src/safe_encode.rs
+++ b/crates/matrix-sdk-indexeddb/src/safe_encode.rs
@@ -1,17 +1,16 @@
 //! Helpers for wasm32/browser environments
 
 use base64::{
-    alphabet,
-    engine::{general_purpose, GeneralPurpose},
-    Engine,
+    Engine, alphabet,
+    engine::{GeneralPurpose, general_purpose},
 };
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{
-    events::{
-        receipt::ReceiptType, GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
-    },
     DeviceId, EventId, MxcUri, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, TransactionId,
     UserId,
+    events::{
+        GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType, receipt::ReceiptType,
+    },
 };
 use wasm_bindgen::JsValue;
 use web_sys::IdbKeyRange;

--- a/crates/matrix-sdk-indexeddb/src/serializer.rs
+++ b/crates/matrix-sdk-indexeddb/src/serializer.rs
@@ -15,14 +15,13 @@
 use std::sync::Arc;
 
 use base64::{
-    alphabet,
-    engine::{general_purpose, GeneralPurpose},
-    Engine,
+    Engine, alphabet,
+    engine::{GeneralPurpose, general_purpose},
 };
 use gloo_utils::format::JsValueSerdeExt;
 use matrix_sdk_crypto::CryptoStoreError;
 use matrix_sdk_store_encryption::{EncryptedValueBase64, StoreCipher};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use wasm_bindgen::JsValue;
 use web_sys::IdbKeyRange;
 use zeroize::Zeroizing;

--- a/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
@@ -18,20 +18,20 @@ use std::{
 };
 
 use gloo_utils::format::JsValueSerdeExt;
-use indexed_db_futures::{prelude::*, request::OpenDbRequest, IdbDatabase, IdbVersionChangeEvent};
+use indexed_db_futures::{IdbDatabase, IdbVersionChangeEvent, prelude::*, request::OpenDbRequest};
 use js_sys::Date as JsDate;
 use matrix_sdk_base::{
-    deserialized_responses::SyncOrStrippedState, store::migration_helpers::RoomInfoV1,
-    StateStoreDataKey,
+    StateStoreDataKey, deserialized_responses::SyncOrStrippedState,
+    store::migration_helpers::RoomInfoV1,
 };
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{
     events::{
+        StateEventType,
         room::{
             create::RoomCreateEventContent,
             member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
         },
-        StateEventType,
     },
     serde::Raw,
 };
@@ -41,8 +41,8 @@ use wasm_bindgen::JsValue;
 use web_sys::IdbTransactionMode;
 
 use super::{
-    deserialize_value, encode_key, encode_to_range, keys, serialize_value, Result, RoomMember,
-    ALL_STORES,
+    ALL_STORES, Result, RoomMember, deserialize_value, encode_key, encode_to_range, keys,
+    serialize_value,
 };
 use crate::IndexeddbStateStoreError;
 
@@ -801,33 +801,34 @@ mod tests {
     use assert_matches2::assert_let;
     use indexed_db_futures::prelude::*;
     use matrix_sdk_base::{
+        RoomMemberships, RoomState, StateStore, StateStoreDataKey, StoreError,
         deserialized_responses::RawMemberEvent,
         store::{RoomLoadSettings, StateStoreExt},
         sync::UnreadNotificationsCount,
-        RoomMemberships, RoomState, StateStore, StateStoreDataKey, StoreError,
     };
     use matrix_sdk_test::{async_test, test_json};
     use ruma::{
+        EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId,
         events::{
+            AnySyncStateEvent, StateEventType,
             room::{
                 create::RoomCreateEventContent,
                 member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
             },
-            AnySyncStateEvent, StateEventType,
         },
         room_id,
         serde::Raw,
-        server_name, user_id, EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId,
+        server_name, user_id,
     };
     use serde_json::json;
     use uuid::Uuid;
     use wasm_bindgen::JsValue;
 
-    use super::{old_keys, MigrationConflictStrategy, CURRENT_DB_VERSION, CURRENT_META_DB_VERSION};
+    use super::{CURRENT_DB_VERSION, CURRENT_META_DB_VERSION, MigrationConflictStrategy, old_keys};
     use crate::{
-        safe_encode::SafeEncode,
-        state_store::{encode_key, keys, serialize_value, Result},
         IndexeddbStateStore, IndexeddbStateStoreError,
+        safe_encode::SafeEncode,
+        state_store::{Result, encode_key, keys, serialize_value},
     };
 
     const CUSTOM_DATA_KEY: &[u8] = b"custom_data_key";

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -23,31 +23,31 @@ use gloo_utils::format::JsValueSerdeExt;
 use growable_bloom_filter::GrowableBloom;
 use indexed_db_futures::prelude::*;
 use matrix_sdk_base::{
+    MinimalRoomMemberEvent, RoomInfo, RoomMemberships, StateStoreDataKey, StateStoreDataValue,
     deserialized_responses::{DisplayName, RawAnySyncOrStrippedState},
     store::{
         ChildTransactionId, ComposerDraft, DependentQueuedRequest, DependentQueuedRequestKind,
         QueuedRequest, QueuedRequestKind, RoomLoadSettings, SentRequestKey,
         SerializableEventContent, ServerCapabilities, StateChanges, StateStore, StoreError,
     },
-    MinimalRoomMemberEvent, RoomInfo, RoomMemberships, StateStoreDataKey, StateStoreDataValue,
 };
 use matrix_sdk_store_encryption::{Error as EncryptionError, StoreCipher};
 use ruma::{
-    canonical_json::{redact, RedactedBecause},
+    CanonicalJsonObject, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri,
+    OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId, TransactionId, UserId,
+    canonical_json::{RedactedBecause, redact},
     events::{
+        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncStateEvent,
+        GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType, SyncStateEvent,
         presence::PresenceEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::member::{
             MembershipState, RoomMemberEventContent, StrippedRoomMemberEvent, SyncRoomMemberEvent,
         },
-        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncStateEvent,
-        GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType, SyncStateEvent,
     },
     serde::Raw,
-    CanonicalJsonObject, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri,
-    OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId, TransactionId, UserId,
 };
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tracing::{debug, warn};
 use wasm_bindgen::JsValue;
 use web_sys::IdbKeyRange;
@@ -68,7 +68,9 @@ pub enum IndexeddbStateStoreError {
     DomException { name: String, message: String, code: u16 },
     #[error(transparent)]
     StoreError(#[from] StoreError),
-    #[error("Can't migrate {name} from {old_version} to {new_version} without deleting data. See MigrationConflictStrategy for ways to configure.")]
+    #[error(
+        "Can't migrate {name} from {old_version} to {new_version} without deleting data. See MigrationConflictStrategy for ways to configure."
+    )]
     MigrationConflict { name: String, old_version: u32, new_version: u32 },
 }
 
@@ -1805,8 +1807,8 @@ mod migration_tests {
     use assert_matches2::assert_matches;
     use matrix_sdk_base::store::{QueuedRequestKind, SerializableEventContent};
     use ruma::{
-        events::room::message::RoomMessageEventContent, room_id, OwnedRoomId, OwnedTransactionId,
-        TransactionId,
+        OwnedRoomId, OwnedTransactionId, TransactionId,
+        events::room::message::RoomMessageEventContent, room_id,
     };
     use serde::{Deserialize, Serialize};
 

--- a/crates/matrix-sdk-qrcode/src/types.rs
+++ b/crates/matrix-sdk-qrcode/src/types.rs
@@ -21,7 +21,7 @@ use vodozemac::Ed25519PublicKey;
 
 use crate::{
     error::{DecodingError, EncodingError},
-    utils::{to_bytes, to_qr_code, HEADER, MAX_MODE, MIN_SECRET_LEN, VERSION},
+    utils::{HEADER, MAX_MODE, MIN_SECRET_LEN, VERSION, to_bytes, to_qr_code},
 };
 
 /// An enum representing the different modes for a QR verification code.

--- a/crates/matrix-sdk-qrcode/src/utils.rs
+++ b/crates/matrix-sdk-qrcode/src/utils.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use qrcode::{bits::Bits, EcLevel, QrCode, Version};
+use qrcode::{EcLevel, QrCode, Version, bits::Bits};
 use ruma_common::serde::Base64;
 use vodozemac::Ed25519PublicKey;
 

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -23,38 +23,38 @@ use std::{
 use async_trait::async_trait;
 use deadpool_sqlite::{Object as SqliteAsyncConn, Pool as SqlitePool, Runtime};
 use matrix_sdk_crypto::{
+    Account, DeviceData, GossipRequest, GossippedSecret, SecretInfo, TrackedUser, UserIdentityData,
     olm::{
         InboundGroupSession, OutboundGroupSession, PickledInboundGroupSession,
         PrivateCrossSigningIdentity, SenderDataType, Session, StaticAccountData,
     },
     store::{
+        CryptoStore,
         types::{
             BackupKeys, Changes, DehydratedDeviceKey, PendingChanges, RoomKeyCounts, RoomSettings,
             StoredRoomKeyBundleData,
         },
-        CryptoStore,
     },
     types::events::room_key_withheld::RoomKeyWithheldEvent,
-    Account, DeviceData, GossipRequest, GossippedSecret, SecretInfo, TrackedUser, UserIdentityData,
 };
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{
-    events::secret::request::SecretName, DeviceId, MilliSecondsSinceUnixEpoch, OwnedDeviceId,
-    RoomId, TransactionId, UserId,
+    DeviceId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, RoomId, TransactionId, UserId,
+    events::secret::request::SecretName,
 };
-use rusqlite::{named_params, params_from_iter, OptionalExtension};
-use serde::{de::DeserializeOwned, Serialize};
+use rusqlite::{OptionalExtension, named_params, params_from_iter};
+use serde::{Serialize, de::DeserializeOwned};
 use tokio::{fs, sync::Mutex};
 use tracing::{debug, instrument, warn};
 use vodozemac::Curve25519PublicKey;
 
 use crate::{
+    OpenStoreError, SqliteStoreConfig,
     error::{Error, Result},
     utils::{
-        repeat_vars, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
-        SqliteKeyValueStoreConnExt,
+        Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt, SqliteKeyValueStoreConnExt,
+        repeat_vars,
     },
-    OpenStoreError, SqliteStoreConfig,
 };
 
 /// The database name.
@@ -1050,11 +1050,7 @@ impl CryptoStore for SqliteCryptoStore {
             })
             .collect::<Result<_>>()?;
 
-        if sessions.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(sessions))
-        }
+        if sessions.is_empty() { Ok(None) } else { Ok(Some(sessions)) }
     }
 
     #[instrument(skip(self))]
@@ -1504,7 +1500,7 @@ mod tests {
     use once_cell::sync::Lazy;
     use ruma::{device_id, room_id, user_id};
     use similar_asserts::assert_eq;
-    use tempfile::{tempdir, TempDir};
+    use tempfile::{TempDir, tempdir};
     use tokio::fs;
 
     use super::SqliteCryptoStore;
@@ -1916,7 +1912,7 @@ mod tests {
 mod encrypted_tests {
     use matrix_sdk_crypto::{cryptostore_integration_tests, cryptostore_integration_tests_time};
     use once_cell::sync::Lazy;
-    use tempfile::{tempdir, TempDir};
+    use tempfile::{TempDir, tempdir};
     use tokio::fs;
 
     use super::SqliteCryptoStore;

--- a/crates/matrix-sdk-sqlite/src/lib.rs
+++ b/crates/matrix-sdk-sqlite/src/lib.rs
@@ -37,7 +37,7 @@ pub use self::error::OpenStoreError;
 #[cfg(feature = "event-cache")]
 pub use self::event_cache_store::SqliteEventCacheStore;
 #[cfg(feature = "state-store")]
-pub use self::state_store::{SqliteStateStore, DATABASE_NAME as STATE_STORE_DATABASE_NAME};
+pub use self::state_store::{DATABASE_NAME as STATE_STORE_DATABASE_NAME, SqliteStateStore};
 
 #[cfg(test)]
 matrix_sdk_test::init_tracing_for_tests!();

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -9,44 +9,44 @@ use std::{
 use async_trait::async_trait;
 use deadpool_sqlite::{Object as SqliteAsyncConn, Pool as SqlitePool, Runtime};
 use matrix_sdk_base::{
-    deserialized_responses::{DisplayName, RawAnySyncOrStrippedState, SyncOrStrippedState},
-    store::{
-        migration_helpers::RoomInfoV1, ChildTransactionId, DependentQueuedRequest,
-        DependentQueuedRequestKind, QueueWedgeError, QueuedRequest, QueuedRequestKind,
-        RoomLoadSettings, SentRequestKey,
-    },
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, RoomState, StateChanges, StateStore,
     StateStoreDataKey, StateStoreDataValue,
+    deserialized_responses::{DisplayName, RawAnySyncOrStrippedState, SyncOrStrippedState},
+    store::{
+        ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind, QueueWedgeError,
+        QueuedRequest, QueuedRequestKind, RoomLoadSettings, SentRequestKey,
+        migration_helpers::RoomInfoV1,
+    },
 };
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{
-    canonical_json::{redact, RedactedBecause},
+    CanonicalJsonObject, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
+    OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId, TransactionId, UInt, UserId,
+    canonical_json::{RedactedBecause, redact},
     events::{
+        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncStateEvent,
+        GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
         presence::PresenceEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::{
             create::RoomCreateEventContent,
             member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
         },
-        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncStateEvent,
-        GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
     },
     serde::Raw,
-    CanonicalJsonObject, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
-    OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId, TransactionId, UInt, UserId,
 };
 use rusqlite::{OptionalExtension, Transaction};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tokio::fs;
 use tracing::{debug, warn};
 
 use crate::{
+    OpenStoreError, SqliteStoreConfig,
     error::{Error, Result},
     utils::{
-        repeat_vars, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
-        SqliteKeyValueStoreConnExt,
+        Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt, SqliteKeyValueStoreConnExt,
+        repeat_vars,
     },
-    OpenStoreError, SqliteStoreConfig,
 };
 
 mod keys {
@@ -2133,9 +2133,9 @@ struct ReceiptData {
 mod tests {
     use std::sync::atomic::{AtomicU32, Ordering::SeqCst};
 
-    use matrix_sdk_base::{statestore_integration_tests, StateStore, StoreError};
+    use matrix_sdk_base::{StateStore, StoreError, statestore_integration_tests};
     use once_cell::sync::Lazy;
-    use tempfile::{tempdir, TempDir};
+    use tempfile::{TempDir, tempdir};
 
     use super::SqliteStateStore;
 
@@ -2161,13 +2161,13 @@ mod encrypted_tests {
         sync::atomic::{AtomicU32, Ordering::SeqCst},
     };
 
-    use matrix_sdk_base::{statestore_integration_tests, StateStore, StoreError};
+    use matrix_sdk_base::{StateStore, StoreError, statestore_integration_tests};
     use matrix_sdk_test::async_test;
     use once_cell::sync::Lazy;
-    use tempfile::{tempdir, TempDir};
+    use tempfile::{TempDir, tempdir};
 
     use super::SqliteStateStore;
-    use crate::{utils::SqliteAsyncConnExt, SqliteStoreConfig};
+    use crate::{SqliteStoreConfig, utils::SqliteAsyncConnExt};
 
     static TMP_DIR: Lazy<TempDir> = Lazy::new(|| tempdir().unwrap());
     static NUM: AtomicU32 = AtomicU32::new(0);
@@ -2240,43 +2240,43 @@ mod migration_tests {
     use std::{
         path::{Path, PathBuf},
         sync::{
-            atomic::{AtomicU32, Ordering::SeqCst},
             Arc,
+            atomic::{AtomicU32, Ordering::SeqCst},
         },
     };
 
     use as_variant::as_variant;
     use deadpool_sqlite::Runtime;
     use matrix_sdk_base::{
+        RoomState, StateStore,
         media::{MediaFormat, MediaRequestParameters},
         store::{
             ChildTransactionId, DependentQueuedRequestKind, RoomLoadSettings,
             SerializableEventContent,
         },
         sync::UnreadNotificationsCount,
-        RoomState, StateStore,
     };
     use matrix_sdk_test::async_test;
     use once_cell::sync::Lazy;
     use ruma::{
+        EventId, MilliSecondsSinceUnixEpoch, OwnedTransactionId, RoomId, TransactionId, UserId,
         events::{
-            room::{create::RoomCreateEventContent, message::RoomMessageEventContent, MediaSource},
             StateEventType,
+            room::{MediaSource, create::RoomCreateEventContent, message::RoomMessageEventContent},
         },
-        room_id, server_name, user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedTransactionId,
-        RoomId, TransactionId, UserId,
+        room_id, server_name, user_id,
     };
     use rusqlite::Transaction;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use tempfile::{tempdir, TempDir};
+    use tempfile::{TempDir, tempdir};
     use tokio::fs;
 
-    use super::{init, keys, SqliteStateStore, DATABASE_NAME};
+    use super::{DATABASE_NAME, SqliteStateStore, init, keys};
     use crate::{
+        OpenStoreError,
         error::{Error, Result},
         utils::{SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt},
-        OpenStoreError,
     };
 
     static TMP_DIR: Lazy<TempDir> = Lazy::new(|| tempdir().unwrap());

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -20,12 +20,12 @@ use deadpool_sqlite::Object as SqliteAsyncConn;
 use itertools::Itertools;
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::time::SystemTime;
-use rusqlite::{limits::Limit, OptionalExtension, Params, Row, Statement, Transaction};
-use serde::{de::DeserializeOwned, Serialize};
+use rusqlite::{OptionalExtension, Params, Row, Statement, Transaction, limits::Limit};
+use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{
-    error::{Error, Result},
     OpenStoreError, RuntimeConfig,
+    error::{Error, Result},
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -19,19 +19,18 @@
 use std::ops::DerefMut;
 
 use base64::{
-    alphabet,
-    engine::{general_purpose, GeneralPurpose},
-    Engine,
+    Engine, alphabet,
+    engine::{GeneralPurpose, general_purpose},
 };
-use blake3::{derive_key, Hash};
+use blake3::{Hash, derive_key};
 use chacha20poly1305::{
-    aead::{Aead, Error as EncryptionError},
     Key as ChachaKey, KeyInit, XChaCha20Poly1305, XNonce,
+    aead::{Aead, Error as EncryptionError},
 };
 use hmac::Hmac;
 use pbkdf2::pbkdf2;
-use rand::{thread_rng, Error as RandomError, Fill};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use rand::{Error as RandomError, Fill, thread_rng};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sha2::Sha256;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -77,7 +76,9 @@ pub enum Error {
 
     /// Failed to import a store cipher, the export used a passphrase while
     /// we are trying to import it using a key or vice-versa.
-    #[error("Failed to import a store cipher, the export used a passphrase while we are trying to import it using a key or vice-versa")]
+    #[error(
+        "Failed to import a store cipher, the export used a passphrase while we are trying to import it using a key or vice-versa"
+    )]
     KdfMismatch,
 }
 
@@ -812,7 +813,7 @@ struct EncryptedStoreCipher {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     use super::{Error, StoreCipher};
     use crate::{EncryptedValue, EncryptedValueBase64, EncryptedValueBase64DecodeError};

--- a/crates/matrix-sdk-ui/src/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync_service.rs
@@ -30,11 +30,11 @@ use std::{pin::Pin, time::Duration};
 
 use async_stream::stream;
 use futures_core::stream::Stream;
-use futures_util::{pin_mut, StreamExt};
-use matrix_sdk::{sleep::sleep, Client, SlidingSync, LEASE_DURATION_MS};
+use futures_util::{StreamExt, pin_mut};
+use matrix_sdk::{Client, LEASE_DURATION_MS, SlidingSync, sleep::sleep};
 use ruma::{api::client::sync::sync_events::v5 as http, assign};
 use tokio::sync::OwnedMutexGuard;
-use tracing::{debug, instrument, trace, Span};
+use tracing::{Span, debug, instrument, trace};
 
 /// Unit type representing a permit to *use* an [`EncryptionSyncService`].
 ///
@@ -66,11 +66,7 @@ pub enum WithLocking {
 
 impl From<bool> for WithLocking {
     fn from(value: bool) -> Self {
-        if value {
-            Self::Yes
-        } else {
-            Self::No
-        }
+        if value { Self::Yes } else { Self::No }
     }
 }
 

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -14,45 +14,46 @@
 
 use std::{
     collections::{
-        btree_map::{IntoIter, Iter},
         BTreeMap,
+        btree_map::{IntoIter, Iter},
     },
     sync::{Arc, Mutex},
     time::Duration,
 };
 
-use futures_util::{pin_mut, StreamExt as _};
+use futures_util::{StreamExt as _, pin_mut};
 use matrix_sdk::{
-    room::Room, sleep::sleep, Client, ClientBuildError, SlidingSyncList, SlidingSyncMode,
+    Client, ClientBuildError, SlidingSyncList, SlidingSyncMode, room::Room, sleep::sleep,
 };
-use matrix_sdk_base::{deserialized_responses::TimelineEvent, RoomState, StoreError};
+use matrix_sdk_base::{RoomState, StoreError, deserialized_responses::TimelineEvent};
 use ruma::{
+    EventId, OwnedEventId, OwnedRoomId, RoomId, UserId,
     api::client::sync::sync_events::v5 as http,
     assign,
     directory::RoomTypeFilter,
     events::{
+        AnyFullStateEventContent, AnyMessageLikeEventContent, AnyStateEvent,
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, FullStateEventContent, StateEventType,
+        TimelineEventType,
         room::{
             join_rules::JoinRule,
             member::{MembershipState, StrippedRoomMemberEvent},
             message::{Relation, SyncRoomMessageEvent},
         },
-        AnyFullStateEventContent, AnyMessageLikeEventContent, AnyStateEvent,
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent, FullStateEventContent, StateEventType,
-        TimelineEventType,
     },
     html::RemoveReplyFallback,
     push::Action,
     serde::Raw,
-    uint, EventId, OwnedEventId, OwnedRoomId, RoomId, UserId,
+    uint,
 };
 use thiserror::Error;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::{debug, info, instrument, trace, warn};
 
 use crate::{
+    DEFAULT_SANITIZER_MODE,
     encryption_sync_service::{EncryptionSyncPermit, EncryptionSyncService, WithLocking},
     sync_service::SyncService,
-    DEFAULT_SANITIZER_MODE,
 };
 
 /// What kind of process setup do we have for this notification client?

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher as _};
+pub use fuzzy_matcher::{FuzzyMatcher as _, skim::SkimMatcherV2};
 
-use super::{normalize_string, Filter};
+use super::{Filter, normalize_string};
 
 struct FuzzyMatcher {
     matcher: SkimMatcherV2,

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
@@ -21,7 +21,7 @@
 //!
 //! ```rust
 //! use matrix_sdk_ui::room_list_service::{
-//!     filters, RoomListDynamicEntriesController,
+//!     RoomListDynamicEntriesController, filters,
 //! };
 //!
 //! fn configure_room_list(
@@ -67,7 +67,7 @@ mod unread;
 
 pub use all::new_filter as new_filter_all;
 pub use any::new_filter as new_filter_any;
-pub use category::{new_filter as new_filter_category, RoomCategory};
+pub use category::{RoomCategory, new_filter as new_filter_category};
 pub use deduplicate_versions::new_filter as new_filter_deduplicate_versions;
 pub use favourite::new_filter as new_filter_favourite;
 pub use fuzzy_match_room_name::new_filter as new_filter_fuzzy_match_room_name;
@@ -84,12 +84,12 @@ pub use normalized_match_room_name::new_filter as new_filter_normalized_match_ro
 pub use not::new_filter as new_filter_not;
 #[cfg(test)]
 use ruma::RoomId;
-use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
+use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
 pub use unread::new_filter as new_filter_unread;
 #[cfg(test)]
 use wiremock::{
-    matchers::{header, method, path},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path},
 };
 
 /// A trait “alias” that represents a _filter_.

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/normalized_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/normalized_match_room_name.rs
@@ -14,7 +14,7 @@
 
 use tracing::error;
 
-use super::{normalize_string, Filter};
+use super::{Filter, normalize_string};
 
 struct NormalizedMatcher {
     pattern: Option<String>,

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -60,15 +60,15 @@ use std::{sync::Arc, time::Duration};
 
 use async_stream::stream;
 use eyeball::Subscriber;
-use futures_util::{pin_mut, Stream, StreamExt};
+use futures_util::{Stream, StreamExt, pin_mut};
 use matrix_sdk::{
-    event_cache::EventCacheError, timeout::timeout, Client, Error as SlidingSyncError, Room,
-    SlidingSync, SlidingSyncList, SlidingSyncMode,
+    Client, Error as SlidingSyncError, Room, SlidingSync, SlidingSyncList, SlidingSyncMode,
+    event_cache::EventCacheError, timeout::timeout,
 };
 pub use room_list::*;
 use ruma::{
-    api::client::sync::sync_events::v5 as http, assign, directory::RoomTypeFilter,
-    events::StateEventType, OwnedRoomId, RoomId, UInt,
+    OwnedRoomId, RoomId, UInt, api::client::sync::sync_events::v5 as http, assign,
+    directory::RoomTypeFilter, events::StateEventType,
 };
 pub use state::*;
 use thiserror::Error;
@@ -457,16 +457,16 @@ pub enum SyncIndicator {
 mod tests {
     use std::future::ready;
 
-    use futures_util::{pin_mut, StreamExt};
+    use futures_util::{StreamExt, pin_mut};
     use matrix_sdk::{
-        config::RequestConfig, test_utils::client::mock_matrix_session, Client, SlidingSyncMode,
+        Client, SlidingSyncMode, config::RequestConfig, test_utils::client::mock_matrix_session,
     };
     use matrix_sdk_test::async_test;
     use ruma::api::MatrixVersion;
     use serde_json::json;
-    use wiremock::{http::Method, Match, Mock, MockServer, Request, ResponseTemplate};
+    use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate, http::Method};
 
-    use super::{Error, RoomListService, State, ALL_ROOMS_LIST_NAME};
+    use super::{ALL_ROOMS_LIST_NAME, Error, RoomListService, State};
 
     async fn new_client() -> (Client, MockServer) {
         let session = mock_matrix_session();

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -20,10 +20,10 @@ use async_stream::stream;
 use eyeball::{SharedObservable, Subscriber};
 use eyeball_im::{Vector, VectorDiff};
 use eyeball_im_util::vector::VectorObserverExt;
-use futures_util::{pin_mut, stream, Stream, StreamExt as _};
+use futures_util::{Stream, StreamExt as _, pin_mut, stream};
 use matrix_sdk::{
-    executor::{spawn, JoinHandle},
     Client, SlidingSync, SlidingSyncList,
+    executor::{JoinHandle, spawn},
 };
 use matrix_sdk_base::RoomInfoNotableUpdate;
 use tokio::{
@@ -33,9 +33,9 @@ use tokio::{
 use tracing::{error, trace};
 
 use super::{
+    Error, Room, State,
     filters::BoxedFilterFn,
     sorters::{new_sorter_lexicographic, new_sorter_name, new_sorter_recency},
-    Error, Room, State,
 };
 
 /// A `RoomList` represents a list of rooms, from a

--- a/crates/matrix-sdk-ui/src/room_list_service/state.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/state.rs
@@ -17,7 +17,7 @@
 use std::{future::ready, sync::Mutex};
 
 use eyeball::{SharedObservable, Subscriber};
-use matrix_sdk::{sliding_sync::Range, SlidingSync, SlidingSyncMode};
+use matrix_sdk::{SlidingSync, SlidingSyncMode, sliding_sync::Range};
 use ruma::time::{Duration, Instant};
 
 use super::Error;

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -28,21 +28,22 @@ use std::{sync::Arc, time::Duration};
 
 use eyeball::{SharedObservable, Subscriber};
 use futures_util::{
-    future::{select, Either},
-    pin_mut, StreamExt as _,
+    StreamExt as _,
+    future::{Either, select},
+    pin_mut,
 };
 use matrix_sdk::{
-    config::RequestConfig,
-    executor::{spawn, JoinHandle},
-    sleep::sleep,
     Client,
+    config::RequestConfig,
+    executor::{JoinHandle, spawn},
+    sleep::sleep,
 };
 use thiserror::Error;
 use tokio::sync::{
-    mpsc::{Receiver, Sender},
     Mutex as AsyncMutex, OwnedMutexGuard,
+    mpsc::{Receiver, Sender},
 };
-use tracing::{error, info, instrument, trace, warn, Instrument, Level, Span};
+use tracing::{Instrument, Level, Span, error, info, instrument, trace, warn};
 
 use crate::{
     encryption_sync_service::{self, EncryptionSyncPermit, EncryptionSyncService, WithLocking},

--- a/crates/matrix-sdk-ui/src/timeline/algorithms.rs
+++ b/crates/matrix-sdk-ui/src/timeline/algorithms.rs
@@ -20,8 +20,8 @@ use ruma::EventId;
 #[cfg(doc)]
 use super::controller::TimelineMetadata;
 use super::{
-    event_item::EventTimelineItemKind, item::TimelineUniqueId, EventTimelineItem,
-    ReactionsByKeyBySender, TimelineEventItemId, TimelineItem,
+    EventTimelineItem, ReactionsByKeyBySender, TimelineEventItemId, TimelineItem,
+    event_item::EventTimelineItemKind, item::TimelineUniqueId,
 };
 
 pub(super) struct EventTimelineItemWithId<'a> {

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -18,25 +18,25 @@ use std::{
 };
 
 use futures_core::Stream;
-use futures_util::{pin_mut, StreamExt};
+use futures_util::{StreamExt, pin_mut};
 use matrix_sdk::{
+    Room,
     crypto::store::types::RoomKeyInfo,
     encryption::backups::BackupState,
     event_cache::{EventsOrigin, RoomEventCache, RoomEventCacheListener, RoomEventCacheUpdate},
     executor::spawn,
     send_queue::RoomSendQueueUpdate,
-    Room,
 };
 use matrix_sdk_base::{SendOutsideWasm, SyncOutsideWasm};
-use ruma::{events::AnySyncTimelineEvent, OwnedEventId, RoomVersionId};
-use tokio::sync::broadcast::{error::RecvError, Receiver};
+use ruma::{OwnedEventId, RoomVersionId, events::AnySyncTimelineEvent};
+use tokio::sync::broadcast::{Receiver, error::RecvError};
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
-use tracing::{info_span, instrument, trace, warn, Instrument, Span};
+use tracing::{Instrument, Span, info_span, instrument, trace, warn};
 
 use super::{
+    DateDividerMode, Error, Timeline, TimelineDropHandle, TimelineFocus,
     controller::{TimelineController, TimelineSettings},
     to_device::{handle_forwarded_room_key_event, handle_room_key_event},
-    DateDividerMode, Error, Timeline, TimelineDropHandle, TimelineFocus,
 };
 use crate::{timeline::event_item::RemoteEventOrigin, unable_to_decrypt_hook::UtdHookManager};
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
@@ -42,17 +42,17 @@ use std::{borrow::Cow, collections::HashMap, sync::Arc};
 use as_variant::as_variant;
 use matrix_sdk::deserialized_responses::EncryptionInfo;
 use ruma::{
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId,
     events::{
+        AnySyncTimelineEvent,
         poll::unstable_start::NewUnstablePollStartEventContentWithoutRelation,
         relation::Replacement, room::message::RoomMessageEventContentWithoutRelation,
-        AnySyncTimelineEvent,
     },
     serde::Raw,
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId,
 };
 use tracing::{info, trace, warn};
 
-use super::{rfind_event_by_item_id, ObservableItemsTransaction};
+use super::{ObservableItemsTransaction, rfind_event_by_item_id};
 use crate::timeline::{
     EventTimelineItem, MsgLikeContent, MsgLikeKind, PollState, ReactionInfo, ReactionStatus,
     TimelineEventItemId, TimelineItem, TimelineItemContent,
@@ -427,7 +427,9 @@ impl Aggregations {
         };
 
         let Some(aggregation) = aggregation else {
-            warn!("incorrect internal state: {aggregation_id:?} was present in the inverted map, not in related-to map.");
+            warn!(
+                "incorrect internal state: {aggregation_id:?} was present in the inverted map, not in related-to map."
+            );
             return Ok(false);
         };
 
@@ -639,11 +641,7 @@ fn resolve_edits(
         }
     }
 
-    if let Some(edit) = best_edit {
-        edit_item(event, edit)
-    } else {
-        false
-    }
+    if let Some(edit) = best_edit { edit_item(event, edit) } else { false }
 }
 
 /// Apply the selected edit to the given EventTimelineItem.
@@ -807,6 +805,8 @@ pub(crate) enum AggregationError {
     #[error("a redaction can't be unapplied")]
     CantUndoRedaction,
 
-    #[error("trying to apply an aggregation of one type to an invalid target: expected {expected}, actual {actual}")]
+    #[error(
+        "trying to apply an aggregation of one type to an invalid target: expected {expected}, actual {actual}"
+    )]
     InvalidType { expected: String, actual: String },
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -20,30 +20,30 @@ use std::{
 use imbl::Vector;
 use matrix_sdk::deserialized_responses::EncryptionInfo;
 use ruma::{
+    EventId, OwnedEventId, OwnedUserId, RoomVersionId,
     events::{
-        poll::unstable_start::UnstablePollStartEventContent, relation::Replacement,
-        room::message::RelationWithoutReplacement, AnyMessageLikeEventContent,
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent, BundledMessageLikeRelations,
+        AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+        BundledMessageLikeRelations, poll::unstable_start::UnstablePollStartEventContent,
+        relation::Replacement, room::message::RelationWithoutReplacement,
     },
     serde::Raw,
-    EventId, OwnedEventId, OwnedUserId, RoomVersionId,
 };
 use tracing::trace;
 
 use super::{
-    super::{subscriber::skip::SkipCount, TimelineItem, TimelineItemKind, TimelineUniqueId},
-    read_receipts::ReadReceipts,
+    super::{TimelineItem, TimelineItemKind, TimelineUniqueId, subscriber::skip::SkipCount},
     Aggregation, AggregationKind, Aggregations, AllRemoteEvents, ObservableItemsTransaction,
     PendingEdit, PendingEditKind,
+    read_receipts::ReadReceipts,
 };
 use crate::{
     timeline::{
+        InReplyToDetails, TimelineEventItemId,
         controller::TimelineFocusKind,
         event_item::{
             extract_bundled_edit_event_json, extract_poll_edit_content,
             extract_room_msg_edit_content,
         },
-        InReplyToDetails, TimelineEventItemId,
     },
     unable_to_decrypt_hook::UtdHookManager,
 };

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -20,36 +20,36 @@ use eyeball_im::VectorDiff;
 use eyeball_im_util::vector::VectorObserverExt;
 use futures_core::Stream;
 use imbl::Vector;
-#[cfg(test)]
-use matrix_sdk::{crypto::OlmMachine, SendOutsideWasm};
 use matrix_sdk::{
+    Result, Room,
     deserialized_responses::TimelineEvent,
     event_cache::{
-        paginator::{PaginationResult, Paginator},
         RoomEventCache, RoomPaginationStatus,
+        paginator::{PaginationResult, Paginator},
     },
     send_queue::{
         LocalEcho, LocalEchoContent, RoomSendQueueUpdate, SendHandle, SendReactionHandle,
     },
-    Result, Room,
 };
+#[cfg(test)]
+use matrix_sdk::{SendOutsideWasm, crypto::OlmMachine};
 use ruma::{
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, RoomVersionId,
+    TransactionId, UserId,
     api::client::receipt::create_receipt::v3::ReceiptType as SendReceiptType,
     events::{
+        AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
+        AnySyncTimelineEvent, MessageLikeEventType,
         poll::unstable_start::UnstablePollStartEventContent,
         reaction::ReactionEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         relation::Annotation,
         room::message::{MessageType, Relation},
-        AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
-        AnySyncTimelineEvent, MessageLikeEventType,
     },
     serde::Raw,
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, RoomVersionId,
-    TransactionId, UserId,
 };
 #[cfg(test)]
-use ruma::{events::receipt::ReceiptEventContent, OwnedRoomId, RoomId};
+use ruma::{OwnedRoomId, RoomId, events::receipt::ReceiptEventContent};
 use tokio::sync::{RwLock, RwLockWriteGuard};
 use tracing::{debug, error, field::debug, info, instrument, trace, warn};
 
@@ -63,23 +63,23 @@ pub(super) use self::{
     state_transaction::TimelineStateTransaction,
 };
 use super::{
+    DateDividerMode, EmbeddedEvent, Error, EventSendState, EventTimelineItem, InReplyToDetails,
+    PaginationError, Profile, TimelineDetails, TimelineEventItemId, TimelineFocus, TimelineItem,
+    TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
     algorithms::{rfind_event_by_id, rfind_event_item},
     event_item::{ReactionStatus, RemoteEventOrigin},
     item::TimelineUniqueId,
     subscriber::TimelineSubscriber,
     threaded_events_loader::ThreadedEventsLoader,
     traits::{Decryptor, RoomDataProvider},
-    DateDividerMode, EmbeddedEvent, Error, EventSendState, EventTimelineItem, InReplyToDetails,
-    PaginationError, Profile, TimelineDetails, TimelineEventItemId, TimelineFocus, TimelineItem,
-    TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
 };
 use crate::{
     timeline::{
+        MsgLikeContent, MsgLikeKind, TimelineEventFilterFn,
         algorithms::rfind_event_by_item_id,
         date_dividers::DateDividerAdjuster,
         event_item::EventTimelineItemKind,
         pinned_events_loader::{PinnedEventsLoader, PinnedEventsLoaderError},
-        MsgLikeContent, MsgLikeKind, TimelineEventFilterFn,
     },
     unable_to_decrypt_hook::UtdHookManager,
 };
@@ -511,7 +511,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
     ) -> Result<bool, PaginationError> {
         let PaginationResult { events, hit_end_of_timeline } = match &*self.focus.read().await {
             TimelineFocusData::Live | TimelineFocusData::PinnedEvents { .. } => {
-                return Err(PaginationError::NotSupported)
+                return Err(PaginationError::NotSupported);
             }
             TimelineFocusData::Event { paginator, .. } => paginator
                 .paginate_backward(num_events.into())
@@ -713,7 +713,9 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                     let new_item = item.with_reactions(reactions);
                     state.items.replace(item_pos, new_item);
                 } else {
-                    warn!("reaction is missing on the item, not removing it locally, but sending redaction.");
+                    warn!(
+                        "reaction is missing on the item, not removing it locally, but sending redaction."
+                    );
                 }
 
                 // Release the lock before running the request.
@@ -738,7 +740,9 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                             let new_item = item.with_reactions(reactions);
                             state.items.replace(item_pos, new_item);
                         } else {
-                            warn!("couldn't find item to re-add reaction anymore; maybe it's been redacted?");
+                            warn!(
+                                "couldn't find item to re-add reaction anymore; maybe it's been redacted?"
+                            );
                         }
                     }
 
@@ -1493,7 +1497,9 @@ impl TimelineController {
                         event_id,
                         state.items.all_remote_events(),
                     ) {
-                        trace!("event referred to new receipt is {relative_pos:?} the previous receipt");
+                        trace!(
+                            "event referred to new receipt is {relative_pos:?} the previous receipt"
+                        );
                         return relative_pos == RelativePosition::After;
                     }
                 }
@@ -1510,7 +1516,9 @@ impl TimelineController {
                         event_id,
                         state.items.all_remote_events(),
                     ) {
-                        trace!("event referred to new receipt is {relative_pos:?} the previous receipt");
+                        trace!(
+                            "event referred to new receipt is {relative_pos:?} the previous receipt"
+                        );
                         return relative_pos == RelativePosition::After;
                     }
                 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -14,7 +14,7 @@
 
 use std::{
     cmp::Ordering,
-    collections::{vec_deque::Iter, VecDeque},
+    collections::{VecDeque, vec_deque::Iter},
     iter::{Enumerate, Skip, Take},
     ops::{Deref, RangeBounds},
     sync::Arc,
@@ -28,7 +28,7 @@ use eyeball_im::{
 use imbl::Vector;
 use ruma::EventId;
 
-use super::{metadata::EventMeta, TimelineItem};
+use super::{TimelineItem, metadata::EventMeta};
 
 /// An `ObservableItems` is a type similar to
 /// [`ObservableVector<Arc<TimelineItem>>`] except the API is limited and,
@@ -450,11 +450,7 @@ impl<'observable_items> ObservableItemsTransaction<'observable_items> {
     /// Return the index where to insert the first remote timeline
     /// item.
     pub fn first_remotes_region_index(&self) -> usize {
-        if self.items.get(0).is_some_and(|item| item.is_timeline_start()) {
-            1
-        } else {
-            0
-        }
+        if self.items.get(0).is_some_and(|item| item.is_timeline_start()) { 1 } else { 0 }
     }
 
     /// Iterate over all timeline items in the _remotes_ region.
@@ -719,17 +715,18 @@ mod observable_items_tests {
     use assert_matches::assert_matches;
     use eyeball_im::VectorDiff;
     use ruma::{
+        MilliSecondsSinceUnixEpoch,
         events::room::message::{MessageType, TextMessageEventContent},
-        owned_user_id, uint, MilliSecondsSinceUnixEpoch,
+        owned_user_id, uint,
     };
     use stream_assert::{assert_next_matches, assert_pending};
 
     use super::*;
     use crate::timeline::{
-        controller::{EventTimelineItemKind, RemoteEventOrigin},
-        event_item::{LocalEventTimelineItem, RemoteEventTimelineItem},
         EventSendState, EventTimelineItem, Message, MsgLikeContent, MsgLikeKind, TimelineDetails,
         TimelineItemContent, TimelineItemKind, TimelineUniqueId, VirtualTimelineItem,
+        controller::{EventTimelineItemKind, RemoteEventOrigin},
+        event_item::{LocalEventTimelineItem, RemoteEventTimelineItem},
     };
 
     fn item(event_id: &str) -> Arc<TimelineItem> {

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -17,18 +17,18 @@ use std::{cmp::Ordering, collections::HashMap};
 use futures_core::Stream;
 use indexmap::IndexMap;
 use ruma::{
-    events::receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, UserId,
+    events::receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
 };
 use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 use tracing::{debug, error, instrument, trace, warn};
 
 use super::{
-    rfind_event_by_id, AllRemoteEvents, ObservableItemsTransaction, RelativePosition,
-    RoomDataProvider, TimelineMetadata, TimelineState,
+    AllRemoteEvents, ObservableItemsTransaction, RelativePosition, RoomDataProvider,
+    TimelineMetadata, TimelineState, rfind_event_by_id,
 };
-use crate::timeline::{controller::TimelineStateTransaction, TimelineItem};
+use crate::timeline::{TimelineItem, controller::TimelineStateTransaction};
 
 /// In-memory caches for read receipts.
 #[derive(Clone, Debug, Default)]
@@ -157,7 +157,9 @@ impl ReadReceipts {
                 // The old receipt is more recent since we can't find the new receipt in the
                 // timeline and we supposedly have all events since the end of the timeline.
                 if !is_own_user_id {
-                    trace!("we had a previous read receipt, but couldn't find the event targeted by the new read receipt in the timeline, exiting");
+                    trace!(
+                        "we had a previous read receipt, but couldn't find the event targeted by the new read receipt in the timeline, exiting"
+                    );
                 }
                 return;
             };

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -19,25 +19,25 @@ use matrix_sdk::{deserialized_responses::TimelineEvent, send_queue::SendHandle};
 #[cfg(test)]
 use ruma::events::receipt::ReceiptEventContent;
 use ruma::{
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId,
     events::{AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent},
     serde::Raw,
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId,
 };
 use tracing::{instrument, trace, warn};
 
 use super::{
     super::{
+        Profile, TimelineItem,
         date_dividers::DateDividerAdjuster,
         event_handler::{
             Flow, TimelineAction, TimelineEventContext, TimelineEventHandler, TimelineItemPosition,
         },
         event_item::RemoteEventOrigin,
         traits::RoomDataProvider,
-        Profile, TimelineItem,
     },
-    observable_items::ObservableItems,
     DateDividerMode, TimelineFocusKind, TimelineMetadata, TimelineSettings,
     TimelineStateTransaction,
+    observable_items::ObservableItems,
 };
 use crate::unable_to_decrypt_hook::UtdHookManager;
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -20,8 +20,8 @@ use matrix_sdk::deserialized_responses::{
     ThreadSummaryStatus, TimelineEvent, TimelineEventKind, UnsignedEventLocation,
 };
 use ruma::{
-    events::AnySyncTimelineEvent, push::Action, serde::Raw, EventId, MilliSecondsSinceUnixEpoch,
-    OwnedEventId, OwnedTransactionId, OwnedUserId, UserId,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, UserId,
+    events::AnySyncTimelineEvent, push::Action, serde::Raw,
 };
 use tracing::{debug, instrument, warn};
 
@@ -33,13 +33,13 @@ use super::{
         event_item::RemoteEventOrigin,
         traits::RoomDataProvider,
     },
-    metadata::EventMeta,
     ObservableItems, ObservableItemsTransaction, TimelineFocusKind, TimelineMetadata,
     TimelineSettings,
+    metadata::EventMeta,
 };
 use crate::timeline::{
-    event_handler::{FailedToParseEvent, RemovedItem, TimelineAction},
     EmbeddedEvent, ThreadSummary, TimelineDetails, VirtualTimelineItem,
+    event_handler::{FailedToParseEvent, RemovedItem, TimelineAction},
 };
 
 pub(in crate::timeline) struct TimelineStateTransaction<'a> {
@@ -159,7 +159,10 @@ impl<'a> TimelineStateTransaction<'a> {
                         )
                         .await;
                     } else {
-                        warn!(event_index, "Set update dropped because there wasn't any attached timeline item index.");
+                        warn!(
+                            event_index,
+                            "Set update dropped because there wasn't any attached timeline item index."
+                        );
                     }
                 }
 
@@ -316,7 +319,10 @@ impl<'a> TimelineStateTransaction<'a> {
                         )
                         .await;
                     } else {
-                        warn!(event_index, "Set update dropped because there wasn't any attached timeline item index.");
+                        warn!(
+                            event_index,
+                            "Set update dropped because there wasn't any attached timeline item index."
+                        );
                     }
                 }
 

--- a/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
@@ -19,11 +19,11 @@ use std::{fmt::Display, sync::Arc};
 
 use chrono::{Datelike, Local, TimeZone};
 use ruma::MilliSecondsSinceUnixEpoch;
-use tracing::{error, event_enabled, instrument, trace, warn, Level};
+use tracing::{Level, error, event_enabled, instrument, trace, warn};
 
 use super::{
-    controller::{ObservableItemsTransaction, TimelineMetadata},
     DateDividerMode, TimelineItem, TimelineItemKind, VirtualTimelineItem,
+    controller::{ObservableItemsTransaction, TimelineMetadata},
 };
 
 #[derive(Debug, PartialEq)]
@@ -300,7 +300,9 @@ impl DateDividerAdjuster {
                     if let Some(last_event_ts) = latest_event_ts {
                         if timestamp_to_date(last_event_ts) == event_date {
                             // There's a previous event with the same date: remove the divider.
-                            trace!("removed date divider @ {item_index} between two events that have the same date");
+                            trace!(
+                                "removed date divider @ {item_index} between two events that have the same date"
+                            );
                             self.ops.insert(insert_op_at, DateDividerOperation::Remove(item_index));
                             return;
                         }
@@ -508,11 +510,7 @@ impl DateDividerAdjuster {
             }
         }
 
-        if report.errors.is_empty() {
-            None
-        } else {
-            Some(report)
-        }
+        if report.errors.is_empty() { None } else { Some(report) }
     }
 
     /// Returns whether the two dates for the given timestamps are the same or
@@ -658,15 +656,15 @@ enum DateDividerInsertError {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_let;
-    use ruma::{owned_event_id, owned_user_id, uint, MilliSecondsSinceUnixEpoch};
+    use ruma::{MilliSecondsSinceUnixEpoch, owned_event_id, owned_user_id, uint};
 
     use super::{super::controller::ObservableItems, DateDividerAdjuster};
     use crate::timeline::{
+        DateDividerMode, EventTimelineItem, MsgLikeContent, TimelineItemContent,
+        VirtualTimelineItem,
         controller::TimelineMetadata,
         date_dividers::timestamp_to_date,
         event_item::{EventTimelineItemKind, RemoteEventTimelineItem},
-        DateDividerMode, EventTimelineItem, MsgLikeContent, TimelineItemContent,
-        VirtualTimelineItem,
     };
 
     fn event_with_ts(timestamp: MilliSecondsSinceUnixEpoch) -> EventTimelineItem {

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 use matrix_sdk::{
-    event_cache::{paginator::PaginatorError, EventCacheError},
+    HttpError,
+    event_cache::{EventCacheError, paginator::PaginatorError},
     room::reply::ReplyError,
     send_queue::RoomSendQueueError,
-    HttpError,
 };
 use thiserror::Error;
 
-use crate::timeline::{pinned_events_loader::PinnedEventsLoaderError, TimelineEventItemId};
+use crate::timeline::{TimelineEventItemId, pinned_events_loader::PinnedEventsLoaderError};
 
 /// Errors specific to the timeline.
 #[derive(Error, Debug)]

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -22,7 +22,12 @@ use matrix_sdk::{
     send_queue::SendHandle,
 };
 use ruma::{
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
+    TransactionId,
     events::{
+        AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncStateEvent,
+        AnySyncTimelineEvent, EventContent, FullStateEventContent, MessageLikeEventType,
+        StateEventType, SyncStateEvent,
         poll::unstable_start::{
             NewUnstablePollStartEventContentWithoutRelation, UnstablePollStartEventContent,
         },
@@ -31,20 +36,18 @@ use ruma::{
         room::message::{
             Relation, RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
         },
-        AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncStateEvent,
-        AnySyncTimelineEvent, EventContent, FullStateEventContent, MessageLikeEventType,
-        StateEventType, SyncStateEvent,
     },
     serde::Raw,
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
-    TransactionId,
 };
 use tracing::{debug, error, field::debug, instrument, trace, warn};
 
 use super::{
+    EmbeddedEvent, EncryptedMessage, EventTimelineItem, InReplyToDetails, MsgLikeContent,
+    MsgLikeKind, OtherState, ReactionStatus, Sticker, ThreadSummary, TimelineDetails, TimelineItem,
+    TimelineItemContent,
     controller::{
-        find_item_and_apply_aggregation, Aggregation, AggregationKind, ObservableItemsTransaction,
-        PendingEditKind, TimelineMetadata, TimelineStateTransaction,
+        Aggregation, AggregationKind, ObservableItemsTransaction, PendingEditKind,
+        TimelineMetadata, TimelineStateTransaction, find_item_and_apply_aggregation,
     },
     date_dividers::DateDividerAdjuster,
     event_item::{
@@ -53,9 +56,6 @@ use super::{
         TimelineEventItemId,
     },
     traits::RoomDataProvider,
-    EmbeddedEvent, EncryptedMessage, EventTimelineItem, InReplyToDetails, MsgLikeContent,
-    MsgLikeKind, OtherState, ReactionStatus, Sticker, ThreadSummary, TimelineDetails, TimelineItem,
-    TimelineItemContent,
 };
 use crate::timeline::controller::aggregations::PendingEdit;
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -17,7 +17,9 @@
 use std::fmt;
 
 use ruma::{
+    OwnedEventId,
     events::{
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, BundledMessageLikeRelations, Mentions,
         poll::unstable_start::{
             NewUnstablePollStartEventContentWithoutRelation, SyncUnstablePollStartEvent,
             UnstablePollStartEventContent,
@@ -25,11 +27,9 @@ use ruma::{
         room::message::{
             MessageType, Relation, RoomMessageEventContentWithoutRelation, SyncRoomMessageEvent,
         },
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent, BundledMessageLikeRelations, Mentions,
     },
     html::RemoveReplyFallback,
     serde::Raw,
-    OwnedEventId,
 };
 use tracing::{error, trace};
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -16,9 +16,12 @@ use std::sync::Arc;
 
 use as_variant::as_variant;
 use matrix_sdk::crypto::types::events::UtdCause;
-use matrix_sdk_base::latest_event::{is_suitable_for_latest_event, PossibleLatestEvent};
+use matrix_sdk_base::latest_event::{PossibleLatestEvent, is_suitable_for_latest_event};
 use ruma::{
+    OwnedDeviceId, OwnedEventId, OwnedMxcUri, OwnedUserId, RoomVersionId, UserId,
     events::{
+        AnyFullStateEventContent, AnySyncTimelineEvent, FullStateEventContent, Mentions,
+        MessageLikeEventType, StateEventType,
         call::{invite::SyncCallInviteEvent, notify::SyncCallNotifyEvent},
         policy::rule::{
             room::PolicyRuleRoomEventContent, server::PolicyRuleServerEventContent,
@@ -50,11 +53,8 @@ use ruma::{
         },
         space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
         sticker::{StickerEventContent, SyncStickerEvent},
-        AnyFullStateEventContent, AnySyncTimelineEvent, FullStateEventContent, Mentions,
-        MessageLikeEventType, StateEventType,
     },
     html::RemoveReplyFallback,
-    OwnedDeviceId, OwnedEventId, OwnedMxcUri, OwnedUserId, RoomVersionId, UserId,
 };
 use tracing::warn;
 
@@ -1052,12 +1052,11 @@ mod tests {
     use assert_matches2::assert_let;
     use matrix_sdk_test::ALICE;
     use ruma::{
-        assign,
+        RoomVersionId, assign,
         events::{
-            room::member::{MembershipState, RoomMemberEventContent},
             FullStateEventContent,
+            room::member::{MembershipState, RoomMemberEventContent},
         },
-        RoomVersionId,
     };
 
     use super::{MembershipChange, RoomMembershipChange, TimelineItemContent};

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/pinned_events.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/pinned_events.rs
@@ -15,8 +15,8 @@
 use std::collections::HashSet;
 
 use ruma::{
-    events::{room::pinned_events::RoomPinnedEventsEventContent, FullStateEventContent},
     OwnedEventId,
+    events::{FullStateEventContent, room::pinned_events::RoomPinnedEventsEventContent},
 };
 
 #[derive(Clone, Debug)]
@@ -78,11 +78,11 @@ mod tests {
     use assert_matches::assert_matches;
     use ruma::{
         events::{
+            FullStateEventContent,
             room::pinned_events::{
                 PossiblyRedactedRoomPinnedEventsEventContent, RedactedRoomPinnedEventsEventContent,
                 RoomPinnedEventsEventContent,
             },
-            FullStateEventContent,
         },
         owned_event_id,
         serde::Raw,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/polls.rs
@@ -17,16 +17,15 @@
 use std::collections::HashMap;
 
 use ruma::{
+    MilliSecondsSinceUnixEpoch, OwnedUserId, UserId,
     events::poll::{
-        compile_unstable_poll_results,
+        PollResponseData, compile_unstable_poll_results,
         start::PollKind,
         unstable_start::{
             NewUnstablePollStartEventContent, NewUnstablePollStartEventContentWithoutRelation,
             UnstablePollStartContentBlock,
         },
-        PollResponseData,
     },
-    MilliSecondsSinceUnixEpoch, OwnedUserId, UserId,
 };
 
 /// Holds the state of a poll.

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -21,11 +21,11 @@ use tracing::{debug, instrument, warn};
 
 use super::TimelineItemContent;
 use crate::timeline::{
+    Error as TimelineError, TimelineItem,
     controller::TimelineMetadata,
     event_handler::TimelineAction,
     event_item::{EventTimelineItem, Profile, TimelineDetails},
     traits::RoomDataProvider,
-    Error as TimelineError, TimelineItem,
 };
 
 /// Details about an event being replied to.

--- a/crates/matrix-sdk-ui/src/timeline/event_item/local.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/local.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use as_variant::as_variant;
-use matrix_sdk::{send_queue::SendHandle, Error};
+use matrix_sdk::{Error, send_queue::SendHandle};
 use ruma::{EventId, OwnedEventId, OwnedTransactionId};
 
 use super::TimelineEventItemId;

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -20,20 +20,20 @@ use std::{
 use as_variant::as_variant;
 use indexmap::IndexMap;
 use matrix_sdk::{
+    Client, Error,
     deserialized_responses::{EncryptionInfo, ShieldState},
     send_queue::{SendHandle, SendReactionHandle},
-    Client, Error,
 };
 use matrix_sdk_base::{
-    deserialized_responses::{ShieldStateCode, SENT_IN_CLEAR},
+    deserialized_responses::{SENT_IN_CLEAR, ShieldStateCode},
     latest_event::LatestEvent,
 };
 use once_cell::sync::Lazy;
 use ruma::{
-    events::{receipt::Receipt, room::message::MessageType, AnySyncTimelineEvent},
-    serde::Raw,
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedTransactionId,
     OwnedUserId, RoomId, RoomVersionId, TransactionId, UserId,
+    events::{AnySyncTimelineEvent, receipt::Receipt, room::message::MessageType},
+    serde::Raw,
 };
 use tracing::warn;
 use unicode_segmentation::UnicodeSegmentation;
@@ -42,13 +42,6 @@ mod content;
 mod local;
 mod remote;
 
-pub(super) use self::{
-    content::{
-        extract_bundled_edit_event_json, extract_poll_edit_content, extract_room_msg_edit_content,
-    },
-    local::LocalEventTimelineItem,
-    remote::{RemoteEventOrigin, RemoteEventTimelineItem},
-};
 pub use self::{
     content::{
         AnyOtherFullStateEventContent, EmbeddedEvent, EncryptedMessage, InReplyToDetails,
@@ -57,6 +50,13 @@ pub use self::{
         ThreadSummary, TimelineItemContent,
     },
     local::EventSendState,
+};
+pub(super) use self::{
+    content::{
+        extract_bundled_edit_event_json, extract_poll_edit_content, extract_room_msg_edit_content,
+    },
+    local::LocalEventTimelineItem,
+    remote::{RemoteEventOrigin, RemoteEventTimelineItem},
 };
 
 /// An item in the timeline that represents at least one event.
@@ -792,23 +792,24 @@ mod tests {
     use assert_matches2::assert_let;
     use matrix_sdk::test_utils::logged_in_client;
     use matrix_sdk_base::{
-        deserialized_responses::TimelineEvent, latest_event::LatestEvent, MinimalStateEvent,
-        OriginalMinimalStateEvent, RequestedRequiredStates,
+        MinimalStateEvent, OriginalMinimalStateEvent, RequestedRequiredStates,
+        deserialized_responses::TimelineEvent, latest_event::LatestEvent,
     };
     use matrix_sdk_test::{async_test, event_factory::EventFactory, sync_state_event};
     use ruma::{
+        RoomId, UInt, UserId,
         api::client::sync::sync_events::v5 as http,
         event_id,
         events::{
+            AnySyncStateEvent,
             room::{
                 member::RoomMemberEventContent,
                 message::{MessageFormat, MessageType},
             },
-            AnySyncStateEvent,
         },
         room_id,
         serde::Raw,
-        user_id, RoomId, UInt, UserId,
+        user_id,
     };
 
     use super::{EventTimelineItem, Profile};
@@ -1006,8 +1007,8 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender_from_the_storage(
-    ) {
+    async fn test_latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender_from_the_storage()
+     {
         // Given a sync event that is suitable to be used as a latest_event, and a room
         // with a member event for the sender
 
@@ -1055,8 +1056,8 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender_from_the_cache(
-    ) {
+    async fn test_latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender_from_the_cache()
+     {
         // Given a sync event that is suitable to be used as a latest_event, a room, and
         // a member event for the sender (which isn't part of the room yet).
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
@@ -17,9 +17,9 @@ use std::{fmt, sync::Arc};
 use indexmap::IndexMap;
 use matrix_sdk::deserialized_responses::EncryptionInfo;
 use ruma::{
-    events::{receipt::Receipt, AnySyncTimelineEvent},
-    serde::Raw,
     OwnedEventId, OwnedTransactionId, OwnedUserId,
+    events::{AnySyncTimelineEvent, receipt::Receipt},
+    serde::Raw,
 };
 
 /// An item for an event that was received from the homeserver.

--- a/crates/matrix-sdk-ui/src/timeline/futures.rs
+++ b/crates/matrix-sdk-ui/src/timeline/futures.rs
@@ -1,7 +1,7 @@
 use std::future::IntoFuture;
 
 use eyeball::SharedObservable;
-use matrix_sdk::{attachment::AttachmentConfig, TransmissionProgress};
+use matrix_sdk::{TransmissionProgress, attachment::AttachmentConfig};
 use matrix_sdk_base::boxed_into_future;
 use mime::Mime;
 use tracing::{Instrument as _, Span};

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -28,34 +28,34 @@ use imbl::Vector;
 #[cfg(feature = "unstable-msc4274")]
 use matrix_sdk::attachment::{AttachmentInfo, Thumbnail};
 use matrix_sdk::{
+    Client, Result,
     attachment::AttachmentConfig,
     deserialized_responses::TimelineEvent,
     event_cache::{EventCacheDropHandles, RoomEventCache},
     event_handler::EventHandlerHandle,
     executor::JoinHandle,
-    room::{edit::EditedContent, reply::Reply, Receipts, Room},
+    room::{Receipts, Room, edit::EditedContent, reply::Reply},
     send_queue::{RoomSendQueueError, SendHandle},
-    Client, Result,
 };
 use mime::Mime;
 use pinned_events_loader::PinnedEventsRoom;
 use ruma::{
+    EventId, OwnedEventId, RoomVersionId, UserId,
     api::client::receipt::create_receipt::v3::ReceiptType,
     events::{
+        AnyMessageLikeEventContent, AnySyncTimelineEvent,
         poll::unstable_start::{NewUnstablePollStartEventContent, UnstablePollStartEventContent},
         receipt::{Receipt, ReceiptThread},
         room::{
             message::RoomMessageEventContentWithoutRelation,
             pinned_events::RoomPinnedEventsEventContent,
         },
-        AnyMessageLikeEventContent, AnySyncTimelineEvent,
     },
-    EventId, OwnedEventId, RoomVersionId, UserId,
 };
 #[cfg(feature = "unstable-msc4274")]
 use ruma::{
-    events::{room::message::FormattedBody, Mentions},
     OwnedTransactionId,
+    events::{Mentions, room::message::FormattedBody},
 };
 use subscriber::TimelineWithDropHandle;
 use thiserror::Error;

--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -15,7 +15,7 @@
 use async_rx::StreamExt as _;
 use async_stream::stream;
 use futures_core::Stream;
-use futures_util::{pin_mut, StreamExt as _};
+use futures_util::{StreamExt as _, pin_mut};
 use matrix_sdk::event_cache::{self, EventCacheError, RoomPaginationStatus};
 use tracing::{instrument, warn};
 

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -14,13 +14,13 @@
 
 use std::{fmt::Formatter, sync::Arc};
 
-use futures_util::{stream, StreamExt};
+use futures_util::{StreamExt, stream};
 use matrix_sdk::{
-    config::RequestConfig, event_cache::paginator::PaginatorError, BoxFuture, Room,
-    SendOutsideWasm, SyncOutsideWasm,
+    BoxFuture, Room, SendOutsideWasm, SyncOutsideWasm, config::RequestConfig,
+    event_cache::paginator::PaginatorError,
 };
 use matrix_sdk_base::deserialized_responses::TimelineEvent;
-use ruma::{events::relation::RelationType, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId};
+use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, events::relation::RelationType};
 use thiserror::Error;
 use tokio::sync::Mutex;
 use tracing::{debug, warn};

--- a/crates/matrix-sdk-ui/src/timeline/subscriber.rs
+++ b/crates/matrix-sdk-ui/src/timeline/subscriber.rs
@@ -25,7 +25,7 @@ use futures_core::Stream;
 use imbl::Vector;
 use pin_project_lite::pin_project;
 
-use super::{controller::ObservableItems, item::TimelineItem, TimelineDropHandle};
+use super::{TimelineDropHandle, controller::ObservableItems, item::TimelineItem};
 
 pin_project! {
     /// A stream that wraps a [`TimelineDropHandle`] so that the `Timeline`
@@ -227,8 +227,8 @@ pub mod skip {
         ///
         /// [`Skip`]: eyeball_im_util::vector::Skip
         #[allow(unused)] // this is not used yet because only a live timeline is using it, but as soon as
-                         // other kind of timelines will use it, we would need it, it's better to have
-                         // this in case of; everything is tested, the logic is made more robust.
+        // other kind of timelines will use it, we would need it, it's better to have
+        // this in case of; everything is tested, the logic is made more robust.
         pub fn compute_next_when_paginating_forwards(&self, _page_size: usize) -> usize {
             // Nothing to do, the count remains unchanged as we skip the first values, not
             // the last values; paginating forwards will add items at the end, not at the

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -18,33 +18,32 @@ use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use imbl::vector;
 use matrix_sdk_test::{
-    async_test,
+    ALICE, BOB, CAROL, async_test,
     event_factory::{EventFactory, PreviousMembership},
-    ALICE, BOB, CAROL,
 };
 use ruma::{
-    event_id,
+    MilliSecondsSinceUnixEpoch, event_id,
     events::{
+        FullStateEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::{
+            ImageInfo,
             member::{MembershipState, RedactedRoomMemberEventContent},
             message::MessageType,
             topic::RedactedRoomTopicEventContent,
-            ImageInfo,
         },
-        FullStateEventContent,
     },
-    mxc_uri, owned_event_id, owned_mxc_uri, user_id, MilliSecondsSinceUnixEpoch,
+    mxc_uri, owned_event_id, owned_mxc_uri, user_id,
 };
 use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
 use crate::timeline::{
+    MembershipChange, MsgLikeContent, MsgLikeKind, TimelineDetails, TimelineItemContent,
+    TimelineItemKind, VirtualTimelineItem,
     controller::TimelineSettings,
     event_item::{AnyOtherFullStateEventContent, RemoteEventOrigin},
     tests::{ReadReceiptMap, TestRoomDataProvider, TestTimelineBuilder},
-    MembershipChange, MsgLikeContent, MsgLikeKind, TimelineDetails, TimelineItemContent,
-    TimelineItemKind, VirtualTimelineItem,
 };
 
 #[async_test]
@@ -381,7 +380,8 @@ async fn test_reply() {
     let date_divider = assert_next_matches!(stream, VectorDiff::PushFront { value } => value);
     assert!(date_divider.is_date_divider());
 
-    let reply_formatted_body = format!("\
+    let reply_formatted_body = format!(
+        "\
         <mx-reply>\
             <blockquote>\
                 <a href=\"https://matrix.to/#/!my_room:server.name/{first_event_id}\">In reply to</a> \
@@ -391,7 +391,8 @@ async fn test_reply() {
             </blockquote>\
         </mx-reply>\
         <p>I'm replying!</p>\
-    ");
+    "
+    );
     let reply_plain = format!(
         "> <{first_event_sender}> I want you to reply\n\
          I'm replying!"

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -18,11 +18,11 @@ use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use matrix_sdk::{assert_next_matches_with_timeout, send_queue::RoomSendQueueUpdate};
 use matrix_sdk_base::store::QueueWedgeError;
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
-    event_id,
-    events::{room::message::RoomMessageEventContent, AnyMessageLikeEventContent},
-    user_id, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch, event_id,
+    events::{AnyMessageLikeEventContent, room::message::RoomMessageEventContent},
+    user_id,
 };
 use stream_assert::{assert_next_matches, assert_pending};
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -20,7 +20,7 @@ use matrix_sdk::deserialized_responses::{
     AlgorithmInfo, EncryptionInfo, VerificationLevel, VerificationState,
 };
 use matrix_sdk_base::deserialized_responses::{DecryptedRoomEvent, TimelineEvent};
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
     event_id,
     events::room::message::{MessageType, RedactedRoomMessageEventContent},

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -27,14 +27,14 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use matrix_sdk::{
     assert_next_matches_with_timeout,
-    crypto::{decrypt_room_key_export, types::events::UtdCause, OlmMachine},
+    crypto::{OlmMachine, decrypt_room_key_export, types::events::UtdCause},
     deserialized_responses::{
         AlgorithmInfo, DecryptedRoomEvent, EncryptionInfo, VerificationLevel, VerificationState,
     },
     test_utils::test_client_builder,
 };
 use matrix_sdk_base::deserialized_responses::{TimelineEvent, UnableToDecryptReason};
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
     assign, event_id,
     events::room::encrypted::{
@@ -52,8 +52,8 @@ use tokio::time::sleep;
 use super::TestTimeline;
 use crate::{
     timeline::{
-        tests::{TestRoomDataProvider, TestTimelineBuilder},
         EncryptedMessage, MsgLikeContent, MsgLikeKind, TimelineDetails, TimelineItemContent,
+        tests::{TestRoomDataProvider, TestTimelineBuilder},
     },
     unable_to_decrypt_hook::{UnableToDecryptHook, UnableToDecryptInfo, UtdHookManager},
 };

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -17,21 +17,21 @@ use std::sync::Arc;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use matrix_sdk::deserialized_responses::TimelineEvent;
-use matrix_sdk_test::{async_test, sync_timeline_event, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test, sync_timeline_event};
 use ruma::events::{
+    AnySyncTimelineEvent, TimelineEventType,
     room::{
         member::MembershipState,
         message::{MessageType, RedactedRoomMessageEventContent},
     },
-    AnySyncTimelineEvent, TimelineEventType,
 };
 use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
 use crate::timeline::{
-    controller::TimelineSettings, tests::TestTimelineBuilder, AnyOtherFullStateEventContent,
-    MsgLikeContent, MsgLikeKind, TimelineEventTypeFilter, TimelineItem, TimelineItemContent,
-    TimelineItemKind,
+    AnyOtherFullStateEventContent, MsgLikeContent, MsgLikeKind, TimelineEventTypeFilter,
+    TimelineItem, TimelineItemContent, TimelineItemKind, controller::TimelineSettings,
+    tests::TestTimelineBuilder,
 };
 
 #[async_test]

--- a/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
@@ -15,10 +15,11 @@
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use matrix_sdk::deserialized_responses::TimelineEvent;
-use matrix_sdk_test::{async_test, sync_timeline_event, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test, sync_timeline_event};
 use ruma::{
-    events::{room::message::MessageType, MessageLikeEventType, StateEventType},
-    uint, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch,
+    events::{MessageLikeEventType, StateEventType, room::message::MessageType},
+    uint,
 };
 use stream_assert::assert_next_matches;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -27,39 +27,40 @@ use futures_core::Stream;
 use imbl::vector;
 use indexmap::IndexMap;
 use matrix_sdk::{
+    BoxFuture,
     config::RequestConfig,
     crypto::OlmMachine,
     deserialized_responses::{EncryptionInfo, TimelineEvent},
     event_cache::paginator::{PaginableRoom, PaginatorError},
     room::{EventWithContextResponse, Messages, MessagesOptions, PushContext, Relations},
     send_queue::RoomSendQueueUpdate,
-    BoxFuture,
 };
 use matrix_sdk_base::{
-    crypto::types::events::CryptoContextInfo, latest_event::LatestEvent, RoomInfo, RoomState,
+    RoomInfo, RoomState, crypto::types::events::CryptoContextInfo, latest_event::LatestEvent,
 };
-use matrix_sdk_test::{event_factory::EventFactory, ALICE, DEFAULT_TEST_ROOM_ID};
+use matrix_sdk_test::{ALICE, DEFAULT_TEST_ROOM_ID, event_factory::EventFactory};
 use ruma::{
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
+    OwnedUserId, RoomVersionId, TransactionId, UInt, UserId,
     events::{
+        AnyMessageLikeEventContent, AnyTimelineEvent,
         reaction::ReactionEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         relation::{Annotation, RelationType},
-        AnyMessageLikeEventContent, AnyTimelineEvent,
     },
     int,
     power_levels::NotificationPowerLevels,
     push::{PushConditionPowerLevelsCtx, PushConditionRoomCtx, Ruleset},
     room_id,
     serde::Raw,
-    uint, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
-    OwnedUserId, RoomVersionId, TransactionId, UInt, UserId,
+    uint,
 };
 use tokio::sync::RwLock;
 
 use super::{
-    algorithms::rfind_event_by_item_id, controller::TimelineSettings,
-    event_item::RemoteEventOrigin, traits::RoomDataProvider, EventTimelineItem, Profile,
-    TimelineController, TimelineEventItemId, TimelineFocus, TimelineItem,
+    EventTimelineItem, Profile, TimelineController, TimelineEventItemId, TimelineFocus,
+    TimelineItem, algorithms::rfind_event_by_item_id, controller::TimelineSettings,
+    event_item::RemoteEventOrigin, traits::RoomDataProvider,
 };
 use crate::{
     timeline::pinned_events_loader::PinnedEventsRoom, unable_to_decrypt_hook::UtdHookManager,

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -1,9 +1,10 @@
 use assert_matches2::assert_let;
 use fakes::poll_a2;
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
-    event_id,
+    EventId, OwnedEventId, UserId, event_id,
     events::{
+        AnyMessageLikeEventContent,
         poll::{
             unstable_end::UnstablePollEndEventContent,
             unstable_response::UnstablePollResponseEventContent,
@@ -12,12 +13,11 @@ use ruma::{
                 UnstablePollStartContentBlock,
             },
         },
-        AnyMessageLikeEventContent,
     },
-    server_name, EventId, OwnedEventId, UserId,
+    server_name,
 };
 
-use crate::timeline::{event_item::PollState, tests::TestTimeline, EventTimelineItem};
+use crate::timeline::{EventTimelineItem, event_item::PollState, tests::TestTimeline};
 
 #[async_test]
 async fn test_poll_is_displayed() {

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -20,17 +20,17 @@ use futures_core::Stream;
 use futures_util::{FutureExt as _, StreamExt as _};
 use imbl::vector;
 use matrix_sdk::assert_next_matches_with_timeout;
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
-    event_id, events::AnyMessageLikeEventContent, server_name, uint, EventId,
-    MilliSecondsSinceUnixEpoch, OwnedEventId,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, event_id,
+    events::AnyMessageLikeEventContent, server_name, uint,
 };
 use stream_assert::{assert_next_matches, assert_pending};
 use tokio::time::timeout;
 
 use crate::timeline::{
-    event_item::RemoteEventOrigin, tests::TestTimeline, ReactionStatus, TimelineEventItemId,
-    TimelineItem,
+    ReactionStatus, TimelineEventItemId, TimelineItem, event_item::RemoteEventOrigin,
+    tests::TestTimeline,
 };
 
 const REACTION_KEY: &str = "👍";
@@ -144,13 +144,15 @@ async fn test_redact_reaction_success() {
 
     // Will immediately redact it on the item.
     let event = assert_item_update!(stream, &event_id, item_pos);
-    assert!(event
-        .content()
-        .reactions()
-        .cloned()
-        .unwrap_or_default()
-        .get(&REACTION_KEY.to_owned())
-        .is_none());
+    assert!(
+        event
+            .content()
+            .reactions()
+            .cloned()
+            .unwrap_or_default()
+            .get(&REACTION_KEY.to_owned())
+            .is_none()
+    );
 
     // And send a redaction request for that reaction.
     {

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -16,21 +16,21 @@ use std::sync::Arc;
 
 use eyeball_im::VectorDiff;
 use matrix_sdk::assert_next_matches_with_timeout;
-use matrix_sdk_test::{async_test, event_factory::EventFactory, ALICE, BOB, CAROL};
+use matrix_sdk_test::{ALICE, BOB, CAROL, async_test, event_factory::EventFactory};
 use ruma::{
-    event_id,
+    RoomVersionId, event_id,
     events::{
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::message::{MessageType, RoomMessageEventContent, SyncRoomMessageEvent},
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
     },
-    owned_event_id, room_id, uint, RoomVersionId,
+    owned_event_id, room_id, uint,
 };
 use stream_assert::{assert_next_matches, assert_pending};
 
 use super::{ReadReceiptMap, TestRoomDataProvider};
 use crate::timeline::{
-    controller::TimelineSettings, tests::TestTimelineBuilder, MsgLikeContent, MsgLikeKind,
+    MsgLikeContent, MsgLikeKind, controller::TimelineSettings, tests::TestTimelineBuilder,
 };
 
 fn filter_notice(ev: &AnySyncTimelineEvent, _room_version: &RoomVersionId) -> bool {
@@ -375,12 +375,13 @@ async fn test_read_receipts_updates_on_message_decryption() {
     use std::{io::Cursor, iter};
 
     use assert_matches2::assert_let;
-    use matrix_sdk_base::crypto::{decrypt_room_key_export, OlmMachine};
+    use matrix_sdk_base::crypto::{OlmMachine, decrypt_room_key_export};
     use ruma::{
+        RoomVersionId,
         events::room::encrypted::{
             EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
         },
-        user_id, RoomVersionId,
+        user_id,
     };
 
     use crate::timeline::{EncryptedMessage, TimelineItemContent};

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -16,20 +16,20 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use imbl::vector;
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
     event_id,
     events::{
-        reaction::RedactedReactionEventContent, room::message::OriginalSyncRoomMessageEvent,
-        FullStateEventContent,
+        FullStateEventContent, reaction::RedactedReactionEventContent,
+        room::message::OriginalSyncRoomMessageEvent,
     },
 };
 use stream_assert::{assert_next_matches, assert_pending};
 
 use super::TestTimeline;
 use crate::timeline::{
-    event_item::RemoteEventOrigin, AnyOtherFullStateEventContent, TimelineDetails,
-    TimelineItemContent,
+    AnyOtherFullStateEventContent, TimelineDetails, TimelineItemContent,
+    event_item::RemoteEventOrigin,
 };
 
 #[async_test]
@@ -171,9 +171,9 @@ async fn test_reaction_redaction_timeline_filter() {
         .controller
         .handle_remote_events_with_diffs(
             vec![VectorDiff::Append {
-                values: vector![f
-                    .redacted(*ALICE, RedactedReactionEventContent::new())
-                    .into_event()],
+                values: vector![
+                    f.redacted(*ALICE, RedactedReactionEventContent::new()).into_event()
+                ],
             }],
             RemoteEventOrigin::Sync,
         )

--- a/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
@@ -1,24 +1,24 @@
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use matrix_sdk_base::deserialized_responses::{ShieldState, ShieldStateCode};
-use matrix_sdk_test::{async_test, event_factory::EventFactory, ALICE};
+use matrix_sdk_test::{ALICE, async_test, event_factory::EventFactory};
 use ruma::{
     event_id,
     events::{
+        AnyMessageLikeEventContent,
         room::{
             encrypted::{
                 EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
             },
             message::RoomMessageEventContent,
         },
-        AnyMessageLikeEventContent,
     },
 };
 use stream_assert::{assert_next_matches, assert_pending};
 
 use crate::timeline::{
-    tests::{TestTimeline, TestTimelineBuilder},
     EventSendState,
+    tests::{TestTimeline, TestTimelineBuilder},
 };
 
 #[async_test]

--- a/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
@@ -17,15 +17,15 @@ use assert_matches2::assert_let;
 use chrono::{Datelike, TimeZone, Utc};
 use eyeball_im::VectorDiff;
 use futures_util::{FutureExt, StreamExt as _};
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
     event_id,
-    events::{room::message::RoomMessageEventContent, AnyMessageLikeEventContent},
+    events::{AnyMessageLikeEventContent, room::message::RoomMessageEventContent},
 };
 use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
-use crate::timeline::{traits::RoomDataProvider as _, VirtualTimelineItem};
+use crate::timeline::{VirtualTimelineItem, traits::RoomDataProvider as _};
 
 #[async_test]
 async fn test_date_divider() {

--- a/crates/matrix-sdk-ui/src/timeline/threaded_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/threaded_events_loader.rs
@@ -16,12 +16,12 @@ use std::{fmt::Formatter, sync::Mutex};
 
 use matrix_sdk::{
     event_cache::{
-        paginator::{PaginationResult, PaginatorError},
         PaginationToken,
+        paginator::{PaginationResult, PaginatorError},
     },
     room::{IncludeRelations, RelationsOptions},
 };
-use ruma::{api::Direction, OwnedEventId, UInt};
+use ruma::{OwnedEventId, UInt, api::Direction};
 
 use super::traits::RoomDataProvider;
 

--- a/crates/matrix-sdk-ui/src/timeline/to_device.rs
+++ b/crates/matrix-sdk-ui/src/timeline/to_device.rs
@@ -16,10 +16,10 @@ use std::iter;
 
 use matrix_sdk::event_handler::EventHandler;
 use ruma::{
-    events::{forwarded_room_key::ToDeviceForwardedRoomKeyEvent, room_key::ToDeviceRoomKeyEvent},
     OwnedRoomId,
+    events::{forwarded_room_key::ToDeviceForwardedRoomKeyEvent, room_key::ToDeviceRoomKeyEvent},
 };
-use tracing::{debug_span, trace, Instrument};
+use tracing::{Instrument, debug_span, trace};
 
 use super::controller::TimelineController;
 

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -19,26 +19,26 @@ use indexmap::IndexMap;
 #[cfg(test)]
 use matrix_sdk::crypto::{DecryptionSettings, RoomEventDecryptionResult, TrustRequirement};
 use matrix_sdk::{
+    AsyncTraitDeps, Result, Room, SendOutsideWasm,
     crypto::types::events::CryptoContextInfo,
     deserialized_responses::{EncryptionInfo, TimelineEvent},
     event_cache::paginator::PaginableRoom,
     room::{PushContext, Relations, RelationsOptions},
-    AsyncTraitDeps, Result, Room, SendOutsideWasm,
 };
-use matrix_sdk_base::{latest_event::LatestEvent, RoomInfo};
+use matrix_sdk_base::{RoomInfo, latest_event::LatestEvent};
 use ruma::{
+    EventId, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId, UserId,
     events::{
+        AnyMessageLikeEventContent, AnySyncTimelineEvent,
         fully_read::FullyReadEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
-        AnyMessageLikeEventContent, AnySyncTimelineEvent,
     },
     serde::Raw,
-    EventId, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId, UserId,
 };
 use tracing::error;
 
 use super::{EventTimelineItem, Profile, RedactError, TimelineBuilder};
-use crate::timeline::{self, pinned_events_loader::PinnedEventsRoom, Timeline};
+use crate::timeline::{self, Timeline, pinned_events_loader::PinnedEventsRoom};
 
 pub trait RoomExt {
     /// Get a [`Timeline`] for this room.
@@ -49,7 +49,7 @@ pub trait RoomExt {
     ///
     /// This is the same as using `room.timeline_builder().build()`.
     fn timeline(&self)
-        -> impl Future<Output = Result<Timeline, timeline::Error>> + SendOutsideWasm;
+    -> impl Future<Output = Result<Timeline, timeline::Error>> + SendOutsideWasm;
 
     /// Get a [`TimelineBuilder`] for this room.
     ///
@@ -93,7 +93,7 @@ pub(super) trait RoomDataProvider:
     fn room_version(&self) -> RoomVersionId;
 
     fn crypto_context_info(&self)
-        -> impl Future<Output = CryptoContextInfo> + SendOutsideWasm + '_;
+    -> impl Future<Output = CryptoContextInfo> + SendOutsideWasm + '_;
 
     fn profile_from_user_id<'a>(
         &'a self,

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -25,17 +25,17 @@ use std::{
 
 use growable_bloom_filter::{GrowableBloom, GrowableBloomBuilder};
 use matrix_sdk::{
-    crypto::types::events::UtdCause,
-    executor::{spawn, JoinHandle},
-    sleep::sleep,
     Client,
+    crypto::types::events::UtdCause,
+    executor::{JoinHandle, spawn},
+    sleep::sleep,
 };
 use matrix_sdk_base::{
     SendOutsideWasm, StateStoreDataKey, StateStoreDataValue, StoreError, SyncOutsideWasm,
 };
 use ruma::{
-    time::{Duration, Instant},
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName, UserId,
+    time::{Duration, Instant},
 };
 use tokio::sync::{Mutex as AsyncMutex, MutexGuard};
 use tracing::{error, trace};

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
@@ -1,12 +1,12 @@
 use std::{
     collections::{BTreeMap, HashSet},
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
     },
 };
 
-use futures_util::{pin_mut, StreamExt as _};
+use futures_util::{StreamExt as _, pin_mut};
 use matrix_sdk::{
     config::RequestConfig,
     test_utils::{
@@ -23,13 +23,13 @@ use serde_json::json;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::{error, info, trace, warn};
 use wiremock::{
-    matchers::{method, path},
     Mock, MockGuard, MockServer, Request, ResponseTemplate,
+    matchers::{method, path},
 };
 
 use crate::{
     mock_sync,
-    sliding_sync::{check_requests, PartialSlidingSyncRequest, SlidingSyncMatcher},
+    sliding_sync::{PartialSlidingSyncRequest, SlidingSyncMatcher, check_requests},
     sliding_sync_then_assert_request_and_fake_response,
 };
 

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -14,12 +14,12 @@
 
 use itertools::Itertools as _;
 use matrix_sdk::deserialized_responses::TimelineEvent;
-use ruma::{events::AnyStateEvent, serde::Raw, EventId, RoomId};
+use ruma::{EventId, RoomId, events::AnyStateEvent, serde::Raw};
 use serde::Serialize;
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path, path_regex, query_param, query_param_is_missing},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path, path_regex, query_param, query_param_is_missing},
 };
 
 mod encryption_sync_service;

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -10,8 +10,8 @@ use matrix_sdk::{
     test_utils::{logged_in_client_with_server, mocks::MatrixMockServer},
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
-    SyncResponseBuilder,
+    JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
+    mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::{
     notification_client::{
@@ -22,18 +22,18 @@ use matrix_sdk_ui::{
 };
 use ruma::{
     event_id,
-    events::{room::member::MembershipState, AnyStateEvent, TimelineEventType},
+    events::{AnyStateEvent, TimelineEventType, room::member::MembershipState},
     mxc_uri, room_id, user_id,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path},
     Mock, Request, ResponseTemplate,
+    matchers::{header, method, path},
 };
 
 use crate::{
     mock_sync,
-    sliding_sync::{check_requests, PartialSlidingSyncRequest, SlidingSyncMatcher},
+    sliding_sync::{PartialSlidingSyncRequest, SlidingSyncMatcher, check_requests},
 };
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2,27 +2,27 @@ use std::ops::Not;
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
-use futures_util::{pin_mut, FutureExt, StreamExt};
+use futures_util::{FutureExt, StreamExt, pin_mut};
 use matrix_sdk::{
+    Client, RoomDisplayName,
     config::RequestConfig,
     test_utils::{
         logged_in_client_with_server,
         mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
         set_client_session, test_client_builder,
     },
-    Client, RoomDisplayName,
 };
 use matrix_sdk_base::sync::UnreadNotificationsCount;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, ALICE,
+    ALICE, async_test, event_factory::EventFactory, mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::{
+    RoomListService,
     room_list_service::{
+        ALL_ROOMS_LIST_NAME as ALL_ROOMS, Error, RoomListLoadingState, State, SyncIndicator,
         filters::{new_filter_fuzzy_match_room_name, new_filter_non_left, new_filter_none},
-        Error, RoomListLoadingState, State, SyncIndicator, ALL_ROOMS_LIST_NAME as ALL_ROOMS,
     },
     timeline::{RoomExt as _, TimelineItemKind, VirtualTimelineItem},
-    RoomListService,
 };
 use ruma::{
     api::client::room::create_room::v3::Request as CreateRoomRequest,
@@ -36,8 +36,8 @@ use stream_assert::{assert_next_matches, assert_pending};
 use tempfile::TempDir;
 use tokio::{spawn, sync::mpsc::channel, task::yield_now, time::sleep};
 use wiremock::{
-    matchers::{header, method, path},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path},
 };
 
 use crate::timeline::sliding_sync::{assert_timeline_stream, timeline_event};

--- a/crates/matrix-sdk-ui/tests/integration/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sliding_sync.rs
@@ -1,6 +1,6 @@
 //! Helpers for integration tests involving sliding sync.
 
-use wiremock::{http::Method, Match, MockServer, Request};
+use wiremock::{Match, MockServer, Request, http::Method};
 
 pub(crate) async fn check_requests(server: MockServer, expected_requests: &[serde_json::Value]) {
     let mut num_requests = 0;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/decryption.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/decryption.rs
@@ -21,7 +21,7 @@ use matrix_sdk::{
     linked_chunk::{ChunkIdentifier, LinkedChunkId, Position, Update},
     test_utils::mocks::MatrixMockServer,
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, BOB};
+use matrix_sdk_test::{BOB, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::RoomExt;
 use ruma::{
     event_id,

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -21,7 +21,7 @@ use futures_util::StreamExt;
 use matrix_sdk::{
     executor::spawn, ruma::MilliSecondsSinceUnixEpoch, test_utils::mocks::MatrixMockServer,
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder};
+use matrix_sdk_test::{JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{EventSendState, RoomExt};
 use ruma::{
     event_id,

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -20,21 +20,22 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::{FutureExt, StreamExt};
 use matrix_sdk::{
+    Client,
     room::edit::EditedContent,
     test_utils::mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
-    Client,
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::{
+    Timeline,
     timeline::{
         EditError, Error, EventSendState, MsgLikeContent, MsgLikeKind, RoomExt, TimelineDetails,
         TimelineEventItemId, TimelineItemContent,
     },
-    Timeline,
 };
 use ruma::{
-    event_id,
+    OwnedRoomId, event_id,
     events::{
+        AnyMessageLikeEventContent, AnyTimelineEvent,
         poll::unstable_start::{
             NewUnstablePollStartEventContent, ReplacementUnstablePollStartEventContent,
             UnstablePollAnswer, UnstablePollAnswers, UnstablePollStartContentBlock,
@@ -44,11 +45,9 @@ use ruma::{
             MessageType, RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
             TextMessageEventContent,
         },
-        AnyMessageLikeEventContent, AnyTimelineEvent,
     },
     owned_event_id, room_id,
     serde::Raw,
-    OwnedRoomId,
 };
 use stream_assert::{assert_next_matches, assert_pending};
 use tokio::{task::yield_now, time::sleep};
@@ -877,13 +876,14 @@ async fn test_pending_edit_from_backpagination() {
     let original_event_id = event_id!("$original");
     let edit_event_id = event_id!("$edit");
     h.handle_backpagination(
-        vec![f
-            .text_msg("* hello")
-            .sender(&ALICE)
-            .event_id(edit_event_id)
-            .room(&h.room_id)
-            .edit(original_event_id, RoomMessageEventContent::text_plain("hello").into())
-            .into()],
+        vec![
+            f.text_msg("* hello")
+                .sender(&ALICE)
+                .event_id(edit_event_id)
+                .room(&h.room_id)
+                .edit(original_event_id, RoomMessageEventContent::text_plain("hello").into())
+                .into(),
+        ],
         10,
     )
     .await;
@@ -941,13 +941,14 @@ async fn test_pending_edit_from_backpagination_doesnt_override_pending_edit_from
     // And then I receive an edit from a back-pagination for the same event…
     let edit_event_id2 = event_id!("$edit2");
     h.handle_backpagination(
-        vec![f
-            .text_msg("* aloha")
-            .sender(&ALICE)
-            .event_id(edit_event_id2)
-            .room(&h.room_id)
-            .edit(original_event_id, RoomMessageEventContent::text_plain("aloha").into())
-            .into()],
+        vec![
+            f.text_msg("* aloha")
+                .sender(&ALICE)
+                .event_id(edit_event_id2)
+                .room(&h.room_id)
+                .edit(original_event_id, RoomMessageEventContent::text_plain("aloha").into())
+                .into(),
+        ],
         10,
     )
     .await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -21,8 +21,8 @@ use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
-    SyncResponseBuilder, ALICE, BOB,
+    ALICE, BOB, JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
+    mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::timeline::{TimelineBuilder, TimelineFocus};
 use ruma::{event_id, events::room::message::RoomMessageEventContent, room_id};

--- a/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
@@ -26,7 +26,7 @@ use matrix_sdk::{
     room::reply::{EnforceThread, Reply},
     test_utils::mocks::MatrixMockServer,
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE};
+use matrix_sdk_test::{ALICE, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{AttachmentSource, EventSendState, RoomExt};
 #[cfg(feature = "unstable-msc4274")]
 use matrix_sdk_ui::timeline::{GalleryConfig, GalleryItemInfo};
@@ -37,8 +37,8 @@ use ruma::owned_mxc_uri;
 use ruma::{
     event_id,
     events::room::{
-        message::{MessageType, ReplyWithinThread},
         MediaSource,
+        message::{MessageType, ReplyWithinThread},
     },
     room_id,
 };

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -23,30 +23,30 @@ use matrix_sdk::{
     test_utils::mocks::MatrixMockServer,
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, JoinedRoomBuilder, RoomAccountDataTestEvent,
-    StateTestEvent, ALICE, BOB,
+    ALICE, BOB, JoinedRoomBuilder, RoomAccountDataTestEvent, StateTestEvent, async_test,
+    event_factory::EventFactory,
 };
 use matrix_sdk_ui::{
+    Timeline,
     timeline::{
         AnyOtherFullStateEventContent, Error, EventSendState, RedactError, RoomExt,
         TimelineBuilder, TimelineEventItemId, TimelineItemContent, VirtualTimelineItem,
     },
-    Timeline,
 };
 use ruma::{
-    event_id,
+    EventId, MilliSecondsSinceUnixEpoch, event_id,
     events::room::{
         encryption::RoomEncryptionEventContent,
         message::{RedactedRoomMessageEventContent, RoomMessageEventContent},
     },
-    owned_event_id, room_id, user_id, EventId, MilliSecondsSinceUnixEpoch,
+    owned_event_id, room_id, user_id,
 };
 use serde_json::json;
 use sliding_sync::assert_timeline_stream;
 use stream_assert::assert_pending;
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
 mod decryption;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -18,8 +18,8 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::{
-    future::{join, join3},
     FutureExt, StreamExt as _,
+    future::{join, join3},
 };
 use matrix_sdk::{
     config::SyncSettings,
@@ -30,24 +30,25 @@ use matrix_sdk::{
     },
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
-    StateTestEvent, SyncResponseBuilder, ALICE, BOB,
+    ALICE, BOB, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder, async_test,
+    event_factory::EventFactory, mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::timeline::{AnyOtherFullStateEventContent, RoomExt, TimelineItemContent};
 use once_cell::sync::Lazy;
 use ruma::{
-    events::{room::message::MessageType, FullStateEventContent},
-    room_id, EventId,
+    EventId,
+    events::{FullStateEventContent, room::message::MessageType},
+    room_id,
 };
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 use stream_assert::{assert_next_eq, assert_pending};
 use tokio::{
     spawn,
     time::{sleep, timeout},
 };
 use wiremock::{
-    matchers::{header, method, path_regex, query_param, query_param_is_missing},
     Mock, ResponseTemplate,
+    matchers::{header, method, path_regex, query_param, query_param_is_missing},
 };
 
 use crate::{mock_sync, timeline::sliding_sync::assert_timeline_stream};

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -4,23 +4,25 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt as _;
 use matrix_sdk::{
+    Client, Room,
     config::SyncSettings,
     test_utils::{
         logged_in_client_with_server,
         mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
     },
-    Client, Room,
 };
 use matrix_sdk_base::deserialized_responses::TimelineEvent;
 use matrix_sdk_common::executor::spawn;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent,
-    SyncResponseBuilder, BOB,
+    BOB, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder, async_test,
+    event_factory::EventFactory,
 };
 use matrix_sdk_ui::timeline::{RoomExt, TimelineBuilder, TimelineFocus};
 use ruma::{
-    assign, event_id,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, RoomId, UserId, assign,
+    event_id,
     events::{
+        AnySyncTimelineEvent,
         room::{
             encrypted::{
                 EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
@@ -28,18 +30,17 @@ use ruma::{
             message::RoomMessageEventContentWithoutRelation,
             pinned_events::RoomPinnedEventsEventContent,
         },
-        AnySyncTimelineEvent,
     },
     owned_device_id, owned_room_id, owned_user_id, room_id,
     serde::Raw,
-    user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, RoomId, UserId,
+    user_id,
 };
 use serde_json::json;
 use stream_assert::assert_pending;
 use tokio::time::sleep;
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
 use crate::mock_sync;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
@@ -18,15 +18,15 @@ use assert_matches::assert_matches;
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_common::executor::spawn;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
-    SyncResponseBuilder, ALICE, BOB, CAROL, DEFAULT_TEST_ROOM_ID,
+    ALICE, BOB, CAROL, DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, SyncResponseBuilder, async_test,
+    event_factory::EventFactory, mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::timeline::{RoomExt, TimelineDetails};
 use ruma::events::room::member::MembershipState;
 use serde_json::json;
 use wiremock::{
-    matchers::{method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{method, path_regex},
 };
 
 use crate::mock_sync;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -18,22 +18,22 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
-use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server, Error};
+use matrix_sdk::{Error, config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_base::store::QueueWedgeError;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
-    SyncResponseBuilder, ALICE,
+    ALICE, JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
+    mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::timeline::{EventItemOrigin, EventSendState, RoomExt};
 use ruma::{
-    event_id, events::room::message::RoomMessageEventContent, room_id, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch, event_id, events::room::message::RoomMessageEventContent, room_id,
 };
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
 use tokio::{task::yield_now, time::sleep};
 use wiremock::{
-    matchers::{body_string_contains, header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{body_string_contains, header, method, path_regex},
 };
 
 use crate::mock_sync;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
@@ -18,7 +18,7 @@ use assert_matches2::{assert_let, assert_matches};
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt as _;
 use matrix_sdk::{assert_let_timeout, test_utils::mocks::MatrixMockServer};
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE};
+use matrix_sdk_test::{ALICE, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{EventSendState, ReactionStatus, RoomExt as _};
 use ruma::{event_id, events::room::message::RoomMessageEventContent, room_id};
 use serde_json::json;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -23,19 +23,20 @@ use matrix_sdk::{
     test_utils::mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, JoinedRoomBuilder, RoomAccountDataTestEvent, ALICE,
-    BOB, CAROL,
+    ALICE, BOB, CAROL, JoinedRoomBuilder, RoomAccountDataTestEvent, async_test,
+    event_factory::EventFactory,
 };
 use matrix_sdk_ui::timeline::RoomExt;
 use ruma::{
+    MilliSecondsSinceUnixEpoch, RoomVersionId,
     api::client::receipt::create_receipt::v3::ReceiptType as CreateReceiptType,
     event_id,
     events::{
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, RoomAccountDataEventType,
         receipt::{ReceiptThread, ReceiptType as EventReceiptType},
         room::message::{MessageType, RoomMessageEventContent, SyncRoomMessageEvent},
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent, RoomAccountDataEventType,
     },
-    owned_event_id, room_id, uint, user_id, MilliSecondsSinceUnixEpoch, RoomVersionId,
+    owned_event_id, room_id, uint, user_id,
 };
 use serde_json::json;
 use stream_assert::{assert_pending, assert_ready};

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -10,7 +10,7 @@ use matrix_sdk::{
 };
 use matrix_sdk_base::timeout::timeout;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE, BOB, CAROL,
+    ALICE, BOB, CAROL, JoinedRoomBuilder, async_test, event_factory::EventFactory,
 };
 use matrix_sdk_ui::timeline::{
     Error as TimelineError, EventSendState, MsgLikeContent, MsgLikeKind, RoomExt, TimelineDetails,
@@ -19,17 +19,17 @@ use matrix_sdk_ui::timeline::{
 use ruma::{
     event_id,
     events::{
+        Mentions,
         reaction::RedactedReactionEventContent,
         relation::InReplyTo,
         room::{
+            ImageInfo,
             encrypted::{
                 EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
             },
             message::{Relation, ReplyWithinThread, RoomMessageEventContentWithoutRelation},
-            ImageInfo,
         },
         sticker::{StickerEventContent, StickerMediaSource},
-        Mentions,
     },
     owned_event_id, owned_mxc_uri, room_id,
 };
@@ -37,8 +37,8 @@ use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
 use tokio::task::yield_now;
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, Request, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -18,16 +18,16 @@ use anyhow::{Context as _, Result};
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::{Vector, VectorDiff};
-use futures_util::{pin_mut, Stream, StreamExt};
+use futures_util::{Stream, StreamExt, pin_mut};
 use matrix_sdk::{
-    test_utils::logged_in_client_with_server, Client, SlidingSync, SlidingSyncList,
-    SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
+    Client, SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
+    test_utils::logged_in_client_with_server,
 };
 use matrix_sdk_test::{async_test, mocks::mock_encryption_state};
 use matrix_sdk_ui::timeline::{TimelineBuilder, TimelineItem, TimelineItemKind};
-use ruma::{room_id, user_id, RoomId};
+use ruma::{RoomId, room_id, user_id};
 use serde_json::json;
-use wiremock::{http::Method, Match, Mock, MockServer, Request, ResponseTemplate};
+use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate, http::Method};
 
 macro_rules! receive_response {
     (
@@ -420,8 +420,10 @@ impl Match for SlidingSyncMatcher {
 
 #[async_test]
 async fn test_timeline_basic() -> Result<()> {
-    let (client, server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-        .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
+    let (client, server, sliding_sync) = new_sliding_sync(vec![
+        SlidingSyncList::builder("foo")
+            .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
+    ])
     .await?;
 
     let stream = sliding_sync.sync();
@@ -468,8 +470,10 @@ async fn test_timeline_basic() -> Result<()> {
 
 #[async_test]
 async fn test_timeline_duplicated_events() -> Result<()> {
-    let (client, server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-        .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
+    let (client, server, sliding_sync) = new_sliding_sync(vec![
+        SlidingSyncList::builder("foo")
+            .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
+    ])
     .await?;
 
     let stream = sliding_sync.sync();
@@ -546,8 +550,10 @@ async fn test_timeline_duplicated_events() -> Result<()> {
 
 #[async_test]
 async fn test_timeline_read_receipts_are_updated_live() -> Result<()> {
-    let (client, server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-        .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
+    let (client, server, sliding_sync) = new_sliding_sync(vec![
+        SlidingSyncList::builder("foo")
+            .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
+    ])
     .await?;
 
     let stream = sliding_sync.sync();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -21,8 +21,8 @@ use futures_util::StreamExt;
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_common::executor::spawn;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state,
-    GlobalAccountDataTestEvent, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB,
+    ALICE, BOB, GlobalAccountDataTestEvent, JoinedRoomBuilder, SyncResponseBuilder, async_test,
+    event_factory::EventFactory, mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::timeline::{RoomExt, TimelineDetails};
 use ruma::{

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -21,7 +21,7 @@ use matrix_sdk::{
     assert_let_timeout,
     test_utils::mocks::{MatrixMockServer, RoomRelationsResponseTemplate},
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{RoomExt as _, TimelineBuilder, TimelineDetails, TimelineFocus};
 use ruma::{event_id, events::AnyTimelineEvent, owned_event_id, room_id, serde::Raw, user_id};
 use stream_assert::assert_pending;

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -17,15 +17,14 @@
 use std::time::Duration;
 
 use ruma::{
-    assign,
+    OwnedTransactionId, UInt, assign,
     events::{
-        room::{
-            message::{AudioInfo, FileInfo, FormattedBody, VideoInfo},
-            ImageInfo, ThumbnailInfo,
-        },
         Mentions,
+        room::{
+            ImageInfo, ThumbnailInfo,
+            message::{AudioInfo, FileInfo, FormattedBody, VideoInfo},
+        },
     },
-    OwnedTransactionId, UInt,
 };
 
 use crate::room::reply::Reply;

--- a/crates/matrix-sdk/src/authentication/matrix/login_builder.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/login_builder.rs
@@ -29,7 +29,7 @@ use tracing::{info, instrument};
 use super::MatrixAuth;
 #[cfg(feature = "sso-login")]
 use crate::utils::local_server::LocalServerBuilder;
-use crate::{config::RequestConfig, Result};
+use crate::{Result, config::RequestConfig};
 
 /// The login method.
 ///

--- a/crates/matrix-sdk/src/authentication/matrix/mod.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/mod.rs
@@ -20,9 +20,10 @@ use std::fmt;
 #[cfg(feature = "sso-login")]
 use std::future::Future;
 
-use matrix_sdk_base::{store::RoomLoadSettings, SessionMeta};
+use matrix_sdk_base::{SessionMeta, store::RoomLoadSettings};
 use ruma::{
     api::{
+        OutgoingRequest, SendAccessToken,
         client::{
             account::register,
             session::{
@@ -30,7 +31,6 @@ use ruma::{
             },
             uiaa::UserIdentifier,
         },
-        OutgoingRequest, SendAccessToken,
     },
     serde::JsonObject,
 };
@@ -40,10 +40,10 @@ use tracing::{debug, error, info, instrument};
 use url::Url;
 
 use crate::{
+    Client, Error, RefreshTokenError, Result,
     authentication::AuthData,
     client::SessionChange,
     error::{HttpError, HttpResult},
-    Client, Error, RefreshTokenError, Result,
 };
 
 mod login_builder;
@@ -572,10 +572,10 @@ impl MatrixAuth {
     ///
     /// ```no_run
     /// use matrix_sdk::{
+    ///     Client,
     ///     ruma::api::client::{
     ///         account::register::v3::Request as RegistrationRequest, uiaa,
     ///     },
-    ///     Client,
     /// };
     /// # use url::Url;
     /// # let homeserver = Url::parse("http://example.com").unwrap();
@@ -662,9 +662,9 @@ impl MatrixAuth {
     ///
     /// ```no_run
     /// use matrix_sdk::{
+    ///     Client, SessionMeta, SessionTokens,
     ///     authentication::matrix::MatrixSession,
     ///     ruma::{device_id, user_id},
-    ///     Client, SessionMeta, SessionTokens,
     /// };
     /// # use url::Url;
     /// # async {
@@ -691,7 +691,7 @@ impl MatrixAuth {
     /// [`LoginBuilder::send()`] method returns:
     ///
     /// ```no_run
-    /// use matrix_sdk::{store::RoomLoadSettings, Client};
+    /// use matrix_sdk::{Client, store::RoomLoadSettings};
     /// use url::Url;
     /// # async {
     ///
@@ -815,7 +815,7 @@ impl MatrixAuth {
 ///
 /// ```
 /// use matrix_sdk::{
-///     authentication::matrix::MatrixSession, SessionMeta, SessionTokens,
+///     SessionMeta, SessionTokens, authentication::matrix::MatrixSession,
 /// };
 /// use ruma::{device_id, user_id};
 ///

--- a/crates/matrix-sdk/src/authentication/mod.rs
+++ b/crates/matrix-sdk/src/authentication/mod.rs
@@ -16,9 +16,9 @@
 
 use std::{fmt, sync::Arc};
 
-use matrix_sdk_base::{locks::Mutex, SessionMeta};
+use matrix_sdk_base::{SessionMeta, locks::Mutex};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{broadcast, Mutex as AsyncMutex, OnceCell};
+use tokio::sync::{Mutex as AsyncMutex, OnceCell, broadcast};
 
 pub mod matrix;
 pub mod oauth;

--- a/crates/matrix-sdk/src/authentication/oauth/account_management_url.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/account_management_url.rs
@@ -17,8 +17,8 @@
 //! This is a Matrix extension introduced in [MSC4191](https://github.com/matrix-org/matrix-spec-proposals/pull/4191).
 
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::msc2965::AccountManagementAction,
     OwnedDeviceId,
+    api::client::discovery::get_authorization_server_metadata::msc2965::AccountManagementAction,
 };
 use url::Url;
 

--- a/crates/matrix-sdk/src/authentication/oauth/auth_code_builder.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/auth_code_builder.rs
@@ -15,17 +15,17 @@
 use std::borrow::Cow;
 
 use oauth2::{
-    basic::BasicClient as OAuthClient, AuthUrl, CsrfToken, PkceCodeChallenge, RedirectUrl, Scope,
+    AuthUrl, CsrfToken, PkceCodeChallenge, RedirectUrl, Scope, basic::BasicClient as OAuthClient,
 };
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::msc2965::Prompt, OwnedDeviceId,
-    UserId,
+    OwnedDeviceId, UserId,
+    api::client::discovery::get_authorization_server_metadata::msc2965::Prompt,
 };
 use tracing::{info, instrument};
 use url::Url;
 
 use super::{ClientRegistrationData, OAuth, OAuthError};
-use crate::{authentication::oauth::AuthorizationValidationData, Result};
+use crate::{Result, authentication::oauth::AuthorizationValidationData};
 
 /// Builder type used to configure optional settings for authorization with an
 /// OAuth 2.0 authorization server via the Authorization Code flow.

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::{
-    store::{LockableCryptoStore, Store},
     CryptoStoreError,
+    store::{LockableCryptoStore, Store},
 };
 use matrix_sdk_common::store_locks::{
     CrossProcessStoreLock, CrossProcessStoreLockGuard, LockStoreError,
@@ -229,7 +229,9 @@ pub enum CrossProcessRefreshLockError {
     MissingLock,
 
     /// Cross-process lock was set, but without session callbacks.
-    #[error("reload session callback must be set with Client::set_session_callbacks() for the cross-process lock to work")]
+    #[error(
+        "reload session callback must be set with Client::set_session_callbacks() for the cross-process lock to work"
+    )]
     MissingReloadSession,
 
     /// The store has been created twice.
@@ -244,21 +246,21 @@ mod tests {
 
     use anyhow::Context as _;
     use futures_util::future::join_all;
-    use matrix_sdk_base::{store::RoomLoadSettings, SessionMeta};
+    use matrix_sdk_base::{SessionMeta, store::RoomLoadSettings};
     use matrix_sdk_test::async_test;
     use ruma::{owned_device_id, owned_user_id};
 
     use super::compute_session_hash;
     use crate::{
+        Error,
         authentication::oauth::cross_process::SessionHash,
         test_utils::{
             client::{
-                mock_prev_session_tokens_with_refresh, mock_session_tokens_with_refresh,
-                oauth::mock_session, MockClientBuilder,
+                MockClientBuilder, mock_prev_session_tokens_with_refresh,
+                mock_session_tokens_with_refresh, oauth::mock_session,
             },
             mocks::MatrixMockServer,
         },
-        Error,
     };
 
     #[async_test]

--- a/crates/matrix-sdk/src/authentication/oauth/error.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/error.rs
@@ -17,12 +17,12 @@
 use matrix_sdk_base::deserialized_responses::PrivOwnedStr;
 use oauth2::ErrorResponseType;
 pub use oauth2::{
+    ConfigurationError, HttpClientError, RequestTokenError, RevocationErrorResponseType,
+    StandardErrorResponse,
     basic::{
         BasicErrorResponse, BasicErrorResponseType, BasicRequestTokenError,
         BasicRevocationErrorResponse,
     },
-    ConfigurationError, HttpClientError, RequestTokenError, RevocationErrorResponseType,
-    StandardErrorResponse,
 };
 use ruma::{
     api::client::discovery::get_authorization_server_metadata::msc2965::AuthorizationServerMetadataUrlError,

--- a/crates/matrix-sdk/src/authentication/oauth/http_client.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/http_client.rs
@@ -108,7 +108,7 @@ pub(super) fn check_http_response_json_content_type<T: ErrorResponse + 'static>(
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use oauth2::{basic::BasicErrorResponse, RequestTokenError};
+    use oauth2::{RequestTokenError, basic::BasicErrorResponse};
 
     use super::{check_http_response_json_content_type, check_http_response_status_code};
 

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -178,13 +178,15 @@ use error::{
 use matrix_sdk_base::crypto::types::qr_login::QrCodeData;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::once_cell::sync::OnceCell;
-use matrix_sdk_base::{store::RoomLoadSettings, SessionMeta};
+use matrix_sdk_base::{SessionMeta, store::RoomLoadSettings};
 use oauth2::{
-    basic::BasicClient as OAuthClient, AccessToken, PkceCodeVerifier, RedirectUrl, RefreshToken,
-    RevocationUrl, Scope, StandardErrorResponse, StandardRevocableToken, TokenResponse, TokenUrl,
+    AccessToken, PkceCodeVerifier, RedirectUrl, RefreshToken, RevocationUrl, Scope,
+    StandardErrorResponse, StandardRevocableToken, TokenResponse, TokenUrl,
+    basic::BasicClient as OAuthClient,
 };
 pub use oauth2::{ClientId, CsrfToken};
 use ruma::{
+    DeviceId, OwnedDeviceId,
     api::client::discovery::{
         get_authentication_issuer,
         get_authorization_server_metadata::{
@@ -193,7 +195,6 @@ use ruma::{
         },
     },
     serde::Raw,
-    DeviceId, OwnedDeviceId,
 };
 use serde::{Deserialize, Serialize};
 use sha2::Digest as _;
@@ -226,10 +227,10 @@ pub use self::{
 use self::{
     http_client::OAuthHttpClient,
     oidc_discovery::discover,
-    registration::{register_client, ClientMetadata, ClientRegistrationResponse},
+    registration::{ClientMetadata, ClientRegistrationResponse, register_client},
 };
 use super::{AuthData, SessionTokens};
-use crate::{client::SessionChange, executor::spawn, Client, HttpError, RefreshTokenError, Result};
+use crate::{Client, HttpError, RefreshTokenError, Result, client::SessionChange, executor::spawn};
 
 pub(crate) struct OAuthCtx {
     /// Lock and state when multiple processes may refresh an OAuth 2.0 session.

--- a/crates/matrix-sdk/src/authentication/oauth/oidc_discovery.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/oidc_discovery.rs
@@ -24,9 +24,9 @@ use ruma::{
 use url::Url;
 
 use super::{
+    OAuthHttpClient,
     error::OAuthDiscoveryError,
     http_client::{check_http_response_json_content_type, check_http_response_status_code},
-    OAuthHttpClient,
 };
 
 /// Fetch the OpenID Connect provider metadata.

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
@@ -17,29 +17,28 @@ use std::future::IntoFuture;
 use eyeball::SharedObservable;
 use futures_core::Stream;
 use matrix_sdk_base::{
-    boxed_into_future,
+    SessionMeta, boxed_into_future,
     crypto::types::qr_login::{QrCodeData, QrCodeMode},
     store::RoomLoadSettings,
-    SessionMeta,
 };
 use oauth2::{DeviceCodeErrorResponseType, StandardDeviceAuthorizationResponse};
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::msc2965::AuthorizationServerMetadata,
     OwnedDeviceId,
+    api::client::discovery::get_authorization_server_metadata::msc2965::AuthorizationServerMetadata,
 };
 use tracing::trace;
-use vodozemac::{ecies::CheckCode, Curve25519PublicKey};
+use vodozemac::{Curve25519PublicKey, ecies::CheckCode};
 
 use super::{
+    DeviceAuthorizationOAuthError, QRCodeLoginError, SecureChannelError,
     messages::{LoginFailureReason, QrAuthMessage},
     secure_channel::EstablishedSecureChannel,
-    DeviceAuthorizationOAuthError, QRCodeLoginError, SecureChannelError,
 };
 #[cfg(doc)]
 use crate::authentication::oauth::OAuth;
 use crate::{
-    authentication::oauth::{ClientRegistrationData, OAuthError},
     Client,
+    authentication::oauth::{ClientRegistrationData, OAuthError},
 };
 
 async fn send_unexpected_message_error(
@@ -330,8 +329,8 @@ impl<'a> LoginWithQrCode<'a> {
 #[cfg(all(test, not(target_family = "wasm")))]
 mod test {
     use assert_matches2::{assert_let, assert_matches};
-    use futures_util::{join, StreamExt};
-    use matrix_sdk_base::crypto::types::{qr_login::QrCodeModeData, SecretsBundle};
+    use futures_util::{StreamExt, join};
+    use matrix_sdk_base::crypto::types::{SecretsBundle, qr_login::QrCodeModeData};
     use matrix_sdk_common::executor::spawn;
     use matrix_sdk_test::async_test;
     use serde_json::json;
@@ -340,7 +339,7 @@ mod test {
     use crate::{
         authentication::oauth::qrcode::{
             messages::LoginProtocolType,
-            secure_channel::{test::MockedRendezvousServer, SecureChannel},
+            secure_channel::{SecureChannel, test::MockedRendezvousServer},
         },
         config::RequestConfig,
         http_client::HttpClient,

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
@@ -22,14 +22,14 @@
 //! [`OAuth::login_with_qr_code()`] method.
 
 use as_variant::as_variant;
+use matrix_sdk_base::crypto::SecretImportError;
 pub use matrix_sdk_base::crypto::types::qr_login::{
     LoginQrCodeDecodeError, QrCodeData, QrCodeMode, QrCodeModeData,
 };
-use matrix_sdk_base::crypto::SecretImportError;
 pub use oauth2::{
-    basic::{BasicErrorResponse, BasicRequestTokenError},
     ConfigurationError, DeviceCodeErrorResponse, DeviceCodeErrorResponseType, HttpClientError,
     RequestTokenError, StandardErrorResponse,
+    basic::{BasicErrorResponse, BasicRequestTokenError},
 };
 use thiserror::Error;
 use url::Url;
@@ -187,6 +187,8 @@ pub enum SecureChannelError {
 
     /// Both devices have advertised the same intent in the login attempt, i.e.
     /// both sides claim to be a new device.
-    #[error("The secure channel could not have been established, the two devices have the same login intent")]
+    #[error(
+        "The secure channel could not have been established, the two devices have the same login intent"
+    )]
     InvalidIntent,
 }

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel.rs
@@ -15,17 +15,17 @@
 use std::time::Duration;
 
 use http::{
-    header::{CONTENT_TYPE, ETAG, EXPIRES, IF_MATCH, IF_NONE_MATCH, LAST_MODIFIED},
     HeaderMap, HeaderName, Method, StatusCode,
+    header::{CONTENT_TYPE, ETAG, EXPIRES, IF_MATCH, IF_NONE_MATCH, LAST_MODIFIED},
 };
 use ruma::api::{
-    error::{FromHttpResponseError, HeaderDeserializationError, IntoHttpError, MatrixError},
     EndpointError,
+    error::{FromHttpResponseError, HeaderDeserializationError, IntoHttpError, MatrixError},
 };
 use tracing::{debug, instrument, trace};
 use url::Url;
 
-use crate::{http_client::HttpClient, HttpError, RumaApiError};
+use crate::{HttpError, RumaApiError, http_client::HttpClient};
 
 const TEXT_PLAIN_CONTENT_TYPE: &str = "text/plain";
 #[cfg(test)]
@@ -290,8 +290,8 @@ mod test {
     use serde_json::json;
     use similar_asserts::assert_eq;
     use wiremock::{
-        matchers::{header, method, path},
         Mock, MockServer, ResponseTemplate,
+        matchers::{header, method, path},
     };
 
     use super::*;

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/secure_channel.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/secure_channel.rs
@@ -15,7 +15,7 @@
 #[cfg(test)]
 use matrix_sdk_base::crypto::types::qr_login::QrCodeModeData;
 use matrix_sdk_base::crypto::types::qr_login::{QrCodeData, QrCodeMode};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use tracing::{instrument, trace};
 #[cfg(test)]
 use url::Url;
@@ -24,8 +24,8 @@ use vodozemac::ecies::{CheckCode, Ecies, EstablishedEcies, Message, OutboundCrea
 use vodozemac::ecies::{InboundCreationResult, InitialMessage};
 
 use super::{
-    rendezvous_channel::{InboundChannelCreationResult, RendezvousChannel},
     SecureChannelError as Error,
+    rendezvous_channel::{InboundChannelCreationResult, RendezvousChannel},
 };
 use crate::{config::RequestConfig, http_client::HttpClient};
 
@@ -229,8 +229,8 @@ impl EstablishedSecureChannel {
 #[cfg(all(test, not(target_family = "wasm")))]
 pub(super) mod test {
     use std::sync::{
-        atomic::{AtomicU8, Ordering},
         Arc, Mutex,
+        atomic::{AtomicU8, Ordering},
     };
 
     use matrix_sdk_base::crypto::types::qr_login::QrCodeMode;
@@ -240,8 +240,8 @@ pub(super) mod test {
     use similar_asserts::assert_eq;
     use url::Url;
     use wiremock::{
-        matchers::{method, path},
         Mock, MockGuard, MockServer, ResponseTemplate,
+        matchers::{method, path},
     };
 
     use super::{EstablishedSecureChannel, SecureChannel};

--- a/crates/matrix-sdk/src/authentication/oauth/registration.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/registration.rs
@@ -23,17 +23,17 @@ use language_tags::LanguageTag;
 use matrix_sdk_base::deserialized_responses::PrivOwnedStr;
 use oauth2::{AsyncHttpClient, ClientId, HttpClientError, RequestTokenError};
 use ruma::{
+    SecondsSinceUnixEpoch,
     api::client::discovery::get_authorization_server_metadata::msc2965::{GrantType, ResponseType},
     serde::{PartialEqAsRefStr, Raw, StringEnum},
-    SecondsSinceUnixEpoch,
 };
-use serde::{ser::SerializeMap, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, ser::SerializeMap};
 use url::Url;
 
 use super::{
+    OAuthHttpClient,
     error::OAuthClientRegistrationError,
     http_client::{check_http_response_json_content_type, check_http_response_status_code},
-    OAuthHttpClient,
 };
 
 /// Register a client with an OAuth 2.0 authorization server.

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -4,15 +4,16 @@ use matrix_sdk_base::store::RoomLoadSettings;
 use matrix_sdk_test::async_test;
 use oauth2::{ClientId, CsrfToken, PkceCodeChallenge, RedirectUrl};
 use ruma::{
+    DeviceId, ServerName,
     api::client::discovery::get_authorization_server_metadata::msc2965::Prompt, device_id,
-    owned_device_id, user_id, DeviceId, ServerName,
+    owned_device_id, user_id,
 };
 use serde_json::json;
 use tokio::sync::broadcast::error::TryRecvError;
 use url::Url;
 use wiremock::{
-    matchers::{method, path},
     Mock, ResponseTemplate,
+    matchers::{method, path},
 };
 
 use super::{
@@ -20,19 +21,19 @@ use super::{
     OAuthError, RedirectUriQueryParseError, UrlOrQuery,
 };
 use crate::{
+    Client, Error, SessionChange,
     authentication::oauth::{
-        error::{AuthorizationCodeErrorResponseType, OAuthClientRegistrationError},
         AuthorizationValidationData, ClientRegistrationData, OAuthAuthorizationCodeError,
+        error::{AuthorizationCodeErrorResponseType, OAuthClientRegistrationError},
     },
     test_utils::{
         client::{
-            mock_prev_session_tokens_with_refresh, mock_session_tokens_with_refresh,
+            MockClientBuilder, mock_prev_session_tokens_with_refresh,
+            mock_session_tokens_with_refresh,
             oauth::{mock_client_id, mock_client_metadata, mock_redirect_uri, mock_session},
-            MockClientBuilder,
         },
-        mocks::{oauth::MockServerMetadataBuilder, MatrixMockServer},
+        mocks::{MatrixMockServer, oauth::MockServerMetadataBuilder},
     },
-    Client, Error, SessionChange,
 };
 
 const REDIRECT_URI_STRING: &str = "http://127.0.0.1:6778/oauth/callback";

--- a/crates/matrix-sdk/src/client/builder/homeserver_config.rs
+++ b/crates/matrix-sdk/src/client/builder/homeserver_config.rs
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 use ruma::{
-    api::{
-        client::discovery::{discover_homeserver, get_supported_versions},
-        MatrixVersion,
-    },
     OwnedServerName, ServerName,
+    api::{
+        MatrixVersion,
+        client::discovery::{discover_homeserver, get_supported_versions},
+    },
 };
 use tracing::debug;
 use url::Url;
 
 use crate::{
-    config::RequestConfig, http_client::HttpClient, sanitize_server_name, ClientBuildError,
-    HttpError,
+    ClientBuildError, HttpError, config::RequestConfig, http_client::HttpClient,
+    sanitize_server_name,
 };
 
 /// Configuration for the homeserver.
@@ -205,8 +205,8 @@ mod tests {
     use ruma::OwnedServerName;
     use serde_json::json;
     use wiremock::{
-        matchers::{method, path},
         Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
     };
 
     use super::*;

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -18,22 +18,22 @@ use std::{fmt::Debug, future::IntoFuture};
 
 use eyeball::{SharedObservable, Subscriber};
 use js_int::UInt;
-use matrix_sdk_common::{boxed_into_future, SendOutsideWasm, SyncOutsideWasm};
-use oauth2::{basic::BasicErrorResponseType, RequestTokenError};
+use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm, boxed_into_future};
+use oauth2::{RequestTokenError, basic::BasicErrorResponseType};
 use ruma::api::{
+    OutgoingRequest,
     client::{error::ErrorKind, media},
     error::FromHttpResponseError,
-    OutgoingRequest,
 };
 use tracing::{error, trace};
 
 use super::super::Client;
 use crate::{
+    Error, RefreshTokenError, TransmissionProgress,
     authentication::oauth::OAuthError,
     config::RequestConfig,
     error::{HttpError, HttpResult},
     media::MediaError,
-    Error, RefreshTokenError, TransmissionProgress,
 };
 
 /// `IntoFuture` returned by [`Client::send`].
@@ -119,7 +119,9 @@ where
                                 )) if *error_response.error()
                                     == BasicErrorResponseType::InvalidGrant =>
                                 {
-                                    error!("Token refresh: OAuth 2.0 refresh_token rejected with invalid grant");
+                                    error!(
+                                        "Token refresh: OAuth 2.0 refresh_token rejected with invalid grant"
+                                    );
                                     // The refresh was denied, signal to sign out the user.
                                     client.broadcast_unknown_token(soft_logout);
                                 }

--- a/crates/matrix-sdk/src/encryption/backups/types.rs
+++ b/crates/matrix-sdk/src/encryption/backups/types.rs
@@ -17,14 +17,14 @@ use std::{
     time::Duration,
 };
 
-use matrix_sdk_base::crypto::{store::types::RoomKeyCounts, RoomKeyImportResult};
+use matrix_sdk_base::crypto::{RoomKeyImportResult, store::types::RoomKeyCounts};
 use tokio::sync::broadcast;
 
 use crate::utils::ChannelObservable;
 #[cfg(doc)]
 use crate::{
-    encryption::{backups::Backups, secret_storage::SecretStore},
     Client,
+    encryption::{backups::Backups, secret_storage::SecretStore},
 };
 
 /// The states the upload task can be in.

--- a/crates/matrix-sdk/src/encryption/futures.rs
+++ b/crates/matrix-sdk/src/encryption/futures.rs
@@ -23,7 +23,7 @@ use eyeball::{SharedObservable, Subscriber};
 use matrix_sdk_common::boxed_into_future;
 use ruma::events::room::{EncryptedFile, EncryptedFileInit};
 
-use crate::{config::RequestConfig, Client, Media, Result, TransmissionProgress};
+use crate::{Client, Media, Result, TransmissionProgress, config::RequestConfig};
 
 /// Future returned by [`Client::upload_encrypted_file`].
 #[allow(missing_debug_implementations)]

--- a/crates/matrix-sdk/src/encryption/identities/devices.rs
+++ b/crates/matrix-sdk/src/encryption/identities/devices.rs
@@ -15,16 +15,16 @@
 use std::{collections::BTreeMap, ops::Deref};
 
 use matrix_sdk_base::crypto::{
-    store::CryptoStoreError, Device as BaseDevice, DeviceData, LocalTrust,
-    UserDevices as BaseUserDevices,
+    Device as BaseDevice, DeviceData, LocalTrust, UserDevices as BaseUserDevices,
+    store::CryptoStoreError,
 };
-use ruma::{events::key::verification::VerificationMethod, DeviceId, OwnedDeviceId, OwnedUserId};
+use ruma::{DeviceId, OwnedDeviceId, OwnedUserId, events::key::verification::VerificationMethod};
 
 use super::ManualVerifyError;
 use crate::{
+    Client,
     encryption::verification::{SasVerification, VerificationRequest},
     error::Result,
-    Client,
 };
 
 /// Updates about [`Device`]s which got received over the `/keys/query`

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -15,19 +15,19 @@
 use std::collections::BTreeMap;
 
 use matrix_sdk_base::{
-    crypto::{types::MasterPubkey, CryptoStoreError, UserIdentity as CryptoUserIdentity},
     RoomMemberships,
+    crypto::{CryptoStoreError, UserIdentity as CryptoUserIdentity, types::MasterPubkey},
 };
 use ruma::{
+    OwnedUserId, UserId,
     events::{
         key::verification::VerificationMethod,
         room::message::{MessageType, RoomMessageEventContent},
     },
-    OwnedUserId, UserId,
 };
 
 use super::{ManualVerifyError, RequestVerificationError};
-use crate::{encryption::verification::VerificationRequest, Client};
+use crate::{Client, encryption::verification::VerificationRequest};
 
 /// Updates about [`UserIdentity`]s which got received over the `/keys/query`
 /// endpoint.

--- a/crates/matrix-sdk/src/encryption/recovery/futures.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/futures.rs
@@ -17,10 +17,10 @@
 use std::future::IntoFuture;
 
 use futures_core::Stream;
-use futures_util::{pin_mut, StreamExt};
+use futures_util::{StreamExt, pin_mut};
 use matrix_sdk_common::boxed_into_future;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
-use tracing::{warn, Instrument, Span};
+use tracing::{Instrument, Span, warn};
 
 use super::{EnableProgress, Recovery, RecoveryError, Result};
 use crate::{

--- a/crates/matrix-sdk/src/encryption/recovery/mod.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/mod.rs
@@ -32,7 +32,7 @@
 //! doesn't exist, as well:
 //!
 //! ```no_run
-//! use matrix_sdk::{encryption::EncryptionSettings, Client};
+//! use matrix_sdk::{Client, encryption::EncryptionSettings};
 //!
 //! # async {
 //! # let homeserver = "http://example.org";
@@ -95,9 +95,9 @@ use futures_util::StreamExt as _;
 use ruma::{
     api::client::keys::get_keys,
     events::{
+        GlobalAccountDataEventType,
         secret::{request::SecretName, send::ToDeviceSecretSendEvent},
         secret_storage::{default_key::SecretStorageDefaultKeyEvent, secret::SecretEventContent},
-        GlobalAccountDataEventType,
     },
     serde::Raw,
 };
@@ -109,7 +109,7 @@ use crate::encryption::{
     backups::Backups,
     secret_storage::{SecretStorage, SecretStore},
 };
-use crate::{client::WeakClient, encryption::backups::BackupState, Client};
+use crate::{Client, client::WeakClient, encryption::backups::BackupState};
 
 pub mod futures;
 mod types;

--- a/crates/matrix-sdk/src/encryption/recovery/types.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/types.rs
@@ -24,7 +24,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 #[cfg(doc)]
 use crate::encryption::{
     backups::Backups,
-    recovery::{futures::Enable, Recovery},
+    recovery::{Recovery, futures::Enable},
 };
 
 /// Result type alias for the [`Recovery`] subsystem.

--- a/crates/matrix-sdk/src/encryption/secret_storage/mod.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/mod.rs
@@ -63,15 +63,15 @@
 use std::string::FromUtf8Error;
 
 use matrix_sdk_base::crypto::{
-    secret_storage::{DecodeError, MacError, SecretStorageKey},
     CryptoStoreError, SecretImportError,
+    secret_storage::{DecodeError, MacError, SecretStorageKey},
 };
 use ruma::{
     events::{
+        EventContentFromType, GlobalAccountDataEventType,
         secret_storage::{
             default_key::SecretStorageDefaultKeyEventContent, key::SecretStorageKeyEventContent,
         },
-        EventContentFromType, GlobalAccountDataEventType,
     },
     serde::Raw,
 };

--- a/crates/matrix-sdk/src/encryption/secret_storage/secret_store.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/secret_store.rs
@@ -14,19 +14,19 @@
 
 use std::fmt;
 
-use matrix_sdk_base::crypto::{secret_storage::SecretStorageKey, CrossSigningKeyExport};
+use matrix_sdk_base::crypto::{CrossSigningKeyExport, secret_storage::SecretStorageKey};
 use ruma::{
     events::{
-        secret::request::SecretName, secret_storage::secret::SecretEventContent,
-        GlobalAccountDataEventType,
+        GlobalAccountDataEventType, secret::request::SecretName,
+        secret_storage::secret::SecretEventContent,
     },
     serde::Raw,
 };
 use serde_json::value::to_raw_value;
 use tracing::{
-    error,
+    Span, error,
     field::{debug, display},
-    info, instrument, warn, Span,
+    info, instrument, warn,
 };
 use zeroize::Zeroize;
 

--- a/crates/matrix-sdk/src/encryption/tasks.rs
+++ b/crates/matrix-sdk/src/encryption/tasks.rs
@@ -16,21 +16,21 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use matrix_sdk_common::failures_cache::FailuresCache;
 use ruma::{
+    OwnedEventId, OwnedRoomId,
     events::room::encrypted::{EncryptedEventScheme, OriginalSyncRoomEncryptedEvent},
     serde::Raw,
-    OwnedEventId, OwnedRoomId,
 };
 use tokio::sync::{
-    mpsc::{self, UnboundedReceiver},
     Mutex,
+    mpsc::{self, UnboundedReceiver},
 };
 use tracing::{debug, trace, warn};
 
 use crate::{
+    Client,
     client::WeakClient,
     encryption::backups::UploadState,
-    executor::{spawn, JoinHandle},
-    Client,
+    executor::{JoinHandle, spawn},
 };
 
 /// A cache of room keys we already downloaded.
@@ -360,7 +360,10 @@ impl BackupDownloadTaskListenerState {
             .await
             .unwrap_or(false)
         {
-            debug!(?download_request, "Not performing backup download because key became available while we were sleeping");
+            debug!(
+                ?download_request,
+                "Not performing backup download because key became available while we were sleeping"
+            );
             return false;
         }
 

--- a/crates/matrix-sdk/src/encryption/verification/mod.rs
+++ b/crates/matrix-sdk/src/encryption/verification/mod.rs
@@ -36,13 +36,13 @@ mod sas;
 
 use as_variant::as_variant;
 pub use matrix_sdk_base::crypto::{
-    format_emojis, AcceptSettings, AcceptedProtocols, CancelInfo, Emoji, EmojiShortAuthString,
-    SasState,
+    AcceptSettings, AcceptedProtocols, CancelInfo, Emoji, EmojiShortAuthString, SasState,
+    format_emojis,
 };
 #[cfg(feature = "qrcode")]
 pub use matrix_sdk_base::crypto::{
-    matrix_sdk_qrcode::{DecodingError, EncodingError, QrVerificationData},
     QrVerificationState, ScanError,
+    matrix_sdk_qrcode::{DecodingError, EncodingError, QrVerificationData},
 };
 #[cfg(feature = "qrcode")]
 pub use qrcode::QrVerification;

--- a/crates/matrix-sdk/src/encryption/verification/qrcode.rs
+++ b/crates/matrix-sdk/src/encryption/verification/qrcode.rs
@@ -14,8 +14,8 @@
 
 use futures_core::Stream;
 use matrix_sdk_base::crypto::{
-    matrix_sdk_qrcode::{qrcode::QrCode, EncodingError},
     CancelInfo, DeviceData, QrVerification as BaseQrVerification, QrVerificationState,
+    matrix_sdk_qrcode::{EncodingError, qrcode::QrCode},
 };
 use ruma::{RoomId, UserId};
 

--- a/crates/matrix-sdk/src/encryption/verification/requests.rs
+++ b/crates/matrix-sdk/src/encryption/verification/requests.rs
@@ -16,7 +16,7 @@ use futures_util::{Stream, StreamExt};
 use matrix_sdk_base::crypto::{
     CancelInfo, DeviceData, VerificationRequest as BaseVerificationRequest,
 };
-use ruma::{events::key::verification::VerificationMethod, RoomId};
+use ruma::{RoomId, events::key::verification::VerificationMethod};
 
 #[cfg(feature = "qrcode")]
 use super::{QrVerification, QrVerificationData};

--- a/crates/matrix-sdk/src/encryption/verification/sas.rs
+++ b/crates/matrix-sdk/src/encryption/verification/sas.rs
@@ -16,9 +16,9 @@ use futures_core::Stream;
 use matrix_sdk_base::crypto::{
     AcceptSettings, CancelInfo, DeviceData, Emoji, Sas as BaseSas, SasState,
 };
-use ruma::{events::key::verification::cancel::CancelCode, RoomId, UserId};
+use ruma::{RoomId, UserId, events::key::verification::cancel::CancelCode};
 
-use crate::{error::Result, Client};
+use crate::{Client, error::Result};
 
 /// An object controlling the short auth string verification flow.
 #[derive(Debug, Clone)]

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -25,11 +25,12 @@ use matrix_sdk_base::crypto::{
     CryptoStoreError, DecryptorError, KeyExportError, MegolmError, OlmError,
 };
 use matrix_sdk_base::{
-    event_cache::store::EventCacheStoreError, Error as SdkBaseError, QueueWedgeError, RoomState,
-    StoreError,
+    Error as SdkBaseError, QueueWedgeError, RoomState, StoreError,
+    event_cache::store::EventCacheStoreError,
 };
 use reqwest::Error as ReqwestError;
 use ruma::{
+    IdParseError,
     api::{
         client::{
             error::{ErrorBody, ErrorKind, RetryAfter},
@@ -39,7 +40,6 @@ use ruma::{
     },
     events::tag::InvalidUserTagName,
     push::{InsertPushRuleError, RemovePushRuleError},
-    IdParseError,
 };
 use serde_json::Error as JsonError;
 use thiserror::Error;

--- a/crates/matrix-sdk/src/event_cache/deduplicator.rs
+++ b/crates/matrix-sdk/src/event_cache/deduplicator.rs
@@ -24,8 +24,8 @@ use matrix_sdk_base::{
 use ruma::{OwnedEventId, RoomId};
 
 use super::{
-    room::events::{Event, RoomEvents},
     EventCacheError,
+    room::events::{Event, RoomEvents},
 };
 
 /// Find duplicates in the given collection of events, and return both
@@ -128,7 +128,7 @@ pub(super) struct DeduplicationOutcome {
 mod tests {
     use matrix_sdk_base::{deserialized_responses::TimelineEvent, linked_chunk::ChunkIdentifier};
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
-    use ruma::{owned_event_id, serde::Raw, user_id, EventId};
+    use ruma::{EventId, owned_event_id, serde::Raw, user_id};
 
     use super::*;
 

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -43,19 +43,20 @@ use matrix_sdk_base::{
     store_locks::LockStoreError,
     sync::RoomUpdates,
 };
-use matrix_sdk_common::executor::{spawn, JoinHandle};
+use matrix_sdk_common::executor::{JoinHandle, spawn};
 use room::RoomEventCacheState;
 use ruma::{
-    events::AnySyncEphemeralRoomEvent, serde::Raw, OwnedEventId, OwnedRoomId, RoomId, RoomVersionId,
+    OwnedEventId, OwnedRoomId, RoomId, RoomVersionId, events::AnySyncEphemeralRoomEvent, serde::Raw,
 };
 use tokio::sync::{
-    broadcast::{error::RecvError, Receiver},
-    mpsc, Mutex, RwLock,
+    Mutex, RwLock,
+    broadcast::{Receiver, error::RecvError},
+    mpsc,
 };
-use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument as _, Span};
+use tracing::{Instrument as _, Span, debug, error, info, info_span, instrument, trace, warn};
 
 use self::paginator::PaginatorError;
-use crate::{client::WeakClient, Client};
+use crate::{Client, client::WeakClient};
 
 mod deduplicator;
 mod pagination;
@@ -240,7 +241,9 @@ impl EventCache {
                         match err {
                             EventCacheError::ClientDropped => {
                                 // The client has dropped, exit the listen task.
-                                info!("Closing the event cache global listen task because client dropped");
+                                info!(
+                                    "Closing the event cache global listen task because client dropped"
+                                );
                                 break;
                             }
                             err => {

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -23,8 +23,8 @@ use ruma::api::Direction;
 use tracing::{debug, instrument, trace};
 
 use super::{
-    room::{events::Gap, LoadMoreEventsBackwardsOutcome, RoomEventCacheInner},
     BackPaginationOutcome, EventsOrigin, Result, RoomEventCacheUpdate,
+    room::{LoadMoreEventsBackwardsOutcome, RoomEventCacheInner, events::Gap},
 };
 use crate::{event_cache::EventCacheError, room::MessagesOptions};
 

--- a/crates/matrix-sdk/src/event_cache/paginator.rs
+++ b/crates/matrix-sdk/src/event_cache/paginator.rs
@@ -20,13 +20,13 @@
 use std::{future::Future, sync::Mutex};
 
 use eyeball::{SharedObservable, Subscriber};
-use matrix_sdk_base::{deserialized_responses::TimelineEvent, SendOutsideWasm, SyncOutsideWasm};
-use ruma::{api::Direction, EventId, OwnedEventId, UInt};
+use matrix_sdk_base::{SendOutsideWasm, SyncOutsideWasm, deserialized_responses::TimelineEvent};
+use ruma::{EventId, OwnedEventId, UInt, api::Direction};
 
 use super::pagination::PaginationToken;
 use crate::{
-    room::{EventWithContextResponse, Messages, MessagesOptions, WeakRoom},
     Room,
+    room::{EventWithContextResponse, Messages, MessagesOptions, WeakRoom},
 };
 
 /// Current state of a [`Paginator`].
@@ -488,7 +488,7 @@ mod tests {
     use matrix_sdk_base::deserialized_responses::TimelineEvent;
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
     use once_cell::sync::Lazy;
-    use ruma::{api::Direction, event_id, room_id, uint, user_id, EventId, RoomId, UInt, UserId};
+    use ruma::{EventId, RoomId, UInt, UserId, api::Direction, event_id, room_id, uint, user_id};
     use tokio::{
         spawn,
         sync::{Mutex, Notify},
@@ -999,7 +999,7 @@ mod tests {
 
     mod aborts {
         use super::*;
-        use crate::event_cache::{paginator::PaginationTokens, PaginationToken};
+        use crate::event_cache::{PaginationToken, paginator::PaginationTokens};
 
         #[derive(Clone, Default)]
         struct AbortingRoom {

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -18,8 +18,8 @@ pub use matrix_sdk_base::event_cache::{Event, Gap};
 use matrix_sdk_base::{
     event_cache::store::DEFAULT_CHUNK_CAPACITY,
     linked_chunk::{
-        lazy_loader::{self, LazyLoaderError},
         ChunkContent, ChunkIdentifierGenerator, RawChunk,
+        lazy_loader::{self, LazyLoaderError},
     },
 };
 use matrix_sdk_common::linked_chunk::{
@@ -336,8 +336,8 @@ pub(super) fn sort_positions_descending(positions: &mut [Position]) {
 mod tests {
     use assert_matches::assert_matches;
     use assert_matches2::assert_let;
-    use matrix_sdk_test::{event_factory::EventFactory, ALICE, DEFAULT_TEST_ROOM_ID};
-    use ruma::{event_id, user_id, EventId, OwnedEventId};
+    use matrix_sdk_test::{ALICE, DEFAULT_TEST_ROOM_ID, event_factory::EventFactory};
+    use ruma::{EventId, OwnedEventId, event_id, user_id};
 
     use super::*;
 

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -19,8 +19,8 @@ use std::{
     fmt,
     ops::{Deref, DerefMut},
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
@@ -34,13 +34,14 @@ use matrix_sdk_base::{
     sync::{JoinedRoomUpdate, LeftRoomUpdate, Timeline},
 };
 use ruma::{
-    events::{relation::RelationType, AnyRoomAccountDataEvent, AnySyncEphemeralRoomEvent},
-    serde::Raw,
     EventId, OwnedEventId, OwnedRoomId,
+    events::{AnyRoomAccountDataEvent, AnySyncEphemeralRoomEvent, relation::RelationType},
+    serde::Raw,
 };
 use tokio::sync::{
+    Notify, RwLock,
     broadcast::{Receiver, Sender},
-    mpsc, Notify, RwLock,
+    mpsc,
 };
 use tracing::{instrument, trace, warn};
 
@@ -108,7 +109,9 @@ impl Drop for RoomEventCacheListener {
                 if num_attempts > 1024 {
                     // If we've tried too many times, just give up with a warning; after all, this
                     // is only an optimization.
-                    warn!("couldn't send notification to the auto-shrink channel after 1024 attempts; giving up");
+                    warn!(
+                        "couldn't send notification to the auto-shrink channel after 1024 attempts; giving up"
+                    );
                     return;
                 }
 
@@ -445,7 +448,7 @@ pub(super) enum LoadMoreEventsBackwardsOutcome {
 mod private {
     use std::{
         collections::HashSet,
-        sync::{atomic::AtomicUsize, Arc},
+        sync::{Arc, atomic::AtomicUsize},
     };
 
     use eyeball::SharedObservable;
@@ -453,32 +456,33 @@ mod private {
     use matrix_sdk_base::{
         apply_redaction,
         deserialized_responses::{ThreadSummary, ThreadSummaryStatus, TimelineEventKind},
-        event_cache::{store::EventCacheStoreLock, Event, Gap},
+        event_cache::{Event, Gap, store::EventCacheStoreLock},
         linked_chunk::{
-            lazy_loader, ChunkContent, ChunkIdentifier, ChunkIdentifierGenerator, LinkedChunkId,
-            Position, Update,
+            ChunkContent, ChunkIdentifier, ChunkIdentifierGenerator, LinkedChunkId, Position,
+            Update, lazy_loader,
         },
         serde_helpers::extract_thread_root,
         sync::Timeline,
     };
     use matrix_sdk_common::executor::spawn;
     use ruma::{
+        EventId, OwnedEventId, OwnedRoomId, RoomVersionId,
         events::{
-            relation::RelationType, room::redaction::SyncRoomRedactionEvent, AnySyncTimelineEvent,
-            MessageLikeEventType,
+            AnySyncTimelineEvent, MessageLikeEventType, relation::RelationType,
+            room::redaction::SyncRoomRedactionEvent,
         },
         serde::Raw,
-        EventId, OwnedEventId, OwnedRoomId, RoomVersionId,
     };
     use tracing::{debug, error, instrument, trace, warn};
 
     use super::{
-        super::{deduplicator::DeduplicationOutcome, EventCacheError},
+        super::{EventCacheError, deduplicator::DeduplicationOutcome},
+        EventLocation, LoadMoreEventsBackwardsOutcome,
         events::RoomEvents,
-        sort_positions_descending, EventLocation, LoadMoreEventsBackwardsOutcome,
+        sort_positions_descending,
     };
     use crate::event_cache::{
-        deduplicator::filter_duplicate_events, BackPaginationOutcome, RoomPaginationStatus,
+        BackPaginationOutcome, RoomPaginationStatus, deduplicator::filter_duplicate_events,
     };
 
     /// State for a single room's event cache.
@@ -1532,9 +1536,9 @@ mod tests {
     use matrix_sdk_base::event_cache::Event;
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
     use ruma::{
-        event_id,
+        RoomId, event_id,
         events::{relation::RelationType, room::message::RoomMessageEventContentWithoutRelation},
-        room_id, user_id, RoomId,
+        room_id, user_id,
     };
 
     use crate::test_utils::logged_in_client;
@@ -1794,17 +1798,17 @@ mod timed_tests {
     use eyeball_im::VectorDiff;
     use matrix_sdk_base::{
         event_cache::{
-            store::{EventCacheStore as _, MemoryStore},
             Gap,
+            store::{EventCacheStore as _, MemoryStore},
         },
         linked_chunk::{
-            lazy_loader::from_all_chunks, ChunkContent, ChunkIdentifier, LinkedChunkId, Position,
-            Update,
+            ChunkContent, ChunkIdentifier, LinkedChunkId, Position, Update,
+            lazy_loader::from_all_chunks,
         },
         store::StoreConfig,
         sync::{JoinedRoomUpdate, Timeline},
     };
-    use matrix_sdk_test::{async_test, event_factory::EventFactory, ALICE, BOB};
+    use matrix_sdk_test::{ALICE, BOB, async_test, event_factory::EventFactory};
     use ruma::{
         event_id,
         events::{AnySyncMessageLikeEvent, AnySyncTimelineEvent},
@@ -1814,7 +1818,7 @@ mod timed_tests {
 
     use crate::{
         assert_let_timeout,
-        event_cache::{room::LoadMoreEventsBackwardsOutcome, RoomEventCacheUpdate},
+        event_cache::{RoomEventCacheUpdate, room::LoadMoreEventsBackwardsOutcome},
         test_utils::client::MockClientBuilder,
     };
 

--- a/crates/matrix-sdk/src/event_handler/maps.rs
+++ b/crates/matrix-sdk/src/event_handler/maps.rs
@@ -14,7 +14,7 @@
 
 use std::{
     borrow::Borrow,
-    collections::{btree_map, BTreeMap},
+    collections::{BTreeMap, btree_map},
 };
 
 use ruma::{OwnedRoomId, RoomId};

--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -39,8 +39,8 @@ use std::{
     future::Future,
     pin::Pin,
     sync::{
-        atomic::{AtomicU64, Ordering::SeqCst},
         Arc, RwLock, Weak,
+        atomic::{AtomicU64, Ordering::SeqCst},
     },
     task::{Context, Poll},
 };
@@ -53,13 +53,13 @@ use eyeball::{SharedObservable, Subscriber};
 use futures_core::Stream;
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use matrix_sdk_base::{
-    deserialized_responses::{EncryptionInfo, TimelineEvent},
     SendOutsideWasm, SyncOutsideWasm,
+    deserialized_responses::{EncryptionInfo, TimelineEvent},
 };
 use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
 use pin_project_lite::pin_project;
-use ruma::{events::AnySyncStateEvent, push::Action, serde::Raw, OwnedRoomId};
-use serde::{de::DeserializeOwned, Deserialize};
+use ruma::{OwnedRoomId, events::AnySyncStateEvent, push::Action, serde::Raw};
+use serde::{Deserialize, de::DeserializeOwned};
 use serde_json::value::RawValue as RawJsonValue;
 use tracing::{debug, error, field::debug, instrument, warn};
 
@@ -136,19 +136,11 @@ pub enum HandlerKind {
 
 impl HandlerKind {
     fn message_like_redacted(redacted: bool) -> Self {
-        if redacted {
-            Self::RedactedMessageLike
-        } else {
-            Self::OriginalMessageLike
-        }
+        if redacted { Self::RedactedMessageLike } else { Self::OriginalMessageLike }
     }
 
     fn state_redacted(redacted: bool) -> Self {
-        if redacted {
-            Self::RedactedState
-        } else {
-            Self::OriginalState
-        }
+        if redacted { Self::RedactedState } else { Self::OriginalState }
     }
 }
 
@@ -711,9 +703,8 @@ where
 #[cfg(test)]
 mod tests {
     use matrix_sdk_test::{
-        async_test,
+        DEFAULT_TEST_ROOM_ID, InvitedRoomBuilder, JoinedRoomBuilder, async_test,
         event_factory::{EventFactory, PreviousMembership},
-        InvitedRoomBuilder, JoinedRoomBuilder, DEFAULT_TEST_ROOM_ID,
     };
     use stream_assert::{assert_closed, assert_pending, assert_ready};
     #[cfg(target_family = "wasm")]
@@ -721,8 +712,8 @@ mod tests {
     use std::{
         future,
         sync::{
-            atomic::{AtomicU8, Ordering::SeqCst},
             Arc,
+            atomic::{AtomicU8, Ordering::SeqCst},
         },
     };
 
@@ -733,13 +724,13 @@ mod tests {
     use ruma::{
         event_id,
         events::{
+            AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
             room::{
                 member::{MembershipState, OriginalSyncRoomMemberEvent, StrippedRoomMemberEvent},
                 name::OriginalSyncRoomNameEvent,
                 power_levels::OriginalSyncRoomPowerLevelsEvent,
             },
             typing::SyncTypingEvent,
-            AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
         },
         room_id,
         serde::Raw,
@@ -748,9 +739,9 @@ mod tests {
     use serde_json::json;
 
     use crate::{
+        Client, Room,
         event_handler::Ctx,
         test_utils::{logged_in_client, no_retry_test_client},
-        Client, Room,
     };
 
     static MEMBER_EVENT: Lazy<Raw<AnySyncTimelineEvent>> = Lazy::new(|| {

--- a/crates/matrix-sdk/src/event_handler/static_events.rs
+++ b/crates/matrix-sdk/src/event_handler/static_events.rs
@@ -16,15 +16,14 @@
 
 use ruma::{
     events::{
-        self,
-        presence::{PresenceEvent, PresenceEventContent},
-        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
+        self, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
         AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent, AnySyncStateEvent,
         AnySyncTimelineEvent, AnyToDeviceEvent, EphemeralRoomEventContent,
         GlobalAccountDataEventContent, MessageLikeEventContent, PossiblyRedactedStateEventContent,
         RedactContent, RedactedMessageLikeEventContent, RedactedStateEventContent,
         RoomAccountDataEventContent, StaticEventContent, StaticStateEventContent,
         ToDeviceEventContent,
+        presence::{PresenceEvent, PresenceEventContent},
     },
     serde::Raw,
 };

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -17,8 +17,8 @@ use std::{
     fmt::Debug,
     num::NonZeroUsize,
     sync::{
-        atomic::{AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicU64, Ordering},
     },
     time::Duration,
 };
@@ -28,8 +28,8 @@ use bytesize::ByteSize;
 use eyeball::SharedObservable;
 use http::Method;
 use ruma::api::{
-    error::{FromHttpResponseError, IntoHttpError},
     AuthScheme, MatrixVersion, OutgoingRequest, SendAccessToken,
+    error::{FromHttpResponseError, IntoHttpError},
 };
 use tokio::sync::{Semaphore, SemaphorePermit};
 use tracing::{debug, field::debug, instrument, trace};
@@ -255,8 +255,8 @@ mod tests {
     use std::{
         num::NonZeroUsize,
         sync::{
-            atomic::{AtomicU8, Ordering},
             Arc,
+            atomic::{AtomicU8, Ordering},
         },
         time::Duration,
     };
@@ -264,8 +264,8 @@ mod tests {
     use matrix_sdk_common::executor::spawn;
     use matrix_sdk_test::{async_test, test_json};
     use wiremock::{
-        matchers::{method, path},
         Mock, Request, ResponseTemplate,
+        matchers::{method, path},
     };
 
     use crate::{

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -24,11 +24,11 @@ use bytes::Bytes;
 use bytesize::ByteSize;
 use eyeball::SharedObservable;
 use http::header::CONTENT_LENGTH;
-use reqwest::{tls, Certificate};
-use ruma::api::{error::FromHttpResponseError, IncomingResponse, OutgoingRequest};
+use reqwest::{Certificate, tls};
+use ruma::api::{IncomingResponse, OutgoingRequest, error::FromHttpResponseError};
 use tracing::{debug, info, warn};
 
-use super::{response_to_http_response, HttpClient, TransmissionProgress, DEFAULT_REQUEST_TIMEOUT};
+use super::{DEFAULT_REQUEST_TIMEOUT, HttpClient, TransmissionProgress, response_to_http_response};
 use crate::{
     config::RequestConfig,
     error::{HttpError, RetryKind},
@@ -127,11 +127,7 @@ impl HttpClient {
                         // If we ran into a network failure, only retry if there's some retry limit
                         // associated to this request's configuration; otherwise, we would end up
                         // running an infinite loop of network requests in offline mode.
-                        if has_retry_limit {
-                            default_timeout
-                        } else {
-                            None
-                        }
+                        if has_retry_limit { default_timeout } else { None }
                     }
                 }
             })

--- a/crates/matrix-sdk/src/http_client/wasm.rs
+++ b/crates/matrix-sdk/src/http_client/wasm.rs
@@ -17,9 +17,9 @@ use std::fmt::Debug;
 use bytes::Bytes;
 use bytesize::ByteSize;
 use eyeball::SharedObservable;
-use ruma::api::{error::FromHttpResponseError, IncomingResponse, OutgoingRequest};
+use ruma::api::{IncomingResponse, OutgoingRequest, error::FromHttpResponseError};
 
-use super::{response_to_http_response, HttpClient, TransmissionProgress};
+use super::{HttpClient, TransmissionProgress, response_to_http_response};
 use crate::{config::RequestConfig, error::HttpError};
 
 impl HttpClient {

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -23,12 +23,11 @@ pub use bytes;
 #[cfg(feature = "e2e-encryption")]
 pub use matrix_sdk_base::crypto;
 pub use matrix_sdk_base::{
-    deserialized_responses,
-    store::{self, DynStateStore, MemoryStore, StateStoreExt},
     ComposerDraft, ComposerDraftType, EncryptionState, PredecessorRoom, QueueWedgeError,
     Room as BaseRoom, RoomCreateWithCreatorEventContent, RoomDisplayName, RoomHero, RoomInfo,
     RoomMember as BaseRoomMember, RoomMemberships, RoomState, SessionMeta, StateChanges,
-    StateStore, StoreError, SuccessorRoom,
+    StateStore, StoreError, SuccessorRoom, deserialized_responses,
+    store::{self, DynStateStore, MemoryStore, StateStoreExt},
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;
@@ -66,7 +65,7 @@ pub mod widget;
 pub use account::Account;
 pub use authentication::{AuthApi, AuthSession, SessionTokens};
 pub use client::{
-    sanitize_server_name, Client, ClientBuildError, ClientBuilder, LoopCtrl, SessionChange,
+    Client, ClientBuildError, ClientBuilder, LoopCtrl, SessionChange, sanitize_server_name,
 };
 pub use error::{
     Error, HttpError, HttpResult, NotificationSettingsError, RefreshTokenError, Result,
@@ -77,7 +76,7 @@ pub use http_client::TransmissionProgress;
 pub use matrix_sdk_sqlite::SqliteCryptoStore;
 #[cfg(feature = "sqlite")]
 pub use matrix_sdk_sqlite::{
-    SqliteEventCacheStore, SqliteStateStore, SqliteStoreConfig, STATE_STORE_DATABASE_NAME,
+    STATE_STORE_DATABASE_NAME, SqliteEventCacheStore, SqliteStateStore, SqliteStoreConfig,
 };
 pub use media::Media;
 pub use pusher::Pusher;

--- a/crates/matrix-sdk/src/live_location_share.rs
+++ b/crates/matrix-sdk/src/live_location_share.rs
@@ -19,14 +19,14 @@
 use async_stream::stream;
 use futures_util::Stream;
 use ruma::{
+    MilliSecondsSinceUnixEpoch, OwnedUserId, RoomId,
     events::{
         beacon::OriginalSyncBeaconEvent, beacon_info::BeaconInfoEventContent,
         location::LocationContent,
     },
-    MilliSecondsSinceUnixEpoch, OwnedUserId, RoomId,
 };
 
-use crate::{event_handler::ObservableEventHandler, Client, Room};
+use crate::{Client, Room, event_handler::ObservableEventHandler};
 
 /// An observable live location.
 #[derive(Debug)]

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -27,13 +27,13 @@ use matrix_sdk_base::event_cache::store::media::IgnoreMediaRetentionPolicy;
 pub use matrix_sdk_base::{event_cache::store::media::MediaRetentionPolicy, media::*};
 use mime::Mime;
 use ruma::{
+    MilliSecondsSinceUnixEpoch, MxcUri, OwnedMxcUri, TransactionId, UInt,
     api::{
-        client::{authenticated_media, error::ErrorKind, media},
         MatrixVersion,
+        client::{authenticated_media, error::ErrorKind, media},
     },
     assign,
     events::room::{MediaSource, ThumbnailInfo},
-    MilliSecondsSinceUnixEpoch, MxcUri, OwnedMxcUri, TransactionId, UInt,
 };
 #[cfg(not(target_family = "wasm"))]
 use tempfile::{Builder as TempFileBuilder, NamedTempFile, TempDir};
@@ -41,8 +41,8 @@ use tempfile::{Builder as TempFileBuilder, NamedTempFile, TempDir};
 use tokio::{fs::File as TokioFile, io::AsyncWriteExt};
 
 use crate::{
-    attachment::Thumbnail, client::futures::SendMediaUploadRequest, config::RequestConfig, Client,
-    Error, Result, TransmissionProgress,
+    Client, Error, Result, TransmissionProgress, attachment::Thumbnail,
+    client::futures::SendMediaUploadRequest, config::RequestConfig,
 };
 
 /// A conservative upload speed of 1Mbps
@@ -144,7 +144,9 @@ pub enum MediaError {
     LocalMediaNotFound,
 
     /// The provided media is too large to upload.
-    #[error("The provided media is too large to upload. Maximum upload length is {max} bytes, tried to upload {current} bytes")]
+    #[error(
+        "The provided media is too large to upload. Maximum upload length is {max} bytes, tried to upload {current} bytes"
+    )]
     MediaTooLargeToUpload {
         /// The `max_upload_size` value for this homeserver.
         max: UInt,
@@ -815,8 +817,9 @@ impl Media {
 mod tests {
     use assert_matches2::assert_matches;
     use ruma::{
+        MxcUri,
         events::room::{EncryptedFile, MediaSource},
-        mxc_uri, owned_mxc_uri, uint, MxcUri,
+        mxc_uri, owned_mxc_uri, uint,
     };
     use serde_json::json;
 

--- a/crates/matrix-sdk/src/notification_settings/command.rs
+++ b/crates/matrix-sdk/src/notification_settings/command.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 
 use ruma::{
+    OwnedRoomId,
     push::{
         Action, NewConditionalPushRule, NewPatternedPushRule, NewPushRule, NewSimplePushRule,
         PushCondition, RuleKind, Tweak,
     },
-    OwnedRoomId,
 };
 
 use crate::NotificationSettingsError;

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -18,16 +18,16 @@ use std::sync::Arc;
 
 use indexmap::IndexSet;
 use ruma::{
+    RoomId,
     api::client::push::{
         delete_pushrule, set_pushrule, set_pushrule_actions, set_pushrule_enabled,
     },
     events::push_rules::PushRulesEvent,
     push::{Action, NewPushRule, PredefinedUnderrideRuleId, RuleKind, Ruleset, Tweak},
-    RoomId,
 };
 use tokio::sync::{
-    broadcast::{self, Receiver},
     RwLock,
+    broadcast::{self, Receiver},
 };
 use tracing::{debug, error};
 
@@ -40,8 +40,8 @@ mod rules;
 pub use matrix_sdk_base::notification_settings::RoomNotificationMode;
 
 use crate::{
-    config::RequestConfig, error::NotificationSettingsError, event_handler::EventHandlerDropGuard,
-    Client, Result,
+    Client, Result, config::RequestConfig, error::NotificationSettingsError,
+    event_handler::EventHandlerDropGuard,
 };
 
 /// Whether or not a room is encrypted
@@ -55,11 +55,7 @@ pub enum IsEncrypted {
 
 impl From<bool> for IsEncrypted {
     fn from(value: bool) -> Self {
-        if value {
-            Self::Yes
-        } else {
-            Self::No
-        }
+        if value { Self::Yes } else { Self::No }
     }
 }
 
@@ -74,11 +70,7 @@ pub enum IsOneToOne {
 
 impl From<bool> for IsOneToOne {
     fn from(value: bool) -> Self {
-        if value {
-            Self::Yes
-        } else {
-            Self::No
-        }
+        if value { Self::Yes } else { Self::No }
     }
 }
 
@@ -573,8 +565,8 @@ impl NotificationSettings {
 #[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     };
 
     use assert_matches::assert_matches;
@@ -584,28 +576,28 @@ mod tests {
         test_json,
     };
     use ruma::{
+        OwnedRoomId, RoomId,
         push::{
             Action, AnyPushRuleRef, NewPatternedPushRule, NewPushRule, PredefinedOverrideRuleId,
             PredefinedUnderrideRuleId, RuleKind,
         },
-        OwnedRoomId, RoomId,
     };
     use serde_json::json;
     use stream_assert::{assert_next_eq, assert_pending};
     use tokio_stream::wrappers::BroadcastStream;
     use wiremock::{
-        matchers::{header, method, path, path_regex},
         Mock, MockServer, ResponseTemplate,
+        matchers::{header, method, path, path_regex},
     };
 
     use crate::{
+        Client,
         config::SyncSettings,
         error::NotificationSettingsError,
         notification_settings::{
             IsEncrypted, IsOneToOne, NotificationSettings, RoomNotificationMode,
         },
         test_utils::logged_in_client,
-        Client,
     };
 
     fn get_test_room_id() -> OwnedRoomId {

--- a/crates/matrix-sdk/src/notification_settings/rule_commands.rs
+++ b/crates/matrix-sdk/src/notification_settings/rule_commands.rs
@@ -1,9 +1,9 @@
 use ruma::{
+    RoomId,
     push::{
         Action, NewPushRule, PredefinedContentRuleId, PredefinedOverrideRuleId,
         RemovePushRuleError, RuleKind, Ruleset,
     },
-    RoomId,
 };
 
 use super::command::Command;
@@ -39,7 +39,7 @@ impl RuleCommands {
             _ => {
                 return Err(NotificationSettingsError::InvalidParameter(
                     "cannot insert a rule for this kind.".to_owned(),
-                ))
+                ));
             }
         };
 
@@ -201,12 +201,12 @@ mod tests {
     use assert_matches::assert_matches;
     use matrix_sdk_test::async_test;
     use ruma::{
+        OwnedRoomId, RoomId, UserId,
         push::{
             Action, NewPushRule, NewSimplePushRule, PredefinedContentRuleId,
             PredefinedOverrideRuleId, PredefinedUnderrideRuleId, RemovePushRuleError, RuleKind,
             Ruleset, Tweak,
         },
-        OwnedRoomId, RoomId, UserId,
     };
 
     use super::RuleCommands;
@@ -403,23 +403,29 @@ mod tests {
             .unwrap();
 
         // The ruleset must have been updated.
-        assert!(rule_commands
-            .rules
-            .get(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention)
-            .unwrap()
-            .enabled());
+        assert!(
+            rule_commands
+                .rules
+                .get(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention)
+                .unwrap()
+                .enabled()
+        );
         #[allow(deprecated)]
         {
-            assert!(rule_commands
-                .rules
-                .get(RuleKind::Override, PredefinedOverrideRuleId::ContainsDisplayName)
-                .unwrap()
-                .enabled());
-            assert!(rule_commands
-                .rules
-                .get(RuleKind::Content, PredefinedContentRuleId::ContainsUserName)
-                .unwrap()
-                .enabled());
+            assert!(
+                rule_commands
+                    .rules
+                    .get(RuleKind::Override, PredefinedOverrideRuleId::ContainsDisplayName)
+                    .unwrap()
+                    .enabled()
+            );
+            assert!(
+                rule_commands
+                    .rules
+                    .get(RuleKind::Content, PredefinedContentRuleId::ContainsUserName)
+                    .unwrap()
+                    .enabled()
+            );
         }
 
         // Three commands are expected.
@@ -478,18 +484,22 @@ mod tests {
             .unwrap();
 
         // The ruleset must have been updated.
-        assert!(rule_commands
-            .rules
-            .get(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention)
-            .unwrap()
-            .enabled());
+        assert!(
+            rule_commands
+                .rules
+                .get(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention)
+                .unwrap()
+                .enabled()
+        );
         #[allow(deprecated)]
         {
-            assert!(rule_commands
-                .rules
-                .get(RuleKind::Override, PredefinedOverrideRuleId::RoomNotif)
-                .unwrap()
-                .enabled());
+            assert!(
+                rule_commands
+                    .rules
+                    .get(RuleKind::Override, PredefinedOverrideRuleId::RoomNotif)
+                    .unwrap()
+                    .enabled()
+            );
         }
 
         // Two commands are expected.

--- a/crates/matrix-sdk/src/notification_settings/rules.rs
+++ b/crates/matrix-sdk/src/notification_settings/rules.rs
@@ -3,14 +3,14 @@
 use imbl::HashSet;
 use indexmap::IndexSet;
 use ruma::{
+    RoomId,
     push::{
         AnyPushRuleRef, PatternedPushRule, PredefinedContentRuleId, PredefinedOverrideRuleId,
         PredefinedUnderrideRuleId, PushCondition, RuleKind, Ruleset,
     },
-    RoomId,
 };
 
-use super::{command::Command, rule_commands::RuleCommands, RoomNotificationMode};
+use super::{RoomNotificationMode, command::Command, rule_commands::RuleCommands};
 use crate::{
     error::NotificationSettingsError,
     notification_settings::{IsEncrypted, IsOneToOne},
@@ -319,19 +319,19 @@ pub(crate) mod tests {
         notification_settings::{build_ruleset, get_server_default_ruleset},
     };
     use ruma::{
+        OwnedRoomId, RoomId,
         push::{
             Action, NewConditionalPushRule, NewPushRule, PredefinedContentRuleId,
             PredefinedOverrideRuleId, PredefinedUnderrideRuleId, PushCondition, RuleKind,
         },
-        OwnedRoomId, RoomId,
     };
 
     use super::RuleCommands;
     use crate::{
         error::NotificationSettingsError,
         notification_settings::{
-            rules::{self, Rules},
             IsEncrypted, IsOneToOne, RoomNotificationMode,
+            rules::{self, Rules},
         },
     };
 
@@ -505,9 +505,11 @@ pub(crate) mod tests {
         assert!(rules.is_user_mention_enabled());
         // is_enabled() should also return `true` for
         // PredefinedOverrideRuleId::IsUserMention
-        assert!(rules
-            .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention.as_str())
-            .unwrap());
+        assert!(
+            rules
+                .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention.as_str())
+                .unwrap()
+        );
 
         // If `IsUserMention` is disabled, then is_user_mention_enabled() should return
         // `false` even if the deprecated rules are enabled
@@ -536,9 +538,11 @@ pub(crate) mod tests {
         assert!(!rules.is_user_mention_enabled());
         // is_enabled() should also return `false` for
         // PredefinedOverrideRuleId::IsUserMention
-        assert!(!rules
-            .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention.as_str())
-            .unwrap());
+        assert!(
+            !rules
+                .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention.as_str())
+                .unwrap()
+        );
     }
 
     #[async_test]
@@ -558,9 +562,11 @@ pub(crate) mod tests {
         assert!(rules.is_room_mention_enabled());
         // is_enabled() should also return `true` for
         // PredefinedOverrideRuleId::IsRoomMention
-        assert!(rules
-            .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention.as_str())
-            .unwrap());
+        assert!(
+            rules
+                .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention.as_str())
+                .unwrap()
+        );
 
         // If `IsRoomMention` is present and disabled then is_room_mention_enabled()
         // should return `false` even if the deprecated rule is enabled
@@ -575,9 +581,11 @@ pub(crate) mod tests {
         assert!(!rules.is_room_mention_enabled());
         // is_enabled() should also return `false` for
         // PredefinedOverrideRuleId::IsRoomMention
-        assert!(!rules
-            .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention.as_str())
-            .unwrap());
+        assert!(
+            !rules
+                .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention.as_str())
+                .unwrap()
+        );
     }
 
     #[async_test]
@@ -644,9 +652,11 @@ pub(crate) mod tests {
         rules.apply(rules_commands);
 
         // The rule must have been disabled in the updated rules
-        assert!(!rules
-            .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::Reaction.as_str())
-            .unwrap());
+        assert!(
+            !rules
+                .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::Reaction.as_str())
+                .unwrap()
+        );
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/pusher.rs
+++ b/crates/matrix-sdk/src/pusher.rs
@@ -15,7 +15,7 @@
 
 //! High-level pusher API.
 
-use ruma::api::client::push::{set_pusher, PusherIds};
+use ruma::api::client::push::{PusherIds, set_pusher};
 
 use crate::{Client, Result};
 
@@ -57,8 +57,8 @@ mod tests {
         push::HttpPusherData,
     };
     use wiremock::{
-        matchers::{method, path},
         Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
     };
 
     use crate::test_utils::logged_in_client;

--- a/crates/matrix-sdk/src/room/edit.rs
+++ b/crates/matrix-sdk/src/room/edit.rs
@@ -15,7 +15,11 @@
 //! Facilities to edit existing events.
 
 use ruma::{
+    EventId, RoomId, UserId,
     events::{
+        AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent,
+        AnySyncTimelineEvent, AnyTimelineEvent, Mentions, MessageLikeEvent,
+        OriginalMessageLikeEvent, SyncMessageLikeEvent,
         poll::unstable_start::{
             ReplacementUnstablePollStartEventContent, UnstablePollStartContentBlock,
             UnstablePollStartEventContent,
@@ -24,11 +28,7 @@ use ruma::{
             FormattedBody, MessageType, Relation, ReplacementMetadata, RoomMessageEventContent,
             RoomMessageEventContentWithoutRelation,
         },
-        AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent,
-        AnySyncTimelineEvent, AnyTimelineEvent, Mentions, MessageLikeEvent,
-        OriginalMessageLikeEvent, SyncMessageLikeEvent,
     },
-    EventId, RoomId, UserId,
 };
 use thiserror::Error;
 use tracing::{instrument, warn};
@@ -99,7 +99,9 @@ pub enum EditError {
     Deserialize(#[from] serde_json::Error),
 
     /// We tried to edit an event of type A with content of type B.
-    #[error("The original event type ({target}) isn't the same as the parameter's new content type ({new_content})")]
+    #[error(
+        "The original event type ({target}) isn't the same as the parameter's new content type ({new_content})"
+    )]
     IncompatibleEditType {
         /// The type of the target event.
         target: String,
@@ -336,16 +338,16 @@ mod tests {
     use matrix_sdk_base::deserialized_responses::TimelineEvent;
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
     use ruma::{
-        event_id,
+        EventId, OwnedEventId, event_id,
         events::{
-            room::message::{MessageType, Relation, RoomMessageEventContentWithoutRelation},
             AnyMessageLikeEventContent, AnySyncTimelineEvent, Mentions,
+            room::message::{MessageType, Relation, RoomMessageEventContentWithoutRelation},
         },
-        owned_mxc_uri, owned_user_id, room_id, user_id, EventId, OwnedEventId,
+        owned_mxc_uri, owned_user_id, room_id, user_id,
     };
 
-    use super::{make_edit_event, EditError, EventSource};
-    use crate::{room::edit::EditedContent, Error};
+    use super::{EditError, EventSource, make_edit_event};
+    use crate::{Error, room::edit::EditedContent};
 
     #[derive(Default)]
     struct TestEventCache {

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -24,18 +24,18 @@ use mime::Mime;
 #[cfg(doc)]
 use ruma::events::{MessageLikeUnsigned, SyncMessageLikeEvent};
 use ruma::{
+    OwnedTransactionId, TransactionId,
     api::client::message::send_message_event,
     assign,
     events::{AnyMessageLikeEventContent, MessageLikeEventContent},
     serde::Raw,
-    OwnedTransactionId, TransactionId,
 };
-use tracing::{info, trace, Instrument, Span};
+use tracing::{Instrument, Span, info, trace};
 
 use super::Room;
 use crate::{
-    attachment::AttachmentConfig, config::RequestConfig, utils::IntoRawMessageLikeEventContent,
-    Result, TransmissionProgress,
+    Result, TransmissionProgress, attachment::AttachmentConfig, config::RequestConfig,
+    utils::IntoRawMessageLikeEventContent,
 };
 
 /// Future returned by [`Room::send`].

--- a/crates/matrix-sdk/src/room/identity_status_changes.rs
+++ b/crates/matrix-sdk/src/room/identity_status_changes.rs
@@ -19,19 +19,19 @@ use std::collections::BTreeMap;
 
 use async_stream::stream;
 use futures_core::Stream;
-use futures_util::{stream_select, StreamExt};
+use futures_util::{StreamExt, stream_select};
 use matrix_sdk_base::crypto::{
     IdentityState, IdentityStatusChange, RoomIdentityChange, RoomIdentityState,
 };
-use ruma::{events::room::member::SyncRoomMemberEvent, OwnedUserId, UserId};
+use ruma::{OwnedUserId, UserId, events::room::member::SyncRoomMemberEvent};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
 use super::Room;
 use crate::{
+    Client, Error, Result,
     encryption::identities::{IdentityUpdates, UserIdentity},
     event_handler::EventHandlerDropGuard,
-    Client, Error, Result,
 };
 
 /// Support for creating a stream of batches of [`IdentityStatusChange`].
@@ -199,7 +199,7 @@ fn wrap_room_member_events(
 mod tests {
     use std::time::Duration;
 
-    use futures_util::{pin_mut, FutureExt as _, StreamExt as _};
+    use futures_util::{FutureExt as _, StreamExt as _, pin_mut};
     use matrix_sdk_base::crypto::IdentityState;
     use matrix_sdk_test::{async_test, test_json::keys_query_sets::IdentityChangeDataSet};
     use test_setup::TestSetup;
@@ -591,29 +591,30 @@ mod tests {
 
         use futures_core::Stream;
         use matrix_sdk_base::{
-            crypto::{
-                testing::simulate_key_query_response_for_verification, IdentityStatusChange,
-                OtherUserIdentity,
-            },
             RoomState,
+            crypto::{
+                IdentityStatusChange, OtherUserIdentity,
+                testing::simulate_key_query_response_for_verification,
+            },
         };
         use matrix_sdk_test::{
-            test_json, test_json::keys_query_sets::IdentityChangeDataSet, JoinedRoomBuilder,
-            StateTestEvent, SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
+            DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder,
+            test_json, test_json::keys_query_sets::IdentityChangeDataSet,
         };
         use ruma::{
+            OwnedUserId, TransactionId, UserId,
             api::client::keys::{get_keys, get_keys::v3::Response as KeyQueryResponse},
             events::room::member::MembershipState,
-            owned_user_id, OwnedUserId, TransactionId, UserId,
+            owned_user_id,
         };
         use serde_json::json;
         use wiremock::{
-            matchers::{header, method, path_regex},
             Mock, MockServer, ResponseTemplate,
+            matchers::{header, method, path_regex},
         };
 
         use crate::{
-            encryption::identities::UserIdentity, test_utils::logged_in_client, Client, Room,
+            Client, Room, encryption::identities::UserIdentity, test_utils::logged_in_client,
         };
 
         /// Sets up a client and a room and allows changing user identities and

--- a/crates/matrix-sdk/src/room/knock_requests.rs
+++ b/crates/matrix-sdk/src/room/knock_requests.rs
@@ -15,7 +15,7 @@
 use js_int::UInt;
 use ruma::{EventId, OwnedEventId, OwnedMxcUri, OwnedUserId, RoomId};
 
-use crate::{room::RoomMember, Error, Room};
+use crate::{Error, Room, room::RoomMember};
 
 /// A request to join a room with `knock` join rule.
 #[derive(Debug, Clone)]
@@ -105,15 +105,15 @@ impl KnockRequestMemberInfo {
 // The http mocking library is not supported for wasm32
 #[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
-    use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder};
+    use matrix_sdk_test::{JoinedRoomBuilder, async_test, event_factory::EventFactory};
     use ruma::{
-        event_id, events::room::member::MembershipState, owned_user_id, room_id, user_id, EventId,
+        EventId, event_id, events::room::member::MembershipState, owned_user_id, room_id, user_id,
     };
 
     use crate::{
+        Room,
         room::knock_requests::{KnockRequest, KnockRequestMemberInfo},
         test_utils::mocks::MatrixMockServer,
-        Room,
     };
 
     #[async_test]
@@ -125,12 +125,13 @@ mod tests {
         let user_id = user_id!("@alice:b.c");
 
         let f = EventFactory::new().room(room_id);
-        let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f
-            .member(user_id)
-            .membership(MembershipState::Knock)
-            .event_id(event_id)
-            .into_raw_timeline()
-            .cast()]);
+        let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![
+            f.member(user_id)
+                .membership(MembershipState::Knock)
+                .event_id(event_id)
+                .into_raw_timeline()
+                .cast(),
+        ]);
         let room = server.sync_room(&client, joined_room_builder).await;
 
         let knock_request = make_knock_request(&room, Some(event_id));

--- a/crates/matrix-sdk/src/room/member.rs
+++ b/crates/matrix-sdk/src/room/member.rs
@@ -3,8 +3,8 @@ use std::ops::Deref;
 use ruma::events::room::MediaSource;
 
 use crate::{
-    media::{MediaFormat, MediaRequestParameters},
     BaseRoomMember, Client, Result,
+    media::{MediaFormat, MediaRequestParameters},
 };
 
 /// The high-level `RoomMember` representation
@@ -41,8 +41,8 @@ impl RoomMember {
     ///
     /// ```no_run
     /// use matrix_sdk::{
-    ///     media::MediaFormat, room::RoomMember, ruma::room_id, Client,
-    ///     RoomMemberships,
+    ///     Client, RoomMemberships, media::MediaFormat, room::RoomMember,
+    ///     ruma::room_id,
     /// };
     /// # use url::Url;
     /// # let homeserver = Url::parse("http://example.com").unwrap();

--- a/crates/matrix-sdk/src/room/messages.rs
+++ b/crates/matrix-sdk/src/room/messages.rs
@@ -17,19 +17,20 @@ use std::fmt;
 use futures_util::future::join_all;
 use matrix_sdk_common::{debug::DebugStructExt as _, deserialized_responses::TimelineEvent};
 use ruma::{
+    OwnedEventId, RoomId, UInt,
     api::{
+        Direction,
         client::{
             filter::RoomEventFilter,
             message::get_message_events,
             relations,
             threads::get_threads::{self, v1::IncludeThreads},
         },
-        Direction,
     },
     assign,
-    events::{relation::RelationType, AnyStateEvent, TimelineEventType},
+    events::{AnyStateEvent, TimelineEventType, relation::RelationType},
     serde::Raw,
-    uint, OwnedEventId, RoomId, UInt,
+    uint,
 };
 
 use super::Room;

--- a/crates/matrix-sdk/src/room/power_levels.rs
+++ b/crates/matrix-sdk/src/room/power_levels.rs
@@ -3,14 +3,14 @@
 use std::collections::HashMap;
 
 use ruma::{
+    OwnedUserId,
     events::{
+        StateEventType,
         room::power_levels::{
             PossiblyRedactedRoomPowerLevelsEventContent, RoomPowerLevels,
             RoomPowerLevelsEventContent,
         },
-        StateEventType,
     },
-    OwnedUserId,
 };
 
 use crate::Result;

--- a/crates/matrix-sdk/src/room/privacy_settings.rs
+++ b/crates/matrix-sdk/src/room/privacy_settings.rs
@@ -1,5 +1,6 @@
 use matrix_sdk_base::Room as BaseRoom;
 use ruma::{
+    OwnedRoomAliasId, RoomAliasId,
     api::client::{
         directory::{get_room_visibility, set_room_visibility},
         room::Visibility,
@@ -7,14 +8,13 @@ use ruma::{
     },
     assign,
     events::{
+        EmptyStateKey,
         room::{
             canonical_alias::RoomCanonicalAliasEventContent,
             history_visibility::{HistoryVisibility, RoomHistoryVisibilityEventContent},
             join_rules::{JoinRule, RoomJoinRulesEventContent},
         },
-        EmptyStateKey,
     },
-    OwnedRoomAliasId, RoomAliasId,
 };
 
 use crate::{Client, Result};
@@ -165,13 +165,13 @@ impl<'a> RoomPrivacySettings<'a> {
 mod tests {
     use std::ops::Not;
 
-    use matrix_sdk_test::{async_test, JoinedRoomBuilder, StateTestEvent};
+    use matrix_sdk_test::{JoinedRoomBuilder, StateTestEvent, async_test};
     use ruma::{
         api::client::room::Visibility,
         event_id,
         events::{
-            room::{history_visibility::HistoryVisibility, join_rules::JoinRule},
             StateEventType,
+            room::{history_visibility::HistoryVisibility, join_rules::JoinRule},
         },
         owned_room_alias_id, room_id,
     };

--- a/crates/matrix-sdk/src/room/reply.rs
+++ b/crates/matrix-sdk/src/room/reply.rs
@@ -15,7 +15,9 @@
 //! Facilities to reply to existing events.
 
 use ruma::{
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, RoomId, UserId,
     events::{
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent,
         relation::Thread,
         room::{
             encrypted::Relation as EncryptedRelation,
@@ -24,10 +26,8 @@ use ruma::{
                 RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
             },
         },
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent,
     },
     serde::Raw,
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, RoomId, UserId,
 };
 use serde::Deserialize;
 use thiserror::Error;
@@ -268,19 +268,19 @@ mod tests {
     use matrix_sdk_base::deserialized_responses::TimelineEvent;
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
     use ruma::{
-        event_id,
+        EventId, OwnedEventId, event_id,
         events::{
-            room::message::{Relation, ReplyWithinThread, RoomMessageEventContentWithoutRelation},
             AnySyncTimelineEvent,
+            room::message::{Relation, ReplyWithinThread, RoomMessageEventContentWithoutRelation},
         },
         room_id,
         serde::Raw,
-        user_id, EventId, OwnedEventId,
+        user_id,
     };
     use serde_json::json;
 
-    use super::{make_reply_event, EnforceThread, EventSource, Reply, ReplyError};
-    use crate::{event_cache::EventCacheError, Error};
+    use super::{EnforceThread, EventSource, Reply, ReplyError, make_reply_event};
+    use crate::{Error, event_cache::EventCacheError};
 
     #[derive(Default)]
     struct TestEventCache {

--- a/crates/matrix-sdk/src/room/shared_room_history.rs
+++ b/crates/matrix-sdk/src/room/shared_room_history.rs
@@ -18,10 +18,10 @@ use matrix_sdk_base::{
     crypto::store::types::StoredRoomKeyBundleData,
     media::{MediaFormat, MediaRequestParameters},
 };
-use ruma::{events::room::MediaSource, OwnedUserId, UserId};
+use ruma::{OwnedUserId, UserId, events::room::MediaSource};
 use tracing::{info, instrument, warn};
 
-use crate::{crypto::types::events::room_key_bundle::RoomKeyBundleContent, Error, Result, Room};
+use crate::{Error, Result, Room, crypto::types::events::room_key_bundle::RoomKeyBundleContent};
 
 /// Share any shareable E2EE history in the given room with the given recipient,
 /// as per [MSC4268].

--- a/crates/matrix-sdk/src/room_directory_search.rs
+++ b/crates/matrix-sdk/src/room_directory_search.rs
@@ -19,9 +19,9 @@ use eyeball_im::{ObservableVector, VectorDiff};
 use futures_core::Stream;
 use imbl::Vector;
 use ruma::{
+    OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
     api::client::directory::get_public_rooms_filtered::v3::Request as PublicRoomsFilterRequest,
     directory::{Filter, PublicRoomJoinRule},
-    OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
 };
 
 use crate::{Client, OwnedServerName, Result};
@@ -78,11 +78,7 @@ enum SearchState {
 
 impl SearchState {
     fn next_token(&self) -> Option<&str> {
-        if let Self::Next(next_token) = &self {
-            Some(next_token)
-        } else {
-            None
-        }
+        if let Self::Next(next_token) = &self { Some(next_token) } else { None }
     }
 
     fn is_at_end(&self) -> bool {
@@ -101,7 +97,7 @@ impl SearchState {
 /// # Example
 ///
 /// ```no_run
-/// use matrix_sdk::{room_directory_search::RoomDirectorySearch, Client};
+/// use matrix_sdk::{Client, room_directory_search::RoomDirectorySearch};
 /// use url::Url;
 ///
 /// async {
@@ -220,18 +216,18 @@ mod tests {
     use eyeball_im::VectorDiff;
     use futures_util::StreamExt;
     use matrix_sdk_test::{async_test, test_json};
-    use ruma::{directory::Filter, owned_server_name, serde::Raw, RoomAliasId, RoomId};
+    use ruma::{RoomAliasId, RoomId, directory::Filter, owned_server_name, serde::Raw};
     use serde_json::Value as JsonValue;
     use stream_assert::assert_pending;
     use wiremock::{
-        matchers::{method, path_regex},
         Match, Mock, MockServer, Request, ResponseTemplate,
+        matchers::{method, path_regex},
     };
 
     use crate::{
+        Client,
         room_directory_search::{RoomDescription, RoomDirectorySearch},
         test_utils::logged_in_client,
-        Client,
     };
 
     struct RoomDirectorySearchMatcher {

--- a/crates/matrix-sdk/src/room_preview.rs
+++ b/crates/matrix-sdk/src/room_preview.rs
@@ -21,17 +21,17 @@
 use futures_util::future::join_all;
 use matrix_sdk_base::{RoomHero, RoomInfo, RoomState};
 use ruma::{
+    OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedServerName, RoomId, RoomOrAliasId, ServerName,
     api::client::{membership::joined_members, state::get_state_events},
     directory::PublicRoomJoinRule,
     events::room::{history_visibility::HistoryVisibility, join_rules::JoinRule},
     room::RoomType,
     space::SpaceRoomJoinRule,
-    OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedServerName, RoomId, RoomOrAliasId, ServerName,
 };
 use tokio::try_join;
 use tracing::{instrument, warn};
 
-use crate::{room_directory_search::RoomDirectorySearch, Client, Error, Room};
+use crate::{Client, Error, Room, room_directory_search::RoomDirectorySearch};
 
 /// The preview of a room, be it invited/joined/left, or not.
 #[derive(Debug, Clone)]
@@ -413,7 +413,7 @@ fn ensure_server_names_is_not_empty(
 
 #[cfg(test)]
 mod tests {
-    use ruma::{owned_server_name, room_alias_id, room_id, server_name, RoomOrAliasId, ServerName};
+    use ruma::{RoomOrAliasId, ServerName, owned_server_name, room_alias_id, room_id, server_name};
 
     use crate::room_preview::ensure_server_names_is_not_empty;
 

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -132,8 +132,8 @@ use std::{
     collections::{BTreeMap, HashMap},
     str::FromStr as _,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, RwLock,
+        atomic::{AtomicBool, Ordering},
     },
 };
 
@@ -141,6 +141,7 @@ use as_variant::as_variant;
 #[cfg(feature = "unstable-msc4274")]
 use matrix_sdk_base::store::FinishGalleryItemInfo;
 use matrix_sdk_base::{
+    RoomState, StoreError,
     event_cache::store::EventCacheStoreError,
     media::MediaRequestParameters,
     store::{
@@ -149,34 +150,33 @@ use matrix_sdk_base::{
         SentMediaInfo, SentRequestKey, SerializableEventContent,
     },
     store_locks::LockStoreError,
-    RoomState, StoreError,
 };
-use matrix_sdk_common::executor::{spawn, JoinHandle};
+use matrix_sdk_common::executor::{JoinHandle, spawn};
 use mime::Mime;
 use ruma::{
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId, TransactionId,
     events::{
+        AnyMessageLikeEventContent, EventContent as _, Mentions,
         reaction::ReactionEventContent,
         relation::Annotation,
         room::{
-            message::{FormattedBody, RoomMessageEventContent},
             MediaSource,
+            message::{FormattedBody, RoomMessageEventContent},
         },
-        AnyMessageLikeEventContent, EventContent as _, Mentions,
     },
     serde::Raw,
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId, TransactionId,
 };
-use tokio::sync::{broadcast, oneshot, Mutex, Notify, OwnedMutexGuard};
+use tokio::sync::{Mutex, Notify, OwnedMutexGuard, broadcast, oneshot};
 use tracing::{debug, error, info, instrument, trace, warn};
 
 #[cfg(feature = "e2e-encryption")]
 use crate::crypto::{OlmError, SessionRecipientCollectionError};
 use crate::{
+    Client, Media, Room,
     client::WeakClient,
     config::RequestConfig,
     error::RetryKind,
-    room::{edit::EditedContent, WeakRoom},
-    Client, Media, Room,
+    room::{WeakRoom, edit::EditedContent},
 };
 
 mod upload;
@@ -2503,10 +2503,11 @@ mod tests {
         ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind,
         SerializableEventContent,
     };
-    use matrix_sdk_test::{async_test, JoinedRoomBuilder, SyncResponseBuilder};
+    use matrix_sdk_test::{JoinedRoomBuilder, SyncResponseBuilder, async_test};
     use ruma::{
-        events::{room::message::RoomMessageEventContent, AnyMessageLikeEventContent},
-        room_id, MilliSecondsSinceUnixEpoch, TransactionId,
+        MilliSecondsSinceUnixEpoch, TransactionId,
+        events::{AnyMessageLikeEventContent, room::message::RoomMessageEventContent},
+        room_id,
     };
 
     use super::canonicalize_dependent_requests;

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -18,13 +18,13 @@
 use std::{collections::HashMap, iter::zip};
 
 use matrix_sdk_base::{
+    RoomState,
     event_cache::store::media::IgnoreMediaRetentionPolicy,
     media::{MediaFormat, MediaRequestParameters},
     store::{
         ChildTransactionId, DependentQueuedRequestKind, FinishUploadThumbnailInfo,
         QueuedRequestKind, SentMediaInfo, SentRequestKey, SerializableEventContent,
     },
-    RoomState,
 };
 #[cfg(feature = "unstable-msc4274")]
 use matrix_sdk_base::{
@@ -35,26 +35,26 @@ use mime::Mime;
 #[cfg(feature = "unstable-msc4274")]
 use ruma::events::room::message::{GalleryItemType, GalleryMessageEventContent};
 use ruma::{
-    events::{
-        room::{
-            message::{FormattedBody, MessageType, RoomMessageEventContent},
-            MediaSource, ThumbnailInfo,
-        },
-        AnyMessageLikeEventContent, Mentions,
-    },
     MilliSecondsSinceUnixEpoch, OwnedTransactionId, TransactionId,
+    events::{
+        AnyMessageLikeEventContent, Mentions,
+        room::{
+            MediaSource, ThumbnailInfo,
+            message::{FormattedBody, MessageType, RoomMessageEventContent},
+        },
+    },
 };
-use tracing::{debug, error, instrument, trace, warn, Span};
+use tracing::{Span, debug, error, instrument, trace, warn};
 
 use super::{QueueStorage, RoomSendQueue, RoomSendQueueError};
 use crate::{
+    Client, Media, Room,
     attachment::{AttachmentConfig, Thumbnail},
     room::edit::update_media_caption,
     send_queue::{
         LocalEcho, LocalEchoContent, MediaHandles, RoomSendQueueStorageError, RoomSendQueueUpdate,
         SendHandle,
     },
-    Client, Media, Room,
 };
 #[cfg(feature = "unstable-msc4274")]
 use crate::{

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -6,16 +6,16 @@ use std::{
 };
 
 use matrix_sdk_common::timer;
-use ruma::{api::client::sync::sync_events::v5 as http, OwnedRoomId};
-use tokio::sync::{broadcast::channel, Mutex as AsyncMutex, RwLock as AsyncRwLock};
+use ruma::{OwnedRoomId, api::client::sync::sync_events::v5 as http};
+use tokio::sync::{Mutex as AsyncMutex, RwLock as AsyncRwLock, broadcast::channel};
 
 use super::{
-    cache::{format_storage_key_prefix, restore_sliding_sync_state},
-    sticky_parameters::SlidingSyncStickyManager,
     Error, SlidingSync, SlidingSyncInner, SlidingSyncListBuilder, SlidingSyncPositionMarkers,
     Version,
+    cache::{format_storage_key_prefix, restore_sliding_sync_state},
+    sticky_parameters::SlidingSyncStickyManager,
 };
-use crate::{sliding_sync::SlidingSyncStickyParameters, Client, Result};
+use crate::{Client, Result, sliding_sync::SlidingSyncStickyParameters};
 
 /// Configuration for a Sliding Sync instance.
 ///

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -12,7 +12,7 @@ use tracing::{trace, warn};
 use super::{FrozenSlidingSyncList, SlidingSync, SlidingSyncPositionMarkers};
 #[cfg(feature = "e2e-encryption")]
 use crate::sliding_sync::FrozenSlidingSyncPos;
-use crate::{sliding_sync::SlidingSyncListCachePolicy, Client, Result};
+use crate::{Client, Result, sliding_sync::SlidingSyncListCachePolicy};
 
 /// Be careful: as this is used as a storage key; changing it requires migrating
 /// data!
@@ -201,7 +201,7 @@ mod tests {
         super::SlidingSyncList, format_storage_key_for_sliding_sync_list,
         format_storage_key_prefix, restore_sliding_sync_state, store_sliding_sync_state,
     };
-    use crate::{test_utils::logged_in_client, Result};
+    use crate::{Result, test_utils::logged_in_client};
 
     #[allow(clippy::await_holding_lock)]
     #[async_test]
@@ -214,19 +214,23 @@ mod tests {
         let storage_key = format_storage_key_prefix(sync_id, client.user_id().unwrap());
 
         // Store entries don't exist.
-        assert!(store
-            .get_custom_value(
-                format_storage_key_for_sliding_sync_list(&storage_key, "list_foo").as_bytes()
-            )
-            .await?
-            .is_none());
+        assert!(
+            store
+                .get_custom_value(
+                    format_storage_key_for_sliding_sync_list(&storage_key, "list_foo").as_bytes()
+                )
+                .await?
+                .is_none()
+        );
 
-        assert!(store
-            .get_custom_value(
-                format_storage_key_for_sliding_sync_list(&storage_key, "list_bar").as_bytes()
-            )
-            .await?
-            .is_none());
+        assert!(
+            store
+                .get_custom_value(
+                    format_storage_key_for_sliding_sync_list(&storage_key, "list_bar").as_bytes()
+                )
+                .await?
+                .is_none()
+        );
 
         // Create a new `SlidingSync` instance, and store it.
         let storage_key = {
@@ -256,20 +260,24 @@ mod tests {
         };
 
         // Store entries now exist for `list_foo`.
-        assert!(store
-            .get_custom_value(
-                format_storage_key_for_sliding_sync_list(&storage_key, "list_foo").as_bytes()
-            )
-            .await?
-            .is_some());
+        assert!(
+            store
+                .get_custom_value(
+                    format_storage_key_for_sliding_sync_list(&storage_key, "list_foo").as_bytes()
+                )
+                .await?
+                .is_some()
+        );
 
         // But not for `list_bar`.
-        assert!(store
-            .get_custom_value(
-                format_storage_key_for_sliding_sync_list(&storage_key, "list_bar").as_bytes()
-            )
-            .await?
-            .is_none());
+        assert!(
+            store
+                .get_custom_value(
+                    format_storage_key_for_sliding_sync_list(&storage_key, "list_bar").as_bytes()
+                )
+                .await?
+                .is_none()
+        );
 
         // Create a new `SlidingSync`, and it should be read from the cache.
         let max_number_of_room_stream = Arc::new(RwLock::new(None));

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use matrix_sdk_base::{sync::SyncResponse, RequestedRequiredStates};
+use matrix_sdk_base::{RequestedRequiredStates, sync::SyncResponse};
 use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
 use ruma::api::client::{discovery::get_supported_versions, sync::sync_events::v5 as http};
 use tracing::error;
@@ -40,7 +40,9 @@ pub enum VersionBuilderError {
 
     /// `/versions` does not contain `org.matrix.simplified_msc3575` in its
     /// `unstable_features`, or it's not set to true.
-    #[error("`/versions` does not contain `org.matrix.simplified_msc3575` in its `unstable_features`, or it's not set to true.")]
+    #[error(
+        "`/versions` does not contain `org.matrix.simplified_msc3575` in its `unstable_features`, or it's not set to true."
+    )]
     NativeVersionIsUnset,
 }
 
@@ -288,23 +290,23 @@ mod tests {
 
     use assert_matches::assert_matches;
     use matrix_sdk_base::{
-        notification_settings::RoomNotificationMode, RequestedRequiredStates,
-        RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons,
+        RequestedRequiredStates, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons,
+        notification_settings::RoomNotificationMode,
     };
     use matrix_sdk_test::async_test;
     use ruma::{assign, events::AnySyncTimelineEvent, room_id, serde::Raw};
     use serde_json::json;
     use wiremock::{
-        matchers::{method, path},
         Mock, ResponseTemplate,
+        matchers::{method, path},
     };
 
-    use super::{get_supported_versions, Version, VersionBuilder};
+    use super::{Version, VersionBuilder, get_supported_versions};
     use crate::{
-        error::Result,
-        sliding_sync::{client::SlidingSyncResponseProcessor, http, VersionBuilderError},
-        test_utils::{logged_in_client, logged_in_client_with_server},
         SlidingSyncList, SlidingSyncMode,
+        error::Result,
+        sliding_sync::{VersionBuilderError, client::SlidingSyncResponseProcessor, http},
+        test_utils::{logged_in_client, logged_in_client_with_server},
     };
 
     #[test]

--- a/crates/matrix-sdk/src/sliding_sync/error.rs
+++ b/crates/matrix-sdk/src/sliding_sync/error.rs
@@ -21,7 +21,9 @@ pub enum Error {
     /// A `SlidingSyncListRequestGenerator` has been used without having been
     /// initialized. It happens when a response is handled before a request has
     /// been sent. It usually happens when testing.
-    #[error("The sliding sync list `{0}` is handling a response, but its request generator has not been initialized")]
+    #[error(
+        "The sliding sync list `{0}` is handling a response, but its request generator has not been initialized"
+    )]
     RequestGeneratorHasNotBeenInitialized(String),
 
     /// Ranges have a `start` bound greater than `end`.
@@ -46,7 +48,9 @@ pub enum Error {
     InvalidSlidingSyncIdentifier,
 
     /// A task failed to execute to completion.
-    #[error("A task failed to execute to completion; task description: {task_description}, error: {error}")]
+    #[error(
+        "A task failed to execute to completion; task description: {task_description}, error: {error}"
+    )]
     JoinError {
         /// Task description.
         task_description: String,

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -16,8 +16,8 @@ use super::{
     SlidingSyncListStickyParameters, SlidingSyncMode,
 };
 use crate::{
-    sliding_sync::{cache::restore_sliding_sync_list, sticky_parameters::SlidingSyncStickyManager},
     Client,
+    sliding_sync::{cache::restore_sliding_sync_list, sticky_parameters::SlidingSyncStickyManager},
 };
 
 /// Data that might have been read from the cache.

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -11,7 +11,7 @@ use std::{
 
 use eyeball::{Observable, SharedObservable, Subscriber};
 use futures_core::Stream;
-use ruma::{api::client::sync::sync_events::v5 as http, assign, TransactionId};
+use ruma::{TransactionId, api::client::sync::sync_events::v5 as http, assign};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::Sender;
 use tracing::{instrument, warn};
@@ -20,8 +20,8 @@ pub use self::builder::*;
 use self::sticky::SlidingSyncListStickyParameters;
 pub(super) use self::{frozen::FrozenSlidingSyncList, request_generator::*};
 use super::{
-    sticky_parameters::{LazyTransactionId, SlidingSyncStickyManager},
     Error, SlidingSyncInternalMessage,
+    sticky_parameters::{LazyTransactionId, SlidingSyncStickyManager},
 };
 use crate::Result;
 
@@ -534,7 +534,7 @@ mod tests {
     use tokio::sync::broadcast::{channel, error::TryRecvError};
 
     use super::{SlidingSyncList, SlidingSyncListLoadingState, SlidingSyncMode};
-    use crate::sliding_sync::{sticky_parameters::LazyTransactionId, SlidingSyncInternalMessage};
+    use crate::sliding_sync::{SlidingSyncInternalMessage, sticky_parameters::LazyTransactionId};
 
     macro_rules! assert_json_roundtrip {
         (from $type:ty: $rust_value:expr => $json_value:expr) => {
@@ -1090,7 +1090,7 @@ mod tests {
         list.set_sync_mode(SlidingSyncMode::new_selective());
 
         assert_eq!(list.state(), SlidingSyncListLoadingState::PartiallyLoaded); // we had some partial state, but we can't be sure it's fully loaded until the
-                                                                                // next request
+        // next request
 
         // We need to update the ranges, of course, as they are not managed
         // automatically anymore.

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -31,7 +31,7 @@
 use std::cmp::min;
 
 use super::{Range, Ranges, SlidingSyncMode};
-use crate::{sliding_sync::Error, SlidingSyncListLoadingState};
+use crate::{SlidingSyncListLoadingState, sliding_sync::Error};
 
 /// The kind of request generator.
 #[derive(Debug, PartialEq)]
@@ -336,9 +336,9 @@ mod tests {
     use assert_matches::assert_matches;
 
     use super::{
-        create_range, SlidingSyncListRequestGenerator, SlidingSyncListRequestGeneratorKind,
+        SlidingSyncListRequestGenerator, SlidingSyncListRequestGeneratorKind, create_range,
     };
-    use crate::{sliding_sync::Error, SlidingSyncMode};
+    use crate::{SlidingSyncMode, sliding_sync::Error};
 
     #[test]
     fn test_create_range_from() {

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -15,7 +15,7 @@
 //! The SDK's representation of the result of a `/sync` request.
 
 use std::{
-    collections::{btree_map, BTreeMap},
+    collections::{BTreeMap, btree_map},
     fmt,
     time::Duration,
 };
@@ -31,18 +31,18 @@ use matrix_sdk_base::{
 };
 use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
 use ruma::{
+    OwnedRoomId, RoomId,
     api::client::sync::sync_events::{
         self,
         v3::{InvitedRoom, KnockedRoom},
     },
-    events::{presence::PresenceEvent, AnyGlobalAccountDataEvent},
+    events::{AnyGlobalAccountDataEvent, presence::PresenceEvent},
     serde::Raw,
     time::Instant,
-    OwnedRoomId, RoomId,
 };
 use tracing::{debug, error, warn};
 
-use crate::{event_handler::HandlerKind, Client, Result, Room};
+use crate::{Client, Result, Room, event_handler::HandlerKind};
 
 /// The processed response of a `/sync` request.
 #[derive(Clone, Default)]

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -15,14 +15,14 @@
 //! Augmented [`ClientBuilder`] that can set up an already logged-in user.
 
 use matrix_sdk_base::{
-    store::{RoomLoadSettings, StoreConfig},
     SessionMeta,
+    store::{RoomLoadSettings, StoreConfig},
 };
-use ruma::{api::MatrixVersion, owned_device_id, owned_user_id, OwnedDeviceId, OwnedUserId};
+use ruma::{OwnedDeviceId, OwnedUserId, api::MatrixVersion, owned_device_id, owned_user_id};
 
 use crate::{
-    authentication::matrix::MatrixSession, config::RequestConfig, Client, ClientBuilder,
-    SessionTokens,
+    Client, ClientBuilder, SessionTokens, authentication::matrix::MatrixSession,
+    config::RequestConfig,
 };
 
 /// An augmented [`ClientBuilder`] that also allows for handling session login.
@@ -215,11 +215,11 @@ pub mod oauth {
     use url::Url;
 
     use crate::{
-        authentication::oauth::{
-            registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
-            ClientId, OAuthSession, UserSession,
-        },
         SessionTokens,
+        authentication::oauth::{
+            ClientId, OAuthSession, UserSession,
+            registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
+        },
     };
 
     /// An OAuth 2.0 `ClientId`, for unit or integration tests.

--- a/crates/matrix-sdk/src/test_utils/mocks/encryption.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/encryption.rs
@@ -18,33 +18,33 @@
 use std::{
     collections::BTreeMap,
     future::Future,
-    sync::{atomic::Ordering, Arc, Mutex},
+    sync::{Arc, Mutex, atomic::Ordering},
 };
 
 use matrix_sdk_test::test_json;
 use ruma::{
+    CrossSigningKeyId, DeviceId, MilliSecondsSinceUnixEpoch, OneTimeKeyAlgorithm, OwnedDeviceId,
+    OwnedOneTimeKeyId, OwnedUserId, UserId,
     api::client::{
         keys::upload_signatures::v3::SignedKeys, to_device::send_event_to_device::v3::Messages,
     },
     encryption::{CrossSigningKey, DeviceKeys, OneTimeKey},
     owned_device_id, owned_user_id,
     serde::Raw,
-    CrossSigningKeyId, DeviceId, MilliSecondsSinceUnixEpoch, OneTimeKeyAlgorithm, OwnedDeviceId,
-    OwnedOneTimeKeyId, OwnedUserId, UserId,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{method, path_regex},
     Mock, MockGuard, Request, ResponseTemplate,
+    matchers::{method, path_regex},
 };
 
 use crate::{
+    Client,
     crypto::types::events::room::encrypted::EncryptedToDeviceEvent,
     test_utils::{
         client::MockClientBuilder,
         mocks::{Keys, MatrixMockServer},
     },
-    Client,
 };
 
 /// Extends the `MatrixMockServer` with useful methods to help mocking

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -19,35 +19,35 @@
 
 use std::{
     collections::BTreeMap,
-    sync::{atomic::AtomicU32, Arc, Mutex},
+    sync::{Arc, Mutex, atomic::AtomicU32},
 };
 
 use js_int::UInt;
 use matrix_sdk_base::deserialized_responses::TimelineEvent;
 use matrix_sdk_test::{
-    test_json, InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, LeftRoomBuilder,
-    SyncResponseBuilder,
+    InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, LeftRoomBuilder,
+    SyncResponseBuilder, test_json,
 };
 use percent_encoding::{AsciiSet, CONTROLS};
 use ruma::{
+    DeviceId, MxcUri, OwnedDeviceId, OwnedEventId, OwnedOneTimeKeyId, OwnedRoomId, OwnedUserId,
+    RoomId, ServerName, UserId,
     api::client::{receipt::create_receipt::v3::ReceiptType, room::Visibility},
     device_id,
     directory::PublicRoomsChunk,
     encryption::{CrossSigningKey, DeviceKeys, OneTimeKey},
     events::{
-        room::member::RoomMemberEvent, AnyStateEvent, AnyTimelineEvent, GlobalAccountDataEventType,
-        MessageLikeEventType, RoomAccountDataEventType, StateEventType,
+        AnyStateEvent, AnyTimelineEvent, GlobalAccountDataEventType, MessageLikeEventType,
+        RoomAccountDataEventType, StateEventType, room::member::RoomMemberEvent,
     },
     serde::Raw,
     time::Duration,
-    DeviceId, MxcUri, OwnedDeviceId, OwnedEventId, OwnedOneTimeKeyId, OwnedRoomId, OwnedUserId,
-    RoomId, ServerName, UserId,
 };
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use wiremock::{
-    matchers::{body_partial_json, header, method, path, path_regex, query_param},
     Mock, MockBuilder, MockGuard, MockServer, Request, Respond, ResponseTemplate, Times,
+    matchers::{body_partial_json, header, method, path, path_regex, query_param},
 };
 
 #[cfg(feature = "e2e-encryption")]
@@ -55,7 +55,7 @@ pub mod encryption;
 pub mod oauth;
 
 use super::client::MockClientBuilder;
-use crate::{room::IncludeRelations, Client, OwnedServerName, Room};
+use crate::{Client, OwnedServerName, Room, room::IncludeRelations};
 
 /// Structure used to store the crypto keys uploaded to the server.
 /// They will be served back to clients when requested.

--- a/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
@@ -21,8 +21,8 @@ use ruma::{
 use serde_json::json;
 use url::Url;
 use wiremock::{
-    matchers::{method, path_regex},
     Mock, MockBuilder, ResponseTemplate,
+    matchers::{method, path_regex},
 };
 
 use super::{MatrixMock, MatrixMockServer, MockEndpoint};

--- a/crates/matrix-sdk/src/test_utils/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mod.rs
@@ -6,7 +6,7 @@ use assert_matches2::assert_let;
 use matrix_sdk_base::{deserialized_responses::TimelineEvent, store::RoomLoadSettings};
 use ruma::{
     api::MatrixVersion,
-    events::{room::message::MessageType, AnySyncMessageLikeEvent, AnySyncTimelineEvent},
+    events::{AnySyncMessageLikeEvent, AnySyncTimelineEvent, room::message::MessageType},
 };
 use url::Url;
 
@@ -15,7 +15,7 @@ pub mod client;
 pub mod mocks;
 
 use self::client::mock_matrix_session;
-use crate::{config::RequestConfig, Client, ClientBuilder};
+use crate::{Client, ClientBuilder, config::RequestConfig};
 
 /// Checks that an event is a message-like text event with the given text.
 #[track_caller]

--- a/crates/matrix-sdk/src/utils/local_server.rs
+++ b/crates/matrix-sdk/src/utils/local_server.rs
@@ -45,10 +45,10 @@ use std::{
 };
 
 use axum::{body::Body, response::IntoResponse, routing::any_service};
-use http::{header, HeaderValue, Method, Request, StatusCode};
+use http::{HeaderValue, Method, Request, StatusCode, header};
 use matrix_sdk_base::{boxed_into_future, locks::Mutex};
 use matrix_sdk_common::executor::spawn;
-use rand::{thread_rng, Rng};
+use rand::{Rng, thread_rng};
 use tokio::{net::TcpListener, sync::oneshot};
 use tower::service_fn;
 use url::Url;

--- a/crates/matrix-sdk/src/utils/mod.rs
+++ b/crates/matrix-sdk/src/utils/mod.rs
@@ -24,15 +24,15 @@ use futures_util::StreamExt;
 #[cfg(feature = "markdown")]
 use ruma::events::room::message::FormattedBody;
 use ruma::{
+    RoomAliasId,
     events::{AnyMessageLikeEventContent, AnyStateEventContent},
     serde::Raw,
-    RoomAliasId,
 };
 use serde_json::value::{RawValue as RawJsonValue, Value as JsonValue};
 #[cfg(feature = "e2e-encryption")]
 use tokio::sync::broadcast;
 #[cfg(feature = "e2e-encryption")]
-use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
+use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 
 #[cfg(feature = "local-server")]
 pub mod local_server;
@@ -233,11 +233,7 @@ pub fn formatted_body_from(
     body: Option<&str>,
     formatted_body: Option<FormattedBody>,
 ) -> Option<FormattedBody> {
-    if formatted_body.is_some() {
-        formatted_body
-    } else {
-        body.and_then(FormattedBody::markdown)
-    }
+    if formatted_body.is_some() { formatted_body } else { body.and_then(FormattedBody::markdown) }
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk/src/widget/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/capabilities.rs
@@ -18,12 +18,12 @@
 use std::{fmt, future::Future};
 
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
-use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::SerializeSeq};
 use tracing::{debug, warn};
 
 use super::{
-    filter::{Filter, FilterInput, ToDeviceEventFilter},
     MessageLikeEventFilter, StateEventFilter,
+    filter::{Filter, FilterInput, ToDeviceEventFilter},
 };
 
 /// Must be implemented by a component that provides functionality of deciding

--- a/crates/matrix-sdk/src/widget/filter.rs
+++ b/crates/matrix-sdk/src/widget/filter.rs
@@ -322,8 +322,10 @@ mod tests {
 
     #[test]
     fn test_text_event_filter_does_not_match_image_event() {
-        assert!(!room_message_text_event_filter()
-            .matches(&FilterInput::message_with_msgtype("m.image")));
+        assert!(
+            !room_message_text_event_filter()
+                .matches(&FilterInput::message_with_msgtype("m.image"))
+        );
     }
 
     #[test]
@@ -343,8 +345,10 @@ mod tests {
 
     #[test]
     fn test_reaction_event_filter_matches_reaction() {
-        assert!(reaction_event_filter()
-            .matches(&message_event(&MessageLikeEventType::Reaction.to_string())));
+        assert!(
+            reaction_event_filter()
+                .matches(&message_event(&MessageLikeEventType::Reaction.to_string()))
+        );
     }
 
     #[test]
@@ -383,20 +387,26 @@ mod tests {
 
     #[test]
     fn self_member_event_filter_does_not_match_unrelated_state_event_with_same_state_key() {
-        assert!(!self_member_event_filter()
-            .matches(&FilterInput::state("io.element.test_state_event", "@self.example.me")));
+        assert!(
+            !self_member_event_filter()
+                .matches(&FilterInput::state("io.element.test_state_event", "@self.example.me"))
+        );
     }
 
     #[test]
     fn test_self_member_event_filter_does_not_match_reaction_event() {
-        assert!(!self_member_event_filter()
-            .matches(&message_event(&MessageLikeEventType::Reaction.to_string())));
+        assert!(
+            !self_member_event_filter()
+                .matches(&message_event(&MessageLikeEventType::Reaction.to_string()))
+        );
     }
 
     #[test]
     fn test_self_member_event_filter_only_matches_specific_state_key() {
-        assert!(!self_member_event_filter()
-            .matches(&FilterInput::state(&StateEventType::RoomMember.to_string(), "")));
+        assert!(
+            !self_member_event_filter()
+                .matches(&FilterInput::state(&StateEventType::RoomMember.to_string(), ""))
+        );
     }
 
     // Tests against an `m.room.member` filter with any `state_key`.
@@ -414,20 +424,26 @@ mod tests {
 
     #[test]
     fn test_member_event_filter_does_not_match_room_name_event() {
-        assert!(!member_event_filter()
-            .matches(&FilterInput::state(&TimelineEventType::RoomName.to_string(), "")));
+        assert!(
+            !member_event_filter()
+                .matches(&FilterInput::state(&TimelineEventType::RoomName.to_string(), ""))
+        );
     }
 
     #[test]
     fn test_member_event_filter_does_not_match_reaction_event() {
-        assert!(!member_event_filter()
-            .matches(&message_event(&MessageLikeEventType::Reaction.to_string())));
+        assert!(
+            !member_event_filter()
+                .matches(&message_event(&MessageLikeEventType::Reaction.to_string()))
+        );
     }
 
     #[test]
     fn test_member_event_filter_matches_any_state_key() {
-        assert!(member_event_filter()
-            .matches(&FilterInput::state(&StateEventType::RoomMember.to_string(), "")));
+        assert!(
+            member_event_filter()
+                .matches(&FilterInput::state(&StateEventType::RoomMember.to_string(), ""))
+        );
     }
 
     // Tests against an `m.room.topic` filter with `state_key = ""`
@@ -440,8 +456,10 @@ mod tests {
 
     #[test]
     fn test_topic_event_filter_does_match() {
-        assert!(topic_event_filter()
-            .matches(&FilterInput::state(&StateEventType::RoomTopic.to_string(), "")));
+        assert!(
+            topic_event_filter()
+                .matches(&FilterInput::state(&StateEventType::RoomTopic.to_string(), ""))
+        );
     }
 
     // Tests against an `m.room.message` filter with `msgtype = m.custom`
@@ -456,32 +474,44 @@ mod tests {
 
     #[test]
     fn test_reaction_event_type_does_not_match_room_message_text_event_filter() {
-        assert!(!room_message_text_event_filter()
-            .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string())));
+        assert!(
+            !room_message_text_event_filter()
+                .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string()))
+        );
     }
 
     #[test]
     fn test_room_message_event_without_msgtype_does_not_match_custom_msgtype_filter() {
-        assert!(!room_message_custom_event_filter()
-            .matches(&FilterInput::message_like(&MessageLikeEventType::RoomMessage.to_string())));
+        assert!(
+            !room_message_custom_event_filter().matches(&FilterInput::message_like(
+                &MessageLikeEventType::RoomMessage.to_string()
+            ))
+        );
     }
 
     #[test]
     fn test_reaction_event_type_does_not_match_room_message_custom_event_filter() {
-        assert!(!room_message_custom_event_filter()
-            .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string())));
+        assert!(
+            !room_message_custom_event_filter()
+                .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string()))
+        );
     }
 
     #[test]
     fn test_room_message_event_type_matches_room_message_event_filter() {
-        assert!(room_message_filter()
-            .matches(&FilterInput::message_like(&MessageLikeEventType::RoomMessage.to_string())));
+        assert!(
+            room_message_filter().matches(&FilterInput::message_like(
+                &MessageLikeEventType::RoomMessage.to_string()
+            ))
+        );
     }
 
     #[test]
     fn test_reaction_event_type_does_not_match_room_message_event_filter() {
-        assert!(!room_message_filter()
-            .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string())));
+        assert!(
+            !room_message_filter()
+                .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string()))
+        );
     }
     #[test]
     fn test_convert_raw_event_into_message_like_filter_input() {

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -17,6 +17,7 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
 use ruma::{
+    OwnedUserId,
     api::client::{
         account::request_openid_token, delayed_events::update_delayed_event,
         to_device::send_event_to_device,
@@ -24,15 +25,14 @@ use ruma::{
     events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEventContent},
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
-    OwnedUserId,
 };
-use serde::{de, Deserialize};
+use serde::{Deserialize, de};
 use serde_json::value::RawValue as RawJsonValue;
 use tracing::error;
 
 use super::{
-    from_widget::SendEventResponse, incoming::MatrixDriverResponse, Action,
-    MatrixDriverRequestMeta, WidgetMachine,
+    Action, MatrixDriverRequestMeta, WidgetMachine, from_widget::SendEventResponse,
+    incoming::MatrixDriverResponse,
 };
 use crate::widget::{Capabilities, StateKeySelector};
 
@@ -83,8 +83,8 @@ where
     pub(crate) fn add_response_handler(
         self,
         response_handler: impl FnOnce(Result<T, crate::Error>, &mut WidgetMachine) -> Vec<Action>
-            + Send
-            + 'static,
+        + Send
+        + 'static,
     ) {
         self.request_meta.response_fn = Some(Box::new(move |response, machine| {
             if let Some(response_data) = response.map(T::from_response).transpose() {
@@ -111,7 +111,7 @@ where
 {
     fn from_response(response: MatrixDriverResponse) -> Option<Self> {
         response.try_into().ok() // Delegates to the existing TryInto
-                                 // implementation
+        // implementation
     }
 }
 

--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -14,18 +14,18 @@
 
 use as_variant::as_variant;
 use ruma::{
+    OwnedEventId, OwnedRoomId,
     api::client::{
         delayed_events::{delayed_message_event, delayed_state_event, update_delayed_event},
         error::{ErrorBody, StandardErrorBody},
     },
     events::AnyTimelineEvent,
     serde::Raw,
-    OwnedEventId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 
-use super::{driver_req::SendToDeviceRequest, SendEventRequest, UpdateDelayedEventRequest};
-use crate::{widget::StateKeySelector, Error, HttpError, RumaApiError};
+use super::{SendEventRequest, UpdateDelayedEventRequest, driver_req::SendToDeviceRequest};
+use crate::{Error, HttpError, RumaApiError, widget::StateKeySelector};
 
 #[derive(Deserialize, Debug)]
 #[serde(tag = "action", rename_all = "snake_case", content = "data")]

--- a/crates/matrix-sdk/src/widget/machine/incoming.rs
+++ b/crates/matrix-sdk/src/widget/machine/incoming.rs
@@ -17,7 +17,7 @@ use ruma::{
     events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEvent},
     serde::Raw,
 };
-use serde::{de, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, de};
 use serde_json::value::RawValue as RawJsonValue;
 use uuid::Uuid;
 

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -20,9 +20,9 @@ use driver_req::{ReadStateRequest, UpdateDelayedEventRequest};
 use from_widget::{SendToDeviceEventResponse, UpdateDelayedEventResponse};
 use indexmap::IndexMap;
 use ruma::{
+    OwnedRoomId,
     events::{AnyStateEvent, AnyTimelineEvent},
     serde::{JsonObject, Raw},
-    OwnedRoomId,
 };
 use serde::Serialize;
 use serde_json::value::RawValue as RawJsonValue;
@@ -49,11 +49,11 @@ use self::{
 #[cfg(doc)]
 use super::WidgetDriver;
 use super::{
+    Capabilities, StateEventFilter, StateKeySelector,
     capabilities::{SEND_DELAYED_EVENT, UPDATE_DELAYED_EVENT},
     filter::FilterInput,
-    Capabilities, StateEventFilter, StateKeySelector,
 };
-use crate::{widget::Filter, Error, Result};
+use crate::{Error, Result, widget::Filter};
 
 mod driver_req;
 mod from_widget;
@@ -280,7 +280,7 @@ impl WidgetMachine {
                 return vec![Self::send_from_widget_err_response(
                     raw_request,
                     FromWidgetErrorResponse::from_error(Error::SerdeJson(e)),
-                )]
+                )];
             }
         };
 
@@ -348,7 +348,7 @@ impl WidgetMachine {
                 let CapabilitiesState::Negotiated(capabilities) = &self.capabilities else {
                     return vec![Self::send_from_widget_error_string_response(
                         raw_request,
-                        "Received send update delayed event request before capabilities were negotiated"
+                        "Received send update delayed event request before capabilities were negotiated",
                     )];
                 };
 

--- a/crates/matrix-sdk/src/widget/machine/openid.rs
+++ b/crates/matrix-sdk/src/widget/machine/openid.rs
@@ -15,7 +15,7 @@
 use std::time::Duration;
 
 use ruma::{
-    api::client::account::request_openid_token, authentication::TokenType, OwnedServerName,
+    OwnedServerName, api::client::account::request_openid_token, authentication::TokenType,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/matrix-sdk/src/widget/machine/pending.rs
+++ b/crates/matrix-sdk/src/widget/machine/pending.rs
@@ -15,7 +15,7 @@
 //! A wrapper around a hash map that tracks pending requests and makes sure
 //! that expired requests are removed.
 
-use indexmap::{map::Entry, IndexMap};
+use indexmap::{IndexMap, map::Entry};
 use ruma::time::{Duration, Instant};
 use tracing::warn;
 use uuid::Uuid;

--- a/crates/matrix-sdk/src/widget/machine/tests/api_versions.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/api_versions.rs
@@ -14,7 +14,7 @@
 
 use assert_matches2::assert_let;
 use ruma::owned_room_id;
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 
 use super::WIDGET_ID;
 use crate::widget::machine::{Action, IncomingMessage, WidgetMachine};

--- a/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
@@ -17,12 +17,12 @@ use assert_matches2::assert_let;
 use ruma::owned_room_id;
 use serde_json::{from_value, json};
 
-use super::{parse_msg, WIDGET_ID};
+use super::{WIDGET_ID, parse_msg};
 use crate::widget::{
     capabilities::{READ_EVENT, READ_STATE, READ_TODEVICE},
     machine::{
-        incoming::MatrixDriverResponse, Action, IncomingMessage, MatrixDriverRequestData,
-        WidgetMachine,
+        Action, IncomingMessage, MatrixDriverRequestData, WidgetMachine,
+        incoming::MatrixDriverResponse,
     },
 };
 

--- a/crates/matrix-sdk/src/widget/machine/tests/error.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/error.rs
@@ -16,7 +16,7 @@ use assert_matches2::assert_let;
 use ruma::owned_room_id;
 use serde_json::json;
 
-use super::{capabilities::assert_capabilities_dance, parse_msg, WIDGET_ID};
+use super::{WIDGET_ID, capabilities::assert_capabilities_dance, parse_msg};
 use crate::widget::machine::{Action, IncomingMessage, WidgetMachine};
 
 #[test]

--- a/crates/matrix-sdk/src/widget/machine/tests/openid.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/openid.rs
@@ -16,12 +16,12 @@ use std::time::Duration;
 
 use assert_matches2::assert_let;
 use ruma::{
-    api::client::account::request_openid_token, authentication::TokenType, owned_room_id,
-    ServerName,
+    ServerName, api::client::account::request_openid_token, authentication::TokenType,
+    owned_room_id,
 };
 use serde_json::json;
 
-use super::{parse_msg, WIDGET_ID};
+use super::{WIDGET_ID, parse_msg};
 use crate::widget::machine::{
     Action, IncomingMessage, MatrixDriverRequestData, MatrixDriverResponse, WidgetMachine,
 };

--- a/crates/matrix-sdk/src/widget/machine/to_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/to_widget.rs
@@ -18,11 +18,11 @@ use ruma::{
     events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEvent},
     serde::Raw,
 };
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::value::RawValue as RawJsonValue;
 use tracing::error;
 
-use super::{openid::OpenIdResponse, Action, ToWidgetRequestMeta, WidgetMachine};
+use super::{Action, ToWidgetRequestMeta, WidgetMachine, openid::OpenIdResponse};
 use crate::widget::Capabilities;
 
 /// A handle to a pending `toWidget` request.

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -19,6 +19,7 @@ use std::collections::BTreeMap;
 
 use matrix_sdk_base::deserialized_responses::{EncryptionInfo, RawAnySyncOrStrippedState};
 use ruma::{
+    EventId, OwnedUserId, RoomId, TransactionId,
     api::client::{
         account::request_openid_token::v3::{Request as OpenIdRequest, Response as OpenIdResponse},
         delayed_events::{self, update_delayed_event::unstable::UpdateAction},
@@ -31,21 +32,20 @@ use ruma::{
         AnySyncTimelineEvent, AnyTimelineEvent, AnyToDeviceEvent, AnyToDeviceEventContent,
         MessageLikeEventType, StateEventType, TimelineEventType, ToDeviceEventType,
     },
-    serde::{from_raw_json_value, Raw},
+    serde::{Raw, from_raw_json_value},
     to_device::DeviceIdOrAllDevices,
-    EventId, OwnedUserId, RoomId, TransactionId,
 };
-use serde_json::{value::RawValue as RawJsonValue, Value};
+use serde_json::{Value, value::RawValue as RawJsonValue};
 use tokio::sync::{
-    broadcast::{error::RecvError, Receiver},
-    mpsc::{unbounded_channel, UnboundedReceiver},
+    broadcast::{Receiver, error::RecvError},
+    mpsc::{UnboundedReceiver, unbounded_channel},
 };
 use tracing::{error, trace, warn};
 
-use super::{machine::SendEventResponse, StateKeySelector};
+use super::{StateKeySelector, machine::SendEventResponse};
 use crate::{
-    event_handler::EventHandlerDropGuard, room::MessagesOptions, sync::RoomUpdate, Client, Error,
-    Result, Room,
+    Client, Error, Result, Room, event_handler::EventHandlerDropGuard, room::MessagesOptions,
+    sync::RoomUpdate,
 };
 
 /// Thin wrapper around a [`Room`] that provides functionality relevant for
@@ -399,7 +399,7 @@ fn attach_room_id_state(raw_ev: &Raw<AnySyncStateEvent>, room_id: &RoomId) -> Ra
 mod tests {
     use insta;
     use ruma::{events::AnyTimelineEvent, room_id, serde::Raw};
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     use super::attach_room_id;
 

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -22,7 +22,7 @@ use futures_util::StreamExt;
 use matrix_sdk_common::executor::spawn;
 use ruma::api::client::delayed_events::DelayParameters;
 use serde::de::{self, Deserialize, Deserializer, Visitor};
-use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::{CancellationToken, DropGuard};
 
@@ -33,7 +33,7 @@ use self::{
     },
     matrix::MatrixDriver,
 };
-use crate::{room::Room, Result};
+use crate::{Result, room::Room};
 
 mod capabilities;
 mod filter;

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -22,7 +22,7 @@
 use serde::Serialize;
 use url::Url;
 
-use super::{url_params, WidgetSettings};
+use super::{WidgetSettings, url_params};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/matrix-sdk/src/widget/settings/mod.rs
+++ b/crates/matrix-sdk/src/widget/settings/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use language_tags::LanguageTag;
-use ruma::{api::client::profile::get_profile, DeviceId, RoomId, UserId};
+use ruma::{DeviceId, RoomId, UserId, api::client::profile::get_profile};
 use url::Url;
 
 use crate::Room;

--- a/crates/matrix-sdk/src/widget/settings/url_params.rs
+++ b/crates/matrix-sdk/src/widget/settings/url_params.rs
@@ -87,7 +87,7 @@ pub fn replace_properties(url: &mut Url, props: QueryProperties) {
 mod tests {
     use url::Url;
 
-    use super::{replace_properties, QueryProperties};
+    use super::{QueryProperties, replace_properties};
 
     const EXAMPLE_URL: &str = "\
         https://my.widget.org/custom/path/using/$matrix_display_name/in/it\

--- a/crates/matrix-sdk/tests/integration/account.rs
+++ b/crates/matrix-sdk/tests/integration/account.rs
@@ -1,8 +1,8 @@
 use matrix_sdk_test::async_test;
 use serde_json::json;
 use wiremock::{
-    matchers::{method, path},
     Mock, Request, ResponseTemplate,
+    matchers::{method, path},
 };
 
 use crate::logged_in_client_with_server;
@@ -33,11 +33,9 @@ async fn test_account_deactivation() {
             .mount_as_scoped(&server)
             .await;
 
-        assert!(client
-            .account()
-            .deactivate(Some("FirstIdentityServer"), None, false)
-            .await
-            .is_ok());
+        assert!(
+            client.account().deactivate(Some("FirstIdentityServer"), None, false).await.is_ok()
+        );
     }
 
     {

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -4,31 +4,31 @@ use assert_matches2::{assert_let, assert_matches};
 use eyeball_im::VectorDiff;
 use futures_util::FutureExt;
 use matrix_sdk::{
-    authentication::oauth::{error::OAuthTokenRevocationError, OAuthError},
+    Client, Error, MemoryStore, StateChanges, StateStore,
+    authentication::oauth::{OAuthError, error::OAuthTokenRevocationError},
     config::{RequestConfig, StoreConfig, SyncSettings},
     store::RoomLoadSettings,
     sync::RoomUpdate,
     test_utils::{
         client::mock_matrix_session, mocks::MatrixMockServer, no_retry_test_client_with_server,
     },
-    Client, Error, MemoryStore, StateChanges, StateStore,
 };
-use matrix_sdk_base::{sync::RoomUpdates, RoomState};
+use matrix_sdk_base::{RoomState, sync::RoomUpdates};
 use matrix_sdk_common::executor::spawn;
 use matrix_sdk_test::{
+    DEFAULT_TEST_ROOM_ID, GlobalAccountDataTestEvent, JoinedRoomBuilder, SyncResponseBuilder,
     async_test, sync_state_event,
     test_json::{
-        self,
+        self, TAG,
         sync::{
             MIXED_INVITED_ROOM_ID, MIXED_JOINED_ROOM_ID, MIXED_KNOCKED_ROOM_ID, MIXED_LEFT_ROOM_ID,
             MIXED_SYNC,
         },
         sync_events::PINNED_EVENTS,
-        TAG,
     },
-    GlobalAccountDataTestEvent, JoinedRoomBuilder, SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
 };
 use ruma::{
+    OwnedUserId,
     api::client::{
         directory::{
             get_public_rooms,
@@ -40,19 +40,19 @@ use ruma::{
     directory::Filter,
     event_id,
     events::{
-        direct::{DirectEventContent, OwnedDirectUserIdentifier},
         AnyInitialStateEvent,
+        direct::{DirectEventContent, OwnedDirectUserIdentifier},
     },
     room_id,
     serde::Raw,
-    user_id, OwnedUserId,
+    user_id,
 };
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 use stream_assert::{assert_next_matches, assert_pending};
 use tokio_stream::wrappers::BroadcastStream;
 use wiremock::{
-    matchers::{header, method, path, path_regex},
     Mock, Request, ResponseTemplate,
+    matchers::{header, method, path, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};

--- a/crates/matrix-sdk/tests/integration/encryption.rs
+++ b/crates/matrix-sdk/tests/integration/encryption.rs
@@ -16,8 +16,8 @@ async fn mock_secret_store_with_backup_key(
 ) {
     use serde_json::json;
     use wiremock::{
-        matchers::{header, method, path},
         Mock, ResponseTemplate,
+        matchers::{header, method, path},
     };
 
     Mock::given(method("GET"))

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -16,8 +16,9 @@ use std::{fs::File, io::Write, sync::Arc, time::Duration};
 
 use anyhow::Result;
 use assert_matches::assert_matches;
-use futures_util::{pin_mut, FutureExt, StreamExt};
+use futures_util::{FutureExt, StreamExt, pin_mut};
 use matrix_sdk::{
+    Client, SessionMeta,
     authentication::matrix::MatrixSession,
     config::RequestConfig,
     crypto::{
@@ -26,38 +27,38 @@ use matrix_sdk::{
         types::EventEncryptionAlgorithm,
     },
     encryption::{
-        backups::{futures::SteadyStateError, BackupState, UploadState},
-        secret_storage::SecretStore,
         BackupDownloadStrategy, EncryptionSettings,
+        backups::{BackupState, UploadState, futures::SteadyStateError},
+        secret_storage::SecretStore,
     },
     test_utils::{
         client::mock_session_tokens, no_retry_test_client_with_server,
         test_client_builder_with_server,
     },
-    Client, SessionMeta,
 };
 use matrix_sdk_base::crypto::olm::OutboundGroupSession;
 use matrix_sdk_common::timeout::timeout;
-use matrix_sdk_test::{async_test, JoinedRoomBuilder, SyncResponseBuilder};
+use matrix_sdk_test::{JoinedRoomBuilder, SyncResponseBuilder, async_test};
 use ruma::{
+    EventId, RoomId, TransactionId,
     api::client::room::create_room::v3::Request as CreateRoomRequest,
     assign, device_id, event_id,
     events::room::message::{RoomMessageEvent, RoomMessageEventContent},
-    owned_device_id, owned_user_id, room_id, user_id, EventId, RoomId, TransactionId,
+    owned_device_id, owned_user_id, room_id, user_id,
 };
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tempfile::tempdir;
 use tokio::spawn;
 use vodozemac::{
-    olm::IdentityKeys, Curve25519PublicKey, Curve25519SecretKey, Ed25519PublicKey, Ed25519SecretKey,
+    Curve25519PublicKey, Curve25519SecretKey, Ed25519PublicKey, Ed25519SecretKey, olm::IdentityKeys,
 };
 use wiremock::{
-    matchers::{header, method, path, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path, path_regex},
 };
 
 use crate::{
-    encryption::{mock_secret_store_with_backup_key, BACKUP_DECRYPTION_KEY_BASE64},
+    encryption::{BACKUP_DECRYPTION_KEY_BASE64, mock_secret_store_with_backup_key},
     mock_sync,
 };
 

--- a/crates/matrix-sdk/tests/integration/encryption/recovery.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/recovery.rs
@@ -17,28 +17,28 @@ use std::sync::{Arc, Mutex};
 use assert_matches2::assert_let;
 use futures_util::StreamExt;
 use matrix_sdk::{
+    Client,
     authentication::matrix::MatrixSession,
     config::RequestConfig,
     encryption::{
+        BackupDownloadStrategy, CrossSigningResetAuthType,
         backups::BackupState,
         recovery::{EnableProgress, RecoveryState},
-        BackupDownloadStrategy, CrossSigningResetAuthType,
     },
     test_utils::{
         client::mock_session_tokens, no_retry_test_client_with_server,
         test_client_builder_with_server,
     },
-    Client,
 };
 use matrix_sdk_base::SessionMeta;
 use matrix_sdk_test::async_test;
-use ruma::{api::client::uiaa, device_id, user_id, UserId};
+use ruma::{UserId, api::client::uiaa, device_id, user_id};
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio::spawn;
 use wiremock::{
-    matchers::{header, method, path, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path, path_regex},
 };
 
 use crate::{encryption::mock_secret_store_with_backup_key, logged_in_client_with_server};

--- a/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
@@ -9,19 +9,19 @@ use matrix_sdk::{
 use matrix_sdk_base::SessionMeta;
 use matrix_sdk_test::async_test;
 use ruma::{
-    device_id,
+    UserId, device_id,
     events::{
         secret::request::SecretName,
         secret_storage::{
             default_key::SecretStorageDefaultKeyEventContent, secret::SecretEventContent,
         },
     },
-    user_id, UserId,
+    user_id,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path, path_regex},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path, path_regex},
 };
 
 use crate::logged_in_client_with_server;

--- a/crates/matrix-sdk/tests/integration/encryption/to_device.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/to_device.rs
@@ -13,8 +13,8 @@ use matrix_sdk_test::{async_test, test_json};
 use ruma::{events::AnyToDeviceEvent, serde::Raw};
 use serde_json::json;
 use wiremock::{
-    matchers::{method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{method, path_regex},
 };
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/encryption/verification.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/verification.rs
@@ -1,16 +1,16 @@
 use assert_matches2::assert_matches;
 use futures_util::FutureExt;
 use matrix_sdk::{
+    Client,
     encryption::VerificationState,
     test_utils::{logged_in_client_with_server, mocks::MatrixMockServer},
-    Client,
 };
 use matrix_sdk_test::async_test;
 use ruma::{owned_device_id, owned_user_id, user_id};
 use serde_json::json;
 use wiremock::{
-    matchers::{body_json, method, path},
     Mock, ResponseTemplate,
+    matchers::{body_json, method, path},
 };
 
 async fn bootstrap_cross_signing(client: &Client) {

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -19,17 +19,17 @@ use matrix_sdk::{
     },
 };
 use matrix_sdk_base::event_cache::{
-    store::{EventCacheStore, MemoryStore},
     Gap,
+    store::{EventCacheStore, MemoryStore},
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, GlobalAccountDataTestEvent, JoinedRoomBuilder, ALICE,
-    BOB,
+    ALICE, BOB, GlobalAccountDataTestEvent, JoinedRoomBuilder, async_test,
+    event_factory::EventFactory,
 };
 use ruma::{
-    event_id,
+    EventId, RoomVersionId, event_id,
     events::{AnySyncMessageLikeEvent, AnySyncTimelineEvent, TimelineEventType},
-    room_id, user_id, EventId, RoomVersionId,
+    room_id, user_id,
 };
 use serde_json::json;
 use tokio::{spawn, sync::broadcast, time::sleep};
@@ -1333,10 +1333,9 @@ async fn test_dont_delete_gap_that_wasnt_inserted() {
     server
         .sync_room(
             &client,
-            JoinedRoomBuilder::new(room_id).add_timeline_bulk(vec![f
-                .text_msg("sup")
-                .event_id(event_id!("$3"))
-                .into_raw_sync()]),
+            JoinedRoomBuilder::new(room_id).add_timeline_bulk(vec![
+                f.text_msg("sup").event_id(event_id!("$3")).into_raw_sync(),
+            ]),
         )
         .await;
 
@@ -1479,10 +1478,9 @@ async fn test_apply_redaction_on_an_in_store_event() {
                     // … and its item
                     Update::PushItems {
                         at: Position::new(ChunkIdentifier::new(0), 0),
-                        items: vec![event_factory
-                            .text_msg("foo")
-                            .event_id(event_id!("$ev0"))
-                            .into_event()],
+                        items: vec![
+                            event_factory.text_msg("foo").event_id(event_id!("$ev0")).into_event(),
+                        ],
                     },
                     // chunk #2
                     Update::NewItemsChunk {
@@ -1493,10 +1491,9 @@ async fn test_apply_redaction_on_an_in_store_event() {
                     // … and its item
                     Update::PushItems {
                         at: Position::new(ChunkIdentifier::new(1), 0),
-                        items: vec![event_factory
-                            .text_msg("foo")
-                            .event_id(event_id!("$ev1"))
-                            .into_event()],
+                        items: vec![
+                            event_factory.text_msg("foo").event_id(event_id!("$ev1")).into_event(),
+                        ],
                     },
                 ],
             )

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -3,8 +3,8 @@
 use matrix_sdk::test_utils::logged_in_client_with_server;
 use serde::Serialize;
 use wiremock::{
-    matchers::{header, method, path, query_param, query_param_is_missing},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path, query_param, query_param_is_missing},
 };
 
 mod account;

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -2,34 +2,35 @@ use std::{collections::BTreeMap, sync::Mutex};
 
 use assert_matches::assert_matches;
 use matrix_sdk::{
+    AuthApi, AuthSession, Client, RumaApiError, SessionTokens,
     authentication::matrix::MatrixSession,
     config::RequestConfig,
     test_utils::{logged_in_client_with_server, no_retry_test_client_with_server},
-    AuthApi, AuthSession, Client, RumaApiError, SessionTokens,
 };
 use matrix_sdk_base::SessionMeta;
 use matrix_sdk_test::{async_test, test_json};
 use ruma::{
+    OwnedUserId,
     api::{
+        MatrixVersion,
         client::{
             self as client_api,
-            account::register::{v3::Request as RegistrationRequest, RegistrationKind},
+            account::register::{RegistrationKind, v3::Request as RegistrationRequest},
             keys::upload_signatures::v3::SignedKeys,
             session::get_login_types::v3::LoginType,
             uiaa::{self, AuthData, UserIdentifier},
         },
-        MatrixVersion,
     },
     assign, device_id,
     encryption::CrossSigningKey,
     serde::Raw,
-    user_id, OwnedUserId,
+    user_id,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 use url::Url;
 use wiremock::{
-    matchers::{method, path},
     Mock, MockServer, Request, ResponseTemplate,
+    matchers::{method, path},
 };
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -1,21 +1,21 @@
 use matrix_sdk::{
+    Client,
     config::RequestConfig,
     media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings},
     store::RoomLoadSettings,
     test_utils::{client::mock_matrix_session, logged_in_client_with_server},
-    Client,
 };
 use matrix_sdk_test::async_test;
 use ruma::{
     api::client::media::get_content_thumbnail::v3::Method,
     assign,
-    events::room::{message::ImageMessageEventContent, ImageInfo, MediaSource},
+    events::room::{ImageInfo, MediaSource, message::ImageMessageEventContent},
     mxc_uri, owned_mxc_uri, uint,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path, query_param},
     Mock, ResponseTemplate,
+    matchers::{header, method, path, query_param},
 };
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/notification.rs
+++ b/crates/matrix-sdk/tests/integration/notification.rs
@@ -2,10 +2,10 @@ use assert_matches2::assert_matches;
 use matrix_sdk::{config::SyncSettings, sync::Notification};
 use matrix_sdk_base::deserialized_responses::RawAnySyncOrStrippedTimelineEvent;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, stripped_state_event, sync_state_event, test_json,
-    InvitedRoomBuilder, JoinedRoomBuilder, SyncResponseBuilder,
+    InvitedRoomBuilder, JoinedRoomBuilder, SyncResponseBuilder, async_test,
+    event_factory::EventFactory, stripped_state_event, sync_state_event, test_json,
 };
-use ruma::{event_id, events::StateEventType, room_id, serde::Raw, user_id, OwnedRoomId};
+use ruma::{OwnedRoomId, event_id, events::StateEventType, room_id, serde::Raw, user_id};
 use stream_assert::{assert_pending, assert_ready};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -6,6 +6,7 @@ use std::{
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use matrix_sdk::{
+    HttpError, RefreshTokenError, SessionChange, SessionTokens,
     authentication::matrix::MatrixSession,
     config::RequestConfig,
     executor::spawn,
@@ -14,21 +15,20 @@ use matrix_sdk::{
         client::mock_session_meta, logged_in_client_with_server, no_retry_test_client_with_server,
         test_client_builder_with_server,
     },
-    HttpError, RefreshTokenError, SessionChange, SessionTokens,
 };
 use matrix_sdk_test::{async_test, test_json};
 use ruma::{
     api::{
-        client::{account::register, error::ErrorKind},
         MatrixVersion,
+        client::{account::register, error::ErrorKind},
     },
     assign,
 };
 use serde_json::json;
 use tokio::sync::{broadcast::error::TryRecvError, mpsc};
 use wiremock::{
-    matchers::{body_partial_json, header, method, path},
     Mock, ResponseTemplate,
+    matchers::{body_partial_json, header, method, path},
 };
 
 fn session() -> MatrixSession {

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -6,12 +6,12 @@ use matrix_sdk::{
     room::reply::{EnforceThread, Reply},
     test_utils::mocks::MatrixMockServer,
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, ALICE, DEFAULT_TEST_ROOM_ID};
+use matrix_sdk_test::{ALICE, DEFAULT_TEST_ROOM_ID, async_test, event_factory::EventFactory};
 use ruma::{
     event_id,
     events::{
-        room::{message::ReplyWithinThread, MediaSource},
         Mentions,
+        room::{MediaSource, message::ReplyWithinThread},
     },
     mxc_uri, owned_mxc_uri, owned_user_id, uint,
 };

--- a/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
@@ -1,28 +1,28 @@
 use std::time::{Duration, UNIX_EPOCH};
 
-use futures_util::{pin_mut, FutureExt, StreamExt as _};
+use futures_util::{FutureExt, StreamExt as _, pin_mut};
 use js_int::uint;
 use matrix_sdk::{
     config::SyncSettings, live_location_share::LiveLocationShare,
     test_utils::mocks::MatrixMockServer,
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, test_json,
-    JoinedRoomBuilder, SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
+    DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, SyncResponseBuilder, async_test,
+    event_factory::EventFactory, mocks::mock_encryption_state, test_json,
 };
 use ruma::{
-    event_id,
+    EventId, MilliSecondsSinceUnixEpoch, event_id,
     events::{
         beacon::BeaconEventContent, beacon_info::BeaconInfoEventContent, location::AssetType,
     },
     owned_event_id, room_id,
     time::SystemTime,
-    user_id, EventId, MilliSecondsSinceUnixEpoch,
+    user_id,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{body_partial_json, header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{body_partial_json, header, method, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};
@@ -392,13 +392,14 @@ async fn test_observing_live_location_does_not_return_own_beacon_updates() {
 
     let f = EventFactory::new().room(room_id);
 
-    let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f
-        .event(BeaconInfoEventContent::new(None, Duration::from_secs(60), false, None))
-        .event_id(event_id)
-        .sender(user_id)
-        .state_key(user_id)
-        .into_raw_timeline()
-        .cast()]);
+    let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![
+        f.event(BeaconInfoEventContent::new(None, Duration::from_secs(60), false, None))
+            .event_id(event_id)
+            .sender(user_id)
+            .state_key(user_id)
+            .into_raw_timeline()
+            .cast(),
+    ]);
 
     let room = server.sync_room(&client, joined_room_builder).await;
 

--- a/crates/matrix-sdk/tests/integration/room/beacon_info/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon_info/mod.rs
@@ -2,16 +2,15 @@ use std::time::Duration;
 
 use js_int::uint;
 use matrix_sdk::config::SyncSettings;
-use matrix_sdk_test::{async_test, test_json, DEFAULT_TEST_ROOM_ID};
+use matrix_sdk_test::{DEFAULT_TEST_ROOM_ID, async_test, test_json};
 use ruma::{
-    event_id,
-    events::{location::AssetType, AnySyncStateEvent, StateEventType},
-    MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch, event_id,
+    events::{AnySyncStateEvent, StateEventType, location::AssetType},
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{body_partial_json, header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{body_partial_json, header, method, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -3,27 +3,27 @@ use std::{collections::BTreeMap, iter, time::Duration};
 use assert_matches2::{assert_let, assert_matches};
 use js_int::uint;
 use matrix_sdk::{
-    config::SyncSettings, room::RoomMember, test_utils::mocks::MatrixMockServer, RoomDisplayName,
-    RoomMemberships,
+    RoomDisplayName, RoomMemberships, config::SyncSettings, room::RoomMember,
+    test_utils::mocks::MatrixMockServer,
 };
 use matrix_sdk_test::{
-    async_test, bulk_room_members, event_factory::EventFactory, sync_state_event, test_json,
-    GlobalAccountDataTestEvent, JoinedRoomBuilder, LeftRoomBuilder, StateTestEvent,
-    SyncResponseBuilder, BOB, DEFAULT_TEST_ROOM_ID,
+    BOB, DEFAULT_TEST_ROOM_ID, GlobalAccountDataTestEvent, JoinedRoomBuilder, LeftRoomBuilder,
+    StateTestEvent, SyncResponseBuilder, async_test, bulk_room_members,
+    event_factory::EventFactory, sync_state_event, test_json,
 };
 use ruma::{
     event_id,
     events::{
+        AnySyncStateEvent, AnySyncTimelineEvent, StateEventType,
         direct::DirectUserIdentifier,
         room::{avatar, member::MembershipState, message::RoomMessageEventContent},
-        AnySyncStateEvent, AnySyncTimelineEvent, StateEventType,
     },
     mxc_uri, owned_room_alias_id, room_id, room_version_id, user_id,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{body_json, header, method, path, path_regex},
     Mock, ResponseTemplate,
+    matchers::{body_json, header, method, path, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};

--- a/crates/matrix-sdk/tests/integration/room/left.rs
+++ b/crates/matrix-sdk/tests/integration/room/left.rs
@@ -4,18 +4,19 @@ use assert_matches2::assert_matches;
 use matrix_sdk::{config::SyncSettings, linked_chunk::LinkedChunkId};
 use matrix_sdk_base::{RoomInfoNotableUpdateReasons, RoomState};
 use matrix_sdk_test::{
-    async_test, test_json, GlobalAccountDataTestEvent, LeftRoomBuilder, SyncResponseBuilder,
-    DEFAULT_TEST_ROOM_ID,
+    DEFAULT_TEST_ROOM_ID, GlobalAccountDataTestEvent, LeftRoomBuilder, SyncResponseBuilder,
+    async_test, test_json,
 };
 use ruma::{
+    OwnedRoomOrAliasId,
     events::direct::{DirectEventContent, DirectUserIdentifier},
-    user_id, OwnedRoomOrAliasId,
+    user_id,
 };
 use serde_json::json;
 use tokio::task::yield_now;
 use wiremock::{
-    matchers::{header, method, path, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};

--- a/crates/matrix-sdk/tests/integration/room/notification_mode.rs
+++ b/crates/matrix-sdk/tests/integration/room/notification_mode.rs
@@ -4,14 +4,14 @@ use assert_matches::assert_matches;
 use matrix_sdk::{config::SyncSettings, notification_settings::RoomNotificationMode};
 use matrix_sdk_base::RoomState;
 use matrix_sdk_test::{
-    async_test, GlobalAccountDataTestEvent, InvitedRoomBuilder, JoinedRoomBuilder,
-    SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
+    DEFAULT_TEST_ROOM_ID, GlobalAccountDataTestEvent, InvitedRoomBuilder, JoinedRoomBuilder,
+    SyncResponseBuilder, async_test,
 };
 use ruma::room_id;
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};

--- a/crates/matrix-sdk/tests/integration/room/spaces.rs
+++ b/crates/matrix-sdk/tests/integration/room/spaces.rs
@@ -2,17 +2,17 @@ use std::time::Duration;
 
 use assert_matches2::assert_let;
 use futures_util::StreamExt;
-use matrix_sdk::{config::SyncSettings, room::ParentSpace, Client};
-use matrix_sdk_test::{async_test, test_json, DEFAULT_TEST_ROOM_ID};
+use matrix_sdk::{Client, config::SyncSettings, room::ParentSpace};
+use matrix_sdk_test::{DEFAULT_TEST_ROOM_ID, async_test, test_json};
 use once_cell::sync::Lazy;
-use ruma::{room_id, RoomId};
-use serde_json::{json, Value as JsonValue};
+use ruma::{RoomId, room_id};
+use serde_json::{Value as JsonValue, json};
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
-use crate::{logged_in_client_with_server, mock_sync, MockServer};
+use crate::{MockServer, logged_in_client_with_server, mock_sync};
 
 pub static DEFAULT_TEST_SPACE_ID: Lazy<&RoomId> =
     Lazy::new(|| room_id!("!hIMjEx205EXNyjVPCV:localhost"));
@@ -173,8 +173,8 @@ async fn test_parent_space_undeserializable() {
     let (client, server) = logged_in_client_with_server().await;
 
     let mut sync = PARENT_SPACE_SYNC.clone();
-    sync["rooms"]["join"][DEFAULT_TEST_ROOM_ID.as_str()]["timeline"]["events"][0]["content"]
-        ["canonical"] = JsonValue::from("true"); // invalid, must be a boolean
+    sync["rooms"]["join"][DEFAULT_TEST_ROOM_ID.as_str()]["timeline"]["events"][0]["content"]["canonical"] =
+        JsonValue::from("true"); // invalid, must be a boolean
     initial_sync_with_m_space_parent(&client, &server, &sync).await;
 
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();

--- a/crates/matrix-sdk/tests/integration/room/tags.rs
+++ b/crates/matrix-sdk/tests/integration/room/tags.rs
@@ -1,17 +1,18 @@
 use std::{collections::BTreeMap, ops::Not, time::Duration};
 
-use matrix_sdk::{config::SyncSettings, Client, Room};
+use matrix_sdk::{Client, Room, config::SyncSettings};
 use matrix_sdk_test::{
-    async_test, test_json, JoinedRoomBuilder, RoomAccountDataTestEvent, SyncResponseBuilder,
+    JoinedRoomBuilder, RoomAccountDataTestEvent, SyncResponseBuilder, async_test, test_json,
 };
 use ruma::{
+    RoomId,
     events::tag::{TagInfo, TagName, Tags},
-    room_id, RoomId,
+    room_id,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};

--- a/crates/matrix-sdk/tests/integration/room_preview.rs
+++ b/crates/matrix-sdk/tests/integration/room_preview.rs
@@ -6,20 +6,20 @@ use matrix_sdk::{
 };
 use matrix_sdk_base::{RequestedRequiredStates, RoomState};
 use matrix_sdk_test::{
-    async_test, InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, SyncResponseBuilder,
+    InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, SyncResponseBuilder, async_test,
 };
 use ruma::{
+    RoomId,
     api::client::sync::sync_events::{v5 as sliding_sync_http, v5::response::Hero},
     assign,
     events::room::member::MembershipState,
     owned_user_id, room_id,
     space::SpaceRoomJoinRule,
-    RoomId,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
 use crate::mock_sync;

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -17,33 +17,33 @@ use std::{pin::pin, time::Duration};
 use assert_matches::assert_matches;
 use futures_util::FutureExt;
 use matrix_sdk::{
+    Client,
     test_utils::mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
     widget::{
         Capabilities, CapabilitiesProvider, WidgetDriver, WidgetDriverHandle, WidgetSettings,
     },
-    Client,
 };
 use matrix_sdk_common::{executor::spawn, timeout::timeout};
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent, ALICE, BOB,
+    ALICE, BOB, JoinedRoomBuilder, StateTestEvent, async_test, event_factory::EventFactory,
 };
 use once_cell::sync::Lazy;
 use ruma::{
-    event_id,
+    OwnedRoomId, event_id,
     events::{
-        room::{member::MembershipState, message::RoomMessageEventContent},
         AnySyncStateEvent, MessageLikeEventType, StateEventType,
+        room::{member::MembershipState, message::RoomMessageEventContent},
     },
     owned_room_id, room_id,
     serde::{JsonObject, Raw},
-    user_id, OwnedRoomId,
+    user_id,
 };
 use serde::Serialize;
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 use tracing::error;
 use wiremock::{
-    matchers::{method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{method, path_regex},
 };
 
 /// Create a JSON string from a [`json!`][serde_json::json] "literal".

--- a/examples/autojoin/src/main.rs
+++ b/examples/autojoin/src/main.rs
@@ -1,9 +1,9 @@
 use std::{env, process::exit};
 
 use matrix_sdk::{
-    config::SyncSettings, ruma::events::room::member::StrippedRoomMemberEvent, Client, Room,
+    Client, Room, config::SyncSettings, ruma::events::room::member::StrippedRoomMemberEvent,
 };
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 
 async fn on_stripped_state_member(
     room_member: StrippedRoomMemberEvent,

--- a/examples/backups/src/main.rs
+++ b/examples/backups/src/main.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use clap::Parser;
-use futures_util::{pin_mut, StreamExt};
+use futures_util::{StreamExt, pin_mut};
 use matrix_sdk::{
+    Client,
     config::SyncSettings,
     encryption::{backups::BackupState, secret_storage::SecretStore},
-    Client,
 };
 use url::Url;
 

--- a/examples/command_bot/src/main.rs
+++ b/examples/command_bot/src/main.rs
@@ -1,11 +1,11 @@
 use std::{env, process::exit};
 
 use matrix_sdk::{
+    Client, Room, RoomState,
     config::SyncSettings,
     ruma::events::room::message::{
         MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent,
     },
-    Client, Room, RoomState,
 };
 
 async fn on_room_message(event: OriginalSyncRoomMessageEvent, room: Room) {

--- a/examples/cross_signing_bootstrap/src/main.rs
+++ b/examples/cross_signing_bootstrap/src/main.rs
@@ -6,10 +6,10 @@ use std::{
 
 use anyhow::Result;
 use matrix_sdk::{
+    Client, LoopCtrl,
     config::SyncSettings,
     encryption::CrossSigningResetAuthType,
-    ruma::{api::client::uiaa, OwnedUserId},
-    Client, LoopCtrl,
+    ruma::{OwnedUserId, api::client::uiaa},
 };
 use url::Url;
 

--- a/examples/custom_events/src/main.rs
+++ b/examples/custom_events/src/main.rs
@@ -13,15 +13,17 @@ use std::{
     env,
     process::exit,
     sync::{
-        atomic::{AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicU64, Ordering},
     },
 };
 
 use matrix_sdk::{
+    Client, Room, RoomState,
     config::SyncSettings,
     event_handler::Ctx,
     ruma::{
+        OwnedEventId,
         events::{
             macros::EventContent,
             room::{
@@ -29,12 +31,10 @@ use matrix_sdk::{
                 message::{MessageType, OriginalSyncRoomMessageEvent},
             },
         },
-        OwnedEventId,
     },
-    Client, Room, RoomState,
 };
 use serde::{Deserialize, Serialize};
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 
 // We use ruma to define our custom events. Just declare the events content
 // by deriving from `EventContent` and define `ruma_events` for the metadata

--- a/examples/emoji_verification/src/main.rs
+++ b/examples/emoji_verification/src/main.rs
@@ -4,19 +4,19 @@ use anyhow::Result;
 use clap::Parser;
 use futures_util::stream::StreamExt;
 use matrix_sdk::{
+    Client,
     config::SyncSettings,
     encryption::verification::{
-        format_emojis, Emoji, SasState, SasVerification, Verification, VerificationRequest,
-        VerificationRequestState,
+        Emoji, SasState, SasVerification, Verification, VerificationRequest,
+        VerificationRequestState, format_emojis,
     },
     ruma::{
+        UserId,
         events::{
             key::verification::request::ToDeviceKeyVerificationRequestEvent,
             room::message::{MessageType, OriginalSyncRoomMessageEvent},
         },
-        UserId,
     },
-    Client,
 };
 use url::Url;
 

--- a/examples/get_profiles/src/main.rs
+++ b/examples/get_profiles/src/main.rs
@@ -1,8 +1,8 @@
 use std::{env, process::exit};
 
 use matrix_sdk::{
-    ruma::{api::client::profile, OwnedMxcUri, UserId},
     Client, Result as MatrixResult,
+    ruma::{OwnedMxcUri, UserId, api::client::profile},
 };
 use url::Url;
 

--- a/examples/getting_started/src/main.rs
+++ b/examples/getting_started/src/main.rs
@@ -13,14 +13,14 @@
 use std::{env, process::exit};
 
 use matrix_sdk::{
+    Client, Room, RoomState,
     config::SyncSettings,
     ruma::events::room::{
         member::StrippedRoomMemberEvent,
         message::{MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent},
     },
-    Client, Room, RoomState,
 };
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 
 /// This is the starting point of the app. `main` is called by rust binaries to
 /// run the program in this case, we use tokio (a reactor) to allow us to use

--- a/examples/image_bot/src/main.rs
+++ b/examples/image_bot/src/main.rs
@@ -1,10 +1,10 @@
 use std::{env, fs, process::exit};
 
 use matrix_sdk::{
+    Client, Room, RoomState,
     attachment::AttachmentConfig,
     config::SyncSettings,
     ruma::events::room::message::{MessageType, OriginalSyncRoomMessageEvent},
-    Client, Room, RoomState,
 };
 use url::Url;
 

--- a/examples/login/src/main.rs
+++ b/examples/login/src/main.rs
@@ -6,12 +6,12 @@ use std::{
 
 use anyhow::anyhow;
 use matrix_sdk::{
+    Client, Room, RoomState,
     config::SyncSettings,
     ruma::{
         api::client::session::get_login_types::v3::{IdentityProvider, LoginType},
         events::room::message::{MessageType, OriginalSyncRoomMessageEvent},
     },
-    Client, Room, RoomState,
 };
 use url::Url;
 

--- a/examples/oauth_cli/src/main.rs
+++ b/examples/oauth_cli/src/main.rs
@@ -22,24 +22,24 @@ use std::{
 use anyhow::bail;
 use futures_util::StreamExt;
 use matrix_sdk::{
+    Client, ClientBuildError, Result, RoomState,
     authentication::oauth::{
-        error::OAuthClientRegistrationError,
-        registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
         AccountManagementActionFull, ClientId, OAuthAuthorizationData, OAuthError, OAuthSession,
         UrlOrQuery, UserSession,
+        error::OAuthClientRegistrationError,
+        registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
     },
     config::SyncSettings,
-    encryption::{recovery::RecoveryState, CrossSigningResetAuthType},
+    encryption::{CrossSigningResetAuthType, recovery::RecoveryState},
     room::Room,
     ruma::{
         events::room::message::{MessageType, OriginalSyncRoomMessageEvent},
         serde::Raw,
     },
     utils::local_server::{LocalServerBuilder, LocalServerRedirectHandle, QueryString},
-    Client, ClientBuildError, Result, RoomState,
 };
 use matrix_sdk_ui::sync_service::SyncService;
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use rand::{Rng, distributions::Alphanumeric, thread_rng};
 use serde::{Deserialize, Serialize};
 use tokio::{fs, io::AsyncBufReadExt as _};
 use url::Url;

--- a/examples/persist_session/src/main.rs
+++ b/examples/persist_session/src/main.rs
@@ -4,15 +4,15 @@ use std::{
 };
 
 use matrix_sdk::{
+    Client, Error, LoopCtrl, Room, RoomState,
     authentication::matrix::MatrixSession,
     config::SyncSettings,
     ruma::{
         api::client::filter::FilterDefinition,
         events::room::message::{MessageType, OriginalSyncRoomMessageEvent},
     },
-    Client, Error, LoopCtrl, Room, RoomState,
 };
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use rand::{Rng, distributions::Alphanumeric, thread_rng};
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 

--- a/examples/qr-login/src/main.rs
+++ b/examples/qr-login/src/main.rs
@@ -1,15 +1,15 @@
 use std::io::Write;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::Parser;
 use futures_util::StreamExt;
 use matrix_sdk::{
+    Client,
     authentication::oauth::{
         qrcode::{LoginProgress, QrCodeData, QrCodeModeData},
         registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
     },
     ruma::serde::Raw,
-    Client,
 };
 use url::Url;
 

--- a/examples/secret_storage/src/main.rs
+++ b/examples/secret_storage/src/main.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use matrix_sdk::{
+    AuthSession, Client, SessionMeta, SessionTokens,
     authentication::matrix::MatrixSession,
     encryption::secret_storage::SecretStore,
-    ruma::{events::secret::request::SecretName, OwnedDeviceId, OwnedUserId},
-    AuthSession, Client, SessionMeta, SessionTokens,
+    ruma::{OwnedDeviceId, OwnedUserId, events::secret::request::SecretName},
 };
 use url::Url;
 

--- a/examples/timeline/src/main.rs
+++ b/examples/timeline/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use futures_util::StreamExt;
-use matrix_sdk::{config::SyncSettings, ruma::OwnedRoomId, Client};
+use matrix_sdk::{Client, config::SyncSettings, ruma::OwnedRoomId};
 use matrix_sdk_ui::timeline::RoomExt;
 use url::Url;
 

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    io::{self, stdout, Write},
+    io::{self, Write, stdout},
     path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, Instant},
@@ -16,23 +16,23 @@ use crossterm::{
     },
     execute,
 };
-use futures_util::{pin_mut, StreamExt as _};
+use futures_util::{StreamExt as _, pin_mut};
 use imbl::Vector;
 use layout::Flex;
 use matrix_sdk::{
+    AuthSession, Client, SqliteCryptoStore, SqliteEventCacheStore, SqliteStateStore,
     authentication::matrix::MatrixSession,
     config::StoreConfig,
     encryption::{BackupDownloadStrategy, EncryptionSettings},
     reqwest::Url,
     ruma::OwnedRoomId,
-    AuthSession, Client, SqliteCryptoStore, SqliteEventCacheStore, SqliteStateStore,
 };
 use matrix_sdk_common::locks::Mutex;
 use matrix_sdk_ui::{
+    Timeline as SdkTimeline,
     room_list_service::{self, filters::new_filter_non_left},
     sync_service::SyncService,
     timeline::{RoomExt as _, TimelineFocus, TimelineItem},
-    Timeline as SdkTimeline,
 };
 use ratatui::{prelude::*, style::palette::tailwind, widgets::*};
 use throbber_widgets_tui::{Throbber, ThrobberState};

--- a/labs/multiverse/src/widgets/recovery/default.rs
+++ b/labs/multiverse/src/widgets/recovery/default.rs
@@ -1,7 +1,7 @@
 use std::{
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     time::Duration,
 };
@@ -10,11 +10,11 @@ use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
 use futures_util::FutureExt as _;
 use layout::Flex;
 use matrix_sdk::{
+    Client,
     encryption::{
         backups::BackupState,
         recovery::{RecoveryError, RecoveryState},
     },
-    Client,
 };
 use matrix_sdk_common::executor::spawn;
 use ratatui::{
@@ -24,7 +24,7 @@ use ratatui::{
 use throbber_widgets_tui::{Throbber, ThrobberState};
 use tokio::task::JoinHandle;
 
-use super::{create_centered_throbber_area, ShouldExit};
+use super::{ShouldExit, create_centered_throbber_area};
 
 #[derive(Debug)]
 pub struct DefaultRecoveryView {

--- a/labs/multiverse/src/widgets/recovery/mod.rs
+++ b/labs/multiverse/src/widgets/recovery/mod.rs
@@ -1,5 +1,5 @@
 use crossterm::event::{KeyCode, KeyEvent};
-use matrix_sdk::{encryption::recovery::RecoveryState, Client};
+use matrix_sdk::{Client, encryption::recovery::RecoveryState};
 use ratatui::prelude::*;
 use recovering::RecoveringView;
 use throbber_widgets_tui::{Throbber, ThrobberState};

--- a/labs/multiverse/src/widgets/recovery/recovering.rs
+++ b/labs/multiverse/src/widgets/recovery/recovering.rs
@@ -1,10 +1,10 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use futures_util::FutureExt as _;
 use matrix_sdk::{
-    encryption::{recovery::RecoveryError, CrossSigningResetAuthType},
+    Client,
+    encryption::{CrossSigningResetAuthType, recovery::RecoveryError},
     reqwest::Url,
     ruma::api::client::uiaa::{AuthData, Password},
-    Client,
 };
 use matrix_sdk_common::executor::spawn;
 use ratatui::{
@@ -14,7 +14,7 @@ use ratatui::{
 use throbber_widgets_tui::{Throbber, ThrobberState};
 use tokio::{
     sync::{
-        mpsc::{unbounded_channel, UnboundedSender},
+        mpsc::{UnboundedSender, unbounded_channel},
         oneshot,
     },
     task::JoinHandle,
@@ -22,7 +22,7 @@ use tokio::{
 use tui_textarea::TextArea;
 
 use super::ShouldExit;
-use crate::widgets::{recovery::create_centered_throbber_area, Hyperlink};
+use crate::widgets::{Hyperlink, recovery::create_centered_throbber_area};
 
 #[derive(Debug)]
 enum ResetState {

--- a/labs/multiverse/src/widgets/room_list.rs
+++ b/labs/multiverse/src/widgets/room_list.rs
@@ -1,13 +1,13 @@
 use std::{collections::HashMap, sync::Arc};
 
 use imbl::Vector;
-use matrix_sdk::{locks::Mutex, ruma::OwnedRoomId, Client, Room};
+use matrix_sdk::{Client, Room, locks::Mutex, ruma::OwnedRoomId};
 use matrix_sdk_ui::sync_service::SyncService;
 use ratatui::{prelude::*, widgets::*};
 
 use crate::{
-    widgets::status::StatusHandle, ALT_ROW_COLOR, HEADER_BG, NORMAL_ROW_COLOR, SELECTED_STYLE_FG,
-    TEXT_COLOR,
+    ALT_ROW_COLOR, HEADER_BG, NORMAL_ROW_COLOR, SELECTED_STYLE_FG, TEXT_COLOR,
+    widgets::status::StatusHandle,
 };
 
 /// Extra room information, like its display name, etc.

--- a/labs/multiverse/src/widgets/room_view/details/read_receipts.rs
+++ b/labs/multiverse/src/widgets/room_view/details/read_receipts.rs
@@ -6,7 +6,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 
-use crate::{widgets::room_view::DetailsState, TEXT_COLOR};
+use crate::{TEXT_COLOR, widgets::room_view::DetailsState};
 
 pub struct ReadReceipts<'a> {
     state: &'a DetailsState<'a>,

--- a/labs/multiverse/src/widgets/room_view/invited_room.rs
+++ b/labs/multiverse/src/widgets/room_view/invited_room.rs
@@ -1,10 +1,10 @@
 use crossterm::event::{Event, KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use futures_util::FutureExt;
-use matrix_sdk::{room::Invite, Room, RoomState};
+use matrix_sdk::{Room, RoomState, room::Invite};
 use ratatui::{prelude::*, widgets::*};
 use throbber_widgets_tui::{Throbber, ThrobberState};
 use tokio::{spawn, task::JoinHandle};
-use tui_framework_experiment::{button, Button};
+use tui_framework_experiment::{Button, button};
 
 use crate::widgets::recovery::create_centered_throbber_area;
 

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -6,20 +6,20 @@ use imbl::Vector;
 use input::MessageOrCommand;
 use invited_room::InvitedRoomView;
 use matrix_sdk::{
+    Client, Room, RoomState,
     locks::Mutex,
     room::reply::{EnforceThread::Threaded, Reply},
     ruma::{
+        OwnedEventId, OwnedRoomId, RoomId, UserId,
         api::client::receipt::create_receipt::v3::ReceiptType,
         events::room::message::{
             ReplyWithinThread, RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
         },
-        OwnedEventId, OwnedRoomId, RoomId, UserId,
     },
-    Client, Room, RoomState,
 };
 use matrix_sdk_ui::{
-    timeline::{TimelineBuilder, TimelineFocus, TimelineItem},
     Timeline,
+    timeline::{TimelineBuilder, TimelineFocus, TimelineItem},
 };
 use ratatui::{prelude::*, widgets::*};
 use tokio::{spawn, sync::OnceCell, task::JoinHandle};
@@ -28,8 +28,8 @@ use tracing::info;
 use self::{details::RoomDetails, input::Input, timeline::TimelineView};
 use super::status::StatusHandle;
 use crate::{
+    HEADER_BG, NORMAL_ROW_COLOR, TEXT_COLOR, Timelines,
     widgets::{recovery::ShouldExit, room_view::timeline::TimelineListState},
-    Timelines, HEADER_BG, NORMAL_ROW_COLOR, TEXT_COLOR,
 };
 
 mod details;

--- a/labs/multiverse/src/widgets/room_view/timeline.rs
+++ b/labs/multiverse/src/widgets/room_view/timeline.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use imbl::Vector;
-use matrix_sdk::ruma::{events::room::message::MessageType, UserId};
+use matrix_sdk::ruma::{UserId, events::room::message::MessageType};
 use matrix_sdk_ui::timeline::{
     MembershipChange, Message, MsgLikeContent, MsgLikeKind, RoomMembershipChange, ThreadSummary,
     TimelineDetails, TimelineItem, TimelineItemContent, TimelineItemKind, VirtualTimelineItem,

--- a/labs/multiverse/src/widgets/status.rs
+++ b/labs/multiverse/src/widgets/status.rs
@@ -1,7 +1,7 @@
 use std::{
     sync::{
-        mpsc::{self, Receiver},
         Arc,
+        mpsc::{self, Receiver},
     },
     time::Duration,
 };
@@ -13,7 +13,7 @@ use ratatui::{
 };
 use tokio::{
     spawn,
-    task::{spawn_blocking, JoinHandle},
+    task::{JoinHandle, spawn_blocking},
     time::sleep,
 };
 

--- a/testing/matrix-sdk-integration-testing/src/helpers.rs
+++ b/testing/matrix-sdk-integration-testing/src/helpers.rs
@@ -10,21 +10,21 @@ use std::{
 use anyhow::Result;
 use assign::assign;
 use matrix_sdk::{
+    Client, ClientBuilder, Room,
     config::{RequestConfig, SyncSettings},
     encryption::EncryptionSettings,
     ruma::{
+        RoomId,
         api::client::{account::register::v3::Request as RegistrationRequest, uiaa},
         time::Instant,
-        RoomId,
     },
     sliding_sync::VersionBuilder,
     sync::SyncResponse,
     timeout::ElapsedError,
-    Client, ClientBuilder, Room,
 };
 use once_cell::sync::Lazy;
 use rand::Rng as _;
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 use tokio::{sync::Mutex, time::sleep};
 
 /// This global maintains temp directories alive for the whole lifetime of the

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/mod.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/mod.rs
@@ -8,31 +8,30 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use assign::assign;
 use matrix_sdk::{
-    assert_next_eq_with_timeout,
-    crypto::{format_emojis, SasState},
+    Client, assert_next_eq_with_timeout,
+    crypto::{SasState, format_emojis},
     encryption::{
+        BackupDownloadStrategy, EncryptionSettings, LocalTrust,
         backups::BackupState,
         recovery::{Recovery, RecoveryState},
         verification::{
             QrVerificationData, QrVerificationState, Verification, VerificationRequestState,
         },
-        BackupDownloadStrategy, EncryptionSettings, LocalTrust,
     },
     ruma::{
+        OwnedEventId,
         api::client::room::create_room::v3::Request as CreateRoomRequest,
         events::{
-            key::verification::{request::ToDeviceKeyVerificationRequestEvent, VerificationMethod},
+            GlobalAccountDataEventType, OriginalSyncMessageLikeEvent,
+            key::verification::{VerificationMethod, request::ToDeviceKeyVerificationRequestEvent},
             room::message::{
                 MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent,
                 SyncRoomMessageEvent,
             },
             secret_storage::secret::SecretEventContent,
-            GlobalAccountDataEventType, OriginalSyncMessageLikeEvent,
         },
-        OwnedEventId,
     },
     timeout::timeout,
-    Client,
 };
 use matrix_sdk_ui::{
     notification_client::{NotificationClient, NotificationProcessSetup},
@@ -51,8 +50,8 @@ mod shared_history;
 // processed twice, meaning incorrect verification states will be found and the
 // process will fail, especially with user verification.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_mutual_sas_verification_with_notification_client_ignores_verification_events(
-) -> Result<()> {
+async fn test_mutual_sas_verification_with_notification_client_ignores_verification_events()
+-> Result<()> {
     let encryption_settings =
         EncryptionSettings { auto_enable_cross_signing: true, ..Default::default() };
     let alice = TestClientBuilder::new("alice")

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/shared_history.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/shared_history.rs
@@ -12,7 +12,7 @@ use matrix_sdk::{
 use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
 use matrix_sdk_ui::sync_service::SyncService;
 use similar_asserts::assert_eq;
-use tracing::{info, Instrument};
+use tracing::{Instrument, info};
 
 use crate::helpers::{SyncTokenAwareClient, TestClientBuilder};
 

--- a/testing/matrix-sdk-integration-testing/src/tests/invitations.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/invitations.rs
@@ -1,7 +1,7 @@
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use assign::assign;
 use matrix_sdk::{
-    ruma::api::client::room::create_room::v3::Request as CreateRoomRequest, RoomState,
+    RoomState, ruma::api::client::room::create_room::v3::Request as CreateRoomRequest,
 };
 
 use crate::helpers::TestClientBuilder;

--- a/testing/matrix-sdk-integration-testing/src/tests/nse.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/nse.rs
@@ -8,22 +8,22 @@ use anyhow::Result;
 use assign::assign;
 use futures::Future;
 use matrix_sdk::{
+    Client, Room,
     encryption::EncryptionSettings,
     ruma::{
+        EventEncryptionAlgorithm, OwnedEventId, OwnedRoomId, RoomId,
         api::client::room::create_room::v3::Request as CreateRoomRequest,
         events::{
+            AnyMessageLikeEventContent, AnySyncTimelineEvent, OriginalSyncMessageLikeEvent,
             room::{
                 encrypted::{OriginalSyncRoomEncryptedEvent, RoomEncryptedEventContent},
                 encryption::RoomEncryptionEventContent,
                 message::{MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent},
             },
             room_key::ToDeviceRoomKeyEvent,
-            AnyMessageLikeEventContent, AnySyncTimelineEvent, OriginalSyncMessageLikeEvent,
         },
         serde::Raw,
-        EventEncryptionAlgorithm, OwnedEventId, OwnedRoomId, RoomId,
     },
-    Client, Room,
 };
 use matrix_sdk_ui::{
     notification_client::{NotificationClient, NotificationEvent, NotificationProcessSetup},
@@ -31,7 +31,7 @@ use matrix_sdk_ui::{
 };
 use serde_json::json;
 use tempfile::tempdir;
-use tracing::{info, instrument, span, Level};
+use tracing::{Level, info, instrument, span};
 
 use crate::helpers::{SyncTokenAwareClient, TestClientBuilder};
 

--- a/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
@@ -2,15 +2,15 @@ use anyhow::Result;
 use assert_matches::assert_matches;
 use assign::assign;
 use matrix_sdk::{
+    Client,
     config::SyncSettings,
     ruma::{
         api::client::room::create_room::v3::Request as CreateRoomRequest,
         events::{
-            room::name::{RoomNameEventContent, SyncRoomNameEvent},
             AnySyncStateEvent, StateEventType,
+            room::name::{RoomNameEventContent, SyncRoomNameEvent},
         },
     },
-    Client,
 };
 
 use crate::helpers::TestClientBuilder;

--- a/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
@@ -3,12 +3,12 @@ use std::{sync::Arc, time::Duration};
 use anyhow::Result;
 use assign::assign;
 use matrix_sdk::{
+    Client, Room, RoomMemberships, RoomState, StateStoreExt,
     event_handler::Ctx,
     ruma::{
         api::client::room::create_room::v3::Request as CreateRoomRequest,
         events::room::member::{MembershipState, StrippedRoomMemberEvent},
     },
-    Client, Room, RoomMemberships, RoomState, StateStoreExt,
 };
 use matrix_sdk_common::executor::spawn;
 use tokio::sync::Notify;

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -3,24 +3,24 @@ use std::time::Duration;
 use anyhow::Result;
 use assert_matches2::{assert_let, assert_matches};
 use matrix_sdk::{
+    RoomState,
     room::MessagesOptions,
     ruma::{
         api::client::room::create_room::v3::Request as CreateRoomRequest,
         assign, event_id, events,
         events::{
-            room::message::RoomMessageEventContent, AnyRoomAccountDataEventContent,
-            AnySyncStateEvent, AnySyncTimelineEvent, EventContent,
+            AnyRoomAccountDataEventContent, AnySyncStateEvent, AnySyncTimelineEvent, EventContent,
+            room::message::RoomMessageEventContent,
         },
         serde::Raw,
         uint,
     },
     test_utils::assert_event_matches_msg,
-    RoomState,
 };
 use tokio::{spawn, time::sleep};
 use tracing::error;
 
-use crate::helpers::{wait_for_room, TestClientBuilder};
+use crate::helpers::{TestClientBuilder, wait_for_room};
 
 #[tokio::test]
 async fn test_event_with_context() -> Result<()> {

--- a/testing/matrix-sdk-integration-testing/src/tests/room_directory_search.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room_directory_search.rs
@@ -21,9 +21,9 @@ use eyeball_im::VectorDiff;
 use futures::StreamExt;
 use matrix_sdk::{
     room_directory_search::RoomDirectorySearch,
-    ruma::api::client::room::{create_room::v3::Request as CreateRoomRequest, Visibility},
+    ruma::api::client::room::{Visibility, create_room::v3::Request as CreateRoomRequest},
 };
-use rand::{thread_rng, Rng};
+use rand::{Rng, thread_rng};
 use stream_assert::assert_pending;
 use tokio::time::sleep;
 use tracing::warn;

--- a/testing/matrix-sdk-integration-testing/src/tests/room_privacy.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room_privacy.rs
@@ -19,9 +19,10 @@ use assign::assign;
 use matrix_sdk::{
     config::SyncSettings,
     ruma::{
+        RoomAliasId,
         api::client::{
             directory::get_public_rooms_filtered,
-            room::{create_room::v3::Request as CreateRoomRequest, Visibility},
+            room::{Visibility, create_room::v3::Request as CreateRoomRequest},
         },
         directory::Filter,
         events::room::{
@@ -32,7 +33,6 @@ use matrix_sdk::{
             },
         },
         serde::Raw,
-        RoomAliasId,
     },
 };
 use matrix_sdk_base::ruma::events::room::canonical_alias::SyncRoomCanonicalAliasEvent;

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -3,21 +3,21 @@
 
 use std::sync::Arc;
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use matrix_sdk::{
+    RoomState,
     config::SyncSettings,
     ruma::{
+        OwnedEventId,
         api::client::room::create_room::v3::Request as CreateRoomRequest,
         assign,
         events::{
-            room::{member::MembershipState, message::RoomMessageEventContent},
             AnyStrippedStateEvent, SyncMessageLikeEvent, TimelineEventType,
+            room::{member::MembershipState, message::RoomMessageEventContent},
         },
-        OwnedEventId,
     },
-    RoomState,
 };
 use matrix_sdk_ui::{
     notification_client::{

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -22,27 +22,26 @@ use eyeball_im::{Vector, VectorDiff};
 use futures::pin_mut;
 use futures_util::{FutureExt, StreamExt};
 use matrix_sdk::{
-    assert_next_with_timeout,
+    Client, Room, RoomState, assert_next_with_timeout,
     config::SyncSettings,
     deserialized_responses::{VerificationLevel, VerificationState},
-    encryption::{backups::BackupState, EncryptionSettings},
+    encryption::{EncryptionSettings, backups::BackupState},
     room::edit::EditedContent,
     ruma::{
+        MilliSecondsSinceUnixEpoch, OwnedEventId, RoomId, UserId,
         api::client::room::create_room::v3::{Request as CreateRoomRequest, RoomPreset},
         events::{
-            room::{encryption::RoomEncryptionEventContent, message::RoomMessageEventContent},
             InitialStateEvent,
+            room::{encryption::RoomEncryptionEventContent, message::RoomMessageEventContent},
         },
-        MilliSecondsSinceUnixEpoch, OwnedEventId, RoomId, UserId,
     },
-    Client, Room, RoomState,
 };
 use matrix_sdk_ui::{
+    Timeline,
     notification_client::NotificationClient,
     room_list_service::RoomListLoadingState,
     sync_service::SyncService,
     timeline::{EventSendState, EventTimelineItem, ReactionStatus, RoomExt, TimelineItem},
-    Timeline,
 };
 use similar_asserts::assert_eq;
 use stream_assert::assert_pending;
@@ -397,9 +396,10 @@ async fn test_enabling_backups_retries_decryption() {
 
     debug!("Creating room…");
 
-    let initial_state =
-        vec![InitialStateEvent::new(RoomEncryptionEventContent::with_recommended_defaults())
-            .to_raw_any()];
+    let initial_state = vec![
+        InitialStateEvent::new(RoomEncryptionEventContent::with_recommended_defaults())
+            .to_raw_any(),
+    ];
 
     let room = alice
         .create_room(assign!(CreateRoomRequest::new(), {
@@ -410,11 +410,12 @@ async fn test_enabling_backups_retries_decryption() {
         .await
         .unwrap();
 
-    assert!(room
-        .latest_encryption_state()
-        .await
-        .expect("We should be able to check that the room is encrypted")
-        .is_encrypted());
+    assert!(
+        room.latest_encryption_state()
+            .await
+            .expect("We should be able to check that the room is encrypted")
+            .is_encrypted()
+    );
 
     let event_id = room
         .send(RoomMessageEventContent::text_plain("It's a secret to everybody!"))
@@ -533,9 +534,10 @@ async fn test_room_keys_received_on_notification_client_trigger_redecryption() {
     debug!("Creating the room…");
 
     // The room needs to be encrypted.
-    let initial_state =
-        vec![InitialStateEvent::new(RoomEncryptionEventContent::with_recommended_defaults())
-            .to_raw_any()];
+    let initial_state = vec![
+        InitialStateEvent::new(RoomEncryptionEventContent::with_recommended_defaults())
+            .to_raw_any(),
+    ];
 
     let alice_room = alice
         .create_room(assign!(CreateRoomRequest::new(), {
@@ -546,11 +548,13 @@ async fn test_room_keys_received_on_notification_client_trigger_redecryption() {
         .await
         .unwrap();
 
-    assert!(alice_room
-        .latest_encryption_state()
-        .await
-        .expect("We should be able to check that the room is encrypted")
-        .is_encrypted());
+    assert!(
+        alice_room
+            .latest_encryption_state()
+            .await
+            .expect("We should be able to check that the room is encrypted")
+            .is_encrypted()
+    );
 
     // Create stream listening for devices.
     let devices_stream = alice
@@ -795,11 +799,12 @@ async fn test_new_users_first_messages_dont_warn_about_insecure_device_if_it_is_
         .await
         .expect("should not fail to create room");
 
-        assert!(room
-            .latest_encryption_state()
-            .await
-            .expect("should be able to check that the room is encrypted")
-            .is_encrypted());
+        assert!(
+            room.latest_encryption_state()
+                .await
+                .expect("should be able to check that the room is encrypted")
+                .is_encrypted()
+        );
 
         room
     }

--- a/testing/matrix-sdk-test-macros/src/lib.rs
+++ b/testing/matrix-sdk-test-macros/src/lib.rs
@@ -1,5 +1,5 @@
 use proc_macro::TokenStream;
-use quote::{format_ident, quote, ToTokens};
+use quote::{ToTokens, format_ident, quote};
 use syn::parse_macro_input;
 
 /// Attribute to use `wasm_bindgen_test` for wasm32 targets and `tokio::test`

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -24,7 +24,13 @@ use matrix_sdk_common::deserialized_responses::{
     TimelineEvent, UnableToDecryptInfo, UnableToDecryptReason,
 };
 use ruma::{
+    EventId, Int, MilliSecondsSinceUnixEpoch, MxcUri, OwnedEventId, OwnedMxcUri, OwnedRoomAliasId,
+    OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId, TransactionId, UInt,
+    UserId,
     events::{
+        AnyMessageLikeEvent, AnyStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,
+        AnyTimelineEvent, BundledMessageLikeRelations, EventContent,
+        RedactedMessageLikeEventContent, RedactedStateEventContent, StateEventContent,
         beacon::BeaconEventContent,
         member_hints::MemberHintsEventContent,
         poll::{
@@ -39,6 +45,7 @@ use ruma::{
         receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
         relation::{Annotation, BundledThread, InReplyTo, Replacement, Thread},
         room::{
+            ImageInfo,
             avatar::{self, RoomAvatarEventContent},
             canonical_alias::RoomCanonicalAliasEventContent,
             create::{PreviousRoom, RoomCreateEventContent},
@@ -55,18 +62,12 @@ use ruma::{
             server_acl::RoomServerAclEventContent,
             tombstone::RoomTombstoneEventContent,
             topic::RoomTopicEventContent,
-            ImageInfo,
         },
         sticker::StickerEventContent,
         typing::TypingEventContent,
-        AnyMessageLikeEvent, AnyStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,
-        AnyTimelineEvent, BundledMessageLikeRelations, EventContent,
-        RedactedMessageLikeEventContent, RedactedStateEventContent, StateEventContent,
     },
     serde::Raw,
-    server_name, EventId, Int, MilliSecondsSinceUnixEpoch, MxcUri, OwnedEventId, OwnedMxcUri,
-    OwnedRoomAliasId, OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId,
-    TransactionId, UInt, UserId,
+    server_name,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -567,8 +568,8 @@ impl EventFactory {
     /// use matrix_sdk_test::event_factory::EventFactory;
     /// use ruma::{
     ///     events::{
-    ///         room::member::{MembershipState, RoomMemberEventContent},
     ///         SyncStateEvent,
+    ///         room::member::{MembershipState, RoomMemberEventContent},
     ///     },
     ///     room_id,
     ///     serde::Raw,
@@ -639,7 +640,7 @@ impl EventFactory {
     ///
     /// use matrix_sdk_test::event_factory::EventFactory;
     /// use ruma::{
-    ///     events::{member_hints::MemberHintsEventContent, SyncStateEvent},
+    ///     events::{SyncStateEvent, member_hints::MemberHintsEventContent},
     ///     owned_user_id, room_id,
     ///     serde::Raw,
     ///     user_id,
@@ -905,10 +906,11 @@ impl EventFactory {
     /// ```
     /// use matrix_sdk_test::event_factory::EventFactory;
     /// use ruma::{
-    ///     events::{beacon::BeaconEventContent, MessageLikeEvent},
+    ///     MilliSecondsSinceUnixEpoch,
+    ///     events::{MessageLikeEvent, beacon::BeaconEventContent},
     ///     owned_event_id, room_id,
     ///     serde::Raw,
-    ///     user_id, MilliSecondsSinceUnixEpoch,
+    ///     user_id,
     /// };
     ///
     /// let factory = EventFactory::new().room(room_id!("!test:localhost"));

--- a/testing/matrix-sdk-test/src/lib.rs
+++ b/testing/matrix-sdk-test/src/lib.rs
@@ -2,10 +2,11 @@ use http::Response;
 pub use matrix_sdk_test_macros::async_test;
 use once_cell::sync::Lazy;
 use ruma::{
+    RoomId, UserId,
     api::{
-        client::sync::sync_events::v3::Response as SyncResponse, IncomingResponse, OutgoingResponse,
+        IncomingResponse, OutgoingResponse, client::sync::sync_events::v3::Response as SyncResponse,
     },
-    room_id, user_id, RoomId, UserId,
+    room_id, user_id,
 };
 use serde_json::Value as JsonValue;
 
@@ -120,9 +121,9 @@ mod sync_builder;
 pub mod test_json;
 
 pub use self::sync_builder::{
-    bulk_room_members, GlobalAccountDataTestEvent, InvitedRoomBuilder, JoinedRoomBuilder,
-    KnockedRoomBuilder, LeftRoomBuilder, PresenceTestEvent, RoomAccountDataTestEvent,
-    StateTestEvent, StrippedStateTestEvent, SyncResponseBuilder,
+    GlobalAccountDataTestEvent, InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder,
+    LeftRoomBuilder, PresenceTestEvent, RoomAccountDataTestEvent, StateTestEvent,
+    StrippedStateTestEvent, SyncResponseBuilder, bulk_room_members,
 };
 
 pub static ALICE: Lazy<&UserId> = Lazy::new(|| user_id!("@alice:server.name"));

--- a/testing/matrix-sdk-test/src/mocks.rs
+++ b/testing/matrix-sdk-test/src/mocks.rs
@@ -15,8 +15,8 @@
 //! Mocks useful to reuse across different testing contexts.
 
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
 use crate::test_json;

--- a/testing/matrix-sdk-test/src/notification_settings/mod.rs
+++ b/testing/matrix-sdk-test/src/notification_settings/mod.rs
@@ -1,9 +1,9 @@
 use ruma::{
+    RoomId, UserId,
     push::{
         Action, NewConditionalPushRule, NewPushRule, NewSimplePushRule, PushCondition, RuleKind,
         Ruleset, Tweak,
     },
-    RoomId, UserId,
 };
 
 pub fn get_server_default_ruleset() -> Ruleset {

--- a/testing/matrix-sdk-test/src/sync_builder/bulk.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/bulk.rs
@@ -1,7 +1,7 @@
 use std::ops::Range;
 
 use ruma::{
-    events::{room::member::MembershipState, AnySyncStateEvent},
+    events::{AnySyncStateEvent, room::member::MembershipState},
     serde::Raw,
 };
 use serde_json::{from_value as from_json_value, json};

--- a/testing/matrix-sdk-test/src/sync_builder/invited_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/invited_room.rs
@@ -1,6 +1,6 @@
 use ruma::{
-    api::client::sync::sync_events::v3::InvitedRoom, events::AnyStrippedStateEvent, serde::Raw,
-    OwnedRoomId, RoomId,
+    OwnedRoomId, RoomId, api::client::sync::sync_events::v3::InvitedRoom,
+    events::AnyStrippedStateEvent, serde::Raw,
 };
 
 use super::StrippedStateTestEvent;

--- a/testing/matrix-sdk-test/src/sync_builder/joined_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/joined_room.rs
@@ -1,16 +1,16 @@
 use ruma::{
+    OwnedRoomId, RoomId,
     api::client::sync::sync_events::v3::JoinedRoom,
     events::{
-        receipt::ReceiptEventContent, typing::TypingEventContent, AnyRoomAccountDataEvent,
-        AnySyncStateEvent, AnySyncTimelineEvent,
+        AnyRoomAccountDataEvent, AnySyncStateEvent, AnySyncTimelineEvent,
+        receipt::ReceiptEventContent, typing::TypingEventContent,
     },
     serde::Raw,
-    OwnedRoomId, RoomId,
 };
-use serde_json::{from_value as from_json_value, Value as JsonValue};
+use serde_json::{Value as JsonValue, from_value as from_json_value};
 
 use super::RoomAccountDataTestEvent;
-use crate::{event_factory::EventBuilder, DEFAULT_TEST_ROOM_ID};
+use crate::{DEFAULT_TEST_ROOM_ID, event_factory::EventBuilder};
 
 pub struct JoinedRoomBuilder {
     pub(super) room_id: OwnedRoomId,

--- a/testing/matrix-sdk-test/src/sync_builder/knocked_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/knocked_room.rs
@@ -1,6 +1,6 @@
 use ruma::{
-    api::client::sync::sync_events::v3::KnockedRoom, events::AnyStrippedStateEvent, serde::Raw,
-    OwnedRoomId, RoomId,
+    OwnedRoomId, RoomId, api::client::sync::sync_events::v3::KnockedRoom,
+    events::AnyStrippedStateEvent, serde::Raw,
 };
 
 use super::StrippedStateTestEvent;

--- a/testing/matrix-sdk-test/src/sync_builder/left_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/left_room.rs
@@ -1,8 +1,8 @@
 use ruma::{
+    OwnedRoomId, RoomId,
     api::client::sync::sync_events::v3::LeftRoom,
     events::{AnyRoomAccountDataEvent, AnySyncStateEvent, AnySyncTimelineEvent},
     serde::Raw,
-    OwnedRoomId, RoomId,
 };
 
 use super::{RoomAccountDataTestEvent, StateTestEvent};

--- a/testing/matrix-sdk-test/src/sync_builder/mod.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/mod.rs
@@ -2,17 +2,17 @@ use std::collections::HashMap;
 
 use http::Response;
 use ruma::{
+    OwnedRoomId, OwnedUserId, UserId,
     api::{
+        IncomingResponse,
         client::sync::sync_events::v3::{
             InvitedRoom, JoinedRoom, KnockedRoom, LeftRoom, Response as SyncResponse,
         },
-        IncomingResponse,
     },
-    events::{presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyToDeviceEvent},
+    events::{AnyGlobalAccountDataEvent, AnyToDeviceEvent, presence::PresenceEvent},
     serde::Raw,
-    OwnedRoomId, OwnedUserId, UserId,
 };
-use serde_json::{from_value as from_json_value, json, Value as JsonValue};
+use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
 use super::test_json;
 

--- a/testing/matrix-sdk-test/src/sync_builder/test_event.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/test_event.rs
@@ -1,11 +1,11 @@
 use ruma::{
     events::{
-        presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
-        AnyStrippedStateEvent, AnySyncStateEvent,
+        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
+        AnySyncStateEvent, presence::PresenceEvent,
     },
     serde::Raw,
 };
-use serde_json::{from_value as from_json_value, Value as JsonValue};
+use serde_json::{Value as JsonValue, from_value as from_json_value};
 
 use crate::test_json;
 

--- a/testing/matrix-sdk-test/src/test_json/api_responses.rs
+++ b/testing/matrix-sdk-test/src/test_json/api_responses.rs
@@ -1,7 +1,7 @@
 //! Responses to client API calls.
 
 use once_cell::sync::Lazy;
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 
 /// `GET /_matrix/client/v3/devices`
 pub static DEVICES: Lazy<JsonValue> = Lazy::new(|| {

--- a/testing/matrix-sdk-test/src/test_json/keys_query.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query.rs
@@ -19,8 +19,8 @@
 use std::{collections::HashMap, iter};
 
 use ruma::{
-    api::client::keys::get_keys::v3::Response as KeyQueryResponse, device_id, user_id, DeviceId,
-    UserId,
+    DeviceId, UserId, api::client::keys::get_keys::v3::Response as KeyQueryResponse, device_id,
+    user_id,
 };
 use serde_json::json;
 
@@ -50,29 +50,45 @@ impl KeysQueryUser {
             device_key_ed22519: "6melQNnhoI9sT2b4VzNPAwa8aB179ym45fON8Yo7kVk",
             device_signature: "Fk45zHAbrd+1j9wZXLjL2Y/+DU/Mnz9yuvlfYBOOT7qExN2Jdud+5BAuNs8nZ/caS4wTF39Kg3zQpzaGERoCBg",
             device_signature_2_name: Some("dO4gmBNW7WC0bXBK81j8uh4me6085fP+keoOm0pH3gw"),
-            device_signature_2_signature: Some("md0Pa1MYlneFb1fp6KCsvZpi2ySb6/G+ULoCbQDWBeDxNEcoNMzf7PEKY04UToCZKUU4LifvRWmiWFDanOlkCQ"),
+            device_signature_2_signature: Some(
+                "md0Pa1MYlneFb1fp6KCsvZpi2ySb6/G+ULoCbQDWBeDxNEcoNMzf7PEKY04UToCZKUU4LifvRWmiWFDanOlkCQ",
+            ),
             master_key_name: Some("/mULSzYNTdHJOBWnBmsvDHhqdHQcWnXRHHmqwzwC7DY"),
-            master_key_signature: Some("6vGDbPO5XzlcwbU3aV+kcck+iHHEBtX85ow2gW5U05/DZdtda/JNVa5Nn7B9lQHNnnrMqt1sX00y/JrIkSS1Aw"),
-            master_key_device_signature: Some("jLxmUPr0Ny2Ai9+NGKGhed9BAuKikOc7r6gr7MQVawePYS95w8NJ8Tzaq9zFFOmIiojACNdQ/ksy3QAdwD6vBQ"),
+            master_key_signature: Some(
+                "6vGDbPO5XzlcwbU3aV+kcck+iHHEBtX85ow2gW5U05/DZdtda/JNVa5Nn7B9lQHNnnrMqt1sX00y/JrIkSS1Aw",
+            ),
+            master_key_device_signature: Some(
+                "jLxmUPr0Ny2Ai9+NGKGhed9BAuKikOc7r6gr7MQVawePYS95w8NJ8Tzaq9zFFOmIiojACNdQ/ksy3QAdwD6vBQ",
+            ),
             self_signing_key_name: Some("dO4gmBNW7WC0bXBK81j8uh4me6085fP+keoOm0pH3gw"),
-            self_signing_key_signature: Some("7md6mwjUK8zjintmffJ0+kImC59/Y8PdySy99EZz5Neu+VMX3LT7txhKO2gC/hmDduRw+JGfGXIiDxR7GmQqDw"),
+            self_signing_key_signature: Some(
+                "7md6mwjUK8zjintmffJ0+kImC59/Y8PdySy99EZz5Neu+VMX3LT7txhKO2gC/hmDduRw+JGfGXIiDxR7GmQqDw",
+            ),
         }
     }
 
     pub(crate) fn bob_b() -> Self {
         Self {
             user_id: user_id!("@bob:localhost"),
-            device_id:  device_id!("ATWKQFSFRN"),
-            device_key_curve25519:  "CY0TWVK1/Kj3ZADuBcGe3UKvpT+IKAPMUsMeJhSDqno",
-            device_key_ed22519:  "TyTQqd6j2JlWZh97r+kTYuCbvqnPoNwO6EGovYsjY00",
-            device_signature:  "BQ9Gp0p+6srF+c8OyruqKKd9R4yaub3THYAyyBB/7X/rG8BwcAqFynzl1aGyFYun4Q+087a5OSiglCXI+/kQAA",
+            device_id: device_id!("ATWKQFSFRN"),
+            device_key_curve25519: "CY0TWVK1/Kj3ZADuBcGe3UKvpT+IKAPMUsMeJhSDqno",
+            device_key_ed22519: "TyTQqd6j2JlWZh97r+kTYuCbvqnPoNwO6EGovYsjY00",
+            device_signature: "BQ9Gp0p+6srF+c8OyruqKKd9R4yaub3THYAyyBB/7X/rG8BwcAqFynzl1aGyFYun4Q+087a5OSiglCXI+/kQAA",
             device_signature_2_name: Some("At1ai1VUZrCncCI7V7fEAJmBShfpqZ30xRzqcEjTjdc"),
-            device_signature_2_signature:  Some("TWmDPaG7t0rZ6luauonELD3dmBDTIRryqXhgsIQRiGint2rJdic8RVyZ6a61bgu6mtBjfvU3prqMNp6sVi16Cg"),
-            master_key_name:  Some("NmI78hY54kE7OZsIjbRE/iCox59t4nzScCNEO6fvtY4"),
-            master_key_signature:  Some("xqLhC3sIUci1W2CNVW7HZWXreQApgjv2RDwB0WPiMd1P4vbZ/qJM0KWqK2piGPWliPi8YVREMrg216KXM3IhCA"),
-            master_key_device_signature:  Some("MBOzCKYPQLQMpBY2lFZJ4c8451xJfQCdhPBb1AHlTUSxKFiWi6V+k1oRRnhQein/PjkIY7ZO+HoOrIeOtbRMAw"),
+            device_signature_2_signature: Some(
+                "TWmDPaG7t0rZ6luauonELD3dmBDTIRryqXhgsIQRiGint2rJdic8RVyZ6a61bgu6mtBjfvU3prqMNp6sVi16Cg",
+            ),
+            master_key_name: Some("NmI78hY54kE7OZsIjbRE/iCox59t4nzScCNEO6fvtY4"),
+            master_key_signature: Some(
+                "xqLhC3sIUci1W2CNVW7HZWXreQApgjv2RDwB0WPiMd1P4vbZ/qJM0KWqK2piGPWliPi8YVREMrg216KXM3IhCA",
+            ),
+            master_key_device_signature: Some(
+                "MBOzCKYPQLQMpBY2lFZJ4c8451xJfQCdhPBb1AHlTUSxKFiWi6V+k1oRRnhQein/PjkIY7ZO+HoOrIeOtbRMAw",
+            ),
             self_signing_key_name: Some("At1ai1VUZrCncCI7V7fEAJmBShfpqZ30xRzqcEjTjdc"),
-            self_signing_key_signature:  Some("Ls6CeoA4LoPCHuSwG96kbhd1dEV09TgdMROIZi6vFz/MT9Wtik6joQi/tQ3zCwIZCSR53ksLO4jG1DD31AiBAA"),
+            self_signing_key_signature: Some(
+                "Ls6CeoA4LoPCHuSwG96kbhd1dEV09TgdMROIZi6vFz/MT9Wtik6joQi/tQ3zCwIZCSR53ksLO4jG1DD31AiBAA",
+            ),
         }
     }
 

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -2,18 +2,19 @@ use std::{collections::BTreeMap, default::Default};
 
 use insta::{assert_json_snapshot, with_settings};
 use ruma::{
+    CanonicalJsonValue, CrossSigningKeyId, CrossSigningOrDeviceSignatures,
+    CrossSigningOrDeviceSigningKeyId, DeviceId, OwnedBase64PublicKey,
+    OwnedBase64PublicKeyOrDeviceId, OwnedDeviceId, OwnedUserId, SigningKeyAlgorithm, UserId,
     api::client::keys::get_keys::v3::Response as KeyQueryResponse,
     device_id,
     encryption::{CrossSigningKey, DeviceKeys, KeyUsage},
     serde::Raw,
-    user_id, CanonicalJsonValue, CrossSigningKeyId, CrossSigningOrDeviceSignatures,
-    CrossSigningOrDeviceSigningKeyId, DeviceId, OwnedBase64PublicKey,
-    OwnedBase64PublicKeyOrDeviceId, OwnedDeviceId, OwnedUserId, SigningKeyAlgorithm, UserId,
+    user_id,
 };
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature};
 
-use super::keys_query::{keys_query, master_keys, KeysQueryUser};
+use super::keys_query::{KeysQueryUser, keys_query, master_keys};
 use crate::{
     ruma_response_from_json, ruma_response_to_json,
     test_json::keys_query::{device_keys_payload, self_signing_keys},

--- a/testing/matrix-sdk-test/src/test_json/members.rs
+++ b/testing/matrix-sdk-test/src/test_json/members.rs
@@ -1,7 +1,7 @@
 //! Example responses to `GET /_matrix/client/v3/rooms/{roomId}/members`
 
 use once_cell::sync::Lazy;
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 
 use super::DEFAULT_TEST_ROOM_ID;
 

--- a/testing/matrix-sdk-test/src/test_json/mod.rs
+++ b/testing/matrix-sdk-test/src/test_json/mod.rs
@@ -5,7 +5,7 @@
 //! the test data needs to be contained within this crate.
 
 use once_cell::sync::Lazy;
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 
 use crate::DEFAULT_TEST_ROOM_ID;
 

--- a/testing/matrix-sdk-test/src/test_json/search_users.rs
+++ b/testing/matrix-sdk-test/src/test_json/search_users.rs
@@ -1,5 +1,5 @@
 use once_cell::sync::Lazy;
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 
 pub static SEARCH_USERS_REQUEST: Lazy<JsonValue> = Lazy::new(|| {
     json!({

--- a/testing/matrix-sdk-test/src/test_json/sync.rs
+++ b/testing/matrix-sdk-test/src/test_json/sync.rs
@@ -1,8 +1,8 @@
 //! Complete sync responses.
 
 use once_cell::sync::Lazy;
-use ruma::{room_id, RoomId};
-use serde_json::{json, Value as JsonValue};
+use ruma::{RoomId, room_id};
+use serde_json::{Value as JsonValue, json};
 
 use crate::DEFAULT_TEST_ROOM_ID;
 

--- a/testing/matrix-sdk-test/src/test_json/sync_events.rs
+++ b/testing/matrix-sdk-test/src/test_json/sync_events.rs
@@ -1,7 +1,7 @@
 //! Discrete events found in a sync response.
 
 use once_cell::sync::Lazy;
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 
 use crate::DEFAULT_TEST_ROOM_ID;
 

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -6,7 +6,7 @@ use std::{
 use clap::{Args, Subcommand, ValueEnum};
 use xshell::cmd;
 
-use crate::{build_docs, sh, workspace, DenyWarnings, Result, NIGHTLY};
+use crate::{DenyWarnings, NIGHTLY, Result, build_docs, sh, workspace};
 
 const WASM_TIMEOUT_ENV_KEY: &str = "WASM_BINDGEN_TEST_TIMEOUT";
 const WASM_TIMEOUT_VALUE: &str = "120";
@@ -399,10 +399,7 @@ fn run_wasm_pack_tests(cmd: Option<WasmFeatureSet>) -> Result<()> {
                 "--no-default-features --features js,indexeddb,e2e-encryption,rustls-tls,testing --lib",
             ),
         ),
-        (
-            WasmFeatureSet::IndexeddbAllFeatures,
-            ("crates/matrix-sdk-indexeddb", ""),
-        ),
+        (WasmFeatureSet::IndexeddbAllFeatures, ("crates/matrix-sdk-indexeddb", "")),
         (
             WasmFeatureSet::IndexeddbCrypto,
             ("crates/matrix-sdk-indexeddb", "--no-default-features --features e2e-encryption"),

--- a/xtask/src/fixup.rs
+++ b/xtask/src/fixup.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand};
 use xshell::cmd;
 
-use crate::{sh, workspace, Result, NIGHTLY};
+use crate::{NIGHTLY, Result, sh, workspace};
 
 #[derive(Args)]
 pub struct FixupArgs {

--- a/xtask/src/kotlin.rs
+++ b/xtask/src/kotlin.rs
@@ -5,7 +5,7 @@ use clap::{Args, Subcommand, ValueEnum};
 use uniffi_bindgen::{bindings::KotlinBindingGenerator, library_mode::generate_bindings};
 use xshell::cmd;
 
-use crate::{sh, workspace, Result};
+use crate::{Result, sh, workspace};
 
 struct PackageValues {
     name: &'static str,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,7 +15,7 @@ use fixup::FixupArgs;
 use kotlin::KotlinArgs;
 use release::ReleaseArgs;
 use swift::SwiftArgs;
-use xshell::{cmd, Shell};
+use xshell::{Shell, cmd};
 
 const NIGHTLY: &str = "nightly-2025-02-20";
 

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand, ValueEnum};
-use xshell::{cmd, Cmd};
+use xshell::{Cmd, cmd};
 
-use crate::{sh, Result};
+use crate::{Result, sh};
 
 #[derive(Args)]
 pub struct ReleaseArgs {
@@ -86,7 +86,9 @@ fn check_prerequisites() {
 
     if cmd!(sh, "cargo release --version").quiet().ignore_stdout().run().is_err() {
         eprintln!("This command requires cargo-release, please install it.");
-        eprintln!("More info can be found at: https://github.com/crate-ci/cargo-release?tab=readme-ov-file#install");
+        eprintln!(
+            "More info can be found at: https://github.com/crate-ci/cargo-release?tab=readme-ov-file#install"
+        );
 
         std::process::exit(1);
     }

--- a/xtask/src/swift.rs
+++ b/xtask/src/swift.rs
@@ -8,7 +8,7 @@ use clap::{Args, Subcommand};
 use uniffi_bindgen::{bindings::SwiftBindingGenerator, library_mode::generate_bindings};
 use xshell::cmd;
 
-use crate::{sh, workspace, Result};
+use crate::{Result, sh, workspace};
 
 /// Builds the SDK for Swift as a Static Library or XCFramework.
 #[derive(Args)]

--- a/xtask/src/workspace.rs
+++ b/xtask/src/workspace.rs
@@ -4,7 +4,7 @@ use camino::Utf8PathBuf;
 use serde::Deserialize;
 use xshell::cmd;
 
-use crate::{sh, Result};
+use crate::{Result, sh};
 
 pub fn root_path() -> Result<Utf8PathBuf> {
     #[derive(Deserialize)]


### PR DESCRIPTION
Ahead of the main upgrade to Rust 2024, to avoid having to rebase that PR over and over again because it will likely take much longer to land than this.

Signed-off-by: Jonas Platte <jplatte+matrix@posteo.de>
