### PR TITLE
feat(crypto): Add RoomSettings::encrypt_state_events

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased] - ReleaseDate
 
 ### Features
+
+- Add `RoomSettings::encrypt_state_events` flag. ([#5511](https://github.com/matrix-org/matrix-rust-sdk/pull/5511))
 - Make sure to accept historic room key bundles only if the sender is trusted
   enough.
   ([#5510](https://github.com/matrix-org/matrix-rust-sdk/pull/5510))

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -18,6 +18,11 @@ rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 default = []
 automatic-room-key-forwarding = []
 experimental-send-custom-to-device = []
+
+# Enable experimental support for encrypting state events; see
+# https://github.com/matrix-org/matrix-rust-sdk/issues/5397.
+experimental-encrypted-state-events = []
+
 js = ["ruma/js", "vodozemac/js", "matrix-sdk-common/js"]
 qrcode = ["dep:matrix-sdk-qrcode"]
 experimental-algorithms = []

--- a/crates/matrix-sdk-crypto/src/machine/tests/room_settings.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/room_settings.rs
@@ -23,6 +23,8 @@ async fn test_stores_and_returns_room_settings() {
 
     let settings = RoomSettings {
         algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+        #[cfg(feature = "experimental-encrypted-state-events")]
+        encrypt_state_events: false,
         only_allow_trusted_devices: true,
         session_rotation_period: Some(Duration::from_secs(10)),
         session_rotation_period_messages: Some(1234),

--- a/crates/matrix-sdk-crypto/src/store/types.rs
+++ b/crates/matrix-sdk-crypto/src/store/types.rs
@@ -414,6 +414,11 @@ pub struct RoomSettings {
     /// The encryption algorithm that should be used in the room.
     pub algorithm: EventEncryptionAlgorithm,
 
+    /// Whether state event encryption is enabled.
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    #[serde(default)]
+    pub encrypt_state_events: bool,
+
     /// Should untrusted devices receive the room key, or should they be
     /// excluded from the conversation.
     pub only_allow_trusted_devices: bool,
@@ -431,6 +436,8 @@ impl Default for RoomSettings {
     fn default() -> Self {
         Self {
             algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+            #[cfg(feature = "experimental-encrypted-state-events")]
+            encrypt_state_events: false,
             only_allow_trusted_devices: false,
             session_rotation_period: None,
             session_rotation_period_messages: None,


### PR DESCRIPTION
- [x] Add `RoomSettings::encrypt_state_events`, which will be used when implementing encrypted state support to the WASM SDK.