### PR TITLE
refactor(base): Don't take room ID in `Notification::push_notification_from_event_if`

### DIFF
--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -277,13 +277,10 @@ pub mod stripped {
         if let Some(push_condition_room_ctx) =
             timeline::get_push_room_context(context, room, room_info).await?
         {
-            let room_id = room.room_id();
-
             // Check every event again for notification.
             for event in state_events.values().flat_map(|map| map.values()) {
                 notification
                     .push_notification_from_event_if(
-                        room_id,
                         &push_condition_room_ctx,
                         event,
                         Action::should_notify,

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -131,7 +131,6 @@ pub async fn build<'notification, 'e2ee>(
                 if let Some(push_condition_room_ctx) = &push_condition_room_ctx {
                     let actions = notification
                         .push_notification_from_event_if(
-                            room_id,
                             push_condition_room_ctx,
                             timeline_event.raw(),
                             Action::should_notify,


### PR DESCRIPTION
It is already in the `PushConditionRoomCtx`, so we don't need an extra argument for it.

