### PR TITLE
feat(indexeddb): implement `Event`-related functions in `EventCacheStore`

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
@@ -748,6 +748,13 @@ macro_rules! event_cache_store_integration_tests {
                     get_event_cache_store().await.unwrap().into_event_cache_store();
                 event_cache_store.test_remove_room().await;
             }
+
+            #[async_test]
+            async fn test_filter_duplicated_events() {
+                let event_cache_store =
+                    get_event_cache_store().await.unwrap().into_event_cache_store();
+                event_cache_store.test_filter_duplicated_events().await;
+            }
         }
     };
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
@@ -762,6 +762,13 @@ macro_rules! event_cache_store_integration_tests {
                     get_event_cache_store().await.unwrap().into_event_cache_store();
                 event_cache_store.test_find_event().await;
             }
+
+            #[async_test]
+            async fn test_save_event() {
+                let event_cache_store =
+                    get_event_cache_store().await.unwrap().into_event_cache_store();
+                event_cache_store.test_save_event().await;
+            }
         }
     };
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
@@ -764,6 +764,13 @@ macro_rules! event_cache_store_integration_tests {
             }
 
             #[async_test]
+            async fn test_find_event_relations() {
+                let event_cache_store =
+                    get_event_cache_store().await.unwrap().into_event_cache_store();
+                event_cache_store.test_find_event_relations().await;
+            }
+
+            #[async_test]
             async fn test_save_event() {
                 let event_cache_store =
                     get_event_cache_store().await.unwrap().into_event_cache_store();

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
@@ -755,6 +755,13 @@ macro_rules! event_cache_store_integration_tests {
                     get_event_cache_store().await.unwrap().into_event_cache_store();
                 event_cache_store.test_filter_duplicated_events().await;
             }
+
+            #[async_test]
+            async fn test_find_event() {
+                let event_cache_store =
+                    get_event_cache_store().await.unwrap().into_event_cache_store();
+                event_cache_store.test_find_event().await;
+            }
         }
     };
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -204,7 +204,7 @@ impl_event_cache_store! {
 
                     for (i, item) in items.into_iter().enumerate() {
                         transaction
-                            .add_item(
+                            .put_item(
                                 room_id,
                                 &types::Event::InBand(InBandEvent {
                                     content: item,

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
@@ -417,6 +417,23 @@ pub type IndexedEventPositionIndex = usize;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IndexedEventRelationKey(IndexedRoomId, IndexedEventId, IndexedRelationType);
 
+impl IndexedEventRelationKey {
+    /// Returns an identical key, but with the related event field updated to
+    /// the given related event. This is helpful when searching for all
+    /// events which are related to the given event.
+    pub fn with_related_event_id(
+        &self,
+        related_event_id: &OwnedEventId,
+        serializer: &IndexeddbSerializer,
+    ) -> Self {
+        let room_id = self.0.clone();
+        let related_event_id =
+            serializer.encode_key_as_string(keys::EVENTS_RELATION_RELATED_EVENTS, related_event_id);
+        let relation_type = self.2.clone();
+        Self(room_id, related_event_id, relation_type)
+    }
+}
+
 impl IndexedKey<Event> for IndexedEventRelationKey {
     const INDEX: Option<&'static str> = Some(keys::EVENTS_RELATION);
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -570,6 +570,17 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         self.delete_items_in_room::<Chunk, IndexedChunkIdKey>(room_id).await
     }
 
+    /// Query IndexedDB for events that match the given event id in the given
+    /// room. If more than one item is found, an error is returned.
+    pub async fn get_event_by_id(
+        &self,
+        room_id: &RoomId,
+        event_id: &OwnedEventId,
+    ) -> Result<Option<Event>, IndexeddbEventCacheStoreTransactionError> {
+        let key = self.serializer.encode_key(room_id, event_id);
+        self.get_item_by_key::<Event, IndexedEventIdKey>(room_id, key).await
+    }
+
     /// Query IndexedDB for events in the given position range in the given
     /// room.
     pub async fn get_events_by_position(

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -94,6 +94,16 @@ impl Event {
             Event::OutOfBand(e) => e.relation(),
         }
     }
+
+    /// Sets the content of the underlying [`GenericEvent`] and returns
+    /// the mutated [`Event`]
+    pub fn with_content(mut self, content: TimelineEvent) -> Self {
+        match self {
+            Event::InBand(ref mut i) => i.content = content,
+            Event::OutOfBand(ref mut o) => o.content = content,
+        }
+        self
+    }
 }
 
 /// A generic representation of an


### PR DESCRIPTION
## Background

This pull request is part of a series of pull requests to add a full IndexedDB implementation of the `EventCacheStore` (see #4617, #4996, #5090, #5138, #5226, #5274, #5343, #5384, #5406). This particular pull request focuses on providing implementations for the `Event`-related functions in `EventCacheStore`.

## Changes

The changes include implementations of the following functions, as well as tests for each of them.

- `EventCacheStore::filter_duplicated_events`
- `EventCacheStore::find_event`
- `EventCacheStore::find_event_relations`
- `EventCacheStore::save_event`

I have also added a few other functions which support the implementation of the functions above.

- `IndexedEventRelationKey::set_related_event`
- `IndexeddbEventCacheStoreTransaction::get_event_by_id`
- `IndexeddbEventCacheStoreTransaction::get_events_by_relation`
- `IndexeddbEventCacheStoreTransaction::get_events_by_related_event`

## Bug Fixes

There is also a small change to how `Update::PushItems` is handled. Namely, if a given item already exists in the database, it will update that item, rather than returning an error. The new behavior is consistent with the SQLite implementation of `EventCacheStore` (see [here](https://github.com/matrix-org/matrix-rust-sdk/blob/471e3c340c0c98418fc3c0384c07ecc763d9d596/crates/matrix-sdk-sqlite/src/event_cache_store.rs#L595)).

This bug was surfaced by [`matrix_sdk_base::event_cache::store::integration_tests::test_find_event_relations`](https://github.com/matrix-org/matrix-rust-sdk/blob/471e3c340c0c98418fc3c0384c07ecc763d9d596/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs#L988).

## Future Work

- Add implementation of `EventCacheStore::try_take_leased_lock` functions without relying on `MemoryStore`
- Add implementation of `EventCacheStoreMedia`

---

- [ ] Public API changes documented in changelogs (optional)


Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>