### PR TITLE
Widget driver: allow state keys to have a _m.call suffix for Element Call

### DIFF
--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -220,6 +220,8 @@ pub fn get_element_call_required_permissions(
                 event_type: StateEventType::CallMember.to_string(),
                 state_key: format!("{own_user_id}_{own_device_id}"),
             },
+            // Same as above for [MSC3779] and [MSC4143](https://github.com/matrix-org/matrix-spec-proposals/pull/4143),
+            // with application suffix
             WidgetEventFilter::StateWithTypeAndStateKey {
                 event_type: StateEventType::CallMember.to_string(),
                 state_key: format!("{own_user_id}_{own_device_id}_m.call"),
@@ -231,6 +233,7 @@ pub fn get_element_call_required_permissions(
                 event_type: StateEventType::CallMember.to_string(),
                 state_key: format!("_{own_user_id}_{own_device_id}"),
             },
+            // Same as above for [MSC4143], with application suffix
             WidgetEventFilter::StateWithTypeAndStateKey {
                 event_type: StateEventType::CallMember.to_string(),
                 state_key: format!("_{own_user_id}_{own_device_id}_m.call"),


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
