### PR TITLE
feat: store the thread subscription status in the database

### DIFF
--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -43,7 +43,10 @@ use super::{
 use crate::{
     RoomInfo, RoomMemberships, RoomState, StateChanges, StateStoreDataKey, StateStoreDataValue,
     deserialized_responses::MemberEvent,
-    store::{ChildTransactionId, QueueWedgeError, Result, SerializableEventContent, StateStoreExt},
+    store::{
+        ChildTransactionId, QueueWedgeError, Result, SerializableEventContent, StateStoreExt,
+        ThreadStatus,
+    },
 };
 
 /// `StateStore` integration tests.
@@ -98,6 +101,8 @@ pub trait StateStoreIntegrationTests {
     async fn test_server_info_saving(&self);
     /// Test fetching room infos based on [`RoomLoadSettings`].
     async fn test_get_room_infos(&self);
+    /// Test loading thread subscriptions.
+    async fn test_thread_subscriptions(&self);
 }
 
 impl StateStoreIntegrationTests for DynStateStore {
@@ -1767,6 +1772,53 @@ impl StateStoreIntegrationTests for DynStateStore {
             assert_eq!(all_rooms.len(), 0);
         }
     }
+
+    async fn test_thread_subscriptions(&self) {
+        let first_thread = event_id!("$t1");
+        let second_thread = event_id!("$t2");
+
+        // At first, there is no thread subscription.
+        let maybe_status = self.load_thread_subscription(room_id(), first_thread).await.unwrap();
+        assert!(maybe_status.is_none());
+
+        let maybe_status = self.load_thread_subscription(room_id(), second_thread).await.unwrap();
+        assert!(maybe_status.is_none());
+
+        // Setting the thread subscription works.
+        self.upsert_thread_subscription(
+            room_id(),
+            first_thread,
+            ThreadStatus::Subscribed { automatic: true },
+        )
+        .await
+        .unwrap();
+
+        self.upsert_thread_subscription(
+            room_id(),
+            second_thread,
+            ThreadStatus::Subscribed { automatic: false },
+        )
+        .await
+        .unwrap();
+
+        // Now, reading the thread subscription returns the expected status.
+        let maybe_status = self.load_thread_subscription(room_id(), first_thread).await.unwrap();
+        assert_eq!(maybe_status, Some(ThreadStatus::Subscribed { automatic: true }));
+        let maybe_status = self.load_thread_subscription(room_id(), second_thread).await.unwrap();
+        assert_eq!(maybe_status, Some(ThreadStatus::Subscribed { automatic: false }));
+
+        // We can override the thread subscription status.
+        self.upsert_thread_subscription(room_id(), first_thread, ThreadStatus::Unsubscribed)
+            .await
+            .unwrap();
+
+        // And it's correctly reflected.
+        let maybe_status = self.load_thread_subscription(room_id(), first_thread).await.unwrap();
+        assert_eq!(maybe_status, Some(ThreadStatus::Unsubscribed));
+        // And the second thread is still subscribed.
+        let maybe_status = self.load_thread_subscription(room_id(), second_thread).await.unwrap();
+        assert_eq!(maybe_status, Some(ThreadStatus::Subscribed { automatic: false }));
+    }
 }
 
 /// Macro building to allow your StateStore implementation to run the entire
