### PR TITLE
FFI: Refactor ClientBuilder::build_with_qr_code into Client::login_with_qr_code

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Breaking changes:
+
+- `ClientBuilder::build_with_qr_code` has been removed. Instead, the Client should be built by passing
+  `QrCodeData::server_name` to `ClientBuilder::server_name_or_homeserver_url`, after which QR login can be performed by
+  calling `Client::login_with_qr_code`. ([#5388](https://github.com/matrix-org/matrix-rust-sdk/pull/5388))
+
 ## [0.13.0] - 2025-07-10
 
 ### Features

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -1,12 +1,9 @@
 use std::{fs, num::NonZeroUsize, path::Path, sync::Arc, time::Duration};
 
-use futures_util::StreamExt;
 #[cfg(not(target_family = "wasm"))]
 use matrix_sdk::reqwest::Certificate;
 use matrix_sdk::{
-    crypto::{
-        types::qr_login::QrCodeModeData, CollectStrategy, DecryptionSettings, TrustRequirement,
-    },
+    crypto::{CollectStrategy, DecryptionSettings, TrustRequirement},
     encryption::{BackupDownloadStrategy, EncryptionSettings},
     event_cache::EventCacheError,
     ruma::{ServerName, UserId},
@@ -22,15 +19,7 @@ use tracing::{debug, error};
 use zeroize::Zeroizing;
 
 use super::client::Client;
-use crate::{
-    authentication::OidcConfiguration,
-    client::ClientSessionDelegate,
-    error::ClientError,
-    helpers::unwrap_or_clone_arc,
-    qr_code::{HumanQrLoginError, QrCodeData, QrLoginProgressListener},
-    runtime::get_runtime_handle,
-    task_handle::TaskHandle,
-};
+use crate::{client::ClientSessionDelegate, error::ClientError, helpers::unwrap_or_clone_arc};
 
 /// A list of bytes containing a certificate in DER or PEM form.
 pub type CertificateBytes = Vec<u8>;
@@ -581,60 +570,6 @@ impl ClientBuilder {
             )
             .await?,
         ))
-    }
-
-    /// Finish the building of the client and attempt to log in using the
-    /// provided [`QrCodeData`].
-    ///
-    /// This method will build the client and immediately attempt to log the
-    /// client in using the provided [`QrCodeData`] using the login
-    /// mechanism described in [MSC4108]. As such this methods requires OAuth
-    /// 2.0 support as well as sliding sync support.
-    ///
-    /// The usage of the progress_listener is required to transfer the
-    /// [`CheckCode`] to the existing client.
-    ///
-    /// [MSC4108]: https://github.com/matrix-org/matrix-spec-proposals/pull/4108
-    pub async fn build_with_qr_code(
-        self: Arc<Self>,
-        qr_code_data: &QrCodeData,
-        oidc_configuration: &OidcConfiguration,
-        progress_listener: Box<dyn QrLoginProgressListener>,
-    ) -> Result<Arc<Client>, HumanQrLoginError> {
-        let QrCodeModeData::Reciprocate { server_name } = &qr_code_data.inner.mode_data else {
-            return Err(HumanQrLoginError::OtherDeviceNotSignedIn);
-        };
-
-        let builder = self.server_name_or_homeserver_url(server_name.to_owned());
-
-        let client = builder.build().await.map_err(|e| match e {
-            ClientBuildError::SlidingSync(_) => HumanQrLoginError::SlidingSyncNotAvailable,
-            _ => {
-                error!("Couldn't build the client {e:?}");
-                HumanQrLoginError::Unknown
-            }
-        })?;
-
-        let registration_data = oidc_configuration
-            .registration_data()
-            .map_err(|_| HumanQrLoginError::OidcMetadataInvalid)?;
-
-        let oauth = client.inner.oauth();
-        let login = oauth.login_with_qr_code(&qr_code_data.inner, Some(&registration_data));
-
-        let mut progress = login.subscribe_to_progress();
-
-        // We create this task, which will get cancelled once it's dropped, just in case
-        // the progress stream doesn't end.
-        let _progress_task = TaskHandle::new(get_runtime_handle().spawn(async move {
-            while let Some(state) = progress.next().await {
-                progress_listener.on_update(state.into());
-            }
-        }));
-
-        login.await?;
-
-        Ok(client)
     }
 }
 


### PR DESCRIPTION
With this PR the FFI's API now matches the SDK and as such allows for checks to be made on the built `Client` before proceeding to log in.

Hopefully the docs make sense, please make any suggestions if they are unclear.
