### PR TITLE
refactor(wasm) Remove some unnecessary wasm32 differentiations

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -126,13 +126,7 @@ impl Deref for EventCacheStoreLockGuard<'_> {
 pub enum EventCacheStoreError {
     /// An error happened in the underlying database backend.
     #[error(transparent)]
-    #[cfg(not(target_family = "wasm"))]
     Backend(Box<dyn std::error::Error + Send + Sync>),
-
-    /// An error happened in the underlying database backend.
-    #[error(transparent)]
-    #[cfg(target_family = "wasm")]
-    Backend(Box<dyn std::error::Error>),
 
     /// The store is locked with a passphrase and an incorrect passphrase
     /// was given.
@@ -175,22 +169,9 @@ impl EventCacheStoreError {
     ///
     /// Shorthand for `EventCacheStoreError::Backend(Box::new(error))`.
     #[inline]
-    #[cfg(not(target_family = "wasm"))]
     pub fn backend<E>(error: E) -> Self
     where
         E: std::error::Error + Send + Sync + 'static,
-    {
-        Self::Backend(Box::new(error))
-    }
-
-    /// Create a new [`Backend`][Self::Backend] error.
-    ///
-    /// Shorthand for `EventCacheStoreError::Backend(Box::new(error))`.
-    #[inline]
-    #[cfg(target_family = "wasm")]
-    pub fn backend<E>(error: E) -> Self
-    where
-        E: std::error::Error + 'static,
     {
         Self::Backend(Box::new(error))
     }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -61,7 +61,7 @@ use crate::{
     deserialized_responses::DisplayName,
     event_cache::store as event_cache_store,
     room::{RoomInfo, RoomInfoNotableUpdate, RoomState},
-    MinimalRoomMemberEvent, Room, RoomStateFilter, SendOutsideWasm, SessionMeta, SyncOutsideWasm,
+    MinimalRoomMemberEvent, Room, RoomStateFilter, SessionMeta,
 };
 
 pub(crate) mod ambiguity_map;
@@ -90,14 +90,8 @@ pub use self::{
 #[derive(Debug, thiserror::Error)]
 pub enum StoreError {
     /// An error happened in the underlying database backend.
-    #[cfg(not(target_family = "wasm"))]
     #[error(transparent)]
     Backend(Box<dyn std::error::Error + Send + Sync>),
-
-    /// An error happened in the underlying database backend.
-    #[cfg(target_family = "wasm")]
-    #[error(transparent)]
-    Backend(Box<dyn std::error::Error>),
     /// An error happened while serializing or deserializing some data.
     #[error(transparent)]
     Json(#[from] serde_json::Error),
@@ -140,7 +134,7 @@ impl StoreError {
     #[inline]
     pub fn backend<E>(error: E) -> Self
     where
-        E: std::error::Error + SendOutsideWasm + SyncOutsideWasm + 'static,
+        E: std::error::Error + Send + Sync + 'static,
     {
         Self::Backend(Box::new(error))
     }

--- a/crates/matrix-sdk/src/authentication/mod.rs
+++ b/crates/matrix-sdk/src/authentication/mod.rs
@@ -48,10 +48,7 @@ impl fmt::Debug for SessionTokens {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
 pub(crate) type SessionCallbackError = Box<dyn std::error::Error + Send + Sync>;
-#[cfg(target_family = "wasm")]
-pub(crate) type SessionCallbackError = Box<dyn std::error::Error>;
 
 #[cfg(not(target_family = "wasm"))]
 pub(crate) type SaveSessionCallback =


### PR DESCRIPTION
Some of these Box<dyn Error + Send + Sync> are okay, but a few are problematic.

Confirmed this still compiles fine on the fully working wasm tree.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
