### PR TITLE
refactor(ffi): Fix clippy lint

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -1574,7 +1574,7 @@ mod galleries {
             let in_reply_to = params
                 .in_reply_to
                 .as_ref()
-                .map(|event_id| EventId::parse(event_id))
+                .map(EventId::parse)
                 .transpose()
                 .map_err(|_| RoomError::InvalidRepliedToEventId)?;
 


### PR DESCRIPTION
It seems to have not been caught in CI because clippy never checks the ffi crates with the default features.