### PR TITLE
fix: Only report duplicate one-time key errors once

### DIFF
--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -73,6 +73,8 @@ pub trait StateStoreIntegrationTests {
     async fn test_sync_token_saving(&self) -> TestResult;
     /// Test UtdHookManagerData saving.
     async fn test_utd_hook_manager_data_saving(&self) -> TestResult;
+    /// Test the saving of the OneTimeKeyAlreadyUploaded key/value data type.
+    async fn test_one_time_key_already_uploaded_data_saving(&self) -> TestResult;
     /// Test stripped room member saving.
     async fn test_stripped_member_saving(&self) -> TestResult;
     /// Test room power levels saving.
@@ -582,6 +584,26 @@ impl StateStoreIntegrationTests for DynStateStore {
             .expect("not UtdHookManagerData");
 
         assert_eq!(read_data, data);
+
+        Ok(())
+    }
+
+    async fn test_one_time_key_already_uploaded_data_saving(&self) -> TestResult {
+        // Before any data is written, the getter should return None.
+        assert!(
+            self.get_kv_data(StateStoreDataKey::OneTimeKeyAlreadyUploaded).await?.is_none(),
+            "Store was not empty at start"
+        );
+
+        self.set_kv_data(
+            StateStoreDataKey::OneTimeKeyAlreadyUploaded,
+            StateStoreDataValue::OneTimeKeyAlreadyUploaded,
+        )
+        .await?;
+
+        let data = self.get_kv_data(StateStoreDataKey::OneTimeKeyAlreadyUploaded).await?;
+        data.expect("The loaded data should be Some");
+
         Ok(())
     }
 
@@ -1902,6 +1924,12 @@ macro_rules! statestore_integration_tests {
             async fn test_utd_hook_manager_data_saving() -> TestResult {
                 let store = get_store().await?.into_state_store();
                 store.test_utd_hook_manager_data_saving().await
+            }
+
+            #[async_test]
+            async fn test_one_time_key_already_uploaded_data_saving() -> TestResult {
+                let store = get_store().await?.into_state_store();
+                store.test_one_time_key_already_uploaded_data_saving().await
             }
 
             #[async_test]

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -1131,6 +1131,10 @@ pub enum StateStoreDataValue {
     /// `matrix_sdk_ui::unable_to_decrypt_hook::UtdHookManager`.
     UtdHookManagerData(GrowableBloom),
 
+    /// A unit value telling us that the client uploaded duplicate one-time
+    /// keys.
+    OneTimeKeyAlreadyUploaded,
+
     /// A composer draft for the room.
     /// To learn more, see [`ComposerDraft`].
     ///
@@ -1234,6 +1238,10 @@ pub enum StateStoreDataKey<'a> {
     /// `matrix_sdk_ui::unable_to_decrypt_hook::UtdHookManager`.
     UtdHookManagerData,
 
+    /// Data remembering if the client already reported that it has uploaded
+    /// duplicate one-time keys.
+    OneTimeKeyAlreadyUploaded,
+
     /// A composer draft for the room.
     /// To learn more, see [`ComposerDraft`].
     ///
@@ -1247,11 +1255,14 @@ pub enum StateStoreDataKey<'a> {
 impl StateStoreDataKey<'_> {
     /// Key to use for the [`SyncToken`][Self::SyncToken] variant.
     pub const SYNC_TOKEN: &'static str = "sync_token";
+
     /// Key to use for the [`ServerInfo`][Self::ServerInfo]
     /// variant.
     pub const SERVER_INFO: &'static str = "server_capabilities"; // Note: this is the old name, kept for backwards compatibility.
+    //
     /// Key prefix to use for the [`Filter`][Self::Filter] variant.
     pub const FILTER: &'static str = "filter";
+
     /// Key prefix to use for the [`UserAvatarUrl`][Self::UserAvatarUrl]
     /// variant.
     pub const USER_AVATAR_URL: &'static str = "user_avatar_url";
@@ -1263,6 +1274,10 @@ impl StateStoreDataKey<'_> {
     /// Key to use for the [`UtdHookManagerData`][Self::UtdHookManagerData]
     /// variant.
     pub const UTD_HOOK_MANAGER_DATA: &'static str = "utd_hook_manager_data";
+
+    /// Key to use for the flag remembering that we already reported that we
+    /// uploaded duplicate one-time keys.
+    pub const ONE_TIME_KEY_ALREADY_UPLOADED: &'static str = "one_time_key_already_uploaded";
 
     /// Key prefix to use for the [`ComposerDraft`][Self::ComposerDraft]
     /// variant.

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -422,6 +422,9 @@ impl IndexeddbStateStore {
             StateStoreDataKey::UtdHookManagerData => {
                 self.encode_key(keys::KV, StateStoreDataKey::UTD_HOOK_MANAGER_DATA)
             }
+            StateStoreDataKey::OneTimeKeyAlreadyUploaded => {
+                self.encode_key(keys::KV, StateStoreDataKey::ONE_TIME_KEY_ALREADY_UPLOADED)
+            }
             StateStoreDataKey::ComposerDraft(room_id, thread_root) => {
                 if let Some(thread_root) = thread_root {
                     self.encode_key(
@@ -563,6 +566,10 @@ impl_state_store!({
                 .map(|f| self.deserialize_value::<GrowableBloom>(&f))
                 .transpose()?
                 .map(StateStoreDataValue::UtdHookManagerData),
+            StateStoreDataKey::OneTimeKeyAlreadyUploaded => value
+                .map(|f| self.deserialize_value::<bool>(&f))
+                .transpose()?
+                .map(|_| StateStoreDataValue::OneTimeKeyAlreadyUploaded),
             StateStoreDataKey::ComposerDraft(_, _) => value
                 .map(|f| self.deserialize_value::<ComposerDraft>(&f))
                 .transpose()?
@@ -603,6 +610,7 @@ impl_state_store!({
             StateStoreDataKey::UtdHookManagerData => self.serialize_value(
                 &value.into_utd_hook_manager_data().expect("Session data not UtdHookManagerData"),
             ),
+            StateStoreDataKey::OneTimeKeyAlreadyUploaded => self.serialize_value(&true),
             StateStoreDataKey::ComposerDraft(_, _) => self.serialize_value(
                 &value.into_composer_draft().expect("Session data not a composer draft"),
             ),

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -387,6 +387,9 @@ impl SqliteStateStore {
             StateStoreDataKey::UtdHookManagerData => {
                 Cow::Borrowed(StateStoreDataKey::UTD_HOOK_MANAGER_DATA)
             }
+            StateStoreDataKey::OneTimeKeyAlreadyUploaded => {
+                Cow::Borrowed(StateStoreDataKey::ONE_TIME_KEY_ALREADY_UPLOADED)
+            }
             StateStoreDataKey::ComposerDraft(room_id, thread_root) => {
                 if let Some(thread_root) = thread_root {
                     Cow::Owned(format!(
@@ -1012,6 +1015,9 @@ impl StateStore for SqliteStateStore {
                     StateStoreDataKey::UtdHookManagerData => {
                         StateStoreDataValue::UtdHookManagerData(self.deserialize_value(&data)?)
                     }
+                    StateStoreDataKey::OneTimeKeyAlreadyUploaded => {
+                        StateStoreDataValue::OneTimeKeyAlreadyUploaded
+                    }
                     StateStoreDataKey::ComposerDraft(_, _) => {
                         StateStoreDataValue::ComposerDraft(self.deserialize_value(&data)?)
                     }
@@ -1047,6 +1053,9 @@ impl StateStore for SqliteStateStore {
             StateStoreDataKey::UtdHookManagerData => self.serialize_value(
                 &value.into_utd_hook_manager_data().expect("Session data not UtdHookManagerData"),
             )?,
+            StateStoreDataKey::OneTimeKeyAlreadyUploaded => {
+                self.serialize_value(&true).expect("We should be able to serialize a boolean")
+            }
             StateStoreDataKey::ComposerDraft(_, _) => self.serialize_value(
                 &value.into_composer_draft().expect("Session data not a composer draft"),
             )?,


### PR DESCRIPTION
Since the server will reject any duplicate one-time keys forever, clients which encounter such an error will spam sentry with such reports.

This patch ensures that we only send the sentry report once.