### PR TITLE
feat(crypto): Add support for encrypted state events to `matrix-sdk-crypto`

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -998,6 +998,11 @@ pub enum UnableToDecryptReason {
     /// cross-signing identity did not satisfy the requested
     /// `TrustRequirement`.
     SenderIdentityNotTrusted(VerificationLevel),
+
+    /// The outer state key could not be verified against the inner encrypted
+    /// state key and type.
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    StateKeyVerificationFailed,
 }
 
 impl UnableToDecryptReason {

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -133,6 +133,12 @@ pub enum MegolmError {
     /// The nested value is the sender's current verification level.
     #[error("decryption failed because trust requirement not satisfied: {0}")]
     SenderIdentityNotTrusted(VerificationLevel),
+
+    /// The outer state key could not be verified against the inner encrypted
+    /// state key and type.
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    #[error("decryption failed because the state key failed to validate")]
+    StateKeyVerificationFailed,
 }
 
 /// Decryption failed because of a mismatch between the identity keys of the

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1364,6 +1364,8 @@ mod tests {
         EncryptedEvent {
             sender: sender.to_owned(),
             event_id: event_id!("$143273582443PhrSn:example.org").to_owned(),
+            #[cfg(feature = "experimental-encrypted-state-events")]
+            state_key: None,
             content,
             origin_server_ts: ruma::MilliSecondsSinceUnixEpoch::now(),
             unsigned: Default::default(),

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -34,7 +34,7 @@ use matrix_sdk_common::{
     BoxFuture,
 };
 #[cfg(feature = "experimental-encrypted-state-events")]
-use ruma::events::{AnyStateEventContent, StateEventContent};
+use ruma::events::{AnyStateEvent, AnyStateEventContent, StateEventContent};
 use ruma::{
     api::client::{
         dehydrated_device::DehydratedDeviceData,
@@ -2261,9 +2261,62 @@ impl OlmMachine {
                 .await;
         }
 
-        let event = serde_json::from_value::<Raw<AnyTimelineEvent>>(decrypted_event.into())?;
+        let decrypted_event =
+            serde_json::from_value::<Raw<AnyTimelineEvent>>(decrypted_event.into())?;
 
-        Ok(DecryptedRoomEvent { event, encryption_info, unsigned_encryption_info })
+        #[cfg(feature = "experimental-encrypted-state-events")]
+        self.verify_packed_state_key(&event, &decrypted_event)?;
+
+        Ok(DecryptedRoomEvent { event: decrypted_event, encryption_info, unsigned_encryption_info })
+    }
+
+    /// If the passed event is a state event, verify its outer packed state key
+    /// matches the inner state key once unpacked.
+    ///
+    /// * `original` - The original encrypted event received over the wire.
+    /// * `decrypted` - The decrypted event.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if
+    ///
+    /// * The original event's state key failed to unpack;
+    /// * The decrypted event could not be deserialised;
+    /// * The unpacked event type does not match the type of the decrypted
+    ///   event;
+    /// * The unpacked event state key does not match the state key of the
+    ///   decrypted event.
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    pub fn verify_packed_state_key(
+        &self,
+        original: &EncryptedEvent,
+        decrypted: &Raw<AnyTimelineEvent>,
+    ) -> MegolmResult<()> {
+        // We only need to verify state events.
+        let Some(raw_state_key) = &original.state_key else { return Ok(()) };
+
+        // Unpack event type and state key from the raw state key.
+        let (outer_event_type, outer_state_key) =
+            raw_state_key.split_once(":").ok_or(MegolmError::StateKeyVerificationFailed)?;
+
+        // Deserialize the decrypted event.
+        let AnyTimelineEvent::State(inner) =
+            decrypted.deserialize().map_err(MegolmError::JsonError)?
+        else {
+            return Err(MegolmError::StateKeyVerificationFailed);
+        };
+
+        // Check event types match, discard if not.
+        let inner_event_type = inner.event_type().to_string();
+        if outer_event_type != inner_event_type {
+            return Err(MegolmError::StateKeyVerificationFailed);
+        }
+
+        // Check state keys match, discard if not.
+        if outer_state_key != inner.state_key() {
+            return Err(MegolmError::StateKeyVerificationFailed);
+        }
+        Ok(())
     }
 
     /// Try to decrypt the events bundled in the `unsigned` object of the given
@@ -3034,6 +3087,8 @@ fn megolm_error_to_utd_info(
         JsonError(_) => UnableToDecryptReason::PayloadDeserializationFailure,
         MismatchedIdentityKeys(_) => UnableToDecryptReason::MismatchedIdentityKeys,
         SenderIdentityNotTrusted(level) => UnableToDecryptReason::SenderIdentityNotTrusted(level),
+        #[cfg(feature = "experimental-encrypted-state-events")]
+        StateKeyVerificationFailed => UnableToDecryptReason::StateKeyVerificationFailed,
 
         // Pass through crypto store errors, which indicate a problem with our
         // application, rather than a UTD.

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -26,6 +26,11 @@ use matrix_sdk_common::{
     executor::spawn,
 };
 use matrix_sdk_test::{async_test, message_like_event_content, ruma_response_from_json, test_json};
+#[cfg(feature = "experimental-encrypted-state-events")]
+use ruma::events::{
+    room::topic::{OriginalRoomTopicEvent, RoomTopicEventContent},
+    StateEvent,
+};
 use ruma::{
     api::client::{
         keys::{get_keys, upload_keys},
@@ -716,6 +721,104 @@ async fn test_megolm_encryption() {
         } else {
             panic!("Decrypted event has a mismatched content");
         }
+    } else {
+        panic!("Decrypted room event has the wrong type");
+    }
+
+    // Just decrypting the event should *not* cause an update on the
+    // inbound_group_session_stream.
+    if let Some(igs) = room_keys_received_stream.next().now_or_never() {
+        panic!("Session stream unexpectedly returned update: {igs:?}");
+    }
+}
+
+#[cfg(feature = "experimental-encrypted-state-events")]
+#[async_test]
+async fn test_megolm_state_encryption() {
+    use ruma::events::{AnyStateEvent, EmptyStateKey};
+
+    let (alice, bob) =
+        get_machine_pair_with_setup_sessions_test_helper(alice_id(), user_id(), false).await;
+    let room_id = room_id!("!test:example.org");
+
+    let to_device_requests = alice
+        .share_room_key(room_id, iter::once(bob.user_id()), EncryptionSettings::default())
+        .await
+        .unwrap();
+
+    let event = ToDeviceEvent::new(
+        alice.user_id().to_owned(),
+        to_device_requests_to_content(to_device_requests),
+    );
+
+    let mut room_keys_received_stream = Box::pin(bob.store().room_keys_received_stream());
+
+    let decryption_settings =
+        DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
+
+    let group_session = bob
+        .store()
+        .with_transaction(|mut tr| async {
+            let res = bob
+                .decrypt_to_device_event(
+                    &mut tr,
+                    &event,
+                    &mut Changes::default(),
+                    &decryption_settings,
+                )
+                .await?;
+            Ok((tr, res))
+        })
+        .await
+        .unwrap()
+        .inbound_group_session
+        .unwrap();
+    let sessions = std::slice::from_ref(&group_session);
+    bob.store().save_inbound_group_sessions(sessions).await.unwrap();
+
+    // when we decrypt the room key, the
+    // inbound_group_session_streamroom_keys_received_stream should tell us
+    // about it.
+    let room_keys = room_keys_received_stream
+        .next()
+        .now_or_never()
+        .flatten()
+        .expect("We should have received an update of room key infos")
+        .unwrap();
+    assert_eq!(room_keys.len(), 1);
+    assert_eq!(room_keys[0].session_id, group_session.session_id());
+
+    let plaintext = "It is a secret to everybody";
+
+    let content = RoomTopicEventContent::new(plaintext.to_owned());
+
+    let encrypted_content =
+        alice.encrypt_state_event(room_id, content, EmptyStateKey).await.unwrap();
+
+    let event = json!({
+        "event_id": "$xxxxx:example.org",
+        "origin_server_ts": MilliSecondsSinceUnixEpoch::now(),
+        "sender": alice.user_id(),
+        "type": "m.room.encrypted",
+        "content": encrypted_content,
+    });
+
+    let event = json_convert(&event).unwrap();
+
+    let decryption_settings =
+        DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
+
+    let decryption_result =
+        bob.try_decrypt_room_event(&event, room_id, &decryption_settings).await.unwrap();
+    assert_let!(RoomEventDecryptionResult::Decrypted(decrypted_event) = decryption_result);
+    let decrypted_event = decrypted_event.event.deserialize().unwrap();
+
+    if let AnyTimelineEvent::State(AnyStateEvent::RoomTopic(StateEvent::Original(
+        OriginalRoomTopicEvent { sender, content, .. },
+    ))) = decrypted_event
+    {
+        assert_eq!(&sender, alice.user_id());
+        assert_eq!(&content.topic, plaintext);
     } else {
         panic!("Decrypted room event has the wrong type");
     }

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -800,6 +800,7 @@ async fn test_megolm_state_encryption() {
         "origin_server_ts": MilliSecondsSinceUnixEpoch::now(),
         "sender": alice.user_id(),
         "type": "m.room.encrypted",
+        "state_key": "m.room.topic:",
         "content": encrypted_content,
     });
 

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -25,6 +25,8 @@ use std::{
 };
 
 use matrix_sdk_common::{deserialized_responses::WithheldCode, locks::RwLock as StdRwLock};
+#[cfg(feature = "experimental-encrypted-state-events")]
+use ruma::events::AnyStateEventContent;
 use ruma::{
     events::{
         room::{encryption::RoomEncryptionEventContent, history_visibility::HistoryVisibility},
@@ -458,6 +460,50 @@ impl OutboundGroupSession {
         session.encrypt(&plaintext)
     }
 
+    /// Encrypt an arbitrary event for the given room.
+    ///
+    /// Beware that a room key needs to be shared before this method
+    /// can be called using the `share_room_key()` method.
+    ///
+    /// # Arguments
+    ///
+    /// * `payload` - The plaintext content of the event that should be
+    ///   encrypted in raw JSON form.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the content can't be serialized.
+    async fn encrypt_inner<T: Serialize>(
+        &self,
+        payload: &T,
+        relates_to: Option<serde_json::Value>,
+    ) -> Raw<RoomEncryptedEventContent> {
+        let ciphertext = self
+            .encrypt_helper(
+                serde_json::to_string(payload).expect("payload serialization never fails"),
+            )
+            .await;
+        let scheme: RoomEventEncryptionScheme = match self.settings.algorithm {
+            EventEncryptionAlgorithm::MegolmV1AesSha2 => MegolmV1AesSha2Content {
+                ciphertext,
+                sender_key: Some(self.account_identity_keys.curve25519),
+                session_id: self.session_id().to_owned(),
+                device_id: Some(self.device_id.clone()),
+            }
+            .into(),
+            #[cfg(feature = "experimental-algorithms")]
+            EventEncryptionAlgorithm::MegolmV2AesSha2 => {
+                MegolmV2AesSha2Content { ciphertext, session_id: self.session_id().to_owned() }
+                    .into()
+            }
+            _ => unreachable!(
+                "An outbound group session is always using one of the supported algorithms"
+            ),
+        };
+        let content = RoomEncryptedEventContent { scheme, relates_to, other: Default::default() };
+        Raw::new(&content).expect("m.room.encrypted event content can always be serialized")
+    }
+
     /// Encrypt a room message for the given room.
     ///
     /// Beware that a room key needs to be shared before this method
@@ -488,35 +534,51 @@ impl OutboundGroupSession {
         }
 
         let payload = Payload { event_type, content, room_id: &self.room_id };
-        let payload_json =
-            serde_json::to_string(&payload).expect("payload serialization never fails");
 
         let relates_to = content
             .get_field::<serde_json::Value>("m.relates_to")
             .expect("serde_json::Value deserialization with valid JSON input never fails");
 
-        let ciphertext = self.encrypt_helper(payload_json).await;
-        let scheme: RoomEventEncryptionScheme = match self.settings.algorithm {
-            EventEncryptionAlgorithm::MegolmV1AesSha2 => MegolmV1AesSha2Content {
-                ciphertext,
-                sender_key: Some(self.account_identity_keys.curve25519),
-                session_id: self.session_id().to_owned(),
-                device_id: Some(self.device_id.clone()),
-            }
-            .into(),
-            #[cfg(feature = "experimental-algorithms")]
-            EventEncryptionAlgorithm::MegolmV2AesSha2 => {
-                MegolmV2AesSha2Content { ciphertext, session_id: self.session_id().to_owned() }
-                    .into()
-            }
-            _ => unreachable!(
-                "An outbound group session is always using one of the supported algorithms"
-            ),
-        };
+        self.encrypt_inner(&payload, relates_to).await
+    }
 
-        let content = RoomEncryptedEventContent { scheme, relates_to, other: Default::default() };
+    /// Encrypt a room state event for the given room.
+    ///
+    /// Beware that a room key needs to be shared before this method
+    /// can be called using the `share_room_key()` method.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` - The plaintext type of the event, the outer type of the
+    ///   event will become `m.room.encrypted`.
+    ///
+    /// * `state_key` - The plaintext state key of the event, the outer state
+    ///   key will be derived from this and the event type.
+    ///
+    /// * `content` - The plaintext content of the message that should be
+    ///   encrypted in raw JSON form.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the content can't be serialized.
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    pub async fn encrypt_state(
+        &self,
+        event_type: &str,
+        state_key: &str,
+        content: &Raw<AnyStateEventContent>,
+    ) -> Raw<RoomEncryptedEventContent> {
+        #[derive(Serialize)]
+        struct Payload<'a> {
+            #[serde(rename = "type")]
+            event_type: &'a str,
+            state_key: &'a str,
+            content: &'a Raw<AnyStateEventContent>,
+            room_id: &'a RoomId,
+        }
 
-        Raw::new(&content).expect("m.room.encrypted event content can always be serialized")
+        let payload = Payload { event_type, state_key, content, room_id: &self.room_id };
+        self.encrypt_inner(&payload, None).await.cast_unchecked()
     }
 
     fn elapsed(&self) -> bool {

--- a/crates/matrix-sdk-crypto/src/types/events/room/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room/mod.rs
@@ -36,6 +36,10 @@ where
     /// The globally unique identifier for this event.
     pub event_id: OwnedEventId,
 
+    /// Present if and only if this event is a state event.
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    pub state_key: Option<String>,
+
     /// The body of this event, as created by the client which sent it.
     pub content: C,
 


### PR DESCRIPTION
Depends on #5511, #5512 and #5523.

- [ ] Add `OutboundGroupSession::encrypt_state`.
- [ ] Add `GroupSessionManager::encrypt_state` and a private helper function `::encrypt_inner`.
- [ ] Add `OlmMachine::encrypt_state_event` and `::encrypt_state_event_raw`.
- [ ] Add naive state key unpacking and verification to `OlmMachine::decrypt_room_event_inner`.
