### PR TITLE
IndexedDB: Add implementation of `MediaRetentionPolicy`-related functions in `EventCacheStoreMedia`

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/builder.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/builder.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License
 
-use std::sync::Arc;
+use std::{rc::Rc, sync::Arc};
 
 use matrix_sdk_base::event_cache::store::MemoryStore;
 use matrix_sdk_store_encryption::StoreCipher;
@@ -66,7 +66,7 @@ impl IndexeddbEventCacheStoreBuilder {
     /// and the provided store cipher.
     pub async fn build(self) -> Result<IndexeddbEventCacheStore, IndexeddbEventCacheStoreError> {
         Ok(IndexeddbEventCacheStore {
-            inner: open_and_upgrade_db(&self.database_name).await?,
+            inner: Rc::new(open_and_upgrade_db(&self.database_name).await?),
             serializer: IndexeddbEventCacheStoreSerializer::new(IndexeddbSerializer::new(
                 self.store_cipher,
             )),

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/builder.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/builder.rs
@@ -14,7 +14,7 @@
 
 use std::{rc::Rc, sync::Arc};
 
-use matrix_sdk_base::event_cache::store::MemoryStore;
+use matrix_sdk_base::event_cache::store::{media::MediaService, MemoryStore};
 use matrix_sdk_store_encryption::StoreCipher;
 use web_sys::DomException;
 
@@ -70,6 +70,7 @@ impl IndexeddbEventCacheStoreBuilder {
             serializer: IndexeddbEventCacheStoreSerializer::new(IndexeddbSerializer::new(
                 self.store_cipher,
             )),
+            media_service: MediaService::new(),
             memory_store: MemoryStore::new(),
         })
     }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
@@ -684,3 +684,30 @@ macro_rules! indexeddb_event_cache_store_integration_tests {
         }
     };
 }
