### PR TITLE
sdk: Improvements and fixes around media APIs

### DIFF
--- a/crates/matrix-sdk/src/config/request.rs
+++ b/crates/matrix-sdk/src/config/request.rs
@@ -19,7 +19,6 @@ use std::{
 };
 
 use matrix_sdk_common::debug::DebugStructExt;
-use ruma::api::MatrixVersion;
 
 use crate::http_client::DEFAULT_REQUEST_TIMEOUT;
 
@@ -49,7 +48,6 @@ pub struct RequestConfig {
     pub(crate) max_retry_time: Option<Duration>,
     pub(crate) max_concurrent_requests: Option<NonZeroUsize>,
     pub(crate) force_auth: bool,
-    pub(crate) force_matrix_version: Option<MatrixVersion>,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -62,7 +60,6 @@ impl Debug for RequestConfig {
             max_retry_time: retry_timeout,
             force_auth,
             max_concurrent_requests,
-            force_matrix_version,
         } = self;
 
         let mut res = fmt.debug_struct("RequestConfig");
@@ -70,8 +67,7 @@ impl Debug for RequestConfig {
             .maybe_field("read_timeout", read_timeout)
             .maybe_field("retry_limit", retry_limit)
             .maybe_field("max_retry_time", retry_timeout)
-            .maybe_field("max_concurrent_requests", max_concurrent_requests)
-            .maybe_field("force_matrix_version", force_matrix_version);
+            .maybe_field("max_concurrent_requests", max_concurrent_requests);
 
         if *force_auth {
             res.field("force_auth", &true);
@@ -90,7 +86,6 @@ impl Default for RequestConfig {
             max_retry_time: Default::default(),
             max_concurrent_requests: Default::default(),
             force_auth: false,
-            force_matrix_version: Default::default(),
         }
     }
 }
@@ -171,17 +166,6 @@ impl RequestConfig {
     #[must_use]
     pub fn force_auth(mut self) -> Self {
         self.force_auth = true;
-        self
-    }
-
-    /// Force the Matrix version used to select which version of the endpoint to
-    /// use.
-    ///
-    /// Can be used to force the use of a stable endpoint when the versions
-    /// advertised by the homeserver do not support it.
-    #[must_use]
-    pub(crate) fn force_matrix_version(mut self, version: MatrixVersion) -> Self {
-        self.force_matrix_version = Some(version);
         self
     }
 }

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -14,7 +14,6 @@
 
 use std::{
     any::type_name,
-    borrow::Cow,
     fmt::Debug,
     num::NonZeroUsize,
     sync::{
@@ -109,15 +108,6 @@ impl HttpClient {
     {
         trace!(request_type = type_name::<R>(), "Serializing request");
 
-        let supported_versions = if let Some(matrix_version) = config.force_matrix_version {
-            Cow::Owned(SupportedVersions {
-                versions: [matrix_version].into(),
-                features: Default::default(),
-            })
-        } else {
-            Cow::Borrowed(supported_versions)
-        };
-
         let send_access_token = match access_token {
             Some(access_token) => {
                 if config.force_auth {
@@ -130,7 +120,7 @@ impl HttpClient {
         };
 
         let request = request
-            .try_into_http_request::<BytesMut>(&homeserver, send_access_token, &supported_versions)?
+            .try_into_http_request::<BytesMut>(&homeserver, send_access_token, supported_versions)?
             .map(|body| body.freeze());
 
         Ok(request)

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -455,7 +455,7 @@ impl Media {
                 } else {
                     #[allow(deprecated)]
                     let request = media::get_content::v3::Request::from_url(&file.url)?;
-                    self.client.send(request).await?.file
+                    self.client.send(request).with_request_config(request_config).await?.file
                 };
 
                 #[cfg(feature = "e2e-encryption")]
@@ -505,7 +505,7 @@ impl Media {
                             request
                         };
 
-                        self.client.send(request).await?.file
+                        self.client.send(request).with_request_config(request_config).await?.file
                     }
                 } else if use_auth {
                     let request = authenticated_media::get_content::v1::Request::from_uri(uri)?;
@@ -513,7 +513,7 @@ impl Media {
                 } else {
                     #[allow(deprecated)]
                     let request = media::get_content::v3::Request::from_url(uri)?;
-                    self.client.send(request).await?.file
+                    self.client.send(request).with_request_config(request_config).await?.file
                 }
             }
         };

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1226,12 +1226,19 @@ impl MatrixMockServer {
     }
 
     /// Create a prebuilt mock for the endpoint used to get the media config of
-    /// the homeserver.
+    /// the homeserver that requires authentication.
     pub fn mock_authenticated_media_config(
         &self,
     ) -> MockEndpoint<'_, AuthenticatedMediaConfigEndpoint> {
         let mock = Mock::given(method("GET")).and(path("/_matrix/client/v1/media/config"));
-        self.mock_endpoint(mock, AuthenticatedMediaConfigEndpoint)
+        self.mock_endpoint(mock, AuthenticatedMediaConfigEndpoint).expect_default_access_token()
+    }
+
+    /// Create a prebuilt mock for the endpoint used to get the media config of
+    /// the homeserver without requiring authentication.
+    pub fn mock_media_config(&self) -> MockEndpoint<'_, MediaConfigEndpoint> {
+        let mock = Mock::given(method("GET")).and(path("/_matrix/media/v3/config"));
+        self.mock_endpoint(mock, MediaConfigEndpoint)
     }
 
     /// Create a prebuilt mock for the endpoint used to log into a session.
@@ -3491,6 +3498,18 @@ impl<'a> MockEndpoint<'a, AuthenticatedMediaConfigEndpoint> {
     pub fn ok_default(self) -> MatrixMock<'a> {
         self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "m.upload.size": UInt::MAX,
+        })))
+    }
+}
+
+/// A prebuilt mock for `GET /_matrix/media/v3/config` request.
+pub struct MediaConfigEndpoint;
+
+impl<'a> MockEndpoint<'a, MediaConfigEndpoint> {
+    /// Returns a successful response with the provided max upload size.
+    pub fn ok(self, max_upload_size: UInt) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "m.upload.size": max_upload_size,
         })))
     }
 }


### PR DESCRIPTION
This includes 3 small commits:

1. Use the new support for (un)stable feature flags in Ruma to decide on whether we will use the authenticated media endpoints, instead of having custom code.
2. Since #5437, the request timeout was ignored in media requests, however that didn't apply to unauthenticated media endpoints because they didn't use the request config. This fixes it.
3. #5119 added a mandatory check when uploading files, using the allowed upload size advertised by the server at the media config endpoint. However that check only supports the authenticated media config endpoint, so users on servers that don't support authenticated media cannot send media anymore. We got a bug report because of that in Fractal, from a user using a private homeserver instance that doesn't support authenticated media. This adds support for the unauthenticated media config endpoint too.
