### PR TITLE
fix(notification_client): Add `m.room.create` to the required sliding sync state

### DIFF
--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -487,6 +487,7 @@ impl NotificationClient {
             (StateEventType::RoomPowerLevels, "".to_owned()),
             (StateEventType::RoomJoinRules, "".to_owned()),
             (StateEventType::CallMember, "*".to_owned()),
+            (StateEventType::RoomCreate, "".to_owned()),
         ];
 
         let invites = SlidingSyncList::builder("invites")

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -22,7 +22,7 @@ use matrix_sdk_ui::{
     sync_service::SyncService,
 };
 use ruma::{
-    event_id,
+    RoomVersionId, event_id,
     events::{TimelineEventType, room::member::MembershipState},
     mxc_uri, room_id, user_id,
 };
@@ -128,6 +128,8 @@ async fn test_notification_client_sliding_sync() {
 
     let event_factory = EventFactory::new().room(room_id);
 
+    let room_create_event = event_factory.create(sender, RoomVersionId::V1).into_raw_sync();
+
     let sender_member_event = event_factory
         .member(sender)
         .display_name(sender_display_name)
@@ -173,6 +175,9 @@ async fn test_notification_client_sliding_sync() {
                         "initial": true,
 
                         "required_state": [
+                            // The room creation event.
+                            room_create_event,
+
                             // Sender's member information.
                             sender_member_event,
 
@@ -230,6 +235,7 @@ async fn test_notification_client_sliding_sync() {
                         ["m.room.power_levels", ""],
                         ["m.room.join_rules", ""],
                         ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.create", ""],
                     ],
                     "filters": {
                         "is_invite": true,
@@ -248,6 +254,7 @@ async fn test_notification_client_sliding_sync() {
                         ["m.room.power_levels", ""],
                         ["m.room.join_rules", ""],
                         ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.create", ""],
                     ],
                     "timeline_limit": 16,
                 },

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3009,7 +3009,11 @@ impl Room {
         let power_levels = match self.power_levels().await {
             Ok(power_levels) => Some(power_levels.into()),
             Err(error) => {
-                error!("Could not compute power levels for push conditions: {error}");
+                if matches!(room_info.state(), RoomState::Joined) {
+                    // It's normal to not have the power levels in a non-joined room, so don't log
+                    // the error if the room is not joined
+                    error!("Could not compute power levels for push conditions: {error}");
+                }
                 None
             }
         };

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3006,7 +3006,13 @@ impl Room {
             return Ok(None);
         };
 
-        let power_levels = self.power_levels().await.ok().map(Into::into);
+        let power_levels = match self.power_levels().await {
+            Ok(power_levels) => Some(power_levels.into()),
+            Err(error) => {
+                error!("Could not compute power levels for push conditions: {error}");
+                None
+            }
+        };
 
         Ok(Some(assign!(
             PushConditionRoomCtx::new(


### PR DESCRIPTION
With this missing in the `SlidingSync` instance created for the notification client, power levels couldn't be computed, and some push rules didn't take effect for notifications.<!-- description of the changes in this PR -->

Should fix https://github.com/matrix-org/matrix-rust-sdk/issues/5485 (https://github.com/element-hq/element-x-android/issues/5113 being the original report on the EXA repo) and the equivalent issue on iOS of `@room` and call notifications being filtered out because they didn't match any push rules.

Kudos to @zecakeh for his help on debugging the issue.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
