### PR TITLE
refactor(tests): Prefer `EventBuilder::into_raw` to `into_raw_(sync/timeline)` then `Raw::cast`

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -74,7 +74,7 @@ pub fn make_test_event_with_event_id(
     if let Some(event_id) = event_id {
         builder = builder.event_id(event_id);
     }
-    let event = builder.into_raw_timeline().cast();
+    let event = builder.into_raw();
 
     TimelineEvent::from_decrypted(
         DecryptedRoomEvent { event, encryption_info, unsigned_encryption_info: None },

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -92,14 +92,12 @@ async fn test_thread_backpagination() {
             .text_msg("Threaded event 4")
             .event_id(event_id!("$4"))
             .in_thread_reply(&thread_root_event_id, event_id!("$2"))
-            .into_raw_sync()
-            .cast(),
+            .into_raw(),
         factory
             .text_msg("Threaded event 3")
             .event_id(event_id!("$3"))
             .in_thread(&thread_root_event_id, event_id!("$2"))
-            .into_raw_sync()
-            .cast(),
+            .into_raw(),
     ];
 
     let batch2 = vec![
@@ -107,14 +105,12 @@ async fn test_thread_backpagination() {
             .text_msg("Threaded event 2")
             .event_id(event_id!("$2"))
             .in_thread(&thread_root_event_id, event_id!("$1"))
-            .into_raw_sync()
-            .cast(),
+            .into_raw(),
         factory
             .text_msg("Threaded event 1")
             .event_id(event_id!("$1"))
             .in_thread(&thread_root_event_id, event_id!("$root"))
-            .into_raw_sync()
-            .cast(),
+            .into_raw(),
     ];
 
     server

--- a/crates/matrix-sdk/src/room/knock_requests.rs
+++ b/crates/matrix-sdk/src/room/knock_requests.rs
@@ -129,8 +129,7 @@ mod tests {
             .member(user_id)
             .membership(MembershipState::Knock)
             .event_id(event_id)
-            .into_raw_timeline()
-            .cast()]);
+            .into_raw()]);
         let room = server.sync_room(&client, joined_room_builder).await;
 
         let knock_request = make_knock_request(&room, Some(event_id));

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -4193,8 +4193,7 @@ mod tests {
             .member(user_id)
             .membership(MembershipState::Knock)
             .event_id(event_id)
-            .into_raw_timeline()
-            .cast()]);
+            .into_raw()]);
         let room = server.sync_room(&client, joined_room_builder).await;
 
         // When loading the initial seen ids, there are none
@@ -4239,8 +4238,8 @@ mod tests {
         let user_id = user_id!("@example:localhost");
 
         let f = EventFactory::new().room(room_id).sender(user_id!("@alice:b.c"));
-        let joined_room_builder = JoinedRoomBuilder::new(room_id)
-            .add_state_bulk(vec![f.member(user_id).into_raw_sync().cast()]);
+        let joined_room_builder =
+            JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f.member(user_id).into_raw()]);
         let room = server.sync_room(&client, joined_room_builder).await;
 
         // When we load the membership details
@@ -4264,8 +4263,8 @@ mod tests {
         let user_id = user_id!("@example:localhost");
 
         let f = EventFactory::new().room(room_id).sender(user_id);
-        let joined_room_builder = JoinedRoomBuilder::new(room_id)
-            .add_state_bulk(vec![f.member(user_id).into_raw_sync().cast()]);
+        let joined_room_builder =
+            JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f.member(user_id).into_raw()]);
         let room = server.sync_room(&client, joined_room_builder).await;
 
         // When we load the membership details
@@ -4292,9 +4291,9 @@ mod tests {
 
         let f = EventFactory::new().room(room_id).sender(sender_id);
         let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![
-            f.member(user_id).into_raw_sync().cast(),
+            f.member(user_id).into_raw(),
             // The sender info comes from the sync
-            f.member(sender_id).into_raw_sync().cast(),
+            f.member(sender_id).into_raw(),
         ]);
         let room = server.sync_room(&client, joined_room_builder).await;
 
@@ -4321,14 +4320,14 @@ mod tests {
         let sender_id = user_id!("@alice:b.c");
 
         let f = EventFactory::new().room(room_id).sender(sender_id);
-        let joined_room_builder = JoinedRoomBuilder::new(room_id)
-            .add_state_bulk(vec![f.member(user_id).into_raw_sync().cast()]);
+        let joined_room_builder =
+            JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f.member(user_id).into_raw()]);
         let room = server.sync_room(&client, joined_room_builder).await;
 
         // We'll receive the member info through the /members endpoint
         server
             .mock_get_members()
