### PR TITLE
docs(crypto): Remove wrong statement about encryption keys for OlmMachine::with_store

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -266,9 +266,6 @@ impl OlmMachine {
 
     /// Create a new OlmMachine with the given [`CryptoStore`].
     ///
-    /// The created machine will keep the encryption keys only in memory and
-    /// once the object is dropped the keys will be lost.
-    ///
     /// If the store already contains encryption keys for the given user/device
     /// pair those will be re-used. Otherwise new ones will be created and
     /// stored.


### PR DESCRIPTION
When using this function, whether encryption keys are dropped depends on the crypto store implementation used.

Signed-off-by: Tobias Fella <tobias.fella@kde.org>