+
+/// This is a partial copy of
+/// [`matrix_sdk_base::event_cache_store_media_integration_tests`] that contains
+/// tests for functions of [`EventCacheStoreMedia`] that are implemented by
+/// [`IndexeddbEventCacheStore`].
+///
+/// This is useful for adding functionality to [`IndexeddbEventCacheStore`] over
+/// multiple pull requests. Once a full implementation [`EventCacheStoreMedia`]
+/// exists, this will be replaced with the actual integration tests referenced
+/// above.
+#[macro_export]
+macro_rules! event_cache_store_media_integration_tests {
+    () => {
+        mod event_cache_store_media_integration_tests {
+            use matrix_sdk_base::event_cache::store::media::EventCacheStoreMediaIntegrationTests;
+            use matrix_sdk_test::async_test;
+
+            use super::get_event_cache_store;
+
+            #[async_test]
+            async fn test_store_media_retention_policy() {
+                let event_cache_store_media = get_event_cache_store().await.unwrap();
+                event_cache_store_media.test_store_media_retention_policy().await;
+            }
+        }
+    };
+}

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -130,6 +130,7 @@ pub mod v1 {
         pub const EVENTS_RELATION_RELATION_TYPES: &str = "events_relation_relation_type";
         pub const GAPS: &str = "gaps";
         pub const GAPS_KEY_PATH: &str = "id";
+        pub const MEDIA_RETENTION_POLICY_KEY: &str = "media_retention_policy";
     }
 
     /// Create all object stores and indices for v1 database

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -109,6 +109,7 @@ pub mod v1 {
 
     pub mod keys {
         pub const CORE: &str = "core";
+        pub const CORE_KEY_PATH: &str = "id";
         pub const LEASES: &str = "leases";
         pub const LEASES_KEY_PATH: &str = "id";
         pub const ROOMS: &str = "rooms";
@@ -142,8 +143,12 @@ pub mod v1 {
     }
 
     /// Create an object store for tracking miscellaneous information
+    ///
+    /// * Primary Key - `id`
     fn create_core_object_store(db: &IdbDatabase) -> Result<(), DomException> {
-        let _ = db.create_object_store(keys::CORE)?;
+        let mut object_store_params = IdbObjectStoreParameters::new();
+        object_store_params.key_path(Some(&keys::CORE_KEY_PATH.into()));
+        let _ = db.create_object_store_with_params(keys::CORE, &object_store_params)?;
         Ok(())
     }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -732,7 +732,8 @@ mod tests {
     use uuid::Uuid;
 
     use crate::{
-        event_cache_store::IndexeddbEventCacheStore, indexeddb_event_cache_store_integration_tests,
+        event_cache_store::IndexeddbEventCacheStore, event_cache_store_media_integration_tests,
+        indexeddb_event_cache_store_integration_tests,
     };
 
     mod unencrypted {
@@ -749,6 +750,8 @@ mod tests {
         event_cache_store_integration_tests_time!();
 
         indexeddb_event_cache_store_integration_tests!();
+
+        event_cache_store_media_integration_tests!();
     }
 
     mod encrypted {
@@ -765,5 +768,7 @@ mod tests {
         event_cache_store_integration_tests_time!();
 
         indexeddb_event_cache_store_integration_tests!();
+
+        event_cache_store_media_integration_tests!();
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -20,7 +20,7 @@ use indexed_db_futures::IdbDatabase;
 use matrix_sdk_base::{
     event_cache::{
         store::{
-            media::{IgnoreMediaRetentionPolicy, MediaRetentionPolicy},
+            media::{EventCacheStoreMedia, IgnoreMediaRetentionPolicy, MediaRetentionPolicy},
             EventCacheStore, MemoryStore,
         },
         Event, Gap,
@@ -33,8 +33,8 @@ use matrix_sdk_base::{
     timer,
 };
 use ruma::{
-    events::relation::RelationType, EventId, MilliSecondsSinceUnixEpoch, MxcUri, OwnedEventId,
-    RoomId,
+    events::relation::RelationType, time::SystemTime, EventId, MilliSecondsSinceUnixEpoch, MxcUri,
+    OwnedEventId, RoomId,
 };
 use tracing::{error, instrument, trace};
 use web_sys::IdbTransactionMode;
@@ -621,6 +621,114 @@ impl EventCacheStore for IndexeddbEventCacheStore {
         let _timer = timer!("method");
         self.memory_store
             .clean_up_media_cache()
+            .await
+            .map_err(IndexeddbEventCacheStoreError::MemoryStore)
+    }
+}
+
+#[cfg(target_family = "wasm")]
+#[async_trait::async_trait(?Send)]
+impl EventCacheStoreMedia for IndexeddbEventCacheStore {
+    type Error = IndexeddbEventCacheStoreError;
+
+    #[instrument(skip_all)]
+    async fn media_retention_policy_inner(
+        &self,
+    ) -> Result<Option<MediaRetentionPolicy>, IndexeddbEventCacheStoreError> {
+        let _timer = timer!("method");
+        self.memory_store
+            .media_retention_policy_inner()
+            .await
+            .map_err(IndexeddbEventCacheStoreError::MemoryStore)
+    }
+
+    #[instrument(skip_all)]
+    async fn set_media_retention_policy_inner(
+        &self,
+        policy: MediaRetentionPolicy,
+    ) -> Result<(), IndexeddbEventCacheStoreError> {
+        let _timer = timer!("method");
+        self.memory_store
+            .set_media_retention_policy_inner(policy)
+            .await
+            .map_err(IndexeddbEventCacheStoreError::MemoryStore)
+    }
+
+    #[instrument(skip_all)]
+    async fn add_media_content_inner(
+        &self,
+        request: &MediaRequestParameters,
+        content: Vec<u8>,
+        current_time: SystemTime,
+        policy: MediaRetentionPolicy,
+        ignore_policy: IgnoreMediaRetentionPolicy,
+    ) -> Result<(), IndexeddbEventCacheStoreError> {
+        let _timer = timer!("method");
+        self.memory_store
+            .add_media_content_inner(request, content, current_time, policy, ignore_policy)
+            .await
+            .map_err(IndexeddbEventCacheStoreError::MemoryStore)
+    }
+
+    #[instrument(skip_all)]
+    async fn set_ignore_media_retention_policy_inner(
+        &self,
+        request: &MediaRequestParameters,
+        ignore_policy: IgnoreMediaRetentionPolicy,
+    ) -> Result<(), IndexeddbEventCacheStoreError> {
+        let _timer = timer!("method");
+        self.memory_store
+            .set_ignore_media_retention_policy_inner(request, ignore_policy)
+            .await
+            .map_err(IndexeddbEventCacheStoreError::MemoryStore)
+    }
+
+    #[instrument(skip_all)]
+    async fn get_media_content_inner(
+        &self,
+        request: &MediaRequestParameters,
+        current_time: SystemTime,
+    ) -> Result<Option<Vec<u8>>, IndexeddbEventCacheStoreError> {
+        let _timer = timer!("method");
+        self.memory_store
+            .get_media_content_inner(request, current_time)
+            .await
+            .map_err(IndexeddbEventCacheStoreError::MemoryStore)
+    }
+
+    #[instrument(skip_all)]
+    async fn get_media_content_for_uri_inner(
+        &self,
+        uri: &MxcUri,
+        current_time: SystemTime,
+    ) -> Result<Option<Vec<u8>>, IndexeddbEventCacheStoreError> {
+        let _timer = timer!("method");
+        self.memory_store
+            .get_media_content_for_uri_inner(uri, current_time)
+            .await
+            .map_err(IndexeddbEventCacheStoreError::MemoryStore)
+    }
+
+    #[instrument(skip_all)]
+    async fn clean_up_media_cache_inner(
+        &self,
+        policy: MediaRetentionPolicy,
+        current_time: SystemTime,
+    ) -> Result<(), IndexeddbEventCacheStoreError> {
+        let _timer = timer!("method");
+        self.memory_store
+            .clean_up_media_cache_inner(policy, current_time)
+            .await
+            .map_err(IndexeddbEventCacheStoreError::MemoryStore)
+    }
+
+    #[instrument(skip_all)]
+    async fn last_media_cleanup_time_inner(
+        &self,
+    ) -> Result<Option<SystemTime>, IndexeddbEventCacheStoreError> {
+        let _timer = timer!("method");
+        self.memory_store
+            .last_media_cleanup_time_inner()
             .await
             .map_err(IndexeddbEventCacheStoreError::MemoryStore)
     }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -624,10 +624,10 @@ impl EventCacheStoreMedia for IndexeddbEventCacheStore {
         &self,
     ) -> Result<Option<MediaRetentionPolicy>, IndexeddbEventCacheStoreError> {
         let _timer = timer!("method");
-        self.memory_store
-            .media_retention_policy_inner()
+        self.transaction(&[MediaRetentionPolicy::OBJECT_STORE], IdbTransactionMode::Readonly)?
+            .get_media_retention_policy()
             .await
-            .map_err(IndexeddbEventCacheStoreError::MemoryStore)
+            .map_err(Into::into)
     }
 
     #[instrument(skip_all)]
@@ -636,10 +636,10 @@ impl EventCacheStoreMedia for IndexeddbEventCacheStore {
         policy: MediaRetentionPolicy,
     ) -> Result<(), IndexeddbEventCacheStoreError> {
         let _timer = timer!("method");
-        self.memory_store
-            .set_media_retention_policy_inner(policy)
+        self.transaction(&[MediaRetentionPolicy::OBJECT_STORE], IdbTransactionMode::Readwrite)?
+            .put_item(&policy)
             .await
-            .map_err(IndexeddbEventCacheStoreError::MemoryStore)
+            .map_err(Into::into)
     }
 
     #[instrument(skip_all)]

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -14,7 +14,7 @@
 
 #![allow(unused)]
 
-use std::time::Duration;
+use std::{rc::Rc, time::Duration};
 
 use indexed_db_futures::IdbDatabase;
 use matrix_sdk_base::{
@@ -63,10 +63,10 @@ pub use error::IndexeddbEventCacheStoreError;
 /// contexts.
 ///
 /// [1]: matrix_sdk_base::event_cache::store::EventCacheStore
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IndexeddbEventCacheStore {
     // A handle to the IndexedDB database
-    inner: IdbDatabase,
+    inner: Rc<IdbDatabase>,
     // A serializer with functionality tailored to `IndexeddbEventCacheStore`
     serializer: IndexeddbEventCacheStoreSerializer,
     // An in-memory store for providing temporary implementations for

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
@@ -52,7 +52,7 @@ impl<T> From<serde_wasm_bindgen::Error> for IndexeddbEventCacheStoreSerializerEr
 /// [`EventCacheStore`][1].
 ///
 /// [1]: matrix_sdk_base::event_cache::store::EventCacheStore
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IndexeddbEventCacheStoreSerializer {
     inner: IndexeddbSerializer,
 }

--- a/crates/matrix-sdk-indexeddb/src/serializer.rs
+++ b/crates/matrix-sdk-indexeddb/src/serializer.rs
@@ -35,6 +35,7 @@ const BASE64: GeneralPurpose = GeneralPurpose::new(&alphabet::STANDARD, general_
 
 /// Handles the functionality of serializing and encrypting data for the
 /// indexeddb store.
+#[derive(Clone)]
 pub struct IndexeddbSerializer {
     store_cipher: Option<Arc<StoreCipher>>,
 }


### PR DESCRIPTION
## Background

This pull request is part of a series of pull requests to add a full IndexedDB implementation of the `EventCacheStore` (see #4617, #4996, #5090, #5138, #5226, #5274, #5343, #5384, #5406, #5414, #5497, #5506, #5540). This particular pull request adds a `MemoryStore`-backed implementation of `EventCacheStoreMedia`, as well as, IndexedDB-backed implementations for `MediaRetentionPolicy`-related functions.

## Changes

The overarching change adds a `MemoryStore`-backed implementation of `EventCacheStoreMedia` for `IndexeddbEventCacheStore`. Furthermore, the implementation of `EventCacheStore` now delegates to the implementation of `EventCacheStoreMedia` via a `MediaService` nested in `IndexeddbEventCacheStore`.

Additionally, there are now implementations and tests for the following `EventCacheStoreMedia` functions.

- `EventCacheStoreMedia::media_retention_policy_inner`
    - Supported by `IndexeddbEventCacheStoreTransaction::get_media_retention_policy`
- `EventCacheStoreMedia::set_media_retention_policy_inner`

And finally, to support these queries, the `CORE` object store now has a primary key with key path `id`.

## Caveats

`EventCacheStoreMedia` requires that the implementing type be `Clone`able. Consequently, some rather minimal changes were required in order to support `Clone`. 

There is, however, one notable change for supporting `Clone`, which is that `IndexeddbEventCacheStore.inner` went from being an `IdbDatabase` to an `Rc<IdbDatabase>`.

While this may seem like a problem in a concurrent environment, it is ultimately not an issue, as IndexedDB ensures that only a single transaction is running at a time. Any interfering transaction will be canceled by IndexedDB and return an error.

The downside of this architecture, however, is that it would require re-trying in a loop if multiple instances of `IndexeddbEventCacheStore` were contending for access. 

An alternative would be to use a `tokio::sync::Mutex` in conjunction with an `Arc`, which would replace the loop with an `await`. The consequences of this are that the implementation of `IndexeddbEventCacheStoreTransaction` becomes rather tricky, as it seems to require a self-referential struct.

I'm not entirely sure why the `EventCacheStoreMedia` requires `Clone` and how it will be used, so I opted for using an `Rc` as it was far more straightforward and still a sound approach. 

## Future Work

- Add implementation of remaining `EventCacheStoreMedia` functions

---

- [ ] Public API changes documented in changelogs (optional)


Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
