### PR TITLE
fix: Properly support event types with variable suffixes

### DIFF
--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -578,7 +578,9 @@ impl StateChanges {
         state_key: &K,
     ) -> Option<&Raw<SyncStateEvent<C>>>
     where
-        C: StaticEventContent + StaticStateEventContent + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False>
+            + StaticStateEventContent
+            + RedactContent,
         C::Redacted: RedactedStateEventContent,
         C::StateKey: Borrow<K>,
         K: AsRef<str> + ?Sized,
@@ -599,7 +601,7 @@ impl StateChanges {
         state_key: &K,
     ) -> Option<&Raw<StrippedStateEvent<C::PossiblyRedacted>>>
     where
-        C: StaticEventContent + StaticStateEventContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False> + StaticStateEventContent,
         C::StateKey: Borrow<K>,
         K: AsRef<str> + ?Sized,
     {
@@ -620,7 +622,9 @@ impl StateChanges {
         state_key: &K,
     ) -> Option<StrippedStateEvent<C::PossiblyRedacted>>
     where
-        C: StaticEventContent + StaticStateEventContent + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False>
+            + StaticStateEventContent
+            + RedactContent,
         C::Redacted: RedactedStateEventContent,
         C::PossiblyRedacted: StaticEventContent + DeserializeOwned,
         C::StateKey: Borrow<K>,

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -788,7 +788,9 @@ pub trait StateStoreExt: StateStore {
         room_id: &RoomId,
     ) -> Result<Option<RawSyncOrStrippedState<C>>, Self::Error>
     where
-        C: StaticEventContent + StaticStateEventContent<StateKey = EmptyStateKey> + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False>
+            + StaticStateEventContent<StateKey = EmptyStateKey>
+            + RedactContent,
         C::Redacted: RedactedStateEventContent,
     {
         Ok(self.get_state_event(room_id, C::TYPE.into(), "").await?.map(|raw| raw.cast()))
@@ -805,7 +807,9 @@ pub trait StateStoreExt: StateStore {
         state_key: &K,
     ) -> Result<Option<RawSyncOrStrippedState<C>>, Self::Error>
     where
-        C: StaticEventContent + StaticStateEventContent + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False>
+            + StaticStateEventContent
+            + RedactContent,
         C::StateKey: Borrow<K>,
         C::Redacted: RedactedStateEventContent,
         K: AsRef<str> + ?Sized + Sync,
@@ -826,7 +830,9 @@ pub trait StateStoreExt: StateStore {
         room_id: &RoomId,
     ) -> Result<Vec<RawSyncOrStrippedState<C>>, Self::Error>
     where
-        C: StaticEventContent + StaticStateEventContent + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False>
+            + StaticStateEventContent
+            + RedactContent,
         C::Redacted: RedactedStateEventContent,
     {
         // FIXME: Could be more efficient, if we had streaming store accessor functions
@@ -852,7 +858,9 @@ pub trait StateStoreExt: StateStore {
         state_keys: I,
     ) -> Result<Vec<RawSyncOrStrippedState<C>>, Self::Error>
     where
-        C: StaticEventContent + StaticStateEventContent + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False>
+            + StaticStateEventContent
+            + RedactContent,
         C::StateKey: Borrow<K>,
         C::Redacted: RedactedStateEventContent,
         K: AsRef<str> + Sized + Sync + 'a,
@@ -876,7 +884,7 @@ pub trait StateStoreExt: StateStore {
         &self,
     ) -> Result<Option<Raw<GlobalAccountDataEvent<C>>>, Self::Error>
     where
-        C: StaticEventContent + GlobalAccountDataEventContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False> + GlobalAccountDataEventContent,
     {
         Ok(self.get_account_data_event(C::TYPE.into()).await?.map(Raw::cast_unchecked))
     }
@@ -893,7 +901,7 @@ pub trait StateStoreExt: StateStore {
         room_id: &RoomId,
     ) -> Result<Option<Raw<RoomAccountDataEvent<C>>>, Self::Error>
     where
-        C: StaticEventContent + RoomAccountDataEventContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False> + RoomAccountDataEventContent,
     {
         Ok(self
             .get_room_account_data_event(room_id, C::TYPE.into())

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -722,7 +722,7 @@ impl Account {
     /// ```
     pub async fn account_data<C>(&self) -> Result<Option<Raw<C>>>
     where
-        C: GlobalAccountDataEventContent + StaticEventContent,
+        C: GlobalAccountDataEventContent + StaticEventContent<IsPrefix = ruma::events::False>,
     {
         get_raw_content(self.client.state_store().get_account_data_event_static::<C>().await?)
     }
@@ -785,7 +785,7 @@ impl Account {
     /// Fetch an account data event of statically-known type from the server.
     pub async fn fetch_account_data_static<C>(&self) -> Result<Option<Raw<C>>>
     where
-        C: GlobalAccountDataEventContent + StaticEventContent,
+        C: GlobalAccountDataEventContent + StaticEventContent<IsPrefix = ruma::events::False>,
     {
         Ok(self.fetch_account_data(C::TYPE.into()).await?.map(Raw::cast_unchecked))
     }

--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -58,7 +58,12 @@ use matrix_sdk_base::{
 };
 use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
 use pin_project_lite::pin_project;
-use ruma::{events::AnySyncStateEvent, push::Action, serde::Raw, OwnedRoomId};
+use ruma::{
+    events::{AnySyncStateEvent, BooleanType},
+    push::Action,
+    serde::Raw,
+    OwnedRoomId,
+};
 use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::value::RawValue as RawJsonValue;
 use tracing::{debug, error, field::debug, instrument, warn};
@@ -158,6 +163,8 @@ pub trait SyncEvent {
     const KIND: HandlerKind;
     #[doc(hidden)]
     const TYPE: Option<&'static str>;
+    #[doc(hidden)]
+    type IsPrefix: BooleanType;
 }
 
 pub(crate) struct EventHandlerWrapper {
@@ -170,9 +177,18 @@ pub(crate) struct EventHandlerWrapper {
 #[derive(Clone, Debug)]
 pub struct EventHandlerHandle {
     pub(crate) ev_kind: HandlerKind,
-    pub(crate) ev_type: Option<&'static str>,
+    pub(crate) ev_type: Option<StaticEventTypePart>,
     pub(crate) room_id: Option<OwnedRoomId>,
     pub(crate) handler_id: u64,
+}
+
+/// The static part of an event type.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum StaticEventTypePart {
+    /// The full event type is static.
+    Full(&'static str),
+    /// Only the prefix of the event type is static.
+    Prefix(&'static str),
 }
 
 /// Interface for event handlers.
@@ -328,8 +344,14 @@ impl Client {
         });
 
         let handler_id = self.inner.event_handlers.counter.fetch_add(1, SeqCst);
-        let handle =
-            EventHandlerHandle { ev_kind: Ev::KIND, ev_type: Ev::TYPE, room_id, handler_id };
+        let ev_type = Ev::TYPE.map(|ev_type| {
+            if Ev::IsPrefix::as_bool() {
+                StaticEventTypePart::Prefix(ev_type)
+            } else {
+                StaticEventTypePart::Full(ev_type)
+            }
+        });
+        let handle = EventHandlerHandle { ev_kind: Ev::KIND, ev_type, room_id, handler_id };
 
         self.inner.event_handlers.add_handler(handle.clone(), handler_fn);
 
@@ -716,6 +738,7 @@ mod tests {
         event_factory::{EventFactory, PreviousMembership},
         InvitedRoomBuilder, JoinedRoomBuilder, DEFAULT_TEST_ROOM_ID,
     };
+    use serde::Serialize;
     use stream_assert::{assert_closed, assert_pending, assert_ready};
     #[cfg(target_family = "wasm")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
@@ -734,11 +757,13 @@ mod tests {
     use ruma::{
         event_id,
         events::{
+            macros::EventContent,
             room::{
                 member::{MembershipState, OriginalSyncRoomMemberEvent, StrippedRoomMemberEvent},
                 name::OriginalSyncRoomNameEvent,
                 power_levels::OriginalSyncRoomPowerLevelsEvent,
             },
+            secret_storage::key::SecretStorageKeyEvent,
             typing::SyncTypingEvent,
             AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
         },
@@ -1308,6 +1333,97 @@ mod tests {
 
         drop(observable_for_room);
         assert_closed!(subscriber_for_room);
+
+        Ok(())
+    }
+
+    #[async_test]
+    #[allow(dependency_on_unit_never_type_fallback)]
+    async fn test_observe_events_with_type_prefix() -> crate::Result<()> {
+        let client = logged_in_client(None).await;
+
+        let observable = client.observe_events::<SecretStorageKeyEvent, ()>();
+
+        let mut subscriber = observable.subscribe();
+
+        assert_pending!(subscriber);
+
+        let mut response_builder = SyncResponseBuilder::new();
+        let response = response_builder
+            .add_global_account_data_bulk([Raw::new(&json!({
+                "content": {
+                    "algorithm": "m.secret_storage.v1.aes-hmac-sha2",
+                    "iv": "gH2iNpiETFhApvW6/FFEJQ",
+                    "mac": "9Lw12m5SKDipNghdQXKjgpfdj1/K7HFI2brO+UWAGoM",
+                    "passphrase": {
+                        "algorithm": "m.pbkdf2",
+                        "salt": "IuLnH7S85YtZmkkBJKwNUKxWF42g9O1H",
+                        "iterations": 10,
+                    },
+                },
+                "type": "m.secret_storage.key.foobar",
+            }))
+            .unwrap()
+            .cast_unchecked()])
+            .build_sync_response();
+        client.process_sync(response).await?;
+
+        let (secret_storage_key, ()) = assert_ready!(subscriber);
+
+        assert_eq!(secret_storage_key.content.key_id, "foobar");
+
+        assert_pending!(subscriber);
+
+        drop(observable);
+        assert_closed!(subscriber);
+
+        Ok(())
+    }
+
+    #[async_test]
+    #[allow(dependency_on_unit_never_type_fallback)]
+    async fn test_observe_room_events_with_type_prefix() -> crate::Result<()> {
+        // To create an event handler for a room account data event type with prefix, we
+        // need to create a custom event type, none exist in the Matrix specification
+        // yet.
+        #[derive(Debug, Clone, EventContent, Serialize)]
+        #[ruma_event(type = "fake.event.*", kind = RoomAccountData)]
+        struct AccountDataWithPrefixEventContent {
+            #[ruma_event(type_fragment)]
+            #[serde(skip)]
+            key_id: String,
+        }
+
+        let room_id = room_id!("!r0.matrix.org");
+        let client = logged_in_client(None).await;
+
+        let observable = client.observe_room_events::<AccountDataWithPrefixEvent, Room>(room_id);
+
+        let mut subscriber = observable.subscribe();
+
+        assert_pending!(subscriber);
+
+        let mut response_builder = SyncResponseBuilder::new();
+        let response = response_builder
+            .add_joined_room(
+                JoinedRoomBuilder::new(room_id).add_account_data_bulk([Raw::new(&json!({
+                    "content": {},
+                    "type": "fake.event.foobar",
+                }))
+                .unwrap()
+                .cast_unchecked()]),
+            )
+            .build_sync_response();
+        client.process_sync(response).await?;
+
+        let (secret_storage_key, _room) = assert_ready!(subscriber);
+
+        assert_eq!(secret_storage_key.content.key_id, "foobar");
+
+        assert_pending!(subscriber);
+
+        drop(observable);
+        assert_closed!(subscriber);
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/event_handler/static_events.rs
+++ b/crates/matrix-sdk/src/event_handler/static_events.rs
@@ -19,10 +19,10 @@ use ruma::{
         self, presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
         AnyStrippedStateEvent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
         AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent, EphemeralRoomEventContent,
-        GlobalAccountDataEventContent, MessageLikeEventContent, PossiblyRedactedStateEventContent,
-        RedactContent, RedactedMessageLikeEventContent, RedactedStateEventContent,
-        RoomAccountDataEventContent, StaticEventContent, StaticStateEventContent,
-        ToDeviceEventContent,
+        False, GlobalAccountDataEventContent, MessageLikeEventContent,
+        PossiblyRedactedStateEventContent, RedactContent, RedactedMessageLikeEventContent,
+        RedactedStateEventContent, RoomAccountDataEventContent, StaticEventContent,
+        StaticStateEventContent, ToDeviceEventContent,
     },
     serde::Raw,
 };
@@ -35,6 +35,7 @@ where
 {
     const KIND: HandlerKind = HandlerKind::GlobalAccountData;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    type IsPrefix = <C as StaticEventContent>::IsPrefix;
 }
 
 impl<C> SyncEvent for events::RoomAccountDataEvent<C>
@@ -43,6 +44,7 @@ where
 {
     const KIND: HandlerKind = HandlerKind::RoomAccountData;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    type IsPrefix = <C as StaticEventContent>::IsPrefix;
 }
 
 impl<C> SyncEvent for events::SyncEphemeralRoomEvent<C>
@@ -51,6 +53,7 @@ where
 {
     const KIND: HandlerKind = HandlerKind::EphemeralRoomData;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    type IsPrefix = <C as StaticEventContent>::IsPrefix;
 }
 
 impl<C> SyncEvent for events::SyncMessageLikeEvent<C>
@@ -60,6 +63,7 @@ where
 {
     const KIND: HandlerKind = HandlerKind::MessageLike;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    type IsPrefix = <C as StaticEventContent>::IsPrefix;
 }
 
 impl<C> SyncEvent for events::OriginalSyncMessageLikeEvent<C>
@@ -68,6 +72,7 @@ where
 {
     const KIND: HandlerKind = HandlerKind::OriginalMessageLike;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    type IsPrefix = <C as StaticEventContent>::IsPrefix;
 }
 
 impl<C> SyncEvent for events::RedactedSyncMessageLikeEvent<C>
@@ -76,24 +81,31 @@ where
 {
     const KIND: HandlerKind = HandlerKind::RedactedMessageLike;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    type IsPrefix = <C as StaticEventContent>::IsPrefix;
 }
 
 impl SyncEvent for events::room::redaction::SyncRoomRedactionEvent {
     const KIND: HandlerKind = HandlerKind::MessageLike;
     const TYPE: Option<&'static str> =
         Some(events::room::redaction::RoomRedactionEventContent::TYPE);
+    type IsPrefix =
+        <events::room::redaction::RoomRedactionEventContent as StaticEventContent>::IsPrefix;
 }
 
 impl SyncEvent for events::room::redaction::OriginalSyncRoomRedactionEvent {
     const KIND: HandlerKind = HandlerKind::OriginalMessageLike;
     const TYPE: Option<&'static str> =
         Some(events::room::redaction::RoomRedactionEventContent::TYPE);
+    type IsPrefix =
+        <events::room::redaction::RoomRedactionEventContent as StaticEventContent>::IsPrefix;
 }
 
 impl SyncEvent for events::room::redaction::RedactedSyncRoomRedactionEvent {
     const KIND: HandlerKind = HandlerKind::RedactedMessageLike;
     const TYPE: Option<&'static str> =
         Some(events::room::redaction::RoomRedactionEventContent::TYPE);
+    type IsPrefix =
+        <events::room::redaction::RoomRedactionEventContent as StaticEventContent>::IsPrefix;
 }
 
 impl<C> SyncEvent for events::SyncStateEvent<C>
@@ -103,6 +115,7 @@ where
 {
     const KIND: HandlerKind = HandlerKind::State;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    type IsPrefix = <C as StaticEventContent>::IsPrefix;
 }
 
 impl<C> SyncEvent for events::OriginalSyncStateEvent<C>
@@ -111,6 +124,7 @@ where
 {
     const KIND: HandlerKind = HandlerKind::OriginalState;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    type IsPrefix = <C as StaticEventContent>::IsPrefix;
 }
 
 impl<C> SyncEvent for events::RedactedSyncStateEvent<C>
@@ -119,6 +133,7 @@ where
 {
     const KIND: HandlerKind = HandlerKind::RedactedState;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    type IsPrefix = <C as StaticEventContent>::IsPrefix;
 }
 
 impl<C> SyncEvent for events::StrippedStateEvent<C>
@@ -127,6 +142,7 @@ where
 {
     const KIND: HandlerKind = HandlerKind::StrippedState;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    type IsPrefix = <C as StaticEventContent>::IsPrefix;
 }
 
 impl<C> SyncEvent for events::ToDeviceEvent<C>
@@ -135,54 +151,65 @@ where
 {
     const KIND: HandlerKind = HandlerKind::ToDevice;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    type IsPrefix = <C as StaticEventContent>::IsPrefix;
 }
 
 impl SyncEvent for PresenceEvent {
     const KIND: HandlerKind = HandlerKind::Presence;
     const TYPE: Option<&'static str> = None;
+    type IsPrefix = False;
 }
 
 impl SyncEvent for AnyGlobalAccountDataEvent {
     const KIND: HandlerKind = HandlerKind::GlobalAccountData;
     const TYPE: Option<&'static str> = None;
+    type IsPrefix = False;
 }
 
 impl SyncEvent for AnyRoomAccountDataEvent {
     const KIND: HandlerKind = HandlerKind::RoomAccountData;
     const TYPE: Option<&'static str> = None;
+    type IsPrefix = False;
 }
 
 impl SyncEvent for AnySyncEphemeralRoomEvent {
     const KIND: HandlerKind = HandlerKind::EphemeralRoomData;
     const TYPE: Option<&'static str> = None;
+    type IsPrefix = False;
 }
 
 impl SyncEvent for AnySyncTimelineEvent {
     const KIND: HandlerKind = HandlerKind::Timeline;
     const TYPE: Option<&'static str> = None;
+    type IsPrefix = False;
 }
 
 impl SyncEvent for AnySyncMessageLikeEvent {
     const KIND: HandlerKind = HandlerKind::MessageLike;
     const TYPE: Option<&'static str> = None;
+    type IsPrefix = False;
 }
 
 impl SyncEvent for AnySyncStateEvent {
     const KIND: HandlerKind = HandlerKind::State;
     const TYPE: Option<&'static str> = None;
+    type IsPrefix = False;
 }
 
 impl SyncEvent for AnyStrippedStateEvent {
     const KIND: HandlerKind = HandlerKind::StrippedState;
     const TYPE: Option<&'static str> = None;
+    type IsPrefix = False;
 }
 
 impl SyncEvent for AnyToDeviceEvent {
     const KIND: HandlerKind = HandlerKind::ToDevice;
     const TYPE: Option<&'static str> = None;
+    type IsPrefix = False;
 }
 
 impl<T: SyncEvent> SyncEvent for Raw<T> {
     const KIND: HandlerKind = T::KIND;
     const TYPE: Option<&'static str> = T::TYPE;
+    type IsPrefix = <T as SyncEvent>::IsPrefix;
 }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1017,7 +1017,9 @@ impl Room {
     /// ```
     pub async fn get_state_events_static<C>(&self) -> Result<Vec<RawSyncOrStrippedState<C>>>
     where
-        C: StaticEventContent + StaticStateEventContent + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False>
+            + StaticStateEventContent
+            + RedactContent,
         C::Redacted: RedactedStateEventContent,
     {
         Ok(self.client.state_store().get_state_events_static(self.room_id()).await?)
@@ -1061,7 +1063,9 @@ impl Room {
         state_keys: I,
     ) -> Result<Vec<RawSyncOrStrippedState<C>>>
     where
-        C: StaticEventContent + StaticStateEventContent + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False>
+            + StaticStateEventContent
+            + RedactContent,
         C::StateKey: Borrow<K>,
         C::Redacted: RedactedStateEventContent,
         K: AsRef<str> + Sized + Sync + 'a,
@@ -1108,7 +1112,9 @@ impl Room {
     /// ```
     pub async fn get_state_event_static<C>(&self) -> Result<Option<RawSyncOrStrippedState<C>>>
     where
-        C: StaticEventContent + StaticStateEventContent<StateKey = EmptyStateKey> + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False>
+            + StaticStateEventContent<StateKey = EmptyStateKey>
+            + RedactContent,
         C::Redacted: RedactedStateEventContent,
     {
         self.get_state_event_static_for_key(&EmptyStateKey).await
@@ -1138,7 +1144,9 @@ impl Room {
         state_key: &K,
     ) -> Result<Option<RawSyncOrStrippedState<C>>>
     where
-        C: StaticEventContent + StaticStateEventContent + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False>
+            + StaticStateEventContent
+            + RedactContent,
         C::StateKey: Borrow<K>,
         C::Redacted: RedactedStateEventContent,
         K: AsRef<str> + ?Sized + Sync,
@@ -1257,7 +1265,7 @@ impl Room {
     /// ```
     pub async fn account_data_static<C>(&self) -> Result<Option<Raw<RoomAccountDataEvent<C>>>>
     where
-        C: StaticEventContent + RoomAccountDataEventContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False> + RoomAccountDataEventContent,
     {
         Ok(self.account_data(C::TYPE.into()).await?.map(Raw::cast_unchecked))
     }


### PR DESCRIPTION
… or add a bound to make it clear that they are not supported by the API.

Thanks to a recent addition in Ruma, we can now identify event types where only the prefix is static with the `IsPrefix` associated type on `StaticEventContent` (`SecretStorageKeyEventContent` is currently the only type where it is `True`).

In the SDK all the APIs that use that bound only support full event types, not prefixes. So we have two commits here:

1. The first one adds a bound `IsPrefix = False` on the `get_*_static` APIs, because they also have sibling APIs that take a non-static event type. We also add the same bound to `EventBuilder` because it's the only supported way currently, and it's not a public API.
2. The second one adds support for event type prefixes to event handlers, since there is no alternative API where we can provide a non-static event type to watch.
