### PR TITLE
refactor(client): have `upload_encrypted_file` own the `Client` instance

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
-
+<t_k€>ku
 All notable changes to this project will be documented in this file.
 
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+- [**breaking**] Change the upload_encrypted_file and make it clone the client instead of owning it. 
 
 ### Features
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Changelog
-<t_k€>ku
 All notable changes to this project will be documented in this file.
 
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
-- [**breaking**] Change the upload_encrypted_file and make it clone the client instead of owning it. 
 
 ### Features
 
@@ -31,6 +29,7 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- [**breaking**] Change the upload_encrypted_file and make it clone the client instead of owning it. The lifetime of the `UploadEncryptedFile` request returned by `Client::upload_encrypted_file()` only depends on the request lifetime now.
 - [**breaking**] Add an `IsPrefix = False` bound to the `account_data()` and
   `fetch_account_data_static()` methods of `Account`. These methods only worked
   for events where the full event type is statically-known, and this is now

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 <!-- next-header -->

--- a/crates/matrix-sdk/src/encryption/futures.rs
+++ b/crates/matrix-sdk/src/encryption/futures.rs
@@ -28,15 +28,15 @@ use crate::{config::RequestConfig, Client, Media, Result, TransmissionProgress};
 /// Future returned by [`Client::upload_encrypted_file`].
 #[allow(missing_debug_implementations)]
 pub struct UploadEncryptedFile<'a, R: ?Sized> {
-    client: &'a Client,
+    client: Client,
     reader: &'a mut R,
     send_progress: SharedObservable<TransmissionProgress>,
     request_config: Option<RequestConfig>,
 }
 
 impl<'a, R: ?Sized> UploadEncryptedFile<'a, R> {
-    pub(crate) fn new(client: &'a Client, reader: &'a mut R) -> Self {
-        Self { client, reader, send_progress: Default::default(), request_config: None }
+    pub(crate) fn new(client:& Client, reader: &'a mut R) -> Self {
+        Self { client: client.clone(), reader, send_progress: Default::default(), request_config: None }
     }
 
     /// Replace the default `SharedObservable` used for tracking upload

--- a/crates/matrix-sdk/src/encryption/futures.rs
+++ b/crates/matrix-sdk/src/encryption/futures.rs
@@ -35,8 +35,13 @@ pub struct UploadEncryptedFile<'a, R: ?Sized> {
 }
 
 impl<'a, R: ?Sized> UploadEncryptedFile<'a, R> {
-    pub(crate) fn new(client:& Client, reader: &'a mut R) -> Self {
-        Self { client: client.clone(), reader, send_progress: Default::default(), request_config: None }
+    pub(crate) fn new(client: &Client, reader: &'a mut R) -> Self {
+        Self {
+            client: client.clone(),
+            reader,
+            send_progress: Default::default(),
+            request_config: None,
+        }
     }
 
     /// Replace the default `SharedObservable` used for tracking upload

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -861,12 +861,8 @@ impl RoomSendQueue {
                     let media_source = if room.latest_encryption_state().await?.is_encrypted() {
                         trace!("upload will be encrypted (encrypted room)");
 
-                        // TODO: clone the Client when creating `UploadEncryptedFile` to avoid the
-                        // borrow and the local variable here. See also issue 5465.
-                        let client = room.client();
-
                         let mut cursor = std::io::Cursor::new(data);
-                        let mut req = client
+                        let mut req = room.client
                             .upload_encrypted_file(&mut cursor)
                             .with_request_config(RequestConfig::short_retry());
                         if let Some(progress) = progress {

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -862,7 +862,8 @@ impl RoomSendQueue {
                         trace!("upload will be encrypted (encrypted room)");
 
                         let mut cursor = std::io::Cursor::new(data);
-                        let mut req = room.client
+                        let mut req = room
+                            .client
                             .upload_encrypted_file(&mut cursor)
                             .with_request_config(RequestConfig::short_retry());
                         if let Some(progress) = progress {


### PR DESCRIPTION
<!-- The Commit make the function upload_encrypted_file clone the client instead of owning it -->

- [ ] Public API changes documented in changelogs (optional)

Signed-off-by: multi multiestunhappydev@gmail.com

Fixes #5465