### PR TITLE
feat(ui): Add `RoomListService::new_with_share_pos`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -119,6 +119,12 @@ impl SyncServiceBuilder {
         Arc::new(Self { builder, ..this })
     }
 
+    pub fn with_share_pos(self: Arc<Self>, enable: bool) -> Arc<Self> {
+        let this = unwrap_or_clone_arc(self);
+        let builder = this.builder.with_share_pos(enable);
+        Arc::new(Self { builder, ..this })
+    }
+
     pub async fn finish(self: Arc<Self>) -> Result<Arc<SyncService>, ClientError> {
         let this = unwrap_or_clone_arc(self);
         Ok(Arc::new(SyncService {


### PR DESCRIPTION
This patch adds the new `RoomListService::new_with_share_pos` constructor. It decides whether the `share_pos` feature of sliding sync should be enabled or not.

`SyncServiceBuilder` gains a new `with_share_pos` method to configure the way the `RoomListService` is built.

The FFI bindings are updated accordingly.