### PR TITLE
feat(send_queue): report progress for media uploads

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -621,6 +621,12 @@ impl Client {
         self.inner.send_queue().set_enabled(enable).await;
     }
 
+    /// Enables or disables progress reporting for media uploads in the send
+    /// queue.
+    pub fn enable_send_queue_upload_progress(&self, enable: bool) {
+        self.inner.send_queue().enable_upload_progress(enable);
+    }
+
     /// Subscribe to the global enablement status of the send queue, at the
     /// client-wide level.
     ///

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -238,7 +238,6 @@ pub enum DependentQueuedRequestKind {
         related_to: OwnedTransactionId,
 
         /// Whether the depended upon request was a thumbnail or a file upload.
-        #[cfg(feature = "unstable-msc4274")]
         #[serde(default = "default_parent_is_thumbnail_upload")]
         parent_is_thumbnail_upload: bool,
     },
@@ -275,7 +274,6 @@ pub enum DependentQueuedRequestKind {
 /// If parent_is_thumbnail_upload is missing, we assume the request is for a
 /// file upload following a thumbnail upload. This was the only possible case
 /// before parent_is_thumbnail_upload was introduced.
-#[cfg(feature = "unstable-msc4274")]
 fn default_parent_is_thumbnail_upload() -> bool {
     true
 }

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1366,7 +1366,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
                     .await;
             }
 
-            RoomSendQueueUpdate::UploadedMedia { related_to, .. } => {
+            RoomSendQueueUpdate::MediaUpload { related_to, .. } => {
                 // TODO(bnjbvr): Do something else?
                 info!(txn_id = %related_to, "some media for a media event has been uploaded");
             }

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -245,6 +245,21 @@ pub struct TransmissionProgress {
     pub total: usize,
 }
 
+/// Progress of an operation in abstract units.
+///
+/// Contrary to [`TransmissionProgress`], this allows tracking the progress
+/// of sending or receiving a payload in estimated pseudo units representing a
+/// percentage. This is helpful in cases where the exact progress in bytes isn't
+/// known, for instance, because encryption (which changes the size) happens on
+/// the fly.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct AbstractProgress {
+    /// How many units were already transferred.
+    pub current: usize,
+    /// How many units there are in total.
+    pub total: usize,
+}
+
 async fn response_to_http_response(
     mut response: reqwest::Response,
 ) -> Result<http::Response<Bytes>, reqwest::Error> {

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -74,7 +74,7 @@ pub use error::{
     Error, HttpError, HttpResult, NotificationSettingsError, RefreshTokenError, Result,
     RumaApiError,
 };
-pub use http_client::TransmissionProgress;
+pub use http_client::{AbstractProgress, TransmissionProgress};
 #[cfg(all(feature = "e2e-encryption", feature = "sqlite"))]
 pub use matrix_sdk_sqlite::SqliteCryptoStore;
 #[cfg(feature = "sqlite")]

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -1557,7 +1557,6 @@ impl QueueStorage {
                         content_type: content_type.to_string(),
                         cache_key: file_media_request,
                         related_to: send_event_txn,
-                        #[cfg(feature = "unstable-msc4274")]
                         parent_is_thumbnail_upload: true,
                     },
                 )
