### PR TITLE
IndexedDB: implement `EventCacheStore::try_take_leased_lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3188,6 +3188,7 @@ dependencies = [
  "async-trait",
  "base64",
  "getrandom 0.2.15",
+ "gloo-timers",
  "gloo-utils",
  "growable-bloom-filter",
  "hkdf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,6 +2996,7 @@ dependencies = [
  "eyeball-im",
  "futures-executor",
  "futures-util",
+ "gloo-timers",
  "growable-bloom-filter",
  "http",
  "matrix-sdk-common",

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -25,8 +25,12 @@ js = [
     "matrix-sdk-store-encryption/js",
 ]
 qrcode = ["matrix-sdk-crypto?/qrcode"]
-automatic-room-key-forwarding = ["matrix-sdk-crypto?/automatic-room-key-forwarding"]
-experimental-send-custom-to-device = ["matrix-sdk-crypto?/experimental-send-custom-to-device"]
+automatic-room-key-forwarding = [
+    "matrix-sdk-crypto?/automatic-room-key-forwarding",
+]
+experimental-send-custom-to-device = [
+    "matrix-sdk-crypto?/experimental-send-custom-to-device",
+]
 uniffi = ["dep:uniffi", "matrix-sdk-crypto?/uniffi", "matrix-sdk-common/uniffi"]
 
 # Private feature, see
@@ -101,6 +105,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test.workspace = true
+gloo-timers = { workspace = true, features = ["futures"] }
 
 [lints]
 workspace = true

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -1432,7 +1432,6 @@ macro_rules! event_cache_store_integration_tests {
 #[macro_export]
 macro_rules! event_cache_store_integration_tests_time {
     () => {
-        #[cfg(not(target_family = "wasm"))]
         mod event_cache_store_integration_tests_time {
             use std::time::Duration;
 
@@ -1440,6 +1439,13 @@ macro_rules! event_cache_store_integration_tests_time {
             use $crate::event_cache::store::IntoEventCacheStore;
 
             use super::get_event_cache_store;
+
+            pub async fn sleep(duration: Duration) {
+                #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+                gloo_timers::future::sleep(duration).await;
+                #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+                tokio::time::sleep(duration).await;
+            }
 
             #[async_test]
             async fn test_lease_locks() {
@@ -1465,26 +1471,26 @@ macro_rules! event_cache_store_integration_tests_time {
                 assert!(!acquired5);
 
                 // That's a nice test we got here, go take a little nap.
-                tokio::time::sleep(Duration::from_millis(50)).await;
+                sleep(Duration::from_millis(50)).await;
 
                 // Still too early.
                 let acquired55 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();
                 assert!(!acquired55);
 
                 // Ok you can take another nap then.
-                tokio::time::sleep(Duration::from_millis(250)).await;
+                sleep(Duration::from_millis(250)).await;
 
                 // At some point, we do get the lock.
                 let acquired6 = store.try_take_leased_lock(0, "key", "bob").await.unwrap();
                 assert!(acquired6);
 
-                tokio::time::sleep(Duration::from_millis(1)).await;
+                sleep(Duration::from_millis(1)).await;
 
                 // The other gets it almost immediately too.
                 let acquired7 = store.try_take_leased_lock(0, "key", "alice").await.unwrap();
                 assert!(acquired7);
 
-                tokio::time::sleep(Duration::from_millis(1)).await;
+                sleep(Duration::from_millis(1)).await;
 
                 // But when we take a longer lease...
                 let acquired8 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -51,6 +51,7 @@ getrandom = { workspace = true, features = ["js"] }
 [dev-dependencies]
 assert_matches.workspace = true
 assert_matches2.workspace = true
+gloo-timers = { workspace = true, features = ["futures"] }
 matrix-sdk-base = { workspace = true, features = ["testing"] }
 matrix-sdk-common = { workspace = true, features = ["js"] }
 matrix-sdk-crypto = { workspace = true, features = ["js", "testing"] }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -109,6 +109,8 @@ pub mod v1 {
 
     pub mod keys {
         pub const CORE: &str = "core";
+        pub const LEASES: &str = "leases";
+        pub const LEASES_KEY_PATH: &str = "id";
         pub const ROOMS: &str = "rooms";
         pub const LINKED_CHUNKS: &str = "linked_chunks";
         pub const LINKED_CHUNKS_KEY_PATH: &str = "id";
@@ -129,16 +131,24 @@ pub mod v1 {
     /// Create all object stores and indices for v1 database
     pub fn create_object_stores(db: &IdbDatabase) -> Result<(), DomException> {
         create_core_object_store(db)?;
+        create_lease_object_store(db)?;
         create_linked_chunks_object_store(db)?;
         create_events_object_store(db)?;
         create_gaps_object_store(db)?;
         Ok(())
     }
 
-    /// Create an object store for tracking miscellaneous information, e.g.,
-    /// leases locks
+    /// Create an object store for tracking miscellaneous information
     fn create_core_object_store(db: &IdbDatabase) -> Result<(), DomException> {
         let _ = db.create_object_store(keys::CORE)?;
+        Ok(())
+    }
+
+    /// Create an object store tracking leases on time-based locks
+    fn create_lease_object_store(db: &IdbDatabase) -> Result<(), DomException> {
+        let mut object_store_params = IdbObjectStoreParameters::new();
+        object_store_params.key_path(Some(&keys::LEASES_KEY_PATH.into()));
+        let _ = db.create_object_store_with_params(keys::LEASES, &object_store_params)?;
         Ok(())
     }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -671,7 +671,10 @@ impl_event_cache_store! {
 
 #[cfg(test)]
 mod tests {
-    use matrix_sdk_base::event_cache::store::{EventCacheStore, EventCacheStoreError};
+    use matrix_sdk_base::{
+        event_cache::store::{EventCacheStore, EventCacheStoreError},
+        event_cache_store_integration_tests_time,
+    };
     use matrix_sdk_test::async_test;
     use uuid::Uuid;
 
@@ -695,6 +698,9 @@ mod tests {
 
         #[cfg(target_family = "wasm")]
         indexeddb_event_cache_store_integration_tests!();
+
+        #[cfg(target_family = "wasm")]
+        event_cache_store_integration_tests_time!();
     }
 
     mod encrypted {
@@ -712,5 +718,8 @@ mod tests {
 
         #[cfg(target_family = "wasm")]
         indexeddb_event_cache_store_integration_tests!();
+
+        #[cfg(target_family = "wasm")]
+        event_cache_store_integration_tests_time!();
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -14,6 +14,8 @@
 
 #![allow(unused)]
 
+use std::time::Duration;
+
 use indexed_db_futures::IdbDatabase;
 use matrix_sdk_base::{
     event_cache::{
@@ -30,15 +32,18 @@ use matrix_sdk_base::{
     media::MediaRequestParameters,
     timer,
 };
-use ruma::{events::relation::RelationType, EventId, MxcUri, OwnedEventId, RoomId};
+use ruma::{
+    events::relation::RelationType, EventId, MilliSecondsSinceUnixEpoch, MxcUri, OwnedEventId,
+    RoomId,
+};
 use tracing::{error, instrument, trace};
 use web_sys::IdbTransactionMode;
 
 use crate::event_cache_store::{
     migrations::current::keys,
-    serializer::IndexeddbEventCacheStoreSerializer,
+    serializer::{traits::Indexed, IndexeddbEventCacheStoreSerializer},
     transaction::{IndexeddbEventCacheStoreTransaction, IndexeddbEventCacheStoreTransactionError},
-    types::{ChunkType, InBandEvent, OutOfBandEvent},
+    types::{ChunkType, InBandEvent, Lease, OutOfBandEvent},
 };
 
 mod builder;
@@ -132,10 +137,27 @@ impl_event_cache_store! {
         holder: &str,
     ) -> Result<bool, IndexeddbEventCacheStoreError> {
         let _timer = timer!("method");
-        self.memory_store
-            .try_take_leased_lock(lease_duration_ms, key, holder)
-            .await
-            .map_err(IndexeddbEventCacheStoreError::MemoryStore)
+
+        let now = Duration::from_millis(MilliSecondsSinceUnixEpoch::now().get().into());
+
+        let transaction =
+            self.transaction(&[Lease::OBJECT_STORE], IdbTransactionMode::Readwrite)?;
+
+        if let Some(lease) = transaction.get_lease_by_id(key).await? {
+            if lease.holder != holder && !lease.expired_at(now) {
+                return Ok(false);
+            }
+        }
+
+        transaction
+            .put_lease(&Lease {
+                key: key.to_owned(),
+                holder: holder.to_owned(),
+                expiration: now + Duration::from_millis(lease_duration_ms.into()),
+            })
+            .await?;
+
+        Ok(true)
     }
 
     #[instrument(skip(self, updates))]

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -12,12 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License
 
+use std::time::Duration;
+
 use matrix_sdk_base::{
     deserialized_responses::TimelineEvent, event_cache::store::extract_event_relation,
     linked_chunk::ChunkIdentifier,
 };
 use ruma::{OwnedEventId, OwnedRoomId, RoomId};
 use serde::{Deserialize, Serialize};
+
+/// Representation of a time-based lock on the entire
+/// [`IndexeddbEventCacheStore`](crate::event_cache_store::IndexeddbEventCacheStore)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Lease {
+    pub key: String,
+    pub holder: String,
+    pub expiration: Duration,
+}
+
+impl Lease {
+    /// Determines whether the lease is expired at a given time `t`
+    pub fn expired_at(&self, t: Duration) -> bool {
+        self.expiration < t
+    }
+}
 
 /// Representation of a [`Chunk`](matrix_sdk_base::linked_chunk::Chunk)
 /// which can be stored in IndexedDB.


### PR DESCRIPTION
## Background

This pull request is part of a series of pull requests to add a full IndexedDB implementation of the `EventCacheStore` (see #4617, #4996, #5090, #5138, #5226, #5274, #5343, #5384, #5406, #5414, #5497). This particular pull request adds an IndexedDB-backed implementation of `EventCacheStore::try_take_leased_lock`.

## Changes

The following types have been added for representing and indexing leased locks.

- `Lease` - the primary type for representing a leased lock.
- `IndexedLease` - an indexed version of `Lease`.
- `IndexedLeaseIdKey` - the primary key of an `IndexedLease`.

To store the types above, an object store (`v1::keys::LEASES`) gets created when upgrading the database to version `1` with primary key `id`.

Additionally, the following transaction functions are added for conveniently working with leases.

- `IndexeddbEventCacheStoreTransaction::get_lease_by_id`
- `IndexeddbEventCacheStoreTransaction::put_lease`

### Tests

`matrix_sdk_base::event_cache_store_integration_tests_time` previously used `tokio::time::sleep` which is not supported on `wasm` targets.

> The time module will only work on WASM platforms that have support for timers (e.g. wasm32-wasi). The timing functions will panic if used on a WASM platform that does not support timers.

(Link to text [here](https://docs.rs/tokio/latest/tokio/index.html#wasm-support)).

I have modified this macro so that when running on `wasm` targets with an unknown operating system, we use a compatible crate, i.e., `gloo_timers`. This way, these tests can be run against the `matrix-sdk-indexeddb` crate.

## Future Work

- Proper handling of `LinkedChunkId` (see [here](https://github.com/matrix-org/matrix-rust-sdk/pull/5414#discussion_r2222985920)).
- Add implementation of `EventCacheStoreMedia`

---

- [ ] Public API changes documented in changelogs (optional)


Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>