### PR TITLE
feat(event cache): find related events faster

### DIFF
--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/009_related_event_index.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/009_related_event_index.sql
@@ -1,0 +1,8 @@
+-- Add an index to speed up queries that look for related events in a room.
+CREATE INDEX "relates_to_idx"
+    ON "events" ("room_id", "relates_to");
+
+-- Add an index to speed up queries that look for related events in a room, with an additional
+-- filter.
+CREATE INDEX "relates_to_rel_type_idx"
+    ON "events" ("room_id", "relates_to", "rel_type");

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -77,7 +77,7 @@ const DATABASE_NAME: &str = "matrix-sdk-event-cache.sqlite3";
 /// This is used to figure whether the SQLite database requires a migration.
 /// Every new SQL migration should imply a bump of this number, and changes in
 /// the [`run_migrations`] function.
-const DATABASE_VERSION: u8 = 8;
+const DATABASE_VERSION: u8 = 9;
 
 /// The string used to identify a chunk of type events, in the `type` field in
 /// the database.
@@ -447,6 +447,16 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
                 "../migrations/event_cache_store/008_linked_chunk_id.sql"
             ))?;
             txn.set_db_version(8)
+        })
+        .await?;
+    }
+
+    if version < 9 {
+        conn.with_transaction(|txn| {
+            txn.execute_batch(include_str!(
+                "../migrations/event_cache_store/009_related_event_index.sql"
+            ))?;
+            txn.set_db_version(9)
         })
         .await?;
     }

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -47,7 +47,7 @@ use matrix_sdk_base::{
     serde_helpers::extract_thread_root_from_content,
     store_locks::LockStoreError,
     sync::RoomUpdates,
-    timer,
+    timer, ThreadingSupport,
 };
 use matrix_sdk_common::executor::{spawn, JoinHandle};
 use room::RoomEventCacheState;
