### PR TITLE
IndexedDB: prepare `matrix-sdk-indexeddb` crate for updating `indexed_db_futures` to latest version

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
@@ -200,13 +200,12 @@ type OldVersion = u32;
 /// * `name` - name of the indexeddb database to be upgraded.
 /// * `version` - version we are upgrading to.
 /// * `f` - closure which will be called if the database is below the version
-///   given. It will be called with three arguments `(db, txn, oldver)`, where:
+///   given. It will be called with two arguments `(db, oldver)`, where:
 ///   * `db` - the [`IdbDatabase`]
-///   * `txn` - the database transaction: a [`IdbTransaction`]
 ///   * `oldver` - the version number before the upgrade.
 async fn do_schema_upgrade<F>(name: &str, version: u32, f: F) -> Result<(), DomException>
 where
-    F: Fn(&IdbDatabase, IdbTransaction<'_>, OldVersion) -> Result<(), JsValue> + 'static,
+    F: Fn(&IdbDatabase, OldVersion) -> Result<(), JsValue> + 'static,
 {
     info!("IndexeddbCryptoStore upgrade schema -> v{version} starting");
     let mut db_req: OpenDbRequest = IdbDatabase::open_u32(name, version)?;
@@ -218,7 +217,7 @@ where
         let old_version = evt.old_version() as u32;
 
         // Run the upgrade code we were supplied
-        f(evt.db(), evt.transaction(), old_version)
+        f(evt.db(), old_version)
     }));
 
     let db = db_req.await?;

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
@@ -157,7 +157,7 @@ pub async fn open_and_upgrade_db(
     }
 
     if old_version < 12 {
-        v11_to_v12::schema_add(name).await?;
+        v11_to_v12::schema_bump(name).await?;
     }
 
     if old_version < 13 {

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/old_keys.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/old_keys.rs
@@ -24,5 +24,7 @@ pub const INBOUND_GROUP_SESSIONS_V1: &str = "inbound_group_sessions";
 /// Also lacked the `backed_up_to` property+index.
 pub const INBOUND_GROUP_SESSIONS_V2: &str = "inbound_group_sessions2";
 
+pub const INBOUND_GROUP_SESSIONS_V3: &str = "inbound_group_sessions3";
+
 /// An old name for [`BACKUP_VERSION_V1`].
 pub const BACKUP_KEY_V1: &str = "backup_key_v1";

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v0_to_v5.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v0_to_v5.rs
@@ -26,7 +26,7 @@ use crate::crypto_store::{
 
 /// Perform schema migrations as needed, up to schema version 5.
 pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 5, |db, _, old_version| {
+    do_schema_upgrade(name, 5, |db, old_version| {
         // An old_version of 1 could either mean actually the first version of the
         // schema, or a completely empty schema that has been created with a
         // call to `IdbDatabase::open` with no explicit "version". So, to determine

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v10_to_v11.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v10_to_v11.rs
@@ -59,5 +59,5 @@ pub(crate) async fn data_migrate(
 pub(crate) async fn schema_bump(name: &str) -> crate::crypto_store::Result<(), DomException> {
     // Just bump the version number to 11 to demonstrate that we have run the data
     // changes from data_migrate.
-    do_schema_upgrade(name, 11, |_, _, _| Ok(())).await
+    do_schema_upgrade(name, 11, |_, _| Ok(())).await
 }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs
@@ -18,5 +18,5 @@ use crate::crypto_store::{migrations::do_schema_upgrade, Result};
 
 /// Perform the schema upgrade v11 to v12, just bumping the schema version
 pub(crate) async fn schema_bump(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 12, |_, _, _| Ok(())).await
+    do_schema_upgrade(name, 12, |_, _| Ok(())).await
 }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs
@@ -12,27 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use indexed_db_futures::IdbKeyPath;
 use web_sys::DomException;
 
-use crate::crypto_store::{
-    keys,
-    migrations::{do_schema_upgrade, old_keys},
-    Result,
-};
+use crate::crypto_store::{migrations::do_schema_upgrade, Result};
 
-/// Perform the schema upgrade v11 to v12, adding an index on
-/// `(curve_key, sender_data_type, session_id)` to `inbound_group_sessions3`.
-pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 12, |_, transaction, _| {
-        let object_store = transaction.object_store(old_keys::INBOUND_GROUP_SESSIONS_V3)?;
-
-        object_store.create_index(
-            keys::INBOUND_GROUP_SESSIONS_SENDER_KEY_INDEX,
-            &IdbKeyPath::str_sequence(&["sender_key", "sender_data_type", "session_id"]),
-        )?;
-
-        Ok(())
-    })
-    .await
+/// Perform the schema upgrade v11 to v12, just bumping the schema version
+pub(crate) async fn schema_bump(name: &str) -> Result<(), DomException> {
+    do_schema_upgrade(name, 12, |_, _, _| Ok(())).await
 }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs
@@ -15,13 +15,17 @@
 use indexed_db_futures::IdbKeyPath;
 use web_sys::DomException;
 
-use crate::crypto_store::{keys, migrations::do_schema_upgrade, Result};
+use crate::crypto_store::{
+    keys,
+    migrations::{do_schema_upgrade, old_keys},
+    Result,
+};
 
 /// Perform the schema upgrade v11 to v12, adding an index on
 /// `(curve_key, sender_data_type, session_id)` to `inbound_group_sessions3`.
 pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
     do_schema_upgrade(name, 12, |_, transaction, _| {
-        let object_store = transaction.object_store(keys::INBOUND_GROUP_SESSIONS_V3)?;
+        let object_store = transaction.object_store(old_keys::INBOUND_GROUP_SESSIONS_V3)?;
 
         object_store.create_index(
             keys::INBOUND_GROUP_SESSIONS_SENDER_KEY_INDEX,

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v12_to_v13.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v12_to_v13.rs
@@ -21,7 +21,7 @@ use crate::crypto_store::{keys, migrations::do_schema_upgrade, Result};
 /// Perform the schema upgrade v12 to v13, adding the
 /// `received_room_key_bundles` store.
 pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 13, |db, _, _| {
+    do_schema_upgrade(name, 13, |db, _| {
         db.create_object_store(keys::RECEIVED_ROOM_KEY_BUNDLES)?;
         Ok(())
     })

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v13_to_v15.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v13_to_v15.rs
@@ -1,0 +1,112 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use indexed_db_futures::{IdbKeyPath, IdbQuerySource};
+use tracing::{debug, info};
+use web_sys::{DomException, IdbTransactionMode};
+
+use crate::{
+    crypto_store::{
+        deserialize_inbound_group_session, keys,
+        migrations::{do_schema_upgrade, old_keys, v8_to_v10, MigrationDb},
+        serialize_inbound_group_session, Result,
+    },
+    serializer::IndexeddbSerializer,
+};
+
+/// Perform the schema upgrade v13 to v14
+///
+/// This creates an identical object store to `inbound_group_sessions3`, but
+/// adds index on `(curve_key, sender_data_type, session_id)`.
+pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
+    do_schema_upgrade(name, 14, |db, _, _| {
+        let object_store = db.create_object_store(keys::INBOUND_GROUP_SESSIONS_V4)?;
+        v8_to_v10::index_add(&object_store)?;
+        object_store.create_index(
+            keys::INBOUND_GROUP_SESSIONS_SENDER_KEY_INDEX,
+            &IdbKeyPath::str_sequence(&["sender_key", "sender_data_type", "session_id"]),
+        )?;
+        Ok(())
+    })
+    .await
+}
+
+/// Migrate data from `inbound_group_sessions3` into `inbound_group_sessions4`.
+pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -> Result<()> {
+    let db = MigrationDb::new(name, 15).await?;
+
+    let txn = db.transaction_on_multi_with_mode(
+        &[old_keys::INBOUND_GROUP_SESSIONS_V3, keys::INBOUND_GROUP_SESSIONS_V4],
+        IdbTransactionMode::Readwrite,
+    )?;
+
+    let inbound_group_sessions3 = txn.object_store(old_keys::INBOUND_GROUP_SESSIONS_V3)?;
+    let inbound_group_sessions4 = txn.object_store(keys::INBOUND_GROUP_SESSIONS_V4)?;
+
+    let row_count = inbound_group_sessions3.count()?.await?;
+    info!(row_count, "Shrinking inbound_group_session records");
+
+    // Iterate through all rows
+    if let Some(cursor) = inbound_group_sessions3.open_cursor()?.await? {
+        let mut idx = 0;
+        loop {
+            idx += 1;
+
+            if idx % 100 == 0 {
+                debug!("Migrating session {idx} of {row_count}");
+            }
+
+            // Deserialize the session from the old store
+            let session = deserialize_inbound_group_session(cursor.value(), serializer)?;
+
+            // Calculate its key in the new table
+            let new_key = serializer.encode_key(
+                keys::INBOUND_GROUP_SESSIONS_V4,
+                (&session.room_id, session.session_id()),
+            );
+
+            // Serialize the session in the new format
+            let new_session = serialize_inbound_group_session(&session, serializer).await?;
+
+            // Write it to the new store
+            inbound_group_sessions4.add_key_val(&new_key, &new_session)?;
+
+            // We are done with the original data, so delete it now.
+            cursor.delete()?;
+
+            // Continue to the next record, or stop if we're done
+            if !cursor.continue_cursor()?.await? {
+                debug!("Migrated {idx} sessions.");
+                break;
+            }
+        }
+    }
+
+    // We have finished with the old store. Clear it, since it is faster to
+    // clear+delete than just delete. See https://www.artificialworlds.net/blog/2024/02/02/deleting-an-indexed-db-store-can-be-incredibly-slow-on-firefox/
+    // for more details.
+    inbound_group_sessions3.clear()?.await?;
+
+    txn.await.into_result()?;
+    Ok(())
+}
+
+/// Perform the schema upgrade v14 to v15, deleting `inbound_group_sessions3`.
+pub(crate) async fn schema_delete(name: &str) -> Result<(), DomException> {
+    do_schema_upgrade(name, 15, |db, _, _| {
+        db.delete_object_store(old_keys::INBOUND_GROUP_SESSIONS_V3)?;
+        Ok(())
+    })
+    .await
+}

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v13_to_v15.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v13_to_v15.rs
@@ -30,7 +30,7 @@ use crate::{
 /// This creates an identical object store to `inbound_group_sessions3`, but
 /// adds index on `(curve_key, sender_data_type, session_id)`.
 pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 14, |db, _, _| {
+    do_schema_upgrade(name, 14, |db, _| {
         let object_store = db.create_object_store(keys::INBOUND_GROUP_SESSIONS_V4)?;
         v8_to_v10::index_add(&object_store)?;
         object_store.create_index(
@@ -104,7 +104,7 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
 
 /// Perform the schema upgrade v14 to v15, deleting `inbound_group_sessions3`.
 pub(crate) async fn schema_delete(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 15, |db, _, _| {
+    do_schema_upgrade(name, 15, |db, _| {
         db.delete_object_store(old_keys::INBOUND_GROUP_SESSIONS_V3)?;
         Ok(())
     })

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v5_to_v7.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v5_to_v7.rs
@@ -36,7 +36,7 @@ use crate::{
 
 /// Perform the schema upgrade v5 to v6, creating `inbound_group_sessions2`.
 pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 6, |db, _, _| {
+    do_schema_upgrade(name, 6, |db, _| {
         let object_store = db.create_object_store(old_keys::INBOUND_GROUP_SESSIONS_V2)?;
 
         add_nonunique_index(
@@ -109,7 +109,7 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
 
 /// Perform the schema upgrade v6 to v7, deleting `inbound_group_sessions`.
 pub(crate) async fn schema_delete(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 7, |db, _, _| {
+    do_schema_upgrade(name, 7, |db, _| {
         db.delete_object_store(old_keys::INBOUND_GROUP_SESSIONS_V1)?;
         Ok(())
     })

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v7_to_v8.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v7_to_v8.rs
@@ -116,7 +116,7 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
 
 /// Perform the schema upgrade v7 to v8, Just bumping the schema version.
 pub(crate) async fn schema_bump(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 8, |_, _, _| {
+    do_schema_upgrade(name, 8, |_, _| {
         // Just bump the version number to 8 to demonstrate that we have run the data
         // changes from prepare_data_for_v8.
         Ok(())

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
@@ -50,7 +50,7 @@ pub(crate) fn index_add(object_store: &IdbObjectStore<'_>) -> Result<(), DomExce
 
 /// Perform the schema upgrade v8 to v9, creating `inbound_group_sessions3`.
 pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 9, |db, _, _| {
+    do_schema_upgrade(name, 9, |db, _| {
         let object_store = db.create_object_store(old_keys::INBOUND_GROUP_SESSIONS_V3)?;
         index_add(&object_store)?;
         Ok(())
@@ -128,7 +128,7 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
 
 /// Perform the schema upgrade v8 to v10, deleting `inbound_group_sessions2`.
 pub(crate) async fn schema_delete(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 10, |db, _, _| {
+    do_schema_upgrade(name, 10, |db, _| {
         db.delete_object_store(old_keys::INBOUND_GROUP_SESSIONS_V2)?;
         Ok(())
     })

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
@@ -51,7 +51,7 @@ pub(crate) fn index_add(object_store: &IdbObjectStore<'_>) -> Result<(), DomExce
 /// Perform the schema upgrade v8 to v9, creating `inbound_group_sessions3`.
 pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
     do_schema_upgrade(name, 9, |db, _, _| {
-        let object_store = db.create_object_store(keys::INBOUND_GROUP_SESSIONS_V3)?;
+        let object_store = db.create_object_store(old_keys::INBOUND_GROUP_SESSIONS_V3)?;
         index_add(&object_store)?;
         Ok(())
     })
@@ -63,12 +63,12 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
     let db = MigrationDb::new(name, 10).await?;
 
     let txn = db.transaction_on_multi_with_mode(
-        &[old_keys::INBOUND_GROUP_SESSIONS_V2, keys::INBOUND_GROUP_SESSIONS_V3],
+        &[old_keys::INBOUND_GROUP_SESSIONS_V2, old_keys::INBOUND_GROUP_SESSIONS_V3],
         IdbTransactionMode::Readwrite,
     )?;
 
     let inbound_group_sessions2 = txn.object_store(old_keys::INBOUND_GROUP_SESSIONS_V2)?;
-    let inbound_group_sessions3 = txn.object_store(keys::INBOUND_GROUP_SESSIONS_V3)?;
+    let inbound_group_sessions3 = txn.object_store(old_keys::INBOUND_GROUP_SESSIONS_V3)?;
 
     let row_count = inbound_group_sessions2.count()?.await?;
     info!(row_count, "Shrinking inbound_group_session records");
@@ -94,7 +94,7 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
 
             // Calculate its key in the new table
             let new_key = serializer.encode_key(
-                keys::INBOUND_GROUP_SESSIONS_V3,
+                old_keys::INBOUND_GROUP_SESSIONS_V3,
                 (&session.room_id, session.session_id()),
             );
 


### PR DESCRIPTION
## Background

This pull request makes the preliminary changes necessary to update [`indexed_db_futures`](https://docs.rs/indexed_db_futures/latest/indexed_db_futures/index.html) in the `matrix-sdk-indexeddb` crate. The reason we'd like to update this dependency is because the version currently used does not fully support the Chrome browser (see #5420).

The latest version of `indexed_db_futures` has significant changes. Many of these changes can be integrated without issue. There is, however, a single change which requires substantive modification to the `matrix-sdk-indexeddb` crate. Namely, one cannot access the active transaction in the callback to update the database (for details, see Alorel/rust-indexed-db#66).

This is only an issue in the `crypto_store` module, where migrations are provided access to the active transaction (see [here](https://github.com/matrix-org/matrix-rust-sdk/blob/ca89700dfe9f29dcd823bb10861807f9d75e0634/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs#L211)). Furthermore, there is only a single migration (`v11_to_v12`) in the `crypto_store` module which makes use of the active transaction (see [here](https://github.com/matrix-org/matrix-rust-sdk/blob/ca89700dfe9f29dcd823bb10861807f9d75e0634/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs#L23)).

For clarity, the reason `v11_to_v12` is problematic in the latest versions of `indexed_db_futures` is because it is simply adding an index to an object store which was created in a different migration and this requires access to the active transaction. All the other migrations create object stores and indices in the same migration, which does not suffer from the same issue.

## Changes

Due to the issues above, I have taken the following steps to prepare `matrix-sdk-indexeddb` for an update to `indexed_db_futures`.

1. Modified the schema upgrade logic so that none of the individual migrations expect access to the active transaction 
2. Removed the logic from the `v11_to_v12` migration, which could no longer be accomplished without the active transaction
3. Added a new set of migrations, `v13_to_v15`, which replicate the logic from `v11_to_v12` in a way that is compatible with later versions of `indexed_db_futures`.

## Alternatives

My guess is that this problem is an oversight in the interface developed in the `indexed_db_futures` crate and not a deeper issue - i.e., it seems it would be possible to expose the active transaction in later versions, as is the case in the current [version](https://docs.rs/indexed_db_futures/0.5.0/indexed_db_futures/struct.IdbVersionChangeEvent.html#method.transaction) used in `matrix-sdk-indexeddb`.

Alternatives to the changes in this pull request include the following.

1. Wait for the maintainer of `indexed_db_futures` to make the necessary modifications in a future version
2. Vendor a version with the necessary modifications specifically for `matrix-sdk-indexeddb`

Neither of these seemed particularly expedient or attractive, so I opted for making changes to the migrations.

## Future Work

- Update `indexed_db_futures` to the latest version - i.e., `0.6.4`

---

- [ ] Public API changes documented in changelogs (optional)


Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
