### PR TITLE
refactor(crypto): Hold a DecryptionSettings in base Client

### DIFF
--- a/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use matrix_sdk_common::deserialized_responses::TimelineEvent;
-use matrix_sdk_crypto::{DecryptionSettings, RoomEventDecryptionResult};
+use matrix_sdk_crypto::RoomEventDecryptionResult;
 use ruma::{events::AnySyncTimelineEvent, serde::Raw, RoomId};
 
 use super::{super::verification, E2EE};
@@ -33,11 +33,11 @@ pub async fn sync_timeline_event(
 ) -> Result<Option<TimelineEvent>> {
     let Some(olm) = e2ee.olm_machine else { return Ok(None) };
 
-    let decryption_settings =
-        DecryptionSettings { sender_device_trust_requirement: e2ee.decryption_trust_requirement };
-
     Ok(Some(
-        match olm.try_decrypt_room_event(event.cast_ref(), room_id, &decryption_settings).await? {
+        match olm
+            .try_decrypt_room_event(event.cast_ref(), room_id, e2ee.decryption_settings)
+            .await?
+        {
             RoomEventDecryptionResult::Decrypted(decrypted) => {
                 // Note: the push actions are set by the caller.
                 let timeline_event = TimelineEvent::from_decrypted(decrypted, None);

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use matrix_sdk_crypto::{OlmMachine, TrustRequirement};
+use matrix_sdk_crypto::{DecryptionSettings, OlmMachine};
 
 pub mod decrypt;
 pub mod to_device;
@@ -22,16 +22,16 @@ pub mod tracked_users;
 #[derive(Clone)]
 pub struct E2EE<'a> {
     pub olm_machine: Option<&'a OlmMachine>,
-    pub decryption_trust_requirement: TrustRequirement,
+    pub decryption_settings: &'a DecryptionSettings,
     pub verification_is_allowed: bool,
 }
 
 impl<'a> E2EE<'a> {
     pub fn new(
         olm_machine: Option<&'a OlmMachine>,
-        decryption_trust_requirement: TrustRequirement,
+        decryption_settings: &'a DecryptionSettings,
         verification_is_allowed: bool,
     ) -> Self {
-        Self { olm_machine, decryption_trust_requirement, verification_is_allowed }
+        Self { olm_machine, decryption_settings, verification_is_allowed }
     }
 }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -75,7 +75,7 @@ impl BaseClient {
                 .collect(),
             processors::e2ee::E2EE::new(
                 olm_machine.as_ref(),
-                self.decryption_trust_requirement,
+                &self.decryption_settings,
                 self.handle_verification_events,
             ),
         )
@@ -152,7 +152,7 @@ impl BaseClient {
                 #[cfg(feature = "e2e-encryption")]
                 processors::e2ee::E2EE::new(
                     self.olm_machine().await.as_ref(),
-                    self.decryption_trust_requirement,
+                    &self.decryption_settings,
                     self.handle_verification_events,
                 ),
                 processors::notification::Notification::new(

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -20,6 +20,8 @@ use std::path::Path;
 use std::{fmt, sync::Arc};
 
 use homeserver_config::*;
+#[cfg(feature = "e2e-encryption")]
+use matrix_sdk_base::crypto::DecryptionSettings;
 use matrix_sdk_base::{store::StoreConfig, BaseClient};
 #[cfg(feature = "sqlite")]
 use matrix_sdk_sqlite::SqliteStoreConfig;
@@ -107,7 +109,7 @@ pub struct ClientBuilder {
     #[cfg(feature = "e2e-encryption")]
     room_key_recipient_strategy: CollectStrategy,
     #[cfg(feature = "e2e-encryption")]
-    decryption_trust_requirement: TrustRequirement,
+    decryption_settings: DecryptionSettings,
     #[cfg(feature = "e2e-encryption")]
     enable_share_history_on_invite: bool,
     cross_process_store_locks_holder_name: String,
@@ -134,7 +136,9 @@ impl ClientBuilder {
             #[cfg(feature = "e2e-encryption")]
             room_key_recipient_strategy: Default::default(),
             #[cfg(feature = "e2e-encryption")]
-            decryption_trust_requirement: TrustRequirement::Untrusted,
+            decryption_settings: DecryptionSettings {
+                sender_device_trust_requirement: TrustRequirement::Untrusted,
+            },
             #[cfg(feature = "e2e-encryption")]
             enable_share_history_on_invite: false,
             cross_process_store_locks_holder_name:
@@ -443,11 +447,8 @@ impl ClientBuilder {
 
     /// Set the trust requirement to be used when decrypting events.
     #[cfg(feature = "e2e-encryption")]
-    pub fn with_decryption_trust_requirement(
-        mut self,
-        trust_requirement: TrustRequirement,
-    ) -> Self {
-        self.decryption_trust_requirement = trust_requirement;
+    pub fn with_decryption_settings(mut self, decryption_settings: DecryptionSettings) -> Self {
+        self.decryption_settings = decryption_settings;
         self
     }
 
@@ -519,7 +520,7 @@ impl ClientBuilder {
             #[cfg(feature = "e2e-encryption")]
             {
                 client.room_key_recipient_strategy = self.room_key_recipient_strategy;
-                client.decryption_trust_requirement = self.decryption_trust_requirement;
+                client.decryption_settings = self.decryption_settings;
             }
 
             client
@@ -975,11 +976,13 @@ pub(crate) mod tests {
         let homeserver = make_mock_homeserver().await;
         let builder = ClientBuilder::new()
             .server_name_or_homeserver_url(homeserver.uri())
-            .with_decryption_trust_requirement(TrustRequirement::CrossSigned);
+            .with_decryption_settings(DecryptionSettings {
+                sender_device_trust_requirement: TrustRequirement::CrossSigned,
+            });
 
         let client = builder.build().await.unwrap();
         assert_matches!(
-            client.base_client().decryption_trust_requirement,
+            client.base_client().decryption_settings.sender_device_trust_requirement,
             TrustRequirement::CrossSigned
         );
     }
@@ -991,11 +994,13 @@ pub(crate) mod tests {
 
         let builder = ClientBuilder::new()
             .server_name_or_homeserver_url(homeserver.uri())
-            .with_decryption_trust_requirement(TrustRequirement::Untrusted);
+            .with_decryption_settings(DecryptionSettings {
+                sender_device_trust_requirement: TrustRequirement::Untrusted,
+            });
 
         let client = builder.build().await.unwrap();
         assert_matches!(
-            client.base_client().decryption_trust_requirement,
+            client.base_client().decryption_settings.sender_device_trust_requirement,
             TrustRequirement::Untrusted
         );
     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -28,7 +28,7 @@ use eyeball_im::{Vector, VectorDiff};
 use futures_core::Stream;
 use futures_util::StreamExt;
 #[cfg(feature = "e2e-encryption")]
-use matrix_sdk_base::crypto::store::LockableCryptoStore;
+use matrix_sdk_base::crypto::{store::LockableCryptoStore, DecryptionSettings};
 use matrix_sdk_base::{
     event_cache::store::EventCacheStoreLock,
     store::{DynStateStore, RoomLoadSettings, ServerInfo, WellKnownResponse},
@@ -2659,6 +2659,12 @@ impl Client {
                 Err(Error::Media(MediaError::FetchMaxUploadSizeFailed(error.to_string())))
             }
         }
+    }
+
+    /// The settings to use for decrypting events.
+    #[cfg(feature = "e2e-encryption")]
+    pub fn decryption_settings(&self) -> &DecryptionSettings {
+        &self.base_client().decryption_settings
     }
 }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -33,10 +33,7 @@ pub use identity_status_changes::IdentityStatusChanges;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::{IdentityStatusChange, RoomIdentityProvider, UserIdentity};
 #[cfg(feature = "e2e-encryption")]
-use matrix_sdk_base::{
-    crypto::{DecryptionSettings, RoomEventDecryptionResult},
-    deserialized_responses::EncryptionInfo,
-};
+use matrix_sdk_base::{crypto::RoomEventDecryptionResult, deserialized_responses::EncryptionInfo};
 use matrix_sdk_base::{
     deserialized_responses::{
         RawAnySyncOrStrippedState, RawSyncOrStrippedState, SyncOrStrippedState,
@@ -1508,12 +1505,12 @@ impl Room {
         let machine = self.client.olm_machine().await;
         let machine = machine.as_ref().ok_or(Error::NoOlmMachine)?;
 
-        let decryption_settings = DecryptionSettings {
-            sender_device_trust_requirement: self.client.base_client().decryption_trust_requirement,
-        };
-
         match machine
-            .try_decrypt_room_event(event.cast_ref(), self.inner.room_id(), &decryption_settings)
+            .try_decrypt_room_event(
+                event.cast_ref(),
+                self.inner.room_id(),
+                self.client.decryption_settings(),
+            )
             .await?
         {
             RoomEventDecryptionResult::Decrypted(decrypted) => {


### PR DESCRIPTION
Previously, we held a `TrustRequirement` inside `Client`, and had to wrap it in a `DecryptionSettings` manually a couple of times.

It feels more right to hold on to a `DecryptionSettings` directly. If there were ever some additional settings, most likely we would need them all here.

If I haven't screwed it up, this should not affect behaviour in any way.

Prep for https://github.com/matrix-org/matrix-rust-sdk/issues/4147