### PR TITLE
ffi (bindings): add suggested role and power level value based functions

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -69,6 +69,14 @@ pub fn suggested_role_for_power_level(
     Ok(RoomMemberRole::suggested_role_for_power_level(power_level.try_into()?))
 }
 
+/// Get the suggested role for the given power level.
+///
+/// Use this if your client allows the creator role to be assigned
+#[matrix_sdk_ffi_macros::export]
+pub fn suggested_role_for_power_level_value(value: i64) -> RoomMemberRole {
+    RoomMemberRole::suggested_role_for_power_level_value(value)
+}
+
 /// Get the suggested power level for the given role.
 ///
 /// Returns an error if the value of the power level is unsupported.
@@ -76,6 +84,14 @@ pub fn suggested_role_for_power_level(
 pub fn suggested_power_level_for_role(role: RoomMemberRole) -> Result<PowerLevel, ClientError> {
     // It's not possible to expose methods on an Enum through Uniffi ☹️
     Ok(role.suggested_power_level().try_into()?)
+}
+
+/// Get the suggested power level value for the given role.
+///
+/// Use this if your client allows the creator role to be assigned
+#[matrix_sdk_ffi_macros::export]
+pub fn suggested_power_level_value_for_role(role: RoomMemberRole) -> i64 {
+    role.suggested_power_level_value()
 }
 
 /// Generates a `matrix.to` permalink to the given userID.

--- a/crates/matrix-sdk/src/room/member.rs
+++ b/crates/matrix-sdk/src/room/member.rs
@@ -139,6 +139,33 @@ impl RoomMemberRole {
         }
     }
 
+    /// Creates a suggested role from the equivalent power level value.
+    /// Prefer this function if your client needs allows for a user to
+    /// be considered a creator without having an infinite power level.
+    pub fn suggested_role_for_power_level_value(value: i64) -> Self {
+        if value >= 150 {
+            Self::Creator
+        } else if value >= 100 {
+            Self::Administrator
+        } else if value >= 50 {
+            Self::Moderator
+        } else {
+            Self::User
+        }
+    }
+
+    /// Get the suggested power level value for this role.
+    /// Prefer this function if your client needs allows for a user to
+    /// be considered a creator without having an infinite power level.
+    pub fn suggested_power_level_value(&self) -> i64 {
+        match self {
+            Self::Creator => 150,
+            Self::Administrator => 100,
+            Self::Moderator => 50,
+            Self::User => 0,
+        }
+    }
+
     /// Get the suggested power level for this role.
     pub fn suggested_power_level(&self) -> UserPowerLevel {
         match self {


### PR DESCRIPTION
The reason for doing this is that in the EX clients we also allow the creators to set other members as creators even if they are not among the original ones, this will set them with a power level of 150 (like superadmins).

This introduces two extra functions that have the purpose of be used if you want an equivalent power level value for a creator.