### PR TITLE
refactor(event cache): streamline `filter_duplicate_events` in preparation for threads

### DIFF
--- a/crates/matrix-sdk/src/event_cache/deduplicator.rs
+++ b/crates/matrix-sdk/src/event_cache/deduplicator.rs
@@ -21,7 +21,7 @@ use matrix_sdk_base::{
     event_cache::store::EventCacheStoreLock,
     linked_chunk::{LinkedChunkId, Position},
 };
-use ruma::{OwnedEventId, RoomId};
+use ruma::OwnedEventId;
 
 use super::{
     room::events::{Event, RoomEvents},
@@ -32,7 +32,7 @@ use super::{
 /// valid events (those with an event id) as well as the event ids of
 /// duplicate events along with their position.
 pub async fn filter_duplicate_events(
-    room_id: &RoomId,
+    linked_chunk_id: LinkedChunkId<'_>,
     store: &EventCacheStoreLock,
     mut events: Vec<Event>,
     room_events: &RoomEvents,
@@ -66,7 +66,7 @@ pub async fn filter_duplicate_events(
     // Let the store do its magic ✨
     let duplicated_event_ids = store
         .filter_duplicated_events(
-            LinkedChunkId::Room(room_id),
+            linked_chunk_id,
             events.iter().filter_map(|event| event.event_id()).collect(),
         )
         .await?;
@@ -241,7 +241,7 @@ mod tests {
             room_events.push_events([event_1.clone(), event_2.clone(), event_3.clone()]);
 
             let outcome = filter_duplicate_events(
-                room_id,
+                LinkedChunkId::Room(room_id),
                 &event_cache_store,
                 vec![event_0.clone(), event_1.clone(), event_2.clone(), event_3.clone()],
                 &room_events,
@@ -256,7 +256,7 @@ mod tests {
         room_events.push_events([event_2.clone(), event_3.clone()]);
 
         let outcome = filter_duplicate_events(
-            room_id,
+            LinkedChunkId::Room(room_id),
             &event_cache_store,
             vec![event_0, event_1, event_2, event_3, event_4],
             &room_events,
@@ -369,7 +369,7 @@ mod tests {
             in_store_duplicated_event_ids,
             non_empty_all_duplicates,
         } = filter_duplicate_events(
-            room_id,
+            LinkedChunkId::Room(room_id),
             &event_cache_store,
             vec![ev1, ev2, ev3, ev4],
             &room_events,

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1291,8 +1291,13 @@ mod private {
                 in_memory_duplicated_event_ids,
                 in_store_duplicated_event_ids,
                 non_empty_all_duplicates: all_duplicates,
-            } = filter_duplicate_events(&self.room, &self.store, timeline.events, &self.events)
-                .await?;
+            } = filter_duplicate_events(
+                LinkedChunkId::Room(self.room.as_ref()),
+                &self.store,
+                timeline.events,
+                &self.events,
+            )
+            .await?;
 
             // If the timeline isn't limited, and we already knew about some past events,
             // then this definitely knows what the timeline head is (either we know
@@ -1382,7 +1387,13 @@ mod private {
                 in_memory_duplicated_event_ids,
                 in_store_duplicated_event_ids,
                 non_empty_all_duplicates: all_duplicates,
-            } = filter_duplicate_events(&self.room, &self.store, events, &self.events).await?;
+            } = filter_duplicate_events(
+                LinkedChunkId::Room(self.room.as_ref()),
+                &self.store,
+                events,
+                &self.events,
+            )
+            .await?;
 
             // If not all the events have been back-paginated, we need to remove the
             // previous ones, otherwise we can end up with misordered events.

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -599,50 +599,6 @@ mod private {
             })
         }
 
-        /// Deduplicate `events` considering all events in `Self::events`.
-        ///
-        /// The returned tuple contains:
-        /// - all events (duplicated or not) with an ID
-        /// - all the duplicated event IDs with their position,
-        /// - a boolean indicating all events (at least one) are duplicates.
-        ///
-        /// This last boolean is useful to know whether we need to store a
-        /// previous-batch token (gap) we received from a server-side
-        /// request (sync or back-pagination), or if we should
-        /// *not* store it.
-        ///
-        /// Since there can be empty back-paginations with a previous-batch
-        /// token (that is, they don't contain any events), we need to
-        /// make sure that there is *at least* one new event that has
-        /// been added. Otherwise, we might conclude something wrong
-        /// because a subsequent back-pagination might
-        /// return non-duplicated events.
-        ///
-        /// If we had already seen all the duplicated events that we're trying
-        /// to add, then it would be wasteful to store a previous-batch
-        /// token, or even touch the linked chunk: we would repeat
-        /// back-paginations for events that we have already seen, and
-        /// possibly misplace them. And we should not be missing
-        /// events either: the already-known events would have their own
-        /// previous-batch token (it might already be consumed).
-        async fn collect_valid_and_duplicated_events(
-            &mut self,
-            events: Vec<Event>,
-        ) -> Result<(DeduplicationOutcome, bool), EventCacheError> {
-            let deduplication_outcome =
-                filter_duplicate_events(&self.room, &self.store, events, &self.events).await?;
-
-            let number_of_events = deduplication_outcome.all_events.len();
-            let number_of_deduplicated_events =
-                deduplication_outcome.in_memory_duplicated_event_ids.len()
-                    + deduplication_outcome.in_store_duplicated_event_ids.len();
-
-            let all_duplicates =
-                number_of_events > 0 && number_of_events == number_of_deduplicated_events;
-
-            Ok((deduplication_outcome, all_duplicates))
-        }
-
         /// Given a fully-loaded linked chunk with no gaps, return the
         /// [`LoadMoreEventsBackwardsOutcome`] expected for this room's cache.
         fn conclude_load_more_for_fully_loaded_chunk(&mut self) -> LoadMoreEventsBackwardsOutcome {
@@ -1330,14 +1286,13 @@ mod private {
         ) -> Result<(bool, Vec<VectorDiff<Event>>), EventCacheError> {
             let mut prev_batch = timeline.prev_batch.take();
 
-            let (
-                DeduplicationOutcome {
-                    all_events: events,
-                    in_memory_duplicated_event_ids,
-                    in_store_duplicated_event_ids,
-                },
-                all_duplicates,
-            ) = self.collect_valid_and_duplicated_events(timeline.events).await?;
+            let DeduplicationOutcome {
+                all_events: events,
+                in_memory_duplicated_event_ids,
+                in_store_duplicated_event_ids,
+                non_empty_all_duplicates: all_duplicates,
+            } = filter_duplicate_events(&self.room, &self.store, timeline.events, &self.events)
+                .await?;
 
             // If the timeline isn't limited, and we already knew about some past events,
             // then this definitely knows what the timeline head is (either we know
@@ -1422,14 +1377,12 @@ mod private {
             // the timeline.
             let network_reached_start = new_gap.is_none();
 
-            let (
-                DeduplicationOutcome {
-                    all_events: mut events,
-                    in_memory_duplicated_event_ids,
-                    in_store_duplicated_event_ids,
-                },
-                all_duplicates,
-            ) = self.collect_valid_and_duplicated_events(events).await?;
+            let DeduplicationOutcome {
+                all_events: mut events,
+                in_memory_duplicated_event_ids,
+                in_store_duplicated_event_ids,
+                non_empty_all_duplicates: all_duplicates,
+            } = filter_duplicate_events(&self.room, &self.store, events, &self.events).await?;
 
             // If not all the events have been back-paginated, we need to remove the
             // previous ones, otherwise we can end up with misordered events.


### PR DESCRIPTION
Splitting up the tiny refactorings that will be useful to store threads' linked chunks in the event cache.

Part of #5123.