### PR TITLE
refactor(sdk): avoid an explicit dependency on ruma-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3410,7 +3410,7 @@ dependencies = [
  "byteorder",
  "image",
  "qrcode",
- "ruma-common",
+ "ruma",
  "thiserror 2.0.11",
  "vodozemac",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "e85e224cef32181029efa106a0
     "unstable-msc4286",
     "unstable-msc4306"
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "e85e224cef32181029efa106a059d277ecfbe87d" }
 sentry = "0.36.0"
 sentry-tracing = "0.36.0"
 serde = { version = "1.0.217", features = ["rc"] }

--- a/crates/matrix-sdk-qrcode/Cargo.toml
+++ b/crates/matrix-sdk-qrcode/Cargo.toml
@@ -21,7 +21,7 @@ js = ["vodozemac/js"]
 [dependencies]
 byteorder.workspace = true
 qrcode = { version = "0.14.1", default-features = false }
-ruma-common.workspace = true
+ruma.workspace = true
 thiserror.workspace = true
 vodozemac.workspace = true
 

--- a/crates/matrix-sdk-qrcode/src/types.rs
+++ b/crates/matrix-sdk-qrcode/src/types.rs
@@ -16,7 +16,7 @@ use std::io::{Cursor, Read};
 
 use byteorder::{BigEndian, ReadBytesExt};
 use qrcode::QrCode;
-use ruma_common::serde::Base64;
+use ruma::serde::Base64;
 use vodozemac::Ed25519PublicKey;
 
 use crate::{

--- a/crates/matrix-sdk-qrcode/src/utils.rs
+++ b/crates/matrix-sdk-qrcode/src/utils.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use qrcode::{bits::Bits, EcLevel, QrCode, Version};
-use ruma_common::serde::Base64;
+use ruma::serde::Base64;
 use vodozemac::Ed25519PublicKey;
 
 use crate::error::EncodingError;


### PR DESCRIPTION
The `ruma-common` crate is reexported by `ruma`, which is in our dependency tree anyways. This change makes it so that qrcode, the only crate that was making use of `ruma-common`, now depends on `ruma`. It may move it further down the line in the compilation pipeline, but this is unlikely to affect compile times in a crazy way. The benefit is that this avoids the burden of having to specify the ruma commit hash twice in the top-level Cargo.toml, as well as replacing it twice when overriding it.
