### PR TITLE
refactor(timeline): remove a few unused `Self` in some read-receipt related methods

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -172,7 +172,6 @@ impl TimelineMetadata {
     ///
     /// Returns `None` if none of the two events could be found in the timeline.
     pub(in crate::timeline) fn compare_events_positions(
-        &self,
         event_a: &EventId,
         event_b: &EventId,
         all_remote_events: &AllRemoteEvents,

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1530,7 +1530,7 @@ impl TimelineController {
                     .await
                 {
                     trace!(%old_pub_read, "found a previous public receipt");
-                    if let Some(relative_pos) = state.meta.compare_events_positions(
+                    if let Some(relative_pos) = TimelineMetadata::compare_events_positions(
                         &old_pub_read,
                         event_id,
                         state.items.all_remote_events(),
@@ -1550,7 +1550,7 @@ impl TimelineController {
                     state.latest_user_read_receipt(own_user_id, receipt_thread.clone(), room).await
                 {
                     trace!(%old_priv_read, "found a previous private receipt");
-                    if let Some(relative_pos) = state.meta.compare_events_positions(
+                    if let Some(relative_pos) = TimelineMetadata::compare_events_positions(
                         &old_priv_read,
                         event_id,
                         state.items.all_remote_events(),
@@ -1565,7 +1565,7 @@ impl TimelineController {
 
             SendReceiptType::FullyRead => {
                 if let Some(prev_event_id) = self.room_data_provider.load_fully_read_marker().await
-                    && let Some(relative_pos) = state.meta.compare_events_positions(
+                    && let Some(relative_pos) = TimelineMetadata::compare_events_positions(
                         &prev_event_id,
                         event_id,
                         state.items.all_remote_events(),

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -735,10 +735,10 @@ impl<P: RoomDataProvider> TimelineState<P> {
         // Let's assume that a private read receipt should be more recent than a public
         // read receipt (otherwise there's no point in the private read receipt),
         // and use it as the default.
-        match self.meta.compare_optional_receipts(
+        match TimelineMetadata::compare_optional_receipts(
             public_read_receipt.as_ref(),
             private_read_receipt.as_ref(),
-            self.items.all_remote_events(),
+            all_remote_events,
         ) {
             Ordering::Greater => public_read_receipt,
             Ordering::Less => private_read_receipt,
@@ -761,7 +761,7 @@ impl<P: RoomDataProvider> TimelineState<P> {
         // Let's assume that a private read receipt should be more recent than a public
         // read receipt, otherwise there's no point in the private read receipt,
         // and use it as default.
-        let (latest_receipt_id, _) = match self.meta.compare_optional_receipts(
+        let (latest_receipt_id, _) = match TimelineMetadata::compare_optional_receipts(
             public_read_receipt,
             private_read_receipt,
             self.items.all_remote_events(),
@@ -819,7 +819,7 @@ impl TimelineMetadata {
 
             // Let's use the unthreaded read receipt as default, since it's the one we
             // should be using.
-            match self.compare_optional_receipts(
+            match Self::compare_optional_receipts(
                 main_thread_read_receipt.as_ref(),
                 unthreaded_read_receipt.as_ref(),
                 all_remote_events,
@@ -845,7 +845,6 @@ impl TimelineMetadata {
     /// not possible to know which one is the more recent, defaults to
     /// `Ordering::Less`, making the right-hand side the default.
     fn compare_optional_receipts(
-        &self,
         lhs: Option<&(OwnedEventId, Receipt)>,
         rhs_or_default: Option<&(OwnedEventId, Receipt)>,
         all_remote_events: &AllRemoteEvents,
@@ -860,7 +859,7 @@ impl TimelineMetadata {
 
         // Compare by position in the timeline.
         if let Some(relative_pos) =
-            self.compare_events_positions(lhs_event_id, rhs_event_id, all_remote_events)
+            Self::compare_events_positions(lhs_event_id, rhs_event_id, all_remote_events)
         {
             if relative_pos == RelativePosition::Before {
                 return Ordering::Greater;


### PR DESCRIPTION
What it says on the tin. 