### PR TITLE
feat(common): Smaller serialised `TimelineEvent`

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -324,18 +324,25 @@ pub enum AlgorithmInfo {
 pub struct EncryptionInfo {
     /// The user ID of the event sender, note this is untrusted data unless the
     /// `verification_state` is `Verified` as well.
+    #[serde(rename = "s")]
     pub sender: OwnedUserId,
+
     /// The device ID of the device that sent us the event, note this is
     /// untrusted data unless `verification_state` is `Verified` as well.
+    #[serde(rename = "d")]
     pub sender_device: Option<OwnedDeviceId>,
+
     /// Information about the algorithm that was used to encrypt the event.
+    #[serde(rename = "a")]
     pub algorithm_info: AlgorithmInfo,
+
     /// The verification state of the device that sent us the event, note this
     /// is the state of the device at the time of decryption. It may change in
     /// the future if a device gets verified or deleted.
     ///
     /// Callers that persist this should mark the state as dirty when a device
     /// change is received down the sync.
+    #[serde(rename = "v")]
     pub verification_state: VerificationState,
 }
 
@@ -359,9 +366,13 @@ impl<'de> Deserialize<'de> for EncryptionInfo {
         // EncryptionInfo the session_id was not in AlgorithmInfo
         #[derive(Deserialize)]
         struct Helper {
+            #[serde(rename = "s", alias = "sender")]
             pub sender: OwnedUserId,
+            #[serde(rename = "d", alias = "sender_device")]
             pub sender_device: Option<OwnedDeviceId>,
+            #[serde(rename = "a", alias = "algorithm_info")]
             pub algorithm_info: AlgorithmInfo,
+            #[serde(rename = "v", alias = "verification_state")]
             pub verification_state: VerificationState,
             #[serde(rename = "session_id")]
             pub old_session_id: Option<String>,
@@ -1478,16 +1489,16 @@ mod tests {
                             "type": "m.room.message",
                         },
                         "ei": {
-                            "sender": "@sender:example.com",
-                            "sender_device": null,
-                            "algorithm_info": {
+                            "s": "@sender:example.com",
+                            "d": null,
+                            "a": {
                                 "MegolmV1AesSha2": {
                                     "curve25519_key": "xxx",
                                     "sender_claimed_keys": {},
                                     "session_id": "xyz",
                                 }
                             },
-                            "verification_state": "Verified",
+                            "v": "Verified",
                         },
                         "uei": {
                             "RelationsReplace": {"UnableToDecrypt": {
@@ -1542,7 +1553,7 @@ mod tests {
                 }
             }
         });
-        assert!(serde_json::from_value::<TimelineEvent>(serialized).is_ok());
+        serde_json::from_value::<TimelineEvent>(serialized).unwrap();
 
         // Test that the previous format can also be deserialized.
         let serialized = json!({


### PR DESCRIPTION
This set of patches is a draft in order to collect opinions from code owners with concrete examples.

The `TimelineEvent` type represents the majority of the events in the Matrix Rust SDK. It's the type used in the Event Cache. This type is stored in the Event Cache database. The goal of this set of patches is to reduce the storage space. How? By renaming many struct fields or enum variants to shorten names. It's a simple trick, low-hanging fruit, that can have a nice impact.

For example:

```diff
pub struct TimelineEvent {
    /// The event itself, together with any information on decryption.
+   #[serde(rename = "k", alias = "kind")]
    pub kind: TimelineEventKind,
```

With this simple change, we save 4 bytes.

If we apply this to `TimelineEventKind`, down to all the sub-types, **excluding** the crypto-related types, we get this:

| for … | saving for 1 value | saving for 100'000 values |
|-|-|-|
| a decrypted event | 113 bytes | 10.78 MiB |
| a UTD | 64 bytes | 6.1 MiB |
| an uncrypted event | 40 bytes | 3.81 MiB |

If we include the crypto-related types, like `AlgorithmInfo`, `VerificationState`, `UnableToDecryptInfo` etc.:

| for … | saving for 1 value | saving for 100'000 values |
|-|-|-|
| a decrypted event | 207 bytes | 19.74 MiB |
| a UTD | ~92 bytes | 8.77 MiB |

Before going further, I would like to collect your feedback. What do you think? Is it worth the changes?

At the time of writing, this set of patches handle the first case (a decrypted event) without changing the crypto-related types.

An (dead) alternative we (@poljar and I) have explored is to compress the data before going inside the database. Compression is effective when sequence of chars are repeating. Here, per row, the word `kind` exists once (excluding the event's content). Compression won't work that much.