-            .ok(vec![f.member(sender_id).into_raw_timeline().cast()])
+            .ok(vec![f.member(sender_id).into_raw()])
             .mock_once()
             .mount()
             .await;
@@ -4358,8 +4357,8 @@ mod tests {
 
         let eid1 = event_id!("$1");
         let eid2 = event_id!("$2");
-        let batch1 = vec![f.text_msg("Thread root 1").event_id(eid1).into_raw_sync().cast()];
-        let batch2 = vec![f.text_msg("Thread root 2").event_id(eid2).into_raw_sync().cast()];
+        let batch1 = vec![f.text_msg("Thread root 1").event_id(eid1).into_raw()];
+        let batch2 = vec![f.text_msg("Thread root 2").event_id(eid2).into_raw()];
 
         server
             .mock_room_threads()
@@ -4401,8 +4400,8 @@ mod tests {
         let target_event_id = owned_event_id!("$target");
         let eid1 = event_id!("$1");
         let eid2 = event_id!("$2");
-        let batch1 = vec![f.text_msg("Related event 1").event_id(eid1).into_raw_sync().cast()];
-        let batch2 = vec![f.text_msg("Related event 2").event_id(eid2).into_raw_sync().cast()];
+        let batch1 = vec![f.text_msg("Related event 1").event_id(eid1).into_raw()];
+        let batch2 = vec![f.text_msg("Related event 2").event_id(eid2).into_raw()];
 
         server
             .mock_room_relations()
@@ -4462,8 +4461,8 @@ mod tests {
         let target_event_id = owned_event_id!("$target");
         let eid1 = event_id!("$1");
         let eid2 = event_id!("$2");
-        let batch1 = vec![f.text_msg("In-thread event 1").event_id(eid1).into_raw_sync().cast()];
-        let batch2 = vec![f.text_msg("In-thread event 2").event_id(eid2).into_raw_sync().cast()];
+        let batch1 = vec![f.text_msg("In-thread event 1").event_id(eid1).into_raw()];
+        let batch2 = vec![f.text_msg("In-thread event 2").event_id(eid2).into_raw()];
 
         server
             .mock_room_relations()

--- a/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
@@ -397,8 +397,7 @@ async fn test_observing_live_location_does_not_return_own_beacon_updates() {
         .event_id(event_id)
         .sender(user_id)
         .state_key(user_id)
-        .into_raw_timeline()
-        .cast()]);
+        .into_raw()]);
 
     let room = server.sync_room(&client, joined_room_builder).await;
 

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -946,8 +946,7 @@ async fn test_call_notifications_dont_notify_room_with_an_existing_call() {
         ))
         .sender(user_id!("@alice:example.org"))
         .state_key("_@alice:example.org_a-device-id")
