### PR TITLE
task(sliding_sync): Avoid logging the entire sliding sync response at the DEBUG level

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -293,7 +293,7 @@ impl SlidingSync {
         };
 
         debug!("Sliding Sync response has been handled by the client");
-        trace!(?sync_response, "Sliding sync response");
+        trace!(?sync_response);
 
         // Commit sticky parameters, if needed.
         if let Some(ref txn_id) = sliding_sync_response.txn_id {

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -292,7 +292,8 @@ impl SlidingSync {
             response_processor.process_and_take_response().await?
         };
 
-        debug!(?sync_response, "Sliding Sync response has been handled by the client");
+        debug!("Sliding Sync response has been handled by the client");
+        trace!(?sync_response, "Sliding sync response");
 
         // Commit sticky parameters, if needed.
         if let Some(ref txn_id) = sliding_sync_response.txn_id {


### PR DESCRIPTION
As discussed in the [dev room](https://matrix.to/#/#matrix-rust-sdk-dev:flipdot.org), don't log so much data at DEBUG level.

I left in a small `debug` message since it seems like it might be helpful, but made the response dump be TRACE.