### PR TITLE
feat(base): Remember when a user accepts an invite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,6 +2952,7 @@ dependencies = [
 name = "matrix-sdk-base"
 version = "0.12.0"
 dependencies = [
+ "anyhow",
  "as_variant",
  "assert_matches",
  "assert_matches2",

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Features
+- The `RoomInfo` now remembers when an invite was explicitly accepted when the
+  `BaseClient::room_joined()` method was called. A new getter for this
+  timestamp exists, the `RoomInfo::invite_accepted_at()` method returns this
+  timestamp.
+  ([#5333](https://github.com/matrix-org/matrix-rust-sdk/pull/5333))
+
 ### Refactor
 
 - The cached `ServerCapabilities` has been renamed to `ServerInfo` and

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -86,6 +86,7 @@ unicode-normalization.workspace = true
 uniffi = { workspace = true, optional = true }
 
 [dev-dependencies]
+anyhow.workspace = true
 assert_matches.workspace = true
 assert_matches2.workspace = true
 assign = "1.1.1"

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1703,4 +1703,47 @@ mod tests {
 
         assert!(client.is_user_ignored(ignored_user_id).await);
     }
+
+    #[async_test]
+    async fn test_joined_at_timestamp_is_set() {
+        let client = logged_in_base_client(None).await;
+        let invited_room_id = room_id!("!invited:localhost");
+        let unknown_room_id = room_id!("!unknown:localhost");
+
+        let mut sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
+            .add_invited_room(InvitedRoomBuilder::new(invited_room_id))
+            .build_sync_response();
+        client.receive_sync_response(response).await.unwrap();
+
+        // Let us first check the initial state, we should have a room in the invite
+        // state.
+        let invited_room = client
+            .get_room(invited_room_id)
+            .expect("The sync should have created a room in the invited state");
+
+        assert_eq!(invited_room.state(), RoomState::Invited);
+        assert!(invited_room.inner.get().invite_accepted_at().is_none());
+
+        // Now we join the room.
+        let joined_room = client
+            .room_joined(invited_room_id)
+            .await
+            .expect("We should be able to mark a room as joined");
+
+        // Yup, there's a timestamp now.
+        assert_eq!(joined_room.state(), RoomState::Joined);
+        assert!(joined_room.inner.get().invite_accepted_at().is_some());
+
+        // If we didn't know about the room before the join, we assume that there wasn't
+        // an invite and we don't record the timestamp.
+        assert!(client.get_room(unknown_room_id).is_none());
+        let unknown_room = client
+            .room_joined(unknown_room_id)
+            .await
+            .expect("We should be able to mark a room as joined");
+
+        assert_eq!(unknown_room.state(), RoomState::Joined);
+        assert!(unknown_room.inner.get().invite_accepted_at().is_none());
+    }
 }

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -121,6 +121,7 @@ impl RoomInfoV1 {
             cached_display_name: None,
             cached_user_defined_notification_mode: None,
             recency_stamp: None,
+            invite_accepted_at: None,
         }
     }
 }


### PR DESCRIPTION
I think that this is necessary to make #5322 somewhat secure.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/4926. 

- [x] Public API changes documented in changelogs (optional)