### PR TITLE
Expose Element Call's new mechanism for sending call notifications

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to this project will be documented in this file.
   calling `Client::login_with_qr_code`. ([#5388](https://github.com/matrix-org/matrix-rust-sdk/pull/5388))
 - The MSRV has been bumped to Rust 1.88.
   ([#5431](https://github.com/matrix-org/matrix-rust-sdk/pull/5431))
+- `Room::send_call_notification` and `Room::send_call_notification_if_needed` have been removed, since the event type they send is outdated, and `Client` is not actually supposed to be able to join MatrixRTC sessions (yet). In practice, users of these methods probably already rely on another MatrixRTC implementation to participate in sessions, and such an implementation should be capable of sending notifications itself.
 
 ## [0.13.0] - 2025-07-10
 

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -44,7 +44,7 @@ use crate::{
     live_location_share::{LastLocation, LiveLocationShare},
     room_member::{RoomMember, RoomMemberWithSenderInfo},
     room_preview::RoomPreview,
-    ruma::{ImageInfo, LocationContent, Mentions, NotifyType},
+    ruma::{ImageInfo, LocationContent},
     runtime::get_runtime_handle,
     timeline::{
         configuration::{TimelineConfiguration, TimelineFilter},
@@ -718,53 +718,6 @@ impl Room {
     pub async fn matrix_to_event_permalink(&self, event_id: String) -> Result<String, ClientError> {
         let event_id = EventId::parse(event_id)?;
         Ok(self.inner.matrix_to_event_permalink(event_id).await?.to_string())
-    }
-
-    /// This will only send a call notification event if appropriate.
-    ///
-    /// This function is supposed to be called whenever the user creates a room
-    /// call. It will send a `m.call.notify` event if:
-    ///  - there is not yet a running call.
-    ///
-    /// It will configure the notify type: ring or notify based on:
-    ///  - is this a DM room -> ring
-    ///  - is this a group with more than one other member -> notify
-    ///
-    /// Returns:
-    ///  - `Ok(true)` if the event was successfully sent.
-    ///  - `Ok(false)` if we didn't send it because it was unnecessary.
-    ///  - `Err(_)` if sending the event failed.
-    pub async fn send_call_notification_if_needed(&self) -> Result<bool, ClientError> {
-        Ok(self.inner.send_call_notification_if_needed().await?)
-    }
-
-    /// Send a call notification event in the current room.
-    ///
-    /// This is only supposed to be used in **custom** situations where the user
-    /// explicitly chooses to send a `m.call.notify` event to invite/notify
-    /// someone explicitly in unusual conditions. The default should be to
-    /// use `send_call_notification_if_necessary` just before a new room call is
-    /// created/joined.
-    ///
-    /// One example could be that the UI allows to start a call with a subset of
-    /// users of the room members first. And then later on the user can
-    /// invite more users to the call.
-    pub async fn send_call_notification(
-        &self,
-        call_id: String,
-        application: RtcApplicationType,
-        notify_type: NotifyType,
-        mentions: Mentions,
-    ) -> Result<(), ClientError> {
-        self.inner
-            .send_call_notification(
-                call_id,
-                application.into(),
-                notify_type.into(),
-                mentions.into(),
-            )
-            .await?;
-        Ok(())
     }
 
     /// Returns whether the send queue for that particular room is enabled or

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
   ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
 - [**breaking**] The MSRV has been bumped to Rust 1.88.
   ([#5431](https://github.com/matrix-org/matrix-rust-sdk/pull/5431))
+- [**breaking**] `Room::send_call_notification` and `Room::send_call_notification_if_needed` have been removed, since the event type they send is outdated, and `Client` is not actually supposed to be able to join MatrixRTC sessions (yet). In practice, users of these methods probably already rely on another MatrixRTC implementation to participate in sessions, and such an implementation should be capable of sending notifications itself.
 
 ### Bugfix
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -86,7 +86,6 @@ use ruma::{
     events::{
         beacon::BeaconEventContent,
         beacon_info::BeaconInfoEventContent,
-        call::notify::{ApplicationType, CallNotifyEventContent, NotifyType},
         direct::DirectEventContent,
         marked_unread::MarkedUnreadEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
@@ -3271,59 +3270,6 @@ impl Room {
         self.client.event_cache().for_room(self.room_id()).await
     }
 
-    /// This will only send a call notification event if appropriate.
-    ///
-    /// This function is supposed to be called whenever the user creates a room
-    /// call. It will send a `m.call.notify` event if:
-    ///  - there is not yet a running call.
-    ///
-    /// It will configure the notify type: ring or notify based on:
-    ///  - is this a DM room -> ring
-    ///  - is this a group with more than one other member -> notify
-    ///
-    /// Returns:
-    ///  - `Ok(true)` if the event was successfully sent.
-    ///  - `Ok(false)` if we didn't send it because it was unnecessary.
-    ///  - `Err(_)` if sending the event failed.
-    pub async fn send_call_notification_if_needed(&self) -> Result<bool> {
-        debug!("Sending call notification for room {} if needed", self.inner.room_id());
-
-        if self.has_active_room_call() {
-            warn!("Room {} has active room call, not sending a new notify event.", self.room_id());
-            return Ok(false);
-        }
-
-        let can_user_trigger_room_notification =
-            self.power_levels().await?.user_can_trigger_room_notification(self.own_user_id());
-
-        if !can_user_trigger_room_notification {
-            warn!(
-                "User can't send notifications to everyone in the room {}. \
-                Not sending a new notify event.",
-                self.room_id()
-            );
-            return Ok(false);
-        }
-
-        let notify_type = if self.is_direct().await.unwrap_or(false) {
-            NotifyType::Ring
-        } else {
-            NotifyType::Notify
-        };
-
-        debug!("Sending `m.call.notify` event with notify type: {notify_type:?}");
-
-        self.send_call_notification(
-            self.room_id().to_string().to_owned(),
-            ApplicationType::Call,
-            notify_type,
-            Mentions::with_room_mention(),
-        )
-        .await?;
-
-        Ok(true)
-    }
-
     /// Get the beacon information event in the room for the `user_id`.
     ///
     /// # Errors
@@ -3418,30 +3364,6 @@ impl Room {
         } else {
             Err(BeaconError::NotLive)
         }
-    }
-
-    /// Send a call notification event in the current room.
-    ///
-    /// This is only supposed to be used in **custom** situations where the user
-    /// explicitly chooses to send a `m.call.notify` event to invite/notify
-    /// someone explicitly in unusual conditions. The default should be to
-    /// use `send_call_notification_if_needed` just before a new room call is
-    /// created/joined.
-    ///
-    /// One example could be that the UI allows to start a call with a subset of
-    /// users of the room members first. And then later on the user can
-    /// invite more users to the call.
-    pub async fn send_call_notification(
-        &self,
-        call_id: String,
-        application: ApplicationType,
-        notify_type: NotifyType,
-        mentions: Mentions,
-    ) -> Result<()> {
-        let call_notify_event_content =
-            CallNotifyEventContent::new(call_id, application, notify_type, mentions);
-        self.send(call_notify_event_content).await?;
-        Ok(())
     }
 
     /// Store the given `ComposerDraft` in the state store using the current

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -75,6 +75,8 @@ struct ElementCallParams {
     sentry_environment: Option<String>,
     hide_screensharing: bool,
     controlled_media_devices: bool,
+    /// Supported since Element Call v0.14.0.
+    send_notification_type: Option<NotificationType>,
 }
 
 /// Defines if a call is encrypted and which encryption system should be used.
@@ -121,6 +123,16 @@ pub enum HeaderStyle {
     AppBar,
     /// No Header (useful for webapps).
     None,
+}
+
+/// Types of call notifications.
+#[derive(Debug, PartialEq, Serialize, uniffi::Enum, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum NotificationType {
+    /// The receiving client should display a visual notification.
+    Notification,
+    /// The receiving client should ring with an audible sound.
+    Ring,
 }
 
 /// Properties to create a new virtual Element Call widget.
@@ -223,6 +235,9 @@ pub struct VirtualElementCallWidgetOptions {
     ///  - `false`: the webview shows a a list of devices injected by the
     ///    client. (used on ios & android)
     pub controlled_media_devices: bool,
+    /// Whether and what type of notification Element Call should send, when
+    /// starting a call.
+    pub send_notification_type: Option<NotificationType>,
 }
 
 impl WidgetSettings {
@@ -285,6 +300,7 @@ impl WidgetSettings {
             rageshake_submit_url: props.rageshake_submit_url,
             hide_screensharing: props.hide_screensharing,
             controlled_media_devices: props.controlled_media_devices,
+            send_notification_type: props.send_notification_type,
         };
 
         let query =


### PR DESCRIPTION
See the commits for details. Element Call now provides a `sendNotificationType` URL parameter which we can use to tell it to send a call notification, so we no longer need the `Room::send_call_notification_if_needed` method provided by this SDK.

- [x] Public API changes documented in changelogs (optional)
