### PR TITLE
Bump Ruma (breaking)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,6 +2049,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,6 +2142,15 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3801,7 +3834,6 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
- "phf_macros",
  "phf_shared 0.11.2",
 ]
 
@@ -3833,19 +3865,6 @@ checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
  "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
-dependencies = [
- "phf_generator 0.11.2",
- "phf_shared 0.11.2",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4464,8 +4483,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d47e42b7dea75a468dea63a230f51331c58d690ca018ea1c6ac782ea98880c"
+source = "git+https://github.com/ruma/ruma?rev=a3663c04511f79f99376924d739f84d839600de6#a3663c04511f79f99376924d739f84d839600de6"
 dependencies = [
  "assign",
  "js_int",
@@ -4481,8 +4499,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9e9c613cfda4923b851c5d8bc442305905bee4f0c2b924564b00e71636c8d4"
+source = "git+https://github.com/ruma/ruma?rev=a3663c04511f79f99376924d739f84d839600de6#a3663c04511f79f99376924d739f84d839600de6"
 dependencies = [
  "as_variant",
  "assign",
@@ -4505,8 +4522,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387e1898e868d32ff7b205e7db327361d5dcf635c00a8ae5865068607595a9cf"
+source = "git+https://github.com/ruma/ruma?rev=a3663c04511f79f99376924d739f84d839600de6#a3663c04511f79f99376924d739f84d839600de6"
 dependencies = [
  "as_variant",
  "base64",
@@ -4533,13 +4549,13 @@ dependencies = [
  "uuid",
  "web-time",
  "wildmatch",
+ "zeroize",
 ]
 
 [[package]]
 name = "ruma-events"
 version = "0.30.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cdc7abec9bc2a9ca0b4831cc26ce97a6a8c39a0bde44a19281a719e861b4293"
+source = "git+https://github.com/ruma/ruma?rev=a3663c04511f79f99376924d739f84d839600de6#a3663c04511f79f99376924d739f84d839600de6"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4559,32 +4575,34 @@ dependencies = [
  "url",
  "web-time",
  "wildmatch",
+ "zeroize",
 ]
 
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2a705c3911870782e036a3a8b676d0166c6c93800b84f6b8b23c981f78ef08"
+source = "git+https://github.com/ruma/ruma?rev=a3663c04511f79f99376924d739f84d839600de6#a3663c04511f79f99376924d739f84d839600de6"
 dependencies = [
+ "headers",
  "http",
+ "http-auth",
  "js_int",
  "mime",
  "ruma-common",
  "ruma-events",
  "serde",
  "serde_json",
+ "thiserror 2.0.11",
+ "tracing",
 ]
 
 [[package]]
 name = "ruma-html"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865afa2321e34fa836ea4c1d77ce0c2bb40f7d13fe18ee3e795091fd8d173a1d"
+source = "git+https://github.com/ruma/ruma?rev=a3663c04511f79f99376924d739f84d839600de6#a3663c04511f79f99376924d739f84d839600de6"
 dependencies = [
  "as_variant",
  "html5ever",
- "phf",
  "tracing",
  "wildmatch",
 ]
@@ -4592,8 +4610,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad674b5e5368c53a2c90fde7dac7e30747004aaf7b1827b72874a25fc06d4d8"
+source = "git+https://github.com/ruma/ruma?rev=a3663c04511f79f99376924d739f84d839600de6#a3663c04511f79f99376924d739f84d839600de6"
 dependencies = [
  "js_int",
  "thiserror 2.0.11",
@@ -4602,8 +4619,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff13fbd6045a7278533390826de316d6116d8582ed828352661337b0c422e1c"
+source = "git+https://github.com/ruma/ruma?rev=a3663c04511f79f99376924d739f84d839600de6#a3663c04511f79f99376924d739f84d839600de6"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",
@@ -5006,6 +5022,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,12 +59,9 @@ proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 rand = "0.8.5"
 reqwest = { version = "0.12.12", default-features = false }
 rmp-serde = "1.3.0"
-# Be careful to use commits from the https://github.com/ruma/ruma/tree/ruma-0.12
-# branch until a proper release with breaking changes happens.
-ruma = { version = "0.12.5", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "a3663c04511f79f99376924d739f84d839600de6", features = [
     "client-api-c",
     "compat-upload-signatures",
-    "compat-user-id",
     "compat-arbitrary-length-ids",
     "compat-tag-info",
     "compat-encrypted-stickers",
@@ -80,7 +77,7 @@ ruma = { version = "0.12.5", features = [
     "unstable-msc4278",
     "unstable-msc4286",
 ] }
-ruma-common = "0.15.4"
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "a3663c04511f79f99376924d739f84d839600de6" }
 sentry = "0.36.0"
 sentry-tracing = "0.36.0"
 serde = { version = "1.0.217", features = ["rc"] }

--- a/bindings/matrix-sdk-crypto-ffi/src/responses.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/responses.rs
@@ -27,7 +27,7 @@ use ruma::{
         to_device::send_event_to_device::v3::Response as ToDeviceResponse,
     },
     assign,
-    events::EventContent,
+    events::MessageLikeEventContent,
     OwnedTransactionId, UserId,
 };
 use serde_json::json;

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking changes:
 
+- The `reason` argument of `Room::report_room` is now required, do to a clarification in the spec.
+  ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
+- `PublicRoomJoinRule` has more variants, supporting all the known values from the spec.
+  ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
+- The fields of `MediaPreviewConfig` are both optional, allowing to use the type for room account
+  data as well as global account data.
+  ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
 - The `event_id` field of `PredecessorRoom` was removed, due to its removal in the Matrix
   specification with MSC4291.
   ([#5419](https://github.com/matrix-org/matrix-rust-sdk/pull/5419))

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking changes:
 
+- `RoomPreview::info()` doesn't return a result anymore. All unknown join rules are handled in the
+  `JoinRule::Custom` variant.
+  ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
 - The `reason` argument of `Room::report_room` is now required, do to a clarification in the spec.
   ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
 - `PublicRoomJoinRule` has more variants, supporting all the known values from the spec.

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -58,7 +58,7 @@ matrix-sdk-ffi-macros.workspace = true
 matrix-sdk-ui = { workspace = true, features = ["uniffi"] }
 mime = "0.3.16"
 once_cell.workspace = true
-ruma = { workspace = true, features = ["html", "unstable-unspecified", "unstable-msc3488", "compat-unset-avatar", "unstable-msc3245-v1-compat", "unstable-msc4278"] }
+ruma = { workspace = true, features = ["html", "unstable-msc3488", "compat-unset-avatar", "unstable-msc3245-v1-compat", "unstable-msc4278"] }
 serde.workspace = true
 serde_json.workspace = true
 sentry = { version = "0.36.0", optional = true, default-features = false, features = [

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2468,9 +2468,7 @@ impl TryFrom<AllowRule> for RumaAllowRule {
         match value {
             AllowRule::RoomMembership { room_id } => {
                 let room_id = RoomId::parse(room_id)?;
-                Ok(Self::RoomMembership(ruma::events::room::join_rules::RoomMembership::new(
-                    room_id,
-                )))
+                Ok(Self::RoomMembership(ruma::room::RoomMembership::new(room_id)))
             }
             AllowRule::Custom { json } => Ok(Self::_Custom(Box::new(serde_json::from_str(&json)?))),
         }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1631,7 +1631,7 @@ impl Client {
     ) -> Result<Option<MediaPreviews>, ClientError> {
         let configuration = self.inner.account().get_media_preview_config_event_content().await?;
         match configuration {
-            Some(configuration) => Ok(Some(configuration.media_previews.into())),
+            Some(configuration) => Ok(configuration.media_previews.map(Into::into)),
             None => Ok(None),
         }
     }
@@ -1652,7 +1652,7 @@ impl Client {
     ) -> Result<Option<InviteAvatars>, ClientError> {
         let configuration = self.inner.account().get_media_preview_config_event_content().await?;
         match configuration {
-            Some(configuration) => Ok(Some(configuration.invite_avatars.into())),
+            Some(configuration) => Ok(configuration.invite_avatars.map(Into::into)),
             None => Ok(None),
         }
     }

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -484,7 +484,7 @@ impl Room {
     /// # Errors
     ///
     /// Returns an error if the room is not found or on rate limit
-    pub async fn report_room(&self, reason: Option<String>) -> Result<(), ClientError> {
+    pub async fn report_room(&self, reason: String) -> Result<(), ClientError> {
         self.inner.report_room(reason).await?;
 
         Ok(())

--- a/bindings/matrix-sdk-ffi/src/room_directory_search.rs
+++ b/bindings/matrix-sdk-ffi/src/room_directory_search.rs
@@ -28,15 +28,21 @@ use crate::{error::ClientError, runtime::get_runtime_handle, task_handle::TaskHa
 pub enum PublicRoomJoinRule {
     Public,
     Knock,
+    Restricted,
+    KnockRestricted,
+    Invite,
 }
 
-impl TryFrom<ruma::directory::PublicRoomJoinRule> for PublicRoomJoinRule {
+impl TryFrom<ruma::room::JoinRuleKind> for PublicRoomJoinRule {
     type Error = String;
 
-    fn try_from(value: ruma::directory::PublicRoomJoinRule) -> Result<Self, Self::Error> {
+    fn try_from(value: ruma::room::JoinRuleKind) -> Result<Self, Self::Error> {
         match value {
-            ruma::directory::PublicRoomJoinRule::Public => Ok(Self::Public),
-            ruma::directory::PublicRoomJoinRule::Knock => Ok(Self::Knock),
+            ruma::room::JoinRuleKind::Public => Ok(Self::Public),
+            ruma::room::JoinRuleKind::Knock => Ok(Self::Knock),
+            ruma::room::JoinRuleKind::Restricted => Ok(Self::Restricted),
+            ruma::room::JoinRuleKind::KnockRestricted => Ok(Self::KnockRestricted),
+            ruma::room::JoinRuleKind::Invite => Ok(Self::Invite),
             rule => Err(format!("unsupported join rule: {rule:?}")),
         }
     }

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -1486,17 +1486,17 @@ impl From<RumaSecretStorageV1AesHmacSha2Properties> for SecretStorageV1AesHmacSh
 #[derive(Clone, uniffi::Record, Default)]
 pub struct MediaPreviewConfig {
     /// The media previews setting for the user.
-    pub media_previews: MediaPreviews,
+    pub media_previews: Option<MediaPreviews>,
 
     /// The invite avatars setting for the user.
-    pub invite_avatars: InviteAvatars,
+    pub invite_avatars: Option<InviteAvatars>,
 }
 
 impl From<MediaPreviewConfigEventContent> for MediaPreviewConfig {
     fn from(value: MediaPreviewConfigEventContent) -> Self {
         Self {
-            media_previews: value.media_previews.into(),
-            invite_avatars: value.invite_avatars.into(),
+            media_previews: value.media_previews.map(Into::into),
+            invite_avatars: value.invite_avatars.map(Into::into),
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
@@ -15,7 +15,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::crypto::types::events::UtdCause;
-use ruma::events::{room::MediaSource as RumaMediaSource, EventContent};
+use ruma::events::{room::MediaSource as RumaMediaSource, MessageLikeEventContent};
 
 use super::{
     content::Reaction,

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -16,6 +16,14 @@ All notable changes to this project will be documented in this file.
   ([#5390](https://github.com/matrix-org/matrix-rust-sdk/pull/5390))
 
 ### Refactor
+- [**breaking**] `RoomInfo::room_version_or_default()` was replaced with
+  `room_version_rules_or_default()`. The room version should only be used for
+  display purposes. The rules contain flags for all the differences in behavior
+  between all known room versions.
+  ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
+- [**breaking**] `MinimalStateEvent::redact()` takes `RedactionRules` instead of
+  a `RoomVersionId`.
+  ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
 - [**breaking**] The `event_id` field of `PredecessorRoom` was removed, due to
   its removal in the Matrix specification with MSC4291.
   ([#5419](https://github.com/matrix-org/matrix-rust-sdk/pull/5419))

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -65,9 +65,9 @@ pub async fn build<'notification, 'e2ee>(
                     AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomRedaction(
                         redaction_event,
                     )) => {
-                        let room_version = room_info.room_version_or_default();
+                        let redaction_rules = room_info.room_version_rules_or_default().redaction;
 
-                        if let Some(redacts) = redaction_event.redacts(&room_version) {
+                        if let Some(redacts) = redaction_event.redacts(&redaction_rules) {
                             room_info
                                 .handle_redaction(redaction_event, timeline_event.raw().cast_ref());
 

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -16,6 +16,7 @@ use matrix_sdk_common::deserialized_responses::TimelineEvent;
 #[cfg(feature = "e2e-encryption")]
 use ruma::events::SyncMessageLikeEvent;
 use ruma::{
+    assign,
     events::{AnySyncMessageLikeEvent, AnySyncTimelineEvent},
     push::{Action, PushConditionRoomCtx},
     UInt, UserId,
@@ -238,11 +239,13 @@ pub async fn get_push_room_context(
         room.power_levels().await.ok()
     };
 
-    Ok(Some(PushConditionRoomCtx {
-        user_id: user_id.to_owned(),
-        room_id: room_id.to_owned(),
-        member_count: UInt::new(member_count).unwrap_or(UInt::MAX),
-        user_display_name,
-        power_levels: power_levels.map(Into::into),
-    }))
+    Ok(Some(assign!(
+        PushConditionRoomCtx::new(
+            room_id.to_owned(),
+            UInt::new(member_count).unwrap_or(UInt::MAX),
+            user_id.to_owned(),
+            user_display_name
+        ),
+        { power_levels: power_levels.map(Into::into) }
+    )))
 }

--- a/crates/matrix-sdk-base/src/room/create.rs
+++ b/crates/matrix-sdk-base/src/room/create.rs
@@ -17,7 +17,7 @@ use ruma::{
     events::{
         macros::EventContent,
         room::create::{PreviousRoom, RoomCreateEventContent},
-        EmptyStateKey, RedactContent, RedactedStateEventContent,
+        EmptyStateKey, RedactContent, RedactedStateEventContent, StateEventType,
     },
     room::RoomType,
     OwnedUserId, RoomVersionId,
@@ -100,6 +100,10 @@ pub type RedactedRoomCreateWithCreatorEventContent = RoomCreateWithCreatorEventC
 
 impl RedactedStateEventContent for RedactedRoomCreateWithCreatorEventContent {
     type StateKey = EmptyStateKey;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::RoomCreate
+    }
 }
 
 impl RedactContent for RoomCreateWithCreatorEventContent {

--- a/crates/matrix-sdk-base/src/room/create.rs
+++ b/crates/matrix-sdk-base/src/room/create.rs
@@ -20,6 +20,7 @@ use ruma::{
         EmptyStateKey, RedactContent, RedactedStateEventContent, StateEventType,
     },
     room::RoomType,
+    room_version_rules::RedactionRules,
     OwnedUserId, RoomVersionId,
 };
 use serde::{Deserialize, Serialize};
@@ -109,10 +110,10 @@ impl RedactedStateEventContent for RedactedRoomCreateWithCreatorEventContent {
 impl RedactContent for RoomCreateWithCreatorEventContent {
     type Redacted = RedactedRoomCreateWithCreatorEventContent;
 
-    fn redact(self, version: &RoomVersionId) -> Self::Redacted {
+    fn redact(self, rules: &RedactionRules) -> Self::Redacted {
         let (content, sender) = self.into_event_content();
         // Use Ruma's redaction algorithm.
-        let content = content.redact(version);
+        let content = content.redact(rules);
         Self::from_event_content(content, sender)
     }
 }

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -476,9 +476,10 @@ impl StateStoreIntegrationTests for DynStateStore {
     }
 
     async fn test_server_info_saving(&self) {
-        let versions = &[MatrixVersion::V1_1, MatrixVersion::V1_2, MatrixVersion::V1_11];
+        let versions =
+            BTreeSet::from([MatrixVersion::V1_1, MatrixVersion::V1_2, MatrixVersion::V1_11]);
         let server_info = ServerInfo::new(
-            versions.iter().map(|version| version.to_string()).collect(),
+            versions.iter().map(|version| version.as_str().unwrap().to_owned()).collect(),
             [("org.matrix.experimental".to_owned(), true)].into(),
             Some(WellKnownResponse {
                 homeserver: HomeserverInfo::new("matrix.example.com".to_owned()),
@@ -504,7 +505,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         let decoded_server_info = stored_info.maybe_decode().unwrap();
         let stored_supported = decoded_server_info.supported_versions();
 
-        assert_eq!(stored_supported.versions.as_ref(), versions);
+        assert_eq!(stored_supported.versions, versions);
         assert_eq!(stored_supported.features.len(), 1);
         assert!(stored_supported.features.contains(&FeatureFlag::from("org.matrix.experimental")));
 

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -35,7 +35,7 @@ use ruma::{
             tombstone::RoomTombstoneEventContent,
             topic::RoomTopicEventContent,
         },
-        EmptyStateKey, EventContent, RedactContent, StateEventContent, StateEventType,
+        EmptyStateKey, RedactContent, StateEventContent, StateEventType,
     },
     OwnedRoomId, OwnedUserId, RoomId,
 };
@@ -222,16 +222,12 @@ struct RoomNameEventContentV1 {
     name: Option<String>,
 }
 
-impl EventContent for RoomNameEventContentV1 {
-    type EventType = StateEventType;
-
-    fn event_type(&self) -> Self::EventType {
-        StateEventType::RoomName
-    }
-}
-
 impl StateEventContent for RoomNameEventContentV1 {
     type StateKey = EmptyStateKey;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::RoomName
+    }
 }
 
 impl RedactContent for RoomNameEventContentV1 {

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -37,6 +37,7 @@ use ruma::{
         },
         EmptyStateKey, RedactContent, StateEventContent, StateEventType,
     },
+    room_version_rules::RedactionRules,
     OwnedRoomId, OwnedUserId, RoomId,
 };
 use serde::{Deserialize, Serialize};
@@ -117,7 +118,7 @@ impl RoomInfoV1 {
             latest_event: latest_event.map(|ev| Box::new(LatestEvent::new(ev))),
             read_receipts: Default::default(),
             base_info: base_info.migrate(create),
-            warned_about_unknown_room_version: Arc::new(false.into()),
+            warned_about_unknown_room_version_rules: Arc::new(false.into()),
             cached_display_name: None,
             cached_user_defined_notification_mode: None,
             recency_stamp: None,
@@ -233,7 +234,7 @@ impl StateEventContent for RoomNameEventContentV1 {
 impl RedactContent for RoomNameEventContentV1 {
     type Redacted = RedactedRoomNameEventContent;
 
-    fn redact(self, _version: &ruma::RoomVersionId) -> Self::Redacted {
+    fn redact(self, _rules: &RedactionRules) -> Self::Redacted {
         RedactedRoomNameEventContent::new()
     }
 }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -614,7 +614,7 @@ impl StateChanges {
     where
         C: StaticEventContent + StaticStateEventContent + RedactContent,
         C::Redacted: RedactedStateEventContent,
-        C::PossiblyRedacted: DeserializeOwned,
+        C::PossiblyRedacted: StaticEventContent + DeserializeOwned,
         C::StateKey: Borrow<K>,
         K: AsRef<str> + ?Sized,
     {

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -20,7 +20,7 @@ use as_variant::as_variant;
 use ruma::{
     events::{
         room::{message::RoomMessageEventContent, MediaSource},
-        AnyMessageLikeEventContent, EventContent as _, RawExt as _,
+        AnyMessageLikeEventContent, MessageLikeEventContent as _, RawExt as _,
     },
     serde::Raw,
     MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedEventId, OwnedTransactionId, OwnedUserId,
@@ -63,7 +63,7 @@ impl SerializableEventContent {
     /// Convert a [`SerializableEventContent`] back into a
     /// [`AnyMessageLikeEventContent`].
     pub fn deserialize(&self) -> Result<AnyMessageLikeEventContent, serde_json::Error> {
-        self.event.deserialize_with_type(self.event_type.clone().into())
+        self.event.deserialize_with_type(&self.event_type)
     }
 
     /// Returns the raw event content along with its type.

--- a/crates/matrix-sdk-base/src/utils.rs
+++ b/crates/matrix-sdk-base/src/utils.rs
@@ -24,7 +24,8 @@ use ruma::{
         RedactContent, RedactedStateEventContent, StateEventContent, StaticStateEventContent,
         SyncStateEvent,
     },
-    EventId, OwnedEventId, RoomVersionId,
+    room_version_rules::RedactionRules,
+    EventId, OwnedEventId,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -118,13 +119,13 @@ where
     /// Redacts this event.
     ///
     /// Does nothing if it is already redacted.
-    pub fn redact(&mut self, room_version: &RoomVersionId)
+    pub fn redact(&mut self, rules: &RedactionRules)
     where
         C: Clone,
     {
         if let MinimalStateEvent::Original(ev) = self {
             *self = MinimalStateEvent::Redacted(RedactedMinimalStateEvent {
-                content: ev.content.clone().redact(room_version),
+                content: ev.content.clone().redact(rules),
                 event_id: ev.event_id.clone(),
             });
         }

--- a/crates/matrix-sdk-common/CHANGELOG.md
+++ b/crates/matrix-sdk-common/CHANGELOG.md
@@ -10,9 +10,19 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Expose the `ROOM_VERSION_RULES_FALLBACK` that should be used when the rules of
+  a room are unknown.
+  ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
 - Expose the `ROOM_VERSION_FALLBACK` that should be used when the version of a
   room is unknown.
   ([#5306](https://github.com/matrix-org/matrix-rust-sdk/pull/5306))
+
+### Refactor
+
+- [**breaking**] `extract_bundled_thread_summary()` returns a
+  `Raw<AnySyncMessageLikeEvent>` for the latest event instead of a
+  `Raw<AnyMessageLikeEvent>`.
+  ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
 
 ## [0.12.0] - 2025-06-10
 

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -17,7 +17,10 @@ use std::{collections::BTreeMap, fmt, sync::Arc};
 #[cfg(doc)]
 use ruma::events::AnyTimelineEvent;
 use ruma::{
-    events::{AnyMessageLikeEvent, AnySyncTimelineEvent, AnyToDeviceEvent, MessageLikeEventType},
+    events::{
+        AnyMessageLikeEvent, AnySyncMessageLikeEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
+        MessageLikeEventType,
+    },
     push::Action,
     serde::{
         AsRefStr, AsStrAsRefStr, DebugAsRefStr, DeserializeFromCowStr, FromString, JsonObject, Raw,
@@ -542,7 +545,7 @@ impl TimelineEvent {
     /// encryption status for it.
     fn from_bundled_latest_event(
         this: &TimelineEventKind,
-        latest_event: Option<Raw<AnyMessageLikeEvent>>,
+        latest_event: Option<Raw<AnySyncMessageLikeEvent>>,
     ) -> Option<Box<Self>> {
         let latest_event = latest_event?;
 
@@ -559,7 +562,9 @@ impl TimelineEvent {
                             // information around.
                             return Some(Box::new(TimelineEvent::from_decrypted(
                                 DecryptedRoomEvent {
-                                    event: latest_event,
+                                    // Safety: A decrypted event always includes a room_id in its
+                                    // payload.
+                                    event: latest_event.cast(),
                                     encryption_info: encryption_info.clone(),
                                     // A bundled latest event is never a thread root. It could have
                                     // a replacement event, but we don't carry this information

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -42,7 +42,7 @@ pub mod ttl_cache;
 #[cfg(all(target_family = "wasm", not(tarpaulin_include)))]
 pub mod js_tracing;
 
-use ruma::RoomVersionId;
+use ruma::{room_version_rules::RoomVersionRules, RoomVersionId};
 pub use store_locks::LEASE_DURATION_MS;
 
 /// Alias for `Send` on non-wasm, empty trait (implemented by everything) on
@@ -108,3 +108,9 @@ uniffi::setup_scaffolding!();
 
 /// The room version to use as a fallback when the version of a room is unknown.
 pub const ROOM_VERSION_FALLBACK: RoomVersionId = RoomVersionId::V11;
+
+/// The room version rules to use as a fallback when the version of a room is
+/// unknown or unsupported.
+///
+/// These are the rules of the [`ROOM_VERSION_FALLBACK`].
+pub const ROOM_VERSION_RULES_FALLBACK: RoomVersionRules = RoomVersionRules::V11;

--- a/crates/matrix-sdk-common/src/serde_helpers.rs
+++ b/crates/matrix-sdk-common/src/serde_helpers.rs
@@ -16,7 +16,7 @@
 //! to access some fields.
 
 use ruma::{
-    events::{relation::BundledThread, AnyMessageLikeEvent, AnySyncTimelineEvent},
+    events::{relation::BundledThread, AnySyncMessageLikeEvent, AnySyncTimelineEvent},
     serde::Raw,
     OwnedEventId,
 };
@@ -76,7 +76,7 @@ struct Unsigned {
 /// Try to extract a bundled thread summary of a timeline event, if available.
 pub fn extract_bundled_thread_summary(
     event: &Raw<AnySyncTimelineEvent>,
-) -> (ThreadSummaryStatus, Option<Raw<AnyMessageLikeEvent>>) {
+) -> (ThreadSummaryStatus, Option<Raw<AnySyncMessageLikeEvent>>) {
     match event.get_field::<Unsigned>("unsigned") {
         Ok(Some(Unsigned { relations: Some(Relations { thread: Some(bundled_thread) }) })) => {
             // Take the count from the bundled thread summary, if available. If it can't be

--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -136,20 +136,19 @@ impl<'a, R: Read + 'a> AttachmentDecryptor<'a, R> {
 
         let hash =
             info.hashes.get("sha256").ok_or(DecryptorError::MissingHash)?.as_bytes().to_owned();
-        let mut key = info.key.k.into_inner();
+        let key = info.key.k.as_bytes();
         let iv = info.iv.into_inner();
 
         if key.len() != KEY_SIZE {
             return Err(DecryptorError::KeyNonceLength);
         }
 
-        let key_array = GenericArray::from_slice(&key);
+        let key_array = GenericArray::from_slice(key);
         let iv = GenericArray::from_exact_iter(iv).ok_or(DecryptorError::KeyNonceLength)?;
 
         let sha = Sha256::default();
 
         let aes = Aes256Ctr::new(key_array, &iv);
-        key.zeroize();
 
         Ok(AttachmentDecryptor { inner: input, expected_hash: hash, sha, aes })
     }

--- a/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
+++ b/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
@@ -334,7 +334,7 @@ pub fn bootstrap_requests_to_keys_query_response(
 /// Helper for [`create_signed_device_of_unverified_user`] and
 /// [`create_unsigned_device`].
 fn dummy_verification_machine() -> VerificationMachine {
-    let account = Account::new(user_id!("@TEST_USER:example.com"));
+    let account = Account::new(user_id!("@test_user:example.com"));
     VerificationMachine::new(
         account.deref().clone(),
         Arc::new(Mutex::new(PrivateCrossSigningIdentity::new(account.user_id().to_owned()))),

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -36,8 +36,8 @@ use ruma::{
         room::message::{
             AddMentions, MessageType, Relation, ReplyWithinThread, RoomMessageEventContent,
         },
-        AnyMessageLikeEvent, AnyMessageLikeEventContent, AnyToDeviceEvent, MessageLikeEvent,
-        OriginalMessageLikeEvent, ToDeviceEventType,
+        AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnyToDeviceEvent,
+        MessageLikeEvent, OriginalMessageLikeEvent, ToDeviceEventType,
     },
     room_id,
     serde::Raw,
@@ -1579,7 +1579,10 @@ async fn test_unsigned_decryption() {
     assert!(first_message.unsigned.relations.replace.is_some());
     // Deserialization of the thread event succeeded, but it is still encrypted.
     let thread = first_message.unsigned.relations.thread.as_ref().unwrap();
-    assert_matches!(thread.latest_event.deserialize(), Ok(AnyMessageLikeEvent::RoomEncrypted(_)));
+    assert_matches!(
+        thread.latest_event.deserialize(),
+        Ok(AnySyncMessageLikeEvent::RoomEncrypted(_))
+    );
 
     let unsigned_encryption_info = raw_decrypted_event.unsigned_encryption_info.unwrap();
     assert_eq!(unsigned_encryption_info.len(), 2);
@@ -1625,7 +1628,7 @@ async fn test_unsigned_decryption() {
     let thread = &first_message.unsigned.relations.thread.as_ref().unwrap();
     assert_matches!(
         thread.latest_event.deserialize(),
-        Ok(AnyMessageLikeEvent::RoomMessage(third_message))
+        Ok(AnySyncMessageLikeEvent::RoomMessage(third_message))
     );
     let third_message = third_message.as_original().unwrap();
     assert_eq!(third_message.content.body(), third_message_text);

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -1442,8 +1442,8 @@ async fn test_unsigned_decryption() {
 
     // Encrypt a second message, an edit.
     let second_message_text = "This is the ~~original~~ edited message";
-    let second_message_content = RoomMessageEventContent::text_plain(second_message_text)
-        .make_replacement(first_message, None);
+    let second_message_content =
+        RoomMessageEventContent::text_plain(second_message_text).make_replacement(first_message);
     let second_message_encrypted_content =
         alice.encrypt_room_event(room_id, second_message_content).await.unwrap();
 

--- a/crates/matrix-sdk-crypto/src/secret_storage.rs
+++ b/crates/matrix-sdk-crypto/src/secret_storage.rs
@@ -36,7 +36,7 @@ use ruma::{
             },
             secret::SecretEncryptedData,
         },
-        EventContent, GlobalAccountDataEventType,
+        GlobalAccountDataEventContent, GlobalAccountDataEventType,
     },
     serde::Base64,
     UInt,

--- a/crates/matrix-sdk-crypto/src/types/events/to_device.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/to_device.rs
@@ -23,7 +23,7 @@ use ruma::{
             request::ToDeviceKeyVerificationRequestEvent, start::ToDeviceKeyVerificationStartEvent,
         },
         secret::request::{SecretName, ToDeviceSecretRequestEvent},
-        EventContent, ToDeviceEventType,
+        ToDeviceEventContent, ToDeviceEventType,
     },
     serde::Raw,
     OwnedUserId, UserId,

--- a/crates/matrix-sdk-crypto/src/types/requests/to_device.rs
+++ b/crates/matrix-sdk-crypto/src/types/requests/to_device.rs
@@ -15,7 +15,7 @@
 use std::{collections::BTreeMap, iter};
 
 use ruma::{
-    events::{AnyToDeviceEventContent, EventContent, ToDeviceEventType},
+    events::{AnyToDeviceEventContent, ToDeviceEventContent, ToDeviceEventType},
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
     OwnedDeviceId, OwnedTransactionId, OwnedUserId, TransactionId, UserId,

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -30,6 +30,13 @@ All notable changes to this project will be documented in this file.
   `matrix_sdk::latest_events::LatestEvents::listen_to_room`
   ([#5369](https://github.com/matrix-org/matrix-rust-sdk/pull/5369))
 
+### Refactor
+
+- [**breaking**] The function provided to `TimelineBuilder::event_filter()`
+  must take `RoomVersionRules` as second argument instead of a `RoomVersionId`.
+  The `default_event_filter()` reflects that change.
+  ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
+
 ## [0.12.0] - 2025-06-10
 
 ### Refactor

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use matrix_sdk::{Room, executor::spawn};
 use matrix_sdk_base::{SendOutsideWasm, SyncOutsideWasm};
-use ruma::{RoomVersionId, events::AnySyncTimelineEvent};
+use ruma::{events::AnySyncTimelineEvent, room_version_rules::RoomVersionRules};
 use tracing::{Instrument, Span, info_span};
 
 use super::{
@@ -129,7 +129,7 @@ impl TimelineBuilder {
     ///   they couldn't be decrypted when the appropriate room key arrives).
     pub fn event_filter<F>(mut self, filter: F) -> Self
     where
-        F: Fn(&AnySyncTimelineEvent, &RoomVersionId) -> bool
+        F: Fn(&AnySyncTimelineEvent, &RoomVersionRules) -> bool
             + SendOutsideWasm
             + SyncOutsideWasm
             + 'static,

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -20,12 +20,13 @@ use std::{
 use imbl::Vector;
 use matrix_sdk::deserialized_responses::EncryptionInfo;
 use ruma::{
-    EventId, OwnedEventId, OwnedUserId, RoomVersionId,
+    EventId, OwnedEventId, OwnedUserId,
     events::{
         AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
         BundledMessageLikeRelations, poll::unstable_start::UnstablePollStartEventContent,
         relation::Replacement, room::message::RelationWithoutReplacement,
     },
+    room_version_rules::RoomVersionRules,
     serde::Raw,
 };
 use tracing::trace;
@@ -80,10 +81,10 @@ pub(in crate::timeline) struct TimelineMetadata {
     /// May be false until we fetch the actual room encryption state.
     pub is_room_encrypted: bool,
 
-    /// Matrix room version of the timeline's room, or a sensible default.
+    /// Rules of the version of the timeline's room, or a sensible default.
     ///
     /// This value is constant over the lifetime of the metadata.
-    pub room_version: RoomVersionId,
+    pub room_version_rules: RoomVersionRules,
 
     /// The own [`OwnedUserId`] of the client who opened the timeline.
     pub(crate) own_user_id: OwnedUserId,
@@ -129,7 +130,7 @@ pub(in crate::timeline) struct TimelineMetadata {
 impl TimelineMetadata {
     pub(in crate::timeline) fn new(
         own_user_id: OwnedUserId,
-        room_version: RoomVersionId,
+        room_version_rules: RoomVersionRules,
         internal_id_prefix: Option<String>,
         unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
         is_room_encrypted: bool,
@@ -145,7 +146,7 @@ impl TimelineMetadata {
             // field, otherwise we'll keep on exiting early in `Self::update_read_marker`.
             has_up_to_date_read_marker_item: true,
             read_receipts: Default::default(),
-            room_version,
+            room_version_rules,
             unable_to_decrypt_hook,
             internal_id_prefix,
             is_room_encrypted,

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -32,8 +32,7 @@ use matrix_sdk::{
     },
 };
 use ruma::{
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, RoomVersionId,
-    TransactionId, UserId,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, TransactionId, UserId,
     api::client::receipt::create_receipt::v3::ReceiptType as SendReceiptType,
     events::{
         AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
@@ -44,6 +43,7 @@ use ruma::{
         relation::Annotation,
         room::message::{MessageType, Relation},
     },
+    room_version_rules::RoomVersionRules,
     serde::Raw,
 };
 #[cfg(test)]
@@ -218,10 +218,10 @@ impl Default for TimelineSettings {
 /// If you have a custom filter, it may be best to chain yours with this one if
 /// you do not want to run into situations where a read receipt is not visible
 /// because it's living on an event that doesn't have a matching timeline item.
-pub fn default_event_filter(event: &AnySyncTimelineEvent, room_version: &RoomVersionId) -> bool {
+pub fn default_event_filter(event: &AnySyncTimelineEvent, rules: &RoomVersionRules) -> bool {
     match event {
         AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomRedaction(ev)) => {
-            if ev.redacts(room_version).is_some() {
+            if ev.redacts(&rules.redaction).is_some() {
                 // This is a redaction of an existing message, we'll only update the previous
                 // message and not render a new entry.
                 false
@@ -328,7 +328,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
         let state = Arc::new(RwLock::new(TimelineState::new(
             focus.clone(),
             room_data_provider.own_user_id().to_owned(),
-            room_data_provider.room_version(),
+            room_data_provider.room_version_rules(),
             internal_id_prefix,
             unable_to_decrypt_hook,
             is_room_encrypted,
@@ -952,7 +952,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                     txn_id.to_owned(),
                     new_event_id.to_owned(),
                     &mut txn.items,
-                    &txn.meta.room_version,
+                    &txn.meta.room_version_rules,
                 ) {
                     trace!("Aggregation marked as sent");
                     txn.commit();
@@ -1311,7 +1311,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
             &mut tr.items,
             &target,
             aggregation,
-            &tr.meta.room_version,
+            &tr.meta.room_version_rules,
         );
 
         tr.commit();

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -19,8 +19,9 @@ use matrix_sdk::{deserialized_responses::TimelineEvent, send_queue::SendHandle};
 #[cfg(test)]
 use ruma::events::receipt::ReceiptEventContent;
 use ruma::{
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId,
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
     events::{AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent},
+    room_version_rules::RoomVersionRules,
     serde::Raw,
 };
 use tracing::{instrument, trace, warn};
@@ -53,7 +54,7 @@ impl<P: RoomDataProvider> TimelineState<P> {
     pub(super) fn new(
         focus: Arc<TimelineFocusKind<P>>,
         own_user_id: OwnedUserId,
-        room_version: RoomVersionId,
+        room_version_rules: RoomVersionRules,
         internal_id_prefix: Option<String>,
         unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
         is_room_encrypted: bool,
@@ -62,7 +63,7 @@ impl<P: RoomDataProvider> TimelineState<P> {
             items: ObservableItems::new(),
             meta: TimelineMetadata::new(
                 own_user_id,
-                room_version,
+                room_version_rules,
                 internal_id_prefix,
                 unable_to_decrypt_hook,
                 is_room_encrypted,

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -398,8 +398,9 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
         thread_root: Option<&EventId>,
         position: TimelineItemPosition,
     ) -> bool {
-        let room_version = room_data_provider.room_version();
-        if !(settings.event_filter)(event, &room_version) {
+        let rules = room_data_provider.room_version_rules();
+
+        if !(settings.event_filter)(event, &rules) {
             // The user filtered out the event.
             return false;
         }

--- a/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
@@ -654,7 +654,10 @@ enum DateDividerInsertError {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_let;
-    use ruma::{MilliSecondsSinceUnixEpoch, owned_event_id, owned_user_id, uint};
+    use ruma::{
+        MilliSecondsSinceUnixEpoch, owned_event_id, owned_user_id,
+        room_version_rules::RoomVersionRules, uint,
+    };
 
     use super::{super::controller::ObservableItems, DateDividerAdjuster};
     use crate::timeline::{
@@ -688,7 +691,7 @@ mod tests {
     }
 
     fn test_metadata() -> TimelineMetadata {
-        TimelineMetadata::new(owned_user_id!("@a:b.c"), ruma::RoomVersionId::V11, None, None, false)
+        TimelineMetadata::new(owned_user_id!("@a:b.c"), RoomVersionRules::V11, None, None, false)
     }
 
     #[test]

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -26,7 +26,7 @@ use ruma::{
     TransactionId,
     events::{
         AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncStateEvent,
-        AnySyncTimelineEvent, EventContent, FullStateEventContent, MessageLikeEventType,
+        AnySyncTimelineEvent, FullStateEventContent, MessageLikeEventContent, MessageLikeEventType,
         StateEventType, SyncStateEvent,
         poll::unstable_start::{
             NewUnstablePollStartEventContentWithoutRelation, UnstablePollStartEventContent,

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -190,7 +190,7 @@ impl TimelineAction {
         thread_root: Option<OwnedEventId>,
         thread_summary: Option<ThreadSummary>,
     ) -> Option<Self> {
-        let room_version = room_data_provider.room_version();
+        let redaction_rules = room_data_provider.room_version_rules().redaction;
 
         let redacted_message_or_none = |event_type: MessageLikeEventType| {
             (event_type != MessageLikeEventType::Reaction)
@@ -199,7 +199,7 @@ impl TimelineAction {
 
         Some(match event {
             AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomRedaction(ev)) => {
-                if let Some(redacts) = ev.redacts(&room_version).map(ToOwned::to_owned) {
+                if let Some(redacts) = ev.redacts(&redaction_rules).map(ToOwned::to_owned) {
                     Self::HandleAggregation {
                         related_event: redacts,
                         kind: HandleAggregationKind::Redaction,
@@ -585,7 +585,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             self.items,
             &target,
             aggregation,
-            &self.meta.room_version,
+            &self.meta.room_version_rules,
         ) {
             // Update all events that replied to this message with the edited content.
             Self::maybe_update_responses(self.meta, self.items, &edited_event_id, &new_item);
@@ -628,7 +628,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             self.items,
             &target,
             aggregation,
-            &self.meta.room_version,
+            &self.meta.room_version_rules,
         );
     }
 
@@ -648,7 +648,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             self.items,
             &target,
             aggregation,
-            &self.meta.room_version,
+            &self.meta.room_version_rules,
         );
     }
 
@@ -664,7 +664,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             self.items,
             &target,
             aggregation,
-            &self.meta.room_version,
+            &self.meta.room_version_rules,
         );
     }
 
@@ -695,7 +695,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             self.items,
             &target,
             aggregation,
-            &self.meta.room_version,
+            &self.meta.room_version_rules,
         ) {
             // Look for any timeline event that's a reply to the redacted event, and redact
             // the replied-to event there as well.
@@ -795,7 +795,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             &self.ctx.flow.timeline_item_id(),
             &mut cowed,
             self.items,
-            &self.meta.room_version,
+            &self.meta.room_version_rules,
         ) {
             warn!("discarding aggregations: {err}");
         }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -18,7 +18,7 @@ use as_variant::as_variant;
 use matrix_sdk::crypto::types::events::UtdCause;
 use matrix_sdk_base::latest_event::{PossibleLatestEvent, is_suitable_for_latest_event};
 use ruma::{
-    OwnedDeviceId, OwnedEventId, OwnedMxcUri, OwnedUserId, RoomVersionId, UserId,
+    OwnedDeviceId, OwnedEventId, OwnedMxcUri, OwnedUserId, UserId,
     events::{
         AnyFullStateEventContent, AnySyncTimelineEvent, FullStateEventContent, Mentions,
         MessageLikeEventType, StateEventType,
@@ -55,6 +55,7 @@ use ruma::{
         sticker::{StickerEventContent, SyncStickerEvent},
     },
     html::RemoveReplyFallback,
+    room_version_rules::RedactionRules,
 };
 use tracing::warn;
 
@@ -514,14 +515,14 @@ impl TimelineItemContent {
         }
     }
 
-    pub(in crate::timeline) fn redact(&self, room_version: &RoomVersionId) -> Self {
+    pub(in crate::timeline) fn redact(&self, rules: &RedactionRules) -> Self {
         match self {
             Self::MsgLike(_) | Self::CallInvite | Self::CallNotify => {
                 TimelineItemContent::MsgLike(MsgLikeContent::redacted())
             }
-            Self::MembershipChange(ev) => Self::MembershipChange(ev.redact(room_version)),
+            Self::MembershipChange(ev) => Self::MembershipChange(ev.redact(rules)),
             Self::ProfileChange(ev) => Self::ProfileChange(ev.redact()),
-            Self::OtherState(ev) => Self::OtherState(ev.redact(room_version)),
+            Self::OtherState(ev) => Self::OtherState(ev.redact(rules)),
             Self::FailedToParseMessageLike { .. } | Self::FailedToParseState { .. } => self.clone(),
         }
     }
@@ -723,10 +724,10 @@ impl RoomMembershipChange {
         self.change
     }
 
-    fn redact(&self, room_version: &RoomVersionId) -> Self {
+    fn redact(&self, rules: &RedactionRules) -> Self {
         Self {
             user_id: self.user_id.clone(),
-            content: FullStateEventContent::Redacted(self.content.clone().redact(room_version)),
+            content: FullStateEventContent::Redacted(self.content.clone().redact(rules)),
             change: self.change,
         }
     }
@@ -957,67 +958,67 @@ impl AnyOtherFullStateEventContent {
         }
     }
 
-    fn redact(&self, room_version: &RoomVersionId) -> Self {
+    fn redact(&self, rules: &RedactionRules) -> Self {
         match self {
-            Self::PolicyRuleRoom(c) => Self::PolicyRuleRoom(FullStateEventContent::Redacted(
-                c.clone().redact(room_version),
-            )),
-            Self::PolicyRuleServer(c) => Self::PolicyRuleServer(FullStateEventContent::Redacted(
-                c.clone().redact(room_version),
-            )),
-            Self::PolicyRuleUser(c) => Self::PolicyRuleUser(FullStateEventContent::Redacted(
-                c.clone().redact(room_version),
-            )),
+            Self::PolicyRuleRoom(c) => {
+                Self::PolicyRuleRoom(FullStateEventContent::Redacted(c.clone().redact(rules)))
+            }
+            Self::PolicyRuleServer(c) => {
+                Self::PolicyRuleServer(FullStateEventContent::Redacted(c.clone().redact(rules)))
+            }
+            Self::PolicyRuleUser(c) => {
+                Self::PolicyRuleUser(FullStateEventContent::Redacted(c.clone().redact(rules)))
+            }
             Self::RoomAliases(c) => {
-                Self::RoomAliases(FullStateEventContent::Redacted(c.clone().redact(room_version)))
+                Self::RoomAliases(FullStateEventContent::Redacted(c.clone().redact(rules)))
             }
             Self::RoomAvatar(c) => {
-                Self::RoomAvatar(FullStateEventContent::Redacted(c.clone().redact(room_version)))
+                Self::RoomAvatar(FullStateEventContent::Redacted(c.clone().redact(rules)))
             }
-            Self::RoomCanonicalAlias(c) => Self::RoomCanonicalAlias(
-                FullStateEventContent::Redacted(c.clone().redact(room_version)),
-            ),
+            Self::RoomCanonicalAlias(c) => {
+                Self::RoomCanonicalAlias(FullStateEventContent::Redacted(c.clone().redact(rules)))
+            }
             Self::RoomCreate(c) => {
-                Self::RoomCreate(FullStateEventContent::Redacted(c.clone().redact(room_version)))
+                Self::RoomCreate(FullStateEventContent::Redacted(c.clone().redact(rules)))
             }
-            Self::RoomEncryption(c) => Self::RoomEncryption(FullStateEventContent::Redacted(
-                c.clone().redact(room_version),
-            )),
-            Self::RoomGuestAccess(c) => Self::RoomGuestAccess(FullStateEventContent::Redacted(
-                c.clone().redact(room_version),
-            )),
+            Self::RoomEncryption(c) => {
+                Self::RoomEncryption(FullStateEventContent::Redacted(c.clone().redact(rules)))
+            }
+            Self::RoomGuestAccess(c) => {
+                Self::RoomGuestAccess(FullStateEventContent::Redacted(c.clone().redact(rules)))
+            }
             Self::RoomHistoryVisibility(c) => Self::RoomHistoryVisibility(
-                FullStateEventContent::Redacted(c.clone().redact(room_version)),
+                FullStateEventContent::Redacted(c.clone().redact(rules)),
             ),
             Self::RoomJoinRules(c) => {
-                Self::RoomJoinRules(FullStateEventContent::Redacted(c.clone().redact(room_version)))
+                Self::RoomJoinRules(FullStateEventContent::Redacted(c.clone().redact(rules)))
             }
             Self::RoomName(c) => {
-                Self::RoomName(FullStateEventContent::Redacted(c.clone().redact(room_version)))
+                Self::RoomName(FullStateEventContent::Redacted(c.clone().redact(rules)))
             }
-            Self::RoomPinnedEvents(c) => Self::RoomPinnedEvents(FullStateEventContent::Redacted(
-                c.clone().redact(room_version),
-            )),
-            Self::RoomPowerLevels(c) => Self::RoomPowerLevels(FullStateEventContent::Redacted(
-                c.clone().redact(room_version),
-            )),
+            Self::RoomPinnedEvents(c) => {
+                Self::RoomPinnedEvents(FullStateEventContent::Redacted(c.clone().redact(rules)))
+            }
+            Self::RoomPowerLevels(c) => {
+                Self::RoomPowerLevels(FullStateEventContent::Redacted(c.clone().redact(rules)))
+            }
             Self::RoomServerAcl(c) => {
-                Self::RoomServerAcl(FullStateEventContent::Redacted(c.clone().redact(room_version)))
+                Self::RoomServerAcl(FullStateEventContent::Redacted(c.clone().redact(rules)))
             }
-            Self::RoomThirdPartyInvite(c) => Self::RoomThirdPartyInvite(
-                FullStateEventContent::Redacted(c.clone().redact(room_version)),
-            ),
+            Self::RoomThirdPartyInvite(c) => {
+                Self::RoomThirdPartyInvite(FullStateEventContent::Redacted(c.clone().redact(rules)))
+            }
             Self::RoomTombstone(c) => {
-                Self::RoomTombstone(FullStateEventContent::Redacted(c.clone().redact(room_version)))
+                Self::RoomTombstone(FullStateEventContent::Redacted(c.clone().redact(rules)))
             }
             Self::RoomTopic(c) => {
-                Self::RoomTopic(FullStateEventContent::Redacted(c.clone().redact(room_version)))
+                Self::RoomTopic(FullStateEventContent::Redacted(c.clone().redact(rules)))
             }
             Self::SpaceChild(c) => {
-                Self::SpaceChild(FullStateEventContent::Redacted(c.clone().redact(room_version)))
+                Self::SpaceChild(FullStateEventContent::Redacted(c.clone().redact(rules)))
             }
             Self::SpaceParent(c) => {
-                Self::SpaceParent(FullStateEventContent::Redacted(c.clone().redact(room_version)))
+                Self::SpaceParent(FullStateEventContent::Redacted(c.clone().redact(rules)))
             }
             Self::_Custom { event_type } => Self::_Custom { event_type: event_type.clone() },
         }
@@ -1042,8 +1043,8 @@ impl OtherState {
         &self.content
     }
 
-    fn redact(&self, room_version: &RoomVersionId) -> Self {
-        Self { state_key: self.state_key.clone(), content: self.content.redact(room_version) }
+    fn redact(&self, rules: &RedactionRules) -> Self {
+        Self { state_key: self.state_key.clone(), content: self.content.redact(rules) }
     }
 }
 
@@ -1052,11 +1053,12 @@ mod tests {
     use assert_matches2::assert_let;
     use matrix_sdk_test::ALICE;
     use ruma::{
-        RoomVersionId, assign,
+        assign,
         events::{
             FullStateEventContent,
             room::member::{MembershipState, RoomMemberEventContent},
         },
+        room_version_rules::RedactionRules,
     };
 
     use super::{MembershipChange, RoomMembershipChange, TimelineItemContent};
@@ -1074,7 +1076,7 @@ mod tests {
             change: Some(MembershipChange::Banned),
         });
 
-        let redacted = content.redact(&RoomVersionId::V11);
+        let redacted = content.redact(&RedactionRules::V11);
         assert_let!(TimelineItemContent::MembershipChange(inner) = redacted);
         assert_eq!(inner.change, Some(MembershipChange::Banned));
         assert_let!(FullStateEventContent::Redacted(inner_content_redacted) = inner.content);

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -31,8 +31,9 @@ use matrix_sdk_base::{
 use once_cell::sync::Lazy;
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedTransactionId,
-    OwnedUserId, RoomId, RoomVersionId, TransactionId, UserId,
+    OwnedUserId, RoomId, TransactionId, UserId,
     events::{AnySyncTimelineEvent, receipt::Receipt, room::message::MessageType},
+    room_version_rules::RedactionRules,
     serde::Raw,
 };
 use tracing::warn;
@@ -534,8 +535,8 @@ impl EventTimelineItem {
     }
 
     /// Create a clone of the current item, with content that's been redacted.
-    pub(super) fn redact(&self, room_version: &RoomVersionId) -> Self {
-        let content = self.content.redact(room_version);
+    pub(super) fn redact(&self, rules: &RedactionRules) -> Self {
+        let content = self.content.redact(rules);
         let kind = match &self.kind {
             EventTimelineItemKind::Local(l) => EventTimelineItemKind::Local(l.clone()),
             EventTimelineItemKind::Remote(r) => EventTimelineItemKind::Remote(r.redact()),

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -39,7 +39,7 @@ use matrix_sdk::{
 use mime::Mime;
 use pinned_events_loader::PinnedEventsRoom;
 use ruma::{
-    EventId, OwnedEventId, RoomVersionId, UserId,
+    EventId, OwnedEventId, UserId,
     api::client::receipt::create_receipt::v3::ReceiptType,
     events::{
         AnyMessageLikeEventContent, AnySyncTimelineEvent,
@@ -50,6 +50,7 @@ use ruma::{
             pinned_events::RoomPinnedEventsEventContent,
         },
     },
+    room_version_rules::RoomVersionRules,
 };
 #[cfg(feature = "unstable-msc4274")]
 use ruma::{
@@ -796,9 +797,9 @@ impl Drop for TimelineDropHandle {
 
 #[cfg(not(target_family = "wasm"))]
 pub type TimelineEventFilterFn =
-    dyn Fn(&AnySyncTimelineEvent, &RoomVersionId) -> bool + Send + Sync;
+    dyn Fn(&AnySyncTimelineEvent, &RoomVersionRules) -> bool + Send + Sync;
 #[cfg(target_family = "wasm")]
-pub type TimelineEventFilterFn = dyn Fn(&AnySyncTimelineEvent, &RoomVersionId) -> bool;
+pub type TimelineEventFilterFn = dyn Fn(&AnySyncTimelineEvent, &RoomVersionRules) -> bool;
 
 /// A source for sending an attachment.
 ///

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -41,7 +41,7 @@ use matrix_sdk_base::{
 use matrix_sdk_test::{ALICE, DEFAULT_TEST_ROOM_ID, event_factory::EventFactory};
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
-    OwnedUserId, TransactionId, UInt, UserId,
+    OwnedUserId, TransactionId, UInt, UserId, assign,
     events::{
         AnyMessageLikeEventContent, AnyTimelineEvent,
         reaction::ReactionEventContent,
@@ -407,18 +407,20 @@ impl RoomDataProvider for TestRoomDataProvider {
 
     async fn push_context(&self) -> Option<PushContext> {
         let push_rules = Ruleset::server_default(&ALICE);
-        let power_levels = PushConditionPowerLevelsCtx {
-            users: BTreeMap::new(),
-            users_default: int!(0),
-            notifications: NotificationPowerLevels::new(),
-        };
-        let push_condition_room_ctx = PushConditionRoomCtx {
-            room_id: room_id!("!my_room:server.name").to_owned(),
-            member_count: uint!(2),
-            user_id: ALICE.to_owned(),
-            user_display_name: "Alice".to_owned(),
-            power_levels: Some(power_levels),
-        };
+        let power_levels = PushConditionPowerLevelsCtx::new(
+            BTreeMap::new(),
+            int!(0),
+            NotificationPowerLevels::new(),
+        );
+        let push_condition_room_ctx = assign!(
+            PushConditionRoomCtx::new(
+                room_id!("!my_room:server.name").to_owned(),
+                uint!(2),
+                ALICE.to_owned(),
+                "Alice".to_owned(),
+            ),
+            { power_levels: Some(power_levels) }
+        );
         Some(PushContext::new(push_condition_room_ctx, push_rules))
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -41,7 +41,7 @@ use matrix_sdk_base::{
 use matrix_sdk_test::{ALICE, DEFAULT_TEST_ROOM_ID, event_factory::EventFactory};
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
-    OwnedUserId, RoomVersionId, TransactionId, UInt, UserId,
+    OwnedUserId, TransactionId, UInt, UserId,
     events::{
         AnyMessageLikeEventContent, AnyTimelineEvent,
         reaction::ReactionEventContent,
@@ -52,6 +52,7 @@ use ruma::{
     power_levels::NotificationPowerLevels,
     push::{PushConditionPowerLevelsCtx, PushConditionRoomCtx, Ruleset},
     room_id,
+    room_version_rules::RoomVersionRules,
     serde::Raw,
     uint,
 };
@@ -349,8 +350,8 @@ impl RoomDataProvider for TestRoomDataProvider {
         &ALICE
     }
 
-    fn room_version(&self) -> RoomVersionId {
-        RoomVersionId::V10
+    fn room_version_rules(&self) -> RoomVersionRules {
+        RoomVersionRules::V10
     }
 
     async fn crypto_context_info(&self) -> CryptoContextInfo {

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -18,13 +18,15 @@ use eyeball_im::VectorDiff;
 use matrix_sdk::assert_next_matches_with_timeout;
 use matrix_sdk_test::{ALICE, BOB, CAROL, async_test, event_factory::EventFactory};
 use ruma::{
-    RoomVersionId, event_id,
+    event_id,
     events::{
         AnySyncMessageLikeEvent, AnySyncTimelineEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::message::{MessageType, RoomMessageEventContent, SyncRoomMessageEvent},
     },
-    owned_event_id, room_id, uint,
+    owned_event_id, room_id,
+    room_version_rules::RoomVersionRules,
+    uint,
 };
 use stream_assert::{assert_next_matches, assert_pending};
 
@@ -34,7 +36,7 @@ use crate::timeline::{
     tests::TestTimelineBuilder,
 };
 
-fn filter_notice(ev: &AnySyncTimelineEvent, _room_version: &RoomVersionId) -> bool {
+fn filter_notice(ev: &AnySyncTimelineEvent, _rules: &RoomVersionRules) -> bool {
     match ev {
         AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
             SyncRoomMessageEvent::Original(msg),
@@ -378,7 +380,6 @@ async fn test_read_receipts_updates_on_message_decryption() {
     use assert_matches2::assert_let;
     use matrix_sdk_base::crypto::{OlmMachine, decrypt_room_key_export};
     use ruma::{
-        RoomVersionId,
         events::room::encrypted::{
             EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
         },
@@ -387,7 +388,7 @@ async fn test_read_receipts_updates_on_message_decryption() {
 
     use crate::timeline::{EncryptedMessage, TimelineItemContent};
 
-    fn filter_text_msg(ev: &AnySyncTimelineEvent, _room_version_id: &RoomVersionId) -> bool {
+    fn filter_text_msg(ev: &AnySyncTimelineEvent, _rules: &RoomVersionRules) -> bool {
         match ev {
             AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
                 SyncRoomMessageEvent::Original(msg),

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -27,12 +27,13 @@ use matrix_sdk::{
 };
 use matrix_sdk_base::{RoomInfo, latest_event::LatestEvent};
 use ruma::{
-    EventId, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId, UserId,
+    EventId, OwnedEventId, OwnedTransactionId, OwnedUserId, UserId,
     events::{
         AnyMessageLikeEventContent, AnySyncTimelineEvent,
         fully_read::FullyReadEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
     },
+    room_version_rules::RoomVersionRules,
     serde::Raw,
 };
 use tracing::error;
@@ -90,7 +91,7 @@ pub(super) trait RoomDataProvider:
     Clone + PaginableRoom + PaginableThread + PinnedEventsRoom + 'static
 {
     fn own_user_id(&self) -> &UserId;
-    fn room_version(&self) -> RoomVersionId;
+    fn room_version_rules(&self) -> RoomVersionRules;
 
     fn crypto_context_info(&self)
     -> impl Future<Output = CryptoContextInfo> + SendOutsideWasm + '_;
@@ -157,8 +158,8 @@ impl RoomDataProvider for Room {
         (**self).own_user_id()
     }
 
-    fn room_version(&self) -> RoomVersionId {
-        (**self).clone_info().room_version_or_default()
+    fn room_version_rules(&self) -> RoomVersionRules {
+        (**self).clone_info().room_version_rules_or_default()
     }
 
     async fn crypto_context_info(&self) -> CryptoContextInfo {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -28,7 +28,7 @@ use matrix_sdk_test::{
 };
 use matrix_sdk_ui::timeline::{RoomExt, TimelineFocus};
 use ruma::{
-    MilliSecondsSinceUnixEpoch, RoomVersionId,
+    MilliSecondsSinceUnixEpoch,
     api::client::receipt::create_receipt::v3::ReceiptType as CreateReceiptType,
     event_id,
     events::{
@@ -36,13 +36,15 @@ use ruma::{
         receipt::{ReceiptThread, ReceiptType as EventReceiptType},
         room::message::{MessageType, RoomMessageEventContent, SyncRoomMessageEvent},
     },
-    owned_event_id, room_id, uint, user_id,
+    owned_event_id, room_id,
+    room_version_rules::RoomVersionRules,
+    uint, user_id,
 };
 use serde_json::json;
 use stream_assert::{assert_pending, assert_ready};
 use tokio::task::yield_now;
 
-fn filter_notice(ev: &AnySyncTimelineEvent, _room_version: &RoomVersionId) -> bool {
+fn filter_notice(ev: &AnySyncTimelineEvent, _rules: &RoomVersionRules) -> bool {
     match ev {
         AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
             SyncRoomMessageEvent::Original(msg),

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -21,6 +21,13 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- [**breaking**] The `reason` argument of `Room::report_room()` is now required,
+  due to a clarification in the spec.
+  ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
+- [**breaking**] The `join_rule` field of `RoomPreview` is now a
+  `JoinRuleSummary`. It has the same variants as `SpaceRoomJoinRule` but
+  contains as summary of the allow rules for the restricted variants.
+  ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
 - [**breaking**] The MSRV has been bumped to Rust 1.88.
   ([#5431](https://github.com/matrix-org/matrix-rust-sdk/pull/5431))
 

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -1139,7 +1139,7 @@ impl Account {
     pub async fn set_media_previews_display_policy(&self, policy: MediaPreviews) -> Result<()> {
         let mut media_preview_config =
             self.fetch_media_preview_config_event_content().await?.unwrap_or_default();
-        media_preview_config.media_previews = policy;
+        media_preview_config.media_previews = Some(policy);
 
         // Updating the unstable account data
         let unstable_media_preview_config =
@@ -1155,7 +1155,7 @@ impl Account {
     pub async fn set_invite_avatars_display_policy(&self, policy: InviteAvatars) -> Result<()> {
         let mut media_preview_config =
             self.fetch_media_preview_config_event_content().await?.unwrap_or_default();
-        media_preview_config.invite_avatars = policy;
+        media_preview_config.invite_avatars = Some(policy);
 
         // Updating the unstable account data
         let unstable_media_preview_config =

--- a/crates/matrix-sdk/src/authentication/matrix/mod.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/mod.rs
@@ -105,20 +105,20 @@ impl MatrixAuth {
         idp_id: Option<&str>,
     ) -> Result<String> {
         let homeserver = self.client.homeserver();
-        let server_versions = self.client.server_versions().await?;
+        let supported_versions = self.client.supported_versions().await?;
 
         let request = if let Some(id) = idp_id {
             sso_login_with_provider::v3::Request::new(id.to_owned(), redirect_url.to_owned())
                 .try_into_http_request::<Vec<u8>>(
                     homeserver.as_str(),
                     SendAccessToken::None,
-                    &server_versions,
+                    &supported_versions,
                 )
         } else {
             sso_login::v3::Request::new(redirect_url.to_owned()).try_into_http_request::<Vec<u8>>(
                 homeserver.as_str(),
                 SendAccessToken::None,
-                &server_versions,
+                &supported_versions,
             )
         };
 

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel.rs
@@ -114,11 +114,18 @@ impl RendezvousChannel {
         client: HttpClient,
         rendezvous_server: &Url,
     ) -> Result<Self, HttpError> {
-        use ruma::api::client::rendezvous::create_rendezvous_session;
+        use ruma::api::{client::rendezvous::create_rendezvous_session, SupportedVersions};
 
         let request = create_rendezvous_session::unstable::Request::default();
         let response = client
-            .send(request, None, rendezvous_server.to_string(), None, &[], Default::default())
+            .send(
+                request,
+                None,
+                rendezvous_server.to_string(),
+                None,
+                &SupportedVersions { versions: Default::default(), features: Default::default() },
+                Default::default(),
+            )
             .await?;
 
         let rendezvous_url = response.url;

--- a/crates/matrix-sdk/src/client/builder/homeserver_config.rs
+++ b/crates/matrix-sdk/src/client/builder/homeserver_config.rs
@@ -15,7 +15,7 @@
 use ruma::{
     api::{
         client::discovery::{discover_homeserver, get_supported_versions},
-        MatrixVersion,
+        MatrixVersion, SupportedVersions,
     },
     OwnedServerName, ServerName,
 };
@@ -185,7 +185,10 @@ async fn discover_homeserver(
             Some(RequestConfig::short_retry()),
             server.to_string(),
             None,
-            &[MatrixVersion::V1_0],
+            &SupportedVersions {
+                versions: [MatrixVersion::V1_0].into(),
+                features: Default::default(),
+            },
             Default::default(),
         )
         .await
@@ -209,7 +212,10 @@ pub(super) async fn get_supported_versions(
             Some(RequestConfig::short_retry()),
             homeserver_url.to_string(),
             None,
-            &[MatrixVersion::V1_0],
+            &SupportedVersions {
+                versions: [MatrixVersion::V1_0].into(),
+                features: Default::default(),
+            },
             Default::default(),
         )
         .await

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -17,7 +17,7 @@ mod homeserver_config;
 
 #[cfg(feature = "sqlite")]
 use std::path::Path;
-use std::{fmt, sync::Arc};
+use std::{collections::BTreeSet, fmt, sync::Arc};
 
 use homeserver_config::*;
 #[cfg(feature = "e2e-encryption")]
@@ -101,7 +101,7 @@ pub struct ClientBuilder {
     store_config: BuilderStoreConfig,
     request_config: RequestConfig,
     respect_login_well_known: bool,
-    server_versions: Option<Box<[MatrixVersion]>>,
+    server_versions: Option<BTreeSet<MatrixVersion>>,
     handle_refresh_tokens: bool,
     base_client: Option<BaseClient>,
     #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1799,7 +1799,7 @@ impl Client {
                 config,
                 homeserver,
                 access_token.as_deref(),
-                &self.server_versions().await?,
+                &self.supported_versions().await?,
                 send_progress,
             )
             .await
@@ -1826,7 +1826,10 @@ impl Client {
                 request_config,
                 self.homeserver().to_string(),
                 None,
-                &[MatrixVersion::V1_0],
+                &SupportedVersions {
+                    versions: [MatrixVersion::V1_0].into(),
+                    features: Default::default(),
+                },
                 Default::default(),
             )
             .await?;
@@ -1853,7 +1856,10 @@ impl Client {
                 Some(RequestConfig::short_retry()),
                 server_url_string,
                 None,
-                &[MatrixVersion::V1_0],
+                &SupportedVersions {
+                    versions: [MatrixVersion::V1_0].into(),
+                    features: Default::default(),
+                },
                 Default::default(),
             )
             .await;
@@ -1997,7 +2003,7 @@ impl Client {
     /// println!("The homeserver supports Matrix 1.1: {supports_1_1:?}");
     /// # anyhow::Ok(()) };
     /// ```
-    pub async fn server_versions(&self) -> HttpResult<Box<[MatrixVersion]>> {
+    pub async fn server_versions(&self) -> HttpResult<BTreeSet<MatrixVersion>> {
         self.get_or_load_and_cache_server_info(|server_info| {
             server_info.supported_versions.as_ref().map(|supported| supported.versions.clone())
         })

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3674,8 +3674,8 @@ pub(crate) mod tests {
             client.account().observe_media_preview_config().await.unwrap();
 
         let initial_value: MediaPreviewConfigEventContent = initial_value.unwrap();
-        assert_eq!(initial_value.invite_avatars, InviteAvatars::Off);
-        assert_eq!(initial_value.media_previews, MediaPreviews::Private);
+        assert_eq!(initial_value.invite_avatars, Some(InviteAvatars::Off));
+        assert_eq!(initial_value.media_previews, Some(MediaPreviews::Private));
         pin_mut!(stream);
         assert_pending!(stream);
 
@@ -3695,8 +3695,8 @@ pub(crate) mod tests {
         assert_next_matches!(
             stream,
             MediaPreviewConfigEventContent {
-                media_previews: MediaPreviews::Off,
-                invite_avatars: InviteAvatars::On,
+                media_previews: Some(MediaPreviews::Off),
+                invite_avatars: Some(InviteAvatars::On),
                 ..
             }
         );
@@ -3725,8 +3725,8 @@ pub(crate) mod tests {
             client.account().observe_media_preview_config().await.unwrap();
 
         let initial_value: MediaPreviewConfigEventContent = initial_value.unwrap();
-        assert_eq!(initial_value.invite_avatars, InviteAvatars::Off);
-        assert_eq!(initial_value.media_previews, MediaPreviews::Private);
+        assert_eq!(initial_value.invite_avatars, Some(InviteAvatars::Off));
+        assert_eq!(initial_value.media_previews, Some(MediaPreviews::Private));
         pin_mut!(stream);
         assert_pending!(stream);
 
@@ -3746,8 +3746,8 @@ pub(crate) mod tests {
         assert_next_matches!(
             stream,
             MediaPreviewConfigEventContent {
-                media_previews: MediaPreviews::Off,
-                invite_avatars: InviteAvatars::On,
+                media_previews: Some(MediaPreviews::Off),
+                invite_avatars: Some(InviteAvatars::On),
                 ..
             }
         );

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -48,7 +48,7 @@ use ruma::{
             directory::{get_public_rooms, get_public_rooms_filtered},
             discovery::{
                 discover_homeserver::{self, RtcFocusInfo},
-                get_capabilities::{self, Capabilities},
+                get_capabilities::{self, v3::Capabilities},
                 get_supported_versions,
             },
             error::ErrorKind,

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -349,8 +349,9 @@ pub struct OAuthCrossSigningResetInfo {
 
 impl OAuthCrossSigningResetInfo {
     fn from_auth_info(auth_info: &UiaaInfo) -> Result<Self> {
-        let parameters =
-            serde_json::from_str::<OAuthCrossSigningResetUiaaParameters>(auth_info.params.get())?;
+        let parameters = serde_json::from_str::<OAuthCrossSigningResetUiaaParameters>(
+            auth_info.params.as_ref().map(|value| value.get()).unwrap_or_default(),
+        )?;
 
         Ok(OAuthCrossSigningResetInfo { approval_url: parameters.reset.url })
     }

--- a/crates/matrix-sdk/src/encryption/recovery/types.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/types.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use matrix_sdk_base::crypto::store::types::RoomKeyCounts;
-use ruma::exports::ruma_macros::EventContent;
+use ruma::events::macros::EventContent;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use zeroize::{Zeroize, ZeroizeOnDrop};

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -577,11 +577,11 @@ impl EventCacheInner {
                 let room = client
                     .get_room(room_id)
                     .ok_or_else(|| EventCacheError::RoomNotFound { room_id: room_id.to_owned() })?;
-                let room_version = room.clone_info().room_version_or_default();
+                let room_version_rules = room.clone_info().room_version_rules_or_default();
 
                 let room_state = RoomEventCacheState::new(
                     room_id.to_owned(),
-                    room_version,
+                    room_version_rules,
                     self.store.clone(),
                     pagination_status.clone(),
                 )

--- a/crates/matrix-sdk/src/event_handler/static_events.rs
+++ b/crates/matrix-sdk/src/event_handler/static_events.rs
@@ -16,11 +16,9 @@
 
 use ruma::{
     events::{
-        self,
-        presence::{PresenceEvent, PresenceEventContent},
-        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent, AnySyncStateEvent,
-        AnySyncTimelineEvent, AnyToDeviceEvent, EphemeralRoomEventContent,
+        self, presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
+        AnyStrippedStateEvent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
+        AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent, EphemeralRoomEventContent,
         GlobalAccountDataEventContent, MessageLikeEventContent, PossiblyRedactedStateEventContent,
         RedactContent, RedactedMessageLikeEventContent, RedactedStateEventContent,
         RoomAccountDataEventContent, StaticEventContent, StaticStateEventContent,
@@ -141,7 +139,7 @@ where
 
 impl SyncEvent for PresenceEvent {
     const KIND: HandlerKind = HandlerKind::Presence;
-    const TYPE: Option<&'static str> = Some(PresenceEventContent::TYPE);
+    const TYPE: Option<&'static str> = None;
 }
 
 impl SyncEvent for AnyGlobalAccountDataEvent {

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -14,6 +14,7 @@
 
 use std::{
     any::type_name,
+    borrow::Cow,
     fmt::Debug,
     num::NonZeroUsize,
     sync::{
@@ -29,7 +30,7 @@ use eyeball::SharedObservable;
 use http::Method;
 use ruma::api::{
     error::{FromHttpResponseError, IntoHttpError},
-    AuthScheme, MatrixVersion, OutgoingRequest, SendAccessToken,
+    AuthScheme, OutgoingRequest, SendAccessToken, SupportedVersions,
 };
 use tokio::sync::{Semaphore, SemaphorePermit};
 use tracing::{debug, field::debug, instrument, trace};
@@ -101,17 +102,20 @@ impl HttpClient {
         config: RequestConfig,
         homeserver: String,
         access_token: Option<&str>,
-        server_versions: &[MatrixVersion],
+        supported_versions: &SupportedVersions,
     ) -> Result<http::Request<Bytes>, IntoHttpError>
     where
         R: OutgoingRequest + Debug,
     {
         trace!(request_type = type_name::<R>(), "Serializing request");
 
-        let server_versions = if config.force_matrix_version.is_some() {
-            config.force_matrix_version.as_slice()
+        let supported_versions = if let Some(matrix_version) = config.force_matrix_version {
+            Cow::Owned(SupportedVersions {
+                versions: [matrix_version].into(),
+                features: Default::default(),
+            })
         } else {
-            server_versions
+            Cow::Borrowed(supported_versions)
         };
 
         let send_access_token = match access_token {
@@ -126,7 +130,7 @@ impl HttpClient {
         };
 
         let request = request
-            .try_into_http_request::<BytesMut>(&homeserver, send_access_token, server_versions)?
+            .try_into_http_request::<BytesMut>(&homeserver, send_access_token, &supported_versions)?
             .map(|body| body.freeze());
 
         Ok(request)
@@ -134,7 +138,7 @@ impl HttpClient {
 
     #[allow(clippy::too_many_arguments)]
     #[instrument(
-        skip(self, request, config, homeserver, access_token, server_versions, send_progress),
+        skip(self, request, config, homeserver, access_token, supported_versions, send_progress),
         fields(
             uri,
             method,
@@ -152,7 +156,7 @@ impl HttpClient {
         config: Option<RequestConfig>,
         homeserver: String,
         access_token: Option<&str>,
-        server_versions: &[MatrixVersion],
+        supported_versions: &SupportedVersions,
         send_progress: SharedObservable<TransmissionProgress>,
     ) -> Result<R::IncomingResponse, HttpError>
     where
@@ -186,7 +190,7 @@ impl HttpClient {
             }
 
             let request = self
-                .serialize_request(request, config, homeserver, access_token, server_versions)
+                .serialize_request(request, config, homeserver, access_token, supported_versions)
                 .map_err(HttpError::IntoHttp)?;
 
             let method = request.method();

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -183,6 +183,7 @@ impl HttpClient {
                 AuthScheme::AccessToken
                 | AuthScheme::AccessTokenOptional
                 | AuthScheme::AppserviceToken
+                | AuthScheme::AppserviceTokenOptional
                 | AuthScheme::None => {}
                 AuthScheme::ServerSignatures => {
                     return Err(HttpError::NotClientRequest);

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2932,13 +2932,15 @@ impl Room {
 
         let power_levels = self.power_levels().await.ok().map(Into::into);
 
-        Ok(Some(PushConditionRoomCtx {
-            user_id: user_id.to_owned(),
-            room_id: room_id.to_owned(),
-            member_count: UInt::new(member_count).unwrap_or(UInt::MAX),
-            user_display_name,
-            power_levels,
-        }))
+        Ok(Some(assign!(
+            PushConditionRoomCtx::new(
+                room_id.to_owned(),
+                UInt::new(member_count).unwrap_or(UInt::MAX),
+                user_id.to_owned(),
+                user_display_name,
+            ),
+            { power_levels }
+        )))
     }
 
     /// Retrieves a [`PushContext`] that can be used to compute the push

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1264,7 +1264,7 @@ impl Room {
     /// use matrix_sdk::ruma::{
     ///     events::{
     ///         marked_unread::MarkedUnreadEventContent,
-    ///         AnyRoomAccountDataEventContent, EventContent,
+    ///         AnyRoomAccountDataEventContent, RoomAccountDataEventContent,
     ///     },
     ///     serde::Raw,
     /// };

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3157,9 +3157,8 @@ impl Room {
     /// # Errors
     ///
     /// Returns an error if the room is not found or on rate limit
-    pub async fn report_room(&self, reason: Option<String>) -> Result<report_room::v3::Response> {
-        let mut request = report_room::v3::Request::new(self.inner.room_id().to_owned());
-        request.reason = reason;
+    pub async fn report_room(&self, reason: String) -> Result<report_room::v3::Response> {
+        let request = report_room::v3::Request::new(self.inner.room_id().to_owned(), reason);
 
         Ok(self.client.send(request).await?)
     }

--- a/crates/matrix-sdk/src/room_directory_search.rs
+++ b/crates/matrix-sdk/src/room_directory_search.rs
@@ -20,8 +20,7 @@ use futures_core::Stream;
 use imbl::Vector;
 use ruma::{
     api::client::directory::get_public_rooms_filtered::v3::Request as PublicRoomsFilterRequest,
-    directory::{Filter, PublicRoomJoinRule},
-    OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
+    directory::Filter, room::JoinRuleKind, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
 };
 
 use crate::{Client, OwnedServerName, Result};
@@ -42,7 +41,7 @@ pub struct RoomDescription {
     /// The room's avatar URL, if any.
     pub avatar_url: Option<OwnedMxcUri>,
     /// The room's join rule.
-    pub join_rule: PublicRoomJoinRule,
+    pub join_rule: JoinRuleKind,
     /// Whether can be previewed
     pub is_world_readable: bool,
     /// The number of members that have joined the room.
@@ -220,7 +219,9 @@ mod tests {
     use eyeball_im::VectorDiff;
     use futures_util::StreamExt;
     use matrix_sdk_test::{async_test, test_json};
-    use ruma::{directory::Filter, owned_server_name, serde::Raw, RoomAliasId, RoomId};
+    use ruma::{
+        directory::Filter, owned_server_name, room::JoinRuleKind, serde::Raw, RoomAliasId, RoomId,
+    };
     use serde_json::Value as JsonValue;
     use stream_assert::assert_pending;
     use wiremock::{
@@ -279,7 +280,7 @@ mod tests {
             topic: Some("Tasty tasty cheese".into()),
             alias: None,
             avatar_url: Some("mxc://bleeker.street/CHEDDARandBRIE".into()),
-            join_rule: ruma::directory::PublicRoomJoinRule::Public,
+            join_rule: JoinRuleKind::Public,
             is_world_readable: true,
             joined_members: 37,
         }
@@ -292,7 +293,7 @@ mod tests {
             topic: Some("Tasty tasty pear".into()),
             alias: RoomAliasId::parse("#murrays:pear.bar").ok(),
             avatar_url: Some("mxc://bleeker.street/pear".into()),
-            join_rule: ruma::directory::PublicRoomJoinRule::Knock,
+            join_rule: JoinRuleKind::Knock,
             is_world_readable: false,
             joined_members: 20,
         }

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -161,7 +161,7 @@ use ruma::{
             message::{FormattedBody, RoomMessageEventContent},
             MediaSource,
         },
-        AnyMessageLikeEventContent, EventContent as _, Mentions,
+        AnyMessageLikeEventContent, Mentions, MessageLikeEventContent as _,
     },
     serde::Raw,
     MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId, RoomId,

--- a/crates/matrix-sdk/tests/integration/event_cache/mod.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/mod.rs
@@ -32,7 +32,9 @@ use ruma::{
         room::message::RoomMessageEventContentWithoutRelation, AnySyncMessageLikeEvent,
         AnySyncTimelineEvent, TimelineEventType,
     },
-    room_id, user_id, EventId, RoomVersionId,
+    room_id,
+    room_version_rules::RedactionRules,
+    user_id, EventId,
 };
 use serde_json::json;
 use tokio::{spawn, sync::broadcast, time::sleep};
@@ -1414,7 +1416,7 @@ async fn test_apply_redaction_when_redaction_comes_later() {
         assert_let!(
             AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomRedaction(ev)) = ev
         );
-        assert_eq!(ev.redacts(&RoomVersionId::V1).unwrap(), event_id!("$1"));
+        assert_eq!(ev.redacts(&RedactionRules::V1).unwrap(), event_id!("$1"));
     }
 
     // Then, we have an update for the redacted event.
@@ -1644,7 +1646,7 @@ async fn test_apply_redaction_when_redacted_and_redaction_are_in_same_sync() {
         assert_let!(
             AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomRedaction(ev)) = ev
         );
-        assert_eq!(ev.redacts(&RoomVersionId::V1).unwrap(), event_id!("$2"));
+        assert_eq!(ev.redacts(&RedactionRules::V1).unwrap(), event_id!("$2"));
     }
 
     // Then the redaction of the event happens separately.

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -1381,5 +1381,5 @@ async fn test_report_room() {
     let _response = client.sync_once(sync_settings).await.unwrap();
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
 
-    room.report_room(Some(reason.to_owned())).await.unwrap();
+    room.report_room(reason.to_owned()).await.unwrap();
 }

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -36,7 +36,7 @@ use ruma::{
             },
             MediaSource,
         },
-        AnyMessageLikeEventContent, EventContent as _, Mentions,
+        AnyMessageLikeEventContent, Mentions, MessageLikeEventContent as _,
     },
     mxc_uri, owned_mxc_uri, owned_user_id, room_id,
     serde::Raw,

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -9,8 +9,8 @@ use matrix_sdk::{
         api::client::room::create_room::v3::Request as CreateRoomRequest,
         assign, event_id, events,
         events::{
-            AnyRoomAccountDataEventContent, AnySyncStateEvent, AnySyncTimelineEvent, EventContent,
-            room::message::RoomMessageEventContent,
+            AnyRoomAccountDataEventContent, AnySyncStateEvent, AnySyncTimelineEvent,
+            RoomAccountDataEventContent, room::message::RoomMessageEventContent,
         },
         serde::Raw,
         uint,

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -34,9 +34,9 @@ use matrix_sdk::{
                 message::RoomMessageEventContent,
             },
         },
-        mxc_uri, owned_server_name, room_id,
-        space::SpaceRoomJoinRule,
-        uint,
+        mxc_uri, owned_server_name,
+        room::JoinRuleSummary,
+        room_id, uint,
     },
     sliding_sync::VersionBuilder,
     test_utils::{logged_in_client_with_server, mocks::MatrixMockServer},
@@ -1235,7 +1235,7 @@ fn assert_room_preview(preview: &RoomPreview, room_alias: &str) {
     assert_eq!(preview.avatar_url.as_ref().unwrap(), mxc_uri!("mxc://localhost/alice"));
     assert_eq!(preview.num_joined_members, 1);
     assert!(preview.room_type.is_none());
-    assert_eq!(preview.join_rule, Some(SpaceRoomJoinRule::Invite));
+    assert_eq!(preview.join_rule, Some(JoinRuleSummary::Invite));
     assert!(preview.is_world_readable.unwrap());
 }
 

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -28,7 +28,7 @@ use ruma::{
     OwnedRoomId, OwnedTransactionId, OwnedUserId, OwnedVoipId, RoomId, RoomVersionId,
     TransactionId, UInt, UserId, VoipVersionId,
     events::{
-        AnyMessageLikeEvent, AnyStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,
+        AnyStateEvent, AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent,
         AnyTimelineEvent, BundledMessageLikeRelations, Mentions, RedactedMessageLikeEventContent,
         RedactedStateEventContent, StateEventContent, StaticEventContent,
         beacon::BeaconEventContent,
@@ -202,7 +202,7 @@ impl<E: StaticEventContent> EventBuilder<E> {
     /// this event.
     pub fn with_bundled_thread_summary(
         mut self,
-        latest_event: Raw<AnyMessageLikeEvent>,
+        latest_event: Raw<AnySyncMessageLikeEvent>,
         count: usize,
         current_user_participated: bool,
     ) -> Self {

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -238,7 +238,12 @@ impl<E: StaticEventContent> EventBuilder<E> {
         self.state_key = Some(state_key.into());
         self
     }
+}
 
+impl<E> EventBuilder<E>
+where
+    E: StaticEventContent + Serialize,
+{
     #[inline(always)]
     fn construct_json(self, requires_room: bool) -> serde_json::Value {
         // Use the `sender` preferably, or resort to the `redacted_because` sender if
@@ -454,19 +459,28 @@ impl EventBuilder<StickerEventContent> {
     }
 }
 
-impl<E: StaticEventContent> From<EventBuilder<E>> for Raw<AnySyncTimelineEvent> {
+impl<E: StaticEventContent> From<EventBuilder<E>> for Raw<AnySyncTimelineEvent>
+where
+    E: Serialize,
+{
     fn from(val: EventBuilder<E>) -> Self {
         val.into_raw_sync()
     }
 }
 
-impl<E: StaticEventContent> From<EventBuilder<E>> for Raw<AnyTimelineEvent> {
+impl<E: StaticEventContent> From<EventBuilder<E>> for Raw<AnyTimelineEvent>
+where
+    E: Serialize,
+{
     fn from(val: EventBuilder<E>) -> Self {
         val.into_raw_timeline()
     }
 }
 
-impl<E: StaticEventContent> From<EventBuilder<E>> for TimelineEvent {
+impl<E: StaticEventContent> From<EventBuilder<E>> for TimelineEvent
+where
+    E: Serialize,
+{
     fn from(val: EventBuilder<E>) -> Self {
         val.into_event()
     }


### PR DESCRIPTION
This is ~~more or less~~ ready, with all the changes that are required due to breaking changes in Ruma. ~~I still need to fix a few tests. I will probably open other PRs soon to try to make this slightly smaller (but there is not much to do).~~

I tried to split the commits by source of the change, so I recommend to review this commit by commit. However after the first commit the code doesn't compile unless all the other commits are applied, so I recommend to squash everything when merging.

~~Note that currently Ruma is not ready for a release with those breaking changes, however it should be ready in a few weeks.~~ Ruma should be ready for release when the support for [room version 12](https://matrix.org/blog/2025/07/security-predisclosure/) is added in the next few days.

This is supposed to be part of 3 PRs:

1. This one, that bumps Ruma to a commit on main that has the same features that we already use in the SDK, while having the least amount of changes possible. (probably the biggest one).
2. Bump to the latest commit before support for room version 12. Will have ~300 lines changed.
3. Bump to the latest commit with support for room version 12.