### PR TITLE
fix(ffi): make `RoomInfo` power levels optional as they can be missing depending on the required state

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room/room_info.rs
@@ -67,7 +67,9 @@ pub struct RoomInfo {
     /// The history visibility for this room, if known.
     history_visibility: RoomHistoryVisibility,
     /// This room's current power levels.
-    power_levels: Arc<RoomPowerLevels>,
+    ///
+    /// Can be missing if the room power levels event is missing from the store.
+    power_levels: Option<Arc<RoomPowerLevels>>,
 }
 
 impl RoomInfo {
@@ -82,10 +84,11 @@ impl RoomInfo {
             warn!("Failed to parse join rule: {e:?}");
         }
 
-        let power_levels = RoomPowerLevels::new(
-            room.power_levels().await.map_err(matrix_sdk::Error::from)?,
-            room.own_user_id().to_owned(),
-        );
+        let power_levels = room
+            .power_levels()
+            .await
+            .ok()
+            .map(|p| RoomPowerLevels::new(p, room.own_user_id().to_owned()));
 
         Ok(Self {
             id: room.room_id().to_string(),
@@ -137,7 +140,7 @@ impl RoomInfo {
             pinned_event_ids,
             join_rule: join_rule.ok(),
             history_visibility: room.history_visibility_or_default().try_into()?,
-            power_levels: Arc::new(power_levels),
+            power_levels: power_levels.map(Arc::new),
         })
     }
 }


### PR DESCRIPTION
The `m.room.power_levels` state event is not part of the room list required state and computing the RoomInfo would fail in that case.