### PR TITLE
feat(sdk,base): Introduce the new `LatestEvents` API, part 5: Make it persistent

### DIFF
--- a/crates/matrix-sdk-base/src/room/latest_event.rs
+++ b/crates/matrix-sdk-base/src/room/latest_event.rs
@@ -21,7 +21,7 @@ use ruma::{OwnedRoomId, events::AnySyncTimelineEvent, serde::Raw};
 use super::Room;
 #[cfg(feature = "e2e-encryption")]
 use super::RoomInfoNotableUpdateReasons;
-use crate::latest_event::LatestEvent;
+use crate::latest_event::{LatestEvent, LatestEventValue};
 
 impl Room {
     /// The size of the latest_encrypted_events RingBuffer
@@ -32,6 +32,11 @@ impl Room {
     /// sliding sync.
     pub fn latest_event(&self) -> Option<LatestEvent> {
         self.inner.read().latest_event.as_deref().cloned()
+    }
+
+    /// Return the [`LatestEventValue`] of this room.
+    pub fn new_latest_event(&self) -> LatestEventValue {
+        self.inner.read().new_latest_event.clone()
     }
 
     /// Return the most recent few encrypted events. When the keys come through

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1191,7 +1191,7 @@ pub fn apply_redaction(
 
 /// Indicates that a notable update of `RoomInfo` has been applied, and why.
 ///
-/// A room info notable update is an update that can be interested for other
+/// A room info notable update is an update that can be interesting for other
 /// parts of the code. This mechanism is used in coordination with
 /// [`BaseClient::room_info_notable_update_receiver`][baseclient] (and
 /// `Room::inner` plus `Room::room_info_notable_update_sender`) where `RoomInfo`

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1043,6 +1043,11 @@ impl RoomInfo {
         self.latest_event.as_deref()
     }
 
+    /// Sets the new `LatestEventValue`.
+    pub fn set_new_latest_event(&mut self, new_value: LatestEventValue) {
+        self.new_latest_event = new_value;
+    }
+
     /// Updates the recency stamp of this room.
     ///
     /// Please read [`Self::recency_stamp`] to learn more.

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -1449,6 +1449,7 @@ mod tests {
         assert!(client_room.latest_event().is_none());
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[async_test]
     async fn test_cached_latest_event_can_be_redacted() {
         // Given a logged-in client

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -45,7 +45,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     MinimalStateEvent, OriginalMinimalStateEvent, RoomInfo, RoomState,
     deserialized_responses::SyncOrStrippedState,
-    latest_event::LatestEvent,
+    latest_event::{LatestEvent, LatestEventValue},
     room::{BaseRoomInfo, RoomSummary, SyncInfo},
     sync::UnreadNotificationsCount,
 };
@@ -116,6 +116,7 @@ impl RoomInfoV1 {
             sync_info,
             encryption_state_synced,
             latest_event: latest_event.map(|ev| Box::new(LatestEvent::new(ev))),
+            new_latest_event: LatestEventValue::None,
             read_receipts: Default::default(),
             base_info: base_info.migrate(create),
             warned_about_unknown_room_version_rules: Arc::new(false.into()),

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -636,8 +636,7 @@ impl Client {
     }
 
     /// Returns a receiver that gets events for each room info update. To watch
-    /// for new events, use `receiver.resubscribe()`. Each event contains the
-    /// room and a boolean whether this event should trigger a room list update.
+    /// for new events, use `receiver.resubscribe()`.
     pub fn room_info_notable_update_receiver(&self) -> broadcast::Receiver<RoomInfoNotableUpdate> {
         self.base_client().room_info_notable_update_receiver()
     }

--- a/crates/matrix-sdk/src/latest_events/latest_event.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event.rs
@@ -140,7 +140,7 @@ impl LatestEvent {
     #[instrument(skip_all)]
     async fn store(&mut self, new_value: LatestEventValue) {
         let Some(room) = self.weak_room.get() else {
-            warn!(room_id = ?self.weak_room.room_id(), "Cannot store the latest event value because the room cannot be upgrading");
+            warn!(room_id = ?self.weak_room.room_id(), "Cannot store the latest event value because the room cannot be accessed");
             return;
         };
 

--- a/crates/matrix-sdk/src/latest_events/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/mod.rs
@@ -290,9 +290,7 @@ impl RegisteredRooms {
                     if room_latest_event.per_thread.contains_key(thread_id).not() {
                         room_latest_event.per_thread.insert(
                             thread_id.to_owned(),
-                            room_latest_event
-                                .create_latest_event_for(room_id, Some(thread_id))
-                                .await,
+                            room_latest_event.create_latest_event_for(Some(thread_id)).await,
                         );
                     }
                 }
@@ -464,40 +462,25 @@ impl RoomLatestEvents {
         };
 
         Ok(Some(Self {
-            for_the_room: Self::create_latest_event_for_inner(
-                room_id,
-                None,
-                &room_event_cache,
-                &weak_room,
-            )
-            .await,
+            for_the_room: Self::create_latest_event_for_inner(&weak_room, None, &room_event_cache)
+                .await,
             per_thread: HashMap::new(),
             weak_room,
             room_event_cache,
         }))
     }
 
-    async fn create_latest_event_for(
-        &self,
-        room_id: &RoomId,
-        thread_id: Option<&EventId>,
-    ) -> LatestEvent {
-        Self::create_latest_event_for_inner(
-            room_id,
-            thread_id,
-            &self.room_event_cache,
-            &self.weak_room,
-        )
-        .await
+    async fn create_latest_event_for(&self, thread_id: Option<&EventId>) -> LatestEvent {
+        Self::create_latest_event_for_inner(&self.weak_room, thread_id, &self.room_event_cache)
+            .await
     }
 
     async fn create_latest_event_for_inner(
-        room_id: &RoomId,
+        weak_room: &WeakRoom,
         thread_id: Option<&EventId>,
         room_event_cache: &RoomEventCache,
-        weak_room: &WeakRoom,
     ) -> LatestEvent {
-        LatestEvent::new(room_id, thread_id, room_event_cache, weak_room).await
+        LatestEvent::new(weak_room, thread_id, room_event_cache).await
     }
 
     /// Get the [`LatestEvent`] for the room.


### PR DESCRIPTION
This set of patches make the `LatestEventValue` persistent by:

- setting it in `RoomInfo`,
- persisting the `RoomInfo` in the `StateStore`,
- emitting a `RoomInfoNotableUpdateReasons::LATEST_EVENT`.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4112