### PR TITLE
feat: Encrypted state events (MSC3414)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "e73f302e4df7f5f0511fca1aa4
     "compat-lax-room-create-deser",
     "compat-lax-room-topic-deser",
     "unstable-msc3401",
+    "unstable-msc3414",
     "unstable-msc3488",
     "unstable-msc3489",
     "unstable-msc4075",

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -118,6 +118,8 @@ pub async fn update_any_room(
         ambiguity_cache,
         &mut new_user_ids,
         state_store,
+        #[cfg(feature = "e2e-encryption")]
+        e2ee.clone(),
     )
     .await?;
 

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -76,6 +76,8 @@ pub async fn update_joined_room(
         ambiguity_cache,
         &mut new_user_ids,
         state_store,
+        #[cfg(feature = "e2e-encryption")]
+        e2ee.clone(),
     )
     .await?;
 
@@ -180,6 +182,8 @@ pub async fn update_left_room(
         ambiguity_cache,
         &mut (),
         state_store,
+        #[cfg(feature = "e2e-encryption")]
+        e2ee.clone(),
     )
     .await?;
 

--- a/crates/matrix-sdk-base/src/room/encryption.rs
+++ b/crates/matrix-sdk-base/src/room/encryption.rs
@@ -36,6 +36,10 @@ pub enum EncryptionState {
     /// The room is encrypted.
     Encrypted,
 
+    /// The room is encrypted, additionally requiring state events to be
+    /// encrypted.
+    StateEncrypted,
+
     /// The room is not encrypted.
     NotEncrypted,
 
@@ -45,9 +49,16 @@ pub enum EncryptionState {
 }
 
 impl EncryptionState {
-    /// Check whether `EncryptionState` is [`Encrypted`][Self::Encrypted].
+    /// Check whether `EncryptionState` is [`Encrypted`][Self::Encrypted] or
+    /// [`StateEncrypted`][Self::StateEncrypted].
     pub fn is_encrypted(&self) -> bool {
-        matches!(self, Self::Encrypted)
+        matches!(self, Self::Encrypted | Self::StateEncrypted)
+    }
+
+    /// Check whether `EncryptionState` is
+    /// [`StateEncrypted`][Self::StateEncrypted].
+    pub fn is_state_encrypted(&self) -> bool {
+        matches!(self, Self::StateEncrypted)
     }
 
     /// Check whether `EncryptionState` is [`Unknown`][Self::Unknown].

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -619,10 +619,18 @@ impl RoomInfo {
     pub fn encryption_state(&self) -> EncryptionState {
         if !self.encryption_state_synced {
             EncryptionState::Unknown
-        } else if self.base_info.encryption.is_some() {
-            EncryptionState::Encrypted
         } else {
-            EncryptionState::NotEncrypted
+            self.base_info
+                .encryption
+                .as_ref()
+                .map(|state| {
+                    if state.encrypt_state_events {
+                        EncryptionState::StateEncrypted
+                    } else {
+                        EncryptionState::Encrypted
+                    }
+                })
+                .unwrap_or(EncryptionState::NotEncrypted)
         }
     }
 

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::{
+    borrow::Borrow,
     collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
     time::Duration,
@@ -44,8 +45,9 @@ use ruma::{
     },
     assign,
     events::{
+        room::encrypted::unstable_state::StateRoomEncryptedEventContent,
         secret::request::SecretName, AnyMessageLikeEvent, AnyMessageLikeEventContent,
-        AnyToDeviceEvent, MessageLikeEventContent,
+        AnyStateEventContent, AnyToDeviceEvent, MessageLikeEventContent, StateEventContent,
     },
     serde::{JsonObject, Raw},
     DeviceId, MilliSecondsSinceUnixEpoch, OneTimeKeyAlgorithm, OwnedDeviceId, OwnedDeviceKeyId,
@@ -1098,6 +1100,62 @@ impl OlmMachine {
         content: &Raw<AnyMessageLikeEventContent>,
     ) -> MegolmResult<Raw<RoomEncryptedEventContent>> {
         self.inner.group_session_manager.encrypt(room_id, event_type, content).await
+    }
+
+    /// Encrypt a state event for the given room.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room for which the event should be
+    ///   encrypted.
+    ///
+    /// * `content` - The plaintext content of the event that should be
+    ///   encrypted.
+    ///
+    /// * `state_key` - The associated state key of the event.
+    pub async fn encrypt_state_event<C, K>(
+        &self,
+        room_id: &RoomId,
+        content: C,
+        state_key: K,
+    ) -> MegolmResult<Raw<StateRoomEncryptedEventContent>>
+    where
+        C: StateEventContent,
+        C::StateKey: Borrow<K>,
+        K: AsRef<str>,
+    {
+        let event_type = content.event_type().to_string();
+        let content = Raw::new(&content)?.cast_unchecked();
+        self.encrypt_state_event_raw(room_id, &event_type, state_key.as_ref(), &content).await
+    }
+
+    /// Encrypt a state event for the given state event using its raw JSON
+    /// content and state key.
+    ///
+    /// This method is equivalent to [`OlmMachine::encrypt_state_event`]
+    /// method but operates on an arbitrary JSON value instead of strongly-typed
+    /// event content struct.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room for which the message should be
+    ///   encrypted.
+    ///
+    /// * `content` - The plaintext content of the event that should be
+    ///   encrypted as a raw JSON value.
+    ///
+    /// * `state_key` - The associated state key of the event.
+    pub async fn encrypt_state_event_raw(
+        &self,
+        room_id: &RoomId,
+        event_type: &str,
+        state_key: &str,
+        content: &Raw<AnyStateEventContent>,
+    ) -> MegolmResult<Raw<StateRoomEncryptedEventContent>> {
+        self.inner
+            .group_session_manager
+            .encrypt_state(room_id, event_type, state_key, content)
+            .await
     }
 
     /// Forces the currently active room key, which is used to encrypt messages,

--- a/crates/matrix-sdk-crypto/src/machine/tests/room_settings.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/room_settings.rs
@@ -23,6 +23,7 @@ async fn test_stores_and_returns_room_settings() {
 
     let settings = RoomSettings {
         algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+        encrypt_state_events: false,
         only_allow_trusted_devices: true,
         session_rotation_period: Some(Duration::from_secs(10)),
         session_rotation_period_messages: Some(1234),

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -1163,6 +1163,7 @@ macro_rules! cryptostore_integration_tests {
                 let room_1 = room_id!("!test_1:localhost");
                 let settings_1 = RoomSettings {
                     algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+                    encrypt_state_events: false,
                     only_allow_trusted_devices: true,
                     session_rotation_period: Some(Duration::from_secs(10)),
                     session_rotation_period_messages: Some(123),

--- a/crates/matrix-sdk-crypto/src/store/types.rs
+++ b/crates/matrix-sdk-crypto/src/store/types.rs
@@ -411,6 +411,9 @@ pub struct RoomSettings {
     /// The encryption algorithm that should be used in the room.
     pub algorithm: EventEncryptionAlgorithm,
 
+    /// Whether state event encryption is enabled.
+    pub encrypt_state_events: bool,
+
     /// Should untrusted devices receive the room key, or should they be
     /// excluded from the conversation.
     pub only_allow_trusted_devices: bool,
@@ -428,6 +431,7 @@ impl Default for RoomSettings {
     fn default() -> Self {
         Self {
             algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+            encrypt_state_events: false,
             only_allow_trusted_devices: false,
             session_rotation_period: None,
             session_rotation_period_messages: None,

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -322,7 +322,7 @@ impl<'a> IntoFuture for SendAttachment<'a> {
     }
 }
 
-/// TODO: Future returned by `Room::send_state_event_raw`.
+/// Future returned by [`Room::send_state_event_raw`].
 #[allow(missing_debug_implementations)]
 pub struct SendStateEventRaw<'a> {
     room: &'a Room,

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -356,6 +356,20 @@ impl<'a> SendStateEvent<'a> {
     }
 }
 
+impl<'a> IntoFuture for SendStateEvent<'a> {
+    type Output = Result<send_state_event::v3::Response>;
+    boxed_into_future!(extra_bounds: 'a);
+
+    fn into_future(self) -> Self::IntoFuture {
+        let Self { room, state_key, event_type, content, request_config } = self;
+        Box::pin(async move {
+            let content = content?;
+            assign!(room.send_state_event_raw(&event_type, &state_key, content), { request_config })
+                .await
+        })
+    }
+}
+
 /// Future returned by [`Room::send_state_event_raw`].
 #[allow(missing_debug_implementations)]
 pub struct SendStateEventRaw<'a> {

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/mod.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/mod.rs
@@ -43,6 +43,7 @@ use tracing::{debug, warn};
 use crate::helpers::{SyncTokenAwareClient, TestClientBuilder};
 
 mod shared_history;
+mod state_events;
 
 // This test reproduces a bug seen on clients that use the same `Client`
 // instance for both the usual sliding sync loop and for getting the event for a

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/state_events.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/state_events.rs
@@ -1,0 +1,150 @@
+use std::{ops::Deref, time::Duration};
+
+use anyhow::Result;
+use assert_matches2::assert_let;
+use assign::assign;
+use futures::{FutureExt, StreamExt, pin_mut};
+use matrix_sdk::{
+    assert_let_decrypted_state_event_content,
+    encryption::EncryptionSettings,
+    ruma::{
+        api::client::room::create_room::v3::{Request as CreateRoomRequest, RoomPreset},
+        events::AnyStateEventContent,
+    },
+};
+use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
+use matrix_sdk_ui::sync_service::SyncService;
+use similar_asserts::assert_eq;
+use tracing::{Instrument, info};
+
+use crate::helpers::{SyncTokenAwareClient, TestClientBuilder};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_e2ee_state_events() -> Result<()> {
+    let alice_span = tracing::info_span!("alice");
+    let bob_span = tracing::info_span!("bob");
+
+    let encryption_settings =
+        EncryptionSettings { auto_enable_cross_signing: true, ..Default::default() };
+
+    let alice = TestClientBuilder::new("alice")
+        .use_sqlite()
+        .encryption_settings(encryption_settings)
+        .enable_share_history_on_invite(true)
+        .build()
+        .await?;
+
+    let sync_service_span = tracing::info_span!(parent: &alice_span, "sync_service");
+    let alice_sync_service = SyncService::builder(alice.clone())
+        .with_parent_span(sync_service_span)
+        .build()
+        .await
+        .expect("Could not build alice sync service");
+
+    alice.encryption().wait_for_e2ee_initialization_tasks().await;
+    alice_sync_service.start().await;
+
+    let bob = SyncTokenAwareClient::new(
+        TestClientBuilder::new("bob")
+            .encryption_settings(encryption_settings)
+            .enable_share_history_on_invite(true)
+            .build()
+            .await?,
+    );
+
+    // Alice creates an encrypted room ...
+    let alice_room = alice
+        .create_room(assign!(CreateRoomRequest::new(), {
+            name: Some("Cat Photos".to_owned()),
+            preset: Some(RoomPreset::PublicChat),
+        }))
+        .await?;
+    alice_room.enable_encryption_with_state().await?;
+
+    // HACK: wait for sync
+    let _ = tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // (sanity checks)
+    assert!(alice_room.encryption_state().is_encrypted(), "Encryption was not enabled.");
+    assert!(
+        alice_room.encryption_state().is_state_encrypted(),
+        "State encryption was not enabled."
+    );
+
+    info!(room_id = ?alice_room.room_id(), "Alice has created and enabled encryption in the room");
+
+    // ... and changes the room name
+    let rename_event_id = alice_room
+        .set_name("Dog Photos".to_owned())
+        .await
+        .expect("We should be able to rename the room")
+        .event_id;
+
+    let bundle_stream = bob
+        .encryption()
+        .historic_room_key_stream()
+        .await
+        .expect("We should be able to get the bundle stream");
+
+    // Alice invites Bob to the room
+    alice_room.invite_user_by_id(bob.user_id().unwrap()).await?;
+
+    // Alice is done. Bob has been invited and the room key bundle should have been
+    // sent out. Let's stop syncing so the logs contain less noise.
+    alice_sync_service.stop().await;
+
+    let bob_response = bob.sync_once().instrument(bob_span.clone()).await?;
+
+    // Bob should have received a to-device event with the payload
+    assert_eq!(bob_response.to_device.len(), 1);
+    let to_device_event = &bob_response.to_device[0];
+    assert_let!(ProcessedToDeviceEvent::Decrypted { raw, .. } = to_device_event);
+    assert_eq!(
+        raw.get_field::<String>("type").unwrap().unwrap(),
+        "io.element.msc4268.room_key_bundle"
+    );
+
+    bob.get_room(alice_room.room_id()).expect("Bob should have received the invite");
+
+    pin_mut!(bundle_stream);
+
+    let info = bundle_stream
+        .next()
+        .now_or_never()
+        .flatten()
+        .expect("We should be notified about the received bundle");
+
+    assert_eq!(Some(info.sender.deref()), alice.user_id());
+    assert_eq!(info.room_id, alice_room.room_id());
+
+    let bob_room = bob
+        .join_room_by_id(alice_room.room_id())
+        .instrument(bob_span.clone())
+        .await
+        .expect("Bob should be able to accept the invitation from Alice");
+
+    // Sync the room, so the rename event arrives.
+    let _ = bob.sync_once().instrument(bob_span.clone()).await?;
+
+    // Check it has been applied.
+    assert_eq!(
+        "Dog Photos",
+        bob_room.name().unwrap(),
+        "Bob's copy of the room name should have updated."
+    );
+
+    // Let's also check we can inspect the payload manually.
+    let rename_event = bob_room
+        .event(&rename_event_id, None)
+        .instrument(bob_span.clone())
+        .await
+        .expect("Bob should be able to fetch the historic event.");
+
+    assert_let_decrypted_state_event_content!(
+        AnyStateEventContent::RoomName(content) = rename_event
+    );
+
+    assert_eq!("Dog Photos", content.name);
+
+    Ok(())
+}


### PR DESCRIPTION
Implements support for encrypted state events under `m.room.encrypted`, as outlined in [MSC3414](https://github.com/matrix-org/matrix-spec-proposals/blob/travis/msc/encrypted-state/proposals/3414-encrypted-state.md).

- (base) Modifies `state_events::sync::dispatch` to require `E2EE` when end-to-end encryption is enabled, using it to decrypt `m.room.encrypted` state events when received.
- (base) Declares `m.room.encrypted` as required state by default.
- (crypto) Introduces `encrypt_state_event` and `encrypt_state_event_raw` to `OlmMachine` and `OutboundGroupSession`;
- (sdk) Modifies `Room::send_state_event` and `Room::send_state_event_Raw` to return `SendStateEvent` and `SendStateEventRaw` futures respectifely, that each function similarly to their message-like counterparts.
- (integration) Add an integration test for encrypted room renaming.