### PR TITLE
fix(media): Use the right value to get no timeouts when downloading media

### DIFF
--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -439,7 +439,7 @@ impl Media {
             .request_config()
             // Downloading a file should have no timeout as we don't know the network connectivity
             // available for the user or the file size
-            .timeout(None);
+            .timeout(Some(Duration::MAX));
 
         // Use the authenticated endpoints when the server supports it.
         let supported_versions = self.client.supported_versions().await?;


### PR DESCRIPTION
Using `Option::None` will just make `reqwest` use the default `Client`'s timeout value, instead of setting an infinite timeout value. Using `Some(Duration::MAX)` should achieve the desired behaviour instead.

Fixes https://github.com/element-hq/element-x-ios/issues/4437.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
