### PR TITLE
FFI: Pass existing device ID to url_for_oidc

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - `ClientBuilder::build_with_qr_code` has been removed. Instead, the Client should be built by passing
   `QrCodeData::server_name` to `ClientBuilder::server_name_or_homeserver_url`, after which QR login can be performed by
   calling `Client::login_with_qr_code`. ([#5388](https://github.com/matrix-org/matrix-rust-sdk/pull/5388))
+- `Client::url_for_oidc` now allows passing an optional existing device id from a previous login call.
+  ([#5394](https://github.com/matrix-org/matrix-rust-sdk/pull/5394))
 
 ## [0.13.0] - 2025-07-10
 

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -8,11 +8,11 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking changes:
 
+- `Client::url_for_oidc` now allows passing an optional existing device id from a previous login call.
+  ([#5394](https://github.com/matrix-org/matrix-rust-sdk/pull/5394))
 - `ClientBuilder::build_with_qr_code` has been removed. Instead, the Client should be built by passing
   `QrCodeData::server_name` to `ClientBuilder::server_name_or_homeserver_url`, after which QR login can be performed by
   calling `Client::login_with_qr_code`. ([#5388](https://github.com/matrix-org/matrix-rust-sdk/pull/5388))
-- `Client::url_for_oidc` now allows passing an optional existing device id from a previous login call.
-  ([#5394](https://github.com/matrix-org/matrix-rust-sdk/pull/5394))
 
 ## [0.13.0] - 2025-07-10
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -472,7 +472,7 @@ impl Client {
         let registration_data = oidc_configuration.registration_data()?;
         let redirect_uri = oidc_configuration.redirect_uri()?;
 
-        let device_id = device_id.map(|id| OwnedDeviceId::from(id));
+        let device_id = device_id.map(OwnedDeviceId::from);
 
         let mut url_builder =
             self.inner.oauth().login(redirect_uri, device_id, Some(registration_data));


### PR DESCRIPTION
Currently, each time `Client.url_for_oidc` is called, a new device ID is generated as `OAuth.login` is passed `None` as the `device_id` parameter.

This closes #5392.

Signed-off-by: fl0lli <github@fl0lli.de>