### PR TITLE
feat(wasm): Address timeline panic to avoid resume_unwind on Wasm

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -1565,7 +1565,10 @@ mod galleries {
                         return Ok(());
                     }
                     error!("task panicked! resuming panic from here.");
+                    #[cfg(not(target_family = "wasm"))]
                     panic::resume_unwind(err.into_panic());
+                    #[cfg(target_family = "wasm")]
+                    panic!("task panicked! {err}");
                 }
             }
         }


### PR DESCRIPTION
<!-- description of the changes in this PR -->
It doesn't seem to be possible to do a resume_unwind on Wasm. Given how severe a panic is, this seems like an acceptable workaround for now.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
