### PR TITLE
IndexedDB: remove assumption that all `EventCacheStore` keys contain a `RoomId`

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -162,6 +162,7 @@ impl_event_cache_store! {
                         .add_chunk(
                             room_id,
                             &types::Chunk {
+                                room_id: room_id.to_owned(),
                                 identifier: new.index(),
                                 previous: previous.map(|i| i.index()),
                                 next: next.map(|i| i.index()),
@@ -185,6 +186,7 @@ impl_event_cache_store! {
                         .add_chunk(
                             room_id,
                             &types::Chunk {
+                                room_id: room_id.to_owned(),
                                 identifier: new.index(),
                                 previous: previous.map(|i| i.index()),
                                 next: next.map(|i| i.index()),

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -209,6 +209,7 @@ impl_event_cache_store! {
                             .put_item(
                                 room_id,
                                 &types::Event::InBand(InBandEvent {
+                                    room_id: room_id.to_owned(),
                                     content: item,
                                     position: types::Position {
                                         chunk_identifier,
@@ -229,6 +230,7 @@ impl_event_cache_store! {
                         .put_event(
                             room_id,
                             &types::Event::InBand(InBandEvent {
+                                room_id: room_id.to_owned(),
                                 content: item,
                                 position: at.into(),
                             }),
@@ -526,7 +528,7 @@ impl_event_cache_store! {
             self.transaction(&[keys::EVENTS], IdbTransactionMode::Readwrite)?;
         let event = match transaction.get_event_by_id(room_id, &event_id).await? {
             Some(mut inner) => inner.with_content(event),
-            None => types::Event::OutOfBand(OutOfBandEvent { content: event, position: () }),
+            None => types::Event::OutOfBand(OutOfBandEvent { room_id: room_id.to_owned(), content: event, position: () }),
         };
         transaction.put_event(room_id, &event).await?;
         transaction.commit().await?;

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -447,7 +447,7 @@ impl_event_cache_store! {
         let mut duplicated = Vec::new();
         for event_id in events {
             if let Some(types::Event::InBand(event)) =
-                transaction.get_event_by_id(room_id, event_id.clone()).await?
+                transaction.get_event_by_id(room_id, &event_id).await?
             {
                 duplicated.push((event_id, event.position.into()));
             }
@@ -466,7 +466,7 @@ impl_event_cache_store! {
         let transaction =
             self.transaction(&[keys::EVENTS], IdbTransactionMode::Readonly)?;
         transaction
-            .get_event_by_id(room_id, event_id.to_owned())
+            .get_event_by_id(room_id, event_id)
             .await
             .map(|ok| ok.map(Into::into))
             .map_err(Into::into)
@@ -522,7 +522,7 @@ impl_event_cache_store! {
         };
         let transaction =
             self.transaction(&[keys::EVENTS], IdbTransactionMode::Readwrite)?;
-        let event = match transaction.get_event_by_id(room_id, event_id).await? {
+        let event = match transaction.get_event_by_id(room_id, &event_id).await? {
             Some(mut inner) => inner.with_content(event),
             None => types::Event::OutOfBand(OutOfBandEvent { content: event, position: () }),
         };

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -177,6 +177,7 @@ impl_event_cache_store! {
                         .add_item(
                             room_id,
                             &types::Gap {
+                                room_id: room_id.to_owned(),
                                 chunk_identifier: new.index(),
                                 prev_token: gap.prev_token,
                             },

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -488,7 +488,7 @@ impl_event_cache_store! {
         match filters {
             Some(relation_types) if !relation_types.is_empty() => {
                 for relation_type in relation_types {
-                    let relation = (event_id.to_owned(), relation_type.clone());
+                    let relation = (event_id, relation_type);
                     let events = transaction.get_events_by_relation(room_id, relation).await?;
                     for event in events {
                         let position = event.position().map(Into::into);
@@ -498,7 +498,7 @@ impl_event_cache_store! {
             }
             _ => {
                 for event in
-                    transaction.get_events_by_related_event(room_id, event_id.to_owned()).await?
+                    transaction.get_events_by_related_event(room_id, event_id).await?
                 {
                     let position = event.position().map(Into::into);
                     related_events.push((event.into(), position));

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -160,7 +160,6 @@ impl_event_cache_store! {
                     trace!(%room_id, "Inserting new chunk (prev={previous:?}, new={new:?}, next={next:?})");
                     transaction
                         .add_chunk(
-                            room_id,
                             &types::Chunk {
                                 room_id: room_id.to_owned(),
                                 identifier: new.index(),
@@ -175,7 +174,6 @@ impl_event_cache_store! {
                     trace!(%room_id, "Inserting new gap (prev={previous:?}, new={new:?}, next={next:?})");
                     transaction
                         .add_item(
-                            room_id,
                             &types::Gap {
                                 room_id: room_id.to_owned(),
                                 chunk_identifier: new.index(),
@@ -185,7 +183,6 @@ impl_event_cache_store! {
                         .await?;
                     transaction
                         .add_chunk(
-                            room_id,
                             &types::Chunk {
                                 room_id: room_id.to_owned(),
                                 identifier: new.index(),
@@ -207,8 +204,7 @@ impl_event_cache_store! {
 
                     for (i, item) in items.into_iter().enumerate() {
                         transaction
-                            .put_item(
-                                room_id,
+                            .put_event(
                                 &types::Event::InBand(InBandEvent {
                                     room_id: room_id.to_owned(),
                                     content: item,
@@ -229,7 +225,6 @@ impl_event_cache_store! {
 
                     transaction
                         .put_event(
-                            room_id,
                             &types::Event::InBand(InBandEvent {
                                 room_id: room_id.to_owned(),
                                 content: item,
@@ -531,7 +526,7 @@ impl_event_cache_store! {
             Some(mut inner) => inner.with_content(event),
             None => types::Event::OutOfBand(OutOfBandEvent { room_id: room_id.to_owned(), content: event, position: () }),
         };
-        transaction.put_event(room_id, &event).await?;
+        transaction.put_event(&event).await?;
         transaction.commit().await?;
         Ok(())
     }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
@@ -71,7 +71,7 @@ impl IndexeddbEventCacheStoreSerializer {
     ///
     /// Note that the particular key which is encoded is defined by the type
     /// `K`.
-    pub fn encode_key<T, K>(&self, room_id: &RoomId, components: &K::KeyComponents) -> K
+    pub fn encode_key<T, K>(&self, room_id: &RoomId, components: K::KeyComponents<'_>) -> K
     where
         T: Indexed,
         K: IndexedKey<T>,
@@ -86,7 +86,7 @@ impl IndexeddbEventCacheStoreSerializer {
     pub fn encode_key_as_value<T, K>(
         &self,
         room_id: &RoomId,
-        components: &K::KeyComponents,
+        components: K::KeyComponents<'_>,
     ) -> Result<JsValue, serde_wasm_bindgen::Error>
     where
         T: Indexed,
@@ -129,12 +129,11 @@ impl IndexeddbEventCacheStoreSerializer {
     pub fn encode_key_component_range<'a, T, K>(
         &self,
         room_id: &RoomId,
-        range: impl Into<IndexedKeyRange<&'a K::KeyComponents>>,
+        range: impl Into<IndexedKeyRange<K::KeyComponents<'a>>>,
     ) -> Result<IdbKeyRange, serde_wasm_bindgen::Error>
     where
         T: Indexed,
         K: IndexedKeyComponentBounds<T> + Serialize,
-        K::KeyComponents: 'a,
     {
         let range = match range.into() {
             IndexedKeyRange::Only(components) => {

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
@@ -106,18 +106,13 @@ impl IndexeddbEventCacheStoreSerializer {
     ) -> Result<IdbKeyRange, serde_wasm_bindgen::Error>
     where
         T: Indexed,
-        K: IndexedKeyBounds<T> + Serialize,
+        K: Serialize,
     {
         use serde_wasm_bindgen::to_value;
         Ok(match range.into() {
             IndexedKeyRange::Only(key) => IdbKeyRange::only(&to_value(&key)?)?,
             IndexedKeyRange::Bound(lower, upper) => {
                 IdbKeyRange::bound(&to_value(&lower)?, &to_value(&upper)?)?
-            }
-            IndexedKeyRange::All => {
-                let lower = to_value(&K::lower_key(room_id, &self.inner))?;
-                let upper = to_value(&K::upper_key(room_id, &self.inner))?;
-                IdbKeyRange::bound(&lower, &upper).expect("construct key range")
             }
         })
     }
@@ -133,7 +128,7 @@ impl IndexeddbEventCacheStoreSerializer {
     ) -> Result<IdbKeyRange, serde_wasm_bindgen::Error>
     where
         T: Indexed,
-        K: IndexedKeyComponentBounds<T> + Serialize,
+        K: IndexedKey<T> + Serialize,
     {
         let range = match range.into() {
             IndexedKeyRange::Only(components) => {
@@ -142,11 +137,6 @@ impl IndexeddbEventCacheStoreSerializer {
             IndexedKeyRange::Bound(lower, upper) => {
                 let lower = K::encode(room_id, lower, &self.inner);
                 let upper = K::encode(room_id, upper, &self.inner);
-                IndexedKeyRange::Bound(lower, upper)
-            }
-            IndexedKeyRange::All => {
-                let lower = K::lower_key(room_id, &self.inner);
-                let upper = K::upper_key(room_id, &self.inner);
                 IndexedKeyRange::Bound(lower, upper)
             }
         };

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
@@ -71,12 +71,12 @@ impl IndexeddbEventCacheStoreSerializer {
     ///
     /// Note that the particular key which is encoded is defined by the type
     /// `K`.
-    pub fn encode_key<T, K>(&self, room_id: &RoomId, components: K::KeyComponents<'_>) -> K
+    pub fn encode_key<T, K>(&self, _: &RoomId, components: K::KeyComponents<'_>) -> K
     where
         T: Indexed,
         K: IndexedKey<T>,
     {
-        K::encode(room_id, components, &self.inner)
+        K::encode(components, &self.inner)
     }
 
     /// Encodes a key for a [`Indexed`] type as a [`JsValue`].
@@ -132,11 +132,11 @@ impl IndexeddbEventCacheStoreSerializer {
     {
         let range = match range.into() {
             IndexedKeyRange::Only(components) => {
-                IndexedKeyRange::Only(K::encode(room_id, components, &self.inner))
+                IndexedKeyRange::Only(K::encode(components, &self.inner))
             }
             IndexedKeyRange::Bound(lower, upper) => {
-                let lower = K::encode(room_id, lower, &self.inner);
-                let upper = K::encode(room_id, upper, &self.inner);
+                let lower = K::encode(lower, &self.inner);
+                let upper = K::encode(upper, &self.inner);
                 IndexedKeyRange::Bound(lower, upper)
             }
         };

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
@@ -163,9 +163,8 @@ impl IndexeddbEventCacheStoreSerializer {
         T: Indexed,
         T::IndexedType: Serialize,
     {
-        let indexed = t
-            .to_indexed(room_id, &self.inner)
-            .map_err(IndexeddbEventCacheStoreSerializerError::Indexing)?;
+        let indexed =
+            t.to_indexed(&self.inner).map_err(IndexeddbEventCacheStoreSerializerError::Indexing)?;
         serde_wasm_bindgen::to_value(&indexed).map_err(Into::into)
     }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
@@ -71,7 +71,7 @@ impl IndexeddbEventCacheStoreSerializer {
     ///
     /// Note that the particular key which is encoded is defined by the type
     /// `K`.
-    pub fn encode_key<T, K>(&self, _: &RoomId, components: K::KeyComponents<'_>) -> K
+    pub fn encode_key<T, K>(&self, components: K::KeyComponents<'_>) -> K
     where
         T: Indexed,
         K: IndexedKey<T>,
@@ -85,14 +85,13 @@ impl IndexeddbEventCacheStoreSerializer {
     /// `K`.
     pub fn encode_key_as_value<T, K>(
         &self,
-        room_id: &RoomId,
         components: K::KeyComponents<'_>,
     ) -> Result<JsValue, serde_wasm_bindgen::Error>
     where
         T: Indexed,
         K: IndexedKey<T> + Serialize,
     {
-        serde_wasm_bindgen::to_value(&self.encode_key::<T, K>(room_id, components))
+        serde_wasm_bindgen::to_value(&self.encode_key::<T, K>(components))
     }
 
     /// Encodes a key component range for an [`Indexed`] type.
@@ -101,7 +100,6 @@ impl IndexeddbEventCacheStoreSerializer {
     /// `K`.
     pub fn encode_key_range<T, K>(
         &self,
-        room_id: &RoomId,
         range: impl Into<IndexedKeyRange<K>>,
     ) -> Result<IdbKeyRange, serde_wasm_bindgen::Error>
     where
@@ -123,7 +121,6 @@ impl IndexeddbEventCacheStoreSerializer {
     /// `K`.
     pub fn encode_key_component_range<'a, T, K>(
         &self,
-        room_id: &RoomId,
         range: impl Into<IndexedKeyRange<K::KeyComponents<'a>>>,
     ) -> Result<IdbKeyRange, serde_wasm_bindgen::Error>
     where
@@ -140,13 +137,12 @@ impl IndexeddbEventCacheStoreSerializer {
                 IndexedKeyRange::Bound(lower, upper)
             }
         };
-        self.encode_key_range::<T, K>(room_id, range)
+        self.encode_key_range::<T, K>(range)
     }
 
     /// Serializes an [`Indexed`] type into a [`JsValue`]
     pub fn serialize<T>(
         &self,
-        room_id: &RoomId,
         t: &T,
     ) -> Result<JsValue, IndexeddbEventCacheStoreSerializerError<T::Error>>
     where

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -54,7 +54,7 @@ pub trait IndexedKey<T: Indexed> {
     const INDEX: Option<&'static str> = None;
 
     /// Any extra data used to construct the key.
-    type KeyComponents;
+    type KeyComponents<'a>;
 
     /// Encodes the key components into a type that can be used as a key in
     /// IndexedDB.
@@ -65,7 +65,7 @@ pub trait IndexedKey<T: Indexed> {
     /// encrypted before storage.
     fn encode(
         room_id: &RoomId,
-        components: &Self::KeyComponents,
+        components: Self::KeyComponents<'_>,
         serializer: &IndexeddbSerializer,
     ) -> Self;
 }
@@ -104,12 +104,12 @@ where
 {
     /// Constructs the lower bound of the key.
     fn lower_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        <Self as IndexedKey<T>>::encode(room_id, &Self::lower_key_components(), serializer)
+        <Self as IndexedKey<T>>::encode(room_id, Self::lower_key_components(), serializer)
     }
 
     /// Constructs the upper bound of the key.
     fn upper_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        <Self as IndexedKey<T>>::encode(room_id, &Self::upper_key_components(), serializer)
+        <Self as IndexedKey<T>>::encode(room_id, Self::upper_key_components(), serializer)
     }
 }
 
@@ -123,8 +123,8 @@ where
 /// get a better overview of how these two interact.
 pub trait IndexedKeyComponentBounds<T: Indexed>: IndexedKeyBounds<T> {
     /// Constructs the lower bound of the key components.
-    fn lower_key_components() -> Self::KeyComponents;
+    fn lower_key_components() -> Self::KeyComponents<'static>;
 
     /// Constructs the upper bound of the key components.
-    fn upper_key_components() -> Self::KeyComponents;
+    fn upper_key_components() -> Self::KeyComponents<'static>;
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -86,10 +86,10 @@ pub trait IndexedKey<T: Indexed> {
 /// the proper bound.
 pub trait IndexedKeyBounds<T: Indexed>: IndexedKey<T> {
     /// Constructs the lower bound of the key.
-    fn lower_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self;
+    fn lower_key(serializer: &IndexeddbSerializer) -> Self;
 
     /// Constructs the upper bound of the key.
-    fn upper_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self;
+    fn upper_key(serializer: &IndexeddbSerializer) -> Self;
 }
 
 impl<T, K> IndexedKeyBounds<T> for K
@@ -98,12 +98,12 @@ where
     K: IndexedKeyComponentBounds<T> + Sized,
 {
     /// Constructs the lower bound of the key.
-    fn lower_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
+    fn lower_key(serializer: &IndexeddbSerializer) -> Self {
         <Self as IndexedKey<T>>::encode(Self::lower_key_components(), serializer)
     }
 
     /// Constructs the upper bound of the key.
-    fn upper_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
+    fn upper_key(serializer: &IndexeddbSerializer) -> Self {
         <Self as IndexedKey<T>>::encode(Self::upper_key_components(), serializer)
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -128,3 +128,52 @@ pub trait IndexedKeyComponentBounds<T: Indexed>: IndexedKeyBounds<T> {
     /// Constructs the upper bound of the key components.
     fn upper_key_components() -> Self::KeyComponents<'static>;
 }
+
+/// A trait for constructing the bounds of an [`IndexedKey`] given a prefix `P`
+/// of that key.
+///
+/// The key bounds should be constructed by keeping the prefix constant while
+/// the remaining components of the key are set to their lower and upper limits.
+///
+/// This is useful when constructing prefixed range queries in IndexedDB.
+///
+/// Note that the [`IndexedPrefixKeyComponentBounds`] helps to specify the upper
+/// and lower bounds of the components that are used to create the final key,
+/// while the `IndexedPrefixKeyBounds` are the upper and lower bounds of the
+/// final key itself.
+///
+/// For details on the differences between key bounds and key component bounds,
+/// see the documentation on [`IndexedKeyBounds`].
+pub trait IndexedPrefixKeyBounds<T: Indexed, P>: IndexedKey<T> {
+    /// Constructs the lower bound of the key while maintaining a constant
+    /// prefix.
+    fn lower_key_with_prefix(prefix: P, serializer: &IndexeddbSerializer) -> Self;
+
+    /// Constructs the upper bound of the key while maintaining a constant
+    /// prefix.
+    fn upper_key_with_prefix(prefix: P, serializer: &IndexeddbSerializer) -> Self;
+}
+
+/// A trait for constructing the bounds of the components of an [`IndexedKey`]
+/// given a prefix `P` of that key.
+///
+/// The key component bounds should be constructed by keeping the prefix
+/// constant while the remaining components of the key are set to their lower
+/// and upper limits.
+///
+/// This is useful when constructing range queries in IndexedDB.
+///
+/// Note that this trait should not be implemented for key components that are
+/// going to be encrypted as ordering properties will not be preserved.
+///
+/// One may be interested to read the documentation of [`IndexedKeyBounds`] to
+/// get a better overview of how these two interact.
+pub trait IndexedPrefixKeyComponentBounds<'a, T: Indexed, P: 'a>: IndexedKey<T> {
+    /// Constructs the lower bound of the key components while maintaining a
+    /// constant prefix.
+    fn lower_key_components_with_prefix(prefix: P) -> Self::KeyComponents<'a>;
+
+    /// Constructs the upper bound of the key components while maintaining a
+    /// constant prefix.
+    fn upper_key_components_with_prefix(prefix: P) -> Self::KeyComponents<'a>;
+}

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -35,7 +35,6 @@ pub trait Indexed: Sized {
     /// Converts the high-level type into an indexed type.
     fn to_indexed(
         &self,
-        room_id: &RoomId,
         serializer: &IndexeddbSerializer,
     ) -> Result<Self::IndexedType, Self::Error>;
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs
@@ -62,11 +62,7 @@ pub trait IndexedKey<T: Indexed> {
     /// argument, which provides the necessary context for encryption and
     /// decryption, in the case that certain components of the key must be
     /// encrypted before storage.
-    fn encode(
-        room_id: &RoomId,
-        components: Self::KeyComponents<'_>,
-        serializer: &IndexeddbSerializer,
-    ) -> Self;
+    fn encode(components: Self::KeyComponents<'_>, serializer: &IndexeddbSerializer) -> Self;
 }
 
 /// A trait for constructing the bounds of an [`IndexedKey`].
@@ -103,12 +99,12 @@ where
 {
     /// Constructs the lower bound of the key.
     fn lower_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        <Self as IndexedKey<T>>::encode(room_id, Self::lower_key_components(), serializer)
+        <Self as IndexedKey<T>>::encode(Self::lower_key_components(), serializer)
     }
 
     /// Constructs the upper bound of the key.
     fn upper_key(room_id: &RoomId, serializer: &IndexeddbSerializer) -> Self {
-        <Self as IndexedKey<T>>::encode(room_id, Self::upper_key_components(), serializer)
+        <Self as IndexedKey<T>>::encode(Self::upper_key_components(), serializer)
     }
 }
 
@@ -151,6 +147,21 @@ pub trait IndexedPrefixKeyBounds<T: Indexed, P>: IndexedKey<T> {
     /// Constructs the upper bound of the key while maintaining a constant
     /// prefix.
     fn upper_key_with_prefix(prefix: P, serializer: &IndexeddbSerializer) -> Self;
+}
+
+impl<'a, T, K, P> IndexedPrefixKeyBounds<T, P> for K
+where
+    T: Indexed,
+    K: IndexedPrefixKeyComponentBounds<'a, T, P> + Sized,
+    P: 'a,
+{
+    fn lower_key_with_prefix(prefix: P, serializer: &IndexeddbSerializer) -> Self {
+        <Self as IndexedKey<T>>::encode(Self::lower_key_components_with_prefix(prefix), serializer)
+    }
+
+    fn upper_key_with_prefix(prefix: P, serializer: &IndexeddbSerializer) -> Self {
+        <Self as IndexedKey<T>>::encode(Self::upper_key_components_with_prefix(prefix), serializer)
+    }
 }
 
 /// A trait for constructing the bounds of the components of an [`IndexedKey`]

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
@@ -136,12 +136,9 @@ static INDEXED_KEY_UPPER_EVENT_POSITION: LazyLock<Position> = LazyLock::new(|| P
 /// Representation of a range of keys of type `K`. This is loosely
 /// correlated with [IDBKeyRange][1], with a few differences.
 ///
-/// Firstly, this enum only provides a single way to express a bounded range
+/// Namely, this enum only provides a single way to express a bounded range
 /// which is always inclusive on both bounds. While all ranges can still be
 /// represented, [`IDBKeyRange`][1] provides more flexibility in this regard.
-///
-/// Secondly, this enum provides a way to express the range of all keys
-/// of type `K`.
 ///
 /// [1]: https://developer.mozilla.org/en-US/docs/Web/API/IDBKeyRange
 #[derive(Debug, Copy, Clone)]
@@ -160,8 +157,6 @@ pub enum IndexedKeyRange<K> {
     ///
     /// [1]: https://developer.mozilla.org/en-US/docs/Web/API/IDBKeyRange/bound
     Bound(K, K),
-    /// Represents an inclusive range of all keys of type `K`.
-    All,
 }
 
 impl<'a, C: 'a> IndexedKeyRange<C> {
@@ -184,8 +179,17 @@ impl<'a, C: 'a> IndexedKeyRange<C> {
                 K::encode(room_id, lower, serializer),
                 K::encode(room_id, upper, serializer),
             ),
-            Self::All => IndexedKeyRange::All,
         }
+    }
+}
+
+impl<K> IndexedKeyRange<K> {
+    pub fn all<T>(room_id: &RoomId, serializer: &IndexeddbSerializer) -> IndexedKeyRange<K>
+    where
+        T: Indexed,
+        K: IndexedKeyBounds<T>,
+    {
+        IndexedKeyRange::Bound(K::lower_key(room_id, serializer), K::upper_key(room_id, serializer))
     }
 }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
@@ -340,7 +340,7 @@ impl Indexed for Event {
         let relation = self.relation().map(|(related_event, relation_type)| {
             IndexedEventRelationKey::encode(
                 room_id,
-                (related_event, RelationType::from(relation_type)),
+                (&related_event, &RelationType::from(relation_type)),
                 serializer,
             )
         });
@@ -441,7 +441,7 @@ impl IndexedEventRelationKey {
     /// events which are related to the given event.
     pub fn with_related_event_id(
         &self,
-        related_event_id: &OwnedEventId,
+        related_event_id: &EventId,
         serializer: &IndexeddbSerializer,
     ) -> Self {
         let room_id = self.0.clone();
@@ -455,11 +455,11 @@ impl IndexedEventRelationKey {
 impl IndexedKey<Event> for IndexedEventRelationKey {
     const INDEX: Option<&'static str> = Some(keys::EVENTS_RELATION);
 
-    type KeyComponents<'a> = (OwnedEventId, RelationType);
+    type KeyComponents<'a> = (&'a EventId, &'a RelationType);
 
     fn encode(
         room_id: &RoomId,
-        (related_event_id, relation_type): (OwnedEventId, RelationType),
+        (related_event_id, relation_type): (&EventId, &RelationType),
         serializer: &IndexeddbSerializer,
     ) -> Self {
         let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id);

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
@@ -224,17 +224,16 @@ impl Indexed for Chunk {
 
     fn to_indexed(
         &self,
-        room_id: &RoomId,
         serializer: &IndexeddbSerializer,
     ) -> Result<Self::IndexedType, Self::Error> {
         Ok(IndexedChunk {
             id: <IndexedChunkIdKey as IndexedKey<Chunk>>::encode(
-                room_id,
+                &self.room_id,
                 ChunkIdentifier::new(self.identifier),
                 serializer,
             ),
             next: IndexedNextChunkIdKey::encode(
-                room_id,
+                &self.room_id,
                 self.next.map(ChunkIdentifier::new),
                 serializer,
             ),
@@ -384,17 +383,16 @@ impl Indexed for Event {
 
     fn to_indexed(
         &self,
-        room_id: &RoomId,
         serializer: &IndexeddbSerializer,
     ) -> Result<Self::IndexedType, Self::Error> {
         let event_id = self.event_id().ok_or(Self::Error::NoEventId)?;
-        let id = IndexedEventIdKey::encode(room_id, &event_id, serializer);
+        let id = IndexedEventIdKey::encode(self.room_id(), &event_id, serializer);
         let position = self
             .position()
-            .map(|position| IndexedEventPositionKey::encode(room_id, position, serializer));
+            .map(|position| IndexedEventPositionKey::encode(self.room_id(), position, serializer));
         let relation = self.relation().map(|(related_event, relation_type)| {
             IndexedEventRelationKey::encode(
-                room_id,
+                self.room_id(),
                 (&related_event, &RelationType::from(relation_type)),
                 serializer,
             )
@@ -564,12 +562,11 @@ impl Indexed for Gap {
 
     fn to_indexed(
         &self,
-        room_id: &RoomId,
         serializer: &IndexeddbSerializer,
     ) -> Result<Self::IndexedType, Self::Error> {
         Ok(IndexedGap {
             id: <IndexedGapIdKey as IndexedKey<Gap>>::encode(
-                room_id,
+                &self.room_id,
                 ChunkIdentifier::new(self.chunk_identifier),
                 serializer,
             ),

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
@@ -62,20 +62,75 @@ const INDEXED_KEY_LOWER_CHARACTER: char = '\u{0000}';
 /// [1]: https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane
 const INDEXED_KEY_UPPER_CHARACTER: char = '\u{FFFF}';
 
+/// A [`ChunkIdentifier`] constructed with `0`.
+///
+/// This value is useful for constructing a key range over all keys which
+/// contain [`ChunkIdentifier`]s when used in conjunction with
+/// [`INDEXED_KEY_UPPER_CHUNK_IDENTIFIER`].
+static INDEXED_KEY_LOWER_CHUNK_IDENTIFIER: LazyLock<ChunkIdentifier> =
+    LazyLock::new(|| ChunkIdentifier::new(0));
+
+/// A [`ChunkIdentifier`] constructed with [`js_sys::Number::MAX_SAFE_INTEGER`].
+///
+/// This value is useful for constructing a key range over all keys which
+/// contain [`ChunkIdentifier`]s when used in conjunction with
+/// [`INDEXED_KEY_LOWER_CHUNK_IDENTIFIER`].
+static INDEXED_KEY_UPPER_CHUNK_IDENTIFIER: LazyLock<ChunkIdentifier> =
+    LazyLock::new(|| ChunkIdentifier::new(js_sys::Number::MAX_SAFE_INTEGER as u64));
+
 /// An [`OwnedEventId`] constructed with [`INDEXED_KEY_LOWER_CHARACTER`].
 ///
-/// This value is useful for constructing a key range over all [`Event`]s when
-/// used in conjunction with [`INDEXED_KEY_UPPER_EVENT_ID`].
+/// This value is useful for constructing a key range over all keys which
+/// contain [`EventId`]s when used in conjunction with
+/// [`INDEXED_KEY_UPPER_EVENT_ID`].
 static INDEXED_KEY_LOWER_EVENT_ID: LazyLock<OwnedEventId> = LazyLock::new(|| {
     OwnedEventId::try_from(format!("${INDEXED_KEY_LOWER_CHARACTER}")).expect("valid event id")
 });
 
 /// An [`OwnedEventId`] constructed with [`INDEXED_KEY_UPPER_CHARACTER`].
 ///
-/// This value is useful for constructing a key range over all [`Event`]s when
-/// used in conjunction with [`INDEXED_KEY_LOWER_EVENT_ID`].
+/// This value is useful for constructing a key range over all keys which
+/// contain [`EventId`]s when used in conjunction with
+/// [`INDEXED_KEY_LOWER_EVENT_ID`].
 static INDEXED_KEY_UPPER_EVENT_ID: LazyLock<OwnedEventId> = LazyLock::new(|| {
     OwnedEventId::try_from(format!("${INDEXED_KEY_UPPER_CHARACTER}")).expect("valid event id")
+});
+
+/// The lowest possible index that can be used to reference an [`Event`] inside
+/// a [`Chunk`] - i.e., `0`.
+///
+/// This value is useful for constructing a key range over all keys which
+/// contain [`Position`]s when used in conjunction with
+/// [`INDEXED_KEY_UPPER_EVENT_INDEX`].
+const INDEXED_KEY_LOWER_EVENT_INDEX: usize = 0;
+
+/// The highest possible index that can be used to reference an [`Event`] inside
+/// a [`Chunk`] - i.e., [`js_sys::Number::MAX_SAFE_INTEGER`].
+///
+/// This value is useful for constructing a key range over all keys which
+/// contain [`Position`]s when used in conjunction with
+/// [`INDEXED_KEY_LOWER_EVENT_INDEX`].
+const INDEXED_KEY_UPPER_EVENT_INDEX: usize = js_sys::Number::MAX_SAFE_INTEGER as usize;
+
+/// The lowest possible [`Position`] that can be used to reference an [`Event`].
+///
+/// This value is useful for constructing a key range over all keys which
+/// contain [`Position`]s when used in conjunction with
+/// [`INDEXED_KEY_UPPER_EVENT_INDEX`].
+static INDEXED_KEY_LOWER_EVENT_POSITION: LazyLock<Position> = LazyLock::new(|| Position {
+    chunk_identifier: INDEXED_KEY_LOWER_CHUNK_IDENTIFIER.index(),
+    index: INDEXED_KEY_LOWER_EVENT_INDEX,
+});
+
+/// The highest possible [`Position`] that can be used to reference an
+/// [`Event`].
+///
+/// This value is useful for constructing a key range over all keys which
+/// contain [`Position`]s when used in conjunction with
+/// [`INDEXED_KEY_LOWER_EVENT_INDEX`].
+static INDEXED_KEY_UPPER_EVENT_POSITION: LazyLock<Position> = LazyLock::new(|| Position {
+    chunk_identifier: INDEXED_KEY_UPPER_CHUNK_IDENTIFIER.index(),
+    index: INDEXED_KEY_UPPER_EVENT_INDEX,
 });
 
 /// Representation of a range of keys of type `K`. This is loosely
@@ -221,11 +276,11 @@ impl IndexedKey<Chunk> for IndexedChunkIdKey {
 
 impl IndexedKeyComponentBounds<Chunk> for IndexedChunkIdKey {
     fn lower_key_components() -> Self::KeyComponents<'static> {
-        ChunkIdentifier::new(0)
+        *INDEXED_KEY_LOWER_CHUNK_IDENTIFIER
     }
 
     fn upper_key_components() -> Self::KeyComponents<'static> {
-        ChunkIdentifier::new(js_sys::Number::MAX_SAFE_INTEGER as u64)
+        *INDEXED_KEY_UPPER_CHUNK_IDENTIFIER
     }
 }
 
@@ -292,7 +347,7 @@ impl IndexedKeyComponentBounds<Chunk> for IndexedNextChunkIdKey {
     }
 
     fn upper_key_components() -> Self::KeyComponents<'static> {
-        Some(ChunkIdentifier::new(js_sys::Number::MAX_SAFE_INTEGER as u64))
+        Some(*INDEXED_KEY_UPPER_CHUNK_IDENTIFIER)
     }
 }
 
@@ -411,14 +466,11 @@ impl IndexedKey<Event> for IndexedEventPositionKey {
 
 impl IndexedKeyComponentBounds<Event> for IndexedEventPositionKey {
     fn lower_key_components() -> Self::KeyComponents<'static> {
-        Position { chunk_identifier: 0, index: 0 }
+        *INDEXED_KEY_LOWER_EVENT_POSITION
     }
 
     fn upper_key_components() -> Self::KeyComponents<'static> {
-        Position {
-            chunk_identifier: js_sys::Number::MAX_SAFE_INTEGER as u64,
-            index: js_sys::Number::MAX_SAFE_INTEGER as usize,
-        }
+        *INDEXED_KEY_UPPER_EVENT_POSITION
     }
 }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
@@ -528,23 +528,6 @@ pub type IndexedEventPositionIndex = usize;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IndexedEventRelationKey(IndexedRoomId, IndexedEventId, IndexedRelationType);
 
-impl IndexedEventRelationKey {
-    /// Returns an identical key, but with the related event field updated to
-    /// the given related event. This is helpful when searching for all
-    /// events which are related to the given event.
-    pub fn with_related_event_id(
-        &self,
-        related_event_id: &EventId,
-        serializer: &IndexeddbSerializer,
-    ) -> Self {
-        let room_id = self.0.clone();
-        let related_event_id =
-            serializer.encode_key_as_string(keys::EVENTS_RELATION_RELATED_EVENTS, related_event_id);
-        let relation_type = self.2.clone();
-        Self(room_id, related_event_id, relation_type)
-    }
-}
-
 impl IndexedKey<Event> for IndexedEventRelationKey {
     const INDEX: Option<&'static str> = Some(keys::EVENTS_RELATION);
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs
@@ -165,11 +165,7 @@ pub enum IndexedKeyRange<K> {
 impl<'a, C: 'a> IndexedKeyRange<C> {
     /// Encodes a range of key components of type `K::KeyComponents`
     /// into a range of keys of type `K`.
-    pub fn encoded<T, K>(
-        self,
-        room_id: &RoomId,
-        serializer: &IndexeddbSerializer,
-    ) -> IndexedKeyRange<K>
+    pub fn encoded<T, K>(self, serializer: &IndexeddbSerializer) -> IndexedKeyRange<K>
     where
         T: Indexed,
         K: IndexedKey<T, KeyComponents<'a> = C>,
@@ -194,12 +190,12 @@ impl<K> IndexedKeyRange<K> {
         }
     }
 
-    pub fn all<T>(room_id: &RoomId, serializer: &IndexeddbSerializer) -> IndexedKeyRange<K>
+    pub fn all<T>(serializer: &IndexeddbSerializer) -> IndexedKeyRange<K>
     where
         T: Indexed,
         K: IndexedKeyBounds<T>,
     {
-        IndexedKeyRange::Bound(K::lower_key(room_id, serializer), K::upper_key(room_id, serializer))
+        IndexedKeyRange::Bound(K::lower_key(serializer), K::upper_key(serializer))
     }
 
     pub fn all_with_prefix<T, P>(prefix: P, serializer: &IndexeddbSerializer) -> IndexedKeyRange<K>

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -651,10 +651,8 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         room_id: &RoomId,
         related_event_id: &EventId,
     ) -> Result<Vec<Event>, IndexeddbEventCacheStoreTransactionError> {
-        let prefix = (room_id, related_event_id);
-        let lower = IndexedEventRelationKey::lower_key_with_prefix(prefix, self.serializer.inner());
-        let upper = IndexedEventRelationKey::upper_key_with_prefix(prefix, self.serializer.inner());
-        let range = IndexedKeyRange::Bound(lower, upper);
+        let range =
+            IndexedKeyRange::all_with_prefix((room_id, related_event_id), self.serializer.inner());
         self.get_items_by_key::<Event, IndexedEventRelationKey>(range).await
     }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -17,7 +17,7 @@ use matrix_sdk_base::{
     event_cache::{store::EventCacheStoreError, Event as RawEvent, Gap as RawGap},
     linked_chunk::{ChunkContent, ChunkIdentifier, RawChunk},
 };
-use ruma::{events::relation::RelationType, OwnedEventId, RoomId};
+use ruma::{events::relation::RelationType, EventId, OwnedEventId, RoomId};
 use serde::{
     de::{DeserializeOwned, Error},
     Serialize,
@@ -571,7 +571,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     pub async fn get_event_by_id(
         &self,
         room_id: &RoomId,
-        event_id: OwnedEventId,
+        event_id: &EventId,
     ) -> Result<Option<Event>, IndexeddbEventCacheStoreTransactionError> {
         let key = self.serializer.encode_key(room_id, event_id);
         self.get_item_by_key::<Event, IndexedEventIdKey>(room_id, key).await

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -632,7 +632,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     pub async fn get_events_by_relation(
         &self,
         room_id: &RoomId,
-        range: impl Into<IndexedKeyRange<(OwnedEventId, RelationType)>>,
+        range: impl Into<IndexedKeyRange<(&EventId, &RelationType)>>,
     ) -> Result<Vec<Event>, IndexeddbEventCacheStoreTransactionError> {
         let range = range.into().encoded(room_id, self.serializer.inner());
         self.get_items_by_key::<Event, IndexedEventRelationKey>(room_id, range).await
@@ -643,12 +643,12 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     pub async fn get_events_by_related_event(
         &self,
         room_id: &RoomId,
-        related_event_id: OwnedEventId,
+        related_event_id: &EventId,
     ) -> Result<Vec<Event>, IndexeddbEventCacheStoreTransactionError> {
         let lower = IndexedEventRelationKey::lower_key(room_id, self.serializer.inner())
-            .with_related_event_id(&related_event_id, self.serializer.inner());
+            .with_related_event_id(related_event_id, self.serializer.inner());
         let upper = IndexedEventRelationKey::upper_key(room_id, self.serializer.inner())
-            .with_related_event_id(&related_event_id, self.serializer.inner());
+            .with_related_event_id(related_event_id, self.serializer.inner());
         let range = IndexedKeyRange::Bound(lower, upper);
         self.get_items_by_key::<Event, IndexedEventRelationKey>(room_id, range).await
     }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -111,7 +111,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         T: Indexed,
         T::IndexedType: DeserializeOwned,
         T::Error: AsyncErrorDeps,
-        K: IndexedKeyBounds<T> + Serialize,
+        K: IndexedKey<T> + Serialize,
     {
         let range = self.serializer.encode_key_range::<T, K>(room_id, range)?;
         let object_store = self.transaction.object_store(T::OBJECT_STORE)?;
@@ -141,7 +141,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         T: Indexed + 'b,
         T::IndexedType: DeserializeOwned,
         T::Error: AsyncErrorDeps,
-        K: IndexedKeyComponentBounds<T> + Serialize + 'b,
+        K: IndexedKey<T> + Serialize + 'b,
     {
         let range: IndexedKeyRange<K> = range.into().encoded(room_id, self.serializer.inner());
         self.get_items_by_key::<T, K>(room_id, range).await
@@ -158,7 +158,11 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         T::Error: AsyncErrorDeps,
         K: IndexedKeyBounds<T> + Serialize,
     {
-        self.get_items_by_key::<T, K>(room_id, IndexedKeyRange::All).await
+        self.get_items_by_key::<T, K>(
+            room_id,
+            IndexedKeyRange::all(room_id, self.serializer.inner()),
+        )
+        .await
     }
 
     /// Query IndexedDB for items that match the given key in the given room. If
@@ -172,7 +176,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         T: Indexed,
         T::IndexedType: DeserializeOwned,
         T::Error: AsyncErrorDeps,
-        K: IndexedKeyBounds<T> + Serialize,
+        K: IndexedKey<T> + Serialize,
     {
         let mut items = self.get_items_by_key::<T, K>(room_id, key).await?;
         if items.len() > 1 {
@@ -192,7 +196,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         T: Indexed + 'b,
         T::IndexedType: DeserializeOwned,
         T::Error: AsyncErrorDeps,
-        K: IndexedKeyComponentBounds<T> + Serialize + 'b,
+        K: IndexedKey<T> + Serialize + 'b,
     {
         let mut items = self.get_items_by_key_components::<T, K>(room_id, components).await?;
         if items.len() > 1 {
@@ -212,7 +216,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         T: Indexed,
         T::IndexedType: DeserializeOwned,
         T::Error: AsyncErrorDeps,
-        K: IndexedKeyBounds<T> + Serialize,
+        K: IndexedKey<T> + Serialize,
     {
         let range = self.serializer.encode_key_range::<T, K>(room_id, range)?;
         let object_store = self.transaction.object_store(T::OBJECT_STORE)?;
@@ -235,7 +239,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         T: Indexed + 'b,
         T::IndexedType: DeserializeOwned,
         T::Error: AsyncErrorDeps,
-        K: IndexedKeyBounds<T> + Serialize + 'b,
+        K: IndexedKey<T> + Serialize + 'b,
     {
         let range: IndexedKeyRange<K> = range.into().encoded(room_id, self.serializer.inner());
         self.get_items_count_by_key::<T, K>(room_id, range).await
@@ -252,7 +256,11 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         T::Error: AsyncErrorDeps,
         K: IndexedKeyBounds<T> + Serialize,
     {
-        self.get_items_count_by_key::<T, K>(room_id, IndexedKeyRange::All).await
+        self.get_items_count_by_key::<T, K>(
+            room_id,
+            IndexedKeyRange::all(room_id, self.serializer.inner()),
+        )
+        .await
     }
 
     /// Query IndexedDB for the item with the maximum key in the given room.
@@ -264,9 +272,12 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         T: Indexed,
         T::IndexedType: DeserializeOwned,
         T::Error: AsyncErrorDeps,
-        K: IndexedKey<T> + IndexedKeyBounds<T> + Serialize,
+        K: IndexedKeyBounds<T> + Serialize,
     {
-        let range = self.serializer.encode_key_range::<T, K>(room_id, IndexedKeyRange::All)?;
+        let range = self.serializer.encode_key_range::<T, K>(
+            room_id,
+            IndexedKeyRange::all(room_id, self.serializer.inner()),
+        )?;
         let direction = IdbCursorDirection::Prev;
         let object_store = self.transaction.object_store(T::OBJECT_STORE)?;
         if let Some(index) = K::INDEX {
@@ -339,7 +350,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     ) -> Result<(), IndexeddbEventCacheStoreTransactionError>
     where
         T: Indexed,
-        K: IndexedKeyBounds<T> + Serialize,
+        K: IndexedKey<T> + Serialize,
     {
         let range = self.serializer.encode_key_range::<T, K>(room_id, range)?;
         let object_store = self.transaction.object_store(T::OBJECT_STORE)?;
@@ -366,7 +377,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     ) -> Result<(), IndexeddbEventCacheStoreTransactionError>
     where
         T: Indexed + 'b,
-        K: IndexedKeyBounds<T> + Serialize + 'b,
+        K: IndexedKey<T> + Serialize + 'b,
     {
         let range: IndexedKeyRange<K> = range.into().encoded(room_id, self.serializer.inner());
         self.delete_items_by_key::<T, K>(room_id, range).await
@@ -381,7 +392,11 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         T: Indexed,
         K: IndexedKeyBounds<T> + Serialize,
     {
-        self.delete_items_by_key::<T, K>(room_id, IndexedKeyRange::All).await
+        self.delete_items_by_key::<T, K>(
+            room_id,
+            IndexedKeyRange::all(room_id, self.serializer.inner()),
+        )
+        .await
     }
 
     /// Delete item that matches the given key components in the given room from
@@ -393,7 +408,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     ) -> Result<(), IndexeddbEventCacheStoreTransactionError>
     where
         T: Indexed + 'b,
-        K: IndexedKeyBounds<T> + Serialize + 'b,
+        K: IndexedKey<T> + Serialize + 'b,
     {
         self.delete_items_by_key_components::<T, K>(room_id, key).await
     }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -71,6 +71,14 @@ impl From<Event> for TimelineEvent {
 }
 
 impl Event {
+    /// The [`RoomId`] of the room in which the underlying event exists.
+    pub fn room_id(&self) -> &RoomId {
+        match self {
+            Event::InBand(e) => &e.room_id,
+            Event::OutOfBand(e) => &e.room_id,
+        }
+    }
+
     /// The [`OwnedEventId`] of the underlying event.
     pub fn event_id(&self) -> Option<OwnedEventId> {
         match self {
@@ -116,6 +124,8 @@ impl Event {
 /// in-band or out-of-band.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GenericEvent<P> {
+    /// The room in which the event exists.
+    pub room_id: OwnedRoomId,
     /// The full content of the event.
     pub content: TimelineEvent,
     /// The position of the event, if it is in a chunk.

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -16,13 +16,15 @@ use matrix_sdk_base::{
     deserialized_responses::TimelineEvent, event_cache::store::extract_event_relation,
     linked_chunk::ChunkIdentifier,
 };
-use ruma::OwnedEventId;
+use ruma::{OwnedEventId, OwnedRoomId, RoomId};
 use serde::{Deserialize, Serialize};
 
 /// Representation of a [`Chunk`](matrix_sdk_base::linked_chunk::Chunk)
 /// which can be stored in IndexedDB.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Chunk {
+    /// The room in which the chunk exists.
+    pub room_id: OwnedRoomId,
     /// The identifier of the chunk - i.e.,
     /// [`ChunkIdentifier`](matrix_sdk_base::linked_chunk::ChunkIdentifier).
     pub identifier: u64,

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -181,6 +181,8 @@ impl From<matrix_sdk_base::linked_chunk::Position> for Position {
 /// which can be stored in IndexedDB.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Gap {
+    /// The room in which the gap exists.
+    pub room_id: OwnedRoomId,
     /// The identifier of the chunk containing this gap.
     pub chunk_identifier: u64,
     /// The token to use in the query, extracted from a previous "from" /


### PR DESCRIPTION
## Background

This pull request is part of a series of pull requests to add a full IndexedDB implementation of the `EventCacheStore` (see #4617, #4996, #5090, #5138, #5226, #5274, #5343, #5384, #5406, #5414). This particular pull request focuses on removing the assumption that all `EventCacheStore` keys contain a `RoomId`. This refactoring is necessary in order to support the queries related to leases and media, which make no reference to rooms - e.g., [here](https://docs.rs/matrix-sdk-base/0.13.0/matrix_sdk_base/event_cache/store/trait.EventCacheStore.html#tymethod.try_take_leased_lock), [here](https://docs.rs/matrix-sdk-base/0.13.0/matrix_sdk_base/event_cache/store/trait.EventCacheStore.html#tymethod.get_media_content_for_uri), [here](https://docs.rs/matrix-sdk-base/0.13.0/matrix_sdk_base/event_cache/store/trait.EventCacheStore.html#tymethod.media_retention_policy), etc.

## Changes

### No References to `RoomId` in Serialization Traits

The overarching change is that each of the traits in [`event_cache_store::serializer::traits`](https://github.com/mgoldenberg/matrix-rust-sdk/blob/indexeddb-event-cache-store-room-id-key-component/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs) no longer makes reference to a `RoomId`, which ultimately lays the foundation for keys which do not contain a `RoomId`. For the existing keys - all of which contain a `RoomId` - their components are now fully represented in [`IndexedKey::KeyComponents`](https://github.com/mgoldenberg/matrix-rust-sdk/blob/3054131840b21c3f3d35fedff4c1a65d6bb15b8d/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs#L56). 

So, for instance, [`IndexedChunkIdKey`](https://github.com/matrix-org/matrix-rust-sdk/blob/872713c4bc024ac9246dfa72f834584ebe92a3d7/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs#L188) previously had the following [implementation](https://github.com/matrix-org/matrix-rust-sdk/blob/872713c4bc024ac9246dfa72f834584ebe92a3d7/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs#L190-L202).

```rust
impl IndexedKey<Chunk> for IndexedChunkIdKey {
    type KeyComponents = ChunkIdentifier;

    fn encode(
        room_id: &RoomId,
        chunk_id: &ChunkIdentifier,
        serializer: &IndexeddbSerializer,
    ) -> Self { /* -- snip -- */ }
}
``` 

But now, has an updated [implementation](https://github.com/mgoldenberg/matrix-rust-sdk/blob/3054131840b21c3f3d35fedff4c1a65d6bb15b8d/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs#L282-L293). 

```rust
impl IndexedKey<Chunk> for IndexedChunkIdKey {
    type KeyComponents<'a> = (&'a RoomId, ChunkIdentifier);


    fn encode(
        (room_id, chunk_id): Self::KeyComponents<'_>,
        serializer: &IndexeddbSerializer,
    ) -> Self { /* -- snip -- */ }
}
```

### Additional Traits for Representing Prefix Keys

By encoding the `RoomId` as an element of `IndexedKey::KeyComponents`, the trait [`IndexedKeyComponentBounds`](https://github.com/matrix-org/matrix-rust-sdk/blob/872713c4bc024ac9246dfa72f834584ebe92a3d7/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs#L124-L130), which expresses the bounds of the key components, now includes the lower and upper bounds of the `RoomId` as well. This becomes insufficient as the existing queries are always minimally searching within the bounds of a single room.

Consequently, I have added a trait for constructing key components bounds that allows one to hold leading components constant, while providing bounds on the remaining components. So, `IndexedKeyComponentBounds` is supplemented by [`IndexedPrefixKeyComponentBounds`](https://github.com/mgoldenberg/matrix-rust-sdk/blob/3054131840b21c3f3d35fedff4c1a65d6bb15b8d/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/traits.rs#L181-L189) shown below.

```rust
pub trait IndexedKeyComponentBounds<T: Indexed>: IndexedKeyBounds<T> {
    fn lower_key_components() -> Self::KeyComponents<'static>;
    fn upper_key_components() -> Self::KeyComponents<'static>;
}

pub trait IndexedPrefixKeyComponentBounds<'a, T: Indexed, P: 'a>: IndexedKey<T> {
    fn lower_key_components_with_prefix(prefix: P) -> Self::KeyComponents<'a>;
    fn upper_key_components_with_prefix(prefix: P) -> Self::KeyComponents<'a>;
}
```


Let's again consider `IndexedChunkIdKey`. Previously, this key had an [implementation](https://github.com/matrix-org/matrix-rust-sdk/blob/872713c4bc024ac9246dfa72f834584ebe92a3d7/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs#L204-L212) of `IndexedKeyComponentBounds`, shown below.

```rust
impl IndexedKeyComponentBounds<Chunk> for IndexedChunkIdKey {
    fn lower_key_components() -> Self::KeyComponents {
        ChunkIdentifier::new(0)
    }

    fn upper_key_components() -> Self::KeyComponents {
        ChunkIdentifier::new(js_sys::Number::MAX_SAFE_INTEGER as u64)
    }
}
```

When `RoomId` becomes a key component, the functions above would provide us with the lower and upper bounds of keys **_for all chunks in all rooms_**. 

Alternatively, a relevant [implementation](https://github.com/mgoldenberg/matrix-rust-sdk/blob/3054131840b21c3f3d35fedff4c1a65d6bb15b8d/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/types.rs#L295-L303) of `IndexedPrefixKeyComponentBounds` can provide us with the lower and upper bounds of keys for **_all chunks in a single room_**.

```rust
impl<'a> IndexedPrefixKeyComponentBounds<'a, Chunk, &'a RoomId> for IndexedChunkIdKey {
    fn lower_key_components_with_prefix(room_id: &'a RoomId) -> Self::KeyComponents<'a> {
        (room_id, ChunkIdentifier::new(0))
    }

    fn upper_key_components_with_prefix(room_id: &'a RoomId) -> Self::KeyComponents<'a> {
        (room_id, ChunkIdentifier::new(js_sys::Number::MAX_SAFE_INTEGER as u64))
    }
}
```

#### Propogate Changes

The remaining changes are simply propogations of the changes outlined above. These include adding and removing references to `RoomId` where necessary, modifying type constraints on certain generalized functions, etc.

## Future Work

- Proper handling of `LinkedChunkId` (see [here](https://github.com/matrix-org/matrix-rust-sdk/pull/5414#discussion_r2222985920)).
- Add implementation of `EventCacheStore::try_take_leased_lock` functions without relying on `MemoryStore`
- Add implementation of `EventCacheStoreMedia`

---

- [ ] Public API changes documented in changelogs (optional)


Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
