### PR TITLE
feat(wasm): Adjust platform init on Wasm to avoid tokio environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,6 +878,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3094,6 +3104,7 @@ dependencies = [
  "anyhow",
  "as_variant",
  "async-compat",
+ "console_error_panic_hook",
  "extension-trait",
  "eyeball-im",
  "futures-util",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -80,6 +80,7 @@ uuid = { version = "1.4.1", features = ["v4"] }
 zeroize.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]
+console_error_panic_hook = "0.1.7"
 tokio = { workspace = true, features = ["sync", "macros"] }
 uniffi.workspace = true
 


### PR DESCRIPTION
The multi-threaded tokio environment does not work in Wasm, nor does Logging.

`console_error_panic_hook` turns rust panics into JS console statements.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