-        .into_raw_sync()
-        .cast();
+        .into_raw();
 
     sync_builder.add_joined_room(
         JoinedRoomBuilder::default()
@@ -1042,12 +1041,8 @@ async fn test_subscribe_to_knock_requests() {
 
     let user_id = user_id!("@alice:b.c");
     let knock_event_id = event_id!("$alice-knock:b.c");
-    let knock_event = f
-        .member(user_id)
-        .membership(MembershipState::Knock)
-        .event_id(knock_event_id)
-        .into_raw_timeline()
-        .cast();
+    let knock_event =
+        f.member(user_id).membership(MembershipState::Knock).event_id(knock_event_id).into_raw();
 
     server.mock_get_members().ok(vec![knock_event]).mock_once().mount().await;
 
@@ -1075,11 +1070,8 @@ async fn test_subscribe_to_knock_requests() {
     assert!(seen_knock.is_seen);
 
     // If we then receive a new member event for Alice that's not 'knock'
-    let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f
-        .member(user_id)
-        .membership(MembershipState::Invite)
-        .into_raw_timeline()
-        .cast()]);
+    let joined_room_builder = JoinedRoomBuilder::new(room_id)
+        .add_state_bulk(vec![f.member(user_id).membership(MembershipState::Invite).into_raw()]);
     server.sync_room(&client, joined_room_builder).await;
 
     // The knock requests are now empty because we have new member events
@@ -1115,8 +1107,7 @@ async fn test_subscribe_to_knock_requests_reloads_members_on_limited_sync() {
     let f = EventFactory::new().room(room_id);
 
     let user_id = user_id!("@alice:b.c");
-    let knock_event =
-        f.member(user_id).membership(MembershipState::Knock).into_raw_timeline().cast();
+    let knock_event = f.member(user_id).membership(MembershipState::Knock).into_raw();
 
     server
         .mock_get_members()
@@ -1162,12 +1153,8 @@ async fn test_remove_outdated_seen_knock_requests_ids_when_membership_changed() 
 
     let user_id = user_id!("@alice:b.c");
     let knock_event_id = event_id!("$alice-knock:b.c");
-    let knock_event = f
-        .member(user_id)
-        .membership(MembershipState::Knock)
-        .event_id(knock_event_id)
-        .into_raw_timeline()
-        .cast();
+    let knock_event =
+        f.member(user_id).membership(MembershipState::Knock).event_id(knock_event_id).into_raw();
 
     // When syncing the room, we'll have a knock request coming from alice
     let room = server
@@ -1183,8 +1170,7 @@ async fn test_remove_outdated_seen_knock_requests_ids_when_membership_changed() 
 
     // If we then load the members again and the previously knocking member is in
     // another state now
-    let joined_event =
-        f.member(user_id).membership(MembershipState::Join).into_raw_timeline().cast();
+    let joined_event = f.member(user_id).membership(MembershipState::Join).into_raw();
 
     server.mock_get_members().ok(vec![joined_event]).mock_once().mount().await;
 
@@ -1212,12 +1198,8 @@ async fn test_remove_outdated_seen_knock_requests_ids_when_we_have_an_outdated_k
 
     let user_id = user_id!("@alice:b.c");
     let knock_event_id = event_id!("$alice-knock:b.c");
-    let knock_event = f
-        .member(user_id)
-        .membership(MembershipState::Knock)
-        .event_id(knock_event_id)
-        .into_raw_timeline()
-        .cast();
+    let knock_event =
+        f.member(user_id).membership(MembershipState::Knock).event_id(knock_event_id).into_raw();
 
     // When syncing the room, we'll have a knock request coming from alice
     let room = server
@@ -1237,8 +1219,7 @@ async fn test_remove_outdated_seen_knock_requests_ids_when_we_have_an_outdated_k
         .member(user_id)
         .membership(MembershipState::Knock)
         .event_id(event_id!("$knock-2:b.c"))
-        .into_raw_timeline()
-        .cast();
+        .into_raw();
 
     server.mock_get_members().ok(vec![knock_event]).mock_once().mount().await;
 
@@ -1266,12 +1247,8 @@ async fn test_subscribe_to_knock_requests_clears_seen_ids_on_member_reload() {
 
     let user_id = user_id!("@alice:b.c");
     let knock_event_id = event_id!("$alice-knock:b.c");
-    let knock_event = f
-        .member(user_id)
-        .membership(MembershipState::Knock)
-        .event_id(knock_event_id)
-        .into_raw_timeline()
-        .cast();
+    let knock_event =
+        f.member(user_id).membership(MembershipState::Knock).event_id(knock_event_id).into_raw();
 
     server.mock_get_members().ok(vec![knock_event]).mock_once().mount().await;
 
@@ -1300,8 +1277,7 @@ async fn test_subscribe_to_knock_requests_clears_seen_ids_on_member_reload() {
 
     // If we then load the members again and the previously knocking member is in
     // another state now
-    let joined_event =
-        f.member(user_id).membership(MembershipState::Join).into_raw_timeline().cast();
+    let joined_event = f.member(user_id).membership(MembershipState::Join).into_raw();
 
     server.mock_get_members().ok(vec![joined_event]).mock_once().mount().await;
 
@@ -1347,8 +1323,7 @@ async fn test_room_member_updates_sender_on_full_member_reload() {
         .room(room_id)
         .member(user_id)
         .membership(MembershipState::Join)
-        .into_raw_timeline()
-        .cast();
+        .into_raw();
     server.mock_get_members().ok(vec![joined_event]).mock_once().mount().await;
     room.sync_members().await.expect("could not reload room members");
 
@@ -1374,8 +1349,7 @@ async fn test_room_member_updates_sender_on_partial_members_update() {
         .room(room_id)
         .member(user_id)
         .membership(MembershipState::Join)
-        .into_raw_sync()
-        .cast();
+        .into_raw();
     server
         .sync_room(&client, JoinedRoomBuilder::new(room_id).add_state_bulk(vec![joined_event]))
         .await;


### PR DESCRIPTION
In the main branch of Ruma, a bound was added to `Raw::cast` so that only "safe" casting is allowed. The bound can be ignored by using `Raw::cast_unchecked`, but changing these unnecessary uses now will make the diff smaller later.