### PR TITLE
feat: Experimental encrypted state feature flag with CI support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           - no-sqlite
           - no-encryption-and-sqlite
           - sqlite-cryptostore
+          - experimental-encrypted-state-events
           - rustls-tls
           - markdown
           - socks

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -31,6 +31,15 @@ automatic-room-key-forwarding = [
 experimental-send-custom-to-device = [
     "matrix-sdk-crypto?/experimental-send-custom-to-device",
 ]
+
+# Enable experimental support for encrypting state events; see
+# https://github.com/matrix-org/matrix-rust-sdk/issues/5397.
+experimental-encrypted-state-events = [
+    "e2e-encryption",
+    "ruma/unstable-msc3414",
+    "matrix-sdk-crypto?/experimental-encrypted-state-events"
+]
+
 uniffi = ["dep:uniffi", "matrix-sdk-crypto?/uniffi", "matrix-sdk-common/uniffi"]
 
 # Private feature, see

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -24,6 +24,10 @@ uniffi = ["dep:uniffi"]
 # details.
 test-send-sync = []
 
+# Enable experimental support for encrypting state events; see
+# https://github.com/matrix-org/matrix-rust-sdk/issues/5397.
+experimental-encrypted-state-events = []
+
 [dependencies]
 eyeball-im.workspace = true
 futures-core.workspace = true

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -21,7 +21,9 @@ experimental-send-custom-to-device = []
 
 # Enable experimental support for encrypting state events; see
 # https://github.com/matrix-org/matrix-rust-sdk/issues/5397.
-experimental-encrypted-state-events = []
+experimental-encrypted-state-events = [
+    "matrix-sdk-common/experimental-encrypted-state-events"
+]
 
 js = ["ruma/js", "vodozemac/js", "matrix-sdk-common/js"]
 qrcode = ["dep:matrix-sdk-qrcode"]

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -1163,6 +1163,8 @@ macro_rules! cryptostore_integration_tests {
                 let room_1 = room_id!("!test_1:localhost");
                 let settings_1 = RoomSettings {
                     algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+                    #[cfg(feature = "experimental-encrypted-state-events")]
+                    encrypt_state_events: false,
                     only_allow_trusted_devices: true,
                     session_rotation_period: Some(Duration::from_secs(10)),
                     session_rotation_period_messages: Some(123),

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -19,6 +19,10 @@ crypto-store = ["dep:matrix-sdk-crypto"]
 event-cache = ["dep:matrix-sdk-base"]
 state-store = ["dep:matrix-sdk-base"]
 
+experimental-encrypted-state-events = [
+    "matrix-sdk-crypto?/experimental-encrypted-state-events"
+]
+
 [dependencies]
 as_variant.workspace = true
 async-trait.workspace = true

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -46,6 +46,15 @@ indexeddb = ["matrix-sdk-indexeddb/state-store"]
 qrcode = ["e2e-encryption", "matrix-sdk-base/qrcode"]
 automatic-room-key-forwarding = ["e2e-encryption", "matrix-sdk-base/automatic-room-key-forwarding"]
 experimental-send-custom-to-device = ["e2e-encryption", "matrix-sdk-base/experimental-send-custom-to-device"]
+
+# Enable experimental support for encrypting state events; see
+# https://github.com/matrix-org/matrix-rust-sdk/issues/5397.
+experimental-encrypted-state-events = [
+    "e2e-encryption",
+    "matrix-sdk-base/experimental-encrypted-state-events",
+    "matrix-sdk-sqlite/experimental-encrypted-state-events"
+]
+
 markdown = ["ruma/markdown"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -100,6 +100,7 @@ enum FeatureSet {
     NoSqlite,
     NoEncryptionAndSqlite,
     SqliteCryptostore,
+    ExperimentalEncryptedStateEvents,
     RustlsTls,
     Markdown,
     Socks,
@@ -262,6 +263,10 @@ fn run_feature_tests(cmd: Option<FeatureSet>) -> Result<()> {
             FeatureSet::SqliteCryptostore,
             "--no-default-features --features e2e-encryption,sqlite,native-tls,testing",
         ),
+        (
+            FeatureSet::ExperimentalEncryptedStateEvents,
+            "--no-default-features --features experimental-encrypted-state-events,e2e-encryption,sqlite,native-tls,testing",
+        ),
         (FeatureSet::RustlsTls, "--no-default-features --features rustls-tls,testing"),
         (FeatureSet::Markdown, "--features markdown,testing"),
         (FeatureSet::Socks, "--features socks,testing"),
@@ -313,6 +318,7 @@ fn run_crypto_tests() -> Result<()> {
         "rustup run stable cargo test --doc -p matrix-sdk-crypto --features=experimental-algorithms,testing"
     )
     .run()?;
+    cmd!(sh, "rustup run stable cargo nextest run -p matrix-sdk-crypto --features=experimental-encrypted-state-events").run()?;
 
     cmd!(sh, "rustup run stable cargo nextest run -p matrix-sdk-crypto-ffi").run()?;
 


### PR DESCRIPTION
This PR makes some non-domain-specific changes across multiple crates that are required for proper testing of features implemented for #5397.

* Adds a `experimental-encrypted-state-events` feature flag across the SDK.
* Introduces a feature set into xtask to ensure feature-gated tests are run during CI.
* Minor fix to a test that would otherwise fail with the newly introduced CI.