### PR TITLE
Upgrade matrix-sdk-ui to Rust edition 2024

### DIFF
--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -2,7 +2,7 @@
 name = "matrix-sdk-ui"
 description = "GUI-centric utilities on top of matrix-rust-sdk (experimental)."
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 license = "Apache-2.0"
 rust-version.workspace = true

--- a/crates/matrix-sdk-ui/src/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync_service.rs
@@ -30,11 +30,11 @@ use std::{pin::Pin, time::Duration};
 
 use async_stream::stream;
 use futures_core::stream::Stream;
-use futures_util::{pin_mut, StreamExt};
-use matrix_sdk::{sleep::sleep, Client, SlidingSync, LEASE_DURATION_MS};
+use futures_util::{StreamExt, pin_mut};
+use matrix_sdk::{Client, LEASE_DURATION_MS, SlidingSync, sleep::sleep};
 use ruma::{api::client::sync::sync_events::v5 as http, assign};
 use tokio::sync::OwnedMutexGuard;
-use tracing::{debug, instrument, trace, Span};
+use tracing::{Span, debug, instrument, trace};
 
 /// Unit type representing a permit to *use* an [`EncryptionSyncService`].
 ///
@@ -66,11 +66,7 @@ pub enum WithLocking {
 
 impl From<bool> for WithLocking {
     fn from(value: bool) -> Self {
-        if value {
-            Self::Yes
-        } else {
-            Self::No
-        }
+        if value { Self::Yes } else { Self::No }
     }
 }
 
@@ -130,7 +126,7 @@ impl EncryptionSyncService {
                     // Any other error is fatal
                     return Err(Error::ClientError(err));
                 }
-            };
+            }
         }
 
         Ok(Self { client, sliding_sync, with_locking })

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -18,38 +18,39 @@ use std::{
     time::Duration,
 };
 
-use futures_util::{pin_mut, StreamExt as _};
+use futures_util::{StreamExt as _, pin_mut};
 use matrix_sdk::{
-    room::Room, sleep::sleep, Client, ClientBuildError, SlidingSyncList, SlidingSyncMode,
+    Client, ClientBuildError, SlidingSyncList, SlidingSyncMode, room::Room, sleep::sleep,
 };
-use matrix_sdk_base::{deserialized_responses::TimelineEvent, RoomState, StoreError};
+use matrix_sdk_base::{RoomState, StoreError, deserialized_responses::TimelineEvent};
 use ruma::{
+    EventId, OwnedEventId, OwnedRoomId, RoomId, UserId,
     api::client::sync::sync_events::v5 as http,
     assign,
     directory::RoomTypeFilter,
     events::{
+        AnyFullStateEventContent, AnyMessageLikeEventContent, AnyStateEvent,
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, FullStateEventContent, StateEventType,
+        TimelineEventType,
         room::{
             join_rules::JoinRule,
             member::{MembershipState, StrippedRoomMemberEvent},
             message::{Relation, SyncRoomMessageEvent},
         },
-        AnyFullStateEventContent, AnyMessageLikeEventContent, AnyStateEvent,
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent, FullStateEventContent, StateEventType,
-        TimelineEventType,
     },
     html::RemoveReplyFallback,
     push::Action,
     serde::Raw,
-    uint, EventId, OwnedEventId, OwnedRoomId, RoomId, UserId,
+    uint,
 };
 use thiserror::Error;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::{debug, info, instrument, trace, warn};
 
 use crate::{
+    DEFAULT_SANITIZER_MODE,
     encryption_sync_service::{EncryptionSyncPermit, EncryptionSyncService, WithLocking},
     sync_service::SyncService,
-    DEFAULT_SANITIZER_MODE,
 };
 
 /// What kind of process setup do we have for this notification client?

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/any.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/any.rs
@@ -16,7 +16,7 @@ use super::{BoxedFilterFn, Filter};
 
 /// Create a new filter that will run multiple filters. It returns `true` if at
 /// least one of the filter returns `true`.
-pub fn new_filter(filters: Vec<BoxedFilterFn>) -> impl Filter {
+pub fn new_filter(filters: Vec<BoxedFilterFn>) -> impl Filter + use<> {
     move |room| -> bool { filters.iter().any(|filter| filter(room)) }
 }
 

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher as _};
+pub use fuzzy_matcher::{FuzzyMatcher as _, skim::SkimMatcherV2};
 
