### PR TITLE
refactor: Clean up formatting in many places

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -42,7 +42,10 @@ pub enum RoomListError {
     InvalidRoomId { error: String },
     #[error("Event cache ran into an error: {error}")]
     EventCache { error: String },
-    #[error("The requested room doesn't match the membership requirements {expected:?}, observed {actual:?}")]
+    #[error(
+        "The requested room doesn't match the membership requirements {expected:?}, \
+         observed {actual:?}"
+    )]
     IncorrectRoomMembership { expected: Vec<Membership>, actual: Membership },
 }
 

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -235,7 +235,10 @@ impl SessionVerificationController {
         if sender != self.user_identity.user_id() {
             if let Some(status) = self.encryption.cross_signing_status().await {
                 if !status.is_complete() {
-                    warn!("Cannot verify other users until our own device's cross-signing status is complete: {status:?}");
+                    warn!(
+                        "Cannot verify other users until our own device's cross-signing status \
+                         is complete: {status:?}"
+                    );
                     return;
                 }
             }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -564,7 +564,10 @@ impl Timeline {
                 let event_id = match event_or_transaction_id {
                     EventOrTransactionId::EventId { event_id } => EventId::parse(event_id)?,
                     EventOrTransactionId::TransactionId { .. } => {
-                        warn!("trying to apply an edit to a local echo that doesn't exist in this timeline, aborting");
+                        warn!(
+                            "trying to apply an edit to a local echo that doesn't exist \
+                             in this timeline, aborting"
+                        );
                         return Ok(());
                     }
                 };

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -491,9 +491,15 @@ mod tests {
         cap_assert("org.matrix.msc2762.receive.event:org.matrix.rageshake_request");
         cap_assert("org.matrix.msc2762.receive.event:io.element.call.encryption_keys");
         cap_assert("org.matrix.msc2762.receive.state_event:m.room.create");
-        cap_assert("org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#@my_user:my_domain.org");
-        cap_assert("org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#@my_user:my_domain.org_ABCDEFGHI");
-        cap_assert("org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#_@my_user:my_domain.org_ABCDEFGHI");
+        cap_assert(
+            "org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#@my_user:my_domain.org",
+        );
+        cap_assert(
+            "org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#@my_user:my_domain.org_ABCDEFGHI",
+        );
+        cap_assert(
+            "org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#_@my_user:my_domain.org_ABCDEFGHI",
+        );
         cap_assert("org.matrix.msc2762.send.event:org.matrix.rageshake_request");
         cap_assert("org.matrix.msc2762.send.event:io.element.call.encryption_keys");
     }

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -227,9 +227,10 @@ impl<'de> Deserialize<'de> for LatestEvent {
             Err(err) => variant_errors.push(err),
         }
 
-        Err(serde::de::Error::custom(
-            format!("data did not match any variant of serialized LatestEvent (using serde_json). Observed errors: {variant_errors:?}")
-        ))
+        Err(serde::de::Error::custom(format!(
+            "data did not match any variant of serialized LatestEvent (using serde_json). \
+             Observed errors: {variant_errors:?}"
+        )))
     }
 }
 

--- a/crates/matrix-sdk-base/src/room/knock.rs
+++ b/crates/matrix-sdk-base/src/room/knock.rs
@@ -51,7 +51,11 @@ impl Room {
                     if event.content.membership == MembershipState::Knock {
                         event_to_user_ids.push((event.event_id, event.state_key))
                     } else {
-                        warn!("Could not mark knock event as seen: event {} for user {} is not in Knock membership state.", event.event_id, event.state_key);
+                        warn!(
+                            "Could not mark knock event as seen: event {} for user {} \
+                             is not in Knock membership state.",
+                            event.event_id, event.state_key
+                        );
                     }
                 }
                 _ => warn!(

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -42,8 +42,9 @@ const VERIFICATION_VIOLATION: &str =
     "Encrypted by a previously-verified user who is no longer verified.";
 const UNSIGNED_DEVICE: &str = "Encrypted by a device not verified by its owner.";
 const UNKNOWN_DEVICE: &str = "Encrypted by an unknown or deleted device.";
-const MISMATCHED_SENDER: &str =
-    "The sender of the event does not match the owner of the device that created the Megolm session.";
+const MISMATCHED_SENDER: &str = "\
+    The sender of the event does not match the owner of the device \
+    that created the Megolm session.";
 pub const SENT_IN_CLEAR: &str = "Not encrypted.";
 
 /// Represents the state of verification for a decrypted message sent by a
@@ -588,7 +589,11 @@ impl TimelineEvent {
         match latest_event.get_field::<MessageLikeEventType>("type") {
             Ok(None) => {
                 let event_id = latest_event.get_field::<OwnedEventId>("event_id").ok().flatten();
-                warn!(?event_id, "couldn't deserialize bundled latest thread event: missing `type` field in bundled latest thread event");
+                warn!(
+                    ?event_id,
+                    "couldn't deserialize bundled latest thread event: missing `type` field \
+                     in bundled latest thread event"
+                );
                 None
             }
 

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -486,7 +486,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
         let chunk = match &mut chunk.content {
             ChunkContent::Gap(..) => {
-                return Err(Error::ChunkIsAGap { identifier: chunk_identifier })
+                return Err(Error::ChunkIsAGap { identifier: chunk_identifier });
             }
 
             ChunkContent::Items(current_items) => {
@@ -574,7 +574,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
             let can_unlink_chunk = match &mut chunk.content {
                 ChunkContent::Gap(..) => {
-                    return Err(Error::ChunkIsAGap { identifier: chunk_identifier })
+                    return Err(Error::ChunkIsAGap { identifier: chunk_identifier });
                 }
 
                 ChunkContent::Items(current_items) => {
@@ -644,7 +644,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
         match &mut chunk.content {
             ChunkContent::Gap(..) => {
-                return Err(Error::ChunkIsAGap { identifier: chunk_identifier })
+                return Err(Error::ChunkIsAGap { identifier: chunk_identifier });
             }
 
             ChunkContent::Items(current_items) => {
@@ -1158,7 +1158,10 @@ impl ChunkIdentifierGenerator {
         // Check for overflows.
         // unlikely — TODO: call `std::intrinsics::unlikely` once it's stable.
         if previous == u64::MAX {
-            panic!("No more chunk identifiers available. Congrats, you did it. 2^64 identifiers have been consumed.")
+            panic!(
+                "No more chunk identifiers available. Congrats, you did it. \
+                 2^64 identifiers have been consumed."
+            )
         }
 
         ChunkIdentifier(previous + 1)

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -596,7 +596,9 @@ impl IdentityManager {
                 {
                     Some((master_key, self_signing))
                 } else {
-                    warn!("A user identity didn't contain a self signing pubkey or the key was invalid");
+                    warn!(
+                        "A user identity didn't contain a self signing pubkey or the key was invalid"
+                    );
                     None
                 }
             }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -706,18 +706,18 @@ mod tests {
         // This export usse a more efficient serialization format for bytes. This was
         // exported when the `KnownSenderData` master_key was serialized as an byte
         // array instead of a base64 encoded string.
-        const SERIALIZED_B64: &str =
-            "iaZwaWNrbGWEr2luaXRpYWxfcmF0Y2hldIKlaW5uZXLcAIABYMzfSnBRzMlPKF1uKjYbzLtkzNJ4RcylzN0HzP\
-             9DzON1Tm05zO7M2MzFQsy9Acz9zPnMqDvM4syQzNrMzxF5KzbM4sy9zPUbBWfM7m4/zJzM18zDzMESKgfMkE7M\
-             yszIHszqWjYyQURbzKTMkx7M58zANsy+AGPM2A8tbcyFYczge8ykzMFdbVxJMMyAzN8azJEXGsy8zPJazMMaP8\
-             ziDszmWwfM+My2ajLMr8y+eczTRm9TFadjb3VudGVyAKtzaWduaW5nX2tlecQgefpCr6Duu7QUWzKIeMOFmxv/\
-             NjfcsYwZz8IN2ZOhdaS0c2lnbmluZ19rZXlfdmVyaWZpZWTDpmNvbmZpZ4GndmVyc2lvbqJWMapzZW5kZXJfa2\
-             V52StoMkIySDg2ajFpYmk2SW13ak9UUkhzbTVMamtyT2kyUGtiSXVUb0w0TWtFq3NpZ25pbmdfa2V5gadlZDI1\
-             NTE52StUWHJqNS9UYXpia3Yram1CZDl4UlB4NWNVaFFzNUNnblc1Q1pNRjgvNjZzq3NlbmRlcl9kYXRhgbBTZW\
-             5kZXJVbnZlcmlmaWVkg6d1c2VyX2lks0B2YWxvdTM1Om1hdHJpeC5vcmepZGV2aWNlX2lkqkZJQlNaRlJLUE2q\
-             bWFzdGVyX2tlecQgkOp9s4ClyQujYD7rRZA8xgE6kvYlqKSNnMrQNmSrcuGncm9vbV9pZL4hRWt5VEtGdkViYl\
-             B6SmxhaUhFOm1hdHJpeC5vcmeoaW1wb3J0ZWTCqWJhY2tlZF91cMKyaGlzdG9yeV92aXNpYmlsaXR5wKlhbGdv\
-             cml0aG20bS5tZWdvbG0udjEuYWVzLXNoYTI";
+        const SERIALIZED_B64: &str = "\
+            iaZwaWNrbGWEr2luaXRpYWxfcmF0Y2hldIKlaW5uZXLcAIABYMzfSnBRzMlPKF1uKjYbzLtkzNJ4RcylzN0HzP\
+            9DzON1Tm05zO7M2MzFQsy9Acz9zPnMqDvM4syQzNrMzxF5KzbM4sy9zPUbBWfM7m4/zJzM18zDzMESKgfMkE7M\
+            yszIHszqWjYyQURbzKTMkx7M58zANsy+AGPM2A8tbcyFYczge8ykzMFdbVxJMMyAzN8azJEXGsy8zPJazMMaP8\
+            ziDszmWwfM+My2ajLMr8y+eczTRm9TFadjb3VudGVyAKtzaWduaW5nX2tlecQgefpCr6Duu7QUWzKIeMOFmxv/\
+            NjfcsYwZz8IN2ZOhdaS0c2lnbmluZ19rZXlfdmVyaWZpZWTDpmNvbmZpZ4GndmVyc2lvbqJWMapzZW5kZXJfa2\
+            V52StoMkIySDg2ajFpYmk2SW13ak9UUkhzbTVMamtyT2kyUGtiSXVUb0w0TWtFq3NpZ25pbmdfa2V5gadlZDI1\
+            NTE52StUWHJqNS9UYXpia3Yram1CZDl4UlB4NWNVaFFzNUNnblc1Q1pNRjgvNjZzq3NlbmRlcl9kYXRhgbBTZW\
+            5kZXJVbnZlcmlmaWVkg6d1c2VyX2lks0B2YWxvdTM1Om1hdHJpeC5vcmepZGV2aWNlX2lkqkZJQlNaRlJLUE2q\
+            bWFzdGVyX2tlecQgkOp9s4ClyQujYD7rRZA8xgE6kvYlqKSNnMrQNmSrcuGncm9vbV9pZL4hRWt5VEtGdkViYl\
+            B6SmxhaUhFOm1hdHJpeC5vcmeoaW1wb3J0ZWTCqWJhY2tlZF91cMKyaGlzdG9yeV92aXNpYmlsaXR5wKlhbGdv\
+            cml0aG20bS5tZWdvbG0udjEuYWVzLXNoYTI";
 
         let input = base64_decode(SERIALIZED_B64).unwrap();
         let sender_data: PickledInboundGroupSession = rmp_serde::from_slice(&input)

--- a/crates/matrix-sdk-crypto/src/secret_storage.rs
+++ b/crates/matrix-sdk-crypto/src/secret_storage.rs
@@ -78,11 +78,17 @@ pub enum DecodeError {
     Mac(#[from] MacError),
     /// The MAC of the secret storage key for the MAC check has an incorrect
     /// length.
-    #[error("The MAC of for the secret storage MAC check has an incorrect length, expected: {0}, got: {1}")]
+    #[error(
+        "The MAC of for the secret storage MAC check has an incorrect length, \
+         expected: {0}, got: {1}"
+    )]
     MacLength(usize, usize),
     /// The IV of the secret storage key for the MAC check has an incorrect
     /// length.
-    #[error("The IV of for the secret storage key MAC check has an incorrect length, expected: {0}, got: {1}")]
+    #[error(
+        "The IV of for the secret storage key MAC check has an incorrect length, \
+         expected: {0}, got: {1}"
+    )]
     IvLength(usize, usize),
     /// The secret storage key is using an unsupported secret encryption
     /// algorithm. Currently only the [`m.secret_storage.v1.aes-hmac-sha2`]

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -304,12 +304,12 @@ pub(crate) async fn collect_recipients_for_share_strategy(
                 None => {
                     return Err(OlmError::SessionRecipientCollectionError(
                         SessionRecipientCollectionError::CrossSigningNotSetup,
-                    ))
+                    ));
                 }
                 Some(identity) if !identity.is_verified() => {
                     return Err(OlmError::SessionRecipientCollectionError(
                         SessionRecipientCollectionError::SendingFromUnverifiedDevice,
-                    ))
+                    ));
                 }
                 Some(_) => (),
             }

--- a/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
+++ b/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
@@ -190,7 +190,9 @@ impl CryptoStoreWrapper {
                 let own_identity_is_verified = own_identity_after.is_verified();
 
                 if !own_identity_was_verified_before_change && own_identity_is_verified {
-                    debug!("Own identity is now verified, check all known identities for verification status changes");
+                    debug!(
+                        "Own identity is now verified, check all known identities for verification status changes"
+                    );
                     // We need to review all the other identities to see if they are verified now
                     // and mark them as such
                     self.check_all_identities_and_update_was_previously_verified_flag_if_needed(

--- a/crates/matrix-sdk-crypto/src/types/qr_login.rs
+++ b/crates/matrix-sdk-crypto/src/types/qr_login.rs
@@ -299,11 +299,11 @@ mod test {
     ];
 
     // Test vector for the QR code data in base64 format, self-generated.
-    const QR_CODE_DATA_BASE64: &str =
-        "TUFUUklYAgS0yzZ1QVpQ1jlnoxWX3d5jrWRFfELxjS2gN7pz9y+3PABaaHR0\
-         cHM6Ly9zeW5hcHNlLW9pZGMubGFiLmVsZW1lbnQuZGV2L19zeW5hcHNlL2Ns\
-         aWVudC9yZW5kZXp2b3VzLzAxSFg5SzAwUTFINktQRDQ3RUc0RzFUM1hHACVo\
-         dHRwczovL3N5bmFwc2Utb2lkYy5sYWIuZWxlbWVudC5kZXYv";
+    const QR_CODE_DATA_BASE64: &str = "\
+        TUFUUklYAgS0yzZ1QVpQ1jlnoxWX3d5jrWRFfELxjS2gN7pz9y+3PABaaHR0\
+        cHM6Ly9zeW5hcHNlLW9pZGMubGFiLmVsZW1lbnQuZGV2L19zeW5hcHNlL2Ns\
+        aWVudC9yZW5kZXp2b3VzLzAxSFg5SzAwUTFINktQRDQ3RUc0RzFUM1hHACVo\
+        dHRwczovL3N5bmFwc2Utb2lkYy5sYWIuZWxlbWVudC5kZXYv";
 
     #[test]
     fn parse_qr_data() {

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -367,7 +367,10 @@ impl VerificationMachine {
                 let Some(device_data) =
                     self.store.get_device(event.sender(), r.from_device()).await?
                 else {
-                    warn!("Could not retrieve the device data for the incoming verification request, ignoring it");
+                    warn!(
+                        "Could not retrieve the device data for the incoming verification request, \
+                         ignoring it"
+                    );
                     return Ok(());
                 };
 

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -973,7 +973,7 @@ impl InnerRequest {
                 s.clone().into_canceled(cancelled_by_us, cancel_code)
             }
             InnerRequest::Passive(_) | InnerRequest::Done(_) | InnerRequest::Cancelled(_) => {
-                return None
+                return None;
             }
         });
 
@@ -1390,11 +1390,15 @@ async fn receive_start<T: Clone>(
                                 ),
                                 (Ordering::Greater, _) | (Ordering::Equal, Ordering::Greater)
                             ) {
-                                info!("Started a new SAS verification, replacing an already started one.");
+                                info!(
+                                    "Started a new SAS verification, replacing an already started one."
+                                );
                                 request_state.verification_cache.replace_sas(new.to_owned());
                                 Ok(Some(state.to_transitioned(request_state, new.into())))
                             } else {
-                                info!("Ignored incoming SAS verification from lexicographically larger user/device ID.");
+                                info!(
+                                    "Ignored incoming SAS verification from lexicographically larger user/device ID."
+                                );
                                 Ok(None)
                             }
                         }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v7_to_v8.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v7_to_v8.rs
@@ -101,7 +101,10 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
             }
 
             if !cursor.continue_cursor()?.await? {
-                debug!("Migrated {row_count} sessions: {updated} keys updated and {deleted} obsolete entries deleted.");
+                debug!(
+                    "Migrated {row_count} sessions: {updated} keys updated \
+                     and {deleted} obsolete entries deleted."
+                );
                 break;
             }
         }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -148,7 +148,10 @@ pub enum IndexeddbCryptoStoreError {
     },
     #[error(transparent)]
     CryptoStoreError(#[from] CryptoStoreError),
-    #[error("The schema version of the crypto store is too new. Existing version: {current_version}; max supported version: {max_supported_version}")]
+    #[error(
+        "The schema version of the crypto store is too new. \
+         Existing version: {current_version}; max supported version: {max_supported_version}"
+    )]
     SchemaTooNewError { max_supported_version: u32, current_version: u32 },
 }
 
@@ -1581,7 +1584,9 @@ async fn import_store_cipher_with_key(
             // Loading the cipher with the passphrase was successful. Let's update the
             // stored version of the cipher so that it is encrypted with a key,
             // to save doing this again.
-            debug!("IndexedDbCryptoStore: Migrating passphrase-encrypted store cipher to key-encryption");
+            debug!(
+                "IndexedDbCryptoStore: Migrating passphrase-encrypted store cipher to key-encryption"
+            );
 
             let export = cipher.export_with_key(chacha_key).map_err(CryptoStoreError::backend)?;
             save_store_cipher(db, &export).await?;

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -68,7 +68,10 @@ pub enum IndexeddbStateStoreError {
     DomException { name: String, message: String, code: u16 },
     #[error(transparent)]
     StoreError(#[from] StoreError),
-    #[error("Can't migrate {name} from {old_version} to {new_version} without deleting data. See MigrationConflictStrategy for ways to configure.")]
+    #[error(
+        "Can't migrate {name} from {old_version} to {new_version} without deleting data. \
+         See MigrationConflictStrategy for ways to configure."
+    )]
     MigrationConflict { name: String, old_version: u32, new_version: u32 },
 }
 

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -77,7 +77,10 @@ pub enum Error {
 
     /// Failed to import a store cipher, the export used a passphrase while
     /// we are trying to import it using a key or vice-versa.
-    #[error("Failed to import a store cipher, the export used a passphrase while we are trying to import it using a key or vice-versa")]
+    #[error(
+        "Failed to import a store cipher, the export used a passphrase while we are trying to \
+         import it using a key or vice-versa"
+    )]
     KdfMismatch,
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
@@ -427,7 +427,10 @@ impl Aggregations {
         };
 
         let Some(aggregation) = aggregation else {
-            warn!("incorrect internal state: {aggregation_id:?} was present in the inverted map, not in related-to map.");
+            warn!(
+                "incorrect internal state: {aggregation_id:?} was present in the inverted map, \
+                 not in related-to map."
+            );
             return Ok(false);
         };
 
@@ -807,6 +810,9 @@ pub(crate) enum AggregationError {
     #[error("a redaction can't be unapplied")]
     CantUndoRedaction,
 
-    #[error("trying to apply an aggregation of one type to an invalid target: expected {expected}, actual {actual}")]
+    #[error(
+        "trying to apply an aggregation of one type to an invalid target: \
+         expected {expected}, actual {actual}"
+    )]
     InvalidType { expected: String, actual: String },
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -511,7 +511,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
     ) -> Result<bool, PaginationError> {
         let PaginationResult { events, hit_end_of_timeline } = match &*self.focus.read().await {
             TimelineFocusData::Live | TimelineFocusData::PinnedEvents { .. } => {
-                return Err(PaginationError::NotSupported)
+                return Err(PaginationError::NotSupported);
             }
             TimelineFocusData::Event { paginator, .. } => paginator
                 .paginate_backward(num_events.into())
@@ -713,7 +713,10 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                     let new_item = item.with_reactions(reactions);
                     state.items.replace(item_pos, new_item);
                 } else {
-                    warn!("reaction is missing on the item, not removing it locally, but sending redaction.");
+                    warn!(
+                        "reaction is missing on the item, not removing it locally, \
+                         but sending redaction."
+                    );
                 }
 
                 // Release the lock before running the request.
@@ -738,7 +741,10 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                             let new_item = item.with_reactions(reactions);
                             state.items.replace(item_pos, new_item);
                         } else {
-                            warn!("couldn't find item to re-add reaction anymore; maybe it's been redacted?");
+                            warn!(
+                                "couldn't find item to re-add reaction anymore; \
+                                 maybe it's been redacted?"
+                            );
                         }
                     }
 
