### PR TITLE
feat(test): add a test utils crate to make log initialization possible everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-test-utils"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "ctor",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-test-utils"
-version = "0.13.0"
+version = "0.1.0"
 dependencies = [
  "ctor",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,6 +3183,7 @@ dependencies = [
  "insta",
  "js-sys",
  "matrix-sdk-test-macros",
+ "matrix-sdk-test-utils",
  "proptest",
  "ruma",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3092,6 +3092,7 @@ dependencies = [
  "matrix-sdk-indexeddb",
  "matrix-sdk-sqlite",
  "matrix-sdk-test",
+ "matrix-sdk-test-utils",
  "mime",
  "mime2ext",
  "oauth2",
@@ -3150,6 +3151,7 @@ dependencies = [
  "matrix-sdk-crypto",
  "matrix-sdk-store-encryption",
  "matrix-sdk-test",
+ "matrix-sdk-test-utils",
  "once_cell",
  "regex",
  "ruma",
@@ -3225,6 +3227,7 @@ dependencies = [
  "matrix-sdk-common",
  "matrix-sdk-qrcode",
  "matrix-sdk-test",
+ "matrix-sdk-test-utils",
  "pbkdf2",
  "proptest",
  "rand",
@@ -3381,6 +3384,7 @@ dependencies = [
  "matrix-sdk-base",
  "matrix-sdk-common",
  "matrix-sdk-test",
+ "matrix-sdk-test-utils",
  "matrix-sdk-ui",
  "once_cell",
  "rand",
@@ -3432,6 +3436,7 @@ dependencies = [
  "matrix-sdk-crypto",
  "matrix-sdk-store-encryption",
  "matrix-sdk-test",
+ "matrix-sdk-test-utils",
  "num_cpus",
  "once_cell",
  "rmp-serde",
@@ -3499,6 +3504,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrix-sdk-test-utils"
+version = "0.13.0"
+dependencies = [
+ "ctor",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "matrix-sdk-ui"
 version = "0.13.0"
 dependencies = [
@@ -3527,6 +3540,7 @@ dependencies = [
  "matrix-sdk-base",
  "matrix-sdk-common",
  "matrix-sdk-test",
+ "matrix-sdk-test-utils",
  "mime",
  "once_cell",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ matrix-sdk-qrcode = { path = "crates/matrix-sdk-qrcode", version = "0.13.0" }
 matrix-sdk-sqlite = { path = "crates/matrix-sdk-sqlite", version = "0.13.0", default-features = false }
 matrix-sdk-store-encryption = { path = "crates/matrix-sdk-store-encryption", version = "0.13.0" }
 matrix-sdk-test = { path = "testing/matrix-sdk-test", version = "0.13.0" }
-matrix-sdk-test-utils = { path = "testing/matrix-sdk-test-utils", version = "0.13.0" }
+matrix-sdk-test-utils = { path = "testing/matrix-sdk-test-utils", version = "0.1.0" }
 matrix-sdk-ui = { path = "crates/matrix-sdk-ui", version = "0.13.0", default-features = false }
 matrix-sdk-search = { path = "crates/matrix-sdk-search", version = "0.13.0" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ matrix-sdk-qrcode = { path = "crates/matrix-sdk-qrcode", version = "0.13.0" }
 matrix-sdk-sqlite = { path = "crates/matrix-sdk-sqlite", version = "0.13.0", default-features = false }
 matrix-sdk-store-encryption = { path = "crates/matrix-sdk-store-encryption", version = "0.13.0" }
 matrix-sdk-test = { path = "testing/matrix-sdk-test", version = "0.13.0" }
-matrix-sdk-test-utils = { path = "testing/matrix-sdk-test-utils", version = "0.1.0" }
+matrix-sdk-test-utils = { path = "testing/matrix-sdk-test-utils", version = "0.13.0" }
 matrix-sdk-ui = { path = "crates/matrix-sdk-ui", version = "0.13.0", default-features = false }
 matrix-sdk-search = { path = "crates/matrix-sdk-search", version = "0.13.0" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ matrix-sdk-qrcode = { path = "crates/matrix-sdk-qrcode", version = "0.13.0" }
 matrix-sdk-sqlite = { path = "crates/matrix-sdk-sqlite", version = "0.13.0", default-features = false }
 matrix-sdk-store-encryption = { path = "crates/matrix-sdk-store-encryption", version = "0.13.0" }
 matrix-sdk-test = { path = "testing/matrix-sdk-test", version = "0.13.0" }
+matrix-sdk-test-utils = { path = "testing/matrix-sdk-test-utils", version = "0.13.0" }
 matrix-sdk-ui = { path = "crates/matrix-sdk-ui", version = "0.13.0", default-features = false }
 matrix-sdk-search = { path = "crates/matrix-sdk-search", version = "0.13.0" }
 

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -93,6 +93,7 @@ assign = "1.1.1"
 futures-executor.workspace = true
 http.workspace = true
 matrix-sdk-test.workspace = true
+matrix-sdk-test-utils.workspace = true
 similar-asserts.workspace = true
 stream_assert.workspace = true
 

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -69,7 +69,7 @@ pub use utils::{
 };
 
 #[cfg(test)]
-matrix_sdk_test::init_tracing_for_tests!();
+matrix_sdk_test_utils::init_tracing_for_tests!();
 
 /// The Matrix user session info.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -55,6 +55,7 @@ assert_matches.workspace = true
 assert_matches2.workspace = true
 insta.workspace = true
 matrix-sdk-test-macros = { path = "../../testing/matrix-sdk-test-macros" }
+matrix-sdk-test-utils.workspace = true
 proptest.workspace = true
 wasm-bindgen-test.workspace = true
 

--- a/crates/matrix-sdk-common/src/executor.rs
+++ b/crates/matrix-sdk-common/src/executor.rs
@@ -25,9 +25,6 @@ use std::{
     task::{Context, Poll},
 };
 
-#[cfg(test)]
-matrix_sdk_test_utils::init_tracing_for_tests!();
-
 #[cfg(not(target_family = "wasm"))]
 mod sys {
     pub use tokio::{

--- a/crates/matrix-sdk-common/src/executor.rs
+++ b/crates/matrix-sdk-common/src/executor.rs
@@ -25,6 +25,9 @@ use std::{
     task::{Context, Poll},
 };
 
+#[cfg(test)]
+matrix_sdk_test_utils::init_tracing_for_tests!();
+
 #[cfg(not(target_family = "wasm"))]
 mod sys {
     pub use tokio::{

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -17,6 +17,10 @@
 
 use std::pin::Pin;
 
+#[cfg(test)]
+matrix_sdk_test_utils::init_tracing_for_tests!();
+
+
 use futures_core::Future;
 #[doc(no_inline)]
 pub use ruma;

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -20,7 +20,6 @@ use std::pin::Pin;
 #[cfg(test)]
 matrix_sdk_test_utils::init_tracing_for_tests!();
 
-
 use futures_core::Future;
 #[doc(no_inline)]
 pub use ruma;

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -88,6 +88,7 @@ http.workspace = true
 indoc = "2.0.5"
 insta.workspace = true
 matrix-sdk-test.workspace = true
+matrix-sdk-test-utils.workspace = true
 proptest.workspace = true
 rmp-serde.workspace = true
 similar-asserts.workspace = true

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -114,7 +114,7 @@ pub use vodozemac;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(test)]
-matrix_sdk_test::init_tracing_for_tests!();
+matrix_sdk_test_utils::init_tracing_for_tests!();
 
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -46,6 +46,7 @@ matrix-sdk-base = { workspace = true, features = ["testing"] }
 matrix-sdk-common.workspace = true
 matrix-sdk-crypto = { workspace = true, features = ["testing"] }
 matrix-sdk-test.workspace = true
+matrix-sdk-test-utils.workspace = true
 once_cell.workspace = true
 similar-asserts.workspace = true
 tempfile.workspace = true

--- a/crates/matrix-sdk-sqlite/src/lib.rs
+++ b/crates/matrix-sdk-sqlite/src/lib.rs
@@ -41,7 +41,7 @@ pub use self::event_cache_store::SqliteEventCacheStore;
 pub use self::state_store::{SqliteStateStore, DATABASE_NAME as STATE_STORE_DATABASE_NAME};
 
 #[cfg(test)]
-matrix_sdk_test::init_tracing_for_tests!();
+matrix_sdk_test_utils::init_tracing_for_tests!();
 
 /// A configuration structure used for opening a store.
 #[derive(Clone)]

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -69,6 +69,7 @@ assert_matches2.workspace = true
 eyeball-im-util.workspace = true
 matrix-sdk = { workspace = true, features = ["testing", "sqlite"] }
 matrix-sdk-test.workspace = true
+matrix-sdk-test-utils.workspace = true
 stream_assert.workspace = true
 tempfile.workspace = true
 url.workspace = true

--- a/crates/matrix-sdk-ui/src/lib.rs
+++ b/crates/matrix-sdk-ui/src/lib.rs
@@ -31,7 +31,7 @@ pub use self::{room_list_service::RoomListService, timeline::Timeline};
 const DEFAULT_SANITIZER_MODE: HtmlSanitizerMode = HtmlSanitizerMode::Compat;
 
 #[cfg(test)]
-matrix_sdk_test::init_tracing_for_tests!();
+matrix_sdk_test_utils::init_tracing_for_tests!();
 
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -29,7 +29,7 @@ mod sliding_sync;
 mod sync_service;
 mod timeline;
 
-matrix_sdk_test::init_tracing_for_tests!();
+matrix_sdk_test_utils::init_tracing_for_tests!();
 
 /// Mount a Mock on the given server to handle the `GET /sync` endpoint with
 /// an optional `since` param that returns a 200 status code with the given

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -150,6 +150,7 @@ futures-executor.workspace = true
 insta.workspace = true
 matrix-sdk-base = { workspace = true, features = ["testing"] }
 matrix-sdk-test.workspace = true
+matrix-sdk-test-utils.workspace = true
 serde_urlencoded = "0.7.1"
 similar-asserts.workspace = true
 stream_assert.workspace = true

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -98,4 +98,4 @@ pub mod live_location_share;
 pub mod test_utils;
 
 #[cfg(test)]
-matrix_sdk_test::init_tracing_for_tests!();
+matrix_sdk_test_utils::init_tracing_for_tests!();

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -22,7 +22,7 @@ mod send_queue;
 #[cfg(feature = "experimental-widgets")]
 mod widget;
 
-matrix_sdk_test::init_tracing_for_tests!();
+matrix_sdk_test_utils::init_tracing_for_tests!();
 
 /// Mount a Mock on the given server to handle the `GET /sync` endpoint with
 /// an optional `since` param that returns a 200 status code with the given

--- a/testing/matrix-sdk-integration-testing/Cargo.toml
+++ b/testing/matrix-sdk-integration-testing/Cargo.toml
@@ -25,6 +25,7 @@ matrix-sdk = { workspace = true, default-features = true, features = ["testing",
 matrix-sdk-base = { workspace = true, default-features = true, features = ["testing", "qrcode"] }
 matrix-sdk-common.workspace = true
 matrix-sdk-test.workspace = true
+matrix-sdk-test-utils.workspace = true
 matrix-sdk-ui = { workspace = true, default-features = true }
 once_cell.workspace = true
 rand.workspace = true

--- a/testing/matrix-sdk-integration-testing/src/lib.rs
+++ b/testing/matrix-sdk-integration-testing/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-matrix_sdk_test::init_tracing_for_tests!();
+matrix_sdk_test_utils::init_tracing_for_tests!();
 
 mod helpers;
 mod tests;

--- a/testing/matrix-sdk-test-utils/Cargo.toml
+++ b/testing/matrix-sdk-test-utils/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-edition = "2024"
 homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ruma"]
 license = "Apache-2.0"

--- a/testing/matrix-sdk-test-utils/Cargo.toml
+++ b/testing/matrix-sdk-test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-sdk-test-utils"
-version = "0.13.0"
+version = "0.1.0"
 edition = "2024"
 rust-version.workspace = true
 

--- a/testing/matrix-sdk-test-utils/Cargo.toml
+++ b/testing/matrix-sdk-test-utils/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
+edition = "2024"
+homepage = "https://github.com/matrix-org/matrix-rust-sdk"
+keywords = ["matrix", "chat", "messaging", "ruma"]
+license = "Apache-2.0"
 name = "matrix-sdk-test-utils"
 version = "0.1.0"
 edition = "2024"
 rust-version.workspace = true
+
+[package.metadata.release]
+release = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 ctor = "0.2.9"

--- a/testing/matrix-sdk-test-utils/Cargo.toml
+++ b/testing/matrix-sdk-test-utils/Cargo.toml
@@ -3,7 +3,7 @@ homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ruma"]
 license = "Apache-2.0"
 name = "matrix-sdk-test-utils"
-version = "0.1.0"
+version = "0.13.0"
 edition = "2024"
 rust-version.workspace = true
 

--- a/testing/matrix-sdk-test-utils/Cargo.toml
+++ b/testing/matrix-sdk-test-utils/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "matrix-sdk-test-utils"
+version = "0.13.0"
+edition = "2024"
+rust-version.workspace = true
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+ctor = "0.2.9"
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[lints]
+workspace = true

--- a/testing/matrix-sdk-test-utils/README.md
+++ b/testing/matrix-sdk-test-utils/README.md
@@ -1,0 +1,1 @@
+ Utils function for the test helpers

--- a/testing/matrix-sdk-test-utils/src/lib.rs
+++ b/testing/matrix-sdk-test-utils/src/lib.rs
@@ -1,0 +1,41 @@
+/// Initialize a tracing subscriber if the target architecture is not WASM.
+///
+/// Uses a sensible default filter that can be overridden through the `RUST_LOG`
+/// environment variable and runs once before all tests by using the [`ctor`]
+/// crate.
+///
+/// Invoke this macro once per compilation unit (`lib.rs`, `tests/*.rs`,
+/// `tests/*/main.rs`).
+#[macro_export]
+macro_rules! init_tracing_for_tests {
+    () => {
+        #[cfg(not(target_family = "wasm"))]
+        #[$crate::__macro_support::ctor]
+        fn init_logging() {
+            use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+            use $crate::__macro_support::tracing_subscriber;
+
+            tracing_subscriber::registry()
+                .with(tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                    // Output is only printed for failing tests, but still we shouldn't overload
+                    // the output with unnecessary info. When debugging a specific test, it's easy
+                    // to override this default by setting the `RUST_LOG` environment variable.
+                    //
+                    // Since tracing_subscriber does prefix matching, the `matrix_sdk=` directive
+                    // takes effect for all the main crates (`matrix_sdk_base`, `matrix_sdk_crypto`
+                    // and so on).
+                    "info,matrix_sdk=debug".into()
+                }))
+                .with(tracing_subscriber::fmt::layer().with_test_writer())
+                .init();
+        }
+    };
+}
+
+#[doc(hidden)]
+pub mod __macro_support {
+    #[cfg(not(target_family = "wasm"))]
+    pub use ctor::ctor;
+    #[cfg(not(target_family = "wasm"))]
+    pub use tracing_subscriber;
+}

--- a/testing/matrix-sdk-test/src/lib.rs
+++ b/testing/matrix-sdk-test/src/lib.rs
@@ -72,48 +72,6 @@ macro_rules! stripped_state_event {
     }
 }
 
-/// Initialize a tracing subscriber if the target architecture is not WASM.
-///
-/// Uses a sensible default filter that can be overridden through the `RUST_LOG`
-/// environment variable and runs once before all tests by using the [`ctor`]
-/// crate.
-///
-/// Invoke this macro once per compilation unit (`lib.rs`, `tests/*.rs`,
-/// `tests/*/main.rs`).
-#[macro_export]
-macro_rules! init_tracing_for_tests {
-    () => {
-        #[cfg(not(target_family = "wasm"))]
-        #[$crate::__macro_support::ctor]
-        fn init_logging() {
-            use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-            use $crate::__macro_support::tracing_subscriber;
-
-            tracing_subscriber::registry()
-                .with(tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                    // Output is only printed for failing tests, but still we shouldn't overload
-                    // the output with unnecessary info. When debugging a specific test, it's easy
-                    // to override this default by setting the `RUST_LOG` environment variable.
-                    //
-                    // Since tracing_subscriber does prefix matching, the `matrix_sdk=` directive
-                    // takes effect for all the main crates (`matrix_sdk_base`, `matrix_sdk_crypto`
-                    // and so on).
-                    "info,matrix_sdk=debug".into()
-                }))
-                .with(tracing_subscriber::fmt::layer().with_test_writer())
-                .init();
-        }
-    };
-}
-
-#[doc(hidden)]
-pub mod __macro_support {
-    #[cfg(not(target_family = "wasm"))]
-    pub use ctor::ctor;
-    #[cfg(not(target_family = "wasm"))]
-    pub use tracing_subscriber;
-}
-
 #[cfg(not(target_family = "wasm"))]
 pub mod mocks;
 


### PR DESCRIPTION
This PR allows `init_tracing_for_test` to be called by any other crate in the sdk

Signed-off-by: multi [multiestunhappydev@gmail.com](mailto:multiestunhappydev@gmail.com)

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/5292