### PR TITLE
feat: Add top-level support for decrypting state events

### DIFF
--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -117,6 +117,8 @@ pub async fn update_any_room(
         ambiguity_cache,
         &mut new_user_ids,
         state_store,
+        #[cfg(feature = "experimental-encrypted-state-events")]
+        e2ee.clone(),
     )
     .await?;
 

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -76,6 +76,8 @@ pub async fn update_joined_room(
         ambiguity_cache,
         &mut new_user_ids,
         state_store,
+        #[cfg(feature = "experimental-encrypted-state-events")]
+        e2ee.clone(),
     )
     .await?;
 
@@ -180,6 +182,8 @@ pub async fn update_left_room(
         ambiguity_cache,
         &mut (),
         state_store,
+        #[cfg(feature = "experimental-encrypted-state-events")]
+        e2ee.clone(),
     )
     .await?;
 

--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -42,6 +42,8 @@ pub mod sync {
     use tracing::{error, instrument};
 
     use super::{super::profiles, AnySyncStateEvent, Context, Raw};
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    use crate::response_processors::e2ee;
     use crate::{
         RoomInfo,
         store::{BaseStateStore, Result as StoreResult, ambiguity_map::AmbiguityCache},
@@ -89,6 +91,7 @@ pub mod sync {
         ambiguity_cache: &mut AmbiguityCache,
         new_users: &mut U,
         state_store: &BaseStateStore,
+        #[cfg(feature = "experimental-encrypted-state-events")] e2ee: e2ee::E2EE<'_>,
     ) -> StoreResult<()>
     where
         U: NewUsers,
@@ -140,6 +143,55 @@ pub mod sync {
                         // Do not add the event to `context.state_changes.state`.
                         continue;
                     }
+                }
+
+                #[cfg(feature = "experimental-encrypted-state-events")]
+                AnySyncStateEvent::RoomEncrypted(SyncStateEvent::Original(outer)) => {
+                    use matrix_sdk_crypto::RoomEventDecryptionResult;
+                    use tracing::{trace, warn};
+
+                    trace!(event_id = ?outer.event_id, "Received encrypted state event, attempting decryption...");
+
+                    let Some(olm_machine) = e2ee.olm_machine else {
+                        continue;
+                    };
+
+                    let decrypted_event = olm_machine
+                        .try_decrypt_room_event(
+                            raw_event.cast_ref_unchecked(),
+                            &room_info.room_id,
+                            e2ee.decryption_settings,
+                        )
+                        .await
+                        .expect("OlmMachine was not started");
+
+                    // Skip state events that failed to decrypt.
+                    let RoomEventDecryptionResult::Decrypted(decrypted_event) = decrypted_event
+                    else {
+                        warn!(event_id = ?outer.event_id, "Failed to decrypt state event");
+                        continue;
+                    };
+
+                    // Cast to `AnySyncTimelineEvent`, safe since this is a supertype of
+                    // `AnyTimelineEvent`.
+                    let deserialized_event = match decrypted_event
+                        .event
+                        .deserialize_as::<AnySyncTimelineEvent>()
+                    {
+                        Ok(event) => event,
+                        Err(err) => {
+                            warn!(event_id = ?outer.event_id, "Failed to decrypt state event: {err}");
+                            continue;
+                        }
+                    };
+
+                    // Ensure decrypted event is actually a state event.
+                    let AnySyncTimelineEvent::State(event) = deserialized_event else {
+                        continue;
+                    };
+
+                    trace!(event_id = ?outer.event_id, "Decrypted state event successfully.");
+                    room_info.handle_state_event(&event);
                 }
 
                 _ => {

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -25,6 +25,13 @@ unstable-msc3956 = ["ruma/unstable-msc3956"]
 # Add support for inline media galleries via msgtypes
 unstable-msc4274 = ["matrix-sdk/unstable-msc4274"]
 
+# Enable experimental support for encrypting state events; see
+# https://github.com/matrix-org/matrix-rust-sdk/issues/5397.
+experimental-encrypted-state-events = [
+    "matrix-sdk-base/experimental-encrypted-state-events",
+    "ruma/unstable-msc3414"
+]
+
 [dependencies]
 as_variant.workspace = true
 async-rx.workspace = true

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -30,6 +30,7 @@ use ruma::{
         AnyMessageLikeEventContent, AnySyncTimelineEvent,
         fully_read::FullyReadEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
+        room::encrypted::OriginalSyncRoomEncryptedEvent,
     },
     room_version_rules::RoomVersionRules,
     serde::Raw,
@@ -321,6 +322,10 @@ impl Decryptor for Room {
         raw: &Raw<AnySyncTimelineEvent>,
         push_ctx: Option<&PushContext>,
     ) -> Result<TimelineEvent> {
-        self.decrypt_event(raw.cast_ref_unchecked(), push_ctx).await
+        // Note: We specify the cast type in case the
+        // `experimental-encrypted-state-events` feature is enabled, which provides
+        // multiple cast implementations.
+        self.decrypt_event(raw.cast_ref_unchecked::<OriginalSyncRoomEncryptedEvent>(), push_ctx)
+            .await
     }
 }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -652,14 +652,11 @@ impl Room {
         event: Raw<AnyTimelineEvent>,
         push_ctx: Option<&PushContext>,
     ) -> TimelineEvent {
-        // If we have either an encrypted message-like or state event, try to decrypt.
         #[cfg(feature = "e2e-encryption")]
         if let Ok(AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomEncrypted(
             SyncMessageLikeEvent::Original(_),
         ))) = event.deserialize_as::<AnySyncTimelineEvent>()
         {
-            // Cast safety: The state key is not used during decryption, and the types
-            // overlap sufficiently.
             if let Ok(event) = self.decrypt_event(event.cast_ref_unchecked(), push_ctx).await {
                 return event;
             }

--- a/crates/matrix-sdk/src/test_utils/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mod.rs
@@ -272,6 +272,32 @@ macro_rules! assert_decrypted_message_eq {
 
 /// Given a [`TimelineEvent`], assert that the event is a decrypted state
 /// event, and that its content matches the given pattern via a let binding.
+///
+/// If more than one argument is provided, these will be used as an error
+/// message if the content does not match the provided pattern.
+///
+/// # Examples
+///
+/// ```no_run
+/// # async {
+/// # let client: matrix_sdk::Client = unreachable!();
+/// # let room_id: ruma::OwnedRoomId = unreachable!();
+/// # let event_id: ruma::OwnedEventId = unreachable!();
+/// use matrix_sdk::assert_let_decrypted_state_event_content;
+///
+/// let room =
+///     client.get_room(&room_id).expect("Bob should have received the invite");
+///
+/// let event = room.event(&event_id, None).await?;
+///
+/// assert_let_decrypted_state_event_content!(
+///     ruma::events::AnyStateEventContent::RoomTopic(
+///         ruma::events::room::topic::RoomTopicEventContent { topic, .. }
+///     ) = event
+/// );
+/// assert_eq!(topic, "Encrypted topic!");
+/// # anyhow::Ok(()) };
+/// ```
 #[macro_export]
 macro_rules! assert_let_decrypted_state_event_content {
     ($pat:pat = $event:expr, $($msg:tt)*) => {
@@ -289,12 +315,12 @@ macro_rules! assert_let_decrypted_state_event_content {
         let content =
             deserialized_event.original_content().expect("The event should not have been redacted");
 
-        assert_matches2::assert_let!($pat = content);
+        assert_matches2::assert_let!($pat = content, $($msg)*);
     };
     ($pat:pat = $event:expr) => {
         assert_let_decrypted_state_event_content!(
             $pat = $event,
-            "The decrypted event did not match to the expected value"
+            "The decrypted event did not match the expected value"
         );
     };
 }

--- a/crates/matrix-sdk/src/test_utils/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mod.rs
@@ -270,6 +270,35 @@ macro_rules! assert_decrypted_message_eq {
     }};
 }
 
+/// Given a [`TimelineEvent`], assert that the event is a decrypted state
+/// event, and that its content matches the given pattern via a let binding.
+#[macro_export]
+macro_rules! assert_let_decrypted_state_event_content {
+    ($pat:pat = $event:expr, $($msg:tt)*) => {
+        assert_matches2::assert_let!(
+            $crate::deserialized_responses::TimelineEventKind::Decrypted(decrypted_event) =
+                $event.kind,
+            "Event was not decrypted"
+        );
+
+        let deserialized_event = decrypted_event
+            .event
+            .deserialize_as_unchecked::<$crate::ruma::events::AnyStateEvent>()
+            .expect("We should be able to deserialize the decrypted event");
+
+        let content =
+            deserialized_event.original_content().expect("The event should not have been redacted");
+
+        assert_matches2::assert_let!($pat = content);
+    };
+    ($pat:pat = $event:expr) => {
+        assert_let_decrypted_state_event_content!(
+            $pat = $event,
+            "The decrypted event did not match to the expected value"
+        );
+    };
+}
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! assert_next_eq_with_timeout_impl {

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -43,7 +43,10 @@ use ruma::{
     event_id,
     events::{
         direct::{DirectEventContent, OwnedDirectUserIdentifier},
-        room::{history_visibility::HistoryVisibility, member::MembershipState},
+        room::{
+            encrypted::OriginalSyncRoomEncryptedEvent, history_visibility::HistoryVisibility,
+            member::MembershipState,
+        },
         AnyInitialStateEvent,
     },
     room::JoinRule,
@@ -769,7 +772,7 @@ async fn test_encrypt_room_event() {
         .take()
         .expect("We should have intercepted an `m.room.encrypted` event content");
 
-    let event = Raw::new(&json!({
+    let event: Raw<OriginalSyncRoomEncryptedEvent> = Raw::new(&json!({
         "room_id": room.room_id(),
         "event_id": "$foobar",
         "origin_server_ts": 1600000u64,

--- a/testing/matrix-sdk-integration-testing/Cargo.toml
+++ b/testing/matrix-sdk-integration-testing/Cargo.toml
@@ -21,8 +21,8 @@ futures-core.workspace = true
 futures-util.workspace = true
 http.workspace = true
 json-structural-diff = "0.1.0"
-matrix-sdk = { workspace = true, default-features = true, features = ["testing", "qrcode"] }
-matrix-sdk-base = { workspace = true, default-features = true, features = ["testing", "qrcode"] }
+matrix-sdk = { workspace = true, default-features = true, features = ["testing", "qrcode", "experimental-encrypted-state-events"] }
+matrix-sdk-base = { workspace = true, default-features = true, features = ["testing", "qrcode", "experimental-encrypted-state-events"] }
 matrix-sdk-common.workspace = true
 matrix-sdk-test.workspace = true
 matrix-sdk-test-utils.workspace = true

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/mod.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/mod.rs
@@ -43,6 +43,7 @@ use tracing::{debug, warn};
 use crate::helpers::{SyncTokenAwareClient, TestClientBuilder};
 
 mod shared_history;
+mod state_events;
 
 // This test reproduces a bug seen on clients that use the same `Client`
 // instance for both the usual sliding sync loop and for getting the event for a

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/state_events.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/state_events.rs
@@ -1,0 +1,150 @@
+use std::{ops::Deref, time::Duration};
+
+use anyhow::Result;
+use assert_matches2::assert_let;
+use assign::assign;
+use futures::{FutureExt, StreamExt, pin_mut};
+use matrix_sdk::{
+    assert_let_decrypted_state_event_content,
+    encryption::EncryptionSettings,
+    ruma::{
+        api::client::room::create_room::v3::{Request as CreateRoomRequest, RoomPreset},
+        events::AnyStateEventContent,
+    },
+};
+use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
+use matrix_sdk_ui::sync_service::SyncService;
+use similar_asserts::assert_eq;
+use tracing::{Instrument, info};
+
+use crate::helpers::{SyncTokenAwareClient, TestClientBuilder};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_e2ee_state_events() -> Result<()> {
+    let alice_span = tracing::info_span!("alice");
+    let bob_span = tracing::info_span!("bob");
+
+    let encryption_settings =
+        EncryptionSettings { auto_enable_cross_signing: true, ..Default::default() };
+
+    let alice = TestClientBuilder::new("alice")
+        .use_sqlite()
+        .encryption_settings(encryption_settings)
+        .enable_share_history_on_invite(true)
+        .build()
+        .await?;
+
+    let sync_service_span = tracing::info_span!(parent: &alice_span, "sync_service");
+    let alice_sync_service = SyncService::builder(alice.clone())
+        .with_parent_span(sync_service_span)
+        .build()
+        .await
+        .expect("Could not build alice sync service");
+
+    alice.encryption().wait_for_e2ee_initialization_tasks().await;
+    alice_sync_service.start().await;
+
+    let bob = SyncTokenAwareClient::new(
+        TestClientBuilder::new("bob")
+            .encryption_settings(encryption_settings)
+            .enable_share_history_on_invite(true)
+            .build()
+            .await?,
+    );
+
+    // Alice creates an encrypted room ...
+    let alice_room = alice
+        .create_room(assign!(CreateRoomRequest::new(), {
+            name: Some("Cat Photos".to_owned()),
+            preset: Some(RoomPreset::PublicChat),
+        }))
+        .await?;
+    alice_room.enable_encryption_with_state_event_encryption().await?;
+
+    // HACK: wait for sync
+    let _ = tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // (sanity checks)
+    assert!(alice_room.encryption_state().is_encrypted(), "Encryption was not enabled.");
+    assert!(
+        alice_room.encryption_state().is_state_encrypted(),
+        "State encryption was not enabled."
+    );
+
+    info!(room_id = ?alice_room.room_id(), "Alice has created and enabled encryption in the room");
+
+    // ... and changes the room name
+    let rename_event_id = alice_room
+        .set_name("Dog Photos".to_owned())
+        .await
+        .expect("We should be able to rename the room")
+        .event_id;
+
+    let bundle_stream = bob
+        .encryption()
+        .historic_room_key_stream()
+        .await
+        .expect("We should be able to get the bundle stream");
+
+    // Alice invites Bob to the room
+    alice_room.invite_user_by_id(bob.user_id().unwrap()).await?;
+
+    // Alice is done. Bob has been invited and the room key bundle should have been
+    // sent out. Let's stop syncing so the logs contain less noise.
+    alice_sync_service.stop().await;
+
+    let bob_response = bob.sync_once().instrument(bob_span.clone()).await?;
+
+    // Bob should have received a to-device event with the payload
+    assert_eq!(bob_response.to_device.len(), 1);
+    let to_device_event = &bob_response.to_device[0];
+    assert_let!(ProcessedToDeviceEvent::Decrypted { raw, .. } = to_device_event);
+    assert_eq!(
+        raw.get_field::<String>("type").unwrap().unwrap(),
+        "io.element.msc4268.room_key_bundle"
+    );
+
+    bob.get_room(alice_room.room_id()).expect("Bob should have received the invite");
+
+    pin_mut!(bundle_stream);
+
+    let info = bundle_stream
+        .next()
+        .now_or_never()
+        .flatten()
+        .expect("We should be notified about the received bundle");
+
+    assert_eq!(Some(info.sender.deref()), alice.user_id());
+    assert_eq!(info.room_id, alice_room.room_id());
+
+    let bob_room = bob
+        .join_room_by_id(alice_room.room_id())
+        .instrument(bob_span.clone())
+        .await
+        .expect("Bob should be able to accept the invitation from Alice");
+
+    // Sync the room, so the rename event arrives.
+    let _ = bob.sync_once().instrument(bob_span.clone()).await?;
+
+    // Check it has been applied.
+    assert_eq!(
+        "Dog Photos",
+        bob_room.name().unwrap(),
+        "Bob's copy of the room name should have updated."
+    );
+
+    // Let's also check we can inspect the payload manually.
+    let rename_event = bob_room
+        .event(&rename_event_id, None)
+        .instrument(bob_span.clone())
+        .await
+        .expect("Bob should be able to fetch the historic event.");
+
+    assert_let_decrypted_state_event_content!(
+        AnyStateEventContent::RoomName(content) = rename_event
+    );
+
+    assert_eq!("Dog Photos", content.name);
+
+    Ok(())
+}


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Implements support for decryption of state events. Needs #5545.

- [ ] Introduce a case for `AnySyncStateEvent::RoomEncrypted` to the `state_events` sync response processor.
- [ ] Introduce modified `Room::decrypt_event` and `::try_decrypt_room_event`.
- [ ] Introduce testing macro `assert_let_decrypted_state_event_content`.
- [ ] Add casts and explicit type hints where necessary.
