### PR TITLE
Upgrade Ruma (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,7 +4461,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.3"
-source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
+source = "git+https://github.com/ruma/ruma?rev=4eaf35990ed9f14f1a44997a13ef35cb1d658d3a#4eaf35990ed9f14f1a44997a13ef35cb1d658d3a"
 dependencies = [
  "assign",
  "js_int",
@@ -4477,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.3"
-source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
+source = "git+https://github.com/ruma/ruma?rev=4eaf35990ed9f14f1a44997a13ef35cb1d658d3a#4eaf35990ed9f14f1a44997a13ef35cb1d658d3a"
 dependencies = [
  "as_variant",
  "assign",
@@ -4500,7 +4500,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.2"
-source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
+source = "git+https://github.com/ruma/ruma?rev=4eaf35990ed9f14f1a44997a13ef35cb1d658d3a#4eaf35990ed9f14f1a44997a13ef35cb1d658d3a"
 dependencies = [
  "as_variant",
  "base64",
@@ -4532,7 +4532,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.3"
-source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
+source = "git+https://github.com/ruma/ruma?rev=4eaf35990ed9f14f1a44997a13ef35cb1d658d3a#4eaf35990ed9f14f1a44997a13ef35cb1d658d3a"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.1"
-source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
+source = "git+https://github.com/ruma/ruma?rev=4eaf35990ed9f14f1a44997a13ef35cb1d658d3a#4eaf35990ed9f14f1a44997a13ef35cb1d658d3a"
 dependencies = [
  "http",
  "js_int",
@@ -4571,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.1"
-source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
+source = "git+https://github.com/ruma/ruma?rev=4eaf35990ed9f14f1a44997a13ef35cb1d658d3a#4eaf35990ed9f14f1a44997a13ef35cb1d658d3a"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4583,7 +4583,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
+source = "git+https://github.com/ruma/ruma?rev=4eaf35990ed9f14f1a44997a13ef35cb1d658d3a#4eaf35990ed9f14f1a44997a13ef35cb1d658d3a"
 dependencies = [
  "js_int",
  "thiserror 2.0.11",
@@ -4592,7 +4592,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.1"
-source = "git+https://github.com/ruma/ruma?rev=724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be#724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be"
+source = "git+https://github.com/ruma/ruma?rev=4eaf35990ed9f14f1a44997a13ef35cb1d658d3a#4eaf35990ed9f14f1a44997a13ef35cb1d658d3a"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ reqwest = { version = "0.12.12", default-features = false }
 rmp-serde = "1.3.0"
 # Be careful to use commits from the https://github.com/ruma/ruma/tree/ruma-0.12
 # branch until a proper release with breaking changes happens.
-ruma = { git = "https://github.com/ruma/ruma", rev = "724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "4eaf35990ed9f14f1a44997a13ef35cb1d658d3a", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -68,6 +68,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "724ed061ae3bf9a2b5ccfdbcd5
     "compat-tag-info",
     "compat-encrypted-stickers",
     "compat-lax-room-create-deser",
+    "compat-lax-room-topic-deser",
     "unstable-msc3401",
     "unstable-msc3488",
     "unstable-msc3489",
@@ -78,7 +79,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "724ed061ae3bf9a2b5ccfdbcd5
     "unstable-msc4278",
     "unstable-msc4286",
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "724ed061ae3bf9a2b5ccfdbcd500e77e6069a3be" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "4eaf35990ed9f14f1a44997a13ef35cb1d658d3a" }
 sentry = "0.36.0"
 sentry-tracing = "0.36.0"
 serde = { version = "1.0.217", features = ["rc"] }


### PR DESCRIPTION
It seems that some `m.room.topic` events in the wild have the wrong format for the `m.topic` field (https://github.com/matrix-org/matrix-js-sdk/issues/4902). Since this field was stabilized recently in Ruma, deserializing these events now fails. We added a feature to ignore this field if its deserialization fails.

Thanks to @stefanceriu for reporting this to me.