### PR TITLE
refactor(threads): add support for MSC4306 latest changes and push rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.6"
-source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
+source = "git+https://github.com/ruma/ruma?rev=e73f302e4df7f5f0511fca1aa43853d4cf8416c8#e73f302e4df7f5f0511fca1aa43853d4cf8416c8"
 dependencies = [
  "assign",
  "js_int",
@@ -4438,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.4"
-source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
+source = "git+https://github.com/ruma/ruma?rev=e73f302e4df7f5f0511fca1aa43853d4cf8416c8#e73f302e4df7f5f0511fca1aa43853d4cf8416c8"
 dependencies = [
  "as_variant",
  "assign",
@@ -4461,7 +4461,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.4"
-source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
+source = "git+https://github.com/ruma/ruma?rev=e73f302e4df7f5f0511fca1aa43853d4cf8416c8#e73f302e4df7f5f0511fca1aa43853d4cf8416c8"
 dependencies = [
  "as_variant",
  "base64",
@@ -4494,7 +4494,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.5"
-source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
+source = "git+https://github.com/ruma/ruma?rev=e73f302e4df7f5f0511fca1aa43853d4cf8416c8#e73f302e4df7f5f0511fca1aa43853d4cf8416c8"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4520,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.2"
-source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
+source = "git+https://github.com/ruma/ruma?rev=e73f302e4df7f5f0511fca1aa43853d4cf8416c8#e73f302e4df7f5f0511fca1aa43853d4cf8416c8"
 dependencies = [
  "headers",
  "http",
@@ -4538,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.1"
-source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
+source = "git+https://github.com/ruma/ruma?rev=e73f302e4df7f5f0511fca1aa43853d4cf8416c8#e73f302e4df7f5f0511fca1aa43853d4cf8416c8"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4549,7 +4549,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
+source = "git+https://github.com/ruma/ruma?rev=e73f302e4df7f5f0511fca1aa43853d4cf8416c8#e73f302e4df7f5f0511fca1aa43853d4cf8416c8"
 dependencies = [
  "js_int",
  "thiserror 2.0.11",
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.2"
-source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
+source = "git+https://github.com/ruma/ruma?rev=e73f302e4df7f5f0511fca1aa43853d4cf8416c8#e73f302e4df7f5f0511fca1aa43853d4cf8416c8"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 rand = "0.8.5"
 reqwest = { version = "0.12.12", default-features = false }
 rmp-serde = "1.3.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "a626e6b8521bcaa01bf8b7c4161b26b361b72aff", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "e73f302e4df7f5f0511fca1aa43853d4cf8416c8", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-arbitrary-length-ids",
@@ -78,7 +78,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "a626e6b8521bcaa01bf8b7c416
     "unstable-msc4286",
     "unstable-msc4306"
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "a626e6b8521bcaa01bf8b7c4161b26b361b72aff" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "e73f302e4df7f5f0511fca1aa43853d4cf8416c8" }
 sentry = "0.36.0"
 sentry-tracing = "0.36.0"
 serde = { version = "1.0.217", features = ["rc"] }

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -1112,7 +1112,7 @@ impl Room {
         let thread_root = EventId::parse(thread_root_event_id)?;
         if subscribed {
             // This is a manual subscription.
-            let automatic = false;
+            let automatic = None;
             self.inner.subscribe_thread(thread_root, automatic).await?;
         } else {
             self.inner.unsubscribe_thread(thread_root).await?;

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -1129,25 +1129,22 @@ impl Room {
     pub async fn fetch_thread_subscription(
         &self,
         thread_root_event_id: String,
-    ) -> Result<Option<ThreadStatus>, ClientError> {
+    ) -> Result<Option<ThreadSubscription>, ClientError> {
         let thread_root = EventId::parse(thread_root_event_id)?;
-        Ok(self.inner.fetch_thread_subscription(thread_root).await?.map(|sub| match sub {
-            matrix_sdk::room::ThreadStatus::Subscribed { automatic } => {
-                ThreadStatus::Subscribed { automatic }
-            }
-        }))
+        Ok(self
+            .inner
+            .fetch_thread_subscription(thread_root)
+            .await?
+            .map(|sub| ThreadSubscription { automatic: sub.automatic }))
     }
 }
 
-/// Status of a thread subscription (MSC4306).
-#[derive(uniffi::Enum)]
-pub enum ThreadStatus {
-    /// The thread is subscribed to.
-    Subscribed {
-        /// Whether the thread subscription happened automatically (e.g. after a
-        /// mention) or if it was manually requested by the user.
-        automatic: bool,
-    },
+/// A thread subscription (MSC4306).
+#[derive(uniffi::Record)]
+pub struct ThreadSubscription {
+    /// Whether the thread subscription happened automatically (e.g. after a
+    /// mention) or if it was manually requested by the user.
+    automatic: bool,
 }
 
 /// A listener for receiving new live location shares in a room.

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -1093,8 +1093,8 @@ impl Room {
         Ok(Arc::new(RoomPreview::new(AsyncRuntimeDropped::new(client), room_preview)))
     }
 
-    /// Toggle a MSC4306 subscription to a thread in this room, based on the
-    /// thread root event id.
+    /// Set a MSC4306 subscription to a thread in this room, based on the thread
+    /// root event id.
     ///
     /// If `subscribed` is `true`, it will subscribe to the thread, with a
     /// precision that the subscription was manually requested by the user
@@ -1135,7 +1135,6 @@ impl Room {
             matrix_sdk::room::ThreadStatus::Subscribed { automatic } => {
                 ThreadStatus::Subscribed { automatic }
             }
-            matrix_sdk::room::ThreadStatus::Unsubscribed => ThreadStatus::Unsubscribed,
         }))
     }
 }
@@ -1149,9 +1148,6 @@ pub enum ThreadStatus {
         /// mention) or if it was manually requested by the user.
         automatic: bool,
     },
-
-    /// The thread is not subscribed to.
-    Unsubscribed,
 }
 
 /// A listener for receiving new live location shares in a room.

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -151,9 +151,16 @@ impl fmt::Debug for BaseClient {
 /// explicitly opted into).
 #[derive(Clone, Copy, Debug)]
 pub enum ThreadingSupport {
-    /// Threading enabled
-    Enabled,
-    /// Threading disabled
+    /// Threading enabled.
+    Enabled {
+        /// Enable client-wide thread subscriptions support (MSC4306 / MSC4308).
+        ///
+        /// This may cause filtering out of thread subscriptions, and loading
+        /// the thread subscriptions via the sliding sync extension,
+        /// when the room list service is being used.
+        with_subscriptions: bool,
+    },
+    /// Threading disabled.
     Disabled,
 }
 

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -212,7 +212,7 @@ impl RoomReadReceipts {
         user_id: &UserId,
         threading_support: ThreadingSupport,
     ) {
-        if matches!(threading_support, ThreadingSupport::Enabled)
+        if matches!(threading_support, ThreadingSupport::Enabled { .. })
             && extract_thread_root(event.raw()).is_some()
         {
             return;
@@ -1621,23 +1621,23 @@ mod tests {
         receipts.process_event(
             &make_event(own_alice, event_id!("$some_thread_root")),
             own_alice,
-            ThreadingSupport::Enabled,
+            ThreadingSupport::Enabled { with_subscriptions: false },
         );
         receipts.process_event(
             &make_event(own_alice, event_id!("$some_other_thread_root")),
             own_alice,
-            ThreadingSupport::Enabled,
+            ThreadingSupport::Enabled { with_subscriptions: false },
         );
 
         receipts.process_event(
             &make_event(bob, event_id!("$some_thread_root")),
             own_alice,
-            ThreadingSupport::Enabled,
+            ThreadingSupport::Enabled { with_subscriptions: false },
         );
         receipts.process_event(
             &make_event(bob, event_id!("$some_other_thread_root")),
             own_alice,
-            ThreadingSupport::Enabled,
+            ThreadingSupport::Enabled { with_subscriptions: false },
         );
 
         assert_eq!(receipts.num_unread, 0);
@@ -1648,7 +1648,7 @@ mod tests {
         receipts.process_event(
             &EventFactory::new().text_msg("A").sender(bob).event_id(event_id!("$ida")).into_event(),
             own_alice,
-            ThreadingSupport::Enabled,
+            ThreadingSupport::Enabled { with_subscriptions: false },
         );
 
         assert_eq!(receipts.num_unread, 1);

--- a/crates/matrix-sdk-base/src/response_processors/notification.rs
+++ b/crates/matrix-sdk-base/src/response_processors/notification.rs
@@ -59,7 +59,7 @@ impl<'a> Notification<'a> {
     /// `push_condition_room_ctx`. (based on `Self::push_rules`).
     ///
     /// This method returns the fetched [`Action`]s.
-    pub fn push_notification_from_event_if<E, P>(
+    pub async fn push_notification_from_event_if<E, P>(
         &mut self,
         room_id: &RoomId,
         push_condition_room_ctx: &PushConditionRoomCtx,
@@ -70,7 +70,7 @@ impl<'a> Notification<'a> {
         Raw<E>: Into<RawAnySyncOrStrippedTimelineEvent>,
         P: Fn(&Action) -> bool,
     {
-        let actions = self.push_rules.get_actions(event, push_condition_room_ctx);
+        let actions = self.push_rules.get_actions(event, push_condition_room_ctx).await;
 
         if actions.iter().any(predicate) {
             self.push_notification(room_id, actions.to_owned(), event.clone().into());

--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -279,12 +279,14 @@ pub mod stripped {
 
             // Check every event again for notification.
             for event in state_events.values().flat_map(|map| map.values()) {
-                notification.push_notification_from_event_if(
-                    room_id,
-                    &push_condition_room_ctx,
-                    event,
-                    Action::should_notify,
-                );
+                notification
+                    .push_notification_from_event_if(
+                        room_id,
+                        &push_condition_room_ctx,
+                        event,
+                        Action::should_notify,
+                    )
+                    .await;
             }
         }
 

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -129,12 +129,14 @@ pub async fn build<'notification, 'e2ee>(
                 }
 
                 if let Some(push_condition_room_ctx) = &push_condition_room_ctx {
-                    let actions = notification.push_notification_from_event_if(
-                        room_id,
-                        push_condition_room_ctx,
-                        timeline_event.raw(),
-                        Action::should_notify,
-                    );
+                    let actions = notification
+                        .push_notification_from_event_if(
+                            room_id,
+                            push_condition_room_ctx,
+                            timeline_event.raw(),
+                            Action::should_notify,
+                        )
+                        .await;
 
                     timeline_event.set_push_actions(actions.to_owned());
                 }

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -48,7 +48,7 @@ use crate::{
     deserialized_responses::MemberEvent,
     store::{
         ChildTransactionId, QueueWedgeError, Result, SerializableEventContent, StateStoreExt,
-        ThreadStatus,
+        ThreadSubscription,
     },
 };
 
@@ -1790,7 +1790,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         self.upsert_thread_subscription(
             room_id(),
             first_thread,
-            ThreadStatus::Subscribed { automatic: true },
+            ThreadSubscription { automatic: true },
         )
         .await
         .unwrap();
@@ -1798,32 +1798,32 @@ impl StateStoreIntegrationTests for DynStateStore {
         self.upsert_thread_subscription(
             room_id(),
             second_thread,
-            ThreadStatus::Subscribed { automatic: false },
+            ThreadSubscription { automatic: false },
         )
         .await
         .unwrap();
 
         // Now, reading the thread subscription returns the expected status.
         let maybe_status = self.load_thread_subscription(room_id(), first_thread).await.unwrap();
-        assert_eq!(maybe_status, Some(ThreadStatus::Subscribed { automatic: true }));
+        assert_eq!(maybe_status, Some(ThreadSubscription { automatic: true }));
         let maybe_status = self.load_thread_subscription(room_id(), second_thread).await.unwrap();
-        assert_eq!(maybe_status, Some(ThreadStatus::Subscribed { automatic: false }));
+        assert_eq!(maybe_status, Some(ThreadSubscription { automatic: false }));
 
         // We can override the thread subscription status.
         self.upsert_thread_subscription(
             room_id(),
             first_thread,
-            ThreadStatus::Subscribed { automatic: false },
+            ThreadSubscription { automatic: false },
         )
         .await
         .unwrap();
 
         // And it's correctly reflected.
         let maybe_status = self.load_thread_subscription(room_id(), first_thread).await.unwrap();
-        assert_eq!(maybe_status, Some(ThreadStatus::Subscribed { automatic: false }));
+        assert_eq!(maybe_status, Some(ThreadSubscription { automatic: false }));
         // And the second thread is still subscribed.
         let maybe_status = self.load_thread_subscription(room_id(), second_thread).await.unwrap();
-        assert_eq!(maybe_status, Some(ThreadStatus::Subscribed { automatic: false }));
+        assert_eq!(maybe_status, Some(ThreadSubscription { automatic: false }));
 
         // We can remove a thread subscription.
         self.remove_thread_subscription(room_id(), second_thread).await.unwrap();
@@ -1833,7 +1833,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         assert_eq!(maybe_status, None);
         // And the first thread is still subscribed.
         let maybe_status = self.load_thread_subscription(room_id(), first_thread).await.unwrap();
-        assert_eq!(maybe_status, Some(ThreadStatus::Subscribed { automatic: false }));
+        assert_eq!(maybe_status, Some(ThreadSubscription { automatic: false }));
 
         // Removing a thread subscription for an unknown thread is a no-op.
         self.remove_thread_subscription(room_id(), second_thread).await.unwrap();

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -46,7 +46,7 @@ use super::{
 use crate::{
     MinimalRoomMemberEvent, RoomMemberships, StateStoreDataKey, StateStoreDataValue,
     deserialized_responses::{DisplayName, RawAnySyncOrStrippedState},
-    store::{QueueWedgeError, ThreadStatus},
+    store::{QueueWedgeError, ThreadSubscription},
 };
 
 #[derive(Debug, Default)]
@@ -84,7 +84,7 @@ struct MemoryStoreInner {
     send_queue_events: BTreeMap<OwnedRoomId, Vec<QueuedRequest>>,
     dependent_send_queue_events: BTreeMap<OwnedRoomId, Vec<DependentQueuedRequest>>,
     seen_knock_requests: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, OwnedUserId>>,
-    thread_subscriptions: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, ThreadStatus>>,
+    thread_subscriptions: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, ThreadSubscription>>,
 }
 
 /// In-memory, non-persistent implementation of the `StateStore`.
@@ -958,7 +958,7 @@ impl StateStore for MemoryStore {
         &self,
         room: &RoomId,
         thread_id: &EventId,
-        status: ThreadStatus,
+        subscription: ThreadSubscription,
     ) -> Result<(), Self::Error> {
         self.inner
             .write()
@@ -966,7 +966,7 @@ impl StateStore for MemoryStore {
             .thread_subscriptions
             .entry(room.to_owned())
             .or_default()
-            .insert(thread_id.to_owned(), status);
+            .insert(thread_id.to_owned(), subscription);
         Ok(())
     }
 
@@ -974,7 +974,7 @@ impl StateStore for MemoryStore {
         &self,
         room: &RoomId,
         thread_id: &EventId,
-    ) -> Result<Option<ThreadStatus>, Self::Error> {
+    ) -> Result<Option<ThreadSubscription>, Self::Error> {
         let inner = self.inner.read().unwrap();
         Ok(inner
             .thread_subscriptions

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -982,6 +982,27 @@ impl StateStore for MemoryStore {
             .and_then(|subscriptions| subscriptions.get(thread_id))
             .copied())
     }
+
+    async fn remove_thread_subscription(
+        &self,
+        room: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<(), Self::Error> {
+        let mut inner = self.inner.write().unwrap();
+
+        let Some(room_subs) = inner.thread_subscriptions.get_mut(room) else {
+            return Ok(());
+        };
+
+        room_subs.remove(thread_id);
+
+        if room_subs.is_empty() {
+            // If there are no more subscriptions for this room, remove the room entry.
+            inner.thread_subscriptions.remove(room);
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -462,9 +462,6 @@ pub enum ThreadStatus {
         /// manual user choice.
         automatic: bool,
     },
-    /// The thread is unsubscribed to (it won't cause any notifications or
-    /// automatic subscription anymore).
-    Unsubscribed,
 }
 
 impl ThreadStatus {
@@ -478,7 +475,6 @@ impl ThreadStatus {
                     "manual"
                 }
             }
-            ThreadStatus::Unsubscribed => "unsubscribed",
         }
     }
 
@@ -488,7 +484,6 @@ impl ThreadStatus {
         match s {
             "automatic" => Some(ThreadStatus::Subscribed { automatic: true }),
             "manual" => Some(ThreadStatus::Subscribed { automatic: false }),
-            "unsubscribed" => Some(ThreadStatus::Unsubscribed),
             _ => None,
         }
     }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -453,37 +453,26 @@ pub enum RoomLoadSettings {
     One(OwnedRoomId),
 }
 
-/// Status of a thread subscription, as saved in the state store.
+/// A thread subscription, as saved in the state store.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ThreadStatus {
-    /// The thread is subscribed to.
-    Subscribed {
-        /// Whether the subscription was made automatically by a client, not by
-        /// manual user choice.
-        automatic: bool,
-    },
+pub struct ThreadSubscription {
+    /// Whether the subscription was made automatically by a client, not by
+    /// manual user choice.
+    pub automatic: bool,
 }
 
-impl ThreadStatus {
-    /// Convert the current [`ThreadStatus`] into a string representation.
+impl ThreadSubscription {
+    /// Convert the current [`ThreadSubscription`] into a string representation.
     pub fn as_str(&self) -> &'static str {
-        match self {
-            ThreadStatus::Subscribed { automatic } => {
-                if *automatic {
-                    "automatic"
-                } else {
-                    "manual"
-                }
-            }
-        }
+        if self.automatic { "automatic" } else { "manual" }
     }
 
-    /// Convert a string representation into a [`ThreadStatus`], if it is a
-    /// valid one, or `None` otherwise.
+    /// Convert a string representation into a [`ThreadSubscription`], if it is
+    /// a valid one, or `None` otherwise.
     pub fn from_value(s: &str) -> Option<Self> {
         match s {
-            "automatic" => Some(ThreadStatus::Subscribed { automatic: true }),
-            "manual" => Some(ThreadStatus::Subscribed { automatic: false }),
+            "automatic" => Some(Self { automatic: true }),
+            "manual" => Some(Self { automatic: false }),
             _ => None,
         }
     }

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -481,15 +481,20 @@ pub trait StateStore: AsyncTraitDeps {
     ) -> Result<Vec<DependentQueuedRequest>, Self::Error>;
 
     /// Insert or update a thread subscription for a given room and thread.
-    ///
-    /// Note: there's no way to remove a thread subscription, because it's
-    /// either subscribed to, or unsubscribed to, after it's been saved for
-    /// the first time.
     async fn upsert_thread_subscription(
         &self,
         room: &RoomId,
         thread_id: &EventId,
         status: ThreadStatus,
+    ) -> Result<(), Self::Error>;
+
+    /// Remove a previous thread subscription for a given room and thread.
+    ///
+    /// Note: removing an unknown thread subscription is a no-op.
+    async fn remove_thread_subscription(
+        &self,
+        room: &RoomId,
+        thread_id: &EventId,
     ) -> Result<(), Self::Error>;
 
     /// Loads the current thread subscription for a given room and thread.
@@ -810,6 +815,14 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         thread_id: &EventId,
     ) -> Result<Option<ThreadStatus>, Self::Error> {
         self.0.load_thread_subscription(room, thread_id).await.map_err(Into::into)
+    }
+
+    async fn remove_thread_subscription(
+        &self,
+        room: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<(), Self::Error> {
+        self.0.remove_thread_subscription(room, thread_id).await.map_err(Into::into)
     }
 }
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -55,7 +55,7 @@ use crate::{
     deserialized_responses::{
         DisplayName, RawAnySyncOrStrippedState, RawMemberEvent, RawSyncOrStrippedState,
     },
-    store::ThreadStatus,
+    store::ThreadSubscription,
 };
 
 /// An abstract state store trait that can be used to implement different stores
@@ -485,7 +485,7 @@ pub trait StateStore: AsyncTraitDeps {
         &self,
         room: &RoomId,
         thread_id: &EventId,
-        status: ThreadStatus,
+        subscription: ThreadSubscription,
     ) -> Result<(), Self::Error>;
 
     /// Remove a previous thread subscription for a given room and thread.
@@ -504,7 +504,7 @@ pub trait StateStore: AsyncTraitDeps {
         &self,
         room: &RoomId,
         thread_id: &EventId,
-    ) -> Result<Option<ThreadStatus>, Self::Error>;
+    ) -> Result<Option<ThreadSubscription>, Self::Error>;
 }
 
 #[repr(transparent)]
@@ -804,16 +804,16 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         &self,
         room: &RoomId,
         thread_id: &EventId,
-        status: ThreadStatus,
+        subscription: ThreadSubscription,
     ) -> Result<(), Self::Error> {
-        self.0.upsert_thread_subscription(room, thread_id, status).await.map_err(Into::into)
+        self.0.upsert_thread_subscription(room, thread_id, subscription).await.map_err(Into::into)
     }
 
     async fn load_thread_subscription(
         &self,
         room: &RoomId,
         thread_id: &EventId,
-    ) -> Result<Option<ThreadStatus>, Self::Error> {
+    ) -> Result<Option<ThreadSubscription>, Self::Error> {
         self.0.load_thread_subscription(room, thread_id).await.map_err(Into::into)
     }
 

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -1837,6 +1837,21 @@ impl_state_store!({
 
         Ok(Some(status))
     }
+
+    async fn remove_thread_subscription(&self, room: &RoomId, thread_id: &EventId) -> Result<()> {
+        let encoded_key = self.encode_key(keys::THREAD_SUBSCRIPTIONS, (room, thread_id));
+
+        self.inner
+            .transaction_on_one_with_mode(
+                keys::THREAD_SUBSCRIPTIONS,
+                IdbTransactionMode::Readwrite,
+            )?
+            .object_store(keys::THREAD_SUBSCRIPTIONS)?
+            .delete(&encoded_key)?
+            .await?;
+
+        Ok(())
+    }
 });
 
 /// A room member.

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -13,7 +13,7 @@ use matrix_sdk_base::{
     store::{
         migration_helpers::RoomInfoV1, ChildTransactionId, DependentQueuedRequest,
         DependentQueuedRequestKind, QueueWedgeError, QueuedRequest, QueuedRequestKind,
-        RoomLoadSettings, SentRequestKey, ThreadStatus,
+        RoomLoadSettings, SentRequestKey, ThreadSubscription,
     },
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, RoomState, StateChanges, StateStore,
     StateStoreDataKey, StateStoreDataValue, ROOM_VERSION_FALLBACK, ROOM_VERSION_RULES_FALLBACK,
@@ -2098,11 +2098,11 @@ impl StateStore for SqliteStateStore {
         &self,
         room_id: &RoomId,
         thread_id: &EventId,
-        status: ThreadStatus,
+        subscription: ThreadSubscription,
     ) -> Result<(), Self::Error> {
         let room_id = self.encode_key(keys::THREAD_SUBSCRIPTIONS, room_id);
         let thread_id = self.encode_key(keys::THREAD_SUBSCRIPTIONS, thread_id);
-        let status = status.as_str();
+        let status = subscription.as_str();
 
         self.acquire()
             .await?
@@ -2121,7 +2121,7 @@ impl StateStore for SqliteStateStore {
         &self,
         room_id: &RoomId,
         thread_id: &EventId,
-    ) -> Result<Option<ThreadStatus>, Self::Error> {
+    ) -> Result<Option<ThreadSubscription>, Self::Error> {
         let room_id = self.encode_key(keys::THREAD_SUBSCRIPTIONS, room_id);
         let thread_id = self.encode_key(keys::THREAD_SUBSCRIPTIONS, thread_id);
 
@@ -2136,7 +2136,7 @@ impl StateStore for SqliteStateStore {
             .await
             .optional()?
             .map(|data| {
-                ThreadStatus::from_value(&data).ok_or_else(|| Error::InvalidData {
+                ThreadSubscription::from_value(&data).ok_or_else(|| Error::InvalidData {
                     details: format!("Invalid thread status: {data}"),
                 })
             })

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -2142,6 +2142,25 @@ impl StateStore for SqliteStateStore {
             })
             .transpose()?)
     }
+
+    async fn remove_thread_subscription(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<(), Self::Error> {
+        let room_id = self.encode_key(keys::THREAD_SUBSCRIPTIONS, room_id);
+        let thread_id = self.encode_key(keys::THREAD_SUBSCRIPTIONS, thread_id);
+
+        self.acquire()
+            .await?
+            .execute(
+                "DELETE FROM thread_subscriptions WHERE room_id = ? AND event_id = ?",
+                (room_id, thread_id),
+            )
+            .await?;
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -343,7 +343,11 @@ impl Decryptor for (matrix_sdk_base::crypto::OlmMachine, ruma::OwnedRoomId) {
             .await?
         {
             RoomEventDecryptionResult::Decrypted(decrypted) => {
-                let push_actions = push_ctx.map(|push_ctx| push_ctx.for_event(&decrypted.event));
+                let push_actions = if let Some(push_ctx) = push_ctx {
+                    Some(push_ctx.for_event(&decrypted.event).await)
+                } else {
+                    None
+                };
                 Ok(TimelineEvent::from_decrypted(decrypted, push_actions))
             }
             RoomEventDecryptionResult::UnableToDecrypt(utd_info) => {

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -7,6 +7,7 @@ use std::{
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use matrix_sdk::{
+    ThreadingSupport,
     config::SyncSettings,
     test_utils::{logged_in_client_with_server, mocks::MatrixMockServer},
 };
@@ -23,8 +24,8 @@ use matrix_sdk_ui::{
 };
 use ruma::{
     RoomVersionId, event_id,
-    events::{TimelineEventType, room::member::MembershipState},
-    mxc_uri, room_id, user_id,
+    events::{Mentions, TimelineEventType, room::member::MembershipState},
+    mxc_uri, owned_user_id, room_id, user_id,
 };
 use serde_json::json;
 use wiremock::{
@@ -112,6 +113,234 @@ async fn test_notification_client_with_context() {
     });
     assert_eq!(item.sender_display_name.as_deref(), Some("John Mastodon"));
     assert_eq!(item.sender_avatar_url, Some(sender_avatar_url.to_string()));
+}
+
+#[async_test]
+async fn test_subscribed_threads_get_notifications() {
+    let server = MatrixMockServer::new().await;
+    let client = server
+        .client_builder()
+        .on_builder(|builder| {
+            builder.with_threading_support(ThreadingSupport::Enabled { with_subscriptions: true })
+        })
+        .build()
+        .await;
+
+    let sender = user_id!("@user:example.org");
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let f = EventFactory::new().room(room_id).sender(sender);
+
+    // First, mock an empty sync so the room is known.
+    server.mock_room_state_encryption().plain().mount().await;
+
+    // To have access to the push rules context, we must know the own's member
+    // event.
+    let room = server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_state_event(
+                f.member(client.user_id().unwrap())
+                    .membership(MembershipState::Join)
+                    .display_name("Jean-Michel Rouille"),
+            ),
+        )
+        .await;
+
+    // Sanity check: we can create push rules context.
+    room.push_context().await.unwrap().unwrap();
+
+    // Create a notification client.
+    let sync_service = Arc::new(SyncService::builder(client.clone()).build().await.unwrap());
+    let process_setup = NotificationProcessSetup::SingleProcess { sync_service };
+    let notification_client = NotificationClient::new(client, process_setup).await.unwrap();
+
+    // For a thread I'm subscribed to,
+    let thread_root = event_id!("$thread_root");
+    server
+        .mock_get_thread_subscription()
+        .match_thread_id(thread_root.to_owned())
+        .ok(false)
+        .expect(2)
+        .mount()
+        .await;
+
+    let sender_member_event =
+        f.member(sender).membership(MembershipState::Join).display_name("John Diaspora").into_raw();
+
+    // Considering an in-thread message,
+    let in_thread_event = {
+        let event_id = event_id!("$example_event_id");
+        let event = f
+            .text_msg("hello to you too!")
+            .event_id(event_id)
+            .server_ts(152049794)
+            .in_thread(thread_root, thread_root)
+            .into_event();
+
+        server
+            .mock_room_event_context()
+            .match_event_id()
+            .ok(event.clone(), "", "", vec![sender_member_event.clone()])
+            .mock_once()
+            .mount()
+            .await;
+
+        // Then I get a notification for this message.
+        let item =
+            notification_client.get_notification_with_context(room_id, event_id).await.unwrap();
+        assert_matches!(item, NotificationStatus::Event(..));
+
+        event
+    };
+
+    // Considering the thread root event,
+    let event = f
+        .text_msg("hello world")
+        .event_id(thread_root)
+        .server_ts(152049793)
+        .with_bundled_thread_summary(in_thread_event.raw().clone().cast_unchecked(), 1, false)
+        .into_event();
+
+    server
+        .mock_room_event_context()
+        .match_event_id()
+        .ok(event.clone(), "", "", vec![sender_member_event])
+        .mock_once()
+        .mount()
+        .await;
+
+    // Then I get a notification for the thread root as well.
+    let item =
+        notification_client.get_notification_with_context(room_id, thread_root).await.unwrap();
+    assert_matches!(item, NotificationStatus::Event(..));
+}
+
+#[async_test]
+async fn test_unsubscribed_threads_get_notifications() {
+    let server = MatrixMockServer::new().await;
+    let client = server
+        .client_builder()
+        .on_builder(|builder| {
+            builder.with_threading_support(ThreadingSupport::Enabled { with_subscriptions: true })
+        })
+        .build()
+        .await;
+
+    let sender = user_id!("@user:example.org");
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let f = EventFactory::new().room(room_id).sender(sender);
+
+    // First, mock an empty sync so the room is known.
+    server.mock_room_state_encryption().plain().mount().await;
+
+    // To have access to the push rules context, we must know the own's member
+    // event.
+    let room = server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_state_event(
+                f.member(client.user_id().unwrap())
+                    .membership(MembershipState::Join)
+                    .display_name("Jean-Michel Rouille"),
+            ),
+        )
+        .await;
+
+    // Sanity check: we can create push rules context.
+    room.push_context().await.unwrap().unwrap();
+
+    // Create a notification client.
+    let sync_service = Arc::new(SyncService::builder(client.clone()).build().await.unwrap());
+    let process_setup = NotificationProcessSetup::SingleProcess { sync_service };
+    let notification_client = NotificationClient::new(client.clone(), process_setup).await.unwrap();
+
+    // For a thread with an unknown subscription status (note: we're not mocking the
+    // get endpoint, since 404 is equivalent to no thread status),
+    let thread_root = event_id!("$thread_root");
+
+    let sender_member_event =
+        f.member(sender).membership(MembershipState::Join).display_name("John Diaspora").into_raw();
+
+    // Considering a random in-thread message,
+    let first_thread_response = event_id!("$thread_response1");
+    let in_thread_event = {
+        // Note: contains a mention, but not of me.
+        let event = f
+            .text_msg("hello to you too!")
+            .event_id(first_thread_response)
+            .server_ts(152049794)
+            .in_thread(thread_root, thread_root)
+            .mentions(Mentions::with_user_ids([owned_user_id!("@rando:example.org")]))
+            .into_event();
+
+        server
+            .mock_room_event_context()
+            .match_event_id()
+            .ok(event.clone(), "", "", vec![sender_member_event.clone()])
+            .mock_once()
+            .mount()
+            .await;
+
+        // Then I don't get a notification for it.
+        let item = notification_client
+            .get_notification_with_context(room_id, first_thread_response)
+            .await
+            .unwrap();
+        assert_matches!(item, NotificationStatus::EventFilteredOut);
+
+        event
+    };
+
+    // Considering the thread root event,
+    {
+        let event = f
+            .text_msg("hello world")
+            .event_id(thread_root)
+            .server_ts(152049793)
+            .with_bundled_thread_summary(in_thread_event.raw().clone().cast_unchecked(), 1, false)
+            .into_event();
+
+        server
+            .mock_room_event_context()
+            .match_event_id()
+            .ok(event.clone(), "", "", vec![sender_member_event.clone()])
+            .mock_once()
+            .mount()
+            .await;
+
+        // I do get a notification about it, because it's not technically in the thread.
+        let item =
+            notification_client.get_notification_with_context(room_id, thread_root).await.unwrap();
+        assert_matches!(item, NotificationStatus::Event(..));
+    }
+
+    // But if a new in-thread event mentions me, then I would get subscribed,
+    {
+        let thread_response2 = event_id!("$thread_response2");
+        // Note: event mentions me.
+        let event = f
+            .text_msg("hello world")
+            .event_id(thread_response2)
+            .server_ts(152049793)
+            .in_thread(thread_root, first_thread_response)
+            .mentions(Mentions::with_user_ids(vec![client.user_id().unwrap().to_owned()]))
+            .into_event();
+
+        server
+            .mock_room_event_context()
+            .match_event_id()
+            .ok(event.clone(), "", "", vec![sender_member_event])
+            .mock_once()
+            .mount()
+            .await;
+
+        // Then I do get a notification for the thread root either.
+        let item = notification_client
+            .get_notification_with_context(room_id, thread_response2)
+            .await
+            .unwrap();
+        assert_matches!(item, NotificationStatus::Event(..));
+    }
 }
 
 #[async_test]
@@ -929,7 +1158,12 @@ async fn test_notification_client_context_filters_out_events_from_ignored_users(
         .into_event();
 
     // Mock the /context response
-    server.mock_room_event_context().ok(event, "start", "end").mock_once().mount().await;
+    server
+        .mock_room_event_context()
+        .ok(event, "start", "end", Vec::new())
+        .mock_once()
+        .mount()
+        .await;
 
     let dummy_sync_service = Arc::new(SyncService::builder(client.clone()).build().await.unwrap());
     let process_setup =

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -35,7 +35,7 @@ use matrix_sdk_base::{
     store::{DynStateStore, RoomLoadSettings, ServerInfo, WellKnownResponse},
     sync::{Notification, RoomUpdates},
     BaseClient, RoomInfoNotableUpdate, RoomState, RoomStateFilter, SendOutsideWasm, SessionMeta,
-    StateStoreDataKey, StateStoreDataValue, SyncOutsideWasm,
+    StateStoreDataKey, StateStoreDataValue, SyncOutsideWasm, ThreadingSupport,
 };
 use matrix_sdk_common::ttl_cache::TtlCache;
 #[cfg(feature = "e2e-encryption")]
@@ -2799,6 +2799,19 @@ impl Client {
     #[cfg(feature = "e2e-encryption")]
     pub fn decryption_settings(&self) -> &DecryptionSettings {
         &self.base_client().decryption_settings
+    }
+
+    /// Whether the client is configured to take thread subscriptions (MSC4306
+    /// and MSC4308) into account.
+    ///
+    /// This may cause filtering out of thread subscriptions, and loading the
+    /// thread subscriptions via the sliding sync extension, when the room
+    /// list service is being used.
+    pub fn enabled_thread_subscriptions(&self) -> bool {
+        match self.base_client().threading_support {
+            ThreadingSupport::Enabled { with_subscriptions } => with_subscriptions,
+            ThreadingSupport::Disabled => false,
+        }
     }
 }
 

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -3879,6 +3879,17 @@ impl<'a> MockEndpoint<'a, PutThreadSubscriptionEndpoint> {
         self.respond_with(ResponseTemplate::new(200))
     }
 
+    /// Returns that the server skipped an automated thread subscription,
+    /// because the user unsubscribed to the thread after the event id passed in
+    /// the automatic subscription.
+    pub fn conflicting_unsubscription(mut self) -> MatrixMock<'a> {
+        self.mock = self.mock.and(path_regex(self.endpoint.matchers.endpoint_regexp_uri()));
+        self.respond_with(ResponseTemplate::new(409).set_body_json(json!({
+            "errcode": "IO.ELEMENT.MSC4306.M_CONFLICTING_UNSUBSCRIPTION",
+            "error": "the user unsubscribed after the subscription event id"
+        })))
+    }
+
     /// Match the request parameter against a specific room id.
     pub fn match_room_id(mut self, room_id: OwnedRoomId) -> Self {
         self.endpoint.matchers = self.endpoint.matchers.match_room_id(room_id);

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -2505,15 +2505,16 @@ impl<'a> MockEndpoint<'a, RoomEventContextEndpoint> {
         self
     }
 
-    /// Returns an endpoint that emulates success
+    /// Returns an endpoint that emulates success.
     pub fn ok(
         self,
         event: TimelineEvent,
         start: impl Into<String>,
         end: impl Into<String>,
+        state_events: Vec<Raw<AnyStateEvent>>,
     ) -> MatrixMock<'a> {
         let event_path = if self.endpoint.match_event_id {
-            let event_id = event.kind.event_id().expect("an event id is required");
+            let event_id = event.event_id().expect("an event id is required");
             // The event id should begin with `$`, which would be taken as the end of the
             // regex so we need to escape it
             event_id.as_str().replace("$", "\\$")
@@ -2531,7 +2532,7 @@ impl<'a> MockEndpoint<'a, RoomEventContextEndpoint> {
                 "event": event.into_raw().json(),
                 "end": end.into(),
                 "start": start.into(),
-                "state": []
+                "state": state_events
             })));
         MatrixMock { server: self.server, mock }
     }

--- a/crates/matrix-sdk/tests/integration/room/thread.rs
+++ b/crates/matrix-sdk/tests/integration/room/thread.rs
@@ -1,5 +1,5 @@
 use assert_matches2::assert_matches;
-use matrix_sdk::{room::ThreadStatus, test_utils::mocks::MatrixMockServer};
+use matrix_sdk::{room::ThreadSubscription, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_test::async_test;
 use ruma::{owned_event_id, room_id};
 
@@ -34,9 +34,9 @@ async fn test_subscribe_thread() {
         .mount()
         .await;
 
-    // I can get the subscription status for that same thread.
+    // I can get the subscription for that same thread.
     let subscription = room.fetch_thread_subscription(root_id.clone()).await.unwrap().unwrap();
-    assert_matches!(subscription, ThreadStatus::Subscribed { automatic: true });
+    assert_matches!(subscription, ThreadSubscription { automatic: true });
 
     // If I try to get a subscription for a thread event that's unknown, I get no
     // `ThreadSubscription`, not an error.
@@ -56,8 +56,8 @@ async fn test_subscribe_thread() {
 
     room.unsubscribe_thread(root_id.clone()).await.unwrap();
 
-    // Now, if I retry to get the subscription status for this thread, it doesn't
-    // exist anymore.
+    // Now, if I retry to get the subscription for this thread, it doesn't exist
+    // anymore.
     let subscription = room.fetch_thread_subscription(root_id.clone()).await.unwrap();
     assert_matches!(subscription, None);
 

--- a/crates/matrix-sdk/tests/integration/room/thread.rs
+++ b/crates/matrix-sdk/tests/integration/room/thread.rs
@@ -56,10 +56,10 @@ async fn test_subscribe_thread() {
 
     room.unsubscribe_thread(root_id.clone()).await.unwrap();
 
-    // Now, if I retry to get the subscription status for this thread, it's
-    // unsubscribed.
+    // Now, if I retry to get the subscription status for this thread, it doesn't
+    // exist anymore.
     let subscription = room.fetch_thread_subscription(root_id.clone()).await.unwrap();
-    assert_matches!(subscription, Some(ThreadStatus::Unsubscribed));
+    assert_matches!(subscription, None);
 
     // Subscribing automatically to the thread may also return a `M_SKIPPED` error
     // that should be non-fatal.
@@ -76,5 +76,5 @@ async fn test_subscribe_thread() {
 
     // And in this case, the thread is still unsubscribed.
     let subscription = room.fetch_thread_subscription(root_id).await.unwrap();
-    assert_matches!(subscription, Some(ThreadStatus::Unsubscribed));
+    assert_matches!(subscription, None);
 }

--- a/crates/matrix-sdk/tests/integration/room/thread.rs
+++ b/crates/matrix-sdk/tests/integration/room/thread.rs
@@ -85,7 +85,15 @@ async fn test_thread_push_rule_is_triggered_for_subscribed_threads() {
     // call `Room::fetch_thread_subscription` for threads.
 
     let server = MatrixMockServer::new().await;
-    let client = server.client_builder().build().await;
+    let client = server
+        .client_builder()
+        .on_builder(|builder| {
+            builder.with_threading_support(matrix_sdk::ThreadingSupport::Enabled {
+                with_subscriptions: true,
+            })
+        })
+        .build()
+        .await;
 
     let room_id = room_id!("!test:example.org");
     let room = server.sync_joined_room(&client, room_id).await;

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -534,7 +534,6 @@ impl RoomView {
                                         "subscribed (manual)"
                                     }
                                 }
-                                ThreadStatus::Unsubscribed => "unsubscribed",
                             }
                         ));
                     }

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -491,7 +491,7 @@ impl RoomView {
     async fn subscribe_thread(&mut self) {
         if let TimelineKind::Thread { thread_root, .. } = &self.kind {
             self.call_with_room(async |room, status_handle| {
-                if let Err(err) = room.subscribe_thread(thread_root.clone(), false).await {
+                if let Err(err) = room.subscribe_thread(thread_root.clone(), None).await {
                     status_handle.set_message(format!("error when subscribing to a thread: {err}"));
                 } else {
                     status_handle.set_message("Subscribed to thread!".to_owned());

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -13,7 +13,6 @@ use matrix_sdk::{
         api::client::receipt::create_receipt::v3::ReceiptType,
         events::room::message::RoomMessageEventContent,
     },
-    store::ThreadStatus,
 };
 use matrix_sdk_ui::{
     Timeline,
@@ -526,14 +525,10 @@ impl RoomView {
                     Ok(Some(subscription)) => {
                         status_handle.set_message(format!(
                             "Thread subscription status: {}",
-                            match subscription {
-                                ThreadStatus::Subscribed { automatic } => {
-                                    if automatic {
-                                        "subscribed (automatic)"
-                                    } else {
-                                        "subscribed (manual)"
-                                    }
-                                }
+                            if subscription.automatic {
+                                "subscribed (automatic)"
+                            } else {
+                                "subscribed (manual)"
                             }
                         ));
                     }

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -371,6 +371,12 @@ impl EventBuilder<RoomMessageEventContent> {
         self
     }
 
+    /// Adds the given mentions to the current event.
+    pub fn mentions(mut self, mentions: Mentions) -> Self {
+        self.content.mentions = Some(mentions);
+        self
+    }
+
     /// Adds a replacement relation to the current event, with the new content
     /// passed.
     pub fn edit(


### PR DESCRIPTION
- Updates to the new subscription request, that includes the ID of the event that triggered an automatic subscription.
- Get rid of the "unsubscribed" thread status. Technically a breaking change, but since this is all very experimental and shouldn't have shipped yet, I will likely not do a DB migration for it.
- Updates to Ruma's async evaluation of push rules, that's going to be needed to evaluate the thread subscription push rule
- Fetch the thread subscription status when evaluating thread-related event push conditions.

Part of #4869. Depends on https://github.com/ruma/ruma/pull/2180