### PR TITLE
feat(threads): filter out notifications from threads we haven't subscribed to 

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -1176,22 +1176,29 @@ impl Room {
     pub async fn fetch_thread_subscription(
         &self,
         thread_root_event_id: String,
-    ) -> Result<Option<ThreadSubscription>, ClientError> {
+    ) -> Result<Option<ThreadStatus>, ClientError> {
         let thread_root = EventId::parse(thread_root_event_id)?;
-        Ok(self
-            .inner
-            .fetch_thread_subscription(thread_root)
-            .await?
-            .map(|sub| ThreadSubscription { automatic: sub.automatic }))
+        Ok(self.inner.fetch_thread_subscription(thread_root).await?.map(|sub| match sub {
+            matrix_sdk::room::ThreadStatus::Subscribed { automatic } => {
+                ThreadStatus::Subscribed { automatic }
+            }
+            matrix_sdk::room::ThreadStatus::Unsubscribed => ThreadStatus::Unsubscribed,
+        }))
     }
 }
 
 /// Status of a thread subscription (MSC4306).
-#[derive(uniffi::Record)]
-pub struct ThreadSubscription {
-    /// Whether the thread subscription happened automatically (e.g. after a
-    /// mention) or if it was manually requested by the user.
-    automatic: bool,
+#[derive(uniffi::Enum)]
+pub enum ThreadStatus {
+    /// The thread is subscribed to.
+    Subscribed {
+        /// Whether the thread subscription happened automatically (e.g. after a
+        /// mention) or if it was manually requested by the user.
+        automatic: bool,
+    },
+
+    /// The thread is not subscribed to.
+    Unsubscribed,
 }
 
 /// A listener for receiving new live location shares in a room.

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -151,9 +151,16 @@ impl fmt::Debug for BaseClient {
 /// explicitly opted into).
 #[derive(Clone, Copy, Debug)]
 pub enum ThreadingSupport {
-    /// Threading enabled
-    Enabled,
-    /// Threading disabled
+    /// Threading enabled.
+    Enabled {
+        /// Enable client-wide thread subscriptions support (MSC4306 / MSC4308).
+        ///
+        /// This may cause filtering out of thread subscriptions, and loading
+        /// the thread subscriptions via the sliding sync extension,
+        /// when the room list service is being used.
+        with_subscriptions: bool,
+    },
+    /// Threading disabled.
     Disabled,
 }
 

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -212,7 +212,7 @@ impl RoomReadReceipts {
         user_id: &UserId,
         threading_support: ThreadingSupport,
     ) {
-        if matches!(threading_support, ThreadingSupport::Enabled)
+        if matches!(threading_support, ThreadingSupport::Enabled { .. })
             && extract_thread_root(event.raw()).is_some()
         {
             return;
@@ -1621,23 +1621,23 @@ mod tests {
         receipts.process_event(
             &make_event(own_alice, event_id!("$some_thread_root")),
             own_alice,
-            ThreadingSupport::Enabled,
+            ThreadingSupport::Enabled { with_subscriptions: false },
         );
         receipts.process_event(
             &make_event(own_alice, event_id!("$some_other_thread_root")),
             own_alice,
-            ThreadingSupport::Enabled,
+            ThreadingSupport::Enabled { with_subscriptions: false },
         );
 
         receipts.process_event(
             &make_event(bob, event_id!("$some_thread_root")),
             own_alice,
-            ThreadingSupport::Enabled,
+            ThreadingSupport::Enabled { with_subscriptions: false },
         );
         receipts.process_event(
             &make_event(bob, event_id!("$some_other_thread_root")),
             own_alice,
-            ThreadingSupport::Enabled,
+            ThreadingSupport::Enabled { with_subscriptions: false },
         );
 
         assert_eq!(receipts.num_unread, 0);
@@ -1648,7 +1648,7 @@ mod tests {
         receipts.process_event(
             &EventFactory::new().text_msg("A").sender(bob).event_id(event_id!("$ida")).into_event(),
             own_alice,
-            ThreadingSupport::Enabled,
+            ThreadingSupport::Enabled { with_subscriptions: false },
         );
 
         assert_eq!(receipts.num_unread, 1);

--- a/crates/matrix-sdk-base/src/response_processors/notification.rs
+++ b/crates/matrix-sdk-base/src/response_processors/notification.rs
@@ -56,9 +56,9 @@ impl<'a> Notification<'a> {
     /// Push a new [`sync::Notification`] in [`Self::notifications`] from
     /// `event` if and only if `predicate` returns `true` for at least one of
     /// the [`Action`]s associated to this event and this
-    /// `push_condition_room_ctx`. (based on `Self::push_rules`).
+    /// `push_condition_room_ctx`. (based on [`Self::push_rules`]).
     ///
-    /// This method returns the fetched [`Action`]s.
+    /// This method returns the computed [`Action`]s.
     pub fn push_notification_from_event_if<E, P>(
         &mut self,
         room_id: &RoomId,

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -43,7 +43,10 @@ use super::{
 use crate::{
     RoomInfo, RoomMemberships, RoomState, StateChanges, StateStoreDataKey, StateStoreDataValue,
     deserialized_responses::MemberEvent,
-    store::{ChildTransactionId, QueueWedgeError, Result, SerializableEventContent, StateStoreExt},
+    store::{
+        ChildTransactionId, QueueWedgeError, Result, SerializableEventContent, StateStoreExt,
+        ThreadStatus,
+    },
 };
 
 /// `StateStore` integration tests.
@@ -98,6 +101,8 @@ pub trait StateStoreIntegrationTests {
     async fn test_server_info_saving(&self);
     /// Test fetching room infos based on [`RoomLoadSettings`].
     async fn test_get_room_infos(&self);
+    /// Test loading thread subscriptions.
+    async fn test_thread_subscriptions(&self);
 }
 
 impl StateStoreIntegrationTests for DynStateStore {
@@ -1767,6 +1772,53 @@ impl StateStoreIntegrationTests for DynStateStore {
             assert_eq!(all_rooms.len(), 0);
         }
     }
+
+    async fn test_thread_subscriptions(&self) {
+        let first_thread = event_id!("$t1");
+        let second_thread = event_id!("$t2");
+
+        // At first, there is no thread subscription.
+        let maybe_status = self.load_thread_subscription(room_id(), first_thread).await.unwrap();
+        assert!(maybe_status.is_none());
+
+        let maybe_status = self.load_thread_subscription(room_id(), second_thread).await.unwrap();
+        assert!(maybe_status.is_none());
+
+        // Setting the thread subscription works.
+        self.upsert_thread_subscription(
+            room_id(),
+            first_thread,
+            ThreadStatus::Subscribed { automatic: true },
+        )
+        .await
+        .unwrap();
+
+        self.upsert_thread_subscription(
+            room_id(),
+            second_thread,
+            ThreadStatus::Subscribed { automatic: false },
+        )
+        .await
+        .unwrap();
+
+        // Now, reading the thread subscription returns the expected status.
+        let maybe_status = self.load_thread_subscription(room_id(), first_thread).await.unwrap();
+        assert_eq!(maybe_status, Some(ThreadStatus::Subscribed { automatic: true }));
+        let maybe_status = self.load_thread_subscription(room_id(), second_thread).await.unwrap();
+        assert_eq!(maybe_status, Some(ThreadStatus::Subscribed { automatic: false }));
+
+        // We can override the thread subscription status.
+        self.upsert_thread_subscription(room_id(), first_thread, ThreadStatus::Unsubscribed)
+            .await
+            .unwrap();
+
+        // And it's correctly reflected.
+        let maybe_status = self.load_thread_subscription(room_id(), first_thread).await.unwrap();
+        assert_eq!(maybe_status, Some(ThreadStatus::Unsubscribed));
+        // And the second thread is still subscribed.
+        let maybe_status = self.load_thread_subscription(room_id(), second_thread).await.unwrap();
+        assert_eq!(maybe_status, Some(ThreadStatus::Subscribed { automatic: false }));
+    }
 }
 
 /// Macro building to allow your StateStore implementation to run the entire
@@ -1936,6 +1988,12 @@ macro_rules! statestore_integration_tests {
             async fn test_get_room_infos() {
                 let store = get_store().await.expect("creating store failed").into_state_store();
                 store.test_get_room_infos().await;
+            }
+
+            #[async_test]
+            async fn test_thread_subscriptions() {
+                let store = get_store().await.expect("creating store failed").into_state_store();
+                store.test_thread_subscriptions().await;
             }
         }
     };

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -754,6 +754,7 @@ impl StateStore for MemoryStore {
         inner.room_event_receipts.remove(room_id);
         inner.send_queue_events.remove(room_id);
         inner.dependent_send_queue_events.remove(room_id);
+        inner.thread_subscriptions.remove(room_id);
 
         Ok(())
     }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -439,6 +439,47 @@ pub enum RoomLoadSettings {
     One(OwnedRoomId),
 }
 
+/// Status of a thread subscription, as saved in the state store.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ThreadStatus {
+    /// The thread is subscribed to.
+    Subscribed {
+        /// Whether the subscription was made automatically by a client, not by
+        /// manual user choice.
+        automatic: bool,
+    },
+    /// The thread is unsubscribed to (it won't cause any notifications or
+    /// automatic subscription anymore).
+    Unsubscribed,
+}
+
+impl ThreadStatus {
+    /// Convert the current [`ThreadStatus`] into a string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ThreadStatus::Subscribed { automatic } => {
+                if *automatic {
+                    "automatic"
+                } else {
+                    "manual"
+                }
+            }
+            ThreadStatus::Unsubscribed => "unsubscribed",
+        }
+    }
+
+    /// Convert a string representation into a [`ThreadStatus`], if it is a
+    /// valid one, or `None` otherwise.
+    pub fn from_value(s: &str) -> Option<Self> {
+        match s {
+            "automatic" => Some(ThreadStatus::Subscribed { automatic: true }),
+            "manual" => Some(ThreadStatus::Subscribed { automatic: false }),
+            "unsubscribed" => Some(ThreadStatus::Unsubscribed),
+            _ => None,
+        }
+    }
+}
+
 /// Store state changes and pass them to the StateStore.
 #[derive(Clone, Debug, Default)]
 pub struct StateChanges {

--- a/crates/matrix-sdk-sqlite/migrations/state_store/011_thread_subscriptions.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/011_thread_subscriptions.sql
@@ -1,0 +1,9 @@
+-- Thread subscriptions.
+CREATE TABLE "thread_subscriptions" (
+    "room_id" BLOB NOT NULL,
+    -- Event ID of the thread root.
+    "event_id" BLOB NOT NULL,
+    "status" TEXT NOT NULL,
+
+    PRIMARY KEY ("room_id", "event_id")
+);

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -13,7 +13,7 @@ use matrix_sdk_base::{
     store::{
         migration_helpers::RoomInfoV1, ChildTransactionId, DependentQueuedRequest,
         DependentQueuedRequestKind, QueueWedgeError, QueuedRequest, QueuedRequestKind,
-        RoomLoadSettings, SentRequestKey,
+        RoomLoadSettings, SentRequestKey, ThreadStatus,
     },
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, RoomState, StateChanges, StateStore,
     StateStoreDataKey, StateStoreDataValue, ROOM_VERSION_FALLBACK, ROOM_VERSION_RULES_FALLBACK,
@@ -62,6 +62,7 @@ mod keys {
     pub const DISPLAY_NAME: &str = "display_name";
     pub const SEND_QUEUE: &str = "send_queue_events";
     pub const DEPENDENTS_SEND_QUEUE: &str = "dependent_send_queue_events";
+    pub const THREAD_SUBSCRIPTIONS: &str = "thread_subscriptions";
 }
 
 /// The filename used for the SQLITE database file used by the state store.
@@ -72,7 +73,7 @@ pub const DATABASE_NAME: &str = "matrix-sdk-state.sqlite3";
 /// This is used to figure whether the SQLite database requires a migration.
 /// Every new SQL migration should imply a bump of this number, and changes in
 /// the [`SqliteStateStore::run_migrations`] function.
-const DATABASE_VERSION: u8 = 12;
+const DATABASE_VERSION: u8 = 13;
 
 /// An SQLite-based state store.
 #[derive(Clone)]
@@ -354,6 +355,17 @@ impl SqliteStateStore {
             // of the DB as we removed the media cache.
             conn.vacuum().await?;
             conn.set_kv("version", vec![12]).await?;
+        }
+
+        if from < 13 && to >= 13 {
+            conn.with_transaction(move |txn| {
+                // Run the migration.
+                txn.execute_batch(include_str!(
+                    "../migrations/state_store/011_thread_subscriptions.sql"
+                ))?;
+                txn.set_db_version(13)
+            })
+            .await?;
         }
 
         Ok(())
@@ -2073,6 +2085,55 @@ impl StateStore for SqliteStateStore {
         }
 
         Ok(dependent_events)
+    }
+
+    async fn upsert_thread_subscription(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+        status: ThreadStatus,
+    ) -> Result<(), Self::Error> {
+        let room_id = self.encode_key(keys::THREAD_SUBSCRIPTIONS, room_id);
+        let thread_id = self.encode_key(keys::THREAD_SUBSCRIPTIONS, thread_id);
+        let status = status.as_str();
+
+        self.acquire()
+            .await?
+            .with_transaction(move |txn| {
+                txn.prepare_cached(
+                    "INSERT OR REPLACE INTO thread_subscriptions (room_id, event_id, status)
+                         VALUES (?, ?, ?)",
+                )?
+                .execute((room_id, thread_id, status))
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn load_thread_subscription(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<Option<ThreadStatus>, Self::Error> {
+        let room_id = self.encode_key(keys::THREAD_SUBSCRIPTIONS, room_id);
+        let thread_id = self.encode_key(keys::THREAD_SUBSCRIPTIONS, thread_id);
+
+        Ok(self
+            .acquire()
+            .await?
+            .query_row(
+                "SELECT status FROM thread_subscriptions WHERE room_id = ? AND event_id = ?",
+                (room_id, thread_id),
+                |row| row.get::<_, String>(0),
+            )
+            .await
+            .optional()?
+            .map(|data| {
+                ThreadStatus::from_value(&data).ok_or_else(|| Error::InvalidData {
+                    details: format!("Invalid thread status: {}", data),
+                })
+            })
+            .transpose()?)
     }
 }
 

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1766,6 +1766,13 @@ impl StateStore for SqliteStateStore {
                 this.encode_key(keys::DEPENDENTS_SEND_QUEUE, &room_id);
             txn.remove_room_dependent_send_queue(&dependent_send_queue_room_id)?;
 
+            let thread_subscriptions_room_id =
+                this.encode_key(keys::THREAD_SUBSCRIPTIONS, &room_id);
+            txn.execute(
+                "DELETE FROM thread_subscriptions WHERE room_id = ?",
+                (thread_subscriptions_room_id,),
+            )?;
+
             Ok(())
         })
         .await?;

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -6,6 +6,7 @@ use std::{
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use matrix_sdk::{
+    ThreadingSupport,
     config::SyncSettings,
     test_utils::{logged_in_client_with_server, mocks::MatrixMockServer},
 };
@@ -95,7 +96,11 @@ async fn test_notification_client_with_context() {
 #[async_test]
 async fn test_subscribed_threads_get_notifications() {
     let server = MatrixMockServer::new().await;
-    let client = server.client_builder().enable_thread_subscriptions().build().await;
+    let client = server
+        .client_builder()
+        .threading_support(ThreadingSupport::Enabled { with_subscriptions: true })
+        .build()
+        .await;
 
     let sender = user_id!("@user:example.org");
     let room_id = room_id!("!a98sd12bjh:example.org");
@@ -174,7 +179,11 @@ async fn test_subscribed_threads_get_notifications() {
 #[async_test]
 async fn test_unknown_threads_get_notifications() {
     let server = MatrixMockServer::new().await;
-    let client = server.client_builder().enable_thread_subscriptions().build().await;
+    let client = server
+        .client_builder()
+        .threading_support(ThreadingSupport::Enabled { with_subscriptions: true })
+        .build()
+        .await;
 
     let sender = user_id!("@user:example.org");
     let room_id = room_id!("!a98sd12bjh:example.org");
@@ -281,7 +290,11 @@ async fn test_unknown_threads_get_notifications() {
 #[async_test]
 async fn test_unsubscribed_threads_dont_get_notifications() {
     let server = MatrixMockServer::new().await;
-    let client = server.client_builder().enable_thread_subscriptions().build().await;
+    let client = server
+        .client_builder()
+        .threading_support(ThreadingSupport::Enabled { with_subscriptions: true })
+        .build()
+        .await;
 
     let sender = user_id!("@user:example.org");
     let room_id = room_id!("!a98sd12bjh:example.org");

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::BTreeMap,
     sync::{Arc, Mutex},
-    time::Duration,
 };
 
 use assert_matches::assert_matches;
@@ -39,44 +38,30 @@ use crate::{
 
 #[async_test]
 async fn test_notification_client_with_context() {
-    let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let sender = user_id!("@user:example.org");
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let f = EventFactory::new().room(room_id).sender(sender);
 
     let content = "Hello world!";
     let event_id = event_id!("$example_event_id");
-    let server_ts = 152049794;
-    let sender = user_id!("@user:example.org");
+    let event = f.text_msg(content).event_id(event_id).server_ts(152049794).into_event();
+
     let sender_display_name = "John Mastodon";
     let sender_avatar_url = mxc_uri!("mxc://example.org/avatar");
-    let event_factory = EventFactory::new().room(room_id).sender(sender);
-    let event_json =
-        event_factory.text_msg(content).event_id(event_id).server_ts(server_ts).into_raw_sync();
-
-    let sender_member_event = event_factory
+    let sender_member_event = f
         .member(sender)
         .membership(MembershipState::Join)
         .display_name(sender_display_name)
         .avatar_url(sender_avatar_url)
         .into_raw_timeline();
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id).add_timeline_event(
-            event_factory
-                .text_msg(content)
-                .event_id(event_id)
-                .server_ts(server_ts)
-                .sender(sender)
-                .into_raw_sync(),
-        ),
-    );
-
     // First, mock a sync that contains a text message.
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(&client, JoinedRoomBuilder::new(room_id).add_timeline_event(event.raw().clone()))
+        .await;
 
     // Then, try to simulate receiving a notification for that message.
     let dummy_sync_service = Arc::new(SyncService::builder(client.clone()).build().await.unwrap());
@@ -84,33 +69,26 @@ async fn test_notification_client_with_context() {
         NotificationProcessSetup::SingleProcess { sync_service: dummy_sync_service };
     let notification_client = NotificationClient::new(client, process_setup).await.unwrap();
 
-    {
-        // The notification client retrieves the event via `/rooms/*/context/`.
-        Mock::given(method("GET"))
-            .and(path(format!("/_matrix/client/r0/rooms/{room_id}/context/{event_id}")))
-            .and(header("authorization", "Bearer 1234"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "event": event_json,
-                "state": [sender_member_event]
-            })))
-            .mount(&server)
-            .await;
+    // The notification client retrieves the event via `/rooms/*/context/`.
+    server
+        .mock_room_event_context()
+        .ok(event, "", "", vec![sender_member_event.cast_unchecked()])
+        .mock_once()
+        .mount()
+        .await;
 
-        // The encryption state is also fetched to figure whether the room is encrypted
-        // or not.
-        mock_encryption_state(&server, false).await;
-    }
+    // The encryption state is also fetched to figure whether the room is encrypted
+    // or not.
+    server.mock_room_state_encryption().plain().mount().await;
 
     let item = notification_client.get_notification_with_context(room_id, event_id).await.unwrap();
-
-    server.reset().await;
 
     assert_let!(NotificationStatus::Event(item) = item);
 
     assert_matches!(item.event, NotificationEvent::Timeline(event) => {
         assert_eq!(event.event_type(), TimelineEventType::RoomMessage);
     });
-    assert_eq!(item.sender_display_name.as_deref(), Some("John Mastodon"));
+    assert_eq!(item.sender_display_name.as_deref(), Some(sender_display_name));
     assert_eq!(item.sender_avatar_url, Some(sender_avatar_url.to_string()));
 }
 
@@ -924,7 +902,12 @@ async fn test_notification_client_context_filters_out_events_from_ignored_users(
         .into_event();
 
     // Mock the /context response
-    server.mock_room_event_context().ok(event, "start", "end").mock_once().mount().await;
+    server
+        .mock_room_event_context()
+        .ok(event, "start", "end", Vec::new())
+        .mock_once()
+        .mount()
+        .await;
 
     let dummy_sync_service = Arc::new(SyncService::builder(client.clone()).build().await.unwrap());
     let process_setup =

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -114,7 +114,6 @@ pub struct ClientBuilder {
     enable_share_history_on_invite: bool,
     cross_process_store_locks_holder_name: String,
     threading_support: ThreadingSupport,
-    enable_thread_subscriptions: bool,
 }
 
 impl ClientBuilder {
@@ -146,18 +145,7 @@ impl ClientBuilder {
             cross_process_store_locks_holder_name:
                 Self::DEFAULT_CROSS_PROCESS_STORE_LOCKS_HOLDER_NAME.to_owned(),
             threading_support: ThreadingSupport::Disabled,
-            enable_thread_subscriptions: false,
         }
-    }
-
-    /// Enable client-wide thread subscriptions support (MSC4306 / MSC4308).
-    ///
-    /// This may cause filtering out of thread subscriptions, and loading the
-    /// thread subscriptions via the sliding sync extension, when the room
-    /// list service is being used.
-    pub fn enable_thread_subscriptions(mut self, enable: bool) -> Self {
-        self.enable_thread_subscriptions = enable;
-        self
     }
 
     /// Set the homeserver URL to use.
@@ -619,7 +607,6 @@ impl ClientBuilder {
             #[cfg(feature = "e2e-encryption")]
             self.enable_share_history_on_invite,
             self.cross_process_store_locks_holder_name,
-            self.enable_thread_subscriptions,
         )
         .await;
 

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -114,6 +114,7 @@ pub struct ClientBuilder {
     enable_share_history_on_invite: bool,
     cross_process_store_locks_holder_name: String,
     threading_support: ThreadingSupport,
+    enable_thread_subscriptions: bool,
 }
 
 impl ClientBuilder {
@@ -145,7 +146,18 @@ impl ClientBuilder {
             cross_process_store_locks_holder_name:
                 Self::DEFAULT_CROSS_PROCESS_STORE_LOCKS_HOLDER_NAME.to_owned(),
             threading_support: ThreadingSupport::Disabled,
+            enable_thread_subscriptions: false,
         }
+    }
+
+    /// Enable client-wide thread subscriptions support (MSC4306 / MSC4308).
+    ///
+    /// This may cause filtering out of thread subscriptions, and loading the
+    /// thread subscriptions via the sliding sync extension, when the room
+    /// list service is being used.
+    pub fn enable_thread_subscriptions(mut self, enable: bool) -> Self {
+        self.enable_thread_subscriptions = enable;
+        self
     }
 
     /// Set the homeserver URL to use.
@@ -607,6 +619,7 @@ impl ClientBuilder {
             #[cfg(feature = "e2e-encryption")]
             self.enable_share_history_on_invite,
             self.cross_process_store_locks_holder_name,
+            self.enable_thread_subscriptions,
         )
         .await;
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -350,6 +350,13 @@ pub(crate) struct ClientInner {
     ///
     /// [`LatestEvent`]: crate::latest_event::LatestEvent
     latest_events: OnceCell<LatestEvents>,
+
+    /// Enable client-wide thread subscriptions support (MSC4306 / MSC4308).
+    ///
+    /// This may cause filtering out of thread subscriptions, and loading the
+    /// thread subscriptions via the sliding sync extension, when the room
+    /// list service is being used.
+    pub(crate) enable_thread_subscriptions: bool,
 }
 
 impl ClientInner {
@@ -374,6 +381,7 @@ impl ClientInner {
         #[cfg(feature = "e2e-encryption")] encryption_settings: EncryptionSettings,
         #[cfg(feature = "e2e-encryption")] enable_share_history_on_invite: bool,
         cross_process_store_locks_holder_name: String,
+        enable_thread_subscriptions: bool,
     ) -> Arc<Self> {
         let caches = ClientCaches {
             server_info: server_info.into(),
@@ -409,6 +417,7 @@ impl ClientInner {
             #[cfg(feature = "e2e-encryption")]
             enable_share_history_on_invite,
             server_max_upload_size: Mutex::new(OnceCell::new()),
+            enable_thread_subscriptions,
         };
 
         #[allow(clippy::let_and_return)]
@@ -2704,6 +2713,7 @@ impl Client {
                 #[cfg(feature = "e2e-encryption")]
                 self.inner.enable_share_history_on_invite,
                 cross_process_store_locks_holder_name,
+                self.inner.enable_thread_subscriptions,
             )
             .await,
         };
@@ -2799,6 +2809,16 @@ impl Client {
     #[cfg(feature = "e2e-encryption")]
     pub fn decryption_settings(&self) -> &DecryptionSettings {
         &self.base_client().decryption_settings
+    }
+
+    /// Whether the client is configured to take thread subscriptions (MSC4306
+    /// and MSC4308) into account.
+    ///
+    /// This may cause filtering out of thread subscriptions, and loading the
+    /// thread subscriptions via the sliding sync extension, when the room
+    /// list service is being used.
+    pub fn enabled_thread_subscriptions(&self) -> bool {
+        self.inner.enable_thread_subscriptions
     }
 }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -34,6 +34,7 @@ use http::StatusCode;
 pub use identity_status_changes::IdentityStatusChanges;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::{IdentityStatusChange, RoomIdentityProvider, UserIdentity};
+pub use matrix_sdk_base::store::ThreadStatus;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::{crypto::RoomEventDecryptionResult, deserialized_responses::EncryptionInfo};
 use matrix_sdk_base::{
@@ -3735,10 +3736,21 @@ impl Room {
         self.client
             .send(subscribe_thread::unstable::Request::new(
                 self.room_id().to_owned(),
-                thread_root,
+                thread_root.clone(),
                 automatic,
             ))
             .await?;
+
+        // Immediately save the result into the database.
+        self.client
+            .state_store()
+            .upsert_thread_subscription(
+                self.room_id(),
+                &thread_root,
+                ThreadStatus::Subscribed { automatic },
+            )
+            .await?;
+
         Ok(())
     }
 
@@ -3757,9 +3769,16 @@ impl Room {
         self.client
             .send(unsubscribe_thread::unstable::Request::new(
                 self.room_id().to_owned(),
-                thread_root,
+                thread_root.clone(),
             ))
             .await?;
+
+        // Immediately save the result into the database.
+        self.client
+            .state_store()
+            .upsert_thread_subscription(self.room_id(), &thread_root, ThreadStatus::Unsubscribed)
+            .await?;
+
         Ok(())
     }
 
@@ -3773,8 +3792,8 @@ impl Room {
     ///
     /// # Returns
     ///
-    /// - An `Ok` result with `Some(ThreadSubscription)` if the subscription
-    ///   exists.
+    /// - An `Ok` result with `Some(ThreadStatus)` if we have some subscription
+    ///   information.
     /// - An `Ok` result with `None` if the subscription does not exist, or the
     ///   event couldn't be found, or the event isn't a thread.
     /// - An error if the request fails for any other reason, such as a network
@@ -3782,31 +3801,46 @@ impl Room {
     pub async fn fetch_thread_subscription(
         &self,
         thread_root: OwnedEventId,
-    ) -> Result<Option<ThreadSubscription>> {
+    ) -> Result<Option<ThreadStatus>> {
         let result = self
             .client
             .send(get_thread_subscription::unstable::Request::new(
                 self.room_id().to_owned(),
-                thread_root,
+                thread_root.clone(),
             ))
             .await;
 
         match result {
-            Ok(response) => Ok(Some(ThreadSubscription { automatic: response.automatic })),
+            Ok(response) => Ok(Some(ThreadStatus::Subscribed { automatic: response.automatic })),
             Err(http_error) => match http_error.as_client_api_error() {
-                Some(error) if error.status_code == StatusCode::NOT_FOUND => Ok(None),
+                Some(error) if error.status_code == StatusCode::NOT_FOUND => {
+                    // At this point the server returned no subscriptions, which can mean that the
+                    // endpoint doesn't exist (not enabled/implemented yet on the server), or that
+                    // the thread doesn't exist, or that the user has unsubscribed from it
+                    // previously.
+                    //
+                    // If we had any information about prior unsubscription, we can use it here to
+                    // return something slightly more precise than what the server returned.
+                    let stored_status = self
+                        .client
+                        .state_store()
+                        .load_thread_subscription(self.room_id(), &thread_root)
+                        .await?;
+
+                    if let Some(ThreadStatus::Unsubscribed) = stored_status {
+                        // The thread was unsubscribed from before, so maintain this information.
+                        Ok(Some(ThreadStatus::Unsubscribed))
+                    } else {
+                        // We either have stale information (the thread was marked as subscribed
+                        // to, but the server said it wasn't), or we didn't have any information.
+                        // Return unknown.
+                        Ok(None)
+                    }
+                }
                 _ => Err(http_error.into()),
             },
         }
     }
-}
-
-/// Status of a thread subscription.
-#[derive(Debug, Clone, Copy)]
-pub struct ThreadSubscription {
-    /// Whether the subscription was made automatically by a client, not by
-    /// manual user choice.
-    pub automatic: bool,
 }
 
 #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -16,7 +16,7 @@
 
 use matrix_sdk_base::{
     store::{RoomLoadSettings, StoreConfig},
-    SessionMeta,
+    SessionMeta, ThreadingSupport,
 };
 use ruma::{api::MatrixVersion, owned_device_id, owned_user_id, OwnedDeviceId, OwnedUserId};
 
@@ -64,8 +64,8 @@ impl MockClientBuilder {
     }
 
     /// Enable the thread subscriptions feature for the Client.
-    pub fn enable_thread_subscriptions(mut self) -> Self {
-        self.builder = self.builder.enable_thread_subscriptions(true);
+    pub fn threading_support(mut self, support: ThreadingSupport) -> Self {
+        self.builder = self.builder.with_threading_support(support);
         self
     }
 

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -63,6 +63,12 @@ impl MockClientBuilder {
         self
     }
 
+    /// Enable the thread subscriptions feature for the Client.
+    pub fn enable_thread_subscriptions(mut self) -> Self {
+        self.builder = self.builder.enable_thread_subscriptions(true);
+        self
+    }
+
     /// Enable the share history on invite feature for the Client.
     #[cfg(feature = "e2e-encryption")]
     pub fn enable_share_history_on_invite(mut self) -> Self {

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -2485,15 +2485,16 @@ impl<'a> MockEndpoint<'a, RoomEventContextEndpoint> {
         self
     }
 
-    /// Returns an endpoint that emulates success
+    /// Returns an endpoint that emulates success.
     pub fn ok(
         self,
         event: TimelineEvent,
         start: impl Into<String>,
         end: impl Into<String>,
+        state_events: Vec<Raw<AnyStateEvent>>,
     ) -> MatrixMock<'a> {
         let event_path = if self.endpoint.match_event_id {
-            let event_id = event.kind.event_id().expect("an event id is required");
+            let event_id = event.event_id().expect("an event id is required");
             // The event id should begin with `$`, which would be taken as the end of the
             // regex so we need to escape it
             event_id.as_str().replace("$", "\\$")
@@ -2511,7 +2512,7 @@ impl<'a> MockEndpoint<'a, RoomEventContextEndpoint> {
                 "event": event.into_raw().json(),
                 "end": end.into(),
                 "start": start.into(),
-                "state": []
+                "state": state_events
             })));
         MatrixMock { server: self.server, mock }
     }

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -13,6 +13,7 @@ use matrix_sdk::{
         api::client::receipt::create_receipt::v3::ReceiptType,
         events::room::message::RoomMessageEventContent,
     },
+    store::ThreadStatus,
 };
 use matrix_sdk_ui::{
     Timeline,
@@ -525,7 +526,16 @@ impl RoomView {
                     Ok(Some(subscription)) => {
                         status_handle.set_message(format!(
                             "Thread subscription status: {}",
-                            if subscription.automatic { "automatic" } else { "manual" }
+                            match subscription {
+                                ThreadStatus::Subscribed { automatic } => {
+                                    if automatic {
+                                        "subscribed (automatic)"
+                                    } else {
+                                        "subscribed (manual)"
+                                    }
+                                }
+                                ThreadStatus::Unsubscribed => "unsubscribed",
+                            }
                         ));
                     }
                     Ok(None) => {

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -413,6 +413,12 @@ impl EventBuilder<RoomMessageEventContent> {
 
         self
     }
+
+    /// Add intentional mentions to a given event.
+    pub fn mentions(mut self, mentions: Mentions) -> Self {
+        self.content.mentions = Some(mentions);
+        self
+    }
 }
 
 impl EventBuilder<UnstablePollStartEventContent> {


### PR DESCRIPTION
Based on #5455, this makes it possible to filter out notifications for a thread we haven't subscribed to.

The rules are the following:

- if the thread is subscribed to: keep the notification
- if the thread has no subscription status:
  - if the new event would cause a subscription: keep the notification
  - if the new event wouldn't cause a subscription: dismiss the notification
- if the thread is unsubscribed from: dismiss the notification