### PR TITLE
fix(event cache): disable order assertions entirely

### DIFF
--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -233,6 +233,7 @@ impl RoomEvents {
     }
 
     #[cfg(any(test, debug_assertions))]
+    #[allow(dead_code)] // Temporarily, until we figure out why it's crashing production builds.
     fn assert_event_ordering(&self) {
         let mut iter = self.chunks.items().enumerate();
         let Some((i, (first_event_pos, _))) = iter.next() else {
@@ -265,13 +266,6 @@ impl RoomEvents {
         let updates = self.chunks_updates_as_vectordiffs.take();
 
         self.order_tracker.flush_updates(false);
-
-        #[cfg(any(test, debug_assertions))]
-        {
-            // Assert that the orderings are fully correct for all the events present in the
-            // in-memory linked chunk.
-            self.assert_event_ordering();
-        }
 
         updates
     }


### PR DESCRIPTION
Until we figure out some panics in production this has caused.

This is only a fix for builds that include debug assertions, like the `reldbg` profile for `iOS`.