### PR TITLE
refactor(timeline): simplify the concept of "focus" and refactor building

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -20,25 +20,24 @@ use std::{
 use futures_core::Stream;
 use futures_util::{pin_mut, StreamExt};
 use matrix_sdk::{
-    crypto::store::types::RoomKeyInfo,
-    encryption::backups::BackupState,
-    event_cache::{EventsOrigin, RoomEventCache, RoomEventCacheSubscriber, RoomEventCacheUpdate},
-    executor::spawn,
-    send_queue::RoomSendQueueUpdate,
-    Room,
+    crypto::store::types::RoomKeyInfo, encryption::backups::BackupState, executor::spawn, Room,
 };
 use matrix_sdk_base::{SendOutsideWasm, SyncOutsideWasm};
-use ruma::{events::AnySyncTimelineEvent, OwnedEventId, RoomVersionId};
-use tokio::sync::broadcast::{error::RecvError, Receiver};
+use ruma::{events::AnySyncTimelineEvent, RoomVersionId};
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
-use tracing::{info_span, instrument, trace, warn, Instrument, Span};
+use tracing::{info_span, warn, Instrument, Span};
 
 use super::{
     controller::{TimelineController, TimelineSettings},
     to_device::{handle_forwarded_room_key_event, handle_room_key_event},
     DateDividerMode, Error, Timeline, TimelineDropHandle, TimelineFocus,
 };
-use crate::{timeline::event_item::RemoteEventOrigin, unable_to_decrypt_hook::UtdHookManager};
+use crate::{
+    timeline::tasks::{
+        pinned_events_task, room_event_cache_updates_task, room_send_queue_update_task,
+    },
+    unable_to_decrypt_hook::UtdHookManager,
+};
 
 /// Builder that allows creating and configuring various parts of a
 /// [`Timeline`].
@@ -310,155 +309,6 @@ impl TimelineBuilder {
         }
 
         Ok(timeline)
-    }
-}
-
-/// The task that handles the pinned event IDs updates.
-#[instrument(
-    skip_all,
-    fields(
-        room_id = %timeline_controller.room().room_id(),
-    )
-)]
-async fn pinned_events_task<S>(pinned_event_ids_stream: S, timeline_controller: TimelineController)
-where
-    S: Stream<Item = Vec<OwnedEventId>>,
-{
-    pin_mut!(pinned_event_ids_stream);
-
-    while pinned_event_ids_stream.next().await.is_some() {
-        trace!("received a pinned events update");
-
-        match timeline_controller.reload_pinned_events().await {
-            Ok(Some(events)) => {
-                trace!("successfully reloaded pinned events");
-                timeline_controller
-                    .replace_with_initial_remote_events(
-                        events.into_iter(),
-                        RemoteEventOrigin::Pagination,
-                    )
-                    .await;
-            }
-
-            Ok(None) => {
-                // The list of pinned events hasn't changed since the previous
-                // time.
-            }
-
-            Err(err) => {
-                warn!("Failed to reload pinned events: {err}");
-            }
-        }
-    }
-}
-
-/// The task that handles the [`RoomEventCacheUpdate`]s.
-async fn room_event_cache_updates_task(
-    room_event_cache: RoomEventCache,
-    timeline_controller: TimelineController,
-    mut room_event_cache_subscriber: RoomEventCacheSubscriber,
-    timeline_focus: TimelineFocus,
-) {
-    trace!("Spawned the event subscriber task.");
-
-    loop {
-        trace!("Waiting for an event.");
-
-        let update = match room_event_cache_subscriber.recv().await {
-            Ok(up) => up,
-            Err(RecvError::Closed) => break,
-            Err(RecvError::Lagged(num_skipped)) => {
-                warn!(num_skipped, "Lagged behind event cache updates, resetting timeline");
-
-                // The updates might have lagged, but the room event cache might have
-                // events, so retrieve them and add them back again to the timeline,
-                // after clearing it.
-                let initial_events = room_event_cache.events().await;
-
-                timeline_controller
-                    .replace_with_initial_remote_events(
-                        initial_events.into_iter(),
-                        RemoteEventOrigin::Cache,
-                    )
-                    .await;
-
-                continue;
-            }
-        };
-
-        match update {
-            RoomEventCacheUpdate::MoveReadMarkerTo { event_id } => {
-                trace!(target = %event_id, "Handling fully read marker.");
-                timeline_controller.handle_fully_read_marker(event_id).await;
-            }
-
-            RoomEventCacheUpdate::UpdateTimelineEvents { diffs, origin } => {
-                trace!("Received new timeline events diffs");
-                let origin = match origin {
-                    EventsOrigin::Sync => RemoteEventOrigin::Sync,
-                    EventsOrigin::Pagination => RemoteEventOrigin::Pagination,
-                    EventsOrigin::Cache => RemoteEventOrigin::Cache,
-                };
-
-                let has_diffs = !diffs.is_empty();
-
-                if matches!(
-                    timeline_focus,
-                    TimelineFocus::Live { .. } | TimelineFocus::Thread { .. }
-                ) {
-                    timeline_controller.handle_remote_events_with_diffs(diffs, origin).await;
-                } else {
-                    // Only handle the remote aggregation for a non-live timeline.
-                    timeline_controller.handle_remote_aggregations(diffs, origin).await;
-                }
-
-                if has_diffs && matches!(origin, RemoteEventOrigin::Cache) {
-                    timeline_controller.retry_event_decryption(None).await;
-                }
-            }
-
-            RoomEventCacheUpdate::AddEphemeralEvents { events } => {
-                trace!("Received new ephemeral events from sync.");
-
-                // TODO: (bnjbvr) ephemeral should be handled by the event cache.
-                timeline_controller.handle_ephemeral_events(events).await;
-            }
-
-            RoomEventCacheUpdate::UpdateMembers { ambiguity_changes } => {
-                if !ambiguity_changes.is_empty() {
-                    let member_ambiguity_changes = ambiguity_changes
-                        .values()
-                        .flat_map(|change| change.user_ids())
-                        .collect::<BTreeSet<_>>();
-                    timeline_controller
-                        .force_update_sender_profiles(&member_ambiguity_changes)
-                        .await;
-                }
-            }
-        }
-    }
-}
-
-/// The task that handles the [`RoomSendQueueUpdate`]s.
-async fn room_send_queue_update_task(
-    mut send_queue_stream: Receiver<RoomSendQueueUpdate>,
-    timeline_controller: TimelineController,
-) {
-    trace!("spawned the local echo task!");
-
-    loop {
-        match send_queue_stream.recv().await {
-            Ok(update) => timeline_controller.handle_room_send_queue_update(update).await,
-
-            Err(RecvError::Lagged(num_missed)) => {
-                warn!("missed {num_missed} local echoes, ignoring those missed");
-            }
-
-            Err(RecvError::Closed) => {
-                trace!("channel closed, exiting the local echo handler");
-                break;
-            }
-        }
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -173,8 +173,8 @@ impl TimelineBuilder {
             internal_id_prefix.clone(),
             unable_to_decrypt_hook,
             is_room_encrypted,
-        )
-        .with_settings(settings);
+            settings,
+        );
 
         let has_events = controller.init_focus(&room_event_cache).await?;
 

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -176,7 +176,7 @@ impl TimelineBuilder {
             settings,
         );
 
-        let has_events = controller.init_focus(&room_event_cache).await?;
+        let has_events = controller.init_focus(&focus, &room_event_cache).await?;
 
         let pinned_events_join_handle = if matches!(focus, TimelineFocus::PinnedEvents { .. }) {
             Some(spawn(pinned_events_task(room.pinned_event_ids_stream(), controller.clone())))

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -33,8 +33,9 @@ use super::{
     DateDividerMode, Error, Timeline, TimelineDropHandle, TimelineFocus,
 };
 use crate::{
-    timeline::tasks::{
-        pinned_events_task, room_event_cache_updates_task, room_send_queue_update_task,
+    timeline::{
+        controller::CryptoDropHandles,
+        tasks::{pinned_events_task, room_event_cache_updates_task, room_send_queue_update_task},
     },
     unable_to_decrypt_hook::UtdHookManager,
 };
@@ -284,20 +285,24 @@ impl TimelineBuilder {
             ))
         };
 
+        let crypto_drop_handles = CryptoDropHandles {
+            client,
+            event_handler_handles: event_handlers,
+            room_key_from_backups_join_handle,
+            room_keys_received_join_handle,
+            room_key_backup_enabled_join_handle,
+            encryption_changes_handle,
+        };
+
         let timeline = Timeline {
             controller,
             event_cache: room_event_cache,
             drop_handle: Arc::new(TimelineDropHandle {
-                client,
-                event_handler_handles: event_handlers,
+                _crypto_drop_handles: crypto_drop_handles,
                 room_update_join_handle,
                 pinned_events_join_handle,
-                room_key_from_backups_join_handle,
-                room_key_backup_enabled_join_handle,
-                room_keys_received_join_handle,
                 local_echo_listener_handle,
                 _event_cache_drop_handle: event_cache_drop,
-                encryption_changes_handle,
             }),
         };
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -12,37 +12,48 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeSet, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
+use futures_core::Stream;
+use futures_util::pin_mut;
 use imbl::Vector;
 use itertools::{Either, Itertools as _};
 use matrix_sdk::{
+    crypto::store::types::RoomKeyInfo,
     deserialized_responses::TimelineEventKind as SdkTimelineEventKind,
-    event_handler::EventHandlerHandle, executor::JoinHandle, Client,
+    encryption::backups::BackupState,
+    event_handler::EventHandlerHandle,
+    executor::{spawn, JoinHandle},
+    Client, Room,
 };
 use tokio::sync::{
     mpsc::{self, Receiver, Sender},
     RwLock,
 };
-use tracing::{debug, error, field, info, info_span, Instrument as _};
+use tokio_stream::{wrappers::errors::BroadcastStreamRecvError, StreamExt as _};
+use tracing::{debug, error, field, info, info_span, warn, Instrument as _};
 
 use crate::timeline::{
     controller::{TimelineSettings, TimelineState},
     event_item::EventTimelineItemKind,
+    to_device::{handle_forwarded_room_key_event, handle_room_key_event},
     traits::{Decryptor, RoomDataProvider},
-    EncryptedMessage, EventTimelineItem, TimelineItem, TimelineItemKind,
+    EncryptedMessage, EventTimelineItem, TimelineController, TimelineItem, TimelineItemKind,
 };
 
 /// All the drop handles for the tasks used for crypto, namely message
 /// re-decryption, in the timeline.
 #[derive(Debug)]
 pub(in crate::timeline) struct CryptoDropHandles {
-    pub client: Client,
-    pub event_handler_handles: Vec<EventHandlerHandle>,
-    pub room_key_from_backups_join_handle: JoinHandle<()>,
-    pub room_keys_received_join_handle: JoinHandle<()>,
-    pub room_key_backup_enabled_join_handle: JoinHandle<()>,
-    pub encryption_changes_handle: JoinHandle<()>,
+    client: Client,
+    event_handler_handles: Vec<EventHandlerHandle>,
+    room_key_from_backups_join_handle: JoinHandle<()>,
+    room_keys_received_join_handle: JoinHandle<()>,
+    room_key_backup_enabled_join_handle: JoinHandle<()>,
+    encryption_changes_handle: JoinHandle<()>,
 }
 
 impl Drop for CryptoDropHandles {
@@ -55,6 +66,158 @@ impl Drop for CryptoDropHandles {
         self.room_keys_received_join_handle.abort();
         self.room_key_backup_enabled_join_handle.abort();
         self.encryption_changes_handle.abort();
+    }
+}
+
+/// The task that handles the room keys from backups.
+async fn room_keys_from_backups_task<S>(stream: S, timeline_controller: TimelineController)
+where
+    S: Stream<Item = Result<BTreeMap<String, BTreeSet<String>>, BroadcastStreamRecvError>>,
+{
+    pin_mut!(stream);
+
+    while let Some(update) = stream.next().await {
+        match update {
+            Ok(info) => {
+                let mut session_ids = BTreeSet::new();
+
+                for set in info.into_values() {
+                    session_ids.extend(set);
+                }
+
+                timeline_controller.retry_event_decryption(Some(session_ids)).await;
+            }
+            // We lagged, so retry every event.
+            Err(_) => timeline_controller.retry_event_decryption(None).await,
+        }
+    }
+}
+
+/// The task that handles the [`BackupState`] updates.
+async fn backup_states_task<S>(backup_states_stream: S, timeline_controller: TimelineController)
+where
+    S: Stream<Item = Result<BackupState, BroadcastStreamRecvError>>,
+{
+    pin_mut!(backup_states_stream);
+
+    while let Some(update) = backup_states_stream.next().await {
+        match update {
+            // If the backup got enabled, or we lagged and thus missed that the backup
+            // might be enabled, retry to decrypt all the events. Please note, depending
+            // on the backup download strategy, this might do two things under the
+            // assumption that the backup contains the relevant room keys:
+            //
+            // 1. It will decrypt the events, if `BackupDownloadStrategy` has been set to `OneShot`.
+            // 2. It will fail to decrypt the event, but try to download the room key to decrypt it
+            //    if the `BackupDownloadStrategy` has been set to `AfterDecryptionFailure`.
+            Ok(BackupState::Enabled) | Err(_) => {
+                timeline_controller.retry_event_decryption(None).await;
+            }
+            // The other states aren't interesting since they are either still enabling
+            // the backup or have the backup in the disabled state.
+            Ok(
+                BackupState::Unknown
+                | BackupState::Creating
+                | BackupState::Resuming
+                | BackupState::Disabling
+                | BackupState::Downloading
+                | BackupState::Enabling,
+            ) => (),
+        }
+    }
+}
+
+/// The task that handles the [`RoomKeyInfo`] updates.
+async fn room_key_received_task<S>(
+    room_keys_received_stream: S,
+    timeline_controller: TimelineController,
+) where
+    S: Stream<Item = Result<Vec<RoomKeyInfo>, BroadcastStreamRecvError>>,
+{
+    pin_mut!(room_keys_received_stream);
+
+    let room_id = timeline_controller.room().room_id();
+
+    while let Some(room_keys) = room_keys_received_stream.next().await {
+        let session_ids = match room_keys {
+            Ok(room_keys) => {
+                let session_ids: BTreeSet<String> = room_keys
+                    .into_iter()
+                    .filter(|info| info.room_id == room_id)
+                    .map(|info| info.session_id)
+                    .collect();
+
+                Some(session_ids)
+            }
+            Err(BroadcastStreamRecvError::Lagged(missed_updates)) => {
+                // We lagged, let's retry to decrypt anything we have, maybe something
+                // was received.
+                warn!(
+                    missed_updates,
+                    "The room keys stream has lagged, retrying to decrypt the whole timeline"
+                );
+
+                None
+            }
+        };
+
+        timeline_controller.retry_event_decryption(session_ids).await;
+    }
+}
+
+/// Spawn all the crypto-related tasks that are used to handle re-decryption of
+/// messages.
+pub(in crate::timeline) async fn spawn_crypto_tasks(
+    room: Room,
+    controller: TimelineController,
+) -> CryptoDropHandles {
+    let room_key_handle = room
+        .client()
+        .add_event_handler(handle_room_key_event(controller.clone(), room.room_id().to_owned()));
+
+    let client = room.client();
+    let forwarded_room_key_handle = client.add_event_handler(handle_forwarded_room_key_event(
+        controller.clone(),
+        room.room_id().to_owned(),
+    ));
+
+    let event_handlers = vec![room_key_handle, forwarded_room_key_handle];
+
+    // Not using room.add_event_handler here because RoomKey events are
+    // to-device events that are not received in the context of a room.
+
+    let room_key_from_backups_join_handle = spawn(room_keys_from_backups_task(
+        client.encryption().backups().room_keys_for_room_stream(controller.room().room_id()),
+        controller.clone(),
+    ));
+
+    let room_key_backup_enabled_join_handle =
+        spawn(backup_states_task(client.encryption().backups().state_stream(), controller.clone()));
+
+    // TODO: Technically, this should be the only stream we need to listen to get
+    // notified when we should retry to decrypt an event. We sadly can't do that,
+    // since the cross-process support kills the `OlmMachine` which then in
+    // turn kills this stream. Once this is solved remove all the other ways we
+    // listen for room keys.
+    let room_keys_received_join_handle = {
+        spawn(room_key_received_task(
+            client.encryption().room_keys_received_stream().await.expect(
+                "We should be logged in by now, so we should have access to an `OlmMachine` \
+                     to be able to listen to this stream",
+            ),
+            controller.clone(),
+        ))
+    };
+
+    CryptoDropHandles {
+        client,
+        event_handler_handles: event_handlers,
+        room_key_from_backups_join_handle,
+        room_keys_received_join_handle,
+        room_key_backup_enabled_join_handle,
+        encryption_changes_handle: spawn(async move {
+            controller.handle_encryption_state_changes().await
+        }),
     }
 }
 
@@ -96,8 +259,7 @@ impl<P: RoomDataProvider, D: Decryptor> DecryptionRetryTask<P, D> {
 
         // Spawn the long-running task, providing the receiver so we can listen for
         // decryption requests
-        let handle =
-            matrix_sdk::executor::spawn(decryption_task(state, room_data_provider, receiver));
+        let handle = spawn(decryption_task(state, room_data_provider, receiver));
 
         // Keep hold of the sender so we can send off decryption requests to the task.
         Self { sender, _task_handle: Arc::new(handle), _phantom: Default::default() }

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -38,7 +38,7 @@ use super::{
 };
 use crate::{
     timeline::{
-        controller::TimelineFocusData,
+        controller::TimelineFocusKind,
         event_item::{
             extract_bundled_edit_event_json, extract_poll_edit_content,
             extract_room_msg_edit_content,
@@ -318,7 +318,7 @@ impl TimelineMetadata {
         raw_event: &Raw<AnySyncTimelineEvent>,
         bundled_edit_encryption_info: Option<Arc<EncryptionInfo>>,
         timeline_items: &Vector<Arc<TimelineItem>>,
-        timeline_focus: &TimelineFocusData<P>,
+        timeline_focus: &TimelineFocusKind<P>,
     ) -> (Option<InReplyToDetails>, Option<OwnedEventId>) {
         if let AnySyncTimelineEvent::MessageLike(ev) = event {
             if let Some(content) = ev.original_content() {
@@ -349,7 +349,7 @@ impl TimelineMetadata {
         content: &AnyMessageLikeEventContent,
         remote_ctx: Option<RemoteEventContext<'_>>,
         timeline_items: &Vector<Arc<TimelineItem>>,
-        timeline_focus: &TimelineFocusData<P>,
+        timeline_focus: &TimelineFocusKind<P>,
     ) -> (Option<InReplyToDetails>, Option<OwnedEventId>) {
         match content {
             AnyMessageLikeEventContent::Sticker(content) => {
@@ -453,7 +453,7 @@ impl TimelineMetadata {
     fn extract_reply_and_thread_root<P: RoomDataProvider>(
         relates_to: Option<RelationWithoutReplacement>,
         timeline_items: &Vector<Arc<TimelineItem>>,
-        timeline_focus: &TimelineFocusData<P>,
+        timeline_focus: &TimelineFocusKind<P>,
     ) -> (Option<InReplyToDetails>, Option<OwnedEventId>) {
         let mut thread_root = None;
 
@@ -464,7 +464,7 @@ impl TimelineMetadata {
             RelationWithoutReplacement::Thread(thread) => {
                 thread_root = Some(thread.event_id);
 
-                if matches!(timeline_focus, TimelineFocusData::Thread { .. })
+                if matches!(timeline_focus, TimelineFocusKind::Thread { .. })
                     && thread.is_falling_back
                 {
                     // In general, a threaded event is marked as a response to the previous message

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -285,6 +285,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
             TimelineFocus::Live { hide_threaded_events } => {
                 TimelineFocusKind::Live { hide_threaded_events }
             }
+
             TimelineFocus::Event { target, num_context_events, hide_threaded_events } => {
                 let paginator = Paginator::new(room_data_provider.clone());
                 TimelineFocusKind::Event {
@@ -480,7 +481,9 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
             .subscriber_skip_count
             .compute_next_when_paginating_backwards(num_events.into());
 
-        state.meta.subscriber_skip_count.update(count, &self.focus);
+        // This always happens on a live timeline.
+        let is_live_timeline = true;
+        state.meta.subscriber_skip_count.update(count, is_live_timeline);
 
         needs
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -90,7 +90,7 @@ mod state;
 mod state_transaction;
 
 pub(super) use aggregations::*;
-pub(super) use decryption_retry_task::CryptoDropHandles;
+pub(super) use decryption_retry_task::{spawn_crypto_tasks, CryptoDropHandles};
 
 /// Data associated to the current timeline focus.
 ///

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -90,6 +90,7 @@ mod state;
 mod state_transaction;
 
 pub(super) use aggregations::*;
+pub(super) use decryption_retry_task::CryptoDropHandles;
 
 /// Data associated to the current timeline focus.
 ///

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -279,6 +279,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
         internal_id_prefix: Option<String>,
         unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
         is_room_encrypted: bool,
+        settings: TimelineSettings,
     ) -> Self {
         let focus = match focus {
             TimelineFocus::Live { hide_threaded_events } => {
@@ -323,8 +324,6 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
             unable_to_decrypt_hook,
             is_room_encrypted,
         )));
-
-        let settings = TimelineSettings::default();
 
         let decryption_retry_task =
             DecryptionRetryTask::new(state.clone(), room_data_provider.clone());
@@ -552,11 +551,6 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
     /// Is this timeline receiving events from sync (aka has a live focus)?
     pub(super) fn is_live(&self) -> bool {
         matches!(&*self.focus, TimelineFocusKind::Live { .. })
-    }
-
-    pub(super) fn with_settings(mut self, settings: TimelineSettings) -> Self {
-        self.settings = settings;
-        self
     }
 
     /// Get a copy of the current items in the list.

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -479,7 +479,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
             .subscriber_skip_count
             .compute_next_when_paginating_backwards(num_events.into());
 
-        state.meta.subscriber_skip_count.update(count, &state.timeline_focus);
+        state.meta.subscriber_skip_count.update(count, &self.focus);
 
         needs
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -501,8 +501,8 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                 .paginate_backward(num_events.into())
                 .await
                 .map_err(PaginationError::Paginator)?,
-            TimelineFocusKind::Thread { loader, num_events, .. } => loader
-                .paginate_backwards((*num_events).into())
+            TimelineFocusKind::Thread { loader, .. } => loader
+                .paginate_backwards(num_events.into())
                 .await
                 .map_err(PaginationError::Paginator)?,
         };

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -496,7 +496,7 @@ impl ReadReceiptTimelineUpdate {
     }
 }
 
-impl TimelineStateTransaction<'_> {
+impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
     pub(super) fn handle_explicit_read_receipts(
         &mut self,
         receipt_event_content: ReceiptEventContent,
@@ -536,7 +536,7 @@ impl TimelineStateTransaction<'_> {
     /// Load the read receipts from the store for the given event ID.
     ///
     /// Populates the read receipts in-memory caches.
-    pub(super) async fn load_read_receipts_for_event<P: RoomDataProvider>(
+    pub(super) async fn load_read_receipts_for_event(
         &mut self,
         event_id: &EventId,
         room_data_provider: &P,
@@ -649,10 +649,10 @@ impl TimelineStateTransaction<'_> {
     }
 }
 
-impl TimelineState {
+impl<P: RoomDataProvider> TimelineState<P> {
     /// Populates our own latest read receipt in the in-memory by-user read
     /// receipt cache.
-    pub(super) async fn populate_initial_user_receipt<P: RoomDataProvider>(
+    pub(super) async fn populate_initial_user_receipt(
         &mut self,
         room_data_provider: &P,
         receipt_type: ReceiptType,
@@ -678,7 +678,7 @@ impl TimelineState {
     /// Get the latest read receipt for the given user.
     ///
     /// Useful to get the latest read receipt, whether it's private or public.
-    pub(super) async fn latest_user_read_receipt<P: RoomDataProvider>(
+    pub(super) async fn latest_user_read_receipt(
         &self,
         user_id: &UserId,
         room_data_provider: &P,

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -168,14 +168,14 @@ impl<P: RoomDataProvider> TimelineState<P> {
             txn.meta.process_content_relations(&content, None, &txn.items, txn.focus);
 
         // TODO merge with other should_add, one way or another?
-        let should_add_new_items = match &txn.timeline_focus {
-            TimelineFocusKind::Live { hide_threaded_events } => {
+        let should_add_new_items = match &txn.focus {
+            TimelineFocusData::Live { hide_threaded_events } => {
                 thread_root.is_none() || !hide_threaded_events
             }
-            TimelineFocusKind::Thread { root_event_id } => {
+            TimelineFocusData::Thread { root_event_id, .. } => {
                 thread_root.as_ref().is_some_and(|r| r == root_event_id)
             }
-            TimelineFocusKind::Event { .. } | TimelineFocusKind::PinnedEvents => {
+            TimelineFocusData::Event { .. } | TimelineFocusData::PinnedEvents { .. } => {
                 // Don't add new items to these timelines; aggregations are added independently
                 // of the `should_add_new_items` value.
                 false

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -165,7 +165,7 @@ impl<P: RoomDataProvider> TimelineState<P> {
         let mut date_divider_adjuster = DateDividerAdjuster::new(date_divider_mode);
 
         let (in_reply_to, thread_root) =
-            txn.meta.process_content_relations(&content, None, &txn.items, &txn.timeline_focus);
+            txn.meta.process_content_relations(&content, None, &txn.items, txn.focus);
 
         // TODO merge with other should_add, one way or another?
         let should_add_new_items = match &txn.timeline_focus {

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -36,8 +36,7 @@ use super::{
         Profile, TimelineItem,
     },
     observable_items::ObservableItems,
-    DateDividerMode, TimelineFocusKind, TimelineMetadata, TimelineSettings,
-    TimelineStateTransaction,
+    DateDividerMode, TimelineMetadata, TimelineSettings, TimelineStateTransaction,
 };
 use crate::{timeline::controller::TimelineFocusData, unable_to_decrypt_hook::UtdHookManager};
 
@@ -47,14 +46,11 @@ pub(in crate::timeline) struct TimelineState<P: RoomDataProvider> {
     pub meta: TimelineMetadata,
 
     /// The kind of focus of this timeline.
-    pub timeline_focus: TimelineFocusKind,
-
     focus_data: Arc<TimelineFocusData<P>>,
 }
 
 impl<P: RoomDataProvider> TimelineState<P> {
     pub(super) fn new(
-        timeline_focus: TimelineFocusKind,
         focus_data: Arc<TimelineFocusData<P>>,
         own_user_id: OwnedUserId,
         room_version: RoomVersionId,
@@ -71,7 +67,6 @@ impl<P: RoomDataProvider> TimelineState<P> {
                 unable_to_decrypt_hook,
                 is_room_encrypted,
             ),
-            timeline_focus,
             focus_data,
         }
     }
@@ -304,11 +299,6 @@ impl<P: RoomDataProvider> TimelineState<P> {
     }
 
     pub(super) fn transaction(&mut self) -> TimelineStateTransaction<'_, P> {
-        TimelineStateTransaction::new(
-            &mut self.items,
-            &mut self.meta,
-            self.timeline_focus.clone(),
-            &*self.focus_data,
-        )
+        TimelineStateTransaction::new(&mut self.items, &mut self.meta, &*self.focus_data)
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -159,8 +159,9 @@ impl<P: RoomDataProvider> TimelineState<P> {
 
         let mut date_divider_adjuster = DateDividerAdjuster::new(date_divider_mode);
 
+        let is_thread_focus = matches!(txn.focus, TimelineFocusKind::Thread { .. });
         let (in_reply_to, thread_root) =
-            txn.meta.process_content_relations(&content, None, &txn.items, txn.focus);
+            txn.meta.process_content_relations(&content, None, &txn.items, is_thread_focus);
 
         // TODO merge with other should_add, one way or another?
         let should_add_new_items = match &txn.focus {

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -37,7 +37,7 @@ use super::{
     ObservableItems, ObservableItemsTransaction, TimelineMetadata, TimelineSettings,
 };
 use crate::timeline::{
-    controller::TimelineFocusData,
+    controller::TimelineFocusKind,
     event_handler::{FailedToParseEvent, RemovedItem, TimelineAction},
     EmbeddedEvent, ThreadSummary, TimelineDetails, VirtualTimelineItem,
 };
@@ -59,7 +59,7 @@ pub(in crate::timeline) struct TimelineStateTransaction<'a, P: RoomDataProvider>
     previous_meta: &'a mut TimelineMetadata,
 
     /// The kind of focus of this timeline.
-    pub focus: &'a TimelineFocusData<P>,
+    pub focus: &'a TimelineFocusKind<P>,
 }
 
 impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
@@ -67,7 +67,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
     pub(super) fn new(
         items: &'a mut ObservableItems,
         meta: &'a mut TimelineMetadata,
-        focus: &'a TimelineFocusData<P>,
+        focus: &'a TimelineFocusKind<P>,
     ) -> Self {
         let previous_meta = meta;
         let meta = previous_meta.clone();
@@ -403,12 +403,12 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
         }
 
         match &self.focus {
-            TimelineFocusData::PinnedEvents { .. } => {
+            TimelineFocusKind::PinnedEvents { .. } => {
                 // Only add pinned events for the pinned events timeline.
                 room_data_provider.is_pinned_event(event.event_id())
             }
 
-            TimelineFocusData::Event { hide_threaded_events, .. } => {
+            TimelineFocusKind::Event { hide_threaded_events, .. } => {
                 // If the timeline's filtering out in-thread events, don't add items for
                 // threaded events.
                 if thread_root.is_some() && *hide_threaded_events {
@@ -435,13 +435,13 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 }
             }
 
-            TimelineFocusData::Live { hide_threaded_events } => {
+            TimelineFocusKind::Live { hide_threaded_events } => {
                 // If the timeline's filtering out in-thread events, don't add items for
                 // threaded events.
                 thread_root.is_none() || !hide_threaded_events
             }
 
-            TimelineFocusData::Thread { root_event_id, .. } => {
+            TimelineFocusKind::Thread { root_event_id, .. } => {
                 // Add new items only for the thread root and the thread replies.
                 event.event_id() == root_event_id
                     || thread_root.as_ref().is_some_and(|r| r == root_event_id)

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -34,8 +34,7 @@ use super::{
         traits::RoomDataProvider,
     },
     metadata::EventMeta,
-    ObservableItems, ObservableItemsTransaction, TimelineFocusKind, TimelineMetadata,
-    TimelineSettings,
+    ObservableItems, ObservableItemsTransaction, TimelineMetadata, TimelineSettings,
 };
 use crate::timeline::{
     controller::TimelineFocusData,
@@ -60,8 +59,6 @@ pub(in crate::timeline) struct TimelineStateTransaction<'a, P: RoomDataProvider>
     previous_meta: &'a mut TimelineMetadata,
 
     /// The kind of focus of this timeline.
-    pub timeline_focus: TimelineFocusKind,
-
     pub focus: &'a TimelineFocusData<P>,
 }
 
@@ -70,7 +67,6 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
     pub(super) fn new(
         items: &'a mut ObservableItems,
         meta: &'a mut TimelineMetadata,
-        timeline_focus: TimelineFocusKind,
         focus: &'a TimelineFocusData<P>,
     ) -> Self {
         let previous_meta = meta;
@@ -82,7 +78,6 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             items,
             previous_meta,
             meta,
-            timeline_focus,
             focus,
         }
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -813,7 +813,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 .meta
                 .subscriber_skip_count
                 .compute_next(previous_number_of_items, next_number_of_items);
-            self.meta.subscriber_skip_count.update(count, &self.timeline_focus);
+            self.meta.subscriber_skip_count.update(count, self.focus);
         }
 
         // Replace the pointer to the previous meta with the new one.

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -60,9 +60,9 @@ pub(in crate::timeline) struct TimelineStateTransaction<'a, P: RoomDataProvider>
     previous_meta: &'a mut TimelineMetadata,
 
     /// The kind of focus of this timeline.
-    pub(super) timeline_focus: TimelineFocusKind,
+    pub timeline_focus: TimelineFocusKind,
 
-    focus: &'a TimelineFocusData<P>,
+    pub focus: &'a TimelineFocusData<P>,
 }
 
 impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
@@ -630,7 +630,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                     &raw,
                     bundled_edit_encryption_info,
                     &self.items,
-                    &self.timeline_focus,
+                    self.focus,
                 );
 
                 let should_add = self.should_add_event_item(

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -407,13 +407,13 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             return false;
         }
 
-        match &self.timeline_focus {
-            TimelineFocusKind::PinnedEvents => {
+        match &self.focus {
+            TimelineFocusData::PinnedEvents { .. } => {
                 // Only add pinned events for the pinned events timeline.
                 room_data_provider.is_pinned_event(event.event_id())
             }
 
-            TimelineFocusKind::Event { hide_threaded_events } => {
+            TimelineFocusData::Event { hide_threaded_events, .. } => {
                 // If the timeline's filtering out in-thread events, don't add items for
                 // threaded events.
                 if thread_root.is_some() && *hide_threaded_events {
@@ -440,13 +440,13 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 }
             }
 
-            TimelineFocusKind::Live { hide_threaded_events } => {
+            TimelineFocusData::Live { hide_threaded_events } => {
                 // If the timeline's filtering out in-thread events, don't add items for
                 // threaded events.
                 thread_root.is_none() || !hide_threaded_events
             }
 
-            TimelineFocusKind::Thread { root_event_id } => {
+            TimelineFocusData::Thread { root_event_id, .. } => {
                 // Add new items only for the thread root and the thread replies.
                 event.event_id() == root_event_id
                     || thread_root.as_ref().is_some_and(|r| r == root_event_id)

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -625,7 +625,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                     &raw,
                     bundled_edit_encryption_info,
                     &self.items,
-                    self.focus,
+                    matches!(self.focus, TimelineFocusKind::Thread { .. }),
                 );
 
                 let should_add = self.should_add_event_item(
@@ -808,7 +808,9 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 .meta
                 .subscriber_skip_count
                 .compute_next(previous_number_of_items, next_number_of_items);
-            self.meta.subscriber_skip_count.update(count, self.focus);
+            self.meta
+                .subscriber_skip_count
+                .update(count, matches!(self.focus, TimelineFocusKind::Live { .. }));
         }
 
         // Replace the pointer to the previous meta with the new one.

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -463,8 +463,8 @@ pub(super) struct TimelineEventHandler<'a, 'o> {
 }
 
 impl<'a, 'o> TimelineEventHandler<'a, 'o> {
-    pub(super) fn new(
-        state: &'a mut TimelineStateTransaction<'o>,
+    pub(super) fn new<P: RoomDataProvider>(
+        state: &'a mut TimelineStateTransaction<'o, P>,
         ctx: TimelineEventContext,
     ) -> Self {
         let TimelineStateTransaction { items, meta, .. } = state;

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -78,6 +78,7 @@ mod item;
 mod pagination;
 mod pinned_events_loader;
 mod subscriber;
+mod tasks;
 #[cfg(test)]
 mod tests;
 mod to_device;

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -31,11 +31,10 @@ use matrix_sdk::{
     attachment::AttachmentConfig,
     deserialized_responses::TimelineEvent,
     event_cache::{EventCacheDropHandles, RoomEventCache},
-    event_handler::EventHandlerHandle,
     executor::JoinHandle,
     room::{edit::EditedContent, reply::Reply, Receipts, Room},
     send_queue::{RoomSendQueueError, SendHandle},
-    Client, Result,
+    Result,
 };
 use mime::Mime;
 use pinned_events_loader::PinnedEventsRoom;

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -239,7 +239,7 @@ impl Timeline {
 
     /// Get the latest of the timeline's event items.
     pub async fn latest_event(&self) -> Option<EventTimelineItem> {
-        if self.controller.is_live().await {
+        if self.controller.is_live() {
             self.controller.items().await.last()?.as_event().cloned()
         } else {
             None

--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -27,7 +27,7 @@ impl super::Timeline {
     /// Returns whether we hit the start of the timeline.
     #[instrument(skip_all, fields(room_id = ?self.room().room_id()))]
     pub async fn paginate_backwards(&self, mut num_events: u16) -> Result<bool, Error> {
-        if self.controller.is_live().await {
+        if self.controller.is_live() {
             match self.controller.live_lazy_paginate_backwards(num_events).await {
                 Some(needed_num_events) => {
                     num_events = needed_num_events.try_into().expect(
@@ -55,7 +55,7 @@ impl super::Timeline {
     /// Returns whether we hit the end of the timeline.
     #[instrument(skip_all, fields(room_id = ?self.room().room_id()))]
     pub async fn paginate_forwards(&self, num_events: u16) -> Result<bool, Error> {
-        if self.controller.is_live().await {
+        if self.controller.is_live() {
             Ok(true)
         } else {
             Ok(self.controller.focused_paginate_forwards(num_events).await?)
@@ -104,7 +104,7 @@ impl super::Timeline {
     pub async fn live_back_pagination_status(
         &self,
     ) -> Option<(RoomPaginationStatus, impl Stream<Item = RoomPaginationStatus>)> {
-        if !self.controller.is_live().await {
+        if !self.controller.is_live() {
             return None;
         }
 

--- a/crates/matrix-sdk-ui/src/timeline/subscriber.rs
+++ b/crates/matrix-sdk-ui/src/timeline/subscriber.rs
@@ -109,7 +109,7 @@ impl Stream for TimelineSubscriber {
 pub mod skip {
     use eyeball::{SharedObservable, Subscriber};
 
-    use super::super::controller::TimelineFocusKind;
+    use crate::timeline::{controller::TimelineFocusData, traits::RoomDataProvider};
 
     const MAXIMUM_NUMBER_OF_INITIAL_ITEMS: usize = 20;
 
@@ -248,8 +248,8 @@ pub mod skip {
 
         /// Update the skip count if and only if the timeline has a live focus
         /// ([`TimelineFocusKind::Live`]).
-        pub fn update(&self, count: usize, focus_kind: &TimelineFocusKind) {
-            if matches!(focus_kind, TimelineFocusKind::Live { .. }) {
+        pub fn update<P: RoomDataProvider>(&self, count: usize, focus: &TimelineFocusData<P>) {
+            if matches!(focus, TimelineFocusData::Live { .. }) {
                 self.count.set_if_not_eq(count);
             }
         }

--- a/crates/matrix-sdk-ui/src/timeline/subscriber.rs
+++ b/crates/matrix-sdk-ui/src/timeline/subscriber.rs
@@ -109,8 +109,6 @@ impl Stream for TimelineSubscriber {
 pub mod skip {
     use eyeball::{SharedObservable, Subscriber};
 
-    use crate::timeline::{controller::TimelineFocusKind, traits::RoomDataProvider};
-
     const MAXIMUM_NUMBER_OF_INITIAL_ITEMS: usize = 20;
 
     /// `SkipCount` helps to manage the `count` value used by the [`Skip`]
@@ -248,8 +246,8 @@ pub mod skip {
 
         /// Update the skip count if and only if the timeline has a live focus
         /// ([`TimelineFocusKind::Live`]).
-        pub fn update<P: RoomDataProvider>(&self, count: usize, focus: &TimelineFocusKind<P>) {
-            if matches!(focus, TimelineFocusKind::Live { .. }) {
+        pub fn update(&self, count: usize, is_live_focus: bool) {
+            if is_live_focus {
                 self.count.set_if_not_eq(count);
             }
         }

--- a/crates/matrix-sdk-ui/src/timeline/subscriber.rs
+++ b/crates/matrix-sdk-ui/src/timeline/subscriber.rs
@@ -109,7 +109,7 @@ impl Stream for TimelineSubscriber {
 pub mod skip {
     use eyeball::{SharedObservable, Subscriber};
 
-    use crate::timeline::{controller::TimelineFocusData, traits::RoomDataProvider};
+    use crate::timeline::{controller::TimelineFocusKind, traits::RoomDataProvider};
 
     const MAXIMUM_NUMBER_OF_INITIAL_ITEMS: usize = 20;
 
@@ -248,8 +248,8 @@ pub mod skip {
 
         /// Update the skip count if and only if the timeline has a live focus
         /// ([`TimelineFocusKind::Live`]).
-        pub fn update<P: RoomDataProvider>(&self, count: usize, focus: &TimelineFocusData<P>) {
-            if matches!(focus, TimelineFocusData::Live { .. }) {
+        pub fn update<P: RoomDataProvider>(&self, count: usize, focus: &TimelineFocusKind<P>) {
+            if matches!(focus, TimelineFocusKind::Live { .. }) {
                 self.count.set_if_not_eq(count);
             }
         }

--- a/crates/matrix-sdk-ui/src/timeline/tasks.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tasks.rs
@@ -29,7 +29,8 @@ use tracing::{instrument, trace, warn};
 
 use crate::timeline::{event_item::RemoteEventOrigin, TimelineController, TimelineFocus};
 
-/// The task that handles the pinned event IDs updates.
+/// Long-lived task, in the pinned events focus mode, that updates the timeline
+/// after any changes in the pinned events.
 #[instrument(
     skip_all,
     fields(
@@ -70,7 +71,8 @@ pub(in crate::timeline) async fn pinned_events_task<S>(
     }
 }
 
-/// The task that handles the [`RoomEventCacheUpdate`]s.
+/// Long-lived task that forwards the [`RoomEventCacheUpdate`]s (remote echoes)
+/// to the timeline.
 pub(in crate::timeline) async fn room_event_cache_updates_task(
     room_event_cache: RoomEventCache,
     timeline_controller: TimelineController,
@@ -157,7 +159,8 @@ pub(in crate::timeline) async fn room_event_cache_updates_task(
     }
 }
 
-/// The task that handles the [`RoomSendQueueUpdate`]s.
+/// Long-lived task that forwards [`RoomSendQueueUpdate`]s (local echoes) to the
+/// timeline.
 pub(in crate::timeline) async fn room_send_queue_update_task(
     mut send_queue_stream: Receiver<RoomSendQueueUpdate>,
     timeline_controller: TimelineController,

--- a/crates/matrix-sdk-ui/src/timeline/tasks.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tasks.rs
@@ -1,0 +1,181 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Long-lived tasks for the timeline.
+
+use std::collections::BTreeSet;
+
+use futures_core::Stream;
+use futures_util::pin_mut;
+use matrix_sdk::{
+    event_cache::{EventsOrigin, RoomEventCache, RoomEventCacheSubscriber, RoomEventCacheUpdate},
+    send_queue::RoomSendQueueUpdate,
+};
+use ruma::OwnedEventId;
+use tokio::sync::broadcast::{error::RecvError, Receiver};
+use tokio_stream::StreamExt as _;
+use tracing::{instrument, trace, warn};
+
+use crate::timeline::{event_item::RemoteEventOrigin, TimelineController, TimelineFocus};
+
+/// The task that handles the pinned event IDs updates.
+#[instrument(
+    skip_all,
+    fields(
+        room_id = %timeline_controller.room().room_id(),
+    )
+)]
+pub(in crate::timeline) async fn pinned_events_task<S>(
+    pinned_event_ids_stream: S,
+    timeline_controller: TimelineController,
+) where
+    S: Stream<Item = Vec<OwnedEventId>>,
+{
+    pin_mut!(pinned_event_ids_stream);
+
+    while pinned_event_ids_stream.next().await.is_some() {
+        trace!("received a pinned events update");
+
+        match timeline_controller.reload_pinned_events().await {
+            Ok(Some(events)) => {
+                trace!("successfully reloaded pinned events");
+                timeline_controller
+                    .replace_with_initial_remote_events(
+                        events.into_iter(),
+                        RemoteEventOrigin::Pagination,
+                    )
+                    .await;
+            }
+
+            Ok(None) => {
+                // The list of pinned events hasn't changed since the previous
+                // time.
+            }
+
+            Err(err) => {
+                warn!("Failed to reload pinned events: {err}");
+            }
+        }
+    }
+}
+
+/// The task that handles the [`RoomEventCacheUpdate`]s.
+pub(in crate::timeline) async fn room_event_cache_updates_task(
+    room_event_cache: RoomEventCache,
+    timeline_controller: TimelineController,
+    mut room_event_cache_subscriber: RoomEventCacheSubscriber,
+    timeline_focus: TimelineFocus,
+) {
+    trace!("Spawned the event subscriber task.");
+
+    loop {
+        trace!("Waiting for an event.");
+
+        let update = match room_event_cache_subscriber.recv().await {
+            Ok(up) => up,
+            Err(RecvError::Closed) => break,
+            Err(RecvError::Lagged(num_skipped)) => {
+                warn!(num_skipped, "Lagged behind event cache updates, resetting timeline");
+
+                // The updates might have lagged, but the room event cache might have
+                // events, so retrieve them and add them back again to the timeline,
+                // after clearing it.
+                let initial_events = room_event_cache.events().await;
+
+                timeline_controller
+                    .replace_with_initial_remote_events(
+                        initial_events.into_iter(),
+                        RemoteEventOrigin::Cache,
+                    )
+                    .await;
+
+                continue;
+            }
+        };
+
+        match update {
+            RoomEventCacheUpdate::MoveReadMarkerTo { event_id } => {
+                trace!(target = %event_id, "Handling fully read marker.");
+                timeline_controller.handle_fully_read_marker(event_id).await;
+            }
+
+            RoomEventCacheUpdate::UpdateTimelineEvents { diffs, origin } => {
+                trace!("Received new timeline events diffs");
+                let origin = match origin {
+                    EventsOrigin::Sync => RemoteEventOrigin::Sync,
+                    EventsOrigin::Pagination => RemoteEventOrigin::Pagination,
+                    EventsOrigin::Cache => RemoteEventOrigin::Cache,
+                };
+
+                let has_diffs = !diffs.is_empty();
+
+                if matches!(
+                    timeline_focus,
+                    TimelineFocus::Live { .. } | TimelineFocus::Thread { .. }
+                ) {
+                    timeline_controller.handle_remote_events_with_diffs(diffs, origin).await;
+                } else {
+                    // Only handle the remote aggregation for a non-live timeline.
+                    timeline_controller.handle_remote_aggregations(diffs, origin).await;
+                }
+
+                if has_diffs && matches!(origin, RemoteEventOrigin::Cache) {
+                    timeline_controller.retry_event_decryption(None).await;
+                }
+            }
+
+            RoomEventCacheUpdate::AddEphemeralEvents { events } => {
+                trace!("Received new ephemeral events from sync.");
+
+                // TODO: (bnjbvr) ephemeral should be handled by the event cache.
+                timeline_controller.handle_ephemeral_events(events).await;
+            }
+
+            RoomEventCacheUpdate::UpdateMembers { ambiguity_changes } => {
+                if !ambiguity_changes.is_empty() {
+                    let member_ambiguity_changes = ambiguity_changes
+                        .values()
+                        .flat_map(|change| change.user_ids())
+                        .collect::<BTreeSet<_>>();
+                    timeline_controller
+                        .force_update_sender_profiles(&member_ambiguity_changes)
+                        .await;
+                }
+            }
+        }
+    }
+}
+
+/// The task that handles the [`RoomSendQueueUpdate`]s.
+pub(in crate::timeline) async fn room_send_queue_update_task(
+    mut send_queue_stream: Receiver<RoomSendQueueUpdate>,
+    timeline_controller: TimelineController,
+) {
+    trace!("spawned the local echo task!");
+
+    loop {
+        match send_queue_stream.recv().await {
+            Ok(update) => timeline_controller.handle_room_send_queue_update(update).await,
+
+            Err(RecvError::Lagged(num_missed)) => {
+                warn!("missed {num_missed} local echoes, ignoring those missed");
+            }
+
+            Err(RecvError::Closed) => {
+                trace!("channel closed, exiting the local echo handler");
+                break;
+            }
+        }
+    }
+}

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -121,16 +121,14 @@ impl TestTimelineBuilder {
     }
 
     fn build(self) -> TestTimeline {
-        let mut controller = TimelineController::new(
+        let controller = TimelineController::new(
             self.provider.unwrap_or_default(),
             TimelineFocus::Live { hide_threaded_events: false },
             self.internal_id_prefix,
             self.utd_hook,
             self.is_room_encrypted,
+            self.settings.unwrap_or_default(),
         );
-        if let Some(settings) = self.settings {
-            controller = controller.with_settings(settings);
-        }
         TestTimeline { controller, factory: EventFactory::new() }
     }
 }


### PR DESCRIPTION
There were three different APIs for a `TimelineFocus`, before this PR:

- `TimelineFocus`, which is the public API to be used when building a `Timeline`
- `TimelineFocusKind`, which is a simplified view of the focus of a timeline, used in misc places to make some lightweight decisions
- `TimelineFocusData`, which includes some (inner) mutable data to make useful changes to a timeline: pagination, etc.

This PR unifies the latter two into a single type, that's eventually renamed `TimelineFocusKind`. I find it makes it simpler to understand the different choices, and I even think this might lead to more simplifications later.