### PR TITLE
Upgrade Ruma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4423,7 +4423,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.5"
-source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
+source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
 dependencies = [
  "assign",
  "js_int",
@@ -4439,7 +4439,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.4"
-source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
+source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
 dependencies = [
  "as_variant",
  "assign",
@@ -4462,7 +4462,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.4"
-source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
+source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
 dependencies = [
  "as_variant",
  "base64",
@@ -4495,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.4"
-source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
+source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.2"
-source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
+source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
 dependencies = [
  "headers",
  "http",
@@ -4539,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.1"
-source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
+source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
+source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
 dependencies = [
  "js_int",
  "thiserror 2.0.11",
@@ -4559,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.2"
-source = "git+https://github.com/ruma/ruma?rev=184d4f85b201bc1e932a8344d78575e826f31efa#184d4f85b201bc1e932a8344d78575e826f31efa"
+source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 rand = "0.8.5"
 reqwest = { version = "0.12.12", default-features = false }
 rmp-serde = "1.3.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "184d4f85b201bc1e932a8344d78575e826f31efa", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "bbbe39b5b02f2211fdc5e11383c4b66116f19625", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-arbitrary-length-ids",
@@ -78,7 +78,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "184d4f85b201bc1e932a8344d7
     "unstable-msc4286",
     "unstable-msc4306"
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "184d4f85b201bc1e932a8344d78575e826f31efa" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "bbbe39b5b02f2211fdc5e11383c4b66116f19625" }
 sentry = "0.36.0"
 sentry-tracing = "0.36.0"
 serde = { version = "1.0.217", features = ["rc"] }

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -20,6 +20,13 @@ All notable changes to this project will be documented in this file.
   ([#5390](https://github.com/matrix-org/matrix-rust-sdk/pull/5390))
 
 ### Refactor
+- [**breaking**] The `Stripped` variants of `RawAnySyncOrStrippedTimelineEvent`,
+  `RawAnySyncOrStrippedState` and `AnySyncOrStrippedState` use `StrippedState`
+  instead of `AnyStrippedStateEvent`.
+  ([#5473](https://github.com/matrix-org/matrix-rust-sdk/pull/5473))
+- [**breaking**] The `stripped_state` field of `StateChanges` uses
+  `StrippedState` instead of `AnyStrippedStateEvent`.
+  ([#5473](https://github.com/matrix-org/matrix-rust-sdk/pull/5473))
 - [**breaking**] `RelationalLinkedChunk::items` now takes a `RoomId` instead of an
   `&OwnedLinkedChunkId` parameter.
   ([#5445](https://github.com/matrix-org/matrix-rust-sdk/pull/5445))

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -21,8 +21,9 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, UInt, UserId,
+    api::client::sync::sync_events::StrippedState,
     events::{
-        AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, EventContentFromType,
+        AnySyncStateEvent, AnySyncTimelineEvent, EventContentFromType,
         PossiblyRedactedStateEventContent, RedactContent, RedactedStateEventContent,
         StateEventContent, StaticStateEventContent, StrippedStateEvent, SyncStateEvent,
         room::{
@@ -261,7 +262,7 @@ pub enum RawAnySyncOrStrippedTimelineEvent {
     /// An event from a room in joined or left state.
     Sync(Raw<AnySyncTimelineEvent>),
     /// An event from a room in invited state.
-    Stripped(Raw<AnyStrippedStateEvent>),
+    Stripped(Raw<StrippedState>),
 }
 
 impl From<Raw<AnySyncTimelineEvent>> for RawAnySyncOrStrippedTimelineEvent {
@@ -270,8 +271,8 @@ impl From<Raw<AnySyncTimelineEvent>> for RawAnySyncOrStrippedTimelineEvent {
     }
 }
 
-impl From<Raw<AnyStrippedStateEvent>> for RawAnySyncOrStrippedTimelineEvent {
-    fn from(event: Raw<AnyStrippedStateEvent>) -> Self {
+impl From<Raw<StrippedState>> for RawAnySyncOrStrippedTimelineEvent {
+    fn from(event: Raw<StrippedState>) -> Self {
         Self::Stripped(event)
     }
 }
@@ -283,7 +284,7 @@ pub enum RawAnySyncOrStrippedState {
     /// An event from a room in joined or left state.
     Sync(Raw<AnySyncStateEvent>),
     /// An event from a room in invited state.
-    Stripped(Raw<AnyStrippedStateEvent>),
+    Stripped(Raw<StrippedState>),
 }
 
 impl RawAnySyncOrStrippedState {
@@ -323,7 +324,7 @@ pub enum AnySyncOrStrippedState {
     ///
     /// The value is `Box`ed because it is quite large. Let's keep the size of
     /// `Self` as small as possible.
-    Stripped(Box<AnyStrippedStateEvent>),
+    Stripped(Box<StrippedState>),
 }
 
 impl AnySyncOrStrippedState {
@@ -338,7 +339,7 @@ impl AnySyncOrStrippedState {
 
     /// If this is an `AnyStrippedStateEvent`, return a reference to the inner
     /// event.
-    pub fn as_stripped(&self) -> Option<&AnyStrippedStateEvent> {
+    pub fn as_stripped(&self) -> Option<&StrippedState> {
         match self {
             Self::Sync(_) => None,
             Self::Stripped(ev) => Some(ev),

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -23,6 +23,7 @@ use matrix_sdk_common::deserialized_responses::TimelineEvent;
 use ruma::{
     JsOption, OwnedRoomId, RoomId, UserId,
     api::client::sync::sync_events::{
+        StrippedState,
         v3::{InviteState, InvitedRoom, KnockState, KnockedRoom},
         v5 as http,
     },
@@ -225,7 +226,7 @@ pub async fn update_any_room(
 fn membership(
     context: &mut Context,
     state_events: &[AnySyncStateEvent],
-    invite_state_events: &Option<(Vec<Raw<AnyStrippedStateEvent>>, Vec<AnyStrippedStateEvent>)>,
+    invite_state_events: &Option<(Vec<Raw<StrippedState>>, Vec<AnyStrippedStateEvent>)>,
     store: &BaseStateStore,
     user_id: &UserId,
     room_id: &RoomId,

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -10,13 +10,16 @@ use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, RoomId, TransactionId, UserId,
     api::{
         FeatureFlag, MatrixVersion,
-        client::discovery::discover_homeserver::{HomeserverInfo, RtcFocusInfo},
+        client::{
+            discovery::discover_homeserver::{HomeserverInfo, RtcFocusInfo},
+            sync::sync_events::StrippedState,
+        },
     },
     event_id,
     events::{
         AnyGlobalAccountDataEvent, AnyMessageLikeEventContent, AnyRoomAccountDataEvent,
-        AnyStrippedStateEvent, AnySyncStateEvent, GlobalAccountDataEventType,
-        RoomAccountDataEventType, StateEventType, SyncStateEvent,
+        AnySyncStateEvent, GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
+        SyncStateEvent,
         presence::PresenceEvent,
         receipt::{ReceiptThread, ReceiptType},
         room::{
@@ -195,9 +198,8 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         let stripped_name_json: &JsonValue = &test_json::NAME_STRIPPED;
         let stripped_name_raw =
-            serde_json::from_value::<Raw<AnyStrippedStateEvent>>(stripped_name_json.clone())
-                .unwrap();
-        let stripped_name_event = stripped_name_raw.deserialize().unwrap();
+            serde_json::from_value::<Raw<StrippedState>>(stripped_name_json.clone()).unwrap();
+        let stripped_name_event = stripped_name_raw.deserialize_as().unwrap();
         stripped_room.handle_stripped_state_event(&stripped_name_event);
         changes.stripped_state.insert(
             stripped_room_id.to_owned(),

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -23,10 +23,11 @@ use matrix_sdk_common::{ROOM_VERSION_FALLBACK, ROOM_VERSION_RULES_FALLBACK};
 use ruma::{
     CanonicalJsonObject, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri,
     OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
+    api::client::sync::sync_events::StrippedState,
     canonical_json::{RedactedBecause, redact},
     events::{
-        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncStateEvent, GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
+        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncStateEvent,
+        GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
         presence::PresenceEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::member::{MembershipState, StrippedRoomMemberEvent, SyncRoomMemberEvent},
@@ -68,7 +69,7 @@ struct MemoryStoreInner {
     room_account_data:
         HashMap<OwnedRoomId, HashMap<RoomAccountDataEventType, Raw<AnyRoomAccountDataEvent>>>,
     stripped_room_state:
-        HashMap<OwnedRoomId, HashMap<StateEventType, HashMap<String, Raw<AnyStrippedStateEvent>>>>,
+        HashMap<OwnedRoomId, HashMap<StateEventType, HashMap<String, Raw<StrippedState>>>>,
     stripped_members: HashMap<OwnedRoomId, HashMap<OwnedUserId, MembershipState>>,
     presence: HashMap<OwnedUserId, Raw<PresenceEvent>>,
     room_user_receipts: HashMap<

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -47,11 +47,12 @@ pub use matrix_sdk_store_encryption::Error as StoreEncryptionError;
 use observable_map::ObservableMap;
 use ruma::{
     EventId, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UserId,
+    api::client::sync::sync_events::StrippedState,
     events::{
-        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncStateEvent, EmptyStateKey, GlobalAccountDataEventType, RedactContent,
-        RedactedStateEventContent, RoomAccountDataEventType, StateEventType, StaticEventContent,
-        StaticStateEventContent, StrippedStateEvent, SyncStateEvent,
+        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncStateEvent, EmptyStateKey,
+        GlobalAccountDataEventType, RedactContent, RedactedStateEventContent,
+        RoomAccountDataEventType, StateEventType, StaticEventContent, StaticStateEventContent,
+        StrippedStateEvent, SyncStateEvent,
         presence::PresenceEvent,
         receipt::ReceiptEventContent,
         room::{
@@ -531,11 +532,9 @@ pub struct StateChanges {
     pub redactions: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, Raw<SyncRoomRedactionEvent>>>,
 
     /// A mapping of `RoomId` to a map of event type to a map of state key to
-    /// `AnyStrippedStateEvent`.
-    pub stripped_state: BTreeMap<
-        OwnedRoomId,
-        BTreeMap<StateEventType, BTreeMap<String, Raw<AnyStrippedStateEvent>>>,
-    >,
+    /// `StrippedState`.
+    pub stripped_state:
+        BTreeMap<OwnedRoomId, BTreeMap<StateEventType, BTreeMap<String, Raw<StrippedState>>>>,
 
     /// A map from room id to a map of a display name and a set of user ids that
     /// share that display name in the given room.

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -70,7 +70,7 @@ async fn test_notification() -> Result<()> {
     };
 
     if let Some(event_id) = invited_room.invite_state.events.iter().find_map(|event| {
-        let Ok(AnyStrippedStateEvent::RoomMember(room_member_ev)) = event.deserialize() else {
+        let Ok(AnyStrippedStateEvent::RoomMember(room_member_ev)) = event.deserialize_as() else {
             return None;
         };
 

--- a/testing/matrix-sdk-test/src/lib.rs
+++ b/testing/matrix-sdk-test/src/lib.rs
@@ -66,7 +66,7 @@ macro_rules! stripped_state_event {
     ($( $tt:tt )*) => {
         ::ruma::serde::Raw::new(&::serde_json::json!( $($tt)* ))
             .unwrap()
-            .cast_unchecked::<::ruma::events::AnyStrippedStateEvent>()
+            .cast_unchecked::<::ruma::api::client::sync::sync_events::StrippedState>()
     }
 }
 

--- a/testing/matrix-sdk-test/src/sync_builder/invited_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/invited_room.rs
@@ -1,6 +1,7 @@
 use ruma::{
-    OwnedRoomId, RoomId, api::client::sync::sync_events::v3::InvitedRoom,
-    events::AnyStrippedStateEvent, serde::Raw,
+    OwnedRoomId, RoomId,
+    api::client::sync::sync_events::{StrippedState, v3::InvitedRoom},
+    serde::Raw,
 };
 
 use crate::DEFAULT_TEST_ROOM_ID;
@@ -25,7 +26,7 @@ impl InvitedRoomBuilder {
     }
 
     /// Add an event to the state.
-    pub fn add_state_event(mut self, event: impl Into<Raw<AnyStrippedStateEvent>>) -> Self {
+    pub fn add_state_event(mut self, event: impl Into<Raw<StrippedState>>) -> Self {
         self.inner.invite_state.events.push(event.into());
         self
     }
@@ -33,7 +34,7 @@ impl InvitedRoomBuilder {
     /// Add events to the state in bulk.
     pub fn add_state_bulk<I>(mut self, events: I) -> Self
     where
-        I: IntoIterator<Item = Raw<AnyStrippedStateEvent>>,
+        I: IntoIterator<Item = Raw<StrippedState>>,
     {
         self.inner.invite_state.events.extend(events);
         self

--- a/testing/matrix-sdk-test/src/sync_builder/knocked_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/knocked_room.rs
@@ -1,6 +1,7 @@
 use ruma::{
-    OwnedRoomId, RoomId, api::client::sync::sync_events::v3::KnockedRoom,
-    events::AnyStrippedStateEvent, serde::Raw,
+    OwnedRoomId, RoomId,
+    api::client::sync::sync_events::{StrippedState, v3::KnockedRoom},
+    serde::Raw,
 };
 
 use super::StrippedStateTestEvent;
@@ -34,7 +35,7 @@ impl KnockedRoomBuilder {
     /// Add events to the state in bulk.
     pub fn add_state_bulk<I>(mut self, events: I) -> Self
     where
-        I: IntoIterator<Item = Raw<AnyStrippedStateEvent>>,
+        I: IntoIterator<Item = Raw<StrippedState>>,
     {
         self.inner.knock_state.events.extend(events);
         self

--- a/testing/matrix-sdk-test/src/sync_builder/test_event.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/test_event.rs
@@ -1,7 +1,8 @@
 use ruma::{
+    api::client::sync::sync_events::StrippedState,
     events::{
-        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncStateEvent, presence::PresenceEvent,
+        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncStateEvent,
+        presence::PresenceEvent,
     },
     serde::Raw,
 };
@@ -89,7 +90,7 @@ impl From<StrippedStateTestEvent> for JsonValue {
     }
 }
 
-impl From<StrippedStateTestEvent> for Raw<AnyStrippedStateEvent> {
+impl From<StrippedStateTestEvent> for Raw<StrippedState> {
     fn from(val: StrippedStateTestEvent) -> Self {
         from_json_value(val.into()).unwrap()
     }


### PR DESCRIPTION
This brings in a new breaking change from Ruma, because not all events are stripped in a room's stripped state. For simplicity and minimal changes, we still consider the events as stripped during processing since we mostly care about the `content`.

This also brings in the support for encrypted state events, fyi.
