### PR TITLE
doc(sdk): Fix a typo in the documentation of `EventCacheDropHandles`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -114,7 +114,7 @@ pub enum EventCacheError {
 /// A result using the [`EventCacheError`].
 pub type Result<T> = std::result::Result<T, EventCacheError>;
 
-/// Hold handles to the tasks spawn by a [`RoomEventCache`].
+/// Hold handles to the tasks spawn by a [`EventCache`].
 pub struct EventCacheDropHandles {
     /// Task that listens to room updates.
     listen_updates_task: JoinHandle<()>,


### PR DESCRIPTION
This patch fix a typo in the documentation of `EventCacheDropHandles`: `EventCache` starts the tasks, not `RoomEventCache`.