### PR TITLE
fix(sdk): use a cfg guard instead of `if cfg!` to avoid build failures on !test && !debug_assertions builds

### DIFF
--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -266,7 +266,8 @@ impl RoomEvents {
 
         self.order_tracker.flush_updates(false);
 
-        if cfg!(any(test, debug_assertions)) {
+        #[cfg(any(test, debug_assertions))]
+        {
             // Assert that the orderings are fully correct for all the events present in the
             // in-memory linked chunk.
             self.assert_event_ordering();


### PR DESCRIPTION
What it says on the tin. I'll never learn the rules around `if cfg!`.