### PR TITLE
refactor: Clean up some uses of `Raw`.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -75,7 +75,6 @@ use ruma::{
         },
         tag::TagEventContent,
         GlobalAccountDataEvent as RumaGlobalAccountDataEvent,
-        GlobalAccountDataEventType as RumaGlobalAccountDataEventType,
         RoomAccountDataEvent as RumaRoomAccountDataEvent,
     },
     push::{HttpPusherData as RumaHttpPusherData, PushFormat as RumaPushFormat},
@@ -1253,13 +1252,10 @@ impl Client {
     // Ignored users
 
     pub async fn ignored_users(&self) -> Result<Vec<String>, ClientError> {
-        if let Some(raw_content) = self
-            .inner
-            .account()
-            .fetch_account_data(RumaGlobalAccountDataEventType::IgnoredUserList)
-            .await?
+        if let Some(raw_content) =
+            self.inner.account().fetch_account_data_static::<IgnoredUserListEventContent>().await?
         {
-            let content = raw_content.deserialize_as::<IgnoredUserListEventContent>()?;
+            let content = raw_content.deserialize()?;
             let user_ids: Vec<String> =
                 content.ignored_users.keys().map(|id| id.to_string()).collect();
 

--- a/crates/matrix-sdk-crypto/src/types/events/room_key_withheld.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key_withheld.rs
@@ -585,8 +585,7 @@ pub(super) mod tests {
             sender_key,
             device_id.to_owned(),
         );
-        let content: Raw<RoomKeyWithheldContent> =
-            Raw::new(&content).expect("We can always serialize a withheld content info").cast();
+        let content = Raw::new(&content).expect("We can always serialize a withheld content info");
 
         messages
             .entry(user_id.to_owned())

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -146,7 +146,7 @@ impl EventTimelineItem {
         let raw_sync_event = latest_event.event().raw().clone();
         let encryption_info = latest_event.event().encryption_info().cloned();
 
-        let Ok(event) = raw_sync_event.deserialize_as::<AnySyncTimelineEvent>() else {
+        let Ok(event) = raw_sync_event.deserialize() else {
             warn!("Unable to deserialize latest_event as an AnySyncTimelineEvent!");
             return None;
         };

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -660,7 +660,7 @@ async fn mock_events_endpoint(
             .mock_room_event()
             .room(room_id.to_owned())
             .match_event_id()
-            .ok(TimelineEvent::from_plaintext(event.cast()))
+            .ok(TimelineEvent::from_plaintext(event))
             .mount()
             .await;
     }

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add `Account::fetch_account_data_static` to fetch account data from the server
+  with a statically-known type, with a signature similar to
+  `Account::account_data`.
+  ([#5424](https://github.com/matrix-org/matrix-rust-sdk/pull/5424))
 - Add support to accept historic room key bundles that arrive out of order, i.e.
   the bundle arrives after the invite has already been accepted.
   ([#5322](https://github.com/matrix-org/matrix-rust-sdk/pull/5322))

--- a/crates/matrix-sdk/src/encryption/recovery/mod.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/mod.rs
@@ -408,7 +408,7 @@ impl Recovery {
     /// # let client = Client::new(homeserver).await?;
     /// # let user_id = unimplemented!();
     /// let encryption = client.encryption();
-    ///       
+    ///
     /// if let Some(handle) = encryption.recovery().reset_identity().await? {
     ///     match handle.auth_type() {
     ///         CrossSigningResetAuthType::Uiaa(uiaa) => {
@@ -592,14 +592,9 @@ impl Recovery {
         Ok(self
             .client
             .account()
-            .fetch_account_data(BackupDisabledContent::event_type())
+            .fetch_account_data_static::<BackupDisabledContent>()
             .await?
-            .map(|event| {
-                event
-                    .deserialize_as::<BackupDisabledContent>()
-                    .map(|event| event.disabled)
-                    .unwrap_or(false)
-            })
+            .map(|event| event.deserialize().map(|event| event.disabled).unwrap_or(false))
             .unwrap_or(false))
     }
 

--- a/crates/matrix-sdk/src/encryption/recovery/types.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/types.rs
@@ -13,10 +13,7 @@
 // limitations under the License.
 
 use matrix_sdk_base::crypto::store::types::RoomKeyCounts;
-use ruma::{
-    events::{EventContent, GlobalAccountDataEventType},
-    exports::ruma_macros::EventContent,
-};
+use ruma::exports::ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -114,13 +111,4 @@ pub(super) struct SecretStorageDisabledContent {}
 #[ruma_event(type = "m.org.matrix.custom.backup_disabled", kind = GlobalAccountData)]
 pub(super) struct BackupDisabledContent {
     pub disabled: bool,
-}
-
-impl BackupDisabledContent {
-    /// Get the event type of the [`BackupDisabledContent`] global account data
-    /// event.
-    pub(super) fn event_type() -> GlobalAccountDataEventType {
-        // This is dumb, there's got to be a better way to get to the event type?
-        Self { disabled: false }.event_type()
-    }
 }

--- a/crates/matrix-sdk/src/encryption/secret_storage/mod.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/mod.rs
@@ -283,12 +283,9 @@ impl SecretStorage {
     pub async fn fetch_default_key_id(
         &self,
     ) -> crate::Result<Option<Raw<SecretStorageDefaultKeyEventContent>>> {
-        let maybe_default_key_id = self
-            .client
+        self.client
             .account()
-            .fetch_account_data(GlobalAccountDataEventType::SecretStorageDefaultKey)
-            .await?;
-
-        Ok(maybe_default_key_id.map(|event| event.cast()))
+            .fetch_account_data_static::<SecretStorageDefaultKeyEventContent>()
+            .await
     }
 }

--- a/crates/matrix-sdk/src/encryption/secret_storage/mod.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/mod.rs
@@ -192,8 +192,7 @@ impl SecretStorage {
         let maybe_default_key_id = self.fetch_default_key_id().await?;
 
         if let Some(default_key_id) = maybe_default_key_id {
-            let default_key_id =
-                default_key_id.deserialize_as::<SecretStorageDefaultKeyEventContent>()?;
+            let default_key_id = default_key_id.deserialize()?;
 
             let event_type =
                 GlobalAccountDataEventType::SecretStorageKey(default_key_id.key_id.to_owned());
@@ -273,7 +272,7 @@ impl SecretStorage {
         if let Some(content) = self.fetch_default_key_id().await? {
             // Since we can't delete account data events, we're going to treat
             // deserialization failures as secret storage being disabled.
-            Ok(content.deserialize_as::<SecretStorageDefaultKeyEventContent>().is_ok())
+            Ok(content.deserialize().is_ok())
         } else {
             // No account data event found, must be disabled.
             Ok(false)

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -216,7 +216,7 @@ impl MatrixDriver {
         let room_id = self.room.room_id().to_owned();
 
         let handle = self.room.add_event_handler(move |raw: Raw<AnySyncTimelineEvent>| {
-            let _ = tx.send(attach_room_id(raw.cast_ref(), &room_id));
+            let _ = tx.send(attach_room_id(&raw, &room_id));
             async {}
         });
         let drop_guard = self.room.client().event_handler_drop_guard(handle);


### PR DESCRIPTION
This will allow to have a slightly smaller diff when bumping Ruma.

It also adds `Account::fetch_account_data_static()` to allow to fetch account data using a statically-known type.

This can be reviewed commit by commit. The commit messages have more details about what is happening.