### PR TITLE
IndexedDB: Add transaction functionality for `EventCacheStore` backend

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/error.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/error.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License
 
-#![allow(unused)]
+use matrix_sdk_base::{SendOutsideWasm, SyncOutsideWasm};
 
-mod error;
-mod migrations;
-mod serializer;
-mod transaction;
-mod types;
+/// A trait that combines the necessary traits needed for asynchronous runtimes,
+/// but excludes them when running in a web environment - i.e., when
+/// `#[cfg(target_family = "wasm")]`.
+pub trait AsyncErrorDeps: std::error::Error + SendOutsideWasm + SyncOutsideWasm + 'static {}
+
+impl<T> AsyncErrorDeps for T where T: std::error::Error + SendOutsideWasm + SyncOutsideWasm + 'static
+{}

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -16,4 +16,5 @@
 
 mod migrations;
 mod serializer;
+mod transaction;
 mod types;

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
@@ -98,8 +98,8 @@ impl IndexeddbEventCacheStoreSerializer {
         T: Indexed,
         K: IndexedKeyBounds<T> + Serialize,
     {
-        let lower = serde_wasm_bindgen::to_value(&K::encode_lower(room_id, &self.inner))?;
-        let upper = serde_wasm_bindgen::to_value(&K::encode_upper(room_id, &self.inner))?;
+        let lower = serde_wasm_bindgen::to_value(&K::lower_key(room_id, &self.inner))?;
+        let upper = serde_wasm_bindgen::to_value(&K::upper_key(room_id, &self.inner))?;
         IdbKeyRange::bound(&lower, &upper).map_err(Into::into)
     }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
@@ -61,6 +61,11 @@ impl IndexeddbEventCacheStoreSerializer {
         Self { inner }
     }
 
+    /// Returns a reference to the inner [`IndexeddbSerializer`].
+    pub fn inner(&self) -> &IndexeddbSerializer {
+        &self.inner
+    }
+
     /// Encodes an key for a [`Indexed`] type.
     ///
     /// Note that the particular key which is encoded is defined by the type

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
@@ -28,8 +28,8 @@ use crate::{
     serializer::IndexeddbSerializer,
 };
 
-mod traits;
-mod types;
+pub mod traits;
+pub mod types;
 
 #[derive(Debug, Error)]
 pub enum IndexeddbEventCacheStoreSerializerError<IndexingError> {

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -73,6 +73,22 @@ pub trait IndexedKey<T: Indexed> {
 /// A trait for constructing the bounds of an [`IndexedKey`].
 ///
 /// This is useful when constructing range queries in IndexedDB.
+///
+/// The [`IndexedKeyComponentBounds`] helps to specify the upper and lower
+/// bounds of the components that are used to create the final key, while the
+/// `IndexedKeyBounds` are the upper and lower bounds of the final key itself.
+///
+/// While these concepts are similar and often produce the same results, there
+/// are cases where these two concepts produce very different results. Namely,
+/// when any of the components are encrypted in the process of constructing the
+/// final key, then the component bounds and the key bounds produce very
+/// different results.
+///
+/// So, for instance, consider the `EventId`, which may be encrypted before
+/// being used in a final key. One cannot construct the upper and lower bounds
+/// of the final key using the upper and lower bounds of the `EventId`, because
+/// once the `EventId` is encrypted, the resultant value will no longer express
+/// the proper bound.
 pub trait IndexedKeyBounds<T: Indexed>: IndexedKey<T> {
     /// Constructs the lower bound of the key.
     fn lower_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self;
@@ -102,6 +118,9 @@ where
 /// This is useful when constructing range queries in IndexedDB. Note that this
 /// trait should not be implemented for key components that are going to be
 /// encrypted as ordering properties will not be preserved.
+///
+/// One may be interested to read the documentation of [`IndexedKeyBounds`] to
+/// get a better overview of how these two interact.
 pub trait IndexedKeyComponentBounds<T: Indexed>: IndexedKeyBounds<T> {
     /// Constructs the lower bound of the key components.
     fn lower_key_components() -> Self::KeyComponents;

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -24,6 +24,9 @@ use crate::serializer::IndexeddbSerializer;
 /// decryption, in the case the high-level type must be encrypted before
 /// storage.
 pub trait Indexed: Sized {
+    /// The name of the object store in IndexedDB.
+    const OBJECT_STORE: &'static str;
+
     /// The indexed type that is used for storage in IndexedDB.
     type IndexedType;
     /// The error type that is returned when conversion fails.

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -50,6 +50,9 @@ pub trait Indexed: Sized {
 ///
 /// Each implementation represents a key on an [`Indexed`] type.
 pub trait IndexedKey<T: Indexed> {
+    /// The index name for the key, if it represents an index.
+    const INDEX: Option<&'static str> = None;
+
     /// Any extra data used to construct the key.
     type KeyComponents;
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -68,8 +68,14 @@ pub trait IndexedKey<T: Indexed> {
 ///
 /// This is useful when constructing range queries in IndexedDB.
 pub trait IndexedKeyBounds<T: Indexed>: IndexedKey<T> {
+    /// Constructs the lower bound of the key components.
+    fn lower_key_components() -> Self::KeyComponents;
+
     /// Encodes the lower bound of the key.
     fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self;
+
+    /// Constructs the upper bound of the key components.
+    fn upper_key_components() -> Self::KeyComponents;
 
     /// Encodes the upper bound of the key.
     fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self;

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -68,25 +68,38 @@ pub trait IndexedKey<T: Indexed> {
 ///
 /// This is useful when constructing range queries in IndexedDB.
 pub trait IndexedKeyBounds<T: Indexed>: IndexedKey<T> {
-    /// Constructs the lower bound of the key components.
-    fn lower_key_components() -> Self::KeyComponents;
-
     /// Constructs the lower bound of the key.
-    fn lower_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self
-    where
-        Self: Sized,
-    {
+    fn lower_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self;
+
+    /// Constructs the upper bound of the key.
+    fn upper_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self;
+}
+
+impl<T, K> IndexedKeyBounds<T> for K
+where
+    T: Indexed,
+    K: IndexedKeyComponentBounds<T> + Sized,
+{
+    /// Constructs the lower bound of the key.
+    fn lower_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
         <Self as IndexedKey<T>>::encode(room_id, &Self::lower_key_components(), serializer)
     }
 
-    /// Constructs the upper bound of the key components.
-    fn upper_key_components() -> Self::KeyComponents;
-
     /// Constructs the upper bound of the key.
-    fn upper_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self
-    where
-        Self: Sized,
-    {
+    fn upper_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
         <Self as IndexedKey<T>>::encode(room_id, &Self::upper_key_components(), serializer)
     }
+}
+
+/// A trait for constructing the bounds of the components of an [`IndexedKey`].
+///
+/// This is useful when constructing range queries in IndexedDB. Note that this
+/// trait should not be implemented for key components that are going to be
+/// encrypted as ordering properties will not be preserved.
+pub trait IndexedKeyComponentBounds<T: Indexed>: IndexedKeyBounds<T> {
+    /// Constructs the lower bound of the key components.
+    fn lower_key_components() -> Self::KeyComponents;
+
+    /// Constructs the upper bound of the key components.
+    fn upper_key_components() -> Self::KeyComponents;
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -71,8 +71,8 @@ pub trait IndexedKeyBounds<T: Indexed>: IndexedKey<T> {
     /// Constructs the lower bound of the key components.
     fn lower_key_components() -> Self::KeyComponents;
 
-    /// Encodes the lower bound of the key.
-    fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self
+    /// Constructs the lower bound of the key.
+    fn lower_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self
     where
         Self: Sized,
     {
@@ -82,8 +82,8 @@ pub trait IndexedKeyBounds<T: Indexed>: IndexedKey<T> {
     /// Constructs the upper bound of the key components.
     fn upper_key_components() -> Self::KeyComponents;
 
-    /// Encodes the upper bound of the key.
-    fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self
+    /// Constructs the upper bound of the key.
+    fn upper_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self
     where
         Self: Sized,
     {

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -72,11 +72,21 @@ pub trait IndexedKeyBounds<T: Indexed>: IndexedKey<T> {
     fn lower_key_components() -> Self::KeyComponents;
 
     /// Encodes the lower bound of the key.
-    fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self;
+    fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self
+    where
+        Self: Sized,
+    {
+        <Self as IndexedKey<T>>::encode(room_id, &Self::lower_key_components(), serializer)
+    }
 
     /// Constructs the upper bound of the key components.
     fn upper_key_components() -> Self::KeyComponents;
 
     /// Encodes the upper bound of the key.
-    fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self;
+    fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self
+    where
+        Self: Sized,
+    {
+        <Self as IndexedKey<T>>::encode(room_id, &Self::upper_key_components(), serializer)
+    }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
@@ -139,18 +139,6 @@ impl IndexedKeyBounds<Chunk> for IndexedChunkIdKey {
     fn upper_key_components() -> Self::KeyComponents {
         ChunkIdentifier::new(js_sys::Number::MAX_SAFE_INTEGER as u64)
     }
-
-    fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        <Self as IndexedKey<Chunk>>::encode(room_id, &ChunkIdentifier::new(0), serializer)
-    }
-
-    fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        <Self as IndexedKey<Chunk>>::encode(
-            room_id,
-            &ChunkIdentifier::new(js_sys::Number::MAX_SAFE_INTEGER as u64),
-            serializer,
-        )
-    }
 }
 
 pub type IndexedRoomId = String;
@@ -215,18 +203,6 @@ impl IndexedKeyBounds<Chunk> for IndexedNextChunkIdKey {
 
     fn upper_key_components() -> Self::KeyComponents {
         Some(ChunkIdentifier::new(js_sys::Number::MAX_SAFE_INTEGER as u64))
-    }
-
-    fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        <Self as IndexedKey<Chunk>>::encode(room_id, &None, serializer)
-    }
-
-    fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        <Self as IndexedKey<Chunk>>::encode(
-            room_id,
-            &Some(ChunkIdentifier::new(js_sys::Number::MAX_SAFE_INTEGER as u64)),
-            serializer,
-        )
     }
 }
 
@@ -315,18 +291,6 @@ impl IndexedKeyBounds<Event> for IndexedEventIdKey {
     fn upper_key_components() -> Self::KeyComponents {
         OwnedEventId::try_from(format!("${INDEXED_KEY_UPPER_CHARACTER}")).expect("valid event id")
     }
-
-    fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);
-        let event_id = String::from(INDEXED_KEY_LOWER_CHARACTER);
-        Self(room_id, event_id)
-    }
-
-    fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);
-        let event_id = String::from(INDEXED_KEY_UPPER_CHARACTER);
-        Self(room_id, event_id)
-    }
 }
 
 pub type IndexedEventId = String;
@@ -361,25 +325,6 @@ impl IndexedKeyBounds<Event> for IndexedEventPositionKey {
             chunk_identifier: js_sys::Number::MAX_SAFE_INTEGER as u64,
             index: js_sys::Number::MAX_SAFE_INTEGER as usize,
         }
-    }
-
-    fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        <Self as IndexedKey<Event>>::encode(
-            room_id,
-            &Position { chunk_identifier: 0, index: 0 },
-            serializer,
-        )
-    }
-
-    fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        <Self as IndexedKey<Event>>::encode(
-            room_id,
-            &Position {
-                chunk_identifier: js_sys::Number::MAX_SAFE_INTEGER as u64,
-                index: js_sys::Number::MAX_SAFE_INTEGER as usize,
-            },
-            serializer,
-        )
     }
 }
 
@@ -428,20 +373,6 @@ impl IndexedKeyBounds<Event> for IndexedEventRelationKey {
                 .expect("valid event id"),
             RelationType::from(INDEXED_KEY_UPPER_CHARACTER.to_string()),
         )
-    }
-
-    fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);
-        let related_event_id = String::from(INDEXED_KEY_LOWER_CHARACTER);
-        let relation_type = String::from(INDEXED_KEY_LOWER_CHARACTER);
-        Self(room_id, related_event_id, relation_type)
-    }
-
-    fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);
-        let related_event_id = String::from(INDEXED_KEY_UPPER_CHARACTER);
-        let relation_type = String::from(INDEXED_KEY_UPPER_CHARACTER);
-        Self(room_id, related_event_id, relation_type)
     }
 }
 
