### PR TITLE
Don't error in `import_secrets` if `maybe_enable_backups` errors

### DIFF
--- a/crates/matrix-sdk/src/encryption/secret_storage/secret_store.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/secret_store.rs
@@ -420,7 +420,10 @@ impl SecretStore {
             }
         }
 
-        self.maybe_enable_backups().await?;
+        // We swallow errors here because we don't want backup failures to
+        // result in the whole process erroring.  All errors are logged in
+        // `maybe_enable_backups`.
+        let _ = self.maybe_enable_backups().await;
 
         Ok(())
     }


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-x-android/issues/5099

Since enabling backups is optional, if it fails, it shouldn't cause the whole function to error.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
