### PR TITLE
refactor!(ffi): always use the send queue and remove legacy media upload progress

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking changes:
 
+- The timeline will now always use the send queue to upload medias, so the
+  `UploadParameters::use_send_queue` bool has been removed. Make sure to listen to the send queue's
+  error updates, and to handle send queue restarts.
+  ([#5525](https://github.com/matrix-org/matrix-rust-sdk/pull/5525))
 - Support for the legacy media upload progress has been disabled. Media upload progress is
   available through the send queue, and can be enabled thanks to
   `Client::enable_send_queue_upload_progress()`.

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking changes:
 
+- Support for the legacy media upload progress has been disabled. Media upload progress is
+  available through the send queue, and can be enabled thanks to
+  `Client::enable_send_queue_upload_progress()`.
+  ([#5525](https://github.com/matrix-org/matrix-rust-sdk/pull/5525))
 - `TimelineDiff` is now exported as a true `uniffi::Enum` instead of the weird `uniffi::Object` hybrid. This matches
   both `RoomDirectorySearchEntryUpdate` and `RoomListEntriesUpdate` and can be used in the same way.
   ([#5474](https://github.com/matrix-org/matrix-rust-sdk/pull/5474))


### PR DESCRIPTION
Now that the we media upload progress in the timeline, thanks to @Johennes, we can remove the legacy support, so as to make the API less confusing (before, one could use a `progress_watcher` *and* enable the send queue media upload progress at the same time, and it wasn't clear how these two API would interact / which would be enabled).

Also always use the send queue for media uploads, as it's generally better, stable (after months in production in the EX apps).