### PR TITLE
IndexedDB: Add IndexedDB implementation of `EventCacheStore::load_last_chunk`

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/error.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/error.rs
@@ -59,27 +59,16 @@ impl From<web_sys::DomException> for IndexeddbEventCacheStoreError {
 
 impl From<IndexeddbEventCacheStoreError> for EventCacheStoreError {
     fn from(value: IndexeddbEventCacheStoreError) -> Self {
+        use IndexeddbEventCacheStoreError::*;
+
         match value {
-            IndexeddbEventCacheStoreError::DomException { .. }
-            | IndexeddbEventCacheStoreError::ChunksContainCycle
-            | IndexeddbEventCacheStoreError::ChunksContainDisjointLists
-            | IndexeddbEventCacheStoreError::NoMaxChunkId
-            | IndexeddbEventCacheStoreError::UnableToLoadChunk => {
-                Self::InvalidData { details: value.to_string() }
-            }
-            IndexeddbEventCacheStoreError::Transaction(ref inner) => match inner {
-                IndexeddbEventCacheStoreTransactionError::DomException { .. } => {
-                    Self::InvalidData { details: value.to_string() }
-                }
-                IndexeddbEventCacheStoreTransactionError::Serialization(e) => {
-                    Self::Serialization(serde_json::Error::custom(e.to_string()))
-                }
-                IndexeddbEventCacheStoreTransactionError::ItemIsNotUnique
-                | IndexeddbEventCacheStoreTransactionError::ItemNotFound => {
-                    Self::InvalidData { details: value.to_string() }
-                }
-            },
-            IndexeddbEventCacheStoreError::MemoryStore(inner) => inner,
+            DomException { .. }
+            | ChunksContainCycle
+            | ChunksContainDisjointLists
+            | NoMaxChunkId
+            | UnableToLoadChunk => Self::InvalidData { details: value.to_string() },
+            Transaction(inner) => inner.into(),
+            MemoryStore(inner) => inner,
         }
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/error.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/error.rs
@@ -33,6 +33,14 @@ impl<T> AsyncErrorDeps for T where T: std::error::Error + SendOutsideWasm + Sync
 pub enum IndexeddbEventCacheStoreError {
     #[error("DomException {name} ({code}): {message}")]
     DomException { name: String, message: String, code: u16 },
+    #[error("chunks contain disjoint lists")]
+    ChunksContainDisjointLists,
+    #[error("chunks contain cycle")]
+    ChunksContainCycle,
+    #[error("unable to load chunk")]
+    UnableToLoadChunk,
+    #[error("no max chunk id")]
+    NoMaxChunkId,
     #[error("transaction: {0}")]
     Transaction(#[from] IndexeddbEventCacheStoreTransactionError),
     #[error("media store: {0}")]
@@ -52,7 +60,11 @@ impl From<web_sys::DomException> for IndexeddbEventCacheStoreError {
 impl From<IndexeddbEventCacheStoreError> for EventCacheStoreError {
     fn from(value: IndexeddbEventCacheStoreError) -> Self {
         match value {
-            IndexeddbEventCacheStoreError::DomException { .. } => {
+            IndexeddbEventCacheStoreError::DomException { .. }
+            | IndexeddbEventCacheStoreError::ChunksContainCycle
+            | IndexeddbEventCacheStoreError::ChunksContainDisjointLists
+            | IndexeddbEventCacheStoreError::NoMaxChunkId
+            | IndexeddbEventCacheStoreError::UnableToLoadChunk => {
                 Self::InvalidData { details: value.to_string() }
             }
             IndexeddbEventCacheStoreError::Transaction(ref inner) => match inner {

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
@@ -435,6 +435,73 @@ pub async fn test_linked_chunk_update_is_a_transaction(store: IndexeddbEventCach
     assert!(chunks.is_empty());
 }
 
+pub async fn test_load_last_chunk(store: IndexeddbEventCacheStore) {
+    let room_id = &DEFAULT_TEST_ROOM_ID;
+    let linked_chunk_id = LinkedChunkId::Room(room_id);
+    let event = |msg: &str| make_test_event(room_id, msg);
+
+    // Case #1: no last chunk.
+    let (last_chunk, chunk_identifier_generator) =
+        store.load_last_chunk(linked_chunk_id).await.unwrap();
+    assert!(last_chunk.is_none());
+    assert_eq!(chunk_identifier_generator.current(), 0);
+
+    // Case #2: only one chunk is present.
+    let updates = vec![
+        Update::NewItemsChunk { previous: None, new: ChunkIdentifier::new(42), next: None },
+        Update::PushItems {
+            at: Position::new(ChunkIdentifier::new(42), 0),
+            items: vec![event("saucisse de morteau"), event("comté")],
+        },
+    ];
+    store.handle_linked_chunk_updates(linked_chunk_id, updates).await.unwrap();
+
+    let (last_chunk, chunk_identifier_generator) =
+        store.load_last_chunk(linked_chunk_id).await.unwrap();
+    assert_matches!(last_chunk, Some(last_chunk) => {
+        assert_eq!(last_chunk.identifier, 42);
+        assert!(last_chunk.previous.is_none());
+        assert!(last_chunk.next.is_none());
+        assert_matches!(last_chunk.content, ChunkContent::Items(items) => {
+            assert_eq!(items.len(), 2);
+            check_test_event(&items[0], "saucisse de morteau");
+            check_test_event(&items[1], "comté");
+        });
+    });
+    assert_eq!(chunk_identifier_generator.current(), 42);
+
+    // Case #3: more chunks are present.
+    let updates = vec![
+        Update::NewItemsChunk {
+            previous: Some(ChunkIdentifier::new(42)),
+            new: ChunkIdentifier::new(7),
+            next: None,
+        },
+        Update::PushItems {
+            at: Position::new(ChunkIdentifier::new(7), 0),
+            items: vec![event("fondue"), event("gruyère"), event("mont d'or")],
+        },
+    ];
+    store.handle_linked_chunk_updates(linked_chunk_id, updates).await.unwrap();
+
+    let (last_chunk, chunk_identifier_generator) =
+        store.load_last_chunk(linked_chunk_id).await.unwrap();
+    assert_matches!(last_chunk, Some(last_chunk) => {
+        assert_eq!(last_chunk.identifier, 7);
+        assert_matches!(last_chunk.previous, Some(previous) => {
+            assert_eq!(previous, 42);
+        });
+        assert!(last_chunk.next.is_none());
+        assert_matches!(last_chunk.content, ChunkContent::Items(items) => {
+            assert_eq!(items.len(), 3);
+            check_test_event(&items[0], "fondue");
+            check_test_event(&items[1], "gruyère");
+            check_test_event(&items[2], "mont d'or");
+        });
+    });
+    assert_eq!(chunk_identifier_generator.current(), 42);
+}
+
 /// Macro for generating tests for IndexedDB implementation of
 /// [`EventCacheStore`]
 ///
@@ -545,6 +612,13 @@ macro_rules! indexeddb_event_cache_store_integration_tests {
             async fn test_linked_chunk_update_is_a_transaction() {
                 let store = get_event_cache_store().await.expect("Failed to get event cache store");
                 $crate::event_cache_store::integration_tests::test_linked_chunk_update_is_a_transaction(store)
+                    .await
+            }
+
+            #[async_test]
+            async fn test_load_last_chunk() {
+                let store = get_event_cache_store().await.expect("Failed to get event cache store");
+                $crate::event_cache_store::integration_tests::test_load_last_chunk(store)
                     .await
             }
         }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -406,12 +406,40 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         self.get_item_by_key_components::<Chunk, IndexedChunkIdKey>(room_id, chunk_id).await
     }
 
+    /// Query IndexedDB for chunks such that the next chunk matches the given
+    /// chunk identifier in the given room. If more than one item is found,
+    /// an error is returned.
+    pub async fn get_chunk_by_next_chunk_id(
+        &self,
+        room_id: &RoomId,
+        next_chunk_id: &Option<ChunkIdentifier>,
+    ) -> Result<Option<Chunk>, IndexeddbEventCacheStoreTransactionError> {
+        self.get_item_by_key_components::<Chunk, IndexedNextChunkIdKey>(room_id, next_chunk_id)
+            .await
+    }
+
     /// Query IndexedDB for all chunks in the given room
     pub async fn get_chunks_in_room(
         &self,
         room_id: &RoomId,
     ) -> Result<Vec<Chunk>, IndexeddbEventCacheStoreTransactionError> {
         self.get_items_in_room::<Chunk, IndexedChunkIdKey>(room_id).await
+    }
+
+    /// Query IndexedDB for the number of chunks in the given room.
+    pub async fn get_chunks_count_in_room(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<usize, IndexeddbEventCacheStoreTransactionError> {
+        self.get_items_count_in_room::<Chunk, IndexedChunkIdKey>(room_id).await
+    }
+
+    /// Query IndexedDB for the chunk with the maximum key in the given room.
+    pub async fn get_max_chunk_by_id(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Option<Chunk>, IndexeddbEventCacheStoreTransactionError> {
+        self.get_max_item_by_key::<Chunk, IndexedChunkIdKey>(room_id).await
     }
 
     /// Query IndexedDB for given chunk in given room and additionally query


### PR DESCRIPTION
## Background

This pull request is part of a series of pull requests to add a full IndexedDB implementation of the `EventCacheStore` (see #4617, #4996, #5090, #5138, #5226, #5274, #5343). This particular pull request focuses on providing an implementation of `EventCacheStore::load_last_chunk`.

## Changes

The primary change is the addition of `EventCacheStore::load_last_chunk`, as well as tests for ensuring this is functioning correctly.

There are also a number of additions to `IndexeddbEventCacheStoreTransaction` which support the implementation of `EventCacheStore::load_last_chunk`.

- `get_chunk_by_next_chunk_id`
- `get_chunks_count_in_room`
- `get_max_chunk_id`

These are simply typed wrappers around the generic functions in `IndexeddbEventCacheStoreTransaction`.

## Future Work

- Add remaining implementations of `EventCacheStore` functions without relying on `MemoryStore`.

---

- [ ] Public API changes documented in changelogs (optional)


Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
