### PR TITLE
refactor(sdk): make methods and fields related to `join_rules` `Option`al

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -27,6 +27,12 @@ Breaking changes:
 
 - `Client::reset_server_capabilities` has been renamed to `Client::reset_server_info`.
   ([#5167](https://github.com/matrix-org/matrix-rust-sdk/pull/5167))
+- `RoomPreview::join_rule`, `NotificationItem::join_rule`, `RoomInfo::is_public`, and
+  `Room::is_public()` return values are now optional. They will be set to `None` if the join rule
+  state event is missing for a given room. `NotificationRoomInfo::is_public` has been removed;
+  callers can inspect the value of `NotificationItem::join_rule` to determine if the room is public
+  (i.e. if the join rule is `Public`).
+  ([#XXXX](https://github.com/matrix-org/matrix-rust-sdk/pull/XXXX))
 
 ## [0.12.0] - 2025-06-10
 

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -32,7 +32,7 @@ Breaking changes:
   state event is missing for a given room. `NotificationRoomInfo::is_public` has been removed;
   callers can inspect the value of `NotificationItem::join_rule` to determine if the room is public
   (i.e. if the join rule is `Public`).
-  ([#XXXX](https://github.com/matrix-org/matrix-rust-sdk/pull/XXXX))
+  ([#5278](https://github.com/matrix-org/matrix-rust-sdk/pull/5278))
 
 ## [0.12.0] - 2025-06-10
 

--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -35,7 +35,6 @@ pub struct NotificationRoomInfo {
     pub joined_members_count: u64,
     pub is_encrypted: Option<bool>,
     pub is_direct: bool,
-    pub is_public: bool,
 }
 
 #[derive(uniffi::Record)]
@@ -74,11 +73,10 @@ impl NotificationItem {
                 display_name: item.room_computed_display_name,
                 avatar_url: item.room_avatar_url,
                 canonical_alias: item.room_canonical_alias,
-                join_rule: item.room_join_rule.try_into().ok(),
+                join_rule: item.room_join_rule.map(TryInto::try_into).transpose().ok().flatten(),
                 joined_members_count: item.joined_members_count,
                 is_encrypted: item.is_room_encrypted,
                 is_direct: item.is_direct_message_room,
-                is_public: item.is_room_public,
             },
             is_noisy: item.is_noisy,
             has_mention: item.has_mention,

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -116,7 +116,10 @@ impl Room {
         self.inner.is_direct().await.unwrap_or(false)
     }
 
-    pub fn is_public(&self) -> bool {
+    /// Whether the room can be publicly joined or not, based on its join rule.
+    ///
+    /// Can return `None` if the join rule state event is missing.
+    pub fn is_public(&self) -> Option<bool> {
         self.inner.is_public()
     }
 

--- a/bindings/matrix-sdk-ffi/src/room/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room/room_info.rs
@@ -26,7 +26,11 @@ pub struct RoomInfo {
     topic: Option<String>,
     avatar_url: Option<String>,
     is_direct: bool,
-    is_public: bool,
+    /// Whether the room is public or not, based on the join rules.
+    ///
+    /// Can be `None` if the join rules state event is not available for this
+    /// room.
+    is_public: Option<bool>,
     is_space: bool,
     /// If present, it means the room has been archived/upgraded.
     successor_room: Option<SuccessorRoom>,
@@ -77,10 +81,15 @@ impl RoomInfo {
         let pinned_event_ids =
             room.pinned_event_ids().unwrap_or_default().iter().map(|id| id.to_string()).collect();
 
-        let join_rule = room.join_rule().try_into();
-        if let Err(e) = &join_rule {
-            warn!("Failed to parse join rule: {e:?}");
-        }
+        let join_rule = room
+            .join_rule()
+            .map(TryInto::try_into)
+            .transpose()
+            .inspect_err(|err| {
+                warn!("Failed to parse join rule: {err}");
+            })
+            .ok()
+            .flatten();
 
         let power_levels = RoomPowerLevels::new(
             room.power_levels().await.map_err(matrix_sdk::Error::from)?,
@@ -135,7 +144,7 @@ impl RoomInfo {
             num_unread_notifications: room.num_unread_notifications(),
             num_unread_mentions: room.num_unread_mentions(),
             pinned_event_ids,
-            join_rule: join_rule.ok(),
+            join_rule,
             history_visibility: room.history_visibility_or_default().try_into()?,
             power_levels: Arc::new(power_levels),
         })

--- a/bindings/matrix-sdk-ffi/src/room_preview.rs
+++ b/bindings/matrix-sdk-ffi/src/room_preview.rs
@@ -37,8 +37,9 @@ impl RoomPreview {
             membership: info.state.map(|state| state.into()),
             join_rule: info
                 .join_rule
-                .clone()
-                .try_into()
+                .as_ref()
+                .map(TryInto::try_into)
+                .transpose()
                 .map_err(|_| anyhow::anyhow!("unhandled SpaceRoomJoinRule kind"))?,
             is_direct: info.is_direct,
             heroes: info
@@ -114,17 +115,17 @@ pub struct RoomPreviewInfo {
     /// The membership state for the current user, if known.
     pub membership: Option<Membership>,
     /// The join rule for this room (private, public, knock, etc.).
-    pub join_rule: JoinRule,
+    pub join_rule: Option<JoinRule>,
     /// Whether the room is direct or not, if known.
     pub is_direct: Option<bool>,
     /// Room heroes.
     pub heroes: Option<Vec<RoomHero>>,
 }
 
-impl TryFrom<SpaceRoomJoinRule> for JoinRule {
+impl TryFrom<&SpaceRoomJoinRule> for JoinRule {
     type Error = ();
 
-    fn try_from(join_rule: SpaceRoomJoinRule) -> Result<Self, ()> {
+    fn try_from(join_rule: &SpaceRoomJoinRule) -> Result<Self, ()> {
         Ok(match join_rule {
             SpaceRoomJoinRule::Invite => JoinRule::Invite,
             SpaceRoomJoinRule::Knock => JoinRule::Knock,

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
   ([#5167](https://github.com/matrix-org/matrix-rust-sdk/pull/5167))
 - `Room::join_rule` and `Room::is_public` now return an `Option` to reflect that the join rule
   state event might be missing, in which case they will return `None`.
-  ([#XXXX](https://github.com/matrix-org/matrix-rust-sdk/pull/XXXX))
+  ([#5278](https://github.com/matrix-org/matrix-rust-sdk/pull/5278))
 
 ## [0.12.0] - 2025-06-10
 

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
   additionally contains the well-known response alongside the existing server versions.
   Despite the old name, it does not contain the server capabilities.
   ([#5167](https://github.com/matrix-org/matrix-rust-sdk/pull/5167))
+- `Room::join_rule` and `Room::is_public` now return an `Option` to reflect that the join rule
+  state event might be missing, in which case they will return `None`.
+  ([#XXXX](https://github.com/matrix-org/matrix-rust-sdk/pull/XXXX))
 
 ## [0.12.0] - 2025-06-10
 

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -340,13 +340,15 @@ impl Room {
     }
 
     /// Is the room considered to be public.
-    pub fn is_public(&self) -> bool {
-        matches!(self.join_rule(), JoinRule::Public)
+    ///
+    /// May return `None` if the join rule event is not available.
+    pub fn is_public(&self) -> Option<bool> {
+        self.inner.read().join_rule().map(|join_rule| matches!(join_rule, JoinRule::Public))
     }
 
-    /// Get the join rule policy of this room.
-    pub fn join_rule(&self) -> JoinRule {
-        self.inner.read().join_rule().clone()
+    /// Get the join rule policy of this room, if available.
+    pub fn join_rule(&self) -> Option<JoinRule> {
+        self.inner.read().join_rule().cloned()
     }
 
     /// Get the maximum power level that this room contains.

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -867,13 +867,12 @@ impl RoomInfo {
         }
     }
 
-    /// Returns the join rule for this room.
-    ///
-    /// Defaults to `Public`, if missing.
-    pub fn join_rule(&self) -> &JoinRule {
+    /// Return the join rule for this room, if the `m.room.join_rules` event is
+    /// available.
+    pub fn join_rule(&self) -> Option<&JoinRule> {
         match &self.base_info.join_rules {
-            Some(MinimalStateEvent::Original(ev)) => &ev.content.join_rule,
-            _ => &JoinRule::Public,
+            Some(MinimalStateEvent::Original(ev)) => Some(&ev.content.join_rule),
+            _ => None,
         }
     }
 

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 - `NotificationItem::room_join_rule` is now optional to reflect that the join rule
   state event might be missing, in which case it will be set to `None`. The
   `NotificationItem::is_public` field has been replaced with a method that returns an `Option<bool>`, based on the same logic.
-  ([#XXXX](https://github.com/matrix-org/matrix-rust-sdk/pull/XXXX))
+  ([#5278](https://github.com/matrix-org/matrix-rust-sdk/pull/5278))
 
 ### Bug Fixes
 

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
 - [**breaking**] [`TimelineItemContent::reactions()`] returns an `Option<&ReactionsByKeyBySender>`
   instead of `ReactionsByKeyBySender`. This reflects the fact that some timeline items cannot hold
   reactions at all.
+- `NotificationItem::room_join_rule` is now optional to reflect that the join rule
+  state event might be missing, in which case it will be set to `None`. The
+  `NotificationItem::is_public` field has been replaced with a method that returns an `Option<bool>`, based on the same logic.
+  ([#XXXX](https://github.com/matrix-org/matrix-rust-sdk/pull/XXXX))
 
 ### Bug Fixes
 

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -910,11 +910,11 @@ pub struct NotificationItem {
     /// Room canonical alias.
     pub room_canonical_alias: Option<String>,
     /// Room join rule.
-    pub room_join_rule: JoinRule,
+    ///
+    /// Set to `None` if the join rule for this room is not available.
+    pub room_join_rule: Option<JoinRule>,
     /// Is this room encrypted?
     pub is_room_encrypted: Option<bool>,
-    /// Is this a public room?
-    pub is_room_public: bool,
     /// Is this room considered a direct message?
     pub is_direct_message_room: bool,
     /// Numbers of members who joined the room.
@@ -1010,7 +1010,6 @@ impl NotificationItem {
             room_canonical_alias: room.canonical_alias().map(|c| c.to_string()),
             room_join_rule: room.join_rule(),
             is_direct_message_room: room.is_direct().await?,
-            is_room_public: room.is_public(),
             is_room_encrypted: room
                 .latest_encryption_state()
                 .await
@@ -1023,6 +1022,13 @@ impl NotificationItem {
         };
 
         Ok(item)
+    }
+
+    /// Returns whether this room is public or not, based on the join rule.
+    ///
+    /// Maybe return `None` if the join rule is not available.
+    pub fn is_public(&self) -> Option<bool> {
+        self.room_join_rule.as_ref().map(|rule| matches!(rule, JoinRule::Public))
     }
 }
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to this project will be documented in this file.
 
 - `RoomEventCacheListener` is renamed `RoomEventCacheSubscriber`
   ([#5269](https://github.com/matrix-org/matrix-rust-sdk/pull/5269))
+- `RoomPreview::join_rule` is now optional, and will be set to `None` if the join rule state event
+  is missing for a given room.
+  ([#XXXX](https://github.com/matrix-org/matrix-rust-sdk/pull/XXXX))
 
 ## [0.12.0] - 2025-06-10
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.
   ([#5269](https://github.com/matrix-org/matrix-rust-sdk/pull/5269))
 - `RoomPreview::join_rule` is now optional, and will be set to `None` if the join rule state event
   is missing for a given room.
-  ([#XXXX](https://github.com/matrix-org/matrix-rust-sdk/pull/XXXX))
+  ([#5278](https://github.com/matrix-org/matrix-rust-sdk/pull/5278))
 
 ## [0.12.0] - 2025-06-10
 

--- a/crates/matrix-sdk/src/room_preview.rs
+++ b/crates/matrix-sdk/src/room_preview.rs
@@ -64,7 +64,7 @@ pub struct RoomPreview {
     pub room_type: Option<RoomType>,
 
     /// What's the join rule for this room?
-    pub join_rule: SpaceRoomJoinRule,
+    pub join_rule: Option<SpaceRoomJoinRule>,
 
     /// Is the room world-readable (i.e. is its history_visibility set to
     /// world_readable)?
@@ -102,7 +102,7 @@ impl RoomPreview {
             topic: room_info.topic().map(ToOwned::to_owned),
             avatar_url: room_info.avatar_url().map(ToOwned::to_owned),
             room_type: room_info.room_type().cloned(),
-            join_rule: match room_info.join_rule() {
+            join_rule: room_info.join_rule().map(|rule| match rule {
                 JoinRule::Invite => SpaceRoomJoinRule::Invite,
                 JoinRule::Knock => SpaceRoomJoinRule::Knock,
                 JoinRule::Private => SpaceRoomJoinRule::Private,
@@ -114,7 +114,7 @@ impl RoomPreview {
                     // private (a cautious choice).
                     SpaceRoomJoinRule::Private
                 }
-            },
+            }),
             is_world_readable: room_info
                 .history_visibility()
                 .map(|vis| *vis == HistoryVisibility::WorldReadable),
@@ -287,7 +287,7 @@ impl RoomPreview {
             num_joined_members: response.num_joined_members.into(),
             num_active_members,
             room_type: response.room_type,
-            join_rule: response.join_rule,
+            join_rule: Some(response.join_rule),
             is_world_readable: Some(response.world_readable),
             state,
             is_direct,
@@ -375,14 +375,14 @@ async fn search_for_room_preview_in_room_directory(
             num_active_members: None,
             // Assume it's a room
             room_type: None,
-            join_rule: match room_description.join_rule {
+            join_rule: Some(match room_description.join_rule {
                 PublicRoomJoinRule::Public => SpaceRoomJoinRule::Public,
                 PublicRoomJoinRule::Knock => SpaceRoomJoinRule::Knock,
                 PublicRoomJoinRule::_Custom(rule) => SpaceRoomJoinRule::_Custom(rule),
                 _ => {
                     panic!("Unexpected PublicRoomJoinRule {:?}", room_description.join_rule)
                 }
-            },
+            }),
             is_world_readable: Some(room_description.is_world_readable),
             state: None,
             is_direct: None,

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -1228,7 +1228,7 @@ fn assert_room_preview(preview: &RoomPreview, room_alias: &str) {
     assert_eq!(preview.avatar_url.as_ref().unwrap(), mxc_uri!("mxc://localhost/alice"));
     assert_eq!(preview.num_joined_members, 1);
     assert!(preview.room_type.is_none());
-    assert_eq!(preview.join_rule, SpaceRoomJoinRule::Invite);
+    assert_eq!(preview.join_rule, Some(SpaceRoomJoinRule::Invite));
     assert!(preview.is_world_readable.unwrap());
 }
 


### PR DESCRIPTION
Returning a default value when the state event is missing is an API footgun. Instead, we should return `None` in this case, and let the caller decide what to do with that.

This would've avoided #5275 in the first place. Likely more changelog lines than code lines here…