### PR TITLE
Fix for issue #5381: Leaving room leaves predecessors 

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
 
 ### Bug fixes
 
+- `Room.leave()` will now attempt to leave all reachable predecessors too. 
+  ([#5381](https://github.com/matrix-org/matrix-rust-sdk/pull/5381))
 - When joining a room via `Client::join_room_by_id()`, if the client has `enable_share_history_on_invite` enabled,
   we will correctly check for received room key bundles. Previously this was only done when calling `Room::join`.
   ([#5043](https://github.com/matrix-org/matrix-rust-sdk/pull/5043))

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -276,18 +276,6 @@ impl RetryKind {
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
-    /// Error during room.leave().
-    #[error("an error occurred during room leave")]
-    ErrorDuringRoomLeave,
-
-    /// Error doing a get_room(predecessor).
-    #[error("the predecessor is wrong or forgotten")]
-    PredecessorWrongOrForgotten,
-
-    /// Error doing room.leave()
-    #[error("the predecessor is not Joined or Left")]
-    PredecessorWrongState,
-
     /// Error doing an HTTP request.
     #[error(transparent)]
     Http(Box<HttpError>),

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -277,7 +277,7 @@ impl RetryKind {
 #[non_exhaustive]
 pub enum Error {
     /// Error during room.leave().
-    #[error("an error occured during room leave")]
+    #[error("an error occurred during room leave")]
     ErrorDuringRoomLeave,
 
     /// Error doing a get_room(predecessor).

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -276,6 +276,18 @@ impl RetryKind {
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
+    /// Error during room.leave().
+    #[error("an error occured during room leave")]
+    ErrorDuringRoomLeave,
+
+    /// Error doing a get_room(predecessor).
+    #[error("the predecessor is wrong or forgotten")]
+    PredecessorWrongOrForgotten,
+
+    /// Error doing room.leave()
+    #[error("the predecessor is not Joined or Left")]
+    PredecessorWrongState,
+
     /// Error doing an HTTP request.
     #[error(transparent)]
     Http(Box<HttpError>),

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -365,6 +365,11 @@ impl Room {
             }
         }
 
+        if let Some(pred_room) = self.predecessor_room() {
+            let pred = self.client.get_room(&pred_room.room_id).expect("Couldn't find predecessor");
+            Box::pin(pred.leave()).await?;
+        }
+
         Ok(())
     }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -415,17 +415,13 @@ impl Room {
             if let (Err(e), room) = result {
                 if room.room_id() == self.room_id() {
                     maybe_this_room_failed_with = Some(e);
-                    continue;
+                } else {
+                    warn!("Failure while attempting to leave predecessor room: {e:?}");
                 }
-                warn!("{e:?}");
             }
         }
 
-        if let Some(error) = maybe_this_room_failed_with {
-            return Err(error);
-        }
-
-        Ok(())
+        maybe_this_room_failed_with.map_or(Ok(()), Err)
     }
 
     /// Join this room.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -379,6 +379,8 @@ impl Room {
     /// automatically.
     ///
     /// Only invited and joined rooms can be left.
+    /// Will return an error if the current room fails to leave but
+    /// will only warn if a predecessor fails to leave.
     pub async fn leave(&self) -> Result<()> {
         let mut rooms: Vec<Room> = vec![self.clone()];
         let mut current_room = self;

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -414,6 +414,8 @@ impl Room {
                 .iter()
                 .map(|room| match room.state() {
                     RoomState::Joined => Ok(Some(room.leave_this())),
+                    RoomState::Invited => Ok(Some(room.leave_this())),
+                    RoomState::Knocked => Ok(Some(room.leave_this())),
                     RoomState::Left => Ok(None),
                     _ => Err(Error::PredecessorWrongState),
                 })
@@ -423,7 +425,7 @@ impl Room {
                 .collect::<Vec<_>>();
 
             if join_all(batch).await.iter().any(Result::is_err) {
-                error!("Error occured while leaving room.");
+                error!("Error occurred while leaving room.");
                 return Err(Error::ErrorDuringRoomLeave);
             }
         }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -26,7 +26,9 @@ use std::{
 use async_stream::stream;
 use eyeball::SharedObservable;
 use futures_core::Stream;
-use futures_util::{future::join_all, stream::FuturesUnordered};
+use futures_util::{
+    future::join_all, stream as futures_stream, stream::FuturesUnordered, StreamExt,
+};
 use http::StatusCode;
 #[cfg(feature = "e2e-encryption")]
 pub use identity_status_changes::IdentityStatusChanges;
@@ -124,7 +126,6 @@ use ruma::{
 use serde::de::DeserializeOwned;
 use thiserror::Error;
 use tokio::{join, sync::broadcast};
-use tokio_stream::StreamExt;
 use tracing::{debug, error, info, instrument, trace, warn};
 
 use self::futures::{SendAttachment, SendMessageLikeEvent, SendRawMessageLikeEvent};
@@ -317,13 +318,16 @@ impl Room {
     /// Only invited and joined rooms can be left.
     #[doc(alias = "reject_invitation")]
     #[instrument(skip_all, fields(room_id = ?self.inner.room_id()))]
-    async fn leave_this(&self) -> Result<()> {
+    async fn leave_impl(&self) -> (Result<()>, &Room) {
         let state = self.state();
         if state == RoomState::Left {
-            return Err(Error::WrongRoomState(Box::new(WrongRoomState::new(
-                "Joined or Invited",
-                state,
-            ))));
+            return (
+                Err(Error::WrongRoomState(Box::new(WrongRoomState::new(
+                    "Joined or Invited",
+                    state,
+                )))),
+                self,
+            );
         }
 
         // If the room was in Invited state we should also forget it when declining the
@@ -351,11 +355,13 @@ impl Room {
             error!(?error, ignore_error, should_forget, "Failed to leave the room");
 
             if !ignore_error {
-                return Err(error.into());
+                return (Err(error.into()), self);
             }
         }
 
-        self.client.base_client().room_left(self.room_id()).await?;
+        if let Err(e) = self.client.base_client().room_left(self.room_id()).await {
+            return (Err(e.into()), self);
+        }
 
         if should_forget {
             trace!("Trying to forget the room");
@@ -365,7 +371,7 @@ impl Room {
             }
         }
 
-        Ok(())
+        (Ok(()), self)
     }
 
     /// Leave this room and all predecessors.
@@ -375,59 +381,48 @@ impl Room {
     /// Only invited and joined rooms can be left.
     pub async fn leave(&self) -> Result<()> {
         let mut rooms: Vec<Room> = vec![self.clone()];
-        let mut cur_room = self;
+        let mut current_room = self;
 
-        'leave_aggregate_loop: loop {
-            let pred = cur_room.predecessor_room();
-            let pred = pred.map(|this_pred| {
-                cur_room
-                    .client
-                    .get_room(&this_pred.room_id)
-                    .ok_or(Error::PredecessorWrongOrForgotten)
-            });
+        while let Some(predecessor) = current_room.predecessor_room() {
+            let maybe_predecessor_room = current_room.client.get_room(&predecessor.room_id);
 
-            match pred {
-                None => break 'leave_aggregate_loop,
-                Some(room) => match room {
-                    Ok(room) => {
-                        rooms.push(room);
-                        cur_room = rooms.last().expect("rooms just pushed so can't be empty");
-                    }
-                    Err(e) => {
-                        debug!("Tombstone following terminated early: {e:?}");
-                        break 'leave_aggregate_loop;
-                    }
-                },
+            if let Some(predecessor_room) = maybe_predecessor_room {
+                rooms.push(predecessor_room.clone());
+                current_room = rooms.last().expect("Room just pushed so can't be empty");
+            } else {
+                warn!("Cannot find predecessor room");
+                break;
             }
         }
 
-        let mut rooms_iter = rooms.into_iter();
         let batch_size = 5;
 
-        'leave_action_loop: loop {
-            let batch: Vec<Room> = rooms_iter.by_ref().take(batch_size).collect();
-            if batch.is_empty() {
-                break 'leave_action_loop;
-            }
+        let rooms_futures: Vec<_> = rooms
+            .iter()
+            .filter_map(|room| match room.state() {
+                RoomState::Joined | RoomState::Invited | RoomState::Knocked => {
+                    Some(room.leave_impl())
+                }
+                RoomState::Banned | RoomState::Left => None,
+            })
+            .collect();
 
-            let batch = batch
-                .iter()
-                .map(|room| match room.state() {
-                    RoomState::Joined => Ok(Some(room.leave_this())),
-                    RoomState::Invited => Ok(Some(room.leave_this())),
-                    RoomState::Knocked => Ok(Some(room.leave_this())),
-                    RoomState::Left => Ok(None),
-                    _ => Err(Error::PredecessorWrongState),
-                })
-                .collect::<Result<Vec<Option<_>>, _>>()?
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>();
+        let mut futures_stream = futures_stream::iter(rooms_futures).buffer_unordered(batch_size);
 
-            if join_all(batch).await.iter().any(Result::is_err) {
-                error!("Error occurred while leaving room.");
-                return Err(Error::ErrorDuringRoomLeave);
+        let mut maybe_this_room_failed_with: Option<Error> = None;
+
+        while let Some(result) = futures_stream.next().await {
+            if let (Err(e), room) = result {
+                if room.room_id() == self.room_id() {
+                    maybe_this_room_failed_with = Some(e);
+                    continue;
+                }
+                warn!("{e:?}");
             }
+        }
+
+        if let Some(error) = maybe_this_room_failed_with {
+            return Err(error);
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -3465,7 +3465,7 @@ pub struct UpgradeRoomEndpoint;
 
 impl<'a> MockEndpoint<'a, UpgradeRoomEndpoint> {
     /// Returns a successful response with desired replacement_room ID.
-    pub fn ok_with(self, new_room_id: &RoomId) -> MatrixMock<'a> {       
+    pub fn ok_with(self, new_room_id: &RoomId) -> MatrixMock<'a> {
         self.respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(json!({ "replacement_room": new_room_id.as_str()})),

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1228,6 +1228,13 @@ impl MatrixMockServer {
         self.mock_endpoint(mock, CreateRoomEndpoint).expect_default_access_token()
     }
 
+    /// Create a prebuilt mock for the endpoint used to upgrade a room.
+    pub fn mock_upgrade_room(&self) -> MockEndpoint<'_, UpgradeRoomEndpoint> {
+        let mock =
+            Mock::given(method("POST")).and(path_regex("/_matrix/client/v3/rooms/.*/upgrade"));
+        self.mock_endpoint(mock, UpgradeRoomEndpoint).expect_default_access_token()
+    }
+
     /// Create a prebuilt mock for the endpoint used to pre-allocate a MXC URI
     /// for a media file.
     pub fn mock_media_allocate(&self) -> MockEndpoint<'_, MediaAllocateEndpoint> {
@@ -2951,6 +2958,11 @@ impl<'a> MockEndpoint<'a, RoomLeaveEndpoint> {
         })))
     }
 
+    /// Returns a successful given response
+    pub fn ok_with(self, response: ResponseTemplate) -> MatrixMock<'a> {
+        self.respond_with(response)
+    }
+
     /// Returns a `M_FORBIDDEN` response.
     pub fn forbidden(self) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(403).set_body_json(json!({
@@ -3255,9 +3267,6 @@ impl<'a> MockEndpoint<'a, LoginEndpoint> {
 
     /// Returns a given response on POST /login requests
     ///
-    /// This function
-    /// to-device messages sent via the `/sendToDevice` endpoint.
-    ///
     /// # Arguments
     ///
     /// * `response` - The response that the mock server sends on POST /login
@@ -3447,6 +3456,19 @@ impl<'a> MockEndpoint<'a, CreateRoomEndpoint> {
     pub fn ok(self) -> MatrixMock<'a> {
         self.respond_with(
             ResponseTemplate::new(200).set_body_json(json!({ "room_id": "!room:example.org"})),
+        )
+    }
+}
+
+/// A prebuilt mock for `POST /rooms/{roomId}/upgrade` requests.
+pub struct UpgradeRoomEndpoint;
+
+impl<'a> MockEndpoint<'a, UpgradeRoomEndpoint> {
+    /// Returns a successful response with desired replacement_room ID.
+    pub fn ok_with(self, new_room_id: &RoomId) -> MatrixMock<'a> {       
+        self.respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!({ "replacement_room": new_room_id.as_str()})),
         )
     }
 }

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -2958,11 +2958,6 @@ impl<'a> MockEndpoint<'a, RoomLeaveEndpoint> {
         })))
     }
 
-    /// Returns a successful given response
-    pub fn ok_with(self, response: ResponseTemplate) -> MatrixMock<'a> {
-        self.respond_with(response)
-    }
-
     /// Returns a `M_FORBIDDEN` response.
     pub fn forbidden(self) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(403).set_body_json(json!({

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -231,7 +231,7 @@ async fn test_leave_room_also_leaves_predecessor() -> Result<(), anyhow::Error> 
                     JoinedRoomBuilder::new(room_b_id).add_state_event(
                         EventFactory::new()
                             .create(user, RoomVersionId::V2)
-                            .predecessor(room_a_id, create_room_a_event_id)
+                            .predecessor(room_a_id)
                             .room(room_b_id)
                             .sender(user)
                             .event_id(create_room_b_event_id),
@@ -307,7 +307,7 @@ async fn test_leave_predecessor_before_successor_no_error() -> Result<(), anyhow
                     JoinedRoomBuilder::new(room_b_id).add_state_event(
                         EventFactory::new()
                             .create(user, RoomVersionId::V2)
-                            .predecessor(room_a_id, create_room_a_event_id)
+                            .predecessor(room_a_id)
                             .room(room_b_id)
                             .sender(user)
                             .event_id(create_room_b_event_id),
@@ -351,7 +351,6 @@ async fn test_leave_room_with_fake_predecessor_no_error() -> Result<(), anyhow::
     let user = user_id!("@example:localhost");
     let room_id = room_id!("!room_id:localhost");
     let fake_room_id = room_id!("!fake_room_id:localhost");
-    let create_fake_room_event_id = event_id!("$create_fake_room_event_id:localhost");
     let create_room_event_id = event_id!("$create_room_event_id:localhost");
 
     server
@@ -361,7 +360,7 @@ async fn test_leave_room_with_fake_predecessor_no_error() -> Result<(), anyhow::
                 JoinedRoomBuilder::new(room_id).add_state_event(
                     EventFactory::new()
                         .create(user, RoomVersionId::V2)
-                        .predecessor(fake_room_id, create_fake_room_event_id)
+                        .predecessor(fake_room_id)
                         .room(room_id)
                         .sender(user)
                         .event_id(create_room_event_id),

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -189,12 +189,12 @@ async fn test_leave_room_also_leaves_predecessor() -> Result<(), anyhow::Error> 
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
 
-    let user/*: &UserId */ = user_id!("@example:localhost");
-    let room_a_id/*: &RoomId */ = room_id!("!room_a_id:localhost");
-    let room_b_id/*: &RoomId */ = room_id!("!room_b_id:localhost");
-    let create_room_a_event_id/*: &EventId */ = event_id!("$create_room_a_event_id:localhost");
-    let tombstone_room_a_event_id/*: &EventId */ = event_id!("$tombstone_room_a_event_id:localhost");
-    let create_room_b_event_id/*: &EventId */ = event_id!("$create_room_b_event_id:localhost");
+    let user = user_id!("@example:localhost");
+    let room_a_id = room_id!("!room_a_id:localhost");
+    let room_b_id = room_id!("!room_b_id:localhost");
+    let create_room_a_event_id = event_id!("$create_room_a_event_id:localhost");
+    let tombstone_room_a_event_id = event_id!("$tombstone_room_a_event_id:localhost");
+    let create_room_b_event_id = event_id!("$create_room_b_event_id:localhost");
 
     server
         .mock_sync()
@@ -247,11 +247,7 @@ async fn test_leave_room_also_leaves_predecessor() -> Result<(), anyhow::Error> 
 
     let room_b = client.get_room(room_b_id).expect("Room B not created");
 
-    server
-        .mock_room_leave()
-        .ok_with(ResponseTemplate::new(200).set_body_json(&*test_json::EMPTY))
-        .mount()
-        .await;
+    server.mock_room_leave().ok(room_b_id).mount().await;
 
     assert_eq!(room_a.state(), RoomState::Joined, "Room A not Joined");
     assert_eq!(room_b.state(), RoomState::Joined, "Room B not Joined");

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -24,7 +24,10 @@ use matrix_sdk_test::{
     StateTestEvent, SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
 };
 use ruma::{
-    api::client::{membership::Invite3pidInit, receipt::create_receipt::v3::ReceiptType},
+    api::client::{
+        membership::Invite3pidInit, receipt::create_receipt::v3::ReceiptType,
+        room::upgrade_room::v3::Request as UpgradeRoomRequest,
+    },
     assign, event_id,
     events::{
         call::{
@@ -43,7 +46,7 @@ use ruma::{
         Mentions, RoomAccountDataEventType, TimelineEventType,
     },
     int, mxc_uri, owned_device_id, owned_event_id, room_id, thirdparty, user_id, OwnedUserId,
-    TransactionId,
+    RoomVersionId, TransactionId,
 };
 use serde_json::{from_value, json, Value};
 use stream_assert::assert_pending;
@@ -177,6 +180,86 @@ async fn test_leave_invited_room_also_forgets_it() -> Result<(), anyhow::Error> 
 
     let forgotten_room = client.get_room(room_id);
     assert!(forgotten_room.is_none());
+
+    Ok(())
+}
+
+#[async_test]
+async fn test_leave_room_also_leaves_predecessor() -> Result<(), anyhow::Error> {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let user/*: &UserId */ = user_id!("@example:localhost");
+    let room_a_id/*: &RoomId */ = room_id!("!room_a_id:localhost");
+    let room_b_id/*: &RoomId */ = room_id!("!room_b_id:localhost");
+    let create_room_a_event_id/*: &EventId */ = event_id!("$create_room_a_event_id:localhost");
+    let tombstone_room_a_event_id/*: &EventId */ = event_id!("$tombstone_room_a_event_id:localhost");
+    let create_room_b_event_id/*: &EventId */ = event_id!("$create_room_b_event_id:localhost");
+
+    server
+        .mock_sync()
+        .ok_and_run(&client, |builder| {
+            builder.add_joined_room(
+                JoinedRoomBuilder::new(room_a_id).add_state_event(
+                    EventFactory::new()
+                        .create(user, RoomVersionId::V1)
+                        .room(room_a_id)
+                        .sender(user)
+                        .event_id(create_room_a_event_id),
+                ),
+            );
+        })
+        .await;
+
+    let room_a = client.get_room(room_a_id).expect("Room A not created");
+
+    server.mock_upgrade_room().ok_with(room_b_id).mount().await;
+    server
+        .mock_sync()
+        .ok_and_run(&client, |builder| {
+            builder
+                .add_joined_room(
+                    JoinedRoomBuilder::new(room_a_id).add_state_event(
+                        EventFactory::new()
+                            .room_tombstone("This room (A) repelaced by Room B!", room_b_id)
+                            .room(room_a_id)
+                            .sender(user)
+                            .event_id(tombstone_room_a_event_id),
+                    ),
+                )
+                .add_joined_room(
+                    JoinedRoomBuilder::new(room_b_id).add_state_event(
+                        EventFactory::new()
+                            .create(user, RoomVersionId::V2)
+                            .predecessor(room_a_id, create_room_a_event_id)
+                            .room(room_b_id)
+                            .sender(user)
+                            .event_id(create_room_b_event_id),
+                    ),
+                );
+        })
+        .await;
+
+    let upgrade_req = UpgradeRoomRequest::new(room_a_id.to_owned(), RoomVersionId::V11);
+    let _response = client.send(upgrade_req).await?;
+
+    assert!(room_a.is_tombstoned(), "Room A not tombstoned.");
+
+    let room_b = client.get_room(room_b_id).expect("Room B not created");
+
+    server
+        .mock_room_leave()
+        .ok_with(ResponseTemplate::new(200).set_body_json(&*test_json::EMPTY))
+        .mount()
+        .await;
+
+    assert_eq!(room_a.state(), RoomState::Joined, "Room A not Joined");
+    assert_eq!(room_b.state(), RoomState::Joined, "Room B not Joined");
+
+    room_b.leave().await?;
+
+    assert_eq!(room_b.state(), RoomState::Left, "Room B not Left");
+    assert_eq!(room_a.state(), RoomState::Left, "Room A not Left");
 
     Ok(())
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Made the ```Room.leave``` function recursive to leave predecessor rooms. Also added an integration test to check this.  

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Shrey Patel shreyp@element.io 
