### PR TITLE
refactor(ffi): expose room_version in the FFI RoomInfo

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -8,8 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features:
 
+- Add `room_version` and `privileged_creators_role` to `RoomInfo` ([#5449](https://github.com/matrix-org/matrix-rust-sdk/pull/5449)).
 - The [`unstable-hydra`] feature has been enabled, which enables room v12 changes in the SDK.
-  [(#5450)](https://github.com/matrix-org/matrix-rust-sdk/pull/5450).
+  ([#5450](https://github.com/matrix-org/matrix-rust-sdk/pull/5450)).
 - Add experimental support for
   [MSC4306](https://github.com/matrix-org/matrix-spec-proposals/pull/4306), with the
   `Room::fetch_thread_subscription()` and `Room::set_thread_subscription()` methods.

--- a/bindings/matrix-sdk-ffi/src/room/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room/room_info.rs
@@ -76,6 +76,9 @@ pub struct RoomInfo {
     power_levels: Option<Arc<RoomPowerLevels>>,
     /// This room's version.
     room_version: Option<String>,
+    /// Whether creators are privileged over every other user (have infinite
+    /// power level).
+    privileged_creators_role: bool,
 }
 
 impl RoomInfo {
@@ -155,6 +158,11 @@ impl RoomInfo {
             history_visibility: room.history_visibility_or_default().try_into()?,
             power_levels: power_levels.map(Arc::new),
             room_version: room.version().map(|version| version.to_string()),
+            privileged_creators_role: room
+                .version()
+                .and_then(|version| version.rules())
+                .map(|rules| rules.authorization.explicitly_privilege_room_creators)
+                .unwrap_or_default(),
         })
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room/room_info.rs
@@ -74,6 +74,8 @@ pub struct RoomInfo {
     ///
     /// Can be missing if the room power levels event is missing from the store.
     power_levels: Option<Arc<RoomPowerLevels>>,
+    /// This room's version.
+    room_version: Option<String>,
 }
 
 impl RoomInfo {
@@ -152,6 +154,7 @@ impl RoomInfo {
             join_rule,
             history_visibility: room.history_visibility_or_default().try_into()?,
             power_levels: power_levels.map(Arc::new),
+            room_version: room.version().map(|version| version.to_string()),
         })
     }
 }

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -48,7 +48,8 @@ pub use room_info::{
     RoomInfoNotableUpdateReasons, apply_redaction,
 };
 use ruma::{
-    EventId, OwnedEventId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, RoomId, UserId,
+    EventId, OwnedEventId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, RoomId,
+    RoomVersionId, UserId,
     events::{
         direct::OwnedDirectUserIdentifier,
         receipt::{Receipt, ReceiptThread, ReceiptType},
@@ -468,6 +469,11 @@ impl Room {
     /// unread
     pub fn is_marked_unread(&self) -> bool {
         self.inner.read().base_info.is_marked_unread
+    }
+
+    /// Returns the [`RoomVersionId`] of the room, if known.
+    pub fn version(&self) -> Option<RoomVersionId> {
+        self.inner.read().room_version().cloned()
     }
 
     /// Returns the recency stamp of the room.


### PR DESCRIPTION
## Changes:

- Exposes the room version in the FFI RoomInfo.
- Exposes the `privileged_creators_role` boolean in the FFI RoomInfo, to understand how the retrieved creators ids should be treated.

This is needed on the clients so we can understand whether `RoomInfo.creators` are the ids of the room creators (with no special privileges) or they're users with infinite power level and should be treated differently.

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
