### PR TITLE
feat(sdk): Support room key downloading using `JsonCastable<EncryptedEvent>`

### DIFF
--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -22,7 +22,8 @@ experimental-send-custom-to-device = []
 # Enable experimental support for encrypting state events; see
 # https://github.com/matrix-org/matrix-rust-sdk/issues/5397.
 experimental-encrypted-state-events = [
-    "matrix-sdk-common/experimental-encrypted-state-events"
+    "matrix-sdk-common/experimental-encrypted-state-events",
+    "ruma/unstable-msc3414"
 ]
 
 js = ["ruma/js", "vodozemac/js", "matrix-sdk-common/js"]

--- a/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
@@ -70,6 +70,12 @@ impl JsonCastable<EncryptedEvent>
 {
 }
 
+#[cfg(feature = "experimental-encrypted-state-events")]
+impl JsonCastable<EncryptedEvent>
+    for ruma::events::room::encrypted::unstable_state::OriginalSyncStateRoomEncryptedEvent
+{
+}
+
 /// An m.room.encrypted to-device event.
 pub type EncryptedToDeviceEvent = ToDeviceEvent<ToDeviceEncryptedEventContent>;
 
@@ -229,6 +235,9 @@ impl EventType for RoomEncryptedEventContent {
 }
 
 impl JsonCastable<ruma::events::AnyMessageLikeEventContent> for RoomEncryptedEventContent {}
+
+#[cfg(feature = "experimental-encrypted-state-events")]
+impl JsonCastable<ruma::events::AnyStateEventContent> for RoomEncryptedEventContent {}
 
 /// An enum for per encryption algorithm event contents.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]


### PR DESCRIPTION
This PR introduces feature-gated changes to room key downloading that will allow encrypted state events to trigger downloads using polymorphism. Although this will increase binary size due to monomorphisation, it allows for backwards compatibility with existing SDK code.

- [ ] Declares `AnyStateEventContent` as castable to `RoomEncryptedEventContent`.
- [ ] Declares `EncryptedEvent` as castable to `OriginalSyncStateRoomEncryptedEvent`.
- [ ] Modify `RoomKeyDownloadRequest` to accept a `Raw<EncryptedEvent>`.
- [ ] Introduces a modified `Backups::maybe_download_room_key` and `BackupDownloadTask::trigger_download_for_utd_event` that accepts any `T` castable to `EncryptedEvent`