@@ -1949,24 +1948,11 @@ impl QueueStorage {
                 content_type,
                 cache_key,
                 related_to,
-                #[cfg(feature = "unstable-msc4274")]
                 parent_is_thumbnail_upload,
             } => {
                 let Some(parent_key) = parent_key else {
                     // Not finished yet, we should retry later => false.
                     return Ok(false);
-                };
-                let parent_is_thumbnail_upload = {
-                    cfg_if::cfg_if! {
-                        if #[cfg(feature = "unstable-msc4274")] {
-                            parent_is_thumbnail_upload
-                        } else {
-                            // Before parent_is_thumbnail_upload was introduced, the only
-                            // possible usage for this request was a file upload following
-                            // a thumbnail upload.
-                            true
-                        }
-                    }
                 };
                 self.handle_dependent_file_or_thumbnail_upload(
                     client,

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -667,7 +667,7 @@ impl RoomSendQueue {
                                 &global_update_sender,
                                 &update_sender,
                                 room_id,
-                                RoomSendQueueUpdate::UploadedMedia {
+                                RoomSendQueueUpdate::MediaUpload {
                                     related_to: related_txn_id.as_ref().unwrap_or(&txn_id).clone(),
                                     file: media_info.file,
                                 },
@@ -2219,8 +2219,9 @@ pub enum RoomSendQueueUpdate {
         event_id: OwnedEventId,
     },
 
-    /// A media has been successfully uploaded.
-    UploadedMedia {
+    /// A media upload (consisting of a file and possibly a thumbnail) has made
+    /// progress.
+    MediaUpload {
         /// The media event this uploaded media relates to.
         related_to: OwnedTransactionId,
 

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -138,6 +138,7 @@ use std::{
 };
 
 use as_variant::as_variant;
+use eyeball::SharedObservable;
 #[cfg(feature = "unstable-msc4274")]
 use matrix_sdk_base::store::FinishGalleryItemInfo;
 use matrix_sdk_base::{
@@ -177,7 +178,7 @@ use crate::{
     config::RequestConfig,
     error::RetryKind,
     room::{edit::EditedContent, WeakRoom},
-    Client, Media, Room,
+    Client, Media, Room, TransmissionProgress,
 };
 
 mod upload;
@@ -648,7 +649,7 @@ impl RoomSendQueue {
                 continue;
             };
 
-            match Self::handle_request(&room, queued_request, cancel_upload_rx).await {
+            match Self::handle_request(&room, queued_request, cancel_upload_rx, None).await {
                 Ok(Some(parent_key)) => match queue.mark_as_sent(&txn_id, parent_key.clone()).await
                 {
                     Ok(()) => match parent_key {
@@ -761,6 +762,7 @@ impl RoomSendQueue {
         room: &Room,
         request: QueuedRequest,
         cancel_upload_rx: Option<oneshot::Receiver<()>>,
+        progress: Option<SharedObservable<TransmissionProgress>>,
     ) -> Result<Option<SentRequestKey>, crate::Error> {
         match request.kind {
             QueuedRequestKind::Event { content } => {
@@ -808,18 +810,29 @@ impl RoomSendQueue {
                     let media_source = if room.latest_encryption_state().await?.is_encrypted() {
                         trace!("upload will be encrypted (encrypted room)");
                         let mut cursor = std::io::Cursor::new(data);
-                        let encrypted_file = room
-                            .client()
+                        let client = room.client();
+                        let mut req = client
                             .upload_encrypted_file(&mut cursor)
-                            .with_request_config(RequestConfig::short_retry())
-                            .await?;
+                            .with_request_config(RequestConfig::short_retry());
+
+                        if let Some(progress) = progress {
+                            req = req.with_send_progress_observable(progress);
+                        }
+
+                        let encrypted_file = req.await?;
                         MediaSource::Encrypted(Box::new(encrypted_file))
                     } else {
                         trace!("upload will be in clear text (room without encryption)");
                         let request_config = RequestConfig::short_retry()
                             .timeout(Media::reasonable_upload_timeout(&data));
-                        let res =
-                            room.client().media().upload(&mime, data, Some(request_config)).await?;
+                        let mut req =
+                            room.client().media().upload(&mime, data, Some(request_config));
+
+                        if let Some(progress) = progress {
+                            req = req.with_send_progress_observable(progress);
+                        }
+
+                        let res = req.await?;
                         MediaSource::Plain(res.content_uri)
                     };
 
@@ -827,8 +840,14 @@ impl RoomSendQueue {
                     let media_source = {
                         let request_config = RequestConfig::short_retry()
                             .timeout(Media::reasonable_upload_timeout(&data));
-                        let res =
-                            room.client().media().upload(&mime, data, Some(request_config)).await?;
+                        let mut req =
+                            room.client().media().upload(&mime, data, Some(request_config));
+
+                        if let Some(progress) = progress {
+                            req = req.with_send_progress_observable(progress);
+                        }
+
+                        let res = req.await?;
                         MediaSource::Plain(res.content_uri)
                     };
 

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -46,7 +46,7 @@ use ruma::{
 };
 use tracing::{debug, error, instrument, trace, warn, Span};
 
-use super::{QueueStorage, RoomSendQueue, RoomSendQueueError};
+use super::{QueueStorage, QueueThumbnailInfo, RoomSendQueue, RoomSendQueueError};
 use crate::{
     attachment::{AttachmentConfig, Thumbnail},
     room::edit::update_media_caption,
@@ -170,7 +170,7 @@ fn update_gallery_event_after_upload(
 struct MediaCacheResult {
     upload_thumbnail_txn: Option<OwnedTransactionId>,
     event_thumbnail_info: Option<(MediaSource, Box<ThumbnailInfo>)>,
-    queue_thumbnail_info: Option<(FinishUploadThumbnailInfo, MediaRequestParameters, Mime)>,
+    queue_thumbnail_info: Option<QueueThumbnailInfo>,
 }
 
 impl RoomSendQueue {
@@ -464,11 +464,15 @@ impl RoomSendQueue {
                     thumbnail_media_request.source.clone(),
                     thumbnail_info,
                 )),
-                queue_thumbnail_info: Some((
-                    FinishUploadThumbnailInfo { txn, width: None, height: None },
-                    thumbnail_media_request,
+                queue_thumbnail_info: Some(QueueThumbnailInfo {
+                    finish_upload_thumbnail_info: FinishUploadThumbnailInfo {
+                        txn,
+                        width: None,
+                        height: None,
+                    },
+                    media_request_parameters: thumbnail_media_request,
                     content_type,
-                )),
+                }),
             })
         } else {
             Ok(Default::default())

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -445,6 +445,7 @@ impl RoomSendQueue {
             // Create the information required for filling the thumbnail section of the
             // event.
             let (data, content_type, thumbnail_info) = thumbnail.into_parts();
+            let file_size = data.len();
 
             // Cache thumbnail in the cache store.
             let thumbnail_media_request = Media::make_local_file_media_request(&txn);
@@ -472,6 +473,7 @@ impl RoomSendQueue {
                     },
                     media_request_parameters: thumbnail_media_request,
                     content_type,
+                    file_size,
                 }),
             })
         } else {

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -165,12 +165,12 @@ macro_rules! assert_update {
     // Returns a tuple of (transaction_id, send_handle).
     (($global_watch:ident, $watch:ident) => uploaded { related_to = $related_to:expr, mxc = $mxc:expr }) => {{
         assert_let!(
-            Ok(Ok(RoomSendQueueUpdate::UploadedMedia {
+            Ok(Ok(RoomSendQueueUpdate::MediaUpload {
                 related_to,
                 file,
             })) = timeout(Duration::from_secs(1), $watch.recv()).await
         );
-        assert_matches!($global_watch.recv().await, Ok(SendQueueUpdate { update: RoomSendQueueUpdate::UploadedMedia { .. }, .. }));
+        assert_matches!($global_watch.recv().await, Ok(SendQueueUpdate { update: RoomSendQueueUpdate::MediaUpload { .. }, .. }));
 
         assert_eq!(related_to, $related_to);
         assert_let!(MediaSource::Plain(mxc) = file);


### PR DESCRIPTION
This contains the send queue changes broken out from #5008.

- [ ] Public API changes documented in changelogs (optional)