### PR TITLE
refactor(wasm): Remove special Send/Sync behavior for Wasm on a crypto-store error

### DIFF
--- a/crates/matrix-sdk-crypto/src/store/error.rs
+++ b/crates/matrix-sdk-crypto/src/store/error.rs
@@ -77,13 +77,7 @@ pub enum CryptoStoreError {
 
     /// A problem with the underlying database backend
     #[error(transparent)]
-    #[cfg(not(target_family = "wasm"))]
     Backend(Box<dyn std::error::Error + Send + Sync>),
-
-    /// A problem with the underlying database backend
-    #[error(transparent)]
-    #[cfg(target_family = "wasm")]
-    Backend(Box<dyn std::error::Error>),
 
     /// An error due to an invalid generation in a cross-process locking scheme.
     #[error("invalid lock generation: {0}")]
@@ -95,22 +89,9 @@ impl CryptoStoreError {
     ///
     /// Shorthand for `StoreError::Backend(Box::new(error))`.
     #[inline]
-    #[cfg(not(target_family = "wasm"))]
     pub fn backend<E>(error: E) -> Self
     where
         E: std::error::Error + Send + Sync + 'static,
-    {
-        Self::Backend(Box::new(error))
-    }
-
-    /// Create a new [`Backend`][Self::Backend] error.
-    ///
-    /// Shorthand for `StoreError::Backend(Box::new(error))`.
-    #[inline]
-    #[cfg(target_family = "wasm")]
-    pub fn backend<E>(error: E) -> Self
-    where
-        E: std::error::Error + 'static,
     {
         Self::Backend(Box::new(error))
     }


### PR DESCRIPTION
Not necessary it turns out

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
