### PR TITLE
feat(wasm): Mark CapabilitiesProvider::acquire_capabilities as SendOutsideWasm

### DIFF
--- a/crates/matrix-sdk/src/widget/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/capabilities.rs
@@ -36,7 +36,7 @@ pub trait CapabilitiesProvider: SendOutsideWasm + SyncOutsideWasm + 'static {
     fn acquire_capabilities(
         &self,
         capabilities: Capabilities,
-    ) -> impl Future<Output = Capabilities> + Send;
+    ) -> impl Future<Output = Capabilities> + SendOutsideWasm;
 }
 
 /// Capabilities that a widget can request from a client.


### PR DESCRIPTION
Correct an accidental recent addition of a `Send` trait instead of `SendOutsideWasm`

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
