### PR TITLE
doc(base): Use different Result type in doc example

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -464,7 +464,7 @@ impl BaseClient {
     /// let room = client.room_joined(&room_id, maybe_inviter).await?;
     ///
     /// assert_eq!(room.state(), RoomState::Joined);
-    /// # anyhow::Ok(()) };
+    /// # matrix_sdk_test::TestResult::Ok(()) };
     /// ```
     pub async fn room_joined(
         &self,


### PR DESCRIPTION
A new version of Rust was released today, which means that some doc tests are now checked under WASM.

`anyhow::Ok(())` doesn't work under WASM because it requires the error types to be `Send + Sync`.

