### PR TITLE
feat(sdk): Use `state_after` in sync v2 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "a626e6b8521bcaa01bf8b7c416
     "unstable-msc4140",
     "unstable-msc4143",
     "unstable-msc4171",
+    "unstable-msc4222",
     "unstable-msc4278",
     "unstable-msc4286",
     "unstable-msc4306"

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased] - ReleaseDate
 
 ### Features
+- [**breaking**] The `state` field of `JoinedRoomUpdate` and `LeftRoomUpdate`
+  now uses the `State` enum, depending on whether the state changes were
+  received in the `state` field or the `state_after` field.
+  ([#5488](https://github.com/matrix-org/matrix-rust-sdk/pull/5488))
 - [**breaking**] `RoomCreateWithCreatorEventContent` has a new field
   `additional_creators` that allows to specify additional room creators beside
   the user sending the `m.room.create` event, introduced with room version 12.

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -16,7 +16,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use ruma::{
     OwnedRoomId, OwnedUserId, RoomId,
-    api::client::sync::sync_events::v3::{InvitedRoom, JoinedRoom, KnockedRoom, LeftRoom, State},
+    api::client::sync::sync_events::v3::{
+        InvitedRoom, JoinedRoom, KnockedRoom, LeftRoom, State as RumaState,
+    },
 };
 use tokio::sync::broadcast::Sender;
 use tracing::error;
@@ -29,7 +31,7 @@ use super::{
 };
 use crate::{
     Result, RoomInfoNotableUpdate, RoomState,
-    sync::{InvitedRoomUpdate, JoinedRoomUpdate, KnockedRoomUpdate, LeftRoomUpdate},
+    sync::{InvitedRoomUpdate, JoinedRoomUpdate, KnockedRoomUpdate, LeftRoomUpdate, State},
 };
 
 /// Process updates of a joined room.
@@ -64,39 +66,18 @@ pub async fn update_joined_room(
 
     let mut new_user_ids = BTreeSet::new();
 
-    let state = match joined_room.state {
-        State::Before(state) => {
-            let (raw_state_events, state_events) = state_events::sync::collect(&state.events);
-            state_events::sync::dispatch(
-                context,
-                (&raw_state_events, &state_events),
-                &mut room_info,
-                ambiguity_cache,
-                &mut new_user_ids,
-                state_store,
-            )
-            .await?;
+    let state = State::from_sync_v2(joined_room.state);
+    let (raw_state_events, state_events) = state.collect(&joined_room.timeline.events);
 
-            let (raw_state_events_from_timeline, state_events_from_timeline) =
-                state_events::sync::collect_from_timeline(&joined_room.timeline.events);
-            state_events::sync::dispatch(
-                context,
-                (&raw_state_events_from_timeline, &state_events_from_timeline),
-                &mut room_info,
-                ambiguity_cache,
-                &mut new_user_ids,
-                state_store,
-            )
-            .await?;
-
-            state
-        }
-        // We shouldn't receive other variants because they are opt-in.
-        state => {
-            error!("Unsupported State variant received for joined room: {state:?}");
-            Default::default()
-        }
-    };
+    state_events::sync::dispatch(
+        context,
+        (&raw_state_events, &state_events),
+        &mut room_info,
+        ambiguity_cache,
+        &mut new_user_ids,
+        state_store,
+    )
+    .await?;
 
     ephemeral_events::dispatch(context, &joined_room.ephemeral.events, room_id);
 
@@ -155,7 +136,7 @@ pub async fn update_joined_room(
 
     Ok(JoinedRoomUpdate::new(
         timeline,
-        state.events,
+        state,
         joined_room.account_data.events,
         joined_room.ephemeral.events,
         notification_count,
@@ -189,39 +170,18 @@ pub async fn update_left_room(
     room_info.mark_state_partially_synced();
     room_info.handle_encryption_state(requested_required_states.for_room(room_id));
 
-    let state = match left_room.state {
-        State::Before(state) => {
-            let (raw_state_events, state_events) = state_events::sync::collect(&state.events);
-            state_events::sync::dispatch(
-                context,
-                (&raw_state_events, &state_events),
-                &mut room_info,
-                ambiguity_cache,
-                &mut (),
-                state_store,
-            )
-            .await?;
+    let state = State::from_sync_v2(left_room.state);
+    let (raw_state_events, state_events) = state.collect(&left_room.timeline.events);
 
-            let (raw_state_events_from_timeline, state_events_from_timeline) =
-                state_events::sync::collect_from_timeline(&left_room.timeline.events);
-            state_events::sync::dispatch(
-                context,
-                (&raw_state_events_from_timeline, &state_events_from_timeline),
-                &mut room_info,
-                ambiguity_cache,
-                &mut (),
-                state_store,
-            )
-            .await?;
-
-            state
-        }
-        // We shouldn't receive other variants because they are opt-in.
-        state => {
-            error!("Unsupported State variant received for left room: {state:?}");
-            Default::default()
-        }
-    };
+    state_events::sync::dispatch(
+        context,
+        (&raw_state_events, &state_events),
+        &mut room_info,
+        ambiguity_cache,
+        &mut (),
+        state_store,
+    )
+    .await?;
 
     let timeline = timeline::build(
         context,
@@ -241,12 +201,7 @@ pub async fn update_left_room(
 
     let ambiguity_changes = ambiguity_cache.changes.remove(room_id).unwrap_or_default();
 
-    Ok(LeftRoomUpdate::new(
-        timeline,
-        state.events,
-        left_room.account_data.events,
-        ambiguity_changes,
-    ))
+    Ok(LeftRoomUpdate::new(timeline, state, left_room.account_data.events, ambiguity_changes))
 }
 
 /// Process updates of an invited room.
@@ -319,4 +274,20 @@ pub async fn update_knocked_room(
     context.state_changes.add_room(room_info);
 
     Ok(knocked_room)
+}
+
+impl State {
+    /// Construct a [`State`] from the state changes for a joined or left room
+    /// from a response of the sync v2 endpoint.
+    fn from_sync_v2(state: RumaState) -> Self {
+        match state {
+            RumaState::Before(state) => Self::Before(state.events),
+            RumaState::After(state) => Self::After(state.events),
+            // We shouldn't receive other variants because they are opt-in.
+            state => {
+                error!("Unsupported State variant received for joined room: {state:?}");
+                Self::default()
+            }
+        }
+    }
 }

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -180,10 +180,10 @@ pub struct JoinedRoomUpdate {
     /// The timeline of messages and state changes in the room.
     pub timeline: Timeline,
     /// Updates to the state, between the time indicated by the `since`
-    /// parameter, and the start of the `timeline` (or all state up to the
-    /// start of the `timeline`, if `since` is not given, or `full_state` is
-    /// true).
-    pub state: Vec<Raw<AnySyncStateEvent>>,
+    /// parameter, and the start or the end of the `timeline` (or all state up
+    /// to the start or the end of the `timeline`, if `since` is not given,
+    /// or `full_state` is true).
+    pub state: State,
     /// The private data that this user has attached to this room.
     pub account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
     /// The ephemeral events in the room that aren't recorded in the timeline or
@@ -202,7 +202,7 @@ impl fmt::Debug for JoinedRoomUpdate {
         f.debug_struct("JoinedRoomUpdate")
             .field("unread_notifications", &self.unread_notifications)
             .field("timeline", &self.timeline)
-            .field("state", &DebugListOfRawEvents(&self.state))
+            .field("state", &self.state)
             .field("account_data", &DebugListOfRawEventsNoId(&self.account_data))
             .field("ephemeral", &self.ephemeral)
             .field("ambiguity_changes", &self.ambiguity_changes)
@@ -213,7 +213,7 @@ impl fmt::Debug for JoinedRoomUpdate {
 impl JoinedRoomUpdate {
     pub(crate) fn new(
         timeline: Timeline,
-        state: Vec<Raw<AnySyncStateEvent>>,
+        state: State,
         account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
         ephemeral: Vec<Raw<AnySyncEphemeralRoomEvent>>,
         unread_notifications: UnreadNotificationsCount,
@@ -249,10 +249,10 @@ pub struct LeftRoomUpdate {
     /// when the user left.
     pub timeline: Timeline,
     /// Updates to the state, between the time indicated by the `since`
-    /// parameter, and the start of the `timeline` (or all state up to the
-    /// start of the `timeline`, if `since` is not given, or `full_state` is
-    /// true).
-    pub state: Vec<Raw<AnySyncStateEvent>>,
+    /// parameter, and the start or the end of the `timeline` (or all state up
+    /// to the start or the end of the `timeline`, if `since` is not given, or
+    /// `full_state` is true).
+    pub state: State,
     /// The private data that this user has attached to this room.
     pub account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
     /// Collection of ambiguity changes that room member events trigger.
@@ -265,7 +265,7 @@ pub struct LeftRoomUpdate {
 impl LeftRoomUpdate {
     pub(crate) fn new(
         timeline: Timeline,
-        state: Vec<Raw<AnySyncStateEvent>>,
+        state: State,
         account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
         ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
     ) -> Self {
@@ -278,7 +278,7 @@ impl fmt::Debug for LeftRoomUpdate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("LeftRoomUpdate")
             .field("timeline", &self.timeline)
-            .field("state", &DebugListOfRawEvents(&self.state))
+            .field("state", &self.state)
             .field("account_data", &DebugListOfRawEventsNoId(&self.account_data))
             .field("ambiguity_changes", &self.ambiguity_changes)
             .finish()
@@ -303,6 +303,44 @@ pub struct Timeline {
 impl Timeline {
     pub(crate) fn new(limited: bool, prev_batch: Option<String>) -> Self {
         Self { limited, prev_batch, ..Default::default() }
+    }
+}
+
+/// State changes in the room.
+#[derive(Clone)]
+pub enum State {
+    /// The state changes between the previous sync and the start of the
+    /// timeline.
+    ///
+    /// To get the full list of state changes since the previous sync, the state
+    /// events in [`Timeline`] must be added to these events to update the local
+    /// state.
+    Before(Vec<Raw<AnySyncStateEvent>>),
+
+    /// The state changes between the previous sync and the end of the timeline.
+    ///
+    /// This contains the full list of state changes since the previous sync.
+    /// State events in [`Timeline`] must be ignored to update the local state.
+    After(Vec<Raw<AnySyncStateEvent>>),
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self::Before(vec![])
+    }
+}
+
+#[cfg(not(tarpaulin_include))]
+impl fmt::Debug for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Before(events) => {
+                f.debug_tuple("Before").field(&DebugListOfRawEvents(&events)).finish()
+            }
+            Self::After(events) => {
+                f.debug_tuple("After").field(&DebugListOfRawEvents(&events)).finish()
+            }
+        }
     }
 }
 

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -335,10 +335,10 @@ impl fmt::Debug for State {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Before(events) => {
-                f.debug_tuple("Before").field(&DebugListOfRawEvents(&events)).finish()
+                f.debug_tuple("Before").field(&DebugListOfRawEvents(events)).finish()
             }
             Self::After(events) => {
-                f.debug_tuple("After").field(&DebugListOfRawEvents(&events)).finish()
+                f.debug_tuple("After").field(&DebugListOfRawEvents(events)).finish()
             }
         }
     }

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -179,10 +179,16 @@ pub struct JoinedRoomUpdate {
     pub unread_notifications: UnreadNotificationsCount,
     /// The timeline of messages and state changes in the room.
     pub timeline: Timeline,
-    /// Updates to the state, between the time indicated by the `since`
-    /// parameter, and the start or the end of the `timeline` (or all state up
-    /// to the start or the end of the `timeline`, if `since` is not given,
-    /// or `full_state` is true).
+    /// Updates to the state.
+    ///
+    /// If `since` is missing or `full_state` is true, the start point of the
+    /// update is the beginning of the timeline. Otherwise, the start point
+    /// is the time specified in `since`.
+    ///
+    /// If `state_after` was used, the end point of the update is the end of the
+    /// `timeline`. Otherwise, the end point of these updates is the start of
+    /// the `timeline`, and to calculate room state we must scan the `timeline`
+    /// for state events as well as using this information in this property.
     pub state: State,
     /// The private data that this user has attached to this room.
     pub account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
@@ -248,10 +254,16 @@ pub struct LeftRoomUpdate {
     /// The timeline of messages and state changes in the room up to the point
     /// when the user left.
     pub timeline: Timeline,
-    /// Updates to the state, between the time indicated by the `since`
-    /// parameter, and the start or the end of the `timeline` (or all state up
-    /// to the start or the end of the `timeline`, if `since` is not given, or
-    /// `full_state` is true).
+    /// Updates to the state.
+    ///
+    /// If `since` is missing or `full_state` is true, the start point of the
+    /// update is the beginning of the timeline. Otherwise, the start point
+    /// is the time specified in `since`.
+    ///
+    /// If `state_after` was used, the end point of the update is the end of the
+    /// `timeline`. Otherwise, the end point of these updates is the start of
+    /// the `timeline`, and to calculate room state we must scan the `timeline`
+    /// for state events as well as using this information in this property.
     pub state: State,
     /// The private data that this user has attached to this room.
     pub account_data: Vec<Raw<AnyRoomAccountDataEvent>>,

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- The methods to use the `/v3/sync` endpoint set the `use_state_after` field,
+  which means that, if the server supports it, the response will contain the
+  state changes between the last sync and the end of the timeline.
+  ([#5488](https://github.com/matrix-org/matrix-rust-sdk/pull/5488))
 - Add experimental support for
   [MSC4306](https://github.com/matrix-org/matrix-spec-proposals/pull/4306), with the
   `Room::fetch_thread_subscription()`, `Room::subscribe_thread()` and `Room::unsubscribe_thread()`

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2310,6 +2310,7 @@ impl Client {
             full_state: sync_settings.full_state,
             set_presence: sync_settings.set_presence,
             timeout: sync_settings.timeout,
+            use_state_after: true,
         });
         let mut request_config = self.request_config();
         if let Some(timeout) = sync_settings.timeout {

--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -54,16 +54,12 @@ use futures_core::Stream;
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use matrix_sdk_base::{
     deserialized_responses::{EncryptionInfo, TimelineEvent},
+    sync::State,
     SendOutsideWasm, SyncOutsideWasm,
 };
 use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
 use pin_project_lite::pin_project;
-use ruma::{
-    events::{AnySyncStateEvent, BooleanType},
-    push::Action,
-    serde::Raw,
-    OwnedRoomId,
-};
+use ruma::{events::BooleanType, push::Action, serde::Raw, OwnedRoomId};
 use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::value::RawValue as RawJsonValue;
 use tracing::{debug, error, field::debug, instrument, warn};
@@ -413,7 +409,7 @@ impl Client {
     pub(crate) async fn handle_sync_state_events(
         &self,
         room: Option<&Room>,
-        state_events: &[Raw<AnySyncStateEvent>],
+        state: &State,
     ) -> serde_json::Result<()> {
         #[derive(Deserialize)]
         struct StateEventDetails<'a> {
@@ -421,6 +417,11 @@ impl Client {
             event_type: Cow<'a, str>,
             unsigned: Option<UnsignedDetails>,
         }
+
+        let state_events = match state {
+            State::Before(events) => events,
+            State::After(events) => events,
+        };
 
         // Event handlers for possibly-redacted state events
         self.handle_sync_events(HandlerKind::State, room, state_events).await?;

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -7,7 +7,7 @@ use matrix_sdk::{
     authentication::oauth::{error::OAuthTokenRevocationError, OAuthError},
     config::{RequestConfig, StoreConfig, SyncSettings},
     store::RoomLoadSettings,
-    sync::RoomUpdate,
+    sync::{RoomUpdate, State},
     test_utils::{
         client::mock_matrix_session, mocks::MatrixMockServer, no_retry_test_client_with_server,
     },
@@ -329,7 +329,8 @@ async fn test_room_update_channel() {
 
     assert_eq!(updates.account_data.len(), 1);
     assert_eq!(updates.ephemeral.len(), 1);
-    assert_eq!(updates.state.len(), 9);
+    assert_matches!(updates.state, State::Before(state_events));
+    assert_eq!(state_events.len(), 9);
 
     assert!(updates.timeline.limited);
     assert_eq!(updates.timeline.events.len(), 1);
@@ -359,7 +360,8 @@ async fn test_subscribe_all_room_updates() {
         let (room_id, update) = left.iter().next().unwrap();
 
         assert_eq!(room_id, *MIXED_LEFT_ROOM_ID);
-        assert!(update.state.is_empty());
+        assert_matches!(&update.state, State::Before(state_events));
+        assert!(state_events.is_empty());
         assert_eq!(update.timeline.events.len(), 1);
         assert!(update.account_data.is_empty());
     }
@@ -374,7 +376,8 @@ async fn test_subscribe_all_room_updates() {
 
         assert_eq!(update.account_data.len(), 1);
         assert_eq!(update.ephemeral.len(), 1);
-        assert_eq!(update.state.len(), 1);
+        assert_matches!(&update.state, State::Before(state_events));
+        assert_eq!(state_events.len(), 1);
 
         assert!(update.timeline.limited);
         assert_eq!(update.timeline.events.len(), 1);

--- a/testing/matrix-sdk-test/src/sync_builder/joined_room.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/joined_room.rs
@@ -74,6 +74,12 @@ impl JoinedRoomBuilder {
         self
     }
 
+    /// Add state events to the `state_after` field rather than `state`.
+    pub fn use_state_after(mut self) -> Self {
+        self.inner.state.use_state_after();
+        self
+    }
+
     /// Add an event to the state.
     pub fn add_state_event(mut self, event: impl Into<Raw<AnySyncStateEvent>>) -> Self {
         self.inner.state.events_mut().push(event.into());

--- a/testing/matrix-sdk-test/src/sync_builder/mod.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/mod.rs
@@ -252,13 +252,21 @@ impl SyncResponseBuilder {
 
 /// Helper trait to mutate the data in [`State`].
 trait StateMutExt {
+    /// Use the `After` variant rather than `Before`.
+    fn use_state_after(&mut self);
+    /// Access the inner list of state events.
     fn events_mut(&mut self) -> &mut Vec<Raw<AnySyncStateEvent>>;
 }
 
 impl StateMutExt for State {
+    fn use_state_after(&mut self) {
+        *self = Self::After(Default::default());
+    }
+
     fn events_mut(&mut self) -> &mut Vec<Raw<AnySyncStateEvent>> {
         match self {
             Self::Before(state) => &mut state.events,
+            Self::After(state) => &mut state.events,
             // We don't allow to construct another variant.
             _ => unreachable!(),
         }


### PR DESCRIPTION
It is supposed to be an improvement over `state`, since it allows the
server to send updates to the state that might not be reflected in the
timeline.

This is also the same behavior as in Simplified Sliding Sync.

This is MSC4222 that was accepted and is about to get merged in the spec.
