### PR TITLE
refactor(common): Use a constant for the room version to use as a fallback

### DIFF
--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -24,7 +24,7 @@ use ruma::{
         StateEventType,
     },
     push::{Action, PushConditionRoomCtx},
-    RoomVersionId, UInt, UserId,
+    UInt, UserId,
 };
 use tracing::{instrument, trace, warn};
 
@@ -76,9 +76,9 @@ pub async fn build<'notification, 'e2ee>(
                     AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomRedaction(
                         redaction_event,
                     )) => {
-                        let room_version = room_info.room_version().unwrap_or(&RoomVersionId::V1);
+                        let room_version = room_info.room_version_or_default();
 
-                        if let Some(redacts) = redaction_event.redacts(room_version) {
+                        if let Some(redacts) = redaction_event.redacts(&room_version) {
                             room_info
                                 .handle_redaction(redaction_event, timeline_event.raw().cast_ref());
 

--- a/crates/matrix-sdk-common/CHANGELOG.md
+++ b/crates/matrix-sdk-common/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+- Expose the `ROOM_VERSION_FALLBACK` that should be used when the version of a
+  room is unknown.
+  ([#5306](https://github.com/matrix-org/matrix-rust-sdk/pull/5306))
+
 ## [0.12.0] - 2025-06-10
 
 No notable changes in this release.
@@ -53,5 +59,3 @@ No notable changes in this release.
 ### Refactor
 
 - Move `linked_chunk` from `matrix-sdk` to `matrix-sdk-common`.
-
-

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -42,6 +42,7 @@ pub mod ttl_cache;
 #[cfg(all(target_family = "wasm", not(tarpaulin_include)))]
 pub mod js_tracing;
 
+use ruma::RoomVersionId;
 pub use store_locks::LEASE_DURATION_MS;
 
 /// Alias for `Send` on non-wasm, empty trait (implemented by everything) on
@@ -104,3 +105,6 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
+
+/// The room version to use as a fallback when the version of a room is unknown.
+pub const ROOM_VERSION_FALLBACK: RoomVersionId = RoomVersionId::V11;

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -30,6 +30,7 @@ use matrix_sdk_base::{
         SerializableEventContent, ServerInfo, StateChanges, StateStore, StoreError,
     },
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, StateStoreDataKey, StateStoreDataValue,
+    ROOM_VERSION_FALLBACK,
 };
 use matrix_sdk_store_encryption::{Error as EncryptionError, StoreCipher};
 use ruma::{
@@ -929,10 +930,10 @@ impl_state_store!({
                                         .get(&self.encode_key(keys::ROOM_INFOS, room_id))?
                                         .await?
                                         .and_then(|f| self.deserialize_value::<RoomInfo>(&f).ok())
-                                        .and_then(|info| info.room_version().cloned())
+                                        .map(|info| info.room_version_or_default())
                                         .unwrap_or_else(|| {
-                                            warn!(?room_id, "Unable to find the room version, assume version 9");
-                                            RoomVersionId::V9
+                                            warn!(?room_id, "Unable to find the room version, assuming {ROOM_VERSION_FALLBACK}");
+                                            ROOM_VERSION_FALLBACK
                                         })
                                     );
                                 }

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -46,7 +46,7 @@ use ruma::{
     },
     serde::Raw,
     CanonicalJsonObject, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri,
-    OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId, TransactionId, UserId,
+    OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tracing::{debug, warn};

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -16,7 +16,7 @@ use matrix_sdk_base::{
         RoomLoadSettings, SentRequestKey,
     },
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, RoomState, StateChanges, StateStore,
-    StateStoreDataKey, StateStoreDataValue,
+    StateStoreDataKey, StateStoreDataValue, ROOM_VERSION_FALLBACK,
 };
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{
@@ -33,7 +33,7 @@ use ruma::{
     },
     serde::Raw,
     CanonicalJsonObject, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
-    OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId, TransactionId, UInt, UserId,
+    OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UInt, UserId,
 };
 use rusqlite::{OptionalExtension, Transaction};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -1319,13 +1319,13 @@ impl StateStore for SqliteStateStore {
                             .ok()
                             .flatten()
                             .and_then(|v| this.deserialize_json::<RoomInfo>(&v).ok())
-                            .and_then(|info| info.room_version().cloned())
+                            .map(|info| info.room_version_or_default())
                             .unwrap_or_else(|| {
                                 warn!(
                                     ?room_id,
-                                    "Unable to find the room version, assume version 9"
+                                    "Unable to find the room version, assuming {ROOM_VERSION_FALLBACK}"
                                 );
-                                RoomVersionId::V9
+                                ROOM_VERSION_FALLBACK
                             })
                     };
 

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -42,12 +42,11 @@ use matrix_sdk_base::{
     linked_chunk::lazy_loader::LazyLoaderError,
     store_locks::LockStoreError,
     sync::RoomUpdates,
+    ROOM_VERSION_FALLBACK,
 };
 use matrix_sdk_common::executor::{spawn, JoinHandle};
 use room::RoomEventCacheState;
-use ruma::{
-    events::AnySyncEphemeralRoomEvent, serde::Raw, OwnedEventId, OwnedRoomId, RoomId, RoomVersionId,
-};
+use ruma::{events::AnySyncEphemeralRoomEvent, serde::Raw, OwnedEventId, OwnedRoomId, RoomId};
 use tokio::sync::{
     broadcast::{channel, error::RecvError, Receiver, Sender},
     mpsc, Mutex, RwLock,
@@ -554,8 +553,8 @@ impl EventCacheInner {
                     .as_ref()
                     .map(|room| room.clone_info().room_version_or_default())
                     .unwrap_or_else(|| {
-                        warn!("unknown room version for {room_id}, using default V1");
-                        RoomVersionId::V1
+                        warn!("unknown room version for {room_id}, using default {ROOM_VERSION_FALLBACK}");
+                        ROOM_VERSION_FALLBACK
                     });
 
                 let room_state = RoomEventCacheState::new(


### PR DESCRIPTION
It avoids using different versions in several places for consistency. It also allows to be able to change it in a single place when needed.

This also bumps the fallback to v11 everywhere, since it is the default version for new rooms since Matrix 1.14 and it has the sanest redaction rules.
