### PR TITLE
feat(sdk): `Add RoomEventCache::rfind_event_in_memory_by`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pinned_events_loader.rs
@@ -172,7 +172,8 @@ impl PinnedEventsRoom for Room {
     ) -> BoxFuture<'a, Result<(TimelineEvent, Vec<TimelineEvent>), matrix_sdk::Error>> {
         Box::pin(async move {
             if let Ok((cache, _handles)) = self.event_cache().await {
-                if let Some(ret) = cache.event_with_relations(event_id, related_event_filters).await
+                if let Some(ret) =
+                    cache.find_event_with_relations(event_id, related_event_filters).await
                 {
                     debug!("Loaded pinned event {event_id} and related events from cache");
                     return Ok(ret);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -255,7 +255,7 @@ async fn test_cached_events_are_kept_for_different_room_instances() {
     assert!(!items.is_empty()); // We just loaded some events
     assert_pending!(timeline_stream);
 
-    assert!(room_cache.event(event_id!("$1")).await.is_some());
+    assert!(room_cache.find_event(event_id!("$1")).await.is_some());
 
     // Drop the existing room and timeline instances
     drop(timeline_stream);
@@ -276,7 +276,7 @@ async fn test_cached_events_are_kept_for_different_room_instances() {
 
     let (items, _) = timeline.subscribe().await;
     assert!(!items.is_empty()); // These events came from the cache
-    assert!(room_cache.event(event_id!("$1")).await.is_some());
+    assert!(room_cache.find_event(event_id!("$1")).await.is_some());
 
     // Drop the existing room and timeline instances
     server.server().reset().await;
@@ -401,7 +401,7 @@ async fn test_pinned_timeline_with_no_pinned_events_on_pagination_is_just_empty(
         .expect("Pagination of events should successful");
 
     // Assert the event is loaded and added to the cache
-    assert!(event_cache.event(event_id).await.is_some());
+    assert!(event_cache.find_event(event_id).await.is_some());
 
     // And it won't cause an update in the pinned events timeline since it's not
     // pinned

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -828,15 +828,15 @@ mod tests {
 
         let (room_event_cache, _drop_handles) = room1.event_cache().await.unwrap();
 
-        let found1 = room_event_cache.event(eid1).await.unwrap();
+        let found1 = room_event_cache.find_event(eid1).await.unwrap();
         assert_event_matches_msg(&found1, "hey");
 
-        let found2 = room_event_cache.event(eid2).await.unwrap();
+        let found2 = room_event_cache.find_event(eid2).await.unwrap();
         assert_event_matches_msg(&found2, "you");
 
         // Retrieving the event with id3 from the room which doesn't contain it will
         // fail…
-        assert!(room_event_cache.event(eid3).await.is_none());
+        assert!(room_event_cache.find_event(eid3).await.is_none());
     }
 
     #[async_test]
@@ -857,7 +857,7 @@ mod tests {
         room_event_cache.save_events([f.text_msg("hey there").event_id(event_id).into()]).await;
 
         // Retrieving the event at the room-wide cache works.
-        assert!(room_event_cache.event(event_id).await.is_some());
+        assert!(room_event_cache.find_event(event_id).await.is_some());
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1146,7 +1146,7 @@ mod private {
         /// Find a single event in this room.
         ///
         /// It starts by looking into loaded events in `EventLinkedChunk` before
-        /// looking inside the storage if it is enabled.
+        /// looking inside the storage.
         pub async fn find_event(
             &self,
             event_id: &EventId,

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -230,18 +230,18 @@ impl RoomEventCache {
             .map(|(_loc, event)| event)
     }
 
-    /// Try to find an event by id in this room, along with its related events.
+    /// Try to find an event by ID in this room, along with its related events.
     ///
     /// You can filter which types of related events to retrieve using
     /// `filter`. `None` will retrieve related events of any type.
     ///
     /// The related events are sorted like this:
-    /// - events saved out-of-band with `super::RoomEventCache::save_events`
-    ///   will be located at the beginning of the array.
-    /// - events present in the linked chunk (be it in memory or in the
-    ///   database) will be sorted according to their ordering in the linked
-    ///   chunk.
-    pub async fn event_with_relations(
+    ///
+    /// - events saved out-of-band (with `RoomEventCache::save_events`) will be
+    ///   located at the beginning of the array.
+    /// - events present in the linked chunk (be it in memory or in the storage)
+    ///   will be sorted according to their ordering in the linked chunk.
+    pub async fn find_event_with_relations(
         &self,
         event_id: &EventId,
         filter: Option<Vec<RelationType>>,
@@ -1819,7 +1819,7 @@ mod tests {
 
         let filter = Some(vec![RelationType::Replacement]);
         let (event, related_events) =
-            room_event_cache.event_with_relations(original_id, filter).await.unwrap();
+            room_event_cache.find_event_with_relations(original_id, filter).await.unwrap();
         // Fetched event is the right one.
         let cached_event_id = event.event_id().unwrap();
         assert_eq!(cached_event_id, original_id);
@@ -1833,7 +1833,7 @@ mod tests {
         // Now we'll filter threads instead, there should be no related events
         let filter = Some(vec![RelationType::Thread]);
         let (event, related_events) =
-            room_event_cache.event_with_relations(original_id, filter).await.unwrap();
+            room_event_cache.find_event_with_relations(original_id, filter).await.unwrap();
         // Fetched event is the right one.
         let cached_event_id = event.event_id().unwrap();
         assert_eq!(cached_event_id, original_id);
@@ -1878,7 +1878,7 @@ mod tests {
         room_event_cache.save_events([associated_related_event]).await;
 
         let (event, related_events) =
-            room_event_cache.event_with_relations(original_id, None).await.unwrap();
+            room_event_cache.find_event_with_relations(original_id, None).await.unwrap();
         // Fetched event is the right one.
         let cached_event_id = event.event_id().unwrap();
         assert_eq!(cached_event_id, original_id);
@@ -1926,7 +1926,7 @@ mod tests {
         room_event_cache.save_events([related_event]).await;
 
         let (event, related_events) =
-            room_event_cache.event_with_relations(&original_event_id, None).await.unwrap();
+            room_event_cache.find_event_with_relations(&original_event_id, None).await.unwrap();
         // Fetched event is the right one.
         let cached_event_id = event.event_id().unwrap();
         assert_eq!(cached_event_id, original_event_id);

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -616,8 +616,8 @@ impl Room {
         Ok(event)
     }
 
-    /// Try to load the event from the event cache, if it's enabled, or fetch it
-    /// from the homeserver.
+    /// Try to load the event from the [`EventCache`][crate::event_cache], if
+    /// it's enabled, or fetch it from the homeserver.
     ///
     /// When running the request against the homeserver, it uses the given
     /// [`RequestConfig`] if provided, or the client's default one
@@ -629,7 +629,7 @@ impl Room {
     ) -> Result<TimelineEvent> {
         match self.event_cache().await {
             Ok((event_cache, _drop_handles)) => {
-                if let Some(event) = event_cache.event(event_id).await {
+                if let Some(event) = event_cache.find_event(event_id).await {
                     return Ok(event);
                 }
                 // Fallthrough: try with a request.

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -2573,7 +2573,7 @@ async fn test_relations_ordering() {
 
     // Sanity check: there are no relations for the target event yet.
     let (_, relations) =
-        room_event_cache.event_with_relations(target_event_id, None).await.unwrap();
+        room_event_cache.find_event_with_relations(target_event_id, None).await.unwrap();
     assert!(relations.is_empty());
 
     let edit2 = event_id!("$edit2");
@@ -2623,7 +2623,7 @@ async fn test_relations_ordering() {
 
     // At this point, relations are known for the target event.
     let (_, relations) =
-        room_event_cache.event_with_relations(target_event_id, None).await.unwrap();
+        room_event_cache.find_event_with_relations(target_event_id, None).await.unwrap();
     assert_eq!(relations.len(), 2);
     // And the edit events are correctly ordered according to their position in the
     // linked chunk.
@@ -2654,7 +2654,7 @@ async fn test_relations_ordering() {
 
     // Relations are returned accordingly.
     let (_, relations) =
-        room_event_cache.event_with_relations(target_event_id, None).await.unwrap();
+        room_event_cache.find_event_with_relations(target_event_id, None).await.unwrap();
     assert_eq!(relations.len(), 3);
     assert_eq!(relations[0].event_id().unwrap(), edit2);
     assert_eq!(relations[1].event_id().unwrap(), edit3);
@@ -2675,7 +2675,7 @@ async fn test_relations_ordering() {
     room.event(edit5, None).await.unwrap();
 
     let (_, relations) =
-        room_event_cache.event_with_relations(target_event_id, None).await.unwrap();
+        room_event_cache.find_event_with_relations(target_event_id, None).await.unwrap();
     assert_eq!(relations.len(), 4);
     assert_eq!(relations[0].event_id().unwrap(), edit5);
     assert_eq!(relations[1].event_id().unwrap(), edit2);

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -655,7 +655,7 @@ async fn test_event() {
 
     // Requested event was saved to the cache
     let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
-    assert!(room_event_cache.event(event_id).await.is_some());
+    assert!(room_event_cache.find_event(event_id).await.is_some());
 
     // So we can reload it without hitting the network.
     let timeline_event = room.load_or_fetch_event(event_id, None).await.unwrap();
@@ -728,9 +728,9 @@ async fn test_event_with_context() {
 
     // Requested event and their context ones were saved to the cache
     let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
-    assert!(room_event_cache.event(event_id).await.is_some());
-    assert!(room_event_cache.event(prev_event_id).await.is_some());
-    assert!(room_event_cache.event(next_event_id).await.is_some());
+    assert!(room_event_cache.find_event(event_id).await.is_some());
+    assert!(room_event_cache.find_event(prev_event_id).await.is_some());
+    assert!(room_event_cache.find_event(next_event_id).await.is_some());
 }
 
 #[async_test]


### PR DESCRIPTION
This patch introduces a new method named `RoomEventCache::rfind_event_in_memory_by` to look for an in-memory event, starting from the most recent event, by applying a predicate closure on each event.

Because this method's name has the pattern `find_event*_by`, this patch is also renaming `event` to `find_event_by_id` and `event_with_relations` to `find_event_by_id_with_relations`. I think it is mandatory and it's more Rust idiomatic as it follows the standard library namings. Those methods are no more getters, but methods going over an iterator. Proof is: `RoomEventCache::event` was entirely using `RoomEventCacheState::find_event` (this last naming was correct!).