-use super::{normalize_string, Filter};
+use super::{Filter, normalize_string};
 
 struct FuzzyMatcher {
     matcher: SkimMatcherV2,

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
@@ -44,7 +44,7 @@ impl FuzzyMatcher {
 ///
 /// Rooms are fetched from the `Client`. The pattern and the room names are
 /// normalized with `normalize_string`.
-pub fn new_filter(pattern: &str) -> impl Filter {
+pub fn new_filter(pattern: &str) -> impl Filter + use<> {
     let searcher = FuzzyMatcher::new().with_pattern(pattern);
 
     move |room| -> bool {

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
@@ -21,7 +21,7 @@
 //!
 //! ```rust
 //! use matrix_sdk_ui::room_list_service::{
-//!     filters, RoomListDynamicEntriesController,
+//!     RoomListDynamicEntriesController, filters,
 //! };
 //!
 //! fn configure_room_list(
@@ -67,7 +67,7 @@ mod unread;
 
 pub use all::new_filter as new_filter_all;
 pub use any::new_filter as new_filter_any;
-pub use category::{new_filter as new_filter_category, RoomCategory};
+pub use category::{RoomCategory, new_filter as new_filter_category};
 pub use deduplicate_versions::new_filter as new_filter_deduplicate_versions;
 pub use favourite::new_filter as new_filter_favourite;
 pub use fuzzy_match_room_name::new_filter as new_filter_fuzzy_match_room_name;
@@ -84,12 +84,12 @@ pub use normalized_match_room_name::new_filter as new_filter_normalized_match_ro
 pub use not::new_filter as new_filter_not;
 #[cfg(test)]
 use ruma::RoomId;
-use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
+use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
 pub use unread::new_filter as new_filter_unread;
 #[cfg(test)]
 use wiremock::{
-    matchers::{header, method, path},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path},
 };
 
 /// A trait “alias” that represents a _filter_.

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/normalized_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/normalized_match_room_name.rs
@@ -45,7 +45,7 @@ impl NormalizedMatcher {
 ///
 /// Rooms are fetched from the `Client`. The pattern and the room names are
 /// normalized with `normalize_string`.
-pub fn new_filter(pattern: &str) -> impl Filter {
+pub fn new_filter(pattern: &str) -> impl Filter + use<> {
     let searcher = NormalizedMatcher::new().with_pattern(pattern);
 
     move |room| -> bool {

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/normalized_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/normalized_match_room_name.rs
@@ -14,7 +14,7 @@
 
 use tracing::error;
 
-use super::{normalize_string, Filter};
+use super::{Filter, normalize_string};
 
 struct NormalizedMatcher {
     pattern: Option<String>,

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -326,7 +326,7 @@ impl RoomListService {
         &self,
         delay_before_showing: Duration,
         delay_before_hiding: Duration,
-    ) -> impl Stream<Item = SyncIndicator> {
+    ) -> impl Stream<Item = SyncIndicator> + use<> {
         let mut state = self.state();
 
         stream! {

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -60,15 +60,15 @@ use std::{sync::Arc, time::Duration};
 
 use async_stream::stream;
 use eyeball::Subscriber;
-use futures_util::{pin_mut, Stream, StreamExt};
+use futures_util::{Stream, StreamExt, pin_mut};
 use matrix_sdk::{
-    event_cache::EventCacheError, timeout::timeout, Client, Error as SlidingSyncError, Room,
-    SlidingSync, SlidingSyncList, SlidingSyncMode,
+    Client, Error as SlidingSyncError, Room, SlidingSync, SlidingSyncList, SlidingSyncMode,
+    event_cache::EventCacheError, timeout::timeout,
 };
 pub use room_list::*;
 use ruma::{
-    api::client::sync::sync_events::v5 as http, assign, directory::RoomTypeFilter,
-    events::StateEventType, OwnedRoomId, RoomId, UInt,
+    OwnedRoomId, RoomId, UInt, api::client::sync::sync_events::v5 as http, assign,
+    directory::RoomTypeFilter, events::StateEventType,
 };
 pub use state::*;
 use thiserror::Error;
@@ -501,16 +501,16 @@ pub enum SyncIndicator {
 mod tests {
     use std::future::ready;
 
-    use futures_util::{pin_mut, StreamExt};
+    use futures_util::{StreamExt, pin_mut};
     use matrix_sdk::{
-        config::RequestConfig, test_utils::client::mock_matrix_session, Client, SlidingSyncMode,
+        Client, SlidingSyncMode, config::RequestConfig, test_utils::client::mock_matrix_session,
     };
     use matrix_sdk_test::async_test;
     use ruma::api::MatrixVersion;
     use serde_json::json;
-    use wiremock::{http::Method, Match, Mock, MockServer, Request, ResponseTemplate};
+    use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate, http::Method};
 
-    use super::{Error, RoomListService, State, ALL_ROOMS_LIST_NAME};
+    use super::{ALL_ROOMS_LIST_NAME, Error, RoomListService, State};
 
     async fn new_client() -> (Client, MockServer) {
         let session = mock_matrix_session();

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -20,10 +20,10 @@ use async_stream::stream;
 use eyeball::{SharedObservable, Subscriber};
 use eyeball_im::{Vector, VectorDiff};
 use eyeball_im_util::vector::VectorObserverExt;
-use futures_util::{pin_mut, stream, Stream, StreamExt as _};
+use futures_util::{Stream, StreamExt as _, pin_mut, stream};
 use matrix_sdk::{
-    executor::{spawn, JoinHandle},
     Client, SlidingSync, SlidingSyncList,
+    executor::{JoinHandle, spawn},
 };
 use matrix_sdk_base::RoomInfoNotableUpdate;
 use tokio::{
@@ -33,9 +33,9 @@ use tokio::{
 use tracing::{error, trace};
 
 use super::{
+    Error, Room, State,
     filters::BoxedFilterFn,
     sorters::{new_sorter_lexicographic, new_sorter_name, new_sorter_recency},
-    Error, Room, State,
 };
 
 /// A `RoomList` represents a list of rooms, from a

--- a/crates/matrix-sdk-ui/src/room_list_service/state.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/state.rs
@@ -17,7 +17,7 @@
 use std::{future::ready, sync::Mutex};
 
 use eyeball::{SharedObservable, Subscriber};
-use matrix_sdk::{sliding_sync::Range, SlidingSync, SlidingSyncMode};
+use matrix_sdk::{SlidingSync, SlidingSyncMode, sliding_sync::Range};
 use ruma::time::{Duration, Instant};
 
 use super::Error;

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -28,21 +28,22 @@ use std::{sync::Arc, time::Duration};
 
 use eyeball::{SharedObservable, Subscriber};
 use futures_util::{
-    future::{select, Either},
-    pin_mut, StreamExt as _,
+    StreamExt as _,
+    future::{Either, select},
+    pin_mut,
 };
 use matrix_sdk::{
-    config::RequestConfig,
-    executor::{spawn, JoinHandle},
-    sleep::sleep,
     Client,
+    config::RequestConfig,
+    executor::{JoinHandle, spawn},
+    sleep::sleep,
 };
 use thiserror::Error;
 use tokio::sync::{
-    mpsc::{Receiver, Sender},
     Mutex as AsyncMutex, OwnedMutexGuard,
+    mpsc::{Receiver, Sender},
 };
-use tracing::{error, info, instrument, trace, warn, Instrument, Level, Span};
+use tracing::{Instrument, Level, Span, error, info, instrument, trace, warn};
 
 use crate::{
     encryption_sync_service::{self, EncryptionSyncPermit, EncryptionSyncService, WithLocking},

--- a/crates/matrix-sdk-ui/src/timeline/algorithms.rs
+++ b/crates/matrix-sdk-ui/src/timeline/algorithms.rs
@@ -20,8 +20,8 @@ use ruma::EventId;
 #[cfg(doc)]
 use super::controller::TimelineMetadata;
 use super::{
-    event_item::EventTimelineItemKind, item::TimelineUniqueId, EventTimelineItem,
-    ReactionsByKeyBySender, TimelineEventItemId, TimelineItem,
+    EventTimelineItem, ReactionsByKeyBySender, TimelineEventItemId, TimelineItem,
+    event_item::EventTimelineItemKind, item::TimelineUniqueId,
 };
 
 pub(super) struct EventTimelineItemWithId<'a> {

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -14,14 +14,14 @@
 
 use std::sync::Arc;
 
-use matrix_sdk::{executor::spawn, Room};
+use matrix_sdk::{Room, executor::spawn};
 use matrix_sdk_base::{SendOutsideWasm, SyncOutsideWasm};
-use ruma::{events::AnySyncTimelineEvent, RoomVersionId};
-use tracing::{info_span, Instrument, Span};
+use ruma::{RoomVersionId, events::AnySyncTimelineEvent};
+use tracing::{Instrument, Span, info_span};
 
 use super::{
-    controller::{TimelineController, TimelineSettings},
     DateDividerMode, Error, Timeline, TimelineDropHandle, TimelineFocus,
+    controller::{TimelineController, TimelineSettings},
 };
 use crate::{
     timeline::{

--- a/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
@@ -42,17 +42,17 @@ use std::{borrow::Cow, collections::HashMap, sync::Arc};
 use as_variant::as_variant;
 use matrix_sdk::deserialized_responses::EncryptionInfo;
 use ruma::{
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId,
     events::{
+        AnySyncTimelineEvent,
         poll::unstable_start::NewUnstablePollStartEventContentWithoutRelation,
         relation::Replacement, room::message::RoomMessageEventContentWithoutRelation,
-        AnySyncTimelineEvent,
     },
     serde::Raw,
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId,
 };
 use tracing::{info, trace, warn};
 
-use super::{rfind_event_by_item_id, ObservableItemsTransaction};
+use super::{ObservableItemsTransaction, rfind_event_by_item_id};
 use crate::timeline::{
     EventTimelineItem, MsgLikeContent, MsgLikeKind, PollState, ReactionInfo, ReactionStatus,
     TimelineEventItemId, TimelineItem, TimelineItemContent,
@@ -642,11 +642,7 @@ fn resolve_edits(
         }
     }
 
-    if let Some(edit) = best_edit {
-        edit_item(event, edit)
-    } else {
-        false
-    }
+    if let Some(edit) = best_edit { edit_item(event, edit) } else { false }
 }
 
 /// Apply the selected edit to the given EventTimelineItem.

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -20,29 +20,29 @@ use std::{
 use imbl::Vector;
 use matrix_sdk::deserialized_responses::EncryptionInfo;
 use ruma::{
+    EventId, OwnedEventId, OwnedUserId, RoomVersionId,
     events::{
-        poll::unstable_start::UnstablePollStartEventContent, relation::Replacement,
-        room::message::RelationWithoutReplacement, AnyMessageLikeEventContent,
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent, BundledMessageLikeRelations,
+        AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+        BundledMessageLikeRelations, poll::unstable_start::UnstablePollStartEventContent,
+        relation::Replacement, room::message::RelationWithoutReplacement,
     },
     serde::Raw,
-    EventId, OwnedEventId, OwnedUserId, RoomVersionId,
 };
 use tracing::trace;
 
 use super::{
-    super::{subscriber::skip::SkipCount, TimelineItem, TimelineItemKind, TimelineUniqueId},
-    read_receipts::ReadReceipts,
+    super::{TimelineItem, TimelineItemKind, TimelineUniqueId, subscriber::skip::SkipCount},
     Aggregation, AggregationKind, Aggregations, AllRemoteEvents, ObservableItemsTransaction,
     PendingEdit, PendingEditKind,
+    read_receipts::ReadReceipts,
 };
 use crate::{
     timeline::{
+        InReplyToDetails, TimelineEventItemId,
         event_item::{
             extract_bundled_edit_event_json, extract_poll_edit_content,
             extract_room_msg_edit_content,
         },
-        InReplyToDetails, TimelineEventItemId,
     },
     unable_to_decrypt_hook::UtdHookManager,
 };

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1240,7 +1240,9 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
     }
 
     /// Subscribe to changes in the read receipts of our own user.
-    pub async fn subscribe_own_user_read_receipts_changed(&self) -> impl Stream<Item = ()> {
+    pub async fn subscribe_own_user_read_receipts_changed(
+        &self,
+    ) -> impl Stream<Item = ()> + use<P, D> {
         self.state.read().await.meta.read_receipts.subscribe_own_user_read_receipts_changed()
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -23,31 +23,31 @@ use imbl::Vector;
 #[cfg(test)]
 use matrix_sdk::crypto::OlmMachine;
 use matrix_sdk::{
+    Result, Room,
     deserialized_responses::TimelineEvent,
     event_cache::{RoomEventCache, RoomPaginationStatus},
     paginators::{PaginationResult, Paginator},
     send_queue::{
         LocalEcho, LocalEchoContent, RoomSendQueueUpdate, SendHandle, SendReactionHandle,
     },
-    Result, Room,
 };
 use ruma::{
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, RoomVersionId,
+    TransactionId, UserId,
     api::client::receipt::create_receipt::v3::ReceiptType as SendReceiptType,
     events::{
+        AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
+        AnySyncTimelineEvent, MessageLikeEventType,
         poll::unstable_start::UnstablePollStartEventContent,
         reaction::ReactionEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         relation::Annotation,
         room::message::{MessageType, Relation},
-        AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
-        AnySyncTimelineEvent, MessageLikeEventType,
     },
     serde::Raw,
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, RoomVersionId,
-    TransactionId, UserId,
 };
 #[cfg(test)]
-use ruma::{events::receipt::ReceiptEventContent, OwnedRoomId, RoomId};
+use ruma::{OwnedRoomId, RoomId, events::receipt::ReceiptEventContent};
 use tokio::sync::{RwLock, RwLockWriteGuard};
 use tracing::{debug, error, field::debug, info, instrument, trace, warn};
 
@@ -61,22 +61,22 @@ pub(super) use self::{
     state_transaction::TimelineStateTransaction,
 };
 use super::{
+    DateDividerMode, EmbeddedEvent, Error, EventSendState, EventTimelineItem, InReplyToDetails,
+    PaginationError, Profile, TimelineDetails, TimelineEventItemId, TimelineFocus, TimelineItem,
+    TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
     algorithms::{rfind_event_by_id, rfind_event_item},
     event_item::{ReactionStatus, RemoteEventOrigin},
     item::TimelineUniqueId,
     subscriber::TimelineSubscriber,
     traits::{Decryptor, RoomDataProvider},
-    DateDividerMode, EmbeddedEvent, Error, EventSendState, EventTimelineItem, InReplyToDetails,
-    PaginationError, Profile, TimelineDetails, TimelineEventItemId, TimelineFocus, TimelineItem,
-    TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
 };
 use crate::{
     timeline::{
+        MsgLikeContent, MsgLikeKind, TimelineEventFilterFn,
         algorithms::rfind_event_by_item_id,
         date_dividers::DateDividerAdjuster,
         event_item::TimelineItemHandle,
         pinned_events_loader::{PinnedEventsLoader, PinnedEventsLoaderError},
-        MsgLikeContent, MsgLikeKind, TimelineEventFilterFn,
     },
     unable_to_decrypt_hook::UtdHookManager,
 };
@@ -90,7 +90,7 @@ mod state;
 mod state_transaction;
 
 pub(super) use aggregations::*;
-pub(super) use decryption_retry_task::{spawn_crypto_tasks, CryptoDropHandles};
+pub(super) use decryption_retry_task::{CryptoDropHandles, spawn_crypto_tasks};
 
 /// Data associated to the current timeline focus.
 ///

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -14,7 +14,7 @@
 
 use std::{
     cmp::Ordering,
-    collections::{vec_deque::Iter, VecDeque},
+    collections::{VecDeque, vec_deque::Iter},
     iter::{Enumerate, Skip, Take},
     ops::{Deref, RangeBounds},
     sync::Arc,
@@ -28,7 +28,7 @@ use eyeball_im::{
 use imbl::Vector;
 use ruma::EventId;
 
-use super::{metadata::EventMeta, TimelineItem};
+use super::{TimelineItem, metadata::EventMeta};
 
 /// An `ObservableItems` is a type similar to
 /// [`ObservableVector<Arc<TimelineItem>>`] except the API is limited and,
@@ -450,11 +450,7 @@ impl<'observable_items> ObservableItemsTransaction<'observable_items> {
     /// Return the index where to insert the first remote timeline
     /// item.
     pub fn first_remotes_region_index(&self) -> usize {
-        if self.items.get(0).is_some_and(|item| item.is_timeline_start()) {
-            1
-        } else {
-            0
-        }
+        if self.items.get(0).is_some_and(|item| item.is_timeline_start()) { 1 } else { 0 }
     }
 
     /// Iterate over all timeline items in the _remotes_ region.
@@ -719,17 +715,18 @@ mod observable_items_tests {
     use assert_matches::assert_matches;
     use eyeball_im::VectorDiff;
     use ruma::{
+        MilliSecondsSinceUnixEpoch,
         events::room::message::{MessageType, TextMessageEventContent},
-        owned_user_id, uint, MilliSecondsSinceUnixEpoch,
+        owned_user_id, uint,
     };
     use stream_assert::{assert_next_matches, assert_pending};
 
     use super::*;
     use crate::timeline::{
-        controller::RemoteEventOrigin,
-        event_item::{EventTimelineItemKind, LocalEventTimelineItem, RemoteEventTimelineItem},
         EventSendState, EventTimelineItem, Message, MsgLikeContent, MsgLikeKind, TimelineDetails,
         TimelineItemContent, TimelineItemKind, TimelineUniqueId, VirtualTimelineItem,
+        controller::RemoteEventOrigin,
+        event_item::{EventTimelineItemKind, LocalEventTimelineItem, RemoteEventTimelineItem},
     };
 
     fn item(event_id: &str) -> Arc<TimelineItem> {

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -17,18 +17,18 @@ use std::{cmp::Ordering, collections::HashMap};
 use futures_core::Stream;
 use indexmap::IndexMap;
 use ruma::{
-    events::receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, UserId,
+    events::receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
 };
 use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 use tracing::{debug, error, instrument, trace, warn};
 
 use super::{
-    rfind_event_by_id, AllRemoteEvents, ObservableItemsTransaction, RelativePosition,
-    RoomDataProvider, TimelineMetadata, TimelineState,
+    AllRemoteEvents, ObservableItemsTransaction, RelativePosition, RoomDataProvider,
+    TimelineMetadata, TimelineState, rfind_event_by_id,
 };
-use crate::timeline::{controller::TimelineStateTransaction, TimelineItem};
+use crate::timeline::{TimelineItem, controller::TimelineStateTransaction};
 
 /// In-memory caches for read receipts.
 #[derive(Clone, Debug, Default)]

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -56,7 +56,9 @@ impl ReadReceipts {
     }
 
     /// Subscribe to changes in the read receipts of our own user.
-    pub(super) fn subscribe_own_user_read_receipts_changed(&self) -> impl Stream<Item = ()> {
+    pub(super) fn subscribe_own_user_read_receipts_changed(
+        &self,
+    ) -> impl Stream<Item = ()> + use<> {
         let subscriber = self.own_user_read_receipts_changed_sender.subscribe();
         WatchStream::from_changes(subscriber)
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -19,24 +19,24 @@ use matrix_sdk::{deserialized_responses::TimelineEvent, send_queue::SendHandle};
 #[cfg(test)]
 use ruma::events::receipt::ReceiptEventContent;
 use ruma::{
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId,
     events::{AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent},
     serde::Raw,
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId,
 };
 use tracing::{instrument, trace, warn};
 
 use super::{
     super::{
+        Profile, TimelineItem,
         date_dividers::DateDividerAdjuster,
         event_handler::{
             Flow, TimelineAction, TimelineEventContext, TimelineEventHandler, TimelineItemPosition,
         },
         event_item::RemoteEventOrigin,
         traits::RoomDataProvider,
-        Profile, TimelineItem,
     },
-    observable_items::ObservableItems,
     DateDividerMode, TimelineMetadata, TimelineSettings, TimelineStateTransaction,
+    observable_items::ObservableItems,
 };
 use crate::{timeline::controller::TimelineFocusKind, unable_to_decrypt_hook::UtdHookManager};
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -20,8 +20,8 @@ use matrix_sdk::deserialized_responses::{
     ThreadSummaryStatus, TimelineEvent, TimelineEventKind, UnsignedEventLocation,
 };
 use ruma::{
-    events::AnySyncTimelineEvent, push::Action, serde::Raw, EventId, MilliSecondsSinceUnixEpoch,
-    OwnedEventId, OwnedTransactionId, OwnedUserId, UserId,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, UserId,
+    events::AnySyncTimelineEvent, push::Action, serde::Raw,
 };
 use tracing::{debug, instrument, warn};
 
@@ -33,13 +33,13 @@ use super::{
         event_item::RemoteEventOrigin,
         traits::RoomDataProvider,
     },
-    metadata::EventMeta,
     ObservableItems, ObservableItemsTransaction, TimelineMetadata, TimelineSettings,
+    metadata::EventMeta,
 };
 use crate::timeline::{
+    EmbeddedEvent, ThreadSummary, TimelineDetails, VirtualTimelineItem,
     controller::TimelineFocusKind,
     event_handler::{FailedToParseEvent, RemovedItem, TimelineAction},
-    EmbeddedEvent, ThreadSummary, TimelineDetails, VirtualTimelineItem,
 };
 
 pub(in crate::timeline) struct TimelineStateTransaction<'a, P: RoomDataProvider> {

--- a/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
@@ -19,11 +19,11 @@ use std::{fmt::Display, sync::Arc};
 
 use chrono::{Datelike, Local, TimeZone};
 use ruma::MilliSecondsSinceUnixEpoch;
-use tracing::{error, event_enabled, instrument, trace, warn, Level};
+use tracing::{Level, error, event_enabled, instrument, trace, warn};
 
 use super::{
-    controller::{ObservableItemsTransaction, TimelineMetadata},
     DateDividerMode, TimelineItem, TimelineItemKind, VirtualTimelineItem,
+    controller::{ObservableItemsTransaction, TimelineMetadata},
 };
 
 #[derive(Debug, PartialEq)]
@@ -511,11 +511,7 @@ impl DateDividerAdjuster {
             }
         }
 
-        if report.errors.is_empty() {
-            None
-        } else {
-            Some(report)
-        }
+        if report.errors.is_empty() { None } else { Some(report) }
     }
 
     /// Returns whether the two dates for the given timestamps are the same or
@@ -661,15 +657,15 @@ enum DateDividerInsertError {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_let;
-    use ruma::{owned_event_id, owned_user_id, uint, MilliSecondsSinceUnixEpoch};
+    use ruma::{MilliSecondsSinceUnixEpoch, owned_event_id, owned_user_id, uint};
 
     use super::{super::controller::ObservableItems, DateDividerAdjuster};
     use crate::timeline::{
+        DateDividerMode, EventTimelineItem, MsgLikeContent, TimelineItemContent,
+        VirtualTimelineItem,
         controller::TimelineMetadata,
         date_dividers::timestamp_to_date,
         event_item::{EventTimelineItemKind, RemoteEventTimelineItem},
-        DateDividerMode, EventTimelineItem, MsgLikeContent, TimelineItemContent,
-        VirtualTimelineItem,
     };
 
     fn event_with_ts(timestamp: MilliSecondsSinceUnixEpoch) -> EventTimelineItem {

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 use matrix_sdk::{
-    event_cache::EventCacheError, paginators::PaginatorError, room::reply::ReplyError,
-    send_queue::RoomSendQueueError, HttpError,
+    HttpError, event_cache::EventCacheError, paginators::PaginatorError, room::reply::ReplyError,
+    send_queue::RoomSendQueueError,
 };
 use thiserror::Error;
 
-use crate::timeline::{pinned_events_loader::PinnedEventsLoaderError, TimelineEventItemId};
+use crate::timeline::{TimelineEventItemId, pinned_events_loader::PinnedEventsLoaderError};
 
 /// Errors specific to the timeline.
 #[derive(Error, Debug)]

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -22,7 +22,12 @@ use matrix_sdk::{
     send_queue::SendHandle,
 };
 use ruma::{
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
+    TransactionId,
     events::{
+        AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncStateEvent,
+        AnySyncTimelineEvent, EventContent, FullStateEventContent, MessageLikeEventType,
+        StateEventType, SyncStateEvent,
         poll::unstable_start::{
             NewUnstablePollStartEventContentWithoutRelation, UnstablePollStartEventContent,
         },
@@ -31,20 +36,18 @@ use ruma::{
         room::message::{
             Relation, RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
         },
-        AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncStateEvent,
-        AnySyncTimelineEvent, EventContent, FullStateEventContent, MessageLikeEventType,
-        StateEventType, SyncStateEvent,
     },
     serde::Raw,
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
-    TransactionId,
 };
 use tracing::{debug, error, field::debug, instrument, trace, warn};
 
 use super::{
+    EmbeddedEvent, EncryptedMessage, EventTimelineItem, InReplyToDetails, MsgLikeContent,
+    MsgLikeKind, OtherState, ReactionStatus, Sticker, ThreadSummary, TimelineDetails, TimelineItem,
+    TimelineItemContent,
     controller::{
-        find_item_and_apply_aggregation, Aggregation, AggregationKind, ObservableItemsTransaction,
-        PendingEditKind, TimelineMetadata, TimelineStateTransaction,
+        Aggregation, AggregationKind, ObservableItemsTransaction, PendingEditKind,
+        TimelineMetadata, TimelineStateTransaction, find_item_and_apply_aggregation,
     },
     date_dividers::DateDividerAdjuster,
     event_item::{
@@ -53,9 +56,6 @@ use super::{
         TimelineEventItemId,
     },
     traits::RoomDataProvider,
-    EmbeddedEvent, EncryptedMessage, EventTimelineItem, InReplyToDetails, MsgLikeContent,
-    MsgLikeKind, OtherState, ReactionStatus, Sticker, ThreadSummary, TimelineDetails, TimelineItem,
-    TimelineItemContent,
 };
 use crate::timeline::controller::aggregations::PendingEdit;
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -17,7 +17,9 @@
 use std::fmt;
 
 use ruma::{
+    OwnedEventId,
     events::{
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, BundledMessageLikeRelations, Mentions,
         poll::unstable_start::{
             NewUnstablePollStartEventContentWithoutRelation, SyncUnstablePollStartEvent,
             UnstablePollStartEventContent,
@@ -25,11 +27,9 @@ use ruma::{
         room::message::{
             MessageType, Relation, RoomMessageEventContentWithoutRelation, SyncRoomMessageEvent,
         },
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent, BundledMessageLikeRelations, Mentions,
     },
     html::RemoveReplyFallback,
     serde::Raw,
-    OwnedEventId,
 };
 use tracing::{error, trace};
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -16,9 +16,12 @@ use std::sync::Arc;
 
 use as_variant::as_variant;
 use matrix_sdk::crypto::types::events::UtdCause;
-use matrix_sdk_base::latest_event::{is_suitable_for_latest_event, PossibleLatestEvent};
+use matrix_sdk_base::latest_event::{PossibleLatestEvent, is_suitable_for_latest_event};
 use ruma::{
+    OwnedDeviceId, OwnedEventId, OwnedMxcUri, OwnedUserId, RoomVersionId, UserId,
     events::{
+        AnyFullStateEventContent, AnySyncTimelineEvent, FullStateEventContent, Mentions,
+        MessageLikeEventType, StateEventType,
         call::{invite::SyncCallInviteEvent, notify::SyncCallNotifyEvent},
         policy::rule::{
             room::PolicyRuleRoomEventContent, server::PolicyRuleServerEventContent,
@@ -50,11 +53,8 @@ use ruma::{
         },
         space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
         sticker::{StickerEventContent, SyncStickerEvent},
-        AnyFullStateEventContent, AnySyncTimelineEvent, FullStateEventContent, Mentions,
-        MessageLikeEventType, StateEventType,
     },
     html::RemoveReplyFallback,
-    OwnedDeviceId, OwnedEventId, OwnedMxcUri, OwnedUserId, RoomVersionId, UserId,
 };
 use tracing::warn;
 
@@ -1052,12 +1052,11 @@ mod tests {
     use assert_matches2::assert_let;
     use matrix_sdk_test::ALICE;
     use ruma::{
-        assign,
+        RoomVersionId, assign,
         events::{
-            room::member::{MembershipState, RoomMemberEventContent},
             FullStateEventContent,
+            room::member::{MembershipState, RoomMemberEventContent},
         },
-        RoomVersionId,
     };
 
     use super::{MembershipChange, RoomMembershipChange, TimelineItemContent};

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/pinned_events.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/pinned_events.rs
@@ -15,8 +15,8 @@
 use std::collections::HashSet;
 
 use ruma::{
-    events::{room::pinned_events::RoomPinnedEventsEventContent, FullStateEventContent},
     OwnedEventId,
+    events::{FullStateEventContent, room::pinned_events::RoomPinnedEventsEventContent},
 };
 
 #[derive(Clone, Debug)]
@@ -78,11 +78,11 @@ mod tests {
     use assert_matches::assert_matches;
     use ruma::{
         events::{
+            FullStateEventContent,
             room::pinned_events::{
                 PossiblyRedactedRoomPinnedEventsEventContent, RedactedRoomPinnedEventsEventContent,
                 RoomPinnedEventsEventContent,
             },
-            FullStateEventContent,
         },
         owned_event_id,
         serde::Raw,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/polls.rs
@@ -17,16 +17,15 @@
 use std::collections::HashMap;
 
 use ruma::{
+    MilliSecondsSinceUnixEpoch, OwnedUserId, UserId,
     events::poll::{
-        compile_unstable_poll_results,
+        PollResponseData, compile_unstable_poll_results,
         start::PollKind,
         unstable_start::{
             NewUnstablePollStartEventContent, NewUnstablePollStartEventContentWithoutRelation,
             UnstablePollStartContentBlock,
         },
-        PollResponseData,
     },
-    MilliSecondsSinceUnixEpoch, OwnedUserId, UserId,
 };
 
 /// Holds the state of a poll.

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -21,11 +21,11 @@ use tracing::{debug, instrument, warn};
 
 use super::TimelineItemContent;
 use crate::timeline::{
+    Error as TimelineError, TimelineEventItemId, TimelineItem,
     controller::TimelineMetadata,
     event_handler::TimelineAction,
     event_item::{EventTimelineItem, Profile, TimelineDetails},
     traits::RoomDataProvider,
-    Error as TimelineError, TimelineEventItemId, TimelineItem,
 };
 
 /// Details about an event being replied to.

--- a/crates/matrix-sdk-ui/src/timeline/event_item/local.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/local.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use as_variant::as_variant;
-use matrix_sdk::{send_queue::SendHandle, Error};
+use matrix_sdk::{Error, send_queue::SendHandle};
 use ruma::{EventId, OwnedEventId, OwnedTransactionId};
 
 use super::TimelineEventItemId;

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -20,20 +20,20 @@ use std::{
 use as_variant::as_variant;
 use indexmap::IndexMap;
 use matrix_sdk::{
+    Client, Error,
     deserialized_responses::{EncryptionInfo, ShieldState},
     send_queue::{SendHandle, SendReactionHandle},
-    Client, Error,
 };
 use matrix_sdk_base::{
-    deserialized_responses::{ShieldStateCode, SENT_IN_CLEAR},
+    deserialized_responses::{SENT_IN_CLEAR, ShieldStateCode},
     latest_event::LatestEvent,
 };
 use once_cell::sync::Lazy;
 use ruma::{
-    events::{receipt::Receipt, room::message::MessageType, AnySyncTimelineEvent},
-    serde::Raw,
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedTransactionId,
     OwnedUserId, RoomId, RoomVersionId, TransactionId, UserId,
+    events::{AnySyncTimelineEvent, receipt::Receipt, room::message::MessageType},
+    serde::Raw,
 };
 use tracing::warn;
 use unicode_segmentation::UnicodeSegmentation;
@@ -42,13 +42,6 @@ mod content;
 mod local;
 mod remote;
 
-pub(super) use self::{
-    content::{
-        extract_bundled_edit_event_json, extract_poll_edit_content, extract_room_msg_edit_content,
-    },
-    local::LocalEventTimelineItem,
-    remote::{RemoteEventOrigin, RemoteEventTimelineItem},
-};
 pub use self::{
     content::{
         AnyOtherFullStateEventContent, EmbeddedEvent, EncryptedMessage, InReplyToDetails,
@@ -57,6 +50,13 @@ pub use self::{
         ThreadSummary, TimelineItemContent,
     },
     local::EventSendState,
+};
+pub(super) use self::{
+    content::{
+        extract_bundled_edit_event_json, extract_poll_edit_content, extract_room_msg_edit_content,
+    },
+    local::LocalEventTimelineItem,
+    remote::{RemoteEventOrigin, RemoteEventTimelineItem},
 };
 
 /// An item in the timeline that represents at least one event.
@@ -792,23 +792,24 @@ mod tests {
     use assert_matches2::assert_let;
     use matrix_sdk::test_utils::logged_in_client;
     use matrix_sdk_base::{
-        deserialized_responses::TimelineEvent, latest_event::LatestEvent, MinimalStateEvent,
-        OriginalMinimalStateEvent, RequestedRequiredStates,
+        MinimalStateEvent, OriginalMinimalStateEvent, RequestedRequiredStates,
+        deserialized_responses::TimelineEvent, latest_event::LatestEvent,
     };
     use matrix_sdk_test::{async_test, event_factory::EventFactory, sync_state_event};
     use ruma::{
+        RoomId, UInt, UserId,
         api::client::sync::sync_events::v5 as http,
         event_id,
         events::{
+            AnySyncStateEvent,
             room::{
                 member::RoomMemberEventContent,
                 message::{MessageFormat, MessageType},
             },
-            AnySyncStateEvent,
         },
         room_id,
         serde::Raw,
-        user_id, RoomId, UInt, UserId,
+        user_id,
     };
 
     use super::{EventTimelineItem, Profile};
@@ -1006,8 +1007,8 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender_from_the_storage(
-    ) {
+    async fn test_latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender_from_the_storage()
+     {
         // Given a sync event that is suitable to be used as a latest_event, and a room
         // with a member event for the sender
 
@@ -1055,8 +1056,8 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender_from_the_cache(
-    ) {
+    async fn test_latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender_from_the_cache()
+     {
         // Given a sync event that is suitable to be used as a latest_event, a room, and
         // a member event for the sender (which isn't part of the room yet).
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
@@ -17,9 +17,9 @@ use std::{fmt, sync::Arc};
 use indexmap::IndexMap;
 use matrix_sdk::deserialized_responses::EncryptionInfo;
 use ruma::{
-    events::{receipt::Receipt, AnySyncTimelineEvent},
-    serde::Raw,
     OwnedEventId, OwnedTransactionId, OwnedUserId,
+    events::{AnySyncTimelineEvent, receipt::Receipt},
+    serde::Raw,
 };
 
 /// An item for an event that was received from the homeserver.

--- a/crates/matrix-sdk-ui/src/timeline/futures.rs
+++ b/crates/matrix-sdk-ui/src/timeline/futures.rs
@@ -1,7 +1,7 @@
 use std::future::IntoFuture;
 
 use eyeball::SharedObservable;
-use matrix_sdk::{attachment::AttachmentConfig, TransmissionProgress};
+use matrix_sdk::{TransmissionProgress, attachment::AttachmentConfig};
 use matrix_sdk_base::boxed_into_future;
 use mime::Mime;
 use tracing::{Instrument as _, Span};

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -251,7 +251,8 @@ impl Timeline {
     /// and batches them.
     pub async fn subscribe(
         &self,
-    ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>>) {
+    ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>> + use<>)
+    {
         let (items, stream) = self.controller.subscribe().await;
         let stream = TimelineWithDropHandle::new(stream, self.drop_handle.clone());
         (items, stream)
@@ -560,7 +561,7 @@ impl Timeline {
     }
 
     /// Subscribe to changes in the read receipts of our own user.
-    pub async fn subscribe_own_user_read_receipts_changed(&self) -> impl Stream<Item = ()> {
+    pub async fn subscribe_own_user_read_receipts_changed(&self) -> impl Stream<Item = ()> + use<> {
         self.controller.subscribe_own_user_read_receipts_changed().await
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -28,33 +28,33 @@ use imbl::Vector;
 #[cfg(feature = "unstable-msc4274")]
 use matrix_sdk::attachment::{AttachmentInfo, Thumbnail};
 use matrix_sdk::{
+    Result,
     attachment::AttachmentConfig,
     deserialized_responses::TimelineEvent,
     event_cache::{EventCacheDropHandles, RoomEventCache},
     executor::JoinHandle,
-    room::{edit::EditedContent, reply::Reply, Receipts, Room},
+    room::{Receipts, Room, edit::EditedContent, reply::Reply},
     send_queue::{RoomSendQueueError, SendHandle},
-    Result,
 };
 use mime::Mime;
 use pinned_events_loader::PinnedEventsRoom;
 use ruma::{
+    EventId, OwnedEventId, RoomVersionId, UserId,
     api::client::receipt::create_receipt::v3::ReceiptType,
     events::{
+        AnyMessageLikeEventContent, AnySyncTimelineEvent,
         poll::unstable_start::{NewUnstablePollStartEventContent, UnstablePollStartEventContent},
         receipt::{Receipt, ReceiptThread},
         room::{
             message::RoomMessageEventContentWithoutRelation,
             pinned_events::RoomPinnedEventsEventContent,
         },
-        AnyMessageLikeEventContent, AnySyncTimelineEvent,
     },
-    EventId, OwnedEventId, RoomVersionId, UserId,
 };
 #[cfg(feature = "unstable-msc4274")]
 use ruma::{
-    events::{room::message::FormattedBody, Mentions},
     OwnedTransactionId,
+    events::{Mentions, room::message::FormattedBody},
 };
 use subscriber::TimelineWithDropHandle;
 use thiserror::Error;

--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -15,7 +15,7 @@
 use async_rx::StreamExt as _;
 use async_stream::stream;
 use futures_core::Stream;
-use futures_util::{pin_mut, StreamExt as _};
+use futures_util::{StreamExt as _, pin_mut};
 use matrix_sdk::event_cache::{self, EventCacheError, RoomPaginationStatus};
 use tracing::{instrument, warn};
 

--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -107,7 +107,7 @@ impl super::Timeline {
     /// call to [`Self::paginate_backwards()`].
     pub async fn live_back_pagination_status(
         &self,
-    ) -> Option<(RoomPaginationStatus, impl Stream<Item = RoomPaginationStatus>)> {
+    ) -> Option<(RoomPaginationStatus, impl Stream<Item = RoomPaginationStatus> + use<>)> {
         if !self.controller.is_live() {
             return None;
         }

--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -14,10 +14,10 @@
 
 use std::{fmt::Formatter, sync::Arc};
 
-use futures_util::{stream, StreamExt};
-use matrix_sdk::{config::RequestConfig, BoxFuture, Room, SendOutsideWasm, SyncOutsideWasm};
+use futures_util::{StreamExt, stream};
+use matrix_sdk::{BoxFuture, Room, SendOutsideWasm, SyncOutsideWasm, config::RequestConfig};
 use matrix_sdk_base::deserialized_responses::TimelineEvent;
-use ruma::{events::relation::RelationType, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId};
+use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, events::relation::RelationType};
 use thiserror::Error;
 use tokio::sync::Mutex;
 use tracing::{debug, warn};

--- a/crates/matrix-sdk-ui/src/timeline/subscriber.rs
+++ b/crates/matrix-sdk-ui/src/timeline/subscriber.rs
@@ -25,7 +25,7 @@ use futures_core::Stream;
 use imbl::Vector;
 use pin_project_lite::pin_project;
 
-use super::{controller::ObservableItems, item::TimelineItem, TimelineDropHandle};
+use super::{TimelineDropHandle, controller::ObservableItems, item::TimelineItem};
 
 pin_project! {
     /// A stream that wraps a [`TimelineDropHandle`] so that the `Timeline`
@@ -225,8 +225,8 @@ pub mod skip {
         ///
         /// [`Skip`]: eyeball_im_util::vector::Skip
         #[allow(unused)] // this is not used yet because only a live timeline is using it, but as soon as
-                         // other kind of timelines will use it, we would need it, it's better to have
-                         // this in case of; everything is tested, the logic is made more robust.
+        // other kind of timelines will use it, we would need it, it's better to have
+        // this in case of; everything is tested, the logic is made more robust.
         pub fn compute_next_when_paginating_forwards(&self, _page_size: usize) -> usize {
             // Nothing to do, the count remains unchanged as we skip the first values, not
             // the last values; paginating forwards will add items at the end, not at the

--- a/crates/matrix-sdk-ui/src/timeline/tasks.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tasks.rs
@@ -26,11 +26,11 @@ use matrix_sdk::{
     send_queue::RoomSendQueueUpdate,
 };
 use ruma::OwnedEventId;
-use tokio::sync::broadcast::{error::RecvError, Receiver};
+use tokio::sync::broadcast::{Receiver, error::RecvError};
 use tokio_stream::StreamExt as _;
 use tracing::{instrument, trace, warn};
 
-use crate::timeline::{event_item::RemoteEventOrigin, TimelineController, TimelineFocus};
+use crate::timeline::{TimelineController, TimelineFocus, event_item::RemoteEventOrigin};
 
 /// Long-lived task, in the pinned events focus mode, that updates the timeline
 /// after any changes in the pinned events.

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -18,33 +18,32 @@ use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use imbl::vector;
 use matrix_sdk_test::{
-    async_test,
+    ALICE, BOB, CAROL, async_test,
     event_factory::{EventFactory, PreviousMembership},
-    ALICE, BOB, CAROL,
 };
 use ruma::{
-    event_id,
+    MilliSecondsSinceUnixEpoch, event_id,
     events::{
+        FullStateEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::{
+            ImageInfo,
             member::{MembershipState, RedactedRoomMemberEventContent},
             message::MessageType,
             topic::RedactedRoomTopicEventContent,
-            ImageInfo,
         },
-        FullStateEventContent,
     },
-    mxc_uri, owned_event_id, owned_mxc_uri, user_id, MilliSecondsSinceUnixEpoch,
+    mxc_uri, owned_event_id, owned_mxc_uri, user_id,
 };
 use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
 use crate::timeline::{
+    MembershipChange, MsgLikeContent, MsgLikeKind, TimelineDetails, TimelineItemContent,
+    TimelineItemKind, VirtualTimelineItem,
     controller::TimelineSettings,
     event_item::{AnyOtherFullStateEventContent, RemoteEventOrigin},
     tests::{ReadReceiptMap, TestRoomDataProvider, TestTimelineBuilder},
-    MembershipChange, MsgLikeContent, MsgLikeKind, TimelineDetails, TimelineItemContent,
-    TimelineItemKind, VirtualTimelineItem,
 };
 
 #[async_test]

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -18,11 +18,11 @@ use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use matrix_sdk::{assert_next_matches_with_timeout, send_queue::RoomSendQueueUpdate};
 use matrix_sdk_base::store::QueueWedgeError;
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
-    event_id,
-    events::{room::message::RoomMessageEventContent, AnyMessageLikeEventContent},
-    user_id, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch, event_id,
+    events::{AnyMessageLikeEventContent, room::message::RoomMessageEventContent},
+    user_id,
 };
 use stream_assert::{assert_next_matches, assert_pending};
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -20,7 +20,7 @@ use matrix_sdk::deserialized_responses::{
     AlgorithmInfo, EncryptionInfo, VerificationLevel, VerificationState,
 };
 use matrix_sdk_base::deserialized_responses::{DecryptedRoomEvent, TimelineEvent};
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
     event_id,
     events::room::message::{MessageType, RedactedRoomMessageEventContent},

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -27,14 +27,14 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use matrix_sdk::{
     assert_next_matches_with_timeout,
-    crypto::{decrypt_room_key_export, types::events::UtdCause, OlmMachine},
+    crypto::{OlmMachine, decrypt_room_key_export, types::events::UtdCause},
     deserialized_responses::{
         AlgorithmInfo, DecryptedRoomEvent, EncryptionInfo, VerificationLevel, VerificationState,
     },
     test_utils::test_client_builder,
 };
 use matrix_sdk_base::deserialized_responses::{TimelineEvent, UnableToDecryptReason};
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
     assign, event_id,
     events::room::encrypted::{
@@ -52,8 +52,8 @@ use tokio::time::sleep;
 use super::TestTimeline;
 use crate::{
     timeline::{
-        tests::{TestRoomDataProvider, TestTimelineBuilder},
         EncryptedMessage, MsgLikeContent, MsgLikeKind, TimelineDetails, TimelineItemContent,
+        tests::{TestRoomDataProvider, TestTimelineBuilder},
     },
     unable_to_decrypt_hook::{UnableToDecryptHook, UnableToDecryptInfo, UtdHookManager},
 };

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -17,21 +17,21 @@ use std::sync::Arc;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use matrix_sdk::deserialized_responses::TimelineEvent;
-use matrix_sdk_test::{async_test, sync_timeline_event, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test, sync_timeline_event};
 use ruma::events::{
+    AnySyncTimelineEvent, TimelineEventType,
     room::{
         member::MembershipState,
         message::{MessageType, RedactedRoomMessageEventContent},
     },
-    AnySyncTimelineEvent, TimelineEventType,
 };
 use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
 use crate::timeline::{
-    controller::TimelineSettings, tests::TestTimelineBuilder, AnyOtherFullStateEventContent,
-    MsgLikeContent, MsgLikeKind, TimelineEventTypeFilter, TimelineItem, TimelineItemContent,
-    TimelineItemKind,
+    AnyOtherFullStateEventContent, MsgLikeContent, MsgLikeKind, TimelineEventTypeFilter,
+    TimelineItem, TimelineItemContent, TimelineItemKind, controller::TimelineSettings,
+    tests::TestTimelineBuilder,
 };
 
 #[async_test]

--- a/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
@@ -15,10 +15,11 @@
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use matrix_sdk::deserialized_responses::TimelineEvent;
-use matrix_sdk_test::{async_test, sync_timeline_event, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test, sync_timeline_event};
 use ruma::{
-    events::{room::message::MessageType, MessageLikeEventType, StateEventType},
-    uint, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch,
+    events::{MessageLikeEventType, StateEventType, room::message::MessageType},
+    uint,
 };
 use stream_assert::assert_next_matches;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -27,39 +27,40 @@ use futures_core::Stream;
 use imbl::vector;
 use indexmap::IndexMap;
 use matrix_sdk::{
+    BoxFuture,
     config::RequestConfig,
     crypto::OlmMachine,
     deserialized_responses::{EncryptionInfo, TimelineEvent},
-    paginators::{thread::PaginableThread, PaginableRoom, PaginatorError},
+    paginators::{PaginableRoom, PaginatorError, thread::PaginableThread},
     room::{EventWithContextResponse, Messages, MessagesOptions, PushContext, Relations},
     send_queue::RoomSendQueueUpdate,
-    BoxFuture,
 };
 use matrix_sdk_base::{
-    crypto::types::events::CryptoContextInfo, latest_event::LatestEvent, RoomInfo, RoomState,
+    RoomInfo, RoomState, crypto::types::events::CryptoContextInfo, latest_event::LatestEvent,
 };
-use matrix_sdk_test::{event_factory::EventFactory, ALICE, DEFAULT_TEST_ROOM_ID};
+use matrix_sdk_test::{ALICE, DEFAULT_TEST_ROOM_ID, event_factory::EventFactory};
 use ruma::{
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
+    OwnedUserId, RoomVersionId, TransactionId, UInt, UserId,
     events::{
+        AnyMessageLikeEventContent, AnyTimelineEvent,
         reaction::ReactionEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         relation::{Annotation, RelationType},
-        AnyMessageLikeEventContent, AnyTimelineEvent,
     },
     int,
     power_levels::NotificationPowerLevels,
     push::{PushConditionPowerLevelsCtx, PushConditionRoomCtx, Ruleset},
     room_id,
     serde::Raw,
-    uint, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
-    OwnedUserId, RoomVersionId, TransactionId, UInt, UserId,
+    uint,
 };
 use tokio::sync::RwLock;
 
 use super::{
-    algorithms::rfind_event_by_item_id, controller::TimelineSettings,
-    event_item::RemoteEventOrigin, traits::RoomDataProvider, EventTimelineItem, Profile,
-    TimelineController, TimelineEventItemId, TimelineFocus, TimelineItem,
+    EventTimelineItem, Profile, TimelineController, TimelineEventItemId, TimelineFocus,
+    TimelineItem, algorithms::rfind_event_by_item_id, controller::TimelineSettings,
+    event_item::RemoteEventOrigin, traits::RoomDataProvider,
 };
 use crate::{
     timeline::pinned_events_loader::PinnedEventsRoom, unable_to_decrypt_hook::UtdHookManager,

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -1,16 +1,16 @@
 use assert_matches2::assert_let;
 use fakes::poll_a2;
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
-    event_id,
+    EventId, OwnedEventId, UserId, event_id,
     events::poll::unstable_start::{
         NewUnstablePollStartEventContent, ReplacementUnstablePollStartEventContent,
         UnstablePollStartContentBlock, UnstablePollStartEventContent,
     },
-    server_name, EventId, OwnedEventId, UserId,
+    server_name,
 };
 
-use crate::timeline::{event_item::PollState, tests::TestTimeline, EventTimelineItem};
+use crate::timeline::{EventTimelineItem, event_item::PollState, tests::TestTimeline};
 
 #[async_test]
 async fn test_poll_is_displayed() {

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -20,17 +20,17 @@ use futures_core::Stream;
 use futures_util::{FutureExt as _, StreamExt as _};
 use imbl::vector;
 use matrix_sdk::assert_next_matches_with_timeout;
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
-    event_id, events::AnyMessageLikeEventContent, server_name, uint, EventId,
-    MilliSecondsSinceUnixEpoch, OwnedEventId,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, event_id,
+    events::AnyMessageLikeEventContent, server_name, uint,
 };
 use stream_assert::{assert_next_matches, assert_pending};
 use tokio::time::timeout;
 
 use crate::timeline::{
-    event_item::RemoteEventOrigin, tests::TestTimeline, ReactionStatus, TimelineEventItemId,
-    TimelineItem,
+    ReactionStatus, TimelineEventItemId, TimelineItem, event_item::RemoteEventOrigin,
+    tests::TestTimeline,
 };
 
 const REACTION_KEY: &str = "👍";
@@ -144,13 +144,15 @@ async fn test_redact_reaction_success() {
 
     // Will immediately redact it on the item.
     let event = assert_item_update!(stream, &event_id, item_pos);
-    assert!(event
-        .content()
-        .reactions()
-        .cloned()
-        .unwrap_or_default()
-        .get(&REACTION_KEY.to_owned())
-        .is_none());
+    assert!(
+        event
+            .content()
+            .reactions()
+            .cloned()
+            .unwrap_or_default()
+            .get(&REACTION_KEY.to_owned())
+            .is_none()
+    );
 
     // And send a redaction request for that reaction.
     {

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -16,22 +16,22 @@ use std::sync::Arc;
 
 use eyeball_im::VectorDiff;
 use matrix_sdk::assert_next_matches_with_timeout;
-use matrix_sdk_test::{async_test, event_factory::EventFactory, ALICE, BOB, CAROL};
+use matrix_sdk_test::{ALICE, BOB, CAROL, async_test, event_factory::EventFactory};
 use ruma::{
-    event_id,
+    RoomVersionId, event_id,
     events::{
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::message::{MessageType, RoomMessageEventContent, SyncRoomMessageEvent},
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
     },
-    owned_event_id, room_id, uint, RoomVersionId,
+    owned_event_id, room_id, uint,
 };
 use stream_assert::{assert_next_matches, assert_pending};
 
 use super::{ReadReceiptMap, TestRoomDataProvider};
 use crate::timeline::{
-    controller::TimelineSettings, tests::TestTimelineBuilder, MsgLikeContent, MsgLikeKind,
-    TimelineFocus,
+    MsgLikeContent, MsgLikeKind, TimelineFocus, controller::TimelineSettings,
+    tests::TestTimelineBuilder,
 };
 
 fn filter_notice(ev: &AnySyncTimelineEvent, _room_version: &RoomVersionId) -> bool {
@@ -376,12 +376,13 @@ async fn test_read_receipts_updates_on_message_decryption() {
     use std::{io::Cursor, iter};
 
     use assert_matches2::assert_let;
-    use matrix_sdk_base::crypto::{decrypt_room_key_export, OlmMachine};
+    use matrix_sdk_base::crypto::{OlmMachine, decrypt_room_key_export};
     use ruma::{
+        RoomVersionId,
         events::room::encrypted::{
             EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
         },
-        user_id, RoomVersionId,
+        user_id,
     };
 
     use crate::timeline::{EncryptedMessage, TimelineItemContent};

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -16,20 +16,20 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use imbl::vector;
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
     event_id,
     events::{
-        reaction::RedactedReactionEventContent, room::message::OriginalSyncRoomMessageEvent,
-        FullStateEventContent,
+        FullStateEventContent, reaction::RedactedReactionEventContent,
+        room::message::OriginalSyncRoomMessageEvent,
     },
 };
 use stream_assert::{assert_next_matches, assert_pending};
 
 use super::TestTimeline;
 use crate::timeline::{
-    event_item::RemoteEventOrigin, AnyOtherFullStateEventContent, TimelineDetails,
-    TimelineItemContent,
+    AnyOtherFullStateEventContent, TimelineDetails, TimelineItemContent,
+    event_item::RemoteEventOrigin,
 };
 
 #[async_test]
@@ -171,9 +171,9 @@ async fn test_reaction_redaction_timeline_filter() {
         .controller
         .handle_remote_events_with_diffs(
             vec![VectorDiff::Append {
-                values: vector![f
-                    .redacted(*ALICE, RedactedReactionEventContent::new())
-                    .into_event()],
+                values: vector![
+                    f.redacted(*ALICE, RedactedReactionEventContent::new()).into_event()
+                ],
             }],
             RemoteEventOrigin::Sync,
         )

--- a/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/shields.rs
@@ -1,24 +1,24 @@
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use matrix_sdk_base::deserialized_responses::{ShieldState, ShieldStateCode};
-use matrix_sdk_test::{async_test, event_factory::EventFactory, ALICE};
+use matrix_sdk_test::{ALICE, async_test, event_factory::EventFactory};
 use ruma::{
     event_id,
     events::{
+        AnyMessageLikeEventContent,
         room::{
             encrypted::{
                 EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
             },
             message::RoomMessageEventContent,
         },
-        AnyMessageLikeEventContent,
     },
 };
 use stream_assert::{assert_next_matches, assert_pending};
 
 use crate::timeline::{
-    tests::{TestTimeline, TestTimelineBuilder},
     EventSendState,
+    tests::{TestTimeline, TestTimelineBuilder},
 };
 
 #[async_test]

--- a/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
@@ -17,15 +17,15 @@ use assert_matches2::assert_let;
 use chrono::{Datelike, TimeZone, Utc};
 use eyeball_im::VectorDiff;
 use futures_util::{FutureExt, StreamExt as _};
-use matrix_sdk_test::{async_test, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
     event_id,
-    events::{room::message::RoomMessageEventContent, AnyMessageLikeEventContent},
+    events::{AnyMessageLikeEventContent, room::message::RoomMessageEventContent},
 };
 use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
-use crate::timeline::{traits::RoomDataProvider as _, VirtualTimelineItem};
+use crate::timeline::{VirtualTimelineItem, traits::RoomDataProvider as _};
 
 #[async_test]
 async fn test_date_divider() {

--- a/crates/matrix-sdk-ui/src/timeline/to_device.rs
+++ b/crates/matrix-sdk-ui/src/timeline/to_device.rs
@@ -16,10 +16,10 @@ use std::iter;
 
 use matrix_sdk::event_handler::EventHandler;
 use ruma::{
-    events::{forwarded_room_key::ToDeviceForwardedRoomKeyEvent, room_key::ToDeviceRoomKeyEvent},
     OwnedRoomId,
+    events::{forwarded_room_key::ToDeviceForwardedRoomKeyEvent, room_key::ToDeviceRoomKeyEvent},
 };
-use tracing::{debug_span, trace, Instrument};
+use tracing::{Instrument, debug_span, trace};
 
 use super::controller::TimelineController;
 

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -19,26 +19,26 @@ use indexmap::IndexMap;
 #[cfg(test)]
 use matrix_sdk::crypto::{DecryptionSettings, RoomEventDecryptionResult, TrustRequirement};
 use matrix_sdk::{
+    AsyncTraitDeps, Result, Room, SendOutsideWasm,
     crypto::types::events::CryptoContextInfo,
     deserialized_responses::{EncryptionInfo, TimelineEvent},
-    paginators::{thread::PaginableThread, PaginableRoom},
+    paginators::{PaginableRoom, thread::PaginableThread},
     room::PushContext,
-    AsyncTraitDeps, Result, Room, SendOutsideWasm,
 };
-use matrix_sdk_base::{latest_event::LatestEvent, RoomInfo};
+use matrix_sdk_base::{RoomInfo, latest_event::LatestEvent};
 use ruma::{
+    EventId, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId, UserId,
     events::{
+        AnyMessageLikeEventContent, AnySyncTimelineEvent,
         fully_read::FullyReadEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
-        AnyMessageLikeEventContent, AnySyncTimelineEvent,
     },
     serde::Raw,
-    EventId, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId, UserId,
 };
 use tracing::error;
 
 use super::{EventTimelineItem, Profile, RedactError, TimelineBuilder};
-use crate::timeline::{self, pinned_events_loader::PinnedEventsRoom, Timeline};
+use crate::timeline::{self, Timeline, pinned_events_loader::PinnedEventsRoom};
 
 pub trait RoomExt {
     /// Get a [`Timeline`] for this room.
@@ -49,7 +49,7 @@ pub trait RoomExt {
     ///
     /// This is the same as using `room.timeline_builder().build()`.
     fn timeline(&self)
-        -> impl Future<Output = Result<Timeline, timeline::Error>> + SendOutsideWasm;
+    -> impl Future<Output = Result<Timeline, timeline::Error>> + SendOutsideWasm;
 
     /// Get a [`TimelineBuilder`] for this room.
     ///
@@ -93,7 +93,7 @@ pub(super) trait RoomDataProvider:
     fn room_version(&self) -> RoomVersionId;
 
     fn crypto_context_info(&self)
-        -> impl Future<Output = CryptoContextInfo> + SendOutsideWasm + '_;
+    -> impl Future<Output = CryptoContextInfo> + SendOutsideWasm + '_;
 
     fn profile_from_user_id<'a>(
         &'a self,

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -25,17 +25,17 @@ use std::{
 
 use growable_bloom_filter::{GrowableBloom, GrowableBloomBuilder};
 use matrix_sdk::{
-    crypto::types::events::UtdCause,
-    executor::{spawn, JoinHandle},
-    sleep::sleep,
     Client,
+    crypto::types::events::UtdCause,
+    executor::{JoinHandle, spawn},
+    sleep::sleep,
 };
 use matrix_sdk_base::{
     SendOutsideWasm, StateStoreDataKey, StateStoreDataValue, StoreError, SyncOutsideWasm,
 };
 use ruma::{
-    time::{Duration, Instant},
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName, UserId,
+    time::{Duration, Instant},
 };
 use tokio::sync::{Mutex as AsyncMutex, MutexGuard};
 use tracing::{error, trace};

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
@@ -1,12 +1,12 @@
 use std::{
     collections::{BTreeMap, HashSet},
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
     },
 };
 
-use futures_util::{pin_mut, StreamExt as _};
+use futures_util::{StreamExt as _, pin_mut};
 use matrix_sdk::{
     config::RequestConfig,
     test_utils::{
@@ -23,13 +23,13 @@ use serde_json::json;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::{error, info, trace, warn};
 use wiremock::{
-    matchers::{method, path},
     Mock, MockGuard, MockServer, Request, ResponseTemplate,
+    matchers::{method, path},
 };
 
 use crate::{
     mock_sync,
-    sliding_sync::{check_requests, PartialSlidingSyncRequest, SlidingSyncMatcher},
+    sliding_sync::{PartialSlidingSyncRequest, SlidingSyncMatcher, check_requests},
     sliding_sync_then_assert_request_and_fake_response,
 };
 

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -14,12 +14,12 @@
 
 use itertools::Itertools as _;
 use matrix_sdk::deserialized_responses::TimelineEvent;
-use ruma::{events::AnyStateEvent, serde::Raw, EventId, RoomId};
+use ruma::{EventId, RoomId, events::AnyStateEvent, serde::Raw};
 use serde::Serialize;
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path, path_regex, query_param, query_param_is_missing},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path, path_regex, query_param, query_param_is_missing},
 };
 
 mod encryption_sync_service;

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -11,8 +11,8 @@ use matrix_sdk::{
     test_utils::{logged_in_client_with_server, mocks::MatrixMockServer},
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
-    SyncResponseBuilder,
+    JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
+    mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::{
     notification_client::{
@@ -23,18 +23,18 @@ use matrix_sdk_ui::{
 };
 use ruma::{
     event_id,
-    events::{room::member::MembershipState, AnyStateEvent, TimelineEventType},
+    events::{AnyStateEvent, TimelineEventType, room::member::MembershipState},
     mxc_uri, room_id, user_id,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path},
     Mock, Request, ResponseTemplate,
+    matchers::{header, method, path},
 };
 
 use crate::{
     mock_sync,
-    sliding_sync::{check_requests, PartialSlidingSyncRequest, SlidingSyncMatcher},
+    sliding_sync::{PartialSlidingSyncRequest, SlidingSyncMatcher, check_requests},
 };
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2,27 +2,27 @@ use std::{ops::Not, sync::Arc};
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
-use futures_util::{pin_mut, FutureExt, StreamExt};
+use futures_util::{FutureExt, StreamExt, pin_mut};
 use matrix_sdk::{
+    Client, RoomDisplayName,
     config::RequestConfig,
     test_utils::{
         logged_in_client_with_server,
         mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
         set_client_session, test_client_builder,
     },
-    Client, RoomDisplayName,
 };
 use matrix_sdk_base::sync::UnreadNotificationsCount;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, ALICE,
+    ALICE, async_test, event_factory::EventFactory, mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::{
+    RoomListService,
     room_list_service::{
+        ALL_ROOMS_LIST_NAME as ALL_ROOMS, Error, RoomListLoadingState, State, SyncIndicator,
         filters::{new_filter_fuzzy_match_room_name, new_filter_non_left, new_filter_none},
-        Error, RoomListLoadingState, State, SyncIndicator, ALL_ROOMS_LIST_NAME as ALL_ROOMS,
     },
     timeline::{RoomExt as _, TimelineItemKind, VirtualTimelineItem},
-    RoomListService,
 };
 use ruma::{
     api::client::room::create_room::v3::Request as CreateRoomRequest,
@@ -36,8 +36,8 @@ use stream_assert::{assert_next_matches, assert_pending};
 use tempfile::TempDir;
 use tokio::{spawn, sync::Barrier, task::yield_now, time::sleep};
 use wiremock::{
-    matchers::{header, method, path},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path},
 };
 
 use crate::timeline::sliding_sync::{assert_timeline_stream, timeline_event};

--- a/crates/matrix-sdk-ui/tests/integration/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sliding_sync.rs
@@ -1,6 +1,6 @@
 //! Helpers for integration tests involving sliding sync.
 
-use wiremock::{http::Method, Match, MockServer, Request};
+use wiremock::{Match, MockServer, Request, http::Method};
 
 pub(crate) async fn check_requests(server: MockServer, expected_requests: &[serde_json::Value]) {
     let mut num_requests = 0;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/decryption.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/decryption.rs
@@ -21,7 +21,7 @@ use matrix_sdk::{
     linked_chunk::{ChunkIdentifier, LinkedChunkId, Position, Update},
     test_utils::mocks::MatrixMockServer,
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, BOB};
+use matrix_sdk_test::{BOB, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::RoomExt;
 use ruma::{
     event_id,

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -21,7 +21,7 @@ use futures_util::StreamExt;
 use matrix_sdk::{
     executor::spawn, ruma::MilliSecondsSinceUnixEpoch, test_utils::mocks::MatrixMockServer,
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder};
+use matrix_sdk_test::{JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{EventSendState, RoomExt};
 use ruma::{
     event_id,

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -20,21 +20,22 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::{FutureExt, StreamExt};
 use matrix_sdk::{
+    Client,
     room::edit::EditedContent,
     test_utils::mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
-    Client,
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::{
+    Timeline,
     timeline::{
         EditError, Error, EventSendState, MsgLikeContent, MsgLikeKind, RoomExt, TimelineDetails,
         TimelineEventItemId, TimelineItemContent,
     },
-    Timeline,
 };
 use ruma::{
-    event_id,
+    OwnedRoomId, event_id,
     events::{
+        AnyMessageLikeEventContent, AnyTimelineEvent,
         poll::unstable_start::{
             NewUnstablePollStartEventContent, ReplacementUnstablePollStartEventContent,
             UnstablePollAnswer, UnstablePollAnswers, UnstablePollStartContentBlock,
@@ -44,11 +45,9 @@ use ruma::{
             MessageType, RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
             TextMessageEventContent,
         },
-        AnyMessageLikeEventContent, AnyTimelineEvent,
     },
     owned_event_id, room_id,
     serde::Raw,
-    OwnedRoomId,
 };
 use stream_assert::{assert_next_matches, assert_pending};
 use tokio::{task::yield_now, time::sleep};
@@ -877,13 +876,14 @@ async fn test_pending_edit_from_backpagination() {
     let original_event_id = event_id!("$original");
     let edit_event_id = event_id!("$edit");
     h.handle_backpagination(
-        vec![f
-            .text_msg("* hello")
-            .sender(&ALICE)
-            .event_id(edit_event_id)
-            .room(&h.room_id)
-            .edit(original_event_id, RoomMessageEventContent::text_plain("hello").into())
-            .into()],
+        vec![
+            f.text_msg("* hello")
+                .sender(&ALICE)
+                .event_id(edit_event_id)
+                .room(&h.room_id)
+                .edit(original_event_id, RoomMessageEventContent::text_plain("hello").into())
+                .into(),
+        ],
         10,
     )
     .await;
@@ -941,13 +941,14 @@ async fn test_pending_edit_from_backpagination_doesnt_override_pending_edit_from
     // And then I receive an edit from a back-pagination for the same event…
     let edit_event_id2 = event_id!("$edit2");
     h.handle_backpagination(
-        vec![f
-            .text_msg("* aloha")
-            .sender(&ALICE)
-            .event_id(edit_event_id2)
-            .room(&h.room_id)
-            .edit(original_event_id, RoomMessageEventContent::text_plain("aloha").into())
-            .into()],
+        vec![
+            f.text_msg("* aloha")
+                .sender(&ALICE)
+                .event_id(edit_event_id2)
+                .room(&h.room_id)
+                .edit(original_event_id, RoomMessageEventContent::text_plain("aloha").into())
+                .into(),
+        ],
         10,
     )
     .await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -21,8 +21,8 @@ use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
-    SyncResponseBuilder, ALICE, BOB,
+    ALICE, BOB, JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
+    mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::timeline::{TimelineBuilder, TimelineFocus};
 use ruma::{event_id, events::room::message::RoomMessageEventContent, room_id};

--- a/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
@@ -26,7 +26,7 @@ use matrix_sdk::{
     room::reply::{EnforceThread, Reply},
     test_utils::mocks::MatrixMockServer,
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE};
+use matrix_sdk_test::{ALICE, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{AttachmentSource, EventSendState, RoomExt};
 #[cfg(feature = "unstable-msc4274")]
 use matrix_sdk_ui::timeline::{GalleryConfig, GalleryItemInfo};
@@ -37,8 +37,8 @@ use ruma::owned_mxc_uri;
 use ruma::{
     event_id,
     events::room::{
-        message::{MessageType, ReplyWithinThread},
         MediaSource,
+        message::{MessageType, ReplyWithinThread},
     },
     room_id,
 };

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -23,30 +23,30 @@ use matrix_sdk::{
     test_utils::mocks::MatrixMockServer,
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, JoinedRoomBuilder, RoomAccountDataTestEvent,
-    StateTestEvent, ALICE, BOB,
+    ALICE, BOB, JoinedRoomBuilder, RoomAccountDataTestEvent, StateTestEvent, async_test,
+    event_factory::EventFactory,
 };
 use matrix_sdk_ui::{
+    Timeline,
     timeline::{
         AnyOtherFullStateEventContent, Error, EventSendState, RedactError, RoomExt,
         TimelineBuilder, TimelineEventItemId, TimelineItemContent, VirtualTimelineItem,
     },
-    Timeline,
 };
 use ruma::{
-    event_id,
+    EventId, MilliSecondsSinceUnixEpoch, event_id,
     events::room::{
         encryption::RoomEncryptionEventContent,
         message::{RedactedRoomMessageEventContent, RoomMessageEventContent},
     },
-    owned_event_id, room_id, user_id, EventId, MilliSecondsSinceUnixEpoch,
+    owned_event_id, room_id, user_id,
 };
 use serde_json::json;
 use sliding_sync::assert_timeline_stream;
 use stream_assert::assert_pending;
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
 mod decryption;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -18,8 +18,8 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::{
-    future::{join, join3},
     FutureExt, StreamExt as _,
+    future::{join, join3},
 };
 use matrix_sdk::{
     assert_let_timeout,
@@ -31,24 +31,25 @@ use matrix_sdk::{
     },
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
-    StateTestEvent, SyncResponseBuilder, ALICE, BOB,
+    ALICE, BOB, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder, async_test,
+    event_factory::EventFactory, mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::timeline::{AnyOtherFullStateEventContent, RoomExt, TimelineItemContent};
 use once_cell::sync::Lazy;
 use ruma::{
-    events::{room::message::MessageType, FullStateEventContent},
-    room_id, EventId,
+    EventId,
+    events::{FullStateEventContent, room::message::MessageType},
+    room_id,
 };
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 use stream_assert::{assert_next_eq, assert_pending};
 use tokio::{
     spawn,
     time::{sleep, timeout},
 };
 use wiremock::{
-    matchers::{header, method, path_regex, query_param, query_param_is_missing},
     Mock, ResponseTemplate,
+    matchers::{header, method, path_regex, query_param, query_param_is_missing},
 };
 
 use crate::{mock_sync, timeline::sliding_sync::assert_timeline_stream};

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -4,23 +4,25 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt as _;
 use matrix_sdk::{
+    Client, Room,
     config::SyncSettings,
     test_utils::{
         logged_in_client_with_server,
         mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
     },
-    Client, Room,
 };
 use matrix_sdk_base::deserialized_responses::TimelineEvent;
 use matrix_sdk_common::executor::spawn;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent,
-    SyncResponseBuilder, BOB,
+    BOB, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder, async_test,
+    event_factory::EventFactory,
 };
 use matrix_sdk_ui::timeline::{RoomExt, TimelineBuilder, TimelineFocus};
 use ruma::{
-    assign, event_id,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, RoomId, UserId, assign,
+    event_id,
     events::{
+        AnySyncTimelineEvent,
         room::{
             encrypted::{
                 EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
@@ -28,18 +30,17 @@ use ruma::{
             message::RoomMessageEventContentWithoutRelation,
             pinned_events::RoomPinnedEventsEventContent,
         },
-        AnySyncTimelineEvent,
     },
     owned_device_id, owned_room_id, owned_user_id, room_id,
     serde::Raw,
-    user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, RoomId, UserId,
+    user_id,
 };
 use serde_json::json;
 use stream_assert::assert_pending;
 use tokio::time::sleep;
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
 use crate::mock_sync;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
@@ -18,15 +18,15 @@ use assert_matches::assert_matches;
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_common::executor::spawn;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
-    SyncResponseBuilder, ALICE, BOB, CAROL, DEFAULT_TEST_ROOM_ID,
+    ALICE, BOB, CAROL, DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, SyncResponseBuilder, async_test,
+    event_factory::EventFactory, mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::timeline::{RoomExt, TimelineDetails};
 use ruma::events::room::member::MembershipState;
 use serde_json::json;
 use wiremock::{
-    matchers::{method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{method, path_regex},
 };
 
 use crate::mock_sync;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -18,22 +18,22 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
-use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server, Error};
+use matrix_sdk::{Error, config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_base::store::QueueWedgeError;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, JoinedRoomBuilder,
-    SyncResponseBuilder, ALICE,
+    ALICE, JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
+    mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::timeline::{EventItemOrigin, EventSendState, RoomExt};
 use ruma::{
-    event_id, events::room::message::RoomMessageEventContent, room_id, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch, event_id, events::room::message::RoomMessageEventContent, room_id,
 };
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
 use tokio::{task::yield_now, time::sleep};
 use wiremock::{
-    matchers::{body_string_contains, header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{body_string_contains, header, method, path_regex},
 };
 
 use crate::mock_sync;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
@@ -18,7 +18,7 @@ use assert_matches2::{assert_let, assert_matches};
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt as _;
 use matrix_sdk::{assert_let_timeout, test_utils::mocks::MatrixMockServer};
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE};
+use matrix_sdk_test::{ALICE, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{EventSendState, ReactionStatus, RoomExt as _};
 use ruma::{event_id, events::room::message::RoomMessageEventContent, room_id};
 use serde_json::json;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -23,19 +23,20 @@ use matrix_sdk::{
     test_utils::mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, JoinedRoomBuilder, RoomAccountDataTestEvent, ALICE,
-    BOB, CAROL,
+    ALICE, BOB, CAROL, JoinedRoomBuilder, RoomAccountDataTestEvent, async_test,
+    event_factory::EventFactory,
 };
 use matrix_sdk_ui::timeline::{RoomExt, TimelineFocus};
 use ruma::{
+    MilliSecondsSinceUnixEpoch, RoomVersionId,
     api::client::receipt::create_receipt::v3::ReceiptType as CreateReceiptType,
     event_id,
     events::{
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, RoomAccountDataEventType,
         receipt::{ReceiptThread, ReceiptType as EventReceiptType},
         room::message::{MessageType, RoomMessageEventContent, SyncRoomMessageEvent},
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent, RoomAccountDataEventType,
     },
-    owned_event_id, room_id, uint, user_id, MilliSecondsSinceUnixEpoch, RoomVersionId,
+    owned_event_id, room_id, uint, user_id,
 };
 use serde_json::json;
 use stream_assert::{assert_pending, assert_ready};

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -10,35 +10,35 @@ use matrix_sdk::{
 };
 use matrix_sdk_base::timeout::timeout;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE, BOB, CAROL,
+    ALICE, BOB, CAROL, JoinedRoomBuilder, async_test, event_factory::EventFactory,
 };
 use matrix_sdk_ui::timeline::{
     Error as TimelineError, EventSendState, MsgLikeContent, MsgLikeKind, RoomExt, TimelineDetails,
     TimelineEventItemId, TimelineItemContent,
 };
 use ruma::{
-    event_id,
+    MilliSecondsSinceUnixEpoch, UInt, event_id,
     events::{
+        Mentions,
         reaction::RedactedReactionEventContent,
         relation::InReplyTo,
         room::{
+            ImageInfo,
             encrypted::{
                 EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
             },
             message::{Relation, ReplyWithinThread, RoomMessageEventContentWithoutRelation},
-            ImageInfo,
         },
         sticker::{StickerEventContent, StickerMediaSource},
-        Mentions,
     },
-    owned_event_id, owned_mxc_uri, room_id, MilliSecondsSinceUnixEpoch, UInt,
+    owned_event_id, owned_mxc_uri, room_id,
 };
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
 use tokio::task::yield_now;
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, Request, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -18,16 +18,16 @@ use anyhow::{Context as _, Result};
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::{Vector, VectorDiff};
-use futures_util::{pin_mut, Stream, StreamExt};
+use futures_util::{Stream, StreamExt, pin_mut};
 use matrix_sdk::{
-    test_utils::logged_in_client_with_server, Client, SlidingSync, SlidingSyncList,
-    SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
+    Client, SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
+    test_utils::logged_in_client_with_server,
 };
 use matrix_sdk_test::{async_test, mocks::mock_encryption_state};
 use matrix_sdk_ui::timeline::{TimelineBuilder, TimelineItem, TimelineItemKind};
-use ruma::{room_id, user_id, RoomId};
+use ruma::{RoomId, room_id, user_id};
 use serde_json::json;
-use wiremock::{http::Method, Match, Mock, MockServer, Request, ResponseTemplate};
+use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate, http::Method};
 
 macro_rules! receive_response {
     (
@@ -420,8 +420,10 @@ impl Match for SlidingSyncMatcher {
 
 #[async_test]
 async fn test_timeline_basic() -> Result<()> {
-    let (client, server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-        .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
+    let (client, server, sliding_sync) = new_sliding_sync(vec![
+        SlidingSyncList::builder("foo")
+            .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
+    ])
     .await?;
 
     let stream = sliding_sync.sync();
@@ -468,8 +470,10 @@ async fn test_timeline_basic() -> Result<()> {
 
 #[async_test]
 async fn test_timeline_duplicated_events() -> Result<()> {
-    let (client, server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-        .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
+    let (client, server, sliding_sync) = new_sliding_sync(vec![
+        SlidingSyncList::builder("foo")
+            .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
+    ])
     .await?;
 
     let stream = sliding_sync.sync();
@@ -546,8 +550,10 @@ async fn test_timeline_duplicated_events() -> Result<()> {
 
 #[async_test]
 async fn test_timeline_read_receipts_are_updated_live() -> Result<()> {
-    let (client, server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-        .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
+    let (client, server, sliding_sync) = new_sliding_sync(vec![
+        SlidingSyncList::builder("foo")
+            .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
+    ])
     .await?;
 
     let stream = sliding_sync.sync();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -21,8 +21,8 @@ use futures_util::StreamExt;
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_common::executor::spawn;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state,
-    GlobalAccountDataTestEvent, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB,
+    ALICE, BOB, GlobalAccountDataTestEvent, JoinedRoomBuilder, SyncResponseBuilder, async_test,
+    event_factory::EventFactory, mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::timeline::{RoomExt, TimelineDetails};
 use ruma::{

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -23,18 +23,19 @@ use matrix_sdk::{
     test_utils::mocks::{MatrixMockServer, RoomRelationsResponseTemplate},
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, JoinedRoomBuilder, RoomAccountDataTestEvent, ALICE,
-    BOB,
+    ALICE, BOB, JoinedRoomBuilder, RoomAccountDataTestEvent, async_test,
+    event_factory::EventFactory,
 };
 use matrix_sdk_ui::timeline::{RoomExt as _, TimelineBuilder, TimelineDetails, TimelineFocus};
 use ruma::{
+    MilliSecondsSinceUnixEpoch,
     api::client::receipt::create_receipt::v3::ReceiptType as SendReceiptType,
     event_id,
     events::{
         receipt::{ReceiptThread, ReceiptType},
         room::message::{ReplyWithinThread, RoomMessageEventContentWithoutRelation},
     },
-    owned_event_id, room_id, user_id, MilliSecondsSinceUnixEpoch,
+    owned_event_id, room_id, user_id,
 };
 use stream_assert::assert_pending;
 use tokio::task::yield_now;


### PR DESCRIPTION
I made sure that the two remaining PRs that blocked the large rustfmt PR (https://github.com/matrix-org/matrix-rust-sdk/pull/5225, https://github.com/matrix-org/matrix-rust-sdk/pull/5258) do not touch the UI crate, so this is not going to result in conflicts there.

There were a few more `+ use<_>` clauses added in private interfaces, but they weren't necessary for compilation to succeed, so I omitted them. I doubt they will become required for anything later, but if they do, it's gonna be the same sort of situation as newly-added `-> impl Trait` return types, where surely nobody thinks to add `+ use<>`, and the compiler is hopefully going to suggest doing that where helpful.

Signed-off-by: Jonas Platte
