### PR TITLE
ci: Add feature matrix for integration testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,8 +335,7 @@ jobs:
           target/debug/xtask ci clippy
 
   integration-tests:
-    name: Integration test
-
+    name: 'Integration test (features: ${{ matrix.feature }})'
     runs-on: ubuntu-latest
 
     # run several docker containers with the same networking stack so the hostname 'synapse'
@@ -351,6 +350,13 @@ jobs:
             SERVER_NAME: synapse
         ports:
             - 8008:8008
+
+    strategy:
+      fail-fast: true
+      matrix:
+        feature:
+          - "default"
+          - "experimental-encrypted-state-events"
 
     steps:
       - name: Checkout the repo
@@ -378,7 +384,7 @@ jobs:
           HOMESERVER_URL: "http://localhost:8008"
           HOMESERVER_DOMAIN: "synapse"
         run: |
-          cargo nextest run -p matrix-sdk-integration-testing
+          cargo nextest run -p matrix-sdk-integration-testing --features "${{ matrix.feature }}"
 
   compile-bench:
     name: 🚄 Compile benchmarks

--- a/testing/matrix-sdk-integration-testing/Cargo.toml
+++ b/testing/matrix-sdk-integration-testing/Cargo.toml
@@ -9,6 +9,16 @@ license = "Apache-2.0"
 [package.metadata.release]
 release = false
 
+[features]
+default = []
+
+# Enable experimental support for encrypting state events; see
+# https://github.com/matrix-org/matrix-rust-sdk/issues/5397.
+experimental-encrypted-state-events = [
+    "matrix-sdk/experimental-encrypted-state-events",
+    "matrix-sdk-base/experimental-encrypted-state-events"
+]
+
 [dev-dependencies]
 anyhow.workspace = true
 assert_matches.workspace = true
@@ -21,8 +31,8 @@ futures-core.workspace = true
 futures-util.workspace = true
 http.workspace = true
 json-structural-diff = "0.1.0"
-matrix-sdk = { workspace = true, default-features = true, features = ["testing", "qrcode", "experimental-encrypted-state-events"] }
-matrix-sdk-base = { workspace = true, default-features = true, features = ["testing", "qrcode", "experimental-encrypted-state-events"] }
+matrix-sdk = { workspace = true, default-features = true, features = ["testing", "qrcode"] }
+matrix-sdk-base = { workspace = true, default-features = true, features = ["testing", "qrcode"] }
 matrix-sdk-common.workspace = true
 matrix-sdk-test.workspace = true
 matrix-sdk-test-utils.workspace = true

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/mod.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/mod.rs
@@ -43,6 +43,7 @@ use tracing::{debug, warn};
 use crate::helpers::{SyncTokenAwareClient, TestClientBuilder};
 
 mod shared_history;
+#[cfg(feature = "experimental-encrypted-state-events")]
 mod state_events;
 
 // This test reproduces a bug seen on clients that use the same `Client`


### PR DESCRIPTION
This will resolve a number of [transitive dependency issues](https://github.com/matrix-org/matrix-rust-sdk/actions/runs/17264680104/job/48993934563) when testing crates that do not enable the `experimental-encrypted-state-events` feature flag by default.

- [ ] Add `experimental-encrypted-state-events` feature flag to `matrix-sdk-integration-testing`.
- [ ] Modify `ci.yaml` workflow to introduce a matrix of features over the above crate.

