### PR TITLE
feat(sqlite): Improve throughput of `SqliteEventCacheStore::load_all_chunks_metadata` by 1140%

### DIFF
--- a/benchmarks/benches/linked_chunk.rs
+++ b/benchmarks/benches/linked_chunk.rs
@@ -187,11 +187,14 @@ fn reading(c: &mut Criterion) {
 
                 while events.peek().is_some() {
                     let events_chunk = events.by_ref().take(80).collect::<Vec<_>>();
+
                     if events_chunk.is_empty() {
                         break;
                     }
+
                     lc.push_items_back(events_chunk);
                     lc.push_gap_back(Gap { prev_token: format!("gap{num_gaps}") });
+
                     num_gaps += 1;
                 }
 
@@ -205,30 +208,47 @@ fn reading(c: &mut Criterion) {
             // Define the throughput.
             group.throughput(Throughput::Elements(num_events));
 
-            // Get a bencher.
-            group.bench_function(BenchmarkId::new(store_name, num_events), |bencher| {
-                // Bench the routine.
-                bencher.to_async(&runtime).iter(|| async {
-                    // Load the last chunk first,
-                    let (last_chunk, chunk_id_gen) =
-                        store.load_last_chunk(linked_chunk_id).await.unwrap();
+            // Bench the lazy loader.
+            group.bench_function(
+                BenchmarkId::new(format!("lazy_loader/{store_name}"), num_events),
+                |bencher| {
+                    // Bench the routine.
+                    bencher.to_async(&runtime).iter(|| async {
+                        // Load the last chunk first,
+                        let (last_chunk, chunk_id_gen) =
+                            store.load_last_chunk(linked_chunk_id).await.unwrap();
 
-                    let mut lc =
-                        lazy_loader::from_last_chunk::<128, _, _>(last_chunk, chunk_id_gen)
-                            .expect("no error when reconstructing the linked chunk")
-                            .expect("there is a linked chunk in the store");
+                        let mut lc =
+                            lazy_loader::from_last_chunk::<128, _, _>(last_chunk, chunk_id_gen)
+                                .expect("no error when reconstructing the linked chunk")
+                                .expect("there is a linked chunk in the store");
 
-                    // Then load until the start of the linked chunk.
-                    let mut cur_chunk_id = lc.chunks().next().unwrap().identifier();
-                    while let Some(prev) =
-                        store.load_previous_chunk(linked_chunk_id, cur_chunk_id).await.unwrap()
-                    {
-                        cur_chunk_id = prev.identifier;
-                        lazy_loader::insert_new_first_chunk(&mut lc, prev)
-                            .expect("no error when linking the previous lazy-loaded chunk");
-                    }
-                })
-            });
+                        // Then load until the start of the linked chunk.
+                        let mut cur_chunk_id = lc.chunks().next().unwrap().identifier();
+                        while let Some(prev) =
+                            store.load_previous_chunk(linked_chunk_id, cur_chunk_id).await.unwrap()
+                        {
+                            cur_chunk_id = prev.identifier;
+                            lazy_loader::insert_new_first_chunk(&mut lc, prev)
+                                .expect("no error when linking the previous lazy-loaded chunk");
+                        }
+                    })
+                },
+            );
+
+            // Bench the metadata loader.
+            group.bench_function(
+                BenchmarkId::new(format!("metadata/{store_name}"), num_events),
+                |bencher| {
+                    // Bench the routine.
+                    bencher.to_async(&runtime).iter(|| async {
+                        let _metadata = store
+                            .load_all_chunks_metadata(linked_chunk_id)
+                            .await
+                            .expect("metadata must load");
+                    })
+                },
+            );
 
             {
                 let _guard = runtime.enter();

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/008_linked_chunk_id.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/008_linked_chunk_id.sql
@@ -41,7 +41,7 @@ CREATE TABLE "event_chunks" (
     -- Primary key is the event ID.
     PRIMARY KEY (event_id),
 
-    -- We need a uniqueness constraint over the linked chunk id, `chunk_id` and
+    -- We need a uniqueness constraint over the `linked_chunk_id`, `chunk_id` and
     -- `position` tuple because (i) they must be unique, (ii) it dramatically
     -- improves the performance.
     UNIQUE (linked_chunk_id, chunk_id, position),


### PR DESCRIPTION
This patch changes the query used by `SqliteEventCacheStore::load_all_chunks_metadata`. It was the cause of severe slowness (see https://github.com/matrix-org/matrix-rust-sdk/pull/5407). The new query improves the throughput by +1140% and the time by -91.916%.

This query will visit all chunks of a linked chunk with ID `hashed_linked_chunk_id`. For each chunk, it collects its ID (`ChunkIdentifier`), previous chunk, next chunk, and number of events (`num_events`). If it's a gap, `num_events` is equal to 0, otherwise it counts the number of events in `event_chunks` where `event_chunks.chunk_id = linked_chunks.id`.

Why not using a `(LEFT) JOIN` + `COUNT`? Because for gaps, the entire `event_chunks` will be traversed every time to always count zero events (a gap has no event). It's extremely inefficient. To speed that up, we could use an `INDEX` but it will consume more storage space. Finally, traversing an `INDEX` boils down to traversing a B-tree, which is O(log n), whilst this `CASE` approach is O(1). This solution is a nice trade-off and offers great performance.

> [!NOTE]
>
> Please, note that the more gaps, the slower the query was. Now, the number of gaps isn't impactful.

This change doesn't involve a new schema, no migration is necessary.

## Metrics for 10'000 events (with 1 gap every 80 events)

### Before

<img width="951" height="363" alt="Screenshot 2025-07-15 at 15 41 22" src="https://github.com/user-attachments/assets/33df809c-541e-4ca3-99c1-00c8cd5f7156" />

<br />

<table>
    <thead>
        <tr>
            <th></th>
            <th title="0.95 confidence level" class="ci-bound">Lower bound</th>
            <th>Estimate</th>
            <th title="0.95 confidence level" class="ci-bound">Upper bound</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>Throughput</td>
            <td class="ci-bound">20.650 Kelem/s</td>
            <td>20.686 Kelem/s</td>
            <td class="ci-bound">20.722 Kelem/s</td>
        </tr>
        <tr>
            <td>R²</td>
            <td class="ci-bound">0.1032688</td>
            <td>0.1374475</td>
            <td class="ci-bound">0.1035309</td>
        </tr>
        <tr>
            <td>Mean</td>
            <td class="ci-bound">482.58 ms</td>
            <td>483.43 ms</td>
            <td class="ci-bound">484.27 ms</td>
        </tr>
        <tr>
            <td title="Standard Deviation">Std. Dev.</td>
            <td class="ci-bound">929.07 µs</td>
            <td>1.4376 ms</td>
            <td class="ci-bound">1.7083 ms</td>
        </tr>
        <tr>
            <td>Median</td>
            <td class="ci-bound">481.90 ms</td>
            <td>483.82 ms</td>
            <td class="ci-bound">484.60 ms</td>
        </tr>
        <tr>
            <td title="Median Absolute Deviation">MAD</td>
            <td class="ci-bound">173.82 µs</td>
            <td>2.1061 ms</td>
            <td class="ci-bound">2.4203 ms</td>
        </tr>
    </tbody>
</table>

### After

<img width="962" height="387" alt="Screenshot 2025-07-15 at 15 41 14" src="https://github.com/user-attachments/assets/618096ab-2e6a-4d57-9a04-15ed2ed88c19" />

<br />

<table>
    <thead>
        <tr>
            <th></th>
            <th title="0.95 confidence level" class="ci-bound">Lower bound</th>
            <th>Estimate</th>
            <th title="0.95 confidence level" class="ci-bound">Upper bound</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>Slope</td>
            <td class="ci-bound">39.322 ms</td>
            <td>39.444 ms</td>
            <td class="ci-bound">39.607 ms</td>
        </tr>
        <tr>
            <td>Throughput</td>
            <td class="ci-bound">252.48 Kelem/s</td>
            <td>253.52 Kelem/s</td>
            <td class="ci-bound">254.31 Kelem/s</td>
        </tr>
        <tr>
            <td>R²</td>
            <td class="ci-bound">0.9993976</td>
            <td>0.9995784</td>
            <td class="ci-bound">0.9992583</td>
        </tr>
        <tr>
            <td>Mean</td>
            <td class="ci-bound">39.381 ms</td>
            <td>39.478 ms</td>
            <td class="ci-bound">39.596 ms</td>
        </tr>
        <tr>
            <td title="Standard Deviation">Std. Dev.</td>
            <td class="ci-bound">75.457 µs</td>
            <td>184.96 µs</td>
            <td class="ci-bound">260.35 µs</td>
        </tr>
        <tr>
            <td>Median</td>
            <td class="ci-bound">39.354 ms</td>
            <td>39.459 ms</td>
            <td class="ci-bound">39.546 ms</td>
        </tr>
        <tr>
            <td title="Median Absolute Deviation">MAD</td>
            <td class="ci-bound">23.761 µs</td>
            <td>124.48 µs</td>
            <td class="ci-bound">267.83 µs</td>
        </tr>
    </tbody>
</table>