### PR TITLE
chore(docs): fix a doc comment referring to the wrong type

### DIFF
--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -206,8 +206,7 @@ pub enum QueueWedgeError {
     },
 }
 
-/// The specific user intent that characterizes a
-/// [`DependentQueuedRequestKind`].
+/// The specific user intent that characterizes a [`DependentQueuedRequest`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum DependentQueuedRequestKind {
     /// The event should be edited.


### PR DESCRIPTION
Hey, I want github points too!!1!

(Spotted while reviewing #5008.)