### PR TITLE
feat(sdk): Add `debug!` log when updating the sliding sync pos

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -364,6 +364,8 @@ impl SlidingSync {
         // Everything went well, we can update the position markers.
         //
         // Save the new position markers.
+        debug!(previous_pos = position.pos, new_pos = pos, "Updating `pos`");
+
         position.pos = pos;
 
         Ok(update_summary)


### PR DESCRIPTION
Does exactly what it says on the tin.