@@ -516,14 +447,6 @@ impl IndexedKeyBounds<Gap> for IndexedGapIdKey {
 
     fn upper_key_components() -> Self::KeyComponents {
         <Self as IndexedKeyBounds<Chunk>>::upper_key_components()
-    }
-
-    fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        <IndexedChunkIdKey as IndexedKeyBounds<Chunk>>::encode_lower(room_id, serializer)
-    }
-
-    fn encode_upper(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        <IndexedChunkIdKey as IndexedKeyBounds<Chunk>>::encode_upper(room_id, serializer)
     }
 }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
@@ -144,6 +144,8 @@ pub struct IndexedChunk {
 }
 
 impl Indexed for Chunk {
+    const OBJECT_STORE: &'static str = keys::LINKED_CHUNKS;
+
     type IndexedType = IndexedChunk;
     type Error = CryptoStoreError;
 
@@ -300,6 +302,8 @@ pub enum IndexedEventError {
 }
 
 impl Indexed for Event {
+    const OBJECT_STORE: &'static str = keys::EVENTS;
+
     type IndexedType = IndexedEvent;
     type Error = IndexedEventError;
 
@@ -460,6 +464,8 @@ pub struct IndexedGap {
 }
 
 impl Indexed for Gap {
+    const OBJECT_STORE: &'static str = keys::GAPS;
+
     type IndexedType = IndexedGap;
     type Error = CryptoStoreError;
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
@@ -132,6 +132,14 @@ impl IndexedKey<Chunk> for IndexedChunkIdKey {
 }
 
 impl IndexedKeyBounds<Chunk> for IndexedChunkIdKey {
+    fn lower_key_components() -> Self::KeyComponents {
+        ChunkIdentifier::new(0)
+    }
+
+    fn upper_key_components() -> Self::KeyComponents {
+        ChunkIdentifier::new(js_sys::Number::MAX_SAFE_INTEGER as u64)
+    }
+
     fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
         <Self as IndexedKey<Chunk>>::encode(room_id, &ChunkIdentifier::new(0), serializer)
     }
@@ -201,6 +209,14 @@ impl IndexedKey<Chunk> for IndexedNextChunkIdKey {
 }
 
 impl IndexedKeyBounds<Chunk> for IndexedNextChunkIdKey {
+    fn lower_key_components() -> Self::KeyComponents {
+        None
+    }
+
+    fn upper_key_components() -> Self::KeyComponents {
+        Some(ChunkIdentifier::new(js_sys::Number::MAX_SAFE_INTEGER as u64))
+    }
+
     fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
         <Self as IndexedKey<Chunk>>::encode(room_id, &None, serializer)
     }
@@ -292,6 +308,14 @@ impl IndexedKey<Event> for IndexedEventIdKey {
 }
 
 impl IndexedKeyBounds<Event> for IndexedEventIdKey {
+    fn lower_key_components() -> Self::KeyComponents {
+        OwnedEventId::try_from(format!("${INDEXED_KEY_LOWER_CHARACTER}")).expect("valid event id")
+    }
+
+    fn upper_key_components() -> Self::KeyComponents {
+        OwnedEventId::try_from(format!("${INDEXED_KEY_UPPER_CHARACTER}")).expect("valid event id")
+    }
+
     fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
         let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);
         let event_id = String::from(INDEXED_KEY_LOWER_CHARACTER);
@@ -328,6 +352,17 @@ impl IndexedKey<Event> for IndexedEventPositionKey {
 }
 
 impl IndexedKeyBounds<Event> for IndexedEventPositionKey {
+    fn lower_key_components() -> Self::KeyComponents {
+        Position { chunk_identifier: 0, index: 0 }
+    }
+
+    fn upper_key_components() -> Self::KeyComponents {
+        Position {
+            chunk_identifier: js_sys::Number::MAX_SAFE_INTEGER as u64,
+            index: js_sys::Number::MAX_SAFE_INTEGER as usize,
+        }
+    }
+
     fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
         <Self as IndexedKey<Event>>::encode(
             room_id,
@@ -379,6 +414,22 @@ impl IndexedKey<Event> for IndexedEventRelationKey {
 }
 
 impl IndexedKeyBounds<Event> for IndexedEventRelationKey {
+    fn lower_key_components() -> Self::KeyComponents {
+        (
+            OwnedEventId::try_from(format!("${INDEXED_KEY_LOWER_CHARACTER}"))
+                .expect("valid event id"),
+            RelationType::from(INDEXED_KEY_LOWER_CHARACTER.to_string()),
+        )
+    }
+
+    fn upper_key_components() -> Self::KeyComponents {
+        (
+            OwnedEventId::try_from(format!("${INDEXED_KEY_UPPER_CHARACTER}"))
+                .expect("valid event id"),
+            RelationType::from(INDEXED_KEY_UPPER_CHARACTER.to_string()),
+        )
+    }
+
     fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
         let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);
         let related_event_id = String::from(INDEXED_KEY_LOWER_CHARACTER);
@@ -459,6 +510,14 @@ impl IndexedKey<Gap> for IndexedGapIdKey {
 }
 
 impl IndexedKeyBounds<Gap> for IndexedGapIdKey {
+    fn lower_key_components() -> Self::KeyComponents {
+        <Self as IndexedKeyBounds<Chunk>>::lower_key_components()
+    }
+
+    fn upper_key_components() -> Self::KeyComponents {
+        <Self as IndexedKeyBounds<Chunk>>::upper_key_components()
+    }
+
     fn encode_lower(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
         <IndexedChunkIdKey as IndexedKeyBounds<Chunk>>::encode_lower(room_id, serializer)
     }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
@@ -246,6 +246,8 @@ impl IndexedNextChunkIdKey {
 }
 
 impl IndexedKey<Chunk> for IndexedNextChunkIdKey {
+    const INDEX: Option<&'static str> = Some(keys::LINKED_CHUNKS_NEXT);
+
     type KeyComponents = Option<ChunkIdentifier>;
 
     fn encode(
@@ -379,6 +381,8 @@ pub type IndexedEventId = String;
 pub struct IndexedEventPositionKey(IndexedRoomId, IndexedChunkId, IndexedEventPositionIndex);
 
 impl IndexedKey<Event> for IndexedEventPositionKey {
+    const INDEX: Option<&'static str> = Some(keys::EVENTS_POSITION);
+
     type KeyComponents = Position;
 
     fn encode(room_id: &RoomId, position: &Position, serializer: &IndexeddbSerializer) -> Self {
@@ -414,6 +418,8 @@ pub type IndexedEventPositionIndex = usize;
 pub struct IndexedEventRelationKey(IndexedRoomId, IndexedEventId, IndexedRelationType);
 
 impl IndexedKey<Event> for IndexedEventRelationKey {
+    const INDEX: Option<&'static str> = Some(keys::EVENTS_RELATION);
+
     type KeyComponents = (OwnedEventId, RelationType);
 
     fn encode(

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -385,4 +385,12 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     {
         self.delete_items_by_key_components::<T, K>(room_id, key).await
     }
+
+    /// Clear all items of type `T` in all rooms from IndexedDB
+    pub async fn clear<T>(&self) -> Result<(), IndexeddbEventCacheStoreTransactionError>
+    where
+        T: Indexed,
+    {
+        self.transaction.object_store(T::OBJECT_STORE)?.clear()?.await.map_err(Into::into)
+    }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -59,6 +59,9 @@ impl From<serde_wasm_bindgen::Error> for IndexeddbEventCacheStoreTransactionErro
     }
 }
 
+/// Represents an IndexedDB transaction, but provides a convenient interface for
+/// performing operations relevant to the IndexedDB implementation of
+/// [`EventCacheStore`](matrix_sdk_base::event_cache::store::EventCacheStore).
 pub struct IndexeddbEventCacheStoreTransaction<'a> {
     transaction: IdbTransaction<'a>,
     serializer: &'a IndexeddbEventCacheStoreSerializer,
@@ -72,10 +75,12 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         Self { transaction, serializer }
     }
 
+    /// Returns the underlying IndexedDB transaction.
     pub fn into_inner(self) -> IdbTransaction<'a> {
         self.transaction
     }
 
+    /// Commit all operations tracked in this transaction to IndexedDB.
     pub async fn commit(self) -> Result<(), IndexeddbEventCacheStoreTransactionError> {
         self.transaction.await.into_result().map_err(Into::into)
     }
@@ -128,6 +133,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         self.get_items_by_key::<T, K>(room_id, range).await
     }
 
+    /// Query IndexedDB for all items in the given room by key `K`
     pub async fn get_items_in_room<T, K>(
         &self,
         room_id: &RoomId,

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -1,0 +1,69 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+use indexed_db_futures::{prelude::IdbTransaction, IdbQuerySource};
+use matrix_sdk_base::{
+    event_cache::{Event as RawEvent, Gap as RawGap},
+    linked_chunk::{ChunkContent, ChunkIdentifier, RawChunk},
+};
+use ruma::{events::relation::RelationType, OwnedEventId, RoomId};
+use serde::{de::DeserializeOwned, Serialize};
+use thiserror::Error;
+use web_sys::IdbCursorDirection;
+
+use crate::event_cache_store::{
+    serializer::{
+        traits::{Indexed, IndexedKey, IndexedKeyBounds, IndexedKeyComponentBounds},
+        types::{
+            IndexedChunkIdKey, IndexedEventIdKey, IndexedEventPositionKey, IndexedEventRelationKey,
+            IndexedGapIdKey, IndexedKeyRange, IndexedNextChunkIdKey,
+        },
+        IndexeddbEventCacheStoreSerializer,
+    },
+    types::{Chunk, ChunkType, Event, Gap, Position},
+};
+
+#[derive(Debug, Error)]
+pub enum IndexeddbEventCacheStoreTransactionError {
+    #[error("DomException {name} ({code}): {message}")]
+    DomException { name: String, message: String, code: u16 },
+}
+
+impl From<web_sys::DomException> for IndexeddbEventCacheStoreTransactionError {
+    fn from(value: web_sys::DomException) -> Self {
+        Self::DomException { name: value.name(), message: value.message(), code: value.code() }
+    }
+}
+
+pub struct IndexeddbEventCacheStoreTransaction<'a> {
+    transaction: IdbTransaction<'a>,
+    serializer: &'a IndexeddbEventCacheStoreSerializer,
+}
+
+impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
+    pub fn new(
+        transaction: IdbTransaction<'a>,
+        serializer: &'a IndexeddbEventCacheStoreSerializer,
+    ) -> Self {
+        Self { transaction, serializer }
+    }
+
+    pub fn into_inner(self) -> IdbTransaction<'a> {
+        self.transaction
+    }
+
+    pub async fn commit(self) -> Result<(), IndexeddbEventCacheStoreTransactionError> {
+        self.transaction.await.into_result().map_err(Into::into)
+    }
+}


### PR DESCRIPTION
## Background

This pull request is part of a series of pull requests to add an IndexedDB implementation of the `EventCacheStore` (see #4617, #4996, #5090, #5138, #5226). This particular pull request primarily focuses on providing functionality for easily issuing IndexedDB transaction.

## Changes

The primary change is the addition of `IndexeddbEventCacheStoreTransaction`, which wraps `IdbTransaction` and `IndexedbEventCacheStoreSerializer`. It provides a convenient interface for composing atomic IndexedDB operations. For the sake of brevity, I have only added the generic versions of the functions for these operations, but as we add implementations of the functions in `EventCacheStore`, I will bring in their typed versions where relevant.

Additionally, in order to support some of the generic functions in `IndexeddbEventCacheStoreTransaction`, I have introduced another trait and some minor changes to the existing ones.

- **Added** `IndexedKeyComponentBounds` (trait)
    - Similar to `IndexedKeyBounds`, but generates the lower and upper bounds of the key components, rather than the key itself. This is useful when constructing key ranges, except in the case where a particular key component is encrypted, in which case one must construct the ranges from the keys themselves.
- **Added** `IndexedKeyRange` (type)
    - A type that can be used to express individual keys, as well as key ranges.
- **Changed** `Indexed` (trait)
    - Tracks the name of the object store in which the implementing type stored using an associated constant, `OBJECT_STORE: &'static str`
- **Changed** `IndexedKey` (trait)
    - Tracks the name of the index with which the key is associated (if any) using a function, `index() -> Option<&'static str>`
- **Changed** `IndexedKeyBounds` (trait)
    - `encode_lower_key` -> `lower_key` to more closely mirror `IndexedKeyComponentBounds`
    - `encode_upper_key` -> `upper_key` to more closely mirror `IndexedKeyComponentBounds` 
- **Changed** `IndexeddbEventCacheStoreSerializerError`
    - `Indexing` variant uses generic type, rather than dynamic type so that `Send` and `Sync` don't have to be used as constraints where they aren't necessary.
 
## Future Work

- Add implementation of `EventCacheStore` which uses the transaction type added in this pull request.

---

- [ ] Public API changes documented in changelogs (optional)


Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>