### PR TITLE
Upgrade Ruma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4421,8 +4421,8 @@ dependencies = [
 
 [[package]]
 name = "ruma"
-version = "0.12.5"
-source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
+version = "0.12.6"
+source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
 dependencies = [
  "assign",
  "js_int",
@@ -4438,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.4"
-source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
+source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
 dependencies = [
  "as_variant",
  "assign",
@@ -4461,7 +4461,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.4"
-source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
+source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
 dependencies = [
  "as_variant",
  "base64",
@@ -4493,8 +4493,8 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.30.4"
-source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
+version = "0.30.5"
+source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4520,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.2"
-source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
+source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
 dependencies = [
  "headers",
  "http",
@@ -4538,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.1"
-source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
+source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4549,7 +4549,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
+source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
 dependencies = [
  "js_int",
  "thiserror 2.0.11",
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.2"
-source = "git+https://github.com/ruma/ruma?rev=bbbe39b5b02f2211fdc5e11383c4b66116f19625#bbbe39b5b02f2211fdc5e11383c4b66116f19625"
+source = "git+https://github.com/ruma/ruma?rev=a626e6b8521bcaa01bf8b7c4161b26b361b72aff#a626e6b8521bcaa01bf8b7c4161b26b361b72aff"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 rand = "0.8.5"
 reqwest = { version = "0.12.12", default-features = false }
 rmp-serde = "1.3.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "bbbe39b5b02f2211fdc5e11383c4b66116f19625", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "a626e6b8521bcaa01bf8b7c4161b26b361b72aff", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-arbitrary-length-ids",
@@ -78,7 +78,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "bbbe39b5b02f2211fdc5e11383
     "unstable-msc4286",
     "unstable-msc4306"
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "bbbe39b5b02f2211fdc5e11383c4b66116f19625" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "a626e6b8521bcaa01bf8b7c4161b26b361b72aff" }
 sentry = "0.36.0"
 sentry-tracing = "0.36.0"
 serde = { version = "1.0.217", features = ["rc"] }

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -777,7 +777,7 @@ pub enum RoomEventDecryptionResult {
 /// # use matrix_sdk_crypto::{
 /// #     DecryptionSettings, EncryptionSyncChanges, OlmMachine, TrustRequirement
 /// # };
-/// # use ruma::api::client::sync::sync_events::v3::{Response, JoinedRoom};
+/// # use ruma::api::client::sync::sync_events::v3::{Response, State, JoinedRoom};
 /// # use ruma::{OwnedUserId, serde::Raw, events::AnySyncStateEvent};
 /// # #[tokio::main]
 /// # async fn main() -> Result<()> {
@@ -833,10 +833,12 @@ pub enum RoomEventDecryptionResult {
 ///     for (_, room) in &response.rooms.join {
 ///         // For simplicity reasons we're only looking at the state field of a joined room, but
 ///         // the events in the timeline are important as well.
-///         for event in &room.state.events {
-///             if is_member_event_of_a_joined_user(event) && is_room_encrypted(room) {
-///                 let user_id = get_user_id(event);
-///                 users.push(user_id);
+///         if let State::Before(state) = &room.state {
+///            for event in &state.events {
+///                 if is_member_event_of_a_joined_user(event) && is_room_encrypted(room) {
+///                     let user_id = get_user_id(event);
+///                     users.push(user_id);
+///                 }
 ///             }
 ///         }
 ///     }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -602,14 +602,14 @@ pub enum EncryptedMessage {
     /// Metadata about an event using the `m.megolm.v1.aes-sha2` algorithm.
     MegolmV1AesSha2 {
         /// The Curve25519 key of the sender.
-        #[deprecated = "this field still needs to be sent but should not be used when received"]
+        #[deprecated = "this field should still be sent but should not be used when received"]
         #[doc(hidden)] // Included for Debug formatting only
-        sender_key: String,
+        sender_key: Option<String>,
 
         /// The ID of the sending device.
-        #[deprecated = "this field still needs to be sent but should not be used when received"]
+        #[deprecated = "this field should still be sent but should not be used when received"]
         #[doc(hidden)] // Included for Debug formatting only
-        device_id: OwnedDeviceId,
+        device_id: Option<OwnedDeviceId>,
 
         /// The ID of the session used to encrypt the message.
         session_id: String,

--- a/testing/matrix-sdk-test/src/sync_builder/joined_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/joined_room.rs
@@ -9,7 +9,7 @@ use ruma::{
 };
 use serde_json::{Value as JsonValue, from_value as from_json_value};
 
-use super::RoomAccountDataTestEvent;
+use super::{RoomAccountDataTestEvent, StateMutExt};
 use crate::{DEFAULT_TEST_ROOM_ID, event_factory::EventBuilder};
 
 #[derive(Debug, Clone)]
@@ -76,7 +76,7 @@ impl JoinedRoomBuilder {
 
     /// Add an event to the state.
     pub fn add_state_event(mut self, event: impl Into<Raw<AnySyncStateEvent>>) -> Self {
-        self.inner.state.events.push(event.into());
+        self.inner.state.events_mut().push(event.into());
         self
     }
 
@@ -85,7 +85,7 @@ impl JoinedRoomBuilder {
     where
         I: IntoIterator<Item = Raw<AnySyncStateEvent>>,
     {
-        self.inner.state.events.extend(events);
+        self.inner.state.events_mut().extend(events);
         self
     }
 

--- a/testing/matrix-sdk-test/src/sync_builder/left_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/left_room.rs
@@ -5,7 +5,7 @@ use ruma::{
     serde::Raw,
 };
 
-use super::{RoomAccountDataTestEvent, StateTestEvent};
+use super::{RoomAccountDataTestEvent, StateMutExt, StateTestEvent};
 use crate::DEFAULT_TEST_ROOM_ID;
 
 pub struct LeftRoomBuilder {
@@ -71,7 +71,7 @@ impl LeftRoomBuilder {
 
     /// Add an event to the state.
     pub fn add_state_event(mut self, event: StateTestEvent) -> Self {
-        self.inner.state.events.push(event.into());
+        self.inner.state.events_mut().push(event.into());
         self
     }
 
@@ -80,7 +80,7 @@ impl LeftRoomBuilder {
     where
         I: IntoIterator<Item = Raw<AnySyncStateEvent>>,
     {
-        self.inner.state.events.extend(events);
+        self.inner.state.events_mut().extend(events);
         self
     }
 

--- a/testing/matrix-sdk-test/src/sync_builder/mod.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/mod.rs
@@ -6,10 +6,12 @@ use ruma::{
     api::{
         IncomingResponse,
         client::sync::sync_events::v3::{
-            InvitedRoom, JoinedRoom, KnockedRoom, LeftRoom, Response as SyncResponse,
+            InvitedRoom, JoinedRoom, KnockedRoom, LeftRoom, Response as SyncResponse, State,
         },
     },
-    events::{AnyGlobalAccountDataEvent, AnyToDeviceEvent, presence::PresenceEvent},
+    events::{
+        AnyGlobalAccountDataEvent, AnySyncStateEvent, AnyToDeviceEvent, presence::PresenceEvent,
+    },
     serde::Raw,
 };
 use serde_json::{Value as JsonValue, from_value as from_json_value, json};
@@ -245,5 +247,20 @@ impl SyncResponseBuilder {
         self.left_rooms.clear();
         self.knocked_rooms.clear();
         self.presence.clear();
+    }
+}
+
+/// Helper trait to mutate the data in [`State`].
+trait StateMutExt {
+    fn events_mut(&mut self) -> &mut Vec<Raw<AnySyncStateEvent>>;
+}
+
+impl StateMutExt for State {
+    fn events_mut(&mut self) -> &mut Vec<Raw<AnySyncStateEvent>> {
+        match self {
+            Self::Before(state) => &mut state.events,
+            // We don't allow to construct another variant.
+            _ => unreachable!(),
+        }
     }
 }


### PR DESCRIPTION
This brings 2 important bug fixes:

- Make deprecated fields of `m.room.encrypted` optional: it seems that there are events without these fields in the wild.
- Fix deserialization of `RedactedRoomJoinRulesEventContent`. This was found by a bug report in Fractal that caused the same error as #3557 when restoring the client. So maybe we could consider that this bug is fixed? It is still possible that there is another deserialization error. 

There is also a breaking change in the format of the `state` field in response to `GET /v3/sync`.

