### PR TITLE
chore(sdk): Rename `RoomEventCacheListener` to `RoomEventCacheSubscriber`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -22,7 +22,7 @@ use futures_util::{pin_mut, StreamExt};
 use matrix_sdk::{
     crypto::store::types::RoomKeyInfo,
     encryption::backups::BackupState,
-    event_cache::{EventsOrigin, RoomEventCache, RoomEventCacheListener, RoomEventCacheUpdate},
+    event_cache::{EventsOrigin, RoomEventCache, RoomEventCacheSubscriber, RoomEventCacheUpdate},
     executor::spawn,
     send_queue::RoomSendQueueUpdate,
     Room,
@@ -356,7 +356,7 @@ where
 async fn room_event_cache_updates_task(
     room_event_cache: RoomEventCache,
     timeline_controller: TimelineController,
-    mut event_subscriber: RoomEventCacheListener,
+    mut room_event_cache_subscriber: RoomEventCacheSubscriber,
     timeline_focus: TimelineFocus,
 ) {
     trace!("Spawned the event subscriber task.");
@@ -364,7 +364,7 @@ async fn room_event_cache_updates_task(
     loop {
         trace!("Waiting for an event.");
 
-        let update = match event_subscriber.recv().await {
+        let update = match room_event_cache_subscriber.recv().await {
             Ok(up) => up,
             Err(RecvError::Closed) => break,
             Err(RecvError::Lagged(num_skipped)) => {

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Features
+
 - Add logging to `Room::join`.
   ([#5260](https://github.com/matrix-org/matrix-rust-sdk/pull/5260))
 - `ClientServerCapabilities` has been renamed to `ClientServerInfo`. Alongside this,
@@ -15,6 +17,11 @@ All notable changes to this project will be documented in this file.
 - `Client::add_event_handler`: Set `Option<EncryptionInfo>` in `EventHandlerData` for to-device messages.
   If the to-device message was encrypted, the `EncryptionInfo` will be set. If it is `None` the message was sent in clear.
   ([#5099](https://github.com/matrix-org/matrix-rust-sdk/pull/5099))
+
+### Refactor
+
+- `RoomEventCacheListener` is renamed `RoomEventCacheSubscriber`
+  ([#5269](https://github.com/matrix-org/matrix-rust-sdk/pull/5269))
 
 ## [0.12.0] - 2025-06-10
 

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -193,13 +193,13 @@ impl EventCache {
             // Force-initialize the sender in the [`RoomEventCacheInner`].
             self.inner.auto_shrink_sender.get_or_init(|| tx);
 
-            let auto_shrink_linked_chunk_tasks =
+            let auto_shrink_linked_chunk_task =
                 spawn(Self::auto_shrink_linked_chunk_task(self.inner.clone(), rx));
 
             Arc::new(EventCacheDropHandles {
                 listen_updates_task,
                 ignore_user_list_update_task,
-                auto_shrink_linked_chunk_task: auto_shrink_linked_chunk_tasks,
+                auto_shrink_linked_chunk_task,
             })
         });
 

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -188,13 +188,15 @@ impl EventCache {
                 client.subscribe_to_ignore_user_list_changes(),
             ));
 
-            let (tx, rx) = mpsc::channel(32);
+            let (auto_shrink_sender, auto_shrink_receiver) = mpsc::channel(32);
 
             // Force-initialize the sender in the [`RoomEventCacheInner`].
-            self.inner.auto_shrink_sender.get_or_init(|| tx);
+            self.inner.auto_shrink_sender.get_or_init(|| auto_shrink_sender);
 
-            let auto_shrink_linked_chunk_task =
-                spawn(Self::auto_shrink_linked_chunk_task(self.inner.clone(), rx));
+            let auto_shrink_linked_chunk_task = spawn(Self::auto_shrink_linked_chunk_task(
+                self.inner.clone(),
+                auto_shrink_receiver,
+            ));
 
             Arc::new(EventCacheDropHandles {
                 listen_updates_task,

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -68,6 +68,11 @@ impl fmt::Debug for RoomEventCache {
 
 /// Thin wrapper for a room event cache listener, so as to trigger side-effects
 /// when all listeners are gone.
+///
+/// The current side-effect is: auto-shrinking the [`RoomEventCache`] when no
+/// more listeners are active. This is an optimisation to reduce the number of
+/// data held in memory by a [`RoomEventCache`]: when no more listeners are
+/// active, all data are reduced to the minimum.
 #[allow(missing_debug_implementations)]
 pub struct RoomEventCacheListener {
     /// Underlying receiver of the room event cache's updates.
@@ -174,7 +179,7 @@ impl RoomEventCache {
     ///
     /// Use [`RoomEventCache::events`] to get all current events without the
     /// listener/subscriber. Creating, and especially dropping, a
-    /// [`RoomEventCacheListener`] isn't free.
+    /// [`RoomEventCacheListener`] isn't free, as it triggers side-effects.
     pub async fn subscribe(&self) -> (Vec<Event>, RoomEventCacheListener) {
         let state = self.inner.state.read().await;
         let events = state.events().events().map(|(_position, item)| item.clone()).collect();


### PR DESCRIPTION
Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/5247.

This patch removes a name ambiguity around _listener_ vs. _subscriber_.
Both terms are used to talk about `RoomEventCacheListener`. We usually
use the term _subscriber_ for the type being returned by a `subscribe`
method. The code refers to this sometimes as listener, sometimes
as subscriber, sometimes both in the same sentence, which can be very
confusing! This patch solves this by using the _subscriber_ term only.

Moreover, the term _listener_ refers to a callback (usually a function) that is
passed to an event-based or reactive system, like we have in `matrix_sdk_ffi`
for example. It's not appropriate here.