### PR TITLE
chore: check in the updated compatible ruma version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,7 +4812,7 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.17.1"
-source = "git+https://github.com/ruma/ruma?rev=e73f302e4df7f5f0511fca1aa43853d4cf8416c8#e73f302e4df7f5f0511fca1aa43853d4cf8416c8"
+source = "git+https://github.com/ruma/ruma?rev=0ecd23c32c58be9328fa5f3e33fe0458cc139213#0ecd23c32c58be9328fa5f3e33fe0458cc139213"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3033,7 +3033,6 @@ pub(crate) mod tests {
 
     use super::Client;
     use crate::{
-        assert_let_timeout,
         client::{futures::SendMediaUploadRequest, WeakClient},
         config::{RequestConfig, SyncSettings},
         futures::SendRequest,
@@ -3963,7 +3962,12 @@ pub(crate) mod tests {
 
         // Call the endpoint once to check the timeout.
         let mut stream = Box::pin(client.sync_stream(SyncSettings::new()).await);
-        assert_let_timeout!(Some(Ok(_)) = stream.next());
+
+        timeout(Duration::from_secs(1), async {
+            stream.next().await.unwrap().unwrap();
+        })
+        .await
+        .unwrap();
     }
 
     #[async_test]
@@ -3992,7 +3996,12 @@ pub(crate) mod tests {
         let mut stream = Box::pin(
             client.sync_stream(SyncSettings::new().ignore_timeout_on_first_sync(true)).await,
         );
-        assert_let_timeout!(Some(Ok(_)) = stream.next());
-        assert_let_timeout!(Some(Ok(_)) = stream.next());
+
+        timeout(Duration::from_secs(1), async {
+            stream.next().await.unwrap().unwrap();
+            stream.next().await.unwrap().unwrap();
+        })
+        .await
+        .unwrap();
     }
 }


### PR DESCRIPTION
Likely a fallout of a race merging two PRs (a ruma bump + the introduction of the ruma-signatures usage).