### PR TITLE
feat(timeline): expose timestamp & identifier on embedded events

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - Add `NotificationRoomInfo::topic` to the `NotificationRoomInfo` struct, which
   contains the topic of the room. This is useful for displaying the room topic
   in notifications. ([#5300](https://github.com/matrix-org/matrix-rust-sdk/pull/5300))
+- Add `EmbeddedEventDetails::timestamp` and `EmbeddedEventDetails::event_or_transaction_id`
+  which are already available in regular timeline items.
+  ([#5331](https://github.com/matrix-org/matrix-rust-sdk/pull/5331))
 
 ### Refactor
 

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -704,6 +704,8 @@ impl Timeline {
                     content: replied_to.content.clone().into(),
                     sender: replied_to.sender.to_string(),
                     sender_profile: replied_to.sender_profile.into(),
+                    timestamp: replied_to.timestamp.into(),
+                    event_or_transaction_id: replied_to.identifier.into(),
                 },
             ))),
 

--- a/bindings/matrix-sdk-ffi/src/timeline/reply.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/reply.rs
@@ -15,6 +15,7 @@
 use matrix_sdk_ui::timeline::{EmbeddedEvent, TimelineDetails};
 
 use super::{content::TimelineItemContent, ProfileDetails};
+use crate::{event::EventOrTransactionId, utils::Timestamp};
 
 #[derive(Clone, uniffi::Object)]
 pub struct InReplyToDetails {
@@ -50,8 +51,16 @@ impl From<matrix_sdk_ui::timeline::InReplyToDetails> for InReplyToDetails {
 pub enum EmbeddedEventDetails {
     Unavailable,
     Pending,
-    Ready { content: TimelineItemContent, sender: String, sender_profile: ProfileDetails },
-    Error { message: String },
+    Ready {
+        content: TimelineItemContent,
+        sender: String,
+        sender_profile: ProfileDetails,
+        timestamp: Timestamp,
+        event_or_transaction_id: EventOrTransactionId,
+    },
+    Error {
+        message: String,
+    },
 }
 
 impl From<TimelineDetails<Box<EmbeddedEvent>>> for EmbeddedEventDetails {
@@ -63,6 +72,8 @@ impl From<TimelineDetails<Box<EmbeddedEvent>>> for EmbeddedEventDetails {
                 content: event.content.into(),
                 sender: event.sender.to_string(),
                 sender_profile: event.sender_profile.into(),
+                timestamp: event.timestamp.into(),
+                event_or_transaction_id: event.identifier.into(),
             },
             TimelineDetails::Error(err) => EmbeddedEventDetails::Error { message: err.to_string() },
         }

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - Add `NotificationItem::room_topic` to the `NotificationItem` struct, which
   contains the topic of the room. This is useful for displaying the room topic
   in notifications. ([#5300](https://github.com/matrix-org/matrix-rust-sdk/pull/5300))
+- Add `EmbeddedEvent::timestamp` and `EmbeddedEvent::identifier` which are already
+  available in regular timeline items. ([#5331](https://github.com/matrix-org/matrix-rust-sdk/pull/5331))
 
 ## [0.12.0] - 2025-06-10
 


### PR DESCRIPTION
These are available in normal timeline items. Having them on embedded items, too, allows clients to render them (timestamp) or use them for further operations (event ID).

- [x] Public API changes documented in changelogs (optional)
