### PR TITLE
doc(sdk): Update doc of `SlidingSyncPositionMarkers::pos`

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -815,8 +815,6 @@ impl SlidingSync {
 pub(super) struct SlidingSyncPositionMarkers {
     /// An ephemeral position in the current stream, as received from the
     /// previous `/sync` response, or `None` for the first request.
-    ///
-    /// Should not be persisted.
     pos: Option<String>,
 }
 


### PR DESCRIPTION
With `SlidingSync::share_pos`, the `pos` can be persisted. This comment is outdated.