### PR TITLE
Add a stream that notifies us about received room key bundles

### DIFF
--- a/crates/matrix-sdk-crypto/src/store/types.rs
+++ b/crates/matrix-sdk-crypto/src/store/types.rs
@@ -475,3 +475,26 @@ pub struct RoomKeyWithheldInfo {
     /// withheld.
     pub withheld_event: RoomKeyWithheldEvent,
 }
+
+/// Information about a received historic room key bundle.
+///
+/// This struct contains information needed to uniquely identify a room key
+/// bundle. Only a single bundle per sender for a given room is persisted at a
+/// time.
+///
+/// It is used to notify listeners about received room key bundles.
+#[derive(Debug, Clone)]
+pub struct RoomKeyBundleInfo {
+    /// The user ID of the person that sent us the historic room key bundle.
+    pub sender: OwnedUserId,
+
+    /// The ID of the room the bundle should be used in.
+    pub room_id: OwnedRoomId,
+}
+
+impl From<&StoredRoomKeyBundleData> for RoomKeyBundleInfo {
+    fn from(value: &StoredRoomKeyBundleData) -> Self {
+        let StoredRoomKeyBundleData { sender_user, sender_data: _, bundle_data } = value;
+        Self { sender: sender_user.clone(), room_id: bundle_data.room_id.clone() }
+    }
+}

--- a/crates/matrix-sdk-crypto/src/types/events/room_key_bundle.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key_bundle.rs
@@ -17,10 +17,12 @@
 //!
 //! [MSC4268]: https://github.com/matrix-org/matrix-spec-proposals/pull/4268
 
-use ruma::OwnedRoomId;
+use ruma::{events::room::EncryptedFile, OwnedRoomId};
 use serde::{Deserialize, Serialize};
 
 use super::EventType;
+
+// TODO: We need implement zeroize for this type.
 
 /// The `io.element.msc4268.room_key_bundle` event content. See [MSC4268].
 ///
@@ -31,7 +33,7 @@ pub struct RoomKeyBundleContent {
     pub room_id: OwnedRoomId,
 
     /// The location and encryption info of the key bundle.
-    pub file: ruma::events::room::EncryptedFile,
+    pub file: EncryptedFile,
 }
 
 impl EventType for RoomKeyBundleContent {

--- a/crates/matrix-sdk/src/room/shared_room_history.rs
+++ b/crates/matrix-sdk/src/room/shared_room_history.rs
@@ -129,6 +129,8 @@ pub(super) async fn maybe_accept_key_bundle(room: &Room, inviter: &UserId) -> Re
     else {
         // No bundle received (yet).
         // TODO: deal with the bundle arriving later (https://github.com/matrix-org/matrix-rust-sdk/issues/4926)
+        // We need to check for all them bundles in the store when we create the client
+        // object and we need to process them when they arrive.
         return Ok(());
     };
 


### PR DESCRIPTION
Part of https://github.com/matrix-org/matrix-rust-sdk/issues/4926.

This PR doesn't yet handle room key bundles received out of order. It is rather the building block which will notify us that we need to consider that a bundle might have arrived out of order.