@@ -1493,7 +1499,9 @@ impl TimelineController {
                         event_id,
                         state.items.all_remote_events(),
                     ) {
-                        trace!("event referred to new receipt is {relative_pos:?} the previous receipt");
+                        trace!(
+                            "event referred to new receipt is {relative_pos:?} the previous receipt"
+                        );
                         return relative_pos == RelativePosition::After;
                     }
                 }
@@ -1510,7 +1518,9 @@ impl TimelineController {
                         event_id,
                         state.items.all_remote_events(),
                     ) {
-                        trace!("event referred to new receipt is {relative_pos:?} the previous receipt");
+                        trace!(
+                            "event referred to new receipt is {relative_pos:?} the previous receipt"
+                        );
                         return relative_pos == RelativePosition::After;
                     }
                 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -157,7 +157,10 @@ impl ReadReceipts {
                 // The old receipt is more recent since we can't find the new receipt in the
                 // timeline and we supposedly have all events since the end of the timeline.
                 if !is_own_user_id {
-                    trace!("we had a previous read receipt, but couldn't find the event targeted by the new read receipt in the timeline, exiting");
+                    trace!(
+                        "we had a previous read receipt, but couldn't find the event \
+                         targeted by the new read receipt in the timeline, exiting"
+                    );
                 }
                 return;
             };

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -159,7 +159,10 @@ impl<'a> TimelineStateTransaction<'a> {
                         )
                         .await;
                     } else {
-                        warn!(event_index, "Set update dropped because there wasn't any attached timeline item index.");
+                        warn!(
+                            event_index,
+                            "Set update dropped because there wasn't any attached timeline item index."
+                        );
                     }
                 }
 
