### PR TITLE
refactor(test): avoid proliferation of builder submethods in the `MockClientBuilder`

### DIFF
--- a/benchmarks/benches/event_cache.rs
+++ b/benchmarks/benches/event_cache.rs
@@ -86,12 +86,14 @@ fn handle_room_updates(c: &mut Criterion) {
                                 // Setup code.
                                 let client = server
                                     .client_builder()
-                                    .store_config(
-                                        StoreConfig::new(
-                                            "cross-process-store-locks-holder-name".to_owned(),
+                                    .on_builder(|builder| {
+                                        builder.store_config(
+                                            StoreConfig::new(
+                                                "cross-process-store-locks-holder-name".to_owned(),
+                                            )
+                                            .event_cache_store(store.clone()),
                                         )
-                                        .event_cache_store(store.clone()),
-                                    )
+                                    })
                                     .build()
                                     .await;
 

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -269,7 +269,11 @@ mod tests {
         // Create a client that will use sqlite databases.
 
         let tmp_dir = tempfile::tempdir()?;
-        let client = MockClientBuilder::new(None).sqlite_store(&tmp_dir).unlogged().build().await;
+        let client = MockClientBuilder::new(None)
+            .on_builder(|builder| builder.sqlite_store(&tmp_dir, None))
+            .unlogged()
+            .build()
+            .await;
 
         let tokens = mock_session_tokens_with_refresh();
 
@@ -315,8 +319,12 @@ mod tests {
         server.mock_who_am_i().ok().expect(1).named("whoami").mount().await;
 
         let tmp_dir = tempfile::tempdir()?;
-        let client =
-            server.client_builder().sqlite_store(&tmp_dir).registered_with_oauth().build().await;
+        let client = server
+            .client_builder()
+            .on_builder(|builder| builder.sqlite_store(&tmp_dir, None))
+            .registered_with_oauth()
+            .build()
+            .await;
         let oauth = client.oauth();
 
         // Enable cross-process lock.
@@ -365,7 +373,12 @@ mod tests {
         oauth_server.mock_token().ok().expect(1).named("token").mount().await;
 
         let tmp_dir = tempfile::tempdir()?;
-        let client = server.client_builder().sqlite_store(&tmp_dir).unlogged().build().await;
+        let client = server
+            .client_builder()
+            .on_builder(|builder| builder.sqlite_store(&tmp_dir, None))
+            .unlogged()
+            .build()
+            .await;
         let oauth = client.oauth();
 
         let next_tokens = mock_session_tokens_with_refresh();
@@ -414,7 +427,12 @@ mod tests {
 
         // Create the first client.
         let tmp_dir = tempfile::tempdir()?;
-        let client = server.client_builder().sqlite_store(&tmp_dir).unlogged().build().await;
+        let client = server
+            .client_builder()
+            .on_builder(|builder| builder.sqlite_store(&tmp_dir, None))
+            .unlogged()
+            .build()
+            .await;
 
         let oauth = client.oauth();
         oauth.enable_cross_process_refresh_lock("client1".to_owned()).await?;
@@ -425,15 +443,24 @@ mod tests {
 
         // Create a second client, without restoring it, to test that a token update
         // before restoration doesn't cause new issues.
-        let unrestored_client =
-            server.client_builder().sqlite_store(&tmp_dir).unlogged().build().await;
+        let unrestored_client = server
+            .client_builder()
+            .on_builder(|builder| builder.sqlite_store(&tmp_dir, None))
+            .unlogged()
+            .build()
+            .await;
         let unrestored_oauth = unrestored_client.oauth();
         unrestored_oauth.enable_cross_process_refresh_lock("unrestored_client".to_owned()).await?;
 
         {
             // Create a third client that will run a refresh while the others two are doing
             // nothing.
-            let client3 = server.client_builder().sqlite_store(&tmp_dir).unlogged().build().await;
+            let client3 = server
+                .client_builder()
+                .on_builder(|builder| builder.sqlite_store(&tmp_dir, None))
+                .unlogged()
+                .build()
+                .await;
 
             let oauth3 = client3.oauth();
             oauth3.enable_cross_process_refresh_lock("client3".to_owned()).await?;
@@ -541,7 +568,12 @@ mod tests {
         oauth_server.mock_revocation().ok().expect(1).named("revocation").mount().await;
 
         let tmp_dir = tempfile::tempdir()?;
-        let client = server.client_builder().sqlite_store(&tmp_dir).unlogged().build().await;
+        let client = server
+            .client_builder()
+            .on_builder(|builder| builder.sqlite_store(&tmp_dir, None))
+            .unlogged()
+            .build()
+            .await;
         let oauth = client.oauth().insecure_rewrite_https_to_http();
 
         // Enable cross-process lock.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3069,7 +3069,7 @@ pub(crate) mod tests {
         let server = MatrixMockServer::new().await;
         let client = server
             .client_builder()
-            .request_config(RequestConfig::new().retry_limit(3))
+            .on_builder(|builder| builder.request_config(RequestConfig::new().retry_limit(3)))
             .build()
             .await;
 
@@ -3087,7 +3087,9 @@ pub(crate) mod tests {
         let server = MatrixMockServer::new().await;
         let client = server
             .client_builder()
-            .request_config(RequestConfig::new().max_retry_time(retry_timeout))
+            .on_builder(|builder| {
+                builder.request_config(RequestConfig::new().max_retry_time(retry_timeout))
+            })
             .build()
             .await;
 
@@ -3101,8 +3103,11 @@ pub(crate) mod tests {
     #[async_test]
     async fn test_short_retry_initial_http_requests() {
         let server = MatrixMockServer::new().await;
-        let client =
-            server.client_builder().request_config(RequestConfig::short_retry()).build().await;
+        let client = server
+            .client_builder()
+            .on_builder(|builder| builder.request_config(RequestConfig::short_retry()))
+            .build()
+            .await;
 
         server.mock_login().error500().expect(3..).mount().await;
 
@@ -3318,10 +3323,12 @@ pub(crate) mod tests {
         let client = server
             .client_builder()
             .no_server_versions()
-            .store_config(
-                StoreConfig::new("cross-process-store-locks-holder-name".to_owned())
-                    .state_store(memory_store.clone()),
-            )
+            .on_builder(|builder| {
+                builder.store_config(
+                    StoreConfig::new("cross-process-store-locks-holder-name".to_owned())
+                        .state_store(memory_store.clone()),
+                )
+            })
             .build()
             .await;
 
@@ -3372,10 +3379,12 @@ pub(crate) mod tests {
         let client = server
             .client_builder()
             .no_server_versions()
-            .store_config(
-                StoreConfig::new("cross-process-store-locks-holder-name".to_owned())
-                    .state_store(memory_store.clone()),
-            )
+            .on_builder(|builder| {
+                builder.store_config(
+                    StoreConfig::new("cross-process-store-locks-holder-name".to_owned())
+                        .state_store(memory_store.clone()),
+                )
+            })
             .build()
             .await;
 
@@ -3390,10 +3399,12 @@ pub(crate) mod tests {
         let client = server
             .client_builder()
             .no_server_versions()
-            .store_config(
-                StoreConfig::new("cross-process-store-locks-holder-name".to_owned())
-                    .state_store(memory_store.clone()),
-            )
+            .on_builder(|builder| {
+                builder.store_config(
+                    StoreConfig::new("cross-process-store-locks-holder-name".to_owned())
+                        .state_store(memory_store.clone()),
+                )
+            })
             .build()
             .await;
 
@@ -3424,8 +3435,10 @@ pub(crate) mod tests {
     #[async_test]
     async fn test_no_network_doesnt_cause_infinite_retries() {
         // We want infinite retries for transient errors.
-        let client =
-            MockClientBuilder::new(None).request_config(RequestConfig::new()).build().await;
+        let client = MockClientBuilder::new(None)
+            .on_builder(|builder| builder.request_config(RequestConfig::new()))
+            .build()
+            .await;
 
         // We don't define a mock server on purpose here, so that the error is really a
         // network error.

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -2221,9 +2221,12 @@ mod timed_tests {
         let event_cache_store = Arc::new(MemoryStore::new());
 
         let client = MockClientBuilder::new(None)
-            .store_config(
-                StoreConfig::new("hodlor".to_owned()).event_cache_store(event_cache_store.clone()),
-            )
+            .on_builder(|builder| {
+                builder.store_config(
+                    StoreConfig::new("hodlor".to_owned())
+                        .event_cache_store(event_cache_store.clone()),
+                )
+            })
             .build()
             .await;
 
@@ -2295,9 +2298,12 @@ mod timed_tests {
         let event_cache_store = Arc::new(MemoryStore::new());
 
         let client = MockClientBuilder::new(None)
-            .store_config(
-                StoreConfig::new("hodlor".to_owned()).event_cache_store(event_cache_store.clone()),
-            )
+            .on_builder(|builder| {
+                builder.store_config(
+                    StoreConfig::new("hodlor".to_owned())
+                        .event_cache_store(event_cache_store.clone()),
+                )
+            })
             .build()
             .await;
 
@@ -2434,9 +2440,12 @@ mod timed_tests {
             .unwrap();
 
         let client = MockClientBuilder::new(None)
-            .store_config(
-                StoreConfig::new("hodlor".to_owned()).event_cache_store(event_cache_store.clone()),
-            )
+            .on_builder(|builder| {
+                builder.store_config(
+                    StoreConfig::new("hodlor".to_owned())
+                        .event_cache_store(event_cache_store.clone()),
+                )
+            })
             .build()
             .await;
 
@@ -2585,9 +2594,12 @@ mod timed_tests {
             .unwrap();
 
         let client = MockClientBuilder::new(None)
-            .store_config(
-                StoreConfig::new("hodlor".to_owned()).event_cache_store(event_cache_store.clone()),
-            )
+            .on_builder(|builder| {
+                builder.store_config(
+                    StoreConfig::new("hodlor".to_owned())
+                        .event_cache_store(event_cache_store.clone()),
+                )
+            })
             .build()
             .await;
 
@@ -2706,9 +2718,12 @@ mod timed_tests {
             .unwrap();
 
         let client = MockClientBuilder::new(None)
-            .store_config(
-                StoreConfig::new("holder".to_owned()).event_cache_store(event_cache_store.clone()),
-            )
+            .on_builder(|builder| {
+                builder.store_config(
+                    StoreConfig::new("holder".to_owned())
+                        .event_cache_store(event_cache_store.clone()),
+                )
+            })
             .build()
             .await;
 

--- a/crates/matrix-sdk/tests/integration/encryption/shared_history.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/shared_history.rs
@@ -31,15 +31,21 @@ async fn test_shared_history_out_of_order() {
 
     let alice = matrix_mock_server
         .client_builder_for_crypto_end_to_end(alice_user_id, alice_device_id)
-        .enable_share_history_on_invite()
-        .with_encryption_settings(encryption_settings)
+        .on_builder(|builder| {
+            builder
+                .with_enable_share_history_on_invite(true)
+                .with_encryption_settings(encryption_settings)
+        })
         .build()
         .await;
 
     let bob = matrix_mock_server
         .client_builder_for_crypto_end_to_end(bob_user_id, bob_device_id)
-        .enable_share_history_on_invite()
-        .with_encryption_settings(encryption_settings)
+        .on_builder(|builder| {
+            builder
+                .with_enable_share_history_on_invite(true)
+                .with_encryption_settings(encryption_settings)
+        })
         .build()
         .await;
 

--- a/crates/matrix-sdk/tests/integration/event_cache/mod.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/mod.rs
@@ -1362,7 +1362,11 @@ async fn test_apply_redaction_when_redaction_comes_later() {
     let store_config = StoreConfig::new("hodlor".to_owned())
         .state_store(state_memory_store)
         .event_cache_store(event_cache_store);
-    let client = server.client_builder().store_config(store_config.clone()).build().await;
+    let client = server
+        .client_builder()
+        .on_builder(|builder| builder.store_config(store_config.clone()))
+        .build()
+        .await;
 
     let event_cache = client.event_cache();
 
@@ -1437,7 +1441,11 @@ async fn test_apply_redaction_when_redaction_comes_later() {
     // already redacted.
     drop(client);
 
-    let client = server.client_builder().store_config(store_config).build().await;
+    let client = server
+        .client_builder()
+        .on_builder(|builder| builder.store_config(store_config))
+        .build()
+        .await;
     client.event_cache().subscribe().unwrap();
     let room = client.get_room(room_id).unwrap();
     let (cache, _drop_handles) = room.event_cache().await.unwrap();
@@ -2366,9 +2374,11 @@ async fn test_clear_all_rooms() {
     let server = MatrixMockServer::new().await;
     let client = server
         .client_builder()
-        .store_config(
-            StoreConfig::new("hodlor".to_owned()).event_cache_store(event_cache_store.clone()),
-        )
+        .on_builder(|builder| {
+            builder.store_config(
+                StoreConfig::new("hodlor".to_owned()).event_cache_store(event_cache_store.clone()),
+            )
+        })
         .build()
         .await;
 
@@ -2450,13 +2460,21 @@ async fn test_sync_while_back_paginate() {
     {
         // First, initialize the sync so the client is aware of the room, in the state
         // store.
-        let client = server.client_builder().store_config(store_config.clone()).build().await;
+        let client = server
+            .client_builder()
+            .on_builder(|builder| builder.store_config(store_config.clone()))
+            .build()
+            .await;
         server.sync_joined_room(&client, room_id).await;
     }
 
     // Then, use a new client that will restore the state from the state store, and
     // with an empty event cache store.
-    let client = server.client_builder().store_config(store_config).build().await;
+    let client = server
+        .client_builder()
+        .on_builder(|builder| builder.store_config(store_config))
+        .build()
+        .await;
     let room = client.get_room(room_id).unwrap();
 
     client.event_cache().subscribe().unwrap();
@@ -2558,9 +2576,11 @@ async fn test_relations_ordering() {
 
     let client = server
         .client_builder()
-        .store_config(
-            StoreConfig::new("hodlor".to_owned()).event_cache_store(event_cache_store.clone()),
-        )
+        .on_builder(|builder| {
+            builder.store_config(
+                StoreConfig::new("hodlor".to_owned()).event_cache_store(event_cache_store.clone()),
+            )
+        })
         .build()
         .await;
 

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -584,7 +584,12 @@ async fn test_oauth_refresh_token_handled_success() {
     oauth_server.mock_server_metadata().ok().expect(1..).named("server_metadata").mount().await;
     oauth_server.mock_token().ok().expect(1).named("token").mount().await;
 
-    let client = server.client_builder().unlogged().handle_refresh_tokens().build().await;
+    let client = server
+        .client_builder()
+        .unlogged()
+        .on_builder(|builder| builder.handle_refresh_tokens())
+        .build()
+        .await;
     let oauth = client.oauth();
 
     oauth
@@ -638,7 +643,12 @@ async fn test_oauth_refresh_token_handled_failure() {
     // Return an error to fail the token refresh.
     oauth_server.mock_token().invalid_grant().expect(1).named("token").mount().await;
 
-    let client = server.client_builder().unlogged().handle_refresh_tokens().build().await;
+    let client = server
+        .client_builder()
+        .unlogged()
+        .on_builder(|builder| builder.handle_refresh_tokens())
+        .build()
+        .await;
     let oauth = client.oauth();
 
     oauth
@@ -691,7 +701,12 @@ async fn test_oauth_handle_refresh_tokens() {
 
     oauth_server.mock_server_metadata().ok().expect(1..).named("server_metadata").mount().await;
 
-    let client = server.client_builder().unlogged().handle_refresh_tokens().build().await;
+    let client = server
+        .client_builder()
+        .unlogged()
+        .on_builder(|builder| builder.handle_refresh_tokens())
+        .build()
+        .await;
 
     let oauth = client.oauth();
     oauth

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1637,10 +1637,12 @@ async fn test_reloading_rooms_with_unsent_events() {
 
     let client = mock
         .client_builder()
-        .store_config(
-            StoreConfig::new("cross-process-store-locks-holder-name".to_owned())
-                .state_store(store.clone()),
-        )
+        .on_builder(|builder| {
+            builder.store_config(
+                StoreConfig::new("cross-process-store-locks-holder-name".to_owned())
+                    .state_store(store.clone()),
+            )
+        })
         .build()
         .await;
 
@@ -1689,9 +1691,12 @@ async fn test_reloading_rooms_with_unsent_events() {
 
     let new_client = mock
         .client_builder()
-        .store_config(
-            StoreConfig::new("cross-process-store-locks-holder-name".to_owned()).state_store(store),
-        )
+        .on_builder(|builder| {
+            builder.store_config(
+                StoreConfig::new("cross-process-store-locks-holder-name".to_owned())
+                    .state_store(store),
+            )
+        })
         .build()
         .await;
 


### PR DESCRIPTION

Instead of having one static method duplicating an underlying `ClientBuilder` method, we can pass the builder directly to a closure, that will replace it. Call sites are a bit more verbose, but that would avoid having to add duplicate `MockClientBuilder` methods for each `ClientBuilder` method.

Not too sure about this one; wondering if the current way is better, or if the proposed enhanced way is?