### PR TITLE
contrib: Set our check command to check instead of clippy

### DIFF
--- a/contrib/ide/vscode/settings.json
+++ b/contrib/ide/vscode/settings.json
@@ -1,4 +1,4 @@
 {
-  "rust-analyzer.checkOnSave.command": "clippy",
+  "rust-analyzer.checkOnSave.command": "check",
   "rust-analyzer.rustfmt.extraArgs": ["+nightly"]
 }


### PR DESCRIPTION
Clippy is a bit too heavy to be used as the check on save command in this repo.

Let's set a better default.