@@ -316,7 +319,10 @@ impl<'a> TimelineStateTransaction<'a> {
                         )
                         .await;
                     } else {
-                        warn!(event_index, "Set update dropped because there wasn't any attached timeline item index.");
+                        warn!(
+                            event_index,
+                            "Set update dropped because there wasn't any attached timeline item index."
+                        );
                     }
                 }
 

--- a/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
@@ -300,7 +300,10 @@ impl DateDividerAdjuster {
                     if let Some(last_event_ts) = latest_event_ts {
                         if timestamp_to_date(last_event_ts) == event_date {
                             // There's a previous event with the same date: remove the divider.
-                            trace!("removed date divider @ {item_index} between two events that have the same date");
+                            trace!(
+                                "removed date divider @ {item_index} between two events \
+                                 that have the same date"
+                            );
                             self.ops.insert(insert_op_at, DateDividerOperation::Remove(item_index));
                             return;
                         }

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -381,17 +381,19 @@ async fn test_reply() {
     let date_divider = assert_next_matches!(stream, VectorDiff::PushFront { value } => value);
     assert!(date_divider.is_date_divider());
 
-    let reply_formatted_body = format!("\
-        <mx-reply>\
-            <blockquote>\
-                <a href=\"https://matrix.to/#/!my_room:server.name/{first_event_id}\">In reply to</a> \
-                <a href=\"https://matrix.to/#/{first_event_sender}\">{first_event_sender}</a>\
-                <br>\
-                I want you to reply\
-            </blockquote>\
-        </mx-reply>\
-        <p>I'm replying!</p>\
-    ");
+    let reply_formatted_body = format!(
+        "\
+            <mx-reply>\
+                <blockquote>\
+                    <a href=\"https://matrix.to/#/!my_room:server.name/{first_event_id}\">In reply to</a> \
+                    <a href=\"https://matrix.to/#/{first_event_sender}\">{first_event_sender}</a>\
+                    <br>\
+                    I want you to reply\
+                </blockquote>\
+            </mx-reply>\
+            <p>I'm replying!</p>\
+        "
+    );
     let reply_plain = format!(
         "> <{first_event_sender}> I want you to reply\n\
          I'm replying!"

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -229,7 +229,10 @@ pub enum CrossProcessRefreshLockError {
     MissingLock,
 
     /// Cross-process lock was set, but without session callbacks.
-    #[error("reload session callback must be set with Client::set_session_callbacks() for the cross-process lock to work")]
+    #[error(
+        "reload session callback must be set with Client::set_session_callbacks() \
+         for the cross-process lock to work"
+    )]
     MissingReloadSession,
 
     /// The store has been created twice.

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
@@ -187,6 +187,9 @@ pub enum SecureChannelError {
 
     /// Both devices have advertised the same intent in the login attempt, i.e.
     /// both sides claim to be a new device.
-    #[error("The secure channel could not have been established, the two devices have the same login intent")]
+    #[error(
+        "The secure channel could not have been established, \
+         the two devices have the same login intent"
+    )]
     InvalidIntent,
 }

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -680,7 +680,10 @@ async fn build_indexeddb_store_config(
     };
 
     let store_config = {
-        tracing::warn!("The IndexedDB backend does not implement an event cache store, falling back to the in-memory event cache store…");
+        tracing::warn!(
+            "The IndexedDB backend does not implement an event cache store, \
+             falling back to the in-memory event cache store…"
+        );
         store_config.event_cache_store(matrix_sdk_base::event_cache::store::MemoryStore::new())
     };
 

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -119,7 +119,10 @@ where
                                 )) if *error_response.error()
                                     == BasicErrorResponseType::InvalidGrant =>
                                 {
-                                    error!("Token refresh: OAuth 2.0 refresh_token rejected with invalid grant");
+                                    error!(
+                                        "Token refresh: OAuth 2.0 refresh_token rejected \
+                                         with invalid grant"
+                                    );
                                     // The refresh was denied, signal to sign out the user.
                                     client.broadcast_unknown_token(soft_logout);
                                 }

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -702,7 +702,10 @@ impl Backups {
                 if let Some(kind) = error.client_api_error_kind() {
                     match kind {
                         ErrorKind::NotFound => {
-                            warn!("No backup found on the server, the backup likely got deleted, disabling backups.");
+                            warn!(
+                                "No backup found on the server, the backup likely got deleted, \
+                                 disabling backups."
+                            );
 
                             self.handle_deleted_backup_version(olm_machine).await?;
                         }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1548,7 +1548,10 @@ impl Encryption {
             if prev_holder == lock_value {
                 return Ok(());
             }
-            warn!("Recreating cross-process store lock with a different holder value: prev was {prev_holder}, new is {lock_value}");
+            warn!(
+                "Recreating cross-process store lock with a different holder value: \
+                 prev was {prev_holder}, new is {lock_value}"
+            );
         }
 
         let olm_machine = self.client.base_client().olm_machine().await;

--- a/crates/matrix-sdk/src/encryption/tasks.rs
+++ b/crates/matrix-sdk/src/encryption/tasks.rs
@@ -360,7 +360,10 @@ impl BackupDownloadTaskListenerState {
             .await
             .unwrap_or(false)
         {
-            debug!(?download_request, "Not performing backup download because key became available while we were sleeping");
+            debug!(
+                ?download_request,
+                "Not performing backup download because key became available while we were sleeping"
+            );
             return false;
         }
 

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -245,7 +245,9 @@ impl EventCache {
                         match err {
                             EventCacheError::ClientDropped => {
                                 // The client has dropped, exit the listen task.
-                                info!("Closing the event cache global listen task because client dropped");
+                                info!(
+                                    "Closing the event cache global listen task because client dropped"
+                                );
                                 break;
                             }
                             err => {

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -117,7 +117,10 @@ impl Drop for RoomEventCacheSubscriber {
                 if num_attempts > 1024 {
                     // If we've tried too many times, just give up with a warning; after all, this
                     // is only an optimization.
-                    warn!("couldn't send notification to the auto-shrink channel after 1024 attempts; giving up");
+                    warn!(
+                        "couldn't send notification to the auto-shrink channel \
+                         after 1024 attempts; giving up"
+                    );
                     return;
                 }
 

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -144,7 +144,10 @@ pub enum MediaError {
     LocalMediaNotFound,
 
     /// The provided media is too large to upload.
-    #[error("The provided media is too large to upload. Maximum upload length is {max} bytes, tried to upload {current} bytes")]
+    #[error(
+        "The provided media is too large to upload. \
+         Maximum upload length is {max} bytes, tried to upload {current} bytes"
+    )]
     MediaTooLargeToUpload {
         /// The `max_upload_size` value for this homeserver.
         max: UInt,

--- a/crates/matrix-sdk/src/notification_settings/rule_commands.rs
+++ b/crates/matrix-sdk/src/notification_settings/rule_commands.rs
@@ -39,7 +39,7 @@ impl RuleCommands {
             _ => {
                 return Err(NotificationSettingsError::InvalidParameter(
                     "cannot insert a rule for this kind.".to_owned(),
-                ))
+                ));
             }
         };
 

--- a/crates/matrix-sdk/src/room/edit.rs
+++ b/crates/matrix-sdk/src/room/edit.rs
@@ -99,7 +99,10 @@ pub enum EditError {
     Deserialize(#[from] serde_json::Error),
 
     /// We tried to edit an event of type A with content of type B.
-    #[error("The original event type ({target}) isn't the same as the parameter's new content type ({new_content})")]
+    #[error(
+        "The original event type ({target}) isn't the same as \
+         the parameter's new content type ({new_content})"
+    )]
     IncompatibleEditType {
         /// The type of the target event.
         target: String,

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -40,7 +40,10 @@ pub enum VersionBuilderError {
 
     /// `/versions` does not contain `org.matrix.simplified_msc3575` in its
     /// `unstable_features`, or it's not set to true.
-    #[error("`/versions` does not contain `org.matrix.simplified_msc3575` in its `unstable_features`, or it's not set to true.")]
+    #[error(
+        "`/versions` does not contain `org.matrix.simplified_msc3575` in its `unstable_features`, \
+         or it's not set to true."
+    )]
     NativeVersionIsUnset,
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/error.rs
+++ b/crates/matrix-sdk/src/sliding_sync/error.rs
@@ -21,7 +21,10 @@ pub enum Error {
     /// A `SlidingSyncListRequestGenerator` has been used without having been
     /// initialized. It happens when a response is handled before a request has
     /// been sent. It usually happens when testing.
-    #[error("The sliding sync list `{0}` is handling a response, but its request generator has not been initialized")]
+    #[error(
+        "The sliding sync list `{0}` is handling a response, \
+         but its request generator has not been initialized"
+    )]
     RequestGeneratorHasNotBeenInitialized(String),
 
     /// Ranges have a `start` bound greater than `end`.
@@ -46,7 +49,10 @@ pub enum Error {
     InvalidSlidingSyncIdentifier,
 
     /// A task failed to execute to completion.
-    #[error("A task failed to execute to completion; task description: {task_description}, error: {error}")]
+    #[error(
+        "A task failed to execute to completion; \
+         task description: {task_description}, error: {error}"
+    )]
     JoinError {
         /// Task description.
         task_description: String,

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -280,7 +280,7 @@ impl WidgetMachine {
                 return vec![Self::send_from_widget_err_response(
                     raw_request,
                     FromWidgetErrorResponse::from_error(Error::SerdeJson(e)),
-                )]
+                )];
             }
         };
 
@@ -348,7 +348,8 @@ impl WidgetMachine {
                 let CapabilitiesState::Negotiated(capabilities) = &self.capabilities else {
                     return vec![Self::send_from_widget_error_string_response(
                         raw_request,
-                        "Received send update delayed event request before capabilities were negotiated"
+                        "Received send update delayed event request \
+                         before capabilities were negotiated",
                     )];
                 };
 

--- a/testing/matrix-sdk-test/src/test_json/keys_query.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query.rs
@@ -50,29 +50,45 @@ impl KeysQueryUser {
             device_key_ed22519: "6melQNnhoI9sT2b4VzNPAwa8aB179ym45fON8Yo7kVk",
             device_signature: "Fk45zHAbrd+1j9wZXLjL2Y/+DU/Mnz9yuvlfYBOOT7qExN2Jdud+5BAuNs8nZ/caS4wTF39Kg3zQpzaGERoCBg",
             device_signature_2_name: Some("dO4gmBNW7WC0bXBK81j8uh4me6085fP+keoOm0pH3gw"),
-            device_signature_2_signature: Some("md0Pa1MYlneFb1fp6KCsvZpi2ySb6/G+ULoCbQDWBeDxNEcoNMzf7PEKY04UToCZKUU4LifvRWmiWFDanOlkCQ"),
+            device_signature_2_signature: Some(
+                "md0Pa1MYlneFb1fp6KCsvZpi2ySb6/G+ULoCbQDWBeDxNEcoNMzf7PEKY04UToCZKUU4LifvRWmiWFDanOlkCQ",
+            ),
             master_key_name: Some("/mULSzYNTdHJOBWnBmsvDHhqdHQcWnXRHHmqwzwC7DY"),
-            master_key_signature: Some("6vGDbPO5XzlcwbU3aV+kcck+iHHEBtX85ow2gW5U05/DZdtda/JNVa5Nn7B9lQHNnnrMqt1sX00y/JrIkSS1Aw"),
-            master_key_device_signature: Some("jLxmUPr0Ny2Ai9+NGKGhed9BAuKikOc7r6gr7MQVawePYS95w8NJ8Tzaq9zFFOmIiojACNdQ/ksy3QAdwD6vBQ"),
+            master_key_signature: Some(
+                "6vGDbPO5XzlcwbU3aV+kcck+iHHEBtX85ow2gW5U05/DZdtda/JNVa5Nn7B9lQHNnnrMqt1sX00y/JrIkSS1Aw",
+            ),
+            master_key_device_signature: Some(
+                "jLxmUPr0Ny2Ai9+NGKGhed9BAuKikOc7r6gr7MQVawePYS95w8NJ8Tzaq9zFFOmIiojACNdQ/ksy3QAdwD6vBQ",
+            ),
             self_signing_key_name: Some("dO4gmBNW7WC0bXBK81j8uh4me6085fP+keoOm0pH3gw"),
-            self_signing_key_signature: Some("7md6mwjUK8zjintmffJ0+kImC59/Y8PdySy99EZz5Neu+VMX3LT7txhKO2gC/hmDduRw+JGfGXIiDxR7GmQqDw"),
+            self_signing_key_signature: Some(
+                "7md6mwjUK8zjintmffJ0+kImC59/Y8PdySy99EZz5Neu+VMX3LT7txhKO2gC/hmDduRw+JGfGXIiDxR7GmQqDw",
+            ),
         }
     }
 
     pub(crate) fn bob_b() -> Self {
         Self {
             user_id: user_id!("@bob:localhost"),
-            device_id:  device_id!("ATWKQFSFRN"),
-            device_key_curve25519:  "CY0TWVK1/Kj3ZADuBcGe3UKvpT+IKAPMUsMeJhSDqno",
-            device_key_ed22519:  "TyTQqd6j2JlWZh97r+kTYuCbvqnPoNwO6EGovYsjY00",
-            device_signature:  "BQ9Gp0p+6srF+c8OyruqKKd9R4yaub3THYAyyBB/7X/rG8BwcAqFynzl1aGyFYun4Q+087a5OSiglCXI+/kQAA",
+            device_id: device_id!("ATWKQFSFRN"),
+            device_key_curve25519: "CY0TWVK1/Kj3ZADuBcGe3UKvpT+IKAPMUsMeJhSDqno",
+            device_key_ed22519: "TyTQqd6j2JlWZh97r+kTYuCbvqnPoNwO6EGovYsjY00",
+            device_signature: "BQ9Gp0p+6srF+c8OyruqKKd9R4yaub3THYAyyBB/7X/rG8BwcAqFynzl1aGyFYun4Q+087a5OSiglCXI+/kQAA",
             device_signature_2_name: Some("At1ai1VUZrCncCI7V7fEAJmBShfpqZ30xRzqcEjTjdc"),
-            device_signature_2_signature:  Some("TWmDPaG7t0rZ6luauonELD3dmBDTIRryqXhgsIQRiGint2rJdic8RVyZ6a61bgu6mtBjfvU3prqMNp6sVi16Cg"),
-            master_key_name:  Some("NmI78hY54kE7OZsIjbRE/iCox59t4nzScCNEO6fvtY4"),
-            master_key_signature:  Some("xqLhC3sIUci1W2CNVW7HZWXreQApgjv2RDwB0WPiMd1P4vbZ/qJM0KWqK2piGPWliPi8YVREMrg216KXM3IhCA"),
-            master_key_device_signature:  Some("MBOzCKYPQLQMpBY2lFZJ4c8451xJfQCdhPBb1AHlTUSxKFiWi6V+k1oRRnhQein/PjkIY7ZO+HoOrIeOtbRMAw"),
+            device_signature_2_signature: Some(
+                "TWmDPaG7t0rZ6luauonELD3dmBDTIRryqXhgsIQRiGint2rJdic8RVyZ6a61bgu6mtBjfvU3prqMNp6sVi16Cg",
+            ),
+            master_key_name: Some("NmI78hY54kE7OZsIjbRE/iCox59t4nzScCNEO6fvtY4"),
+            master_key_signature: Some(
+                "xqLhC3sIUci1W2CNVW7HZWXreQApgjv2RDwB0WPiMd1P4vbZ/qJM0KWqK2piGPWliPi8YVREMrg216KXM3IhCA",
+            ),
+            master_key_device_signature: Some(
+                "MBOzCKYPQLQMpBY2lFZJ4c8451xJfQCdhPBb1AHlTUSxKFiWi6V+k1oRRnhQein/PjkIY7ZO+HoOrIeOtbRMAw",
+            ),
             self_signing_key_name: Some("At1ai1VUZrCncCI7V7fEAJmBShfpqZ30xRzqcEjTjdc"),
-            self_signing_key_signature:  Some("Ls6CeoA4LoPCHuSwG96kbhd1dEV09TgdMROIZi6vFz/MT9Wtik6joQi/tQ3zCwIZCSR53ksLO4jG1DD31AiBAA"),
+            self_signing_key_signature: Some(
+                "Ls6CeoA4LoPCHuSwG96kbhd1dEV09TgdMROIZi6vFz/MT9Wtik6joQi/tQ3zCwIZCSR53ksLO4jG1DD31AiBAA",
+            ),
         }
     }
 

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -410,10 +410,7 @@ fn run_wasm_pack_tests(cmd: Option<WasmFeatureSet>) -> Result<()> {
                 "--no-default-features --features js,indexeddb,e2e-encryption,rustls-tls,testing --lib",
             ),
         ),
-        (
-            WasmFeatureSet::IndexeddbAllFeatures,
-            ("crates/matrix-sdk-indexeddb", ""),
-        ),
+        (WasmFeatureSet::IndexeddbAllFeatures, ("crates/matrix-sdk-indexeddb", "")),
         (
             WasmFeatureSet::IndexeddbCrypto,
             ("crates/matrix-sdk-indexeddb", "--no-default-features --features e2e-encryption"),

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -86,7 +86,10 @@ fn check_prerequisites() {
 
     if cmd!(sh, "cargo release --version").quiet().ignore_stdout().run().is_err() {
         eprintln!("This command requires cargo-release, please install it.");
-        eprintln!("More info can be found at: https://github.com/crate-ci/cargo-release?tab=readme-ov-file#install");
+        eprintln!(
+            "More info can be found at: \
+             https://github.com/crate-ci/cargo-release?tab=readme-ov-file#install"
+        );
 
         std::process::exit(1);
     }


### PR DESCRIPTION
Process:
- set style_edition to 2024 in .rustfmt.toml
- run `cargo fmt`
- undo .rustfmt.toml change
- run `cargo fmt` again
- manually rewrap some strings

Should be much less likely to conflict with other PRs than #5255, and reduces the diff of the next iteration of that PR a little.

Signed-off-by: Jonas Platte
