### PR TITLE
widgets: Throw away crypto related fields of raw decrypted to-device

### DIFF
--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -286,6 +286,7 @@ impl MatrixDriver {
                         .and_then(|clean_event_helper| {
                             serde_json::value::to_raw_value(&clean_event_helper)
                         })
+                        .map_err(|err| warn!(?room_id, "Unable to process to-device message for widget: {err}"))
                         .map(|box_value | {
                             tx.send(Raw::from_json(box_value))
                         });

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -35,6 +35,7 @@ use ruma::{
     to_device::DeviceIdOrAllDevices,
     EventId, OwnedUserId, RoomId, TransactionId,
 };
+use serde::{Deserialize, Serialize};
 use serde_json::{value::RawValue as RawJsonValue, Value};
 use tokio::sync::{
     broadcast::{error::RecvError, Receiver},
@@ -267,9 +268,28 @@ impl MatrixDriver {
                         return;
                     };
 
-                    // There are no per-room specific decryption settings, so we can just send to the
-                    // widget
-                    let _ = tx.send(raw);
+                    // There are no per-room specific decryption settings (trust requirements), so we can just send it to the
+                    // widget.
+
+                    // The raw to-device event contains more fields than the widget needs, so we need to clean it up
+                    // to only type/content/sender.
+                    #[derive(Deserialize, Serialize)]
+                    struct CleanEventHelper<'a> {
+                        #[serde(rename = "type")]
+                        event_type: String,
+                        #[serde(borrow)]
+                        content: &'a RawJsonValue,
+                        sender: String,
+                    }
+
+                    let _ = serde_json::from_str::<CleanEventHelper<'_>>(raw.json().get())
+                        .and_then(|clean_event_helper| {
+                            serde_json::value::to_raw_value(&clean_event_helper)
+                        })
+                        .map(|box_value | {
+                            tx.send(Raw::from_json(box_value))
+                        });
+
                 } else {
                     // forward to the widget
                     // It is ok to send an encrypted to-device message even if the room is clear.

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -643,10 +643,9 @@ async fn test_accept_encrypted_to_device_in_e2ee_room() {
     assert_eq!(data["type"], "my.custom.to.device");
     assert_eq!(data["content"]["call_id"], "");
     assert_eq!(data["sender"], "@bob:example.org");
-    // TODO: Currently the rust-sdk is exposing more than type/content/sender in
-    // the event this should be exposed to the widget but it should be fixed
-    // at the crypto crate level see https://github.com/matrix-org/matrix-rust-sdk/pull/5201
-    // assert_eq!(data.len(), 3);
+    // Only these 3 fields should be exposed to the widget (no
+    // `sender_device_keys`/`keys`/..)
+    assert_eq!(data.len(), 3);
 }
 
 /// Test that "internal" to-device messages are never forwarded to the widgets.


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Alternative for https://github.com/matrix-org/matrix-rust-sdk/pull/5201

Ensure that only sender/type/content are exposed to the widgets, and not the crypto-related fields.

Before:
```
{
    "type": "my.custom.to.device",
    "content": {
        "call_id": ""
    },
    "keys": {
        "ed25519": "hk5X9uSb0OwhdAFrlcdtzNkE+AmL/85XdPO5v1Ocgg"
    },
    "recipient": "@alice:example.org",
    "recipient_keys": {
        "ed25519": "WgEu0w6T511+R03R4dUQP53d9OQTVJr6F/cYmF3Civs"
    },
    "sender": "@bob:example.org",
    "sender_device_keys": {
        "algorithms": [
            "m.olm.v1.curve25519-aes-sha2",
            "m.megolm.v1.aes-sha2"
        ],
        "device_id": "B0B0B0B0B",
        "keys": {
            "curve25519:B0B0B0B0B": "Bwl3kZjTnxxKNufqMiG1XoJg1VxGQko5asIy6aq4pUk",
            "ed25519:B0B0B0B0B": "hk5X9uSb0OwhdAFrlcdtzNkE+AmLT/85XdPO5v1Ocgg"
        },
        "signatures": {
            "@bob:example.org": {
                "ed25519:B0B0B0B0B": "XvyTR/3piBBCl4Xq4wHjrjhnJdgMMtXvpMh9itG1Nr9GUI80n8bQ32CtHTZCENk77esgUZ4Tkzy0bUGJRMzZAg"
            }
        },
    	"user_id": "@bob:example.org",
    },
}
```

After
```
{
    "type": "my.custom.to.device",
    "content": {
        "call_id": ""
    },
    "sender": "@bob:example.org",
}
```

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
