### PR TITLE
feat(timeline): consider unthreaded read receipts for `ReceiptThread::Main` timelines when computing timeline items states.

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -515,8 +515,9 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
                 }
 
                 for (user_id, receipt) in receipts {
-                    if own_receipt_thread == ReceiptThread::Unthreaded {
-                        // If the own receipt thread is unthreaded, we maintain maximal
+                    if matches!(own_receipt_thread, ReceiptThread::Unthreaded | ReceiptThread::Main)
+                    {
+                        // If the own receipt thread is unthreaded or main, we maintain maximal
                         // compatibility with clients using either unthreaded or main-thread read
                         // receipts by allowing both here.
                         if !matches!(

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -894,4 +894,6 @@ async fn test_unthreaded_client_updates_threaded_read_receipts() {
     let event_b = timeline.controller.items().await[2].as_event().unwrap().to_owned();
     assert_eq!(event_b.read_receipts().len(), 1);
     assert!(event_b.read_receipts().get(*BOB).is_some());
+
+    assert_pending!(stream);
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -845,6 +845,7 @@ async fn test_unthreaded_client_updates_threaded_read_receipts() {
     assert_next_matches!(stream, VectorDiff::PushBack { .. });
     assert_next_matches!(stream, VectorDiff::PushFront { .. });
     assert_next_matches!(stream, VectorDiff::PushBack { .. });
+    assert_pending!(stream);
 
     // Bob reads the last one from an unthreaded client
     timeline
@@ -859,6 +860,38 @@ async fn test_unthreaded_client_updates_threaded_read_receipts() {
     // Alice's timeline gets updated
     let item_b = assert_next_matches!(stream, VectorDiff::Set { index: 2, value } => value);
     let event_b = item_b.as_event().unwrap();
+    assert_eq!(event_b.read_receipts().len(), 1);
+    assert!(event_b.read_receipts().get(*BOB).is_some());
+    assert_pending!(stream);
+
+    // Then Alice sends a message in a thread
+    let event_c = event_id!("$event_c");
+    let thread_event_id = event_id!("$thread");
+
+    timeline
+        .handle_live_event(
+            f.text_msg("C")
+                .sender(*ALICE)
+                .event_id(event_c)
+                .in_thread(thread_event_id, event_id!("$latest")),
+        )
+        .await;
+
+    // Alice is using a threaded client so the main timeline shouldn't change
+    assert_pending!(stream);
+
+    // Bob reads the threaded message
+    timeline
+        .handle_read_receipts([(
+            event_c.to_owned(),
+            ReceiptType::Read,
+            BOB.to_owned(),
+            ReceiptThread::Thread(thread_event_id.to_owned()),
+        )])
+        .await;
+
+    // The main timeline read receipts are still correct
+    let event_b = timeline.controller.items().await[2].as_event().unwrap().to_owned();
     assert_eq!(event_b.read_receipts().len(), 1);
     assert!(event_b.read_receipts().get(*BOB).is_some());
 }


### PR DESCRIPTION
This patch updates the Timeline Controller's `handle_explicit_read_receipts` method to also consider unthreaded read receipts on **threaded** **main** timelines when calculating timeline items states and adds a test for it.

This picks up from #5442 and fixes https://github.com/matrix-org/matrix-rust-sdk/issues/5440