### PR TITLE
feat(sdk): send threaded read receipts

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -4,6 +4,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use matrix_sdk::{store::RoomLoadSettings, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_base::{
     store::StoreConfig, BaseClient, RoomInfo, RoomState, SessionMeta, StateChanges, StateStore,
+    ThreadingSupport,
 };
 use matrix_sdk_sqlite::SqliteStateStore;
 use matrix_sdk_test::{event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent};
@@ -58,6 +59,7 @@ pub fn receive_all_members_benchmark(c: &mut Criterion) {
     let base_client = BaseClient::new(
         StoreConfig::new("cross-process-store-locks-holder-name".to_owned())
             .state_store(sqlite_store),
+        ThreadingSupport::Disabled,
     );
 
     runtime

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -51,7 +51,6 @@ use ruma::{
                 UnstablePollStartContentBlock,
             },
         },
-        receipt::ReceiptThread,
         room::message::{
             LocationMessageEventContent, MessageType, ReplyWithinThread,
             RoomMessageEventContentWithoutRelation,
@@ -351,9 +350,7 @@ impl Timeline {
         event_id: String,
     ) -> Result<(), ClientError> {
         let event_id = EventId::parse(event_id)?;
-        self.inner
-            .send_single_receipt(receipt_type.into(), ReceiptThread::Unthreaded, event_id)
-            .await?;
+        self.inner.send_single_receipt(receipt_type.into(), event_id).await?;
         Ok(())
     }
 

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -48,7 +48,7 @@ mod utils;
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
 
-pub use client::BaseClient;
+pub use client::{BaseClient, ThreadingSupport};
 #[cfg(any(test, feature = "testing"))]
 pub use http;
 #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk-base/src/room/latest_event.rs
+++ b/crates/matrix-sdk-base/src/room/latest_event.rs
@@ -88,6 +88,7 @@ mod tests_with_e2e_encryption {
     use serde_json::json;
 
     use crate::{
+        client::ThreadingSupport,
         latest_event::LatestEvent,
         response_processors as processors,
         store::{MemoryStore, RoomLoadSettings, StoreConfig},
@@ -107,8 +108,10 @@ mod tests_with_e2e_encryption {
     #[async_test]
     async fn test_setting_the_latest_event_doesnt_cause_a_room_info_notable_update() {
         // Given a room,
-        let client =
-            BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
+        let client = BaseClient::new(
+            StoreConfig::new("cross-process-store-locks-holder-name".to_owned()),
+            ThreadingSupport::Disabled,
+        );
 
         client
             .activate(

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1274,7 +1274,7 @@ mod tests {
                 "num_mentions": 0,
                 "num_notifications": 0,
                 "latest_active": null,
-                "pending": []
+                "pending": [],
             },
             "recency_stamp": 42,
         });

--- a/crates/matrix-sdk-base/src/room/tags.rs
+++ b/crates/matrix-sdk-base/src/room/tags.rs
@@ -82,6 +82,7 @@ mod tests {
 
     use super::{super::BaseRoomInfo, RoomNotableTags};
     use crate::{
+        client::ThreadingSupport,
         response_processors as processors,
         store::{RoomLoadSettings, StoreConfig},
         BaseClient, RoomState, SessionMeta,
@@ -90,8 +91,10 @@ mod tests {
     #[async_test]
     async fn test_is_favourite() {
         // Given a room,
-        let client =
-            BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
+        let client = BaseClient::new(
+            StoreConfig::new("cross-process-store-locks-holder-name".to_owned()),
+            ThreadingSupport::Disabled,
+        );
 
         client
             .activate(
@@ -186,8 +189,10 @@ mod tests {
     #[async_test]
     async fn test_is_low_priority() {
         // Given a room,
-        let client =
-            BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
+        let client = BaseClient::new(
+            StoreConfig::new("cross-process-store-locks-holder-name".to_owned()),
+            ThreadingSupport::Disabled,
+        );
 
         client
             .activate(

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -284,6 +284,7 @@ impl BaseClient {
                 room_previous_events,
                 &joined_room_update.timeline.events,
                 &mut room_info.read_receipts,
+                self.threading_support,
             );
 
             if prev_read_receipts != room_info.read_receipts {
@@ -348,6 +349,7 @@ mod tests {
     #[cfg(feature = "e2e-encryption")]
     use super::processors::room::msc4186::cache_latest_events;
     use crate::{
+        client::ThreadingSupport,
         room::{RoomHero, RoomInfoNotableUpdateReasons},
         store::{RoomLoadSettings, StoreConfig},
         test_utils::logged_in_base_client,
@@ -1157,7 +1159,7 @@ mod tests {
                 let store = StoreConfig::new("cross-process-foo".to_owned());
                 state_store = store.state_store.clone();
 
-                let client = BaseClient::new(store);
+                let client = BaseClient::new(store, ThreadingSupport::Disabled);
                 client
                     .activate(
                         session_meta.clone(),
@@ -1188,7 +1190,7 @@ mod tests {
             let client = {
                 let mut store = StoreConfig::new("cross-process-foo".to_owned());
                 store.state_store = state_store;
-                let client = BaseClient::new(store);
+                let client = BaseClient::new(store, ThreadingSupport::Disabled);
                 client
                     .activate(
                         session_meta,

--- a/crates/matrix-sdk-base/src/test_utils.rs
+++ b/crates/matrix-sdk-base/src/test_utils.rs
@@ -19,6 +19,7 @@
 use ruma::{owned_user_id, UserId};
 
 use crate::{
+    client::ThreadingSupport,
     store::{RoomLoadSettings, StoreConfig},
     BaseClient, SessionMeta,
 };
@@ -26,8 +27,10 @@ use crate::{
 /// Create a [`BaseClient`] with the given user id, if provided, or an hardcoded
 /// one otherwise.
 pub(crate) async fn logged_in_base_client(user_id: Option<&UserId>) -> BaseClient {
-    let client =
-        BaseClient::new(StoreConfig::new("cross-process-store-locks-holder-name".to_owned()));
+    let client = BaseClient::new(
+        StoreConfig::new("cross-process-store-locks-holder-name".to_owned()),
+        ThreadingSupport::Disabled,
+    );
     let user_id =
         user_id.map(|user_id| user_id.to_owned()).unwrap_or_else(|| owned_user_id!("@u:e.uk"));
     client

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Infer timeline read receipt threads for the `send_single_receipt` method from
+  the focus mode and associated `hide_threaded_events` flag. ([5325](https://github.com/matrix-org/matrix-rust-sdk/pull/5325))
 - Add `NotificationItem::room_topic` to the `NotificationItem` struct, which
   contains the topic of the room. This is useful for displaying the room topic
   in notifications. ([#5300](https://github.com/matrix-org/matrix-rust-sdk/pull/5300))

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -20,13 +20,15 @@ use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{
     room::Receipts,
-    test_utils::mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
+    test_utils::mocks::{
+        MatrixMockServer, RoomMessagesResponseTemplate, RoomRelationsResponseTemplate,
+    },
 };
 use matrix_sdk_test::{
     async_test, event_factory::EventFactory, JoinedRoomBuilder, RoomAccountDataTestEvent, ALICE,
     BOB, CAROL,
 };
-use matrix_sdk_ui::timeline::RoomExt;
+use matrix_sdk_ui::timeline::{RoomExt, TimelineFocus};
 use ruma::{
     api::client::receipt::create_receipt::v3::ReceiptType as CreateReceiptType,
     event_id,
@@ -414,7 +416,12 @@ async fn test_send_single_receipt() {
 
     server.mock_room_state_encryption().plain().mount().await;
 
-    let timeline = room.timeline().await.unwrap();
+    let timeline = room
+        .timeline_builder()
+        .with_focus(TimelineFocus::Live { hide_threaded_events: false })
+        .build()
+        .await
+        .unwrap();
 
     // Unknown receipts are sent.
     let first_receipts_event_id = event_id!("$first_receipts_event_id");
@@ -444,27 +451,15 @@ async fn test_send_single_receipt() {
     );
 
     timeline
-        .send_single_receipt(
-            CreateReceiptType::Read,
-            ReceiptThread::Unthreaded,
-            first_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::Read, first_receipts_event_id.to_owned())
         .await
         .unwrap();
     timeline
-        .send_single_receipt(
-            CreateReceiptType::ReadPrivate,
-            ReceiptThread::Unthreaded,
-            first_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::ReadPrivate, first_receipts_event_id.to_owned())
         .await
         .unwrap();
     timeline
-        .send_single_receipt(
-            CreateReceiptType::FullyRead,
-            ReceiptThread::Unthreaded,
-            first_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::FullyRead, first_receipts_event_id.to_owned())
         .await
         .unwrap();
 
@@ -503,27 +498,15 @@ async fn test_send_single_receipt() {
         .await;
 
     timeline
-        .send_single_receipt(
-            CreateReceiptType::Read,
-            ReceiptThread::Unthreaded,
-            first_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::Read, first_receipts_event_id.to_owned())
         .await
         .unwrap();
     timeline
-        .send_single_receipt(
-            CreateReceiptType::ReadPrivate,
-            ReceiptThread::Unthreaded,
-            first_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::ReadPrivate, first_receipts_event_id.to_owned())
         .await
         .unwrap();
     timeline
-        .send_single_receipt(
-            CreateReceiptType::FullyRead,
-            ReceiptThread::Unthreaded,
-            first_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::FullyRead, first_receipts_event_id.to_owned())
         .await
         .unwrap();
 
@@ -555,27 +538,15 @@ async fn test_send_single_receipt() {
     );
 
     timeline
-        .send_single_receipt(
-            CreateReceiptType::Read,
-            ReceiptThread::Unthreaded,
-            second_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::Read, second_receipts_event_id.to_owned())
         .await
         .unwrap();
     timeline
-        .send_single_receipt(
-            CreateReceiptType::ReadPrivate,
-            ReceiptThread::Unthreaded,
-            second_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::ReadPrivate, second_receipts_event_id.to_owned())
         .await
         .unwrap();
     timeline
-        .send_single_receipt(
-            CreateReceiptType::FullyRead,
-            ReceiptThread::Unthreaded,
-            second_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::FullyRead, second_receipts_event_id.to_owned())
         .await
         .unwrap();
 
@@ -648,27 +619,15 @@ async fn test_send_single_receipt() {
     );
 
     timeline
-        .send_single_receipt(
-            CreateReceiptType::Read,
-            ReceiptThread::Unthreaded,
-            third_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::Read, third_receipts_event_id.to_owned())
         .await
         .unwrap();
     timeline
-        .send_single_receipt(
-            CreateReceiptType::ReadPrivate,
-            ReceiptThread::Unthreaded,
-            third_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::ReadPrivate, third_receipts_event_id.to_owned())
         .await
         .unwrap();
     timeline
-        .send_single_receipt(
-            CreateReceiptType::FullyRead,
-            ReceiptThread::Unthreaded,
-            third_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::FullyRead, third_receipts_event_id.to_owned())
         .await
         .unwrap();
 
@@ -705,29 +664,157 @@ async fn test_send_single_receipt() {
         .await;
 
     timeline
-        .send_single_receipt(
-            CreateReceiptType::Read,
-            ReceiptThread::Unthreaded,
-            second_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::Read, second_receipts_event_id.to_owned())
         .await
         .unwrap();
     timeline
-        .send_single_receipt(
-            CreateReceiptType::ReadPrivate,
-            ReceiptThread::Unthreaded,
-            second_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::ReadPrivate, second_receipts_event_id.to_owned())
         .await
         .unwrap();
     timeline
-        .send_single_receipt(
-            CreateReceiptType::FullyRead,
-            ReceiptThread::Unthreaded,
-            second_receipts_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::FullyRead, second_receipts_event_id.to_owned())
         .await
         .unwrap();
+}
+
+#[async_test]
+async fn test_send_single_receipt_threaded() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    // A live timeline will use `main` as the post body `thread_id` parameter
+    // value or no value at all for fully read markers.
+    let timeline = room
+        .timeline_builder()
+        .with_focus(TimelineFocus::Live { hide_threaded_events: true })
+        .build()
+        .await
+        .unwrap();
+
+    let event_id = event_id!("$event_id");
+
+    let mock_post_receipt_guards = (
+        server
+            .mock_send_receipt(CreateReceiptType::Read)
+            .body_matches_partial_json(json!({
+                "thread_id": "main",
+            }))
+            .ok()
+            .expect(1)
+            .named("Public read receipt")
+            .mount_as_scoped()
+            .await,
+        server
+            .mock_send_receipt(CreateReceiptType::ReadPrivate)
+            .body_matches_partial_json(json!({
+                "thread_id": "main",
+            }))
+            .ok()
+            .expect(1)
+            .named("Private read receipt")
+            .mount_as_scoped()
+            .await,
+        server
+            .mock_send_receipt(CreateReceiptType::FullyRead)
+            .body_matches_partial_json(json!({}))
+            .ok()
+            .expect(1)
+            .named("Fully-read marker")
+            .mount_as_scoped()
+            .await,
+    );
+
+    timeline.send_single_receipt(CreateReceiptType::Read, event_id.to_owned()).await.unwrap();
+    timeline
+        .send_single_receipt(CreateReceiptType::ReadPrivate, event_id.to_owned())
+        .await
+        .unwrap();
+    timeline.send_single_receipt(CreateReceiptType::FullyRead, event_id.to_owned()).await.unwrap();
+
+    drop(mock_post_receipt_guards);
+
+    let thread_root_event_id = event_id!("$thread_root");
+
+    // A thread focused timeline will use the thread root event id as the post
+    // body `thread_id` parameter value or no value at all for fully read
+    // markers.
+
+    server
+        .mock_room_event()
+        .match_event_id()
+        .ok(EventFactory::new()
+            .text_msg("Thread root")
+            .sender(user_id!("@alice:b.c"))
+            .event_id(thread_root_event_id)
+            .into())
+        .mock_once()
+        .mount()
+        .await;
+
+    server
+        .mock_room_relations()
+        .match_target_event(thread_root_event_id.to_owned())
+        .ok(RoomRelationsResponseTemplate::default())
+        .mock_once()
+        .mount()
+        .await;
+
+    let timeline = room
+        .timeline_builder()
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root_event_id.to_owned(),
+            num_events: 1,
+        })
+        .build()
+        .await
+        .unwrap();
+
+    let event_id = event_id!("$event_id");
+
+    let mock_post_receipt_guards = (
+        server
+            .mock_send_receipt(CreateReceiptType::Read)
+            .body_matches_partial_json(json!({
+                "thread_id": thread_root_event_id.to_string(),
+            }))
+            .ok()
+            .expect(1)
+            .named("Public read receipt")
+            .mount_as_scoped()
+            .await,
+        server
+            .mock_send_receipt(CreateReceiptType::ReadPrivate)
+            .body_matches_partial_json(json!({
+                "thread_id": thread_root_event_id.to_string(),
+            }))
+            .ok()
+            .expect(1)
+            .named("Private read receipt")
+            .mount_as_scoped()
+            .await,
+        server
+            .mock_send_receipt(CreateReceiptType::FullyRead)
+            .body_matches_partial_json(json!({}))
+            .ok()
+            .expect(1)
+            .named("Fully-read marker")
+            .mount_as_scoped()
+            .await,
+    );
+
+    timeline.send_single_receipt(CreateReceiptType::Read, event_id.to_owned()).await.unwrap();
+    timeline
+        .send_single_receipt(CreateReceiptType::ReadPrivate, event_id.to_owned())
+        .await
+        .unwrap();
+    timeline.send_single_receipt(CreateReceiptType::FullyRead, event_id.to_owned()).await.unwrap();
+
+    drop(mock_post_receipt_guards);
 }
 
 #[async_test]
@@ -780,7 +867,12 @@ async fn test_send_single_receipt_with_unread_flag() {
 
     server.mock_room_state_encryption().plain().mount().await;
 
-    let timeline = room.timeline().await.unwrap();
+    let timeline = room
+        .timeline_builder()
+        .with_focus(TimelineFocus::Live { hide_threaded_events: false })
+        .build()
+        .await
+        .unwrap();
 
     // Unchanged unthreaded receipts are not sent, but the unread flag is unset.
     {
@@ -792,27 +884,15 @@ async fn test_send_single_receipt_with_unread_flag() {
             .await;
 
         timeline
-            .send_single_receipt(
-                CreateReceiptType::Read,
-                ReceiptThread::Unthreaded,
-                first_receipts_event_id.clone(),
-            )
+            .send_single_receipt(CreateReceiptType::Read, first_receipts_event_id.clone())
             .await
             .unwrap();
         timeline
-            .send_single_receipt(
-                CreateReceiptType::ReadPrivate,
-                ReceiptThread::Unthreaded,
-                first_receipts_event_id.clone(),
-            )
+            .send_single_receipt(CreateReceiptType::ReadPrivate, first_receipts_event_id.clone())
             .await
             .unwrap();
         timeline
-            .send_single_receipt(
-                CreateReceiptType::FullyRead,
-                ReceiptThread::Unthreaded,
-                first_receipts_event_id,
-            )
+            .send_single_receipt(CreateReceiptType::FullyRead, first_receipts_event_id)
             .await
             .unwrap();
     }
@@ -850,27 +930,15 @@ async fn test_send_single_receipt_with_unread_flag() {
         );
 
         timeline
-            .send_single_receipt(
-                CreateReceiptType::Read,
-                ReceiptThread::Unthreaded,
-                second_receipts_event_id.clone(),
-            )
+            .send_single_receipt(CreateReceiptType::Read, second_receipts_event_id.clone())
             .await
             .unwrap();
         timeline
-            .send_single_receipt(
-                CreateReceiptType::ReadPrivate,
-                ReceiptThread::Unthreaded,
-                second_receipts_event_id.clone(),
-            )
+            .send_single_receipt(CreateReceiptType::ReadPrivate, second_receipts_event_id.clone())
             .await
             .unwrap();
         timeline
-            .send_single_receipt(
-                CreateReceiptType::FullyRead,
-                ReceiptThread::Unthreaded,
-                second_receipts_event_id.clone(),
-            )
+            .send_single_receipt(CreateReceiptType::FullyRead, second_receipts_event_id.clone())
             .await
             .unwrap();
     }
@@ -885,14 +953,13 @@ async fn test_send_single_receipt_with_unread_flag() {
             .mount_as_scoped()
             .await;
 
-        timeline
-            .send_single_receipt(
-                CreateReceiptType::Read,
-                ReceiptThread::Main,
-                second_receipts_event_id,
-            )
-            .await
-            .unwrap();
+        room.send_single_receipt(
+            CreateReceiptType::Read,
+            ReceiptThread::Main,
+            second_receipts_event_id,
+        )
+        .await
+        .unwrap();
     }
 }
 
@@ -906,7 +973,12 @@ async fn test_mark_as_read() {
 
     server.mock_room_state_encryption().plain().mount().await;
 
-    let timeline = room.timeline().await.unwrap();
+    let timeline = room
+        .timeline_builder()
+        .with_focus(TimelineFocus::Live { hide_threaded_events: false })
+        .build()
+        .await
+        .unwrap();
 
     let original_event_id = event_id!("$original_event_id");
     let reaction_event_id = event_id!("$reaction_event_id");
@@ -947,11 +1019,7 @@ async fn test_mark_as_read() {
         latest_event.event_id().expect("missing event id for latest timeline event item");
 
     let has_sent = timeline
-        .send_single_receipt(
-            CreateReceiptType::Read,
-            ReceiptThread::Unthreaded,
-            latest_event_id.to_owned(),
-        )
+        .send_single_receipt(CreateReceiptType::Read, latest_event_id.to_owned())
         .await
         .unwrap();
 

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -28,7 +28,7 @@ pub use matrix_sdk_base::{
     ComposerDraft, ComposerDraftType, EncryptionState, PredecessorRoom, QueueWedgeError,
     Room as BaseRoom, RoomCreateWithCreatorEventContent, RoomDisplayName, RoomHero, RoomInfo,
     RoomMember as BaseRoomMember, RoomMemberships, RoomState, SessionMeta, StateChanges,
-    StateStore, StoreError, SuccessorRoom,
+    StateStore, StoreError, SuccessorRoom, ThreadingSupport,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -3031,6 +3031,12 @@ impl<'a> MockEndpoint<'a, ReceiptEndpoint> {
     pub fn ok(self) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
     }
+
+    /// Ensures that the body of the request is a superset of the provided
+    /// `body` parameter.
+    pub fn body_matches_partial_json(self, body: Value) -> Self {
+        Self { mock: self.mock.and(body_partial_json(body)), ..self }
+    }
 }
 
 /// A prebuilt mock for `POST /rooms/{roomId}/read_markers` request.


### PR DESCRIPTION
This series of patches introduce proper threading support for sending read receipts and computing room unread counts.

They add a new, client wide, `threads_enabled` feature flag which overtake the old `TimelineFocus:: hide_threaded_events`.

If this feature flag is turned on then the timelines will automatically send [the correct read receipt](https://spec.matrix.org/latest/client-server-api/#threaded-read-receipts) when invoked through the existing `send_read_receipt`/`send_single_receipt`/ method.
The base SDK's read receipts handler will also start ignoring threaded messages when computing room unread counts. A room will be unread only if there are new messages in its main timeline.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/3123