### PR TITLE
fix(sdk,ui): Avoid calling `TimelineEvent::raw()` multiple times

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -187,7 +187,9 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
         room_data_provider: &P,
         date_divider_adjuster: &mut DateDividerAdjuster,
     ) {
-        let deserialized = match event.raw().deserialize() {
+        let raw_event = event.raw();
+
+        let deserialized = match raw_event.deserialize() {
             Ok(deserialized) => deserialized,
             Err(err) => {
                 warn!("Failed to deserialize timeline event: {err}");
@@ -202,7 +204,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
 
         if let Some(action @ TimelineAction::HandleAggregation { .. }) = TimelineAction::from_event(
             deserialized,
-            event.raw(),
+            raw_event,
             room_data_provider,
             None,
             &self.meta,

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1435,7 +1435,7 @@ mod private {
 
             let Ok(AnySyncTimelineEvent::MessageLike(
                 ruma::events::AnySyncMessageLikeEvent::RoomRedaction(redaction),
-            )) = event.raw().deserialize()
+            )) = raw_event.deserialize()
             else {
                 return Ok(());
             };


### PR DESCRIPTION
This patch has spotted 2 places where 2 successive calls to `TimelineEvent::raw()` are made. It fixes that by storing the intermediate `&Raw<_>` into a variable, and by using this variable.