### PR TITLE
fix(ci): free more space in the CI runner for the `codecov` task

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,9 +43,58 @@ jobs:
       # space here.
       - name: Create some more space
         run: |
+          echo "Disk space before cleanup"
+          df -h
+
           cd /opt
           find . -maxdepth 1 -mindepth 1 '!' -path ./containerd '!' -path ./actionarchivecache '!' -path ./runner '!' -path ./runner-cache -exec rm -rf '{}' ';'
           rm -rf /opt/hostedtoolcache
+
+          # Get rid of binaries and libs we're not interested in.
+          sudo rm -rf \
+            /usr/local/julia* \
+            /usr/local/aws*
+
+          sudo rm -rf \
+            /usr/local/bin/minikube \
+            /usr/local/bin/node \
+            /usr/local/bin/stack \
+            /usr/local/bin/bicep \
+            /usr/local/bin/pulumi* \
+            /usr/local/bin/helm \
+            /usr/local/bin/azcopy \
+            /usr/local/bin/packer \
+            /usr/local/bin/cmake-gui \
+            /usr/local/bin/cpack
+
+          sudo rm -rf \
+            /usr/local/share/powershell \
+            /usr/local/share/chromium
+
+          sudo rm -rf /usr/local/lib/android
+
+          echo "::group::/usr/local/bin/*"
+          du -hsc /usr/local/bin/* | sort -h
+          echo "::endgroup::"
+
+          echo "::group::/usr/local/share/*"
+          du -hsc /usr/local/share/* | sort -h
+          echo "::endgroup::"
+
+          echo "::group::/usr/local/*"
+          du -hsc /usr/local/* | sort -h
+          echo "::endgroup::"
+
+          echo "::group::/usr/local/lib/*"
+          du -hsc /usr/local/lib/* | sort -h
+          echo "::endgroup::"
+
+          echo "::group::/opt/*"
+          du -hsc /opt/* | sort -h
+          echo "::endgroup::"
+
+          echo "Disk space after cleanup"
+          df -h
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -56,6 +105,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libsqlite3-dev
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -83,6 +134,10 @@ jobs:
           path: target/debug/xtask
           key: "${{ needs.xtask.outputs.cachekey-linux }}"
           fail-on-cache-miss: true
+
+      - name: Check total disk space before running
+        run: |
+          df -h
 
       - name: Create the coverage report
         run: |


### PR DESCRIPTION
This frees 13 GB of disk space in the Codecov image runner, by getting rid of tools, binaries and libs we're not interested in.

These tools have been identified thanks to the new lines added to detect large files, e.g. `du -hsc /usr/local/bin/* | sort -h`:

- `du -hsc /usr/local/bin/*` will output a summary of the size, in human size format, of every top-level entry in `/usr/local/bin`
- `sort -h` will sort from smallest to largest, in the human size format too

[Example](https://github.com/matrix-org/matrix-rust-sdk/actions/runs/17067856858/job/48389222421#step:4:89).

This idea courtesy of apache/arrow, which has a [script](https://github.com/apache/arrow/blob/main/ci/scripts/util_free_space.sh) to remove such unused space (but many binaries seem to not be present in our image at start, so it might be a bit outdated).

Should help unblocking the codecov step for #5544.