### PR TITLE
fix(notification client): request join rules in `required_state` so as to be able to compute them

### DIFF
--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -498,6 +498,7 @@ impl NotificationClient {
             (StateEventType::RoomCanonicalAlias, "".to_owned()),
             (StateEventType::RoomName, "".to_owned()),
             (StateEventType::RoomPowerLevels, "".to_owned()),
+            (StateEventType::RoomJoinRules, "".to_owned()),
             (StateEventType::CallMember, "*".to_owned()),
         ];
 

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -227,6 +227,7 @@ async fn test_notification_client_sliding_sync() {
                         ["m.room.canonical_alias", ""],
                         ["m.room.name", ""],
                         ["m.room.power_levels", ""],
+                        ["m.room.join_rules", ""],
                         ["org.matrix.msc3401.call.member", "*"],
                     ],
                     "filters": {
@@ -245,6 +246,7 @@ async fn test_notification_client_sliding_sync() {
                         ["m.room.canonical_alias", ""],
                         ["m.room.name", ""],
                         ["m.room.power_levels", ""],
+                        ["m.room.join_rules", ""],
                         ["org.matrix.msc3401.call.member", "*"],
                     ],
                     "timeline_limit": 16,


### PR DESCRIPTION
Fixes #5275.