### PR TITLE
feat(crypto): Add support for encrypted state events to `matrix-sdk-crypto`

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -998,6 +998,11 @@ pub enum UnableToDecryptReason {
     /// cross-signing identity did not satisfy the requested
     /// `TrustRequirement`.
     SenderIdentityNotTrusted(VerificationLevel),
+
+    /// The outer state key could not be verified against the inner encrypted
+    /// state key and type.
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    StateKeyVerificationFailed,
 }
 
 impl UnableToDecryptReason {

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -133,6 +133,12 @@ pub enum MegolmError {
     /// The nested value is the sender's current verification level.
     #[error("decryption failed because trust requirement not satisfied: {0}")]
     SenderIdentityNotTrusted(VerificationLevel),
+
+    /// The outer state key could not be verified against the inner encrypted
+    /// state key and type.
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    #[error("decryption failed because the state key failed to validate")]
+    StateKeyVerificationFailed,
 }
 
 /// Decryption failed because of a mismatch between the identity keys of the

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1364,6 +1364,8 @@ mod tests {
         EncryptedEvent {
             sender: sender.to_owned(),
             event_id: event_id!("$143273582443PhrSn:example.org").to_owned(),
+            #[cfg(feature = "experimental-encrypted-state-events")]
+            state_key: None,
             content,
             origin_server_ts: ruma::MilliSecondsSinceUnixEpoch::now(),
             unsigned: Default::default(),

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -733,13 +733,9 @@ async fn test_megolm_encryption() {
 }
 
 #[cfg(feature = "experimental-encrypted-state-events")]
-#[async_test]
-async fn test_megolm_state_encryption() {
-    use ruma::events::{AnyStateEvent, EmptyStateKey};
-
+async fn megolm_encryption_setup_helper(room_id: &RoomId) -> (OlmMachine, OlmMachine) {
     let (alice, bob) =
         get_machine_pair_with_setup_sessions_test_helper(alice_id(), user_id(), false).await;
-    let room_id = room_id!("!test:example.org");
 
     let to_device_requests = alice
         .share_room_key(room_id, iter::once(bob.user_id()), EncryptionSettings::default())
@@ -774,10 +770,19 @@ async fn test_megolm_state_encryption() {
     let sessions = std::slice::from_ref(&group_session);
     bob.store().save_inbound_group_sessions(sessions).await.unwrap();
 
+    (alice, bob)
+}
+
+#[cfg(feature = "experimental-encrypted-state-events")]
+#[async_test]
+async fn test_megolm_state_encryption() {
+    use ruma::events::{AnyStateEvent, EmptyStateKey};
+
+    let room_id = room_id!("!test:example.org");
+    let (alice, bob) = megolm_encryption_setup_helper(room_id).await;
+
     let plaintext = "It is a secret to everybody";
-
     let content = RoomTopicEventContent::new(plaintext.to_owned());
-
     let encrypted_content =
         alice.encrypt_state_event(room_id, content, EmptyStateKey).await.unwrap();
 
@@ -786,6 +791,7 @@ async fn test_megolm_state_encryption() {
         "origin_server_ts": MilliSecondsSinceUnixEpoch::now(),
         "sender": alice.user_id(),
         "type": "m.room.encrypted",
+        "state_key": "m.room.topic:",
         "content": encrypted_content,
     });
 
@@ -796,7 +802,9 @@ async fn test_megolm_state_encryption() {
 
     let decryption_result =
         bob.try_decrypt_room_event(&event, room_id, &decryption_settings).await.unwrap();
+
     assert_let!(RoomEventDecryptionResult::Decrypted(decrypted_event) = decryption_result);
+
     let decrypted_event = decrypted_event.event.deserialize().unwrap();
 
     if let AnyTimelineEvent::State(AnyStateEvent::RoomTopic(StateEvent::Original(
@@ -808,6 +816,88 @@ async fn test_megolm_state_encryption() {
     } else {
         panic!("Decrypted room event has the wrong type");
     }
+}
+
+#[cfg(feature = "experimental-encrypted-state-events")]
+#[async_test]
+async fn test_megolm_state_encryption_bad_type() {
+    use ruma::events::EmptyStateKey;
+
+    let room_id = room_id!("!test:example.org");
+    let (alice, bob) = megolm_encryption_setup_helper(room_id).await;
+
+    let plaintext = "It is a secret to everybody";
+    let content = RoomTopicEventContent::new(plaintext.to_owned());
+    let encrypted_content =
+        alice.encrypt_state_event(room_id, content, EmptyStateKey).await.unwrap();
+
+    // Malformed events
+    let bad_type_event = json!({
+        "event_id": "$xxxxx:example.org",
+        "origin_server_ts": MilliSecondsSinceUnixEpoch::now(),
+        "sender": alice.user_id(),
+        "type": "m.room.encrypted",
+        "state_key": "m.room.malformed:",
+        "content": encrypted_content,
+    });
+
+    let bad_type_event = json_convert(&bad_type_event).unwrap();
+
+    let decryption_settings =
+        DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
+
+    let bad_type_decryption_result =
+        bob.try_decrypt_room_event(&bad_type_event, room_id, &decryption_settings).await.unwrap();
+
+    assert_matches!(
+        bad_type_decryption_result,
+        RoomEventDecryptionResult::UnableToDecrypt(UnableToDecryptInfo {
+            reason: UnableToDecryptReason::StateKeyVerificationFailed,
+            ..
+        })
+    );
+}
+
+#[cfg(feature = "experimental-encrypted-state-events")]
+#[async_test]
+async fn test_megolm_state_encryption_bad_state_key() {
+    use ruma::events::EmptyStateKey;
+
+    let room_id = room_id!("!test:example.org");
+    let (alice, bob) = megolm_encryption_setup_helper(room_id).await;
+
+    let plaintext = "It is a secret to everybody";
+    let content = RoomTopicEventContent::new(plaintext.to_owned());
+    let encrypted_content =
+        alice.encrypt_state_event(room_id, content, EmptyStateKey).await.unwrap();
+
+    let bad_state_key_event = json!({
+        "event_id": "$xxxxx:example.org",
+        "origin_server_ts": MilliSecondsSinceUnixEpoch::now(),
+        "sender": alice.user_id(),
+        "type": "m.room.encrypted",
+        "state_key": "m.room.malformed:",
+        "content": encrypted_content,
+    });
+
+    let bad_state_key_event = json_convert(&bad_state_key_event).unwrap();
+
+    let decryption_settings =
+        DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
+
+    let bad_state_key_decryption_result = bob
+        .try_decrypt_room_event(&bad_state_key_event, room_id, &decryption_settings)
+        .await
+        .unwrap();
+
+    // Require malformed events fail verification
+    assert_matches!(
+        bad_state_key_decryption_result,
+        RoomEventDecryptionResult::UnableToDecrypt(UnableToDecryptInfo {
+            reason: UnableToDecryptReason::StateKeyVerificationFailed,
+            ..
+        })
+    );
 }
 
 #[async_test]

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -732,6 +732,19 @@ async fn test_megolm_encryption() {
     }
 }
 
+/// Helper function to set up end-to-end Megolm encryption between two devices.
+///
+/// Creates two devices, Alice and Bob, and has Alice create an outgoing Megolm
+/// session in the given room, whose decryption key is shared with Bob via a
+/// to-device message.
+///
+/// # Arguments
+///
+/// * `room_id` - The RoomId for which to set up Megolm encryption.
+///
+/// # Returns
+///
+/// A tuple containing the alice and bob OlmMachine instances.
 #[cfg(feature = "experimental-encrypted-state-events")]
 async fn megolm_encryption_setup_helper(room_id: &RoomId) -> (OlmMachine, OlmMachine) {
     let (alice, bob) =
@@ -773,6 +786,9 @@ async fn megolm_encryption_setup_helper(room_id: &RoomId) -> (OlmMachine, OlmMac
     (alice, bob)
 }
 
+/// Verifies that Megolm-encrypted state events can be encrypted and decrypted
+/// correctly, and that the decrypted event matches the expected type and
+/// content.
 #[cfg(feature = "experimental-encrypted-state-events")]
 #[async_test]
 async fn test_megolm_state_encryption() {
@@ -818,6 +834,9 @@ async fn test_megolm_state_encryption() {
     }
 }
 
+/// Verifies that decryption fails with StateKeyVerificationFailed
+/// when unpacking the state_key of the decrypted event yields an event type
+/// that does not exist or does not match the type in the decrypted ciphertext.
 #[cfg(feature = "experimental-encrypted-state-events")]
 #[async_test]
 async fn test_megolm_state_encryption_bad_type() {
@@ -831,7 +850,6 @@ async fn test_megolm_state_encryption_bad_type() {
     let encrypted_content =
         alice.encrypt_state_event(room_id, content, EmptyStateKey).await.unwrap();
 
-    // Malformed events
     let bad_type_event = json!({
         "event_id": "$xxxxx:example.org",
         "origin_server_ts": MilliSecondsSinceUnixEpoch::now(),
@@ -858,6 +876,9 @@ async fn test_megolm_state_encryption_bad_type() {
     );
 }
 
+/// Verifies that decryption fails with StateKeyVerificationFailed
+/// when unpacking the state_key of the decrypted event yields a state_key
+/// that does not match the state_key in the decrypted ciphertext.
 #[cfg(feature = "experimental-encrypted-state-events")]
 #[async_test]
 async fn test_megolm_state_encryption_bad_state_key() {
@@ -890,7 +911,6 @@ async fn test_megolm_state_encryption_bad_state_key() {
         .await
         .unwrap();
 
-    // Require malformed events fail verification
     assert_matches!(
         bad_state_key_decryption_result,
         RoomEventDecryptionResult::UnableToDecrypt(UnableToDecryptInfo {

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -25,6 +25,8 @@ use std::{
 };
 
 use matrix_sdk_common::{deserialized_responses::WithheldCode, locks::RwLock as StdRwLock};
+#[cfg(feature = "experimental-encrypted-state-events")]
+use ruma::events::AnyStateEventContent;
 use ruma::{
     events::{
         room::{encryption::RoomEncryptionEventContent, history_visibility::HistoryVisibility},
@@ -458,6 +460,50 @@ impl OutboundGroupSession {
         session.encrypt(&plaintext)
     }
 
+    /// Encrypt an arbitrary event for the given room.
+    ///
+    /// Beware that a room key needs to be shared before this method
+    /// can be called using the `share_room_key()` method.
+    ///
+    /// # Arguments
+    ///
+    /// * `payload` - The plaintext content of the event that should be
+    ///   serialized to JSON and encrypted.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the content can't be serialized.
+    async fn encrypt_inner<T: Serialize>(
+        &self,
+        payload: &T,
+        relates_to: Option<serde_json::Value>,
+    ) -> Raw<RoomEncryptedEventContent> {
+        let ciphertext = self
+            .encrypt_helper(
+                serde_json::to_string(payload).expect("payload serialization never fails"),
+            )
+            .await;
+        let scheme: RoomEventEncryptionScheme = match self.settings.algorithm {
+            EventEncryptionAlgorithm::MegolmV1AesSha2 => MegolmV1AesSha2Content {
+                ciphertext,
+                sender_key: Some(self.account_identity_keys.curve25519),
+                session_id: self.session_id().to_owned(),
+                device_id: Some(self.device_id.clone()),
+            }
+            .into(),
+            #[cfg(feature = "experimental-algorithms")]
+            EventEncryptionAlgorithm::MegolmV2AesSha2 => {
+                MegolmV2AesSha2Content { ciphertext, session_id: self.session_id().to_owned() }
+                    .into()
+            }
+            _ => unreachable!(
+                "An outbound group session is always using one of the supported algorithms"
+            ),
+        };
+        let content = RoomEncryptedEventContent { scheme, relates_to, other: Default::default() };
+        Raw::new(&content).expect("m.room.encrypted event content can always be serialized")
+    }
+
     /// Encrypt a room message for the given room.
     ///
     /// Beware that a room key needs to be shared before this method
@@ -488,35 +534,51 @@ impl OutboundGroupSession {
         }
 
         let payload = Payload { event_type, content, room_id: &self.room_id };
-        let payload_json =
-            serde_json::to_string(&payload).expect("payload serialization never fails");
 
         let relates_to = content
             .get_field::<serde_json::Value>("m.relates_to")
             .expect("serde_json::Value deserialization with valid JSON input never fails");
 
-        let ciphertext = self.encrypt_helper(payload_json).await;
-        let scheme: RoomEventEncryptionScheme = match self.settings.algorithm {
-            EventEncryptionAlgorithm::MegolmV1AesSha2 => MegolmV1AesSha2Content {
-                ciphertext,
-                sender_key: Some(self.account_identity_keys.curve25519),
-                session_id: self.session_id().to_owned(),
-                device_id: Some(self.device_id.clone()),
-            }
-            .into(),
-            #[cfg(feature = "experimental-algorithms")]
-            EventEncryptionAlgorithm::MegolmV2AesSha2 => {
-                MegolmV2AesSha2Content { ciphertext, session_id: self.session_id().to_owned() }
-                    .into()
-            }
-            _ => unreachable!(
-                "An outbound group session is always using one of the supported algorithms"
-            ),
-        };
+        self.encrypt_inner(&payload, relates_to).await
+    }
 
-        let content = RoomEncryptedEventContent { scheme, relates_to, other: Default::default() };
+    /// Encrypt a room state event for the given room.
+    ///
+    /// Beware that a room key needs to be shared before this method
+    /// can be called using the `share_room_key()` method.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` - The plaintext type of the event, the outer type of the
+    ///   event will become `m.room.encrypted`.
+    ///
+    /// * `state_key` - The plaintext state key of the event, the outer state
+    ///   key will be derived from this and the event type.
+    ///
+    /// * `content` - The plaintext content of the message that should be
+    ///   encrypted in raw JSON form.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the content can't be serialized.
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    pub async fn encrypt_state(
+        &self,
+        event_type: &str,
+        state_key: &str,
+        content: &Raw<AnyStateEventContent>,
+    ) -> Raw<RoomEncryptedEventContent> {
+        #[derive(Serialize)]
+        struct Payload<'a> {
+            #[serde(rename = "type")]
+            event_type: &'a str,
+            state_key: &'a str,
+            content: &'a Raw<AnyStateEventContent>,
+            room_id: &'a RoomId,
+        }
 
-        Raw::new(&content).expect("m.room.encrypted event content can always be serialized")
+        let payload = Payload { event_type, state_key, content, room_id: &self.room_id };
+        self.encrypt_inner(&payload, None).await
     }
 
     fn elapsed(&self) -> bool {

--- a/crates/matrix-sdk-crypto/src/types/events/room/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room/mod.rs
@@ -36,6 +36,10 @@ where
     /// The globally unique identifier for this event.
     pub event_id: OwnedEventId,
 
+    /// Present if and only if this event is a state event.
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    pub state_key: Option<String>,
+
     /// The body of this event, as created by the client which sent it.
     pub content: C,
 


### PR DESCRIPTION
Depends on #5511, #5512 and #5523.

- [x] Add `OutboundGroupSession::encrypt_state`.
- [x] Add `GroupSessionManager::encrypt_state` and a private helper function `::encrypt_inner`.
- [x] Add `OlmMachine::encrypt_state_event` and `::encrypt_state_event_raw`.
- [x] Add naive state key unpacking and verification to `OlmMachine::decrypt_room_event_inner`.
