### PR TITLE
feat(state store): diagnose and send to sentry deserialization errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3247,6 +3247,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "similar-asserts",
  "tempfile",
  "thiserror 2.0.11",
@@ -4967,9 +4968,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -33,6 +33,7 @@ ruma.workspace = true
 rusqlite = { version = "0.35.0", features = ["limits"] }
 serde.workspace = true
 serde_json.workspace = true
+serde_path_to_error = "0.1.17"
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs"] }
 tracing.workspace = true


### PR DESCRIPTION
There's a bad regression hiding, where some data can't be deserialized from the state store, and we have no clues what caused it. This kind of diagnosis should help figuring out what it is, by (1) logging an error with extra information in the rageshake, (2) sending that error to sentry, when it's been configured at the FFI / tracing layer.