### PR TITLE
feat(sdk): add support for thread subscription endpoints (MSC4306)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4483,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.5"
-source = "git+https://github.com/ruma/ruma?rev=de19ebaf71af620eb17abaefd92e43153f9d041d#de19ebaf71af620eb17abaefd92e43153f9d041d"
+source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
 dependencies = [
  "assign",
  "js_int",
@@ -4499,7 +4499,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.4"
-source = "git+https://github.com/ruma/ruma?rev=de19ebaf71af620eb17abaefd92e43153f9d041d#de19ebaf71af620eb17abaefd92e43153f9d041d"
+source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
 dependencies = [
  "as_variant",
  "assign",
@@ -4522,7 +4522,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.4"
-source = "git+https://github.com/ruma/ruma?rev=de19ebaf71af620eb17abaefd92e43153f9d041d#de19ebaf71af620eb17abaefd92e43153f9d041d"
+source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
 dependencies = [
  "as_variant",
  "base64",
@@ -4555,7 +4555,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.4"
-source = "git+https://github.com/ruma/ruma?rev=de19ebaf71af620eb17abaefd92e43153f9d041d#de19ebaf71af620eb17abaefd92e43153f9d041d"
+source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.2"
-source = "git+https://github.com/ruma/ruma?rev=de19ebaf71af620eb17abaefd92e43153f9d041d#de19ebaf71af620eb17abaefd92e43153f9d041d"
+source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
 dependencies = [
  "headers",
  "http",
@@ -4599,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.1"
-source = "git+https://github.com/ruma/ruma?rev=de19ebaf71af620eb17abaefd92e43153f9d041d#de19ebaf71af620eb17abaefd92e43153f9d041d"
+source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4610,7 +4610,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=de19ebaf71af620eb17abaefd92e43153f9d041d#de19ebaf71af620eb17abaefd92e43153f9d041d"
+source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
 dependencies = [
  "js_int",
  "thiserror 2.0.11",
@@ -4619,7 +4619,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.2"
-source = "git+https://github.com/ruma/ruma?rev=de19ebaf71af620eb17abaefd92e43153f9d041d#de19ebaf71af620eb17abaefd92e43153f9d041d"
+source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "184d4f85b201bc1e932a8344d7
     "unstable-msc4171",
     "unstable-msc4278",
     "unstable-msc4286",
+    "unstable-msc4306"
 ] }
 ruma-common = { git = "https://github.com/ruma/ruma", rev = "184d4f85b201bc1e932a8344d78575e826f31efa" }
 sentry = "0.36.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 rand = "0.8.5"
 reqwest = { version = "0.12.12", default-features = false }
 rmp-serde = "1.3.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "de19ebaf71af620eb17abaefd92e43153f9d041d", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "184d4f85b201bc1e932a8344d78575e826f31efa", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-arbitrary-length-ids",
@@ -77,7 +77,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "de19ebaf71af620eb17abaefd9
     "unstable-msc4278",
     "unstable-msc4286",
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "de19ebaf71af620eb17abaefd92e43153f9d041d" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "184d4f85b201bc1e932a8344d78575e826f31efa" }
 sentry = "0.36.0"
 sentry-tracing = "0.36.0"
 serde = { version = "1.0.217", features = ["rc"] }

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Features:
 
+- Add experimental support for
+  [MSC4306](https://github.com/matrix-org/matrix-spec-proposals/pull/4306), with the
+  `Room::fetch_thread_subscription()` and `Room::set_thread_subscription()` methods.
+  ([#5442](https://github.com/matrix-org/matrix-rust-sdk/pull/5442))
 - [**breaking**] [`GalleryUploadParameters::reply`] and [`UploadParameters::reply`] have been both
   replaced with a new optional `in_reply_to` field, that's a string which will be parsed into an
   `OwnedEventId` when sending the event. The thread relationship will be automatically filled in,

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add experimental support for
+  [MSC4306](https://github.com/matrix-org/matrix-spec-proposals/pull/4306), with the
+  `Room::fetch_thread_subscription()`, `Room::subscribe_thread()` and `Room::unsubscribe_thread()`
+  methods.
+  ([#5442](https://github.com/matrix-org/matrix-rust-sdk/pull/5442))
 - [**breaking**] `RoomMemberRole` has a new `Creator` variant, that
   differentiates room creators with infinite power levels, as introduced in room
   version 12.

--- a/crates/matrix-sdk/tests/integration/room/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/mod.rs
@@ -7,3 +7,4 @@ mod left;
 mod notification_mode;
 mod spaces;
 mod tags;
+mod thread;

--- a/crates/matrix-sdk/tests/integration/room/thread.rs
+++ b/crates/matrix-sdk/tests/integration/room/thread.rs
@@ -1,0 +1,57 @@
+use matrix_sdk::test_utils::mocks::MatrixMockServer;
+use matrix_sdk_test::async_test;
+use ruma::{owned_event_id, room_id};
+
+#[async_test]
+async fn test_subscribe_thread() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!test:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    let root_id = owned_event_id!("$root");
+
+    server
+        .mock_put_thread_subscription()
+        .match_room_id(room_id.to_owned())
+        .match_thread_id(root_id.clone())
+        .ok()
+        .mock_once()
+        .mount()
+        .await;
+
+    // I can subscribe to a thread.
+    room.subscribe_thread(root_id.clone(), true).await.unwrap();
+
+    server
+        .mock_get_thread_subscription()
+        .match_room_id(room_id.to_owned())
+        .match_thread_id(root_id.clone())
+        .ok(true)
+        .mock_once()
+        .mount()
+        .await;
+
+    // I can get the subscription status for that same thread.
+    let subscription = room.fetch_thread_subscription(root_id.clone()).await.unwrap().unwrap();
+    assert!(subscription.automatic);
+
+    // If I try to get a subscription for a thread event that's unknown, I get no
+    // `ThreadSubscription`, not an error.
+    let subscription =
+        room.fetch_thread_subscription(owned_event_id!("$another_root")).await.unwrap();
+    assert!(subscription.is_none());
+
+    // I can also unsubscribe from a thread.
+    server
+        .mock_delete_thread_subscription()
+        .match_room_id(room_id.to_owned())
+        .match_thread_id(root_id.clone())
+        .ok()
+        .mock_once()
+        .mount()
+        .await;
+
+    room.unsubscribe_thread(root_id).await.unwrap();
+}

--- a/labs/multiverse/src/widgets/room_view/input.rs
+++ b/labs/multiverse/src/widgets/room_view/input.rs
@@ -16,6 +16,8 @@ struct Cli {
 pub enum Command {
     Invite { user_id: String },
     Leave,
+    Subscribe,
+    Unsubscribe,
 }
 
 pub enum MessageOrCommand {

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -9,7 +9,8 @@ use matrix_sdk::{
     Client, Room, RoomState,
     locks::Mutex,
     ruma::{
-        OwnedRoomId, RoomId, UserId, api::client::receipt::create_receipt::v3::ReceiptType,
+        OwnedEventId, OwnedRoomId, RoomId, UserId,
+        api::client::receipt::create_receipt::v3::ReceiptType,
         events::room::message::RoomMessageEventContent,
     },
 };
@@ -52,6 +53,7 @@ enum TimelineKind {
 
     Thread {
         room: OwnedRoomId,
+        thread_root: OwnedEventId,
         /// The threaded-focused timeline for this thread.
         timeline: Arc<OnceCell<Arc<Timeline>>>,
         /// Items in the thread timeline (to avoid recomputing them every single
@@ -145,10 +147,11 @@ impl RoomView {
         let i = items.clone();
         let t = thread_timeline.clone();
         let root = root_event_id;
+        let cloned_root = root.clone();
         let r = room.clone();
         let task = spawn(async move {
             let timeline = TimelineBuilder::new(&r)
-                .with_focus(TimelineFocus::Thread { root_event_id: root.clone() })
+                .with_focus(TimelineFocus::Thread { root_event_id: cloned_root })
                 .track_read_marker_and_receipts()
                 .build()
                 .await
@@ -171,6 +174,7 @@ impl RoomView {
         self.timeline_list.unselect();
 
         self.kind = TimelineKind::Thread {
+            thread_root: root,
             room: room.room_id().to_owned(),
             timeline: thread_timeline,
             items,
@@ -223,6 +227,12 @@ impl RoomView {
                             if matches!(self.kind, TimelineKind::Thread { .. }) =>
                         {
                             self.switch_to_room_timeline(None);
+                        }
+
+                        // Pressing 'Alt+s' on a threaded timeline will print the current
+                        // subscription status.
+                        (KeyModifiers::ALT, Char('s')) => {
+                            self.print_thread_subscription_status().await;
                         }
 
                         (KeyModifiers::CONTROL, Char('l')) => {
@@ -477,10 +487,67 @@ impl RoomView {
         self.input.clear();
     }
 
+    async fn subscribe_thread(&mut self) {
+        if let TimelineKind::Thread { thread_root, .. } = &self.kind {
+            self.call_with_room(async |room, status_handle| {
+                if let Err(err) = room.subscribe_thread(thread_root.clone(), false).await {
+                    status_handle.set_message(format!("error when subscribing to a thread: {err}"));
+                } else {
+                    status_handle.set_message("Subscribed to thread!".to_owned());
+                }
+            })
+            .await;
+
+            self.input.clear();
+        }
+    }
+
+    async fn unsubscribe_thread(&mut self) {
+        if let TimelineKind::Thread { thread_root, .. } = &self.kind {
+            self.call_with_room(async |room, status_handle| {
+                if let Err(err) = room.unsubscribe_thread(thread_root.clone()).await {
+                    status_handle
+                        .set_message(format!("error when unsubscribing to a thread: {err}"));
+                } else {
+                    status_handle.set_message("Unsubscribed from thread!".to_owned());
+                }
+            })
+            .await;
+
+            self.input.clear();
+        }
+    }
+
+    async fn print_thread_subscription_status(&mut self) {
+        if let TimelineKind::Thread { thread_root, .. } = &self.kind {
+            self.call_with_room(async |room, status_handle| {
+                match room.fetch_thread_subscription(thread_root.clone()).await {
+                    Ok(Some(subscription)) => {
+                        status_handle.set_message(format!(
+                            "Thread subscription status: {}",
+                            if subscription.automatic { "automatic" } else { "manual" }
+                        ));
+                    }
+                    Ok(None) => {
+                        status_handle
+                            .set_message("Thread is not subscribed or does not exist".to_owned());
+                    }
+                    Err(err) => {
+                        status_handle
+                            .set_message(format!("Error getting thread subscription: {err}"));
+                    }
+                }
+            })
+            .await;
+        }
+    }
+
     async fn handle_command(&mut self, command: input::Command) {
         match command {
             input::Command::Invite { user_id } => self.invite_member(&user_id).await,
             input::Command::Leave => self.leave_room().await,
+            input::Command::Subscribe => self.subscribe_thread().await,
+            input::Command::Unsubscribe => self.unsubscribe_thread().await,
         }
     }
 

--- a/labs/multiverse/src/widgets/status.rs
+++ b/labs/multiverse/src/widgets/status.rs
@@ -89,7 +89,7 @@ impl Status {
                 let status_message = status_message.clone();
 
                 async move {
-                    // Clear the status message in 4 seconds.
+                    // Clear the status message after the standard duration.
                     sleep(MESSAGE_DURATION).await;
                     status_message.lock().take();
                 }


### PR DESCRIPTION
This implements the three new endpoints introduced by [MSC4306](https://github.com/matrix-org/matrix-spec-proposals/pull/4306), with tests and support in multiverse.

Depends on https://github.com/ruma/ruma/pull/2169 and https://github.com/element-hq/synapse/pull/18722.
Part of #4869.