### PR TITLE
fix(sqlite): made `open_with_pool` public again.

### DIFF
--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -118,7 +118,7 @@ impl SqliteStateStore {
 
     /// Create an SQLite-based state store using the given SQLite database pool.
     /// The given passphrase will be used to encrypt private data.
-    async fn open_with_pool(
+    pub async fn open_with_pool(
         pool: SqlitePool,
         passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {


### PR DESCRIPTION
In this [commit](https://github.com/matrix-org/matrix-rust-sdk/commit/339b220488b7c3bc387b9c89fef064bd4bb6fab7#diff-7f0f467e2238b53105e2ce5eadf1e7eff8ac3f635ae6bf16dc93a8b1f36d4d2dL121) `open_with_pool` was changed from public to private.
I'm using this part in my project to share one sql database between my application and the matrix sdk.
If that change from public to private was intentional and you have suggestions how i should solve this i'd love to hear it.


- [ ] Public API changes documented in changelogs (optional)


Signed-off-by: Jakob Lachermeier jakob.lachermeier@posteo.de
