### PR TITLE
feat: Change type of `DecryptedRoomEvent::event` to `Raw<AnyTimelineEvent>`

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -39,7 +39,7 @@ use ruma::{
     },
     events::{
         key::verification::VerificationMethod, room::message::MessageType, AnyMessageLikeEvent,
-        AnySyncMessageLikeEvent, MessageLikeEvent,
+        AnySyncMessageLikeEvent, AnyTimelineEvent, MessageLikeEvent,
     },
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
@@ -902,7 +902,7 @@ impl OlmMachine {
         ))?;
 
         if handle_verification_events {
-            if let Ok(e) = decrypted.event.deserialize() {
+            if let Ok(AnyTimelineEvent::MessageLike(e)) = decrypted.event.deserialize() {
                 match &e {
                     AnyMessageLikeEvent::RoomMessage(MessageLikeEvent::Original(
                         original_event,

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -33,6 +33,7 @@ use ruma::{
     api::client::media::get_content_thumbnail::v3::Method,
     event_id,
     events::{
+        AnyMessageLikeEvent, AnyTimelineEvent,
         relation::RelationType,
         room::{MediaSource, message::RoomMessageEventContentWithoutRelation},
     },
@@ -105,7 +106,7 @@ pub fn check_test_event(event: &TimelineEvent, text: &str) {
 
         // Check event.
         let deserialized = d.event.deserialize().unwrap();
-        assert_matches!(deserialized, ruma::events::AnyMessageLikeEvent::RoomMessage(msg) => {
+        assert_matches!(deserialized, AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(msg)) => {
             assert_eq!(msg.as_original().unwrap().content.body(), text);
         });
     });

--- a/crates/matrix-sdk-common/CHANGELOG.md
+++ b/crates/matrix-sdk-common/CHANGELOG.md
@@ -8,7 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- [**breaking**] Use `Raw<AnyTimelineEvent>` in place of `Raw<AnyMessageLikeEvent>` inside `DecryptedRoomEvent` ([#5512](https://github.com/matrix-org/matrix-rust-sdk/pull/5512/files)).
+- [**breaking**] Use `Raw<AnyTimelineEvent>` in place of `Raw<AnyMessageLikeEvent>`
+  in `DecryptedRoomEvent::event`.
+  ([#5512](https://github.com/matrix-org/matrix-rust-sdk/pull/5512/files)).
+  Affects the following functions:
+  - `OlmMachine::decrypt_room_event` - existing matches on the result's event field
+     should be updated to `AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::...)`
 
 ## [0.13.0] - 2025-07-10
 

--- a/crates/matrix-sdk-common/CHANGELOG.md
+++ b/crates/matrix-sdk-common/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+- [**breaking**] Use `Raw<AnyTimelineEvent>` in place of `Raw<AnyMessageLikeEvent>` inside `DecryptedRoomEvent` ([#5512](https://github.com/matrix-org/matrix-rust-sdk/pull/5512/files)).
+
 ## [0.13.0] - 2025-07-10
 
 ### Features

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -14,12 +14,10 @@
 
 use std::{collections::BTreeMap, fmt, sync::Arc};
 
-#[cfg(doc)]
-use ruma::events::AnyTimelineEvent;
 use ruma::{
     DeviceKeyAlgorithm, OwnedDeviceId, OwnedEventId, OwnedUserId,
     events::{
-        AnyMessageLikeEvent, AnySyncMessageLikeEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, AnyTimelineEvent, AnyToDeviceEvent,
         MessageLikeEventType,
     },
     push::Action,
@@ -651,7 +649,7 @@ impl TimelineEvent {
     }
 
     /// Replace the raw event included in this item by another one.
-    pub fn replace_raw(&mut self, replacement: Raw<AnyMessageLikeEvent>) {
+    pub fn replace_raw(&mut self, replacement: Raw<AnyTimelineEvent>) {
         match &mut self.kind {
             TimelineEventKind::Decrypted(decrypted) => decrypted.event = replacement,
             TimelineEventKind::UnableToDecrypt { event, .. }
@@ -843,7 +841,7 @@ pub struct DecryptedRoomEvent {
     /// encrypted payload *always contains* a room id, by the [spec].
     ///
     /// [spec]: https://spec.matrix.org/v1.12/client-server-api/#mmegolmv1aes-sha2
-    pub event: Raw<AnyMessageLikeEvent>,
+    pub event: Raw<AnyTimelineEvent>,
 
     /// The encryption info about the event.
     pub encryption_info: Arc<EncryptionInfo>,

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -837,7 +837,8 @@ impl fmt::Debug for TimelineEventKind {
 pub struct DecryptedRoomEvent {
     /// The decrypted event.
     ///
-    /// Note: it's not an error that this contains an `AnyMessageLikeEvent`: an
+    /// Note: it's not an error that this contains an [`AnyTimelineEvent`]
+    /// (as opposed to an [`AnySyncTimelineEvent`]): an
     /// encrypted payload *always contains* a room id, by the [spec].
     ///
     /// [spec]: https://spec.matrix.org/v1.12/client-server-api/#mmegolmv1aes-sha2

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -45,7 +45,7 @@ use ruma::{
     assign,
     events::{
         secret::request::SecretName, AnyMessageLikeEvent, AnyMessageLikeEventContent,
-        AnyToDeviceEvent, MessageLikeEventContent,
+        AnyTimelineEvent, AnyToDeviceEvent, MessageLikeEventContent,
     },
     serde::{JsonObject, Raw},
     DeviceId, MilliSecondsSinceUnixEpoch, OneTimeKeyAlgorithm, OwnedDeviceId, OwnedDeviceKeyId,
@@ -2197,7 +2197,7 @@ impl OlmMachine {
                 .await;
         }
 
-        let event = serde_json::from_value::<Raw<AnyMessageLikeEvent>>(decrypted_event.into())?;
+        let event = serde_json::from_value::<Raw<AnyTimelineEvent>>(decrypted_event.into())?;
 
         Ok(DecryptedRoomEvent { event, encryption_info, unsigned_encryption_info })
     }

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -36,8 +36,8 @@ use ruma::{
         room::message::{
             AddMentions, MessageType, Relation, ReplyWithinThread, RoomMessageEventContent,
         },
-        AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnyToDeviceEvent,
-        MessageLikeEvent, OriginalMessageLikeEvent, ToDeviceEventType,
+        AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnyTimelineEvent,
+        AnyToDeviceEvent, MessageLikeEvent, OriginalMessageLikeEvent, ToDeviceEventType,
     },
     room_id,
     serde::Raw,
@@ -706,8 +706,8 @@ async fn test_megolm_encryption() {
     assert_let!(RoomEventDecryptionResult::Decrypted(decrypted_event) = decryption_result);
     let decrypted_event = decrypted_event.event.deserialize().unwrap();
 
-    if let AnyMessageLikeEvent::RoomMessage(MessageLikeEvent::Original(
-        OriginalMessageLikeEvent { sender, content, .. },
+    if let AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
+        MessageLikeEvent::Original(OriginalMessageLikeEvent { sender, content, .. }),
     )) = decrypted_event
     {
         assert_eq!(&sender, alice.user_id());
@@ -1490,7 +1490,10 @@ async fn test_unsigned_decryption() {
         bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
-    assert_matches!(decrypted_event, AnyMessageLikeEvent::RoomMessage(first_message));
+    assert_matches!(
+        decrypted_event,
+        AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(first_message))
+    );
 
     let first_message = first_message.as_original().unwrap();
     assert_eq!(first_message.content.body(), first_message_text);
@@ -1539,7 +1542,10 @@ async fn test_unsigned_decryption() {
         bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
-    assert_matches!(decrypted_event, AnyMessageLikeEvent::RoomMessage(first_message));
+    assert_matches!(
+        decrypted_event,
+        AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(first_message))
+    );
 
     let first_message = first_message.as_original().unwrap();
     assert_eq!(first_message.content.body(), first_message_text);
@@ -1588,7 +1594,10 @@ async fn test_unsigned_decryption() {
         bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
-    assert_matches!(decrypted_event, AnyMessageLikeEvent::RoomMessage(first_message));
+    assert_matches!(
+        decrypted_event,
+        AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(first_message))
+    );
 
     let first_message = first_message.as_original().unwrap();
     assert_eq!(first_message.content.body(), first_message_text);
@@ -1649,7 +1658,10 @@ async fn test_unsigned_decryption() {
         bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
-    assert_matches!(decrypted_event, AnyMessageLikeEvent::RoomMessage(first_message));
+    assert_matches!(
+        decrypted_event,
+        AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(first_message))
+    );
 
     let first_message = first_message.as_original().unwrap();
     assert_eq!(first_message.content.body(), first_message_text);
@@ -1705,7 +1717,10 @@ async fn test_unsigned_decryption() {
         bob.decrypt_room_event(&raw_encrypted_event, room_id, &decryption_settings).await.unwrap();
 
     let decrypted_event = raw_decrypted_event.event.deserialize().unwrap();
-    assert_matches!(decrypted_event, AnyMessageLikeEvent::RoomMessage(first_message));
+    assert_matches!(
+        decrypted_event,
+        AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(first_message))
+    );
 
     let first_message = first_message.as_original().unwrap();
     assert_eq!(first_message.content.body(), first_message_text);

--- a/crates/matrix-sdk/src/test_utils/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mod.rs
@@ -256,6 +256,10 @@ macro_rules! assert_decrypted_message_eq {
             .deserialize()
             .expect("We should be able to deserialize the decrypted event");
 
+        assert_matches2::assert_let!(
+            $crate::ruma::events::AnyTimelineEvent::MessageLike(deserialized_event) = deserialized_event
+        );
+
         let content =
             deserialized_event.original_content().expect("The event should not have been redacted");
         assert_matches2::assert_let!($crate::ruma::events::AnyMessageLikeEventContent::RoomMessage(content) = content);


### PR DESCRIPTION
- [x] Change `DecryptedRoomEvent::event` to `Raw<AnyTimelineEvent>`
- [x] Update usages to pattern match on `AnyTimelineEvent::MessageLike` where necessary
