### PR TITLE
Upgrade Ruma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4460,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.3"
-source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
+source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
 dependencies = [
  "assign",
  "js_int",
@@ -4476,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.3"
-source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
+source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
 dependencies = [
  "as_variant",
  "assign",
@@ -4499,7 +4499,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.2"
-source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
+source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
 dependencies = [
  "as_variant",
  "base64",
@@ -4531,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.3"
-source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
+source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4556,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.1"
-source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
+source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
 dependencies = [
  "http",
  "js_int",
@@ -4570,7 +4570,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.1"
-source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
+source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4582,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
+source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
 dependencies = [
  "js_int",
  "thiserror 2.0.11",
@@ -4591,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.1"
-source = "git+https://github.com/ruma/ruma?rev=d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a#d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a"
+source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,15 +60,15 @@ reqwest = { version = "0.12.12", default-features = false }
 rmp-serde = "1.3.0"
 # Be careful to use commits from the https://github.com/ruma/ruma/tree/ruma-0.12
 # branch until a proper release with breaking changes happens.
-ruma = { git = "https://github.com/ruma/ruma", rev = "d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
     "compat-arbitrary-length-ids",
     "compat-tag-info",
     "compat-encrypted-stickers",
+    "compat-lax-room-create-deser",
     "unstable-msc3401",
-    "unstable-msc3266",
     "unstable-msc3488",
     "unstable-msc3489",
     "unstable-msc4075",
@@ -78,7 +78,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "d1d53e2b7aaf9190f11a5465b9
     "unstable-msc4278",
     "unstable-msc4286",
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "d1d53e2b7aaf9190f11a5465b9edf6a19fc5b59a" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be" }
 sentry = "0.36.0"
 sentry-tracing = "0.36.0"
 serde = { version = "1.0.217", features = ["rc"] }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -20,7 +20,7 @@ use matrix_sdk::{
         api::client::{
             discovery::{
                 discover_homeserver::RtcFocusInfo,
-                get_authorization_server_metadata::msc2965::Prompt as RumaOidcPrompt,
+                get_authorization_server_metadata::v1::Prompt as RumaOidcPrompt,
             },
             push::{EmailPusherData, PusherIds, PusherInit, PusherKind as RumaPusherKind},
             room::{create_room, Visibility},

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -102,7 +102,7 @@ rand = { workspace = true, optional = true }
 ruma = { workspace = true, features = [
     "rand",
     "unstable-msc2448",
-    "unstable-msc2965",
+    "unstable-msc4191",
     "unstable-msc3930",
     "unstable-msc3245-v1-compat",
     "unstable-msc4230",

--- a/crates/matrix-sdk/src/authentication/oauth/account_management_url.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/account_management_url.rs
@@ -17,7 +17,7 @@
 //! This is a Matrix extension introduced in [MSC4191](https://github.com/matrix-org/matrix-spec-proposals/pull/4191).
 
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::msc2965::AccountManagementAction,
+    api::client::discovery::get_authorization_server_metadata::v1::AccountManagementAction,
     OwnedDeviceId,
 };
 use url::Url;

--- a/crates/matrix-sdk/src/authentication/oauth/auth_code_builder.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/auth_code_builder.rs
@@ -18,8 +18,7 @@ use oauth2::{
     basic::BasicClient as OAuthClient, AuthUrl, CsrfToken, PkceCodeChallenge, RedirectUrl, Scope,
 };
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::msc2965::Prompt, OwnedDeviceId,
-    UserId,
+    api::client::discovery::get_authorization_server_metadata::v1::Prompt, OwnedDeviceId, UserId,
 };
 use tracing::{info, instrument};
 use url::Url;

--- a/crates/matrix-sdk/src/authentication/oauth/error.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/error.rs
@@ -25,7 +25,7 @@ pub use oauth2::{
     StandardErrorResponse,
 };
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::msc2965::AuthorizationServerMetadataUrlError,
+    api::client::discovery::get_authorization_server_metadata::v1::AuthorizationServerMetadataUrlError,
     serde::{PartialEqAsRefStr, StringEnum},
 };
 

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -187,7 +187,7 @@ pub use oauth2::{ClientId, CsrfToken};
 use ruma::{
     api::client::discovery::get_authorization_server_metadata::{
         self,
-        msc2965::{AccountManagementAction, AuthorizationServerMetadata},
+        v1::{AccountManagementAction, AuthorizationServerMetadata},
     },
     serde::Raw,
     DeviceId, OwnedDeviceId,
@@ -577,18 +577,17 @@ impl OAuth {
                 .is_some_and(|err| err.status_code == http::StatusCode::NOT_FOUND)
         };
 
-        let response = self
-            .client
-            .send(get_authorization_server_metadata::msc2965::Request::new())
-            .await
-            .map_err(|error| {
-                // If the endpoint returns a 404, i.e. the server doesn't support the endpoint.
-                if is_endpoint_unsupported(&error) {
-                    OAuthDiscoveryError::NotSupported
-                } else {
-                    error.into()
-                }
-            })?;
+        let response =
+            self.client.send(get_authorization_server_metadata::v1::Request::new()).await.map_err(
+                |error| {
+                    // If the endpoint returns a 404, i.e. the server doesn't support the endpoint.
+                    if is_endpoint_unsupported(&error) {
+                        OAuthDiscoveryError::NotSupported
+                    } else {
+                        error.into()
+                    }
+                },
+            )?;
 
         let metadata = response.metadata.deserialize()?;
 

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
@@ -24,7 +24,7 @@ use matrix_sdk_base::{
 };
 use oauth2::{DeviceCodeErrorResponseType, StandardDeviceAuthorizationResponse};
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::msc2965::AuthorizationServerMetadata,
+    api::client::discovery::get_authorization_server_metadata::v1::AuthorizationServerMetadata,
     OwnedDeviceId,
 };
 use tracing::trace;

--- a/crates/matrix-sdk/src/authentication/oauth/registration.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/registration.rs
@@ -23,7 +23,7 @@ use language_tags::LanguageTag;
 use matrix_sdk_base::deserialized_responses::PrivOwnedStr;
 use oauth2::{AsyncHttpClient, ClientId, HttpClientError, RequestTokenError};
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::msc2965::{GrantType, ResponseType},
+    api::client::discovery::get_authorization_server_metadata::v1::{GrantType, ResponseType},
     serde::{PartialEqAsRefStr, Raw, StringEnum},
     SecondsSinceUnixEpoch,
 };

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -4,7 +4,7 @@ use matrix_sdk_base::store::RoomLoadSettings;
 use matrix_sdk_test::async_test;
 use oauth2::{ClientId, CsrfToken, PkceCodeChallenge, RedirectUrl};
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::msc2965::Prompt, device_id,
+    api::client::discovery::get_authorization_server_metadata::v1::Prompt, device_id,
     owned_device_id, user_id, DeviceId, ServerName,
 };
 use tokio::sync::broadcast::error::TryRecvError;

--- a/crates/matrix-sdk/src/client/caches.rs
+++ b/crates/matrix-sdk/src/client/caches.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use matrix_sdk_base::ttl_cache::TtlCache;
-use ruma::api::client::discovery::get_authorization_server_metadata::msc2965::AuthorizationServerMetadata;
+use ruma::api::client::discovery::get_authorization_server_metadata::v1::AuthorizationServerMetadata;
 use tokio::sync::RwLock;
 
 use super::ClientServerInfo;

--- a/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
@@ -15,7 +15,7 @@
 //! Helpers to mock an OAuth 2.0 server for the purpose of integration tests.
 
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::msc2965::AuthorizationServerMetadata,
+    api::client::discovery::get_authorization_server_metadata::v1::AuthorizationServerMetadata,
     serde::Raw,
 };
 use serde_json::json;


### PR DESCRIPTION
Contrary to #5337 which updates Ruma on the `main` branch (which is not ready for a release yet), this updates Ruma on the `ruma-0.12` branch which can be released at any time.

The changes here are due to the stabilization of unstable features.