### PR TITLE
fix(event cache): don't remove duplicated paginated events, if there's no new events

### DIFF
--- a/crates/matrix-sdk/src/event_cache/room/threads.rs
+++ b/crates/matrix-sdk/src/event_cache/room/threads.rs
@@ -231,17 +231,17 @@ impl ThreadEventCache {
 
         let deduplication = self.filter_duplicate_events(topo_ordered_events);
 
-        assert!(
-            deduplication.in_store_duplicated_event_ids.is_empty(),
-            "persistent storage for threads is not implemented yet"
-        );
-        self.remove_in_memory_duplicated_events(deduplication.in_memory_duplicated_event_ids);
-
         let (events, new_gap) = if deduplication.non_empty_all_duplicates {
             // If all events are duplicates, we don't need to do anything; ignore
             // the new events and the new gap.
             (Vec::new(), None)
         } else {
+            assert!(
+                deduplication.in_store_duplicated_event_ids.is_empty(),
+                "persistent storage for threads is not implemented yet"
+            );
+            self.remove_in_memory_duplicated_events(deduplication.in_memory_duplicated_event_ids);
+
             // Keep events and the gap.
             (deduplication.all_events, new_gap)
         };


### PR DESCRIPTION
Another big duh revealed by a test.

Followup to #5123, part of #4869.