@@ -998,9 +998,15 @@ impl EventCacheInner {
                     .ok_or_else(|| EventCacheError::RoomNotFound { room_id: room_id.to_owned() })?;
                 let room_version_rules = room.clone_info().room_version_rules_or_default();
 
+                let enabled_thread_support = matches!(
+                    client.base_client().threading_support,
+                    ThreadingSupport::Enabled { .. }
+                );
+
                 let room_state = RoomEventCacheState::new(
                     room_id.to_owned(),
                     room_version_rules,
+                    enabled_thread_support,
                     self.linked_chunk_update_sender.clone(),
                     self.store.clone(),
                     pagination_status.clone(),

--- a/crates/matrix-sdk/tests/integration/event_cache/threads.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads.rs
@@ -48,10 +48,20 @@ async fn wait_for_initial_events(
     }
 }
 
+async fn client_with_threading_support(server: &MatrixMockServer) -> Client {
+    server
+        .client_builder()
+        .on_builder(|builder| {
+            builder.with_threading_support(ThreadingSupport::Enabled { with_subscriptions: false })
+        })
+        .build()
+        .await
+}
+
 #[async_test]
 async fn test_thread_can_paginate_even_if_seen_sync_event() {
     let server = MatrixMockServer::new().await;
-    let client = server.client_builder().build().await;
+    let client = client_with_threading_support(&server).await;
 
     let room_id = room_id!("!galette:saucisse.bzh");
 
@@ -115,7 +125,7 @@ async fn test_thread_can_paginate_even_if_seen_sync_event() {
 #[async_test]
 async fn test_ignored_user_empties_threads() {
     let server = MatrixMockServer::new().await;
-    let client = server.client_builder().build().await;
+    let client = client_with_threading_support(&server).await;
 
     // Immediately subscribe the event cache to sync updates.
     client.event_cache().subscribe().unwrap();
@@ -207,7 +217,7 @@ async fn test_ignored_user_empties_threads() {
 #[async_test]
 async fn test_gappy_sync_empties_all_threads() {
     let server = MatrixMockServer::new().await;
-    let client = server.client_builder().build().await;
+    let client = client_with_threading_support(&server).await;
 
     // Immediately subscribe the event cache to sync updates.
     client.event_cache().subscribe().unwrap();
@@ -355,7 +365,7 @@ async fn test_gappy_sync_empties_all_threads() {
 #[async_test]
 async fn test_deduplication() {
     let server = MatrixMockServer::new().await;
-    let client = server.client_builder().build().await;
+    let client = client_with_threading_support(&server).await;
 
     // Immediately subscribe the event cache to sync updates.
     client.event_cache().subscribe().unwrap();


### PR DESCRIPTION
This adds indexes to make finding related events faster, on top of #5578.

## Results

The speedup factor is a function of the number of events in the DB, so with the updated benchmark from #5578, at this very precise moment, this gives me the following numbers:

```
Gnuplot not found, using plotters backend
Event cache room updates/Event cache find_event_relations[SQLite]/10 events, #no filter
                        time:   [338.94 µs 352.31 µs 375.31 µs]
                        thrpt:  [26.645 Kelem/s 28.384 Kelem/s 29.504 Kelem/s]
                 change:
                        time:   [-78.035% -75.984% -73.825%] (p = 0.00 < 0.05)
                        thrpt:  [+282.04% +316.39% +355.28%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Event cache room updates/Event cache find_event_relations[SQLite]/10 events, edits filter
                        time:   [350.26 µs 361.38 µs 373.78 µs]
                        thrpt:  [26.754 Kelem/s 27.672 Kelem/s 28.550 Kelem/s]
                 change:
                        time:   [-74.944% -73.970% -73.156%] (p = 0.00 < 0.05)
                        thrpt:  [+272.53% +284.18% +299.11%]
                        Performance has improved.
Event cache room updates/Event cache find_event_relations[SQLite]/100 events, #no filter
                        time:   [2.9294 ms 3.0187 ms 3.1317 ms]
                        thrpt:  [31.931 Kelem/s 33.127 Kelem/s 34.136 Kelem/s]
                 change:
                        time:   [-76.357% -75.234% -74.278%] (p = 0.00 < 0.05)
                        thrpt:  [+288.77% +303.78% +322.96%]
                        Performance has improved.
Event cache room updates/Event cache find_event_relations[SQLite]/100 events, edits filter
                        time:   [3.0400 ms 3.1814 ms 3.3592 ms]
                        thrpt:  [29.769 Kelem/s 31.433 Kelem/s 32.895 Kelem/s]
                 change:
                        time:   [-75.226% -74.305% -73.429%] (p = 0.00 < 0.05)
                        thrpt:  [+276.36% +289.17% +303.65%]
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
Event cache room updates/Event cache find_event_relations[SQLite]/1000 events, #no filter
                        time:   [27.923 ms 28.678 ms 30.137 ms]
                        thrpt:  [33.181 Kelem/s 34.870 Kelem/s 35.812 Kelem/s]
                 change:
                        time:   [-86.070% -84.243% -82.218%] (p = 0.00 < 0.05)
                        thrpt:  [+462.36% +534.63% +617.87%]
                        Performance has improved.
Event cache room updates/Event cache find_event_relations[SQLite]/1000 events, edits filter
                        time:   [30.156 ms 30.483 ms 30.705 ms]
                        thrpt:  [32.568 Kelem/s 32.805 Kelem/s 33.161 Kelem/s]
                 change:
                        time:   [-86.899% -84.861% -82.549%] (p = 0.00 < 0.05)
                        thrpt:  [+473.02% +560.54% +663.31%]
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low severe
  1 (10.00%) high severe
```

## Alternatives

For what it's worth, I've tried other indexes:

- only one of the two indexes in this PR: slower
- extra index for `(event_id, linked_chunk_id)` in `event_chunks`: no significant difference

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/5572 (maybe)(hopefully).