### PR TITLE
fix(xtask): Use `--package` instead of `-p` on `cargo ndk`

### DIFF
--- a/xtask/src/kotlin.rs
+++ b/xtask/src/kotlin.rs
@@ -164,7 +164,7 @@ fn build_for_android_target(
     let sh = sh();
     cmd!(
         sh,
-        "cargo ndk --target {target} -o {dest_dir} build --profile {profile} -p {package_name} --features {features}"
+        "cargo ndk --target {target} -o {dest_dir} build --profile {profile} --package {package_name} --features {features}"
     )
     .run()?;
 


### PR DESCRIPTION
We use `cargo ndk -p {package_name}`, where `-p` is short for `--package`. However, `cargo ndk` has introduced the `-p` option (see https://github.com/bbqsrc/cargo-ndk/commit/c6b93a89a2723ff0fac99b5ac86ae6636a6cf54a), short for `--platform`. It creates a confusion and the command line doesn't execute properly. Let's use the long option `--package` to clarify everything.