@@ -1936,6 +1988,12 @@ macro_rules! statestore_integration_tests {
             async fn test_get_room_infos() {
                 let store = get_store().await.expect("creating store failed").into_state_store();
                 store.test_get_room_infos().await;
+            }
+
+            #[async_test]
+            async fn test_thread_subscriptions() {
+                let store = get_store().await.expect("creating store failed").into_state_store();
+                store.test_thread_subscriptions().await;
             }
         }
     };

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -754,6 +754,7 @@ impl StateStore for MemoryStore {
         inner.room_event_receipts.remove(room_id);
         inner.send_queue_events.remove(room_id);
         inner.dependent_send_queue_events.remove(room_id);
+        inner.thread_subscriptions.remove(room_id);
 
         Ok(())
     }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -102,20 +102,25 @@ pub enum StoreError {
     /// An error happened in the underlying database backend.
     #[error(transparent)]
     Backend(Box<dyn std::error::Error + Send + Sync>),
+
     /// An error happened while serializing or deserializing some data.
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+
     /// An error happened while deserializing a Matrix identifier, e.g. an user
     /// id.
     #[error(transparent)]
     Identifier(#[from] ruma::IdParseError),
+
     /// The store is locked with a passphrase and an incorrect passphrase was
     /// given.
     #[error("The store failed to be unlocked")]
     StoreLocked,
+
     /// An unencrypted store was tried to be unlocked with a passphrase.
     #[error("The store is not encrypted but was tried to be opened with a passphrase")]
     UnencryptedStore,
+
     /// The store failed to encrypt or decrypt some data.
     #[error("Error encrypting or decrypting data from the store: {0}")]
     Encryption(#[from] StoreEncryptionError),
@@ -130,11 +135,19 @@ pub enum StoreError {
         version: {0}, latest version: {1}"
     )]
     UnsupportedDatabaseVersion(usize, usize),
+
     /// Redacting an event in the store has failed.
     ///
     /// This should never happen.
     #[error("Redaction failed: {0}")]
     Redaction(#[source] ruma::canonical_json::RedactionError),
+
+    /// The store contains invalid data.
+    #[error("The store contains invalid data: {details}")]
+    InvalidData {
+        /// Details about which data is invalid, and how.
+        details: String,
+    },
 }
 
 impl StoreError {
@@ -437,6 +450,47 @@ pub enum RoomLoadSettings {
     /// Please, be careful with this option. Read the documentation of
     /// [`RoomLoadSettings`].
     One(OwnedRoomId),
+}
+
+/// Status of a thread subscription, as saved in the state store.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ThreadStatus {
+    /// The thread is subscribed to.
+    Subscribed {
+        /// Whether the subscription was made automatically by a client, not by
+        /// manual user choice.
+        automatic: bool,
+    },
+    /// The thread is unsubscribed to (it won't cause any notifications or
+    /// automatic subscription anymore).
+    Unsubscribed,
+}
+
+impl ThreadStatus {
+    /// Convert the current [`ThreadStatus`] into a string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ThreadStatus::Subscribed { automatic } => {
+                if *automatic {
+                    "automatic"
+                } else {
+                    "manual"
+                }
+            }
+            ThreadStatus::Unsubscribed => "unsubscribed",
+        }
+    }
+
+    /// Convert a string representation into a [`ThreadStatus`], if it is a
+    /// valid one, or `None` otherwise.
+    pub fn from_value(s: &str) -> Option<Self> {
+        match s {
+            "automatic" => Some(ThreadStatus::Subscribed { automatic: true }),
+            "manual" => Some(ThreadStatus::Subscribed { automatic: false }),
+            "unsubscribed" => Some(ThreadStatus::Unsubscribed),
+            _ => None,
+        }
+    }
 }
 
 /// Store state changes and pass them to the StateStore.

--- a/crates/matrix-sdk-sqlite/migrations/state_store/011_thread_subscriptions.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/011_thread_subscriptions.sql
@@ -1,0 +1,9 @@
+-- Thread subscriptions.
+CREATE TABLE "thread_subscriptions" (
+    "room_id" BLOB NOT NULL,
+    -- Event ID of the thread root.
+    "event_id" BLOB NOT NULL,
+    "status" TEXT NOT NULL,
+
+    PRIMARY KEY ("room_id", "event_id")
+);

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1766,6 +1766,13 @@ impl StateStore for SqliteStateStore {
                 this.encode_key(keys::DEPENDENTS_SEND_QUEUE, &room_id);
             txn.remove_room_dependent_send_queue(&dependent_send_queue_room_id)?;
 
+            let thread_subscriptions_room_id =
+                this.encode_key(keys::THREAD_SUBSCRIPTIONS, &room_id);
+            txn.execute(
+                "DELETE FROM thread_subscriptions WHERE room_id = ?",
+                (thread_subscriptions_room_id,),
+            )?;
+
             Ok(())
         })
         .await?;

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -13,6 +13,7 @@ use matrix_sdk::{
         api::client::receipt::create_receipt::v3::ReceiptType,
         events::room::message::RoomMessageEventContent,
     },
+    store::ThreadStatus,
 };
 use matrix_sdk_ui::{
     Timeline,
@@ -525,7 +526,16 @@ impl RoomView {
                     Ok(Some(subscription)) => {
                         status_handle.set_message(format!(
                             "Thread subscription status: {}",
-                            if subscription.automatic { "automatic" } else { "manual" }
+                            match subscription {
+                                ThreadStatus::Subscribed { automatic } => {
+                                    if automatic {
+                                        "subscribed (automatic)"
+                                    } else {
+                                        "subscribed (manual)"
+                                    }
+                                }
+                                ThreadStatus::Unsubscribed => "unsubscribed",
+                            }
                         ));
                     }
                     Ok(None) => {


### PR DESCRIPTION
Some implementation notes:

- instead of using kvdata (`StateStoreDataKey` et al.), I've added a new table for the thread subscriptions, so we can later do queries like "where status is subscribed".
- I've made it so that unsubscribing is remembered on the local device, so the next attempt to fetch a thread subscription may return unsubscribed. The MSC should soon evolve in that direction, in such a way that a thread status can be unsubscribed on the server as well, so I'm just being a bit early here.