### PR TITLE
Fix issue #5366

### DIFF
--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -3230,7 +3230,19 @@ impl<'a> MockEndpoint<'a, LoginEndpoint> {
     pub fn ok(self) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::LOGIN))
     }
+
+    /// Returns a successful response with a given message.
+    pub fn ok_with(self, response: ResponseTemplate) -> MatrixMock<'a> {
+        self.respond_with(response)
+    }
+
+    /// Ensures that the body of the request is a superset of the provided
+    /// `body` parameter.
+    pub fn body_matches_partial_json(self, body: Value) -> Self {
+        Self { mock: self.mock.and(body_partial_json(body)), ..self }
+    }
 }
+
 
 /// A prebuilt mock for `GET /devices` requests.
 pub struct DevicesEndpoint;

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -11,7 +11,9 @@ use matrix_sdk::{
     executor::spawn,
     store::RoomLoadSettings,
     test_utils::{
-        client::mock_session_meta, logged_in_client_with_server, mocks::MatrixMockServer,
+        client::mock_session_meta,
+        logged_in_client_with_server,
+        mocks::{LoginResponseTemplate200, MatrixMockServer},
         no_retry_test_client_with_server, test_client_builder_with_server,
     },
     HttpError, RefreshTokenError, SessionChange, SessionTokens,
@@ -22,7 +24,7 @@ use ruma::{
         client::{account::register, error::ErrorKind},
         MatrixVersion,
     },
-    assign,
+    assign, owned_device_id, owned_user_id,
 };
 use serde_json::json;
 use tokio::sync::{broadcast::error::TryRecvError, mpsc};
@@ -47,7 +49,15 @@ async fn test_login_username_refresh_token() {
     server
         .mock_login()
         .body_matches_partial_json(json!({"refresh_token": true}))
-        .ok_with(ResponseTemplate::new(200).set_body_json(&*test_json::LOGIN_WITH_REFRESH_TOKEN))
+        .ok_with(
+            LoginResponseTemplate200::new(
+                "abc123",
+                owned_device_id!("GHTYAJCE"),
+                owned_user_id!("@cheeky_monkey:matrix.org"),
+            )
+            .expires_in(Duration::from_millis(432000000))
+            .refresh_token("zyx987"),
+        )
         .mount()
         .await;
 
@@ -60,7 +70,7 @@ async fn test_login_username_refresh_token() {
         .send()
         .await
         .unwrap();
-    
+
     assert!(client.is_active(), "Client should be active");
     res.refresh_token.unwrap();
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Change test_login_username_refresh_token to use MatrixMockServer.
Add builders for configurable reesponses for mock login endpoint.
- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
Shrey Patel <shreyp@element.io>