### PR TITLE
refactor: Add `read_timeout` for HTTP requests, make `timeout` optional

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -133,6 +133,11 @@ pub struct ClientBuilder {
     threads_enabled: bool,
 }
 
+/// The timeout applies to each read operation, and resets after a successful
+/// read. This is more appropriate for detecting stalled connections when the
+/// size isn’t known beforehand.
+const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(60);
+
 #[matrix_sdk_ffi_macros::export]
 impl ClientBuilder {
     #[uniffi::constructor]
@@ -539,6 +544,7 @@ impl ClientBuilder {
             if let Some(timeout) = config.timeout {
                 updated_config = updated_config.timeout(Duration::from_millis(timeout));
             }
+            updated_config = updated_config.read_timeout(DEFAULT_READ_TIMEOUT);
             if let Some(max_concurrent_requests) = config.max_concurrent_requests {
                 if max_concurrent_requests > 0 {
                     updated_config = updated_config.max_concurrent_requests(NonZeroUsize::new(

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -31,6 +31,13 @@ All notable changes to this project will be documented in this file.
 - [**breaking**] The MSRV has been bumped to Rust 1.88.
   ([#5431](https://github.com/matrix-org/matrix-rust-sdk/pull/5431))
 
+### Bugfix
+
+- All HTTP requests now have a default `read_timeout` of 60s, which means they'll disconnect if the connection stalls.
+ `RequestConfig::timeout` is now optional and can be disabled on a per-request basis. This will be done for
+ the requests used to download media, so they don't get cancelled after the default 30s timeout for no good reason. 
+ ([#5437](https://github.com/matrix-org/matrix-rust-sdk/pull/5437))
+
 ## [0.13.0] - 2025-07-10
 
 ### Security Fixes

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -20,6 +20,7 @@ use std::{
     future::{ready, Future},
     pin::Pin,
     sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock, Weak},
+    time::Duration,
 };
 
 use caches::ClientCaches;
@@ -2312,7 +2313,8 @@ impl Client {
         });
         let mut request_config = self.request_config();
         if let Some(timeout) = sync_settings.timeout {
-            request_config.timeout = Some(timeout);
+            let base_timeout = request_config.timeout.unwrap_or(Duration::from_secs(30));
+            request_config.timeout = Some(base_timeout + timeout);
         }
 
         let response = self.send(request).with_request_config(request_config).await?;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2312,7 +2312,7 @@ impl Client {
         });
         let mut request_config = self.request_config();
         if let Some(timeout) = sync_settings.timeout {
-            request_config.timeout += timeout;
+            request_config.timeout = Some(timeout);
         }
 
         let response = self.send(request).with_request_config(request_config).await?;

--- a/crates/matrix-sdk/src/config/request.rs
+++ b/crates/matrix-sdk/src/config/request.rs
@@ -44,6 +44,7 @@ use crate::http_client::DEFAULT_REQUEST_TIMEOUT;
 #[derive(Copy, Clone)]
 pub struct RequestConfig {
     pub(crate) timeout: Duration,
+    pub(crate) timeout: Option<Duration>,
     pub(crate) retry_limit: Option<usize>,
     pub(crate) max_retry_time: Option<Duration>,
     pub(crate) max_concurrent_requests: Option<NonZeroUsize>,
@@ -82,6 +83,7 @@ impl Default for RequestConfig {
     fn default() -> Self {
         Self {
             timeout: DEFAULT_REQUEST_TIMEOUT,
+            timeout: Some(DEFAULT_REQUEST_TIMEOUT),
             retry_limit: Default::default(),
             max_retry_time: Default::default(),
             max_concurrent_requests: Default::default(),
@@ -132,8 +134,8 @@ impl RequestConfig {
 
     /// Set the timeout duration for all HTTP requests.
     #[must_use]
-    pub fn timeout(mut self, timeout: Duration) -> Self {
-        self.timeout = timeout;
+    pub fn timeout(mut self, timeout: impl Into<Option<Duration>>) -> Self {
+        self.timeout = timeout.into();
         self
     }
 

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -185,6 +185,10 @@ impl HttpSettings {
             http_client = http_client.timeout(timeout);
         }
 
+        if let Some(read_timeout) = self.read_timeout {
+            http_client = http_client.read_timeout(read_timeout);
+        }
+
         if self.disable_ssl_verification {
             warn!("SSL verification disabled in the HTTP client!");
             http_client = http_client.danger_accept_invalid_certs(true)


### PR DESCRIPTION
Having the `read_timeout` value set allows us to have long network requests that will get cancelled automatically when no data is received for a certain amount of time.

If we combine it with being able to remove the existing default `timeout` value for some requests, it would fix the issue with downloading large files in poor network connectivity scenarios where the download would just cancel automatically after the timeout (30s) was reached.

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
