### PR TITLE
feat(threads): implement msc4308 companion endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4660,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.6"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "assign",
  "js_int",
@@ -4677,7 +4677,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.4"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "as_variant",
  "assign",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.4"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "as_variant",
  "base64",
@@ -4733,7 +4733,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.5"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4759,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.2"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "headers",
  "http",
@@ -4779,7 +4779,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.1"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4790,7 +4790,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "js_int",
  "thiserror 2.0.11",
@@ -4799,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.2"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",
@@ -4814,7 +4814,7 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.17.1"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,8 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "57049282e3a74f67f86e4eb238
     "unstable-msc4222",
     "unstable-msc4278",
     "unstable-msc4286",
-    "unstable-msc4306"
+    "unstable-msc4306",
+    "unstable-msc4308"
 ] }
 sentry = "0.36.0"
 sentry-tracing = "0.36.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 rand = "0.8.5"
 reqwest = { version = "0.12.12", default-features = false }
 rmp-serde = "1.3.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "e85e224cef32181029efa106a059d277ecfbe87d", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "57049282e3a74f67f86e4eb2382a3e649b57cc2b", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-arbitrary-length-ids",

--- a/crates/matrix-sdk-base/src/room/call.rs
+++ b/crates/matrix-sdk-base/src/room/call.rs
@@ -144,6 +144,7 @@ mod tests {
                         focus_active,
                         foci_preferred,
                         Some(timestamp(minutes_ago)),
+                        None,
                     ),
                     CallMemberStateKey::new(user_id.to_owned(), Some(member_id), false),
                 )

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -135,7 +135,7 @@ async fn test_subscribed_threads_get_notifications() {
     // For a thread I'm subscribed to,
     let thread_root = event_id!("$thread_root");
     server
-        .mock_get_thread_subscription()
+        .mock_room_get_thread_subscription()
         .match_thread_id(thread_root.to_owned())
         .ok(false)
         .expect(2)

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- `Client::fetch_thread_subscriptions` implements support for the companion endpoint of the
+  experimental MSC4308, allowing to fetch thread subscriptions for a given range, as specified by
+  the MSC.
+  ([#5590](https://github.com/matrix-org/matrix-rust-sdk/pull/5590))
 - Add a `Client::joined_space_rooms` method that allows retrieving the list of joined spaces.
 - `Room::enable_encryption` and `Room::enable_encryption_with_state_event_encryption` will poll
   the encryption state for up to 3 seconds, rather than checking once after a single sync has

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -61,6 +61,7 @@ use ruma::{
             room::create_room,
             session::login::v3::DiscoveryInfo,
             sync::sync_events,
+            threads::get_thread_subscriptions_changes,
             uiaa,
             user_directory::search_users,
         },
@@ -2892,6 +2893,25 @@ impl Client {
             ThreadingSupport::Enabled { with_subscriptions } => with_subscriptions,
             ThreadingSupport::Disabled => false,
         }
+    }
+
+    /// Fetch thread subscriptions changes between `from` and up to `to`.
+    ///
+    /// The `limit` optional parameter can be used to limit the number of
+    /// entries in a response. It can also be overridden by the server, if
+    /// it's deemed too large.
+    pub async fn fetch_thread_subscriptions(
+        &self,
+        from: Option<String>,
+        to: Option<String>,
+        limit: Option<UInt>,
+    ) -> Result<get_thread_subscriptions_changes::unstable::Response> {
+        let request = assign!(get_thread_subscriptions_changes::unstable::Request::new(), {
+            from,
+            to,
+            limit,
+        });
+        Ok(self.send(request).await?)
     }
 }
 

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1354,27 +1354,31 @@ impl MatrixMockServer {
 
     /// Create a prebuilt mock for the endpoint used to get a single thread
     /// subscription status in a given room.
-    pub fn mock_get_thread_subscription(&self) -> MockEndpoint<'_, GetThreadSubscriptionEndpoint> {
+    pub fn mock_room_get_thread_subscription(
+        &self,
+    ) -> MockEndpoint<'_, RoomGetThreadSubscriptionEndpoint> {
         let mock = Mock::given(method("GET"));
-        self.mock_endpoint(mock, GetThreadSubscriptionEndpoint::default())
+        self.mock_endpoint(mock, RoomGetThreadSubscriptionEndpoint::default())
             .expect_default_access_token()
     }
 
     /// Create a prebuilt mock for the endpoint used to define a thread
     /// subscription in a given room.
-    pub fn mock_put_thread_subscription(&self) -> MockEndpoint<'_, PutThreadSubscriptionEndpoint> {
+    pub fn mock_room_put_thread_subscription(
+        &self,
+    ) -> MockEndpoint<'_, RoomPutThreadSubscriptionEndpoint> {
         let mock = Mock::given(method("PUT"));
-        self.mock_endpoint(mock, PutThreadSubscriptionEndpoint::default())
+        self.mock_endpoint(mock, RoomPutThreadSubscriptionEndpoint::default())
             .expect_default_access_token()
     }
 
     /// Create a prebuilt mock for the endpoint used to delete a thread
     /// subscription in a given room.
-    pub fn mock_delete_thread_subscription(
+    pub fn mock_room_delete_thread_subscription(
         &self,
-    ) -> MockEndpoint<'_, DeleteThreadSubscriptionEndpoint> {
+    ) -> MockEndpoint<'_, RoomDeleteThreadSubscriptionEndpoint> {
         let mock = Mock::given(method("DELETE"));
-        self.mock_endpoint(mock, DeleteThreadSubscriptionEndpoint::default())
+        self.mock_endpoint(mock, RoomDeleteThreadSubscriptionEndpoint::default())
             .expect_default_access_token()
     }
 
@@ -3991,11 +3995,11 @@ impl ThreadSubscriptionMatchers {
 /// A prebuilt mock for `GET
 /// /client/*/rooms/{room_id}/threads/{thread_root}/subscription`
 #[derive(Default)]
-pub struct GetThreadSubscriptionEndpoint {
+pub struct RoomGetThreadSubscriptionEndpoint {
     matchers: ThreadSubscriptionMatchers,
 }
 
-impl<'a> MockEndpoint<'a, GetThreadSubscriptionEndpoint> {
+impl<'a> MockEndpoint<'a, RoomGetThreadSubscriptionEndpoint> {
     /// Returns a successful response for the given thread subscription.
     pub fn ok(mut self, automatic: bool) -> MatrixMock<'a> {
         self.mock = self.mock.and(path_regex(self.endpoint.matchers.endpoint_regexp_uri()));
@@ -4019,11 +4023,11 @@ impl<'a> MockEndpoint<'a, GetThreadSubscriptionEndpoint> {
 /// A prebuilt mock for `PUT
 /// /client/*/rooms/{room_id}/threads/{thread_root}/subscription`
 #[derive(Default)]
-pub struct PutThreadSubscriptionEndpoint {
+pub struct RoomPutThreadSubscriptionEndpoint {
     matchers: ThreadSubscriptionMatchers,
 }
 
-impl<'a> MockEndpoint<'a, PutThreadSubscriptionEndpoint> {
+impl<'a> MockEndpoint<'a, RoomPutThreadSubscriptionEndpoint> {
     /// Returns a successful response for the given setting of thread
     /// subscription.
     pub fn ok(mut self) -> MatrixMock<'a> {
@@ -4064,11 +4068,11 @@ impl<'a> MockEndpoint<'a, PutThreadSubscriptionEndpoint> {
 /// A prebuilt mock for `DELETE
 /// /client/*/rooms/{room_id}/threads/{thread_root}/subscription`
 #[derive(Default)]
-pub struct DeleteThreadSubscriptionEndpoint {
+pub struct RoomDeleteThreadSubscriptionEndpoint {
     matchers: ThreadSubscriptionMatchers,
 }
 
-impl<'a> MockEndpoint<'a, DeleteThreadSubscriptionEndpoint> {
+impl<'a> MockEndpoint<'a, RoomDeleteThreadSubscriptionEndpoint> {
     /// Returns a successful response for the deletion of a given thread
     /// subscription.
     pub fn ok(mut self) -> MatrixMock<'a> {

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, time::Duration};
+use std::{collections::BTreeMap, ops::Not as _, time::Duration};
 
 use assert_matches2::{assert_let, assert_matches};
 use eyeball_im::VectorDiff;
@@ -49,10 +49,11 @@ use ruma::{
         },
         AnyInitialStateEvent,
     },
+    owned_event_id, owned_room_id,
     room::JoinRule,
     room_id,
     serde::Raw,
-    user_id, OwnedUserId,
+    uint, user_id, OwnedUserId,
 };
 use serde_json::{json, Value as JsonValue};
 use stream_assert::{assert_next_matches, assert_pending};
@@ -1539,4 +1540,55 @@ async fn test_server_vendor_info_with_missing_fields() {
     // Should use defaults for missing fields
     assert_eq!(server_info.server_name, "unknown");
     assert_eq!(server_info.version, "unknown");
+}
+
+#[async_test]
+async fn test_fetch_thread_subscriptions() {
+    use ruma::api::client::threads::get_thread_subscriptions_changes::unstable::{
+        ThreadSubscription, ThreadUnsubscription,
+    };
+
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room1 = owned_room_id!("!room1:example.com");
+    let room2 = owned_room_id!("!room2:example.com");
+    let room3 = owned_room_id!("!room3:example.com");
+
+    let thread1 = owned_event_id!("$thread1:example.com");
+    let thread2 = owned_event_id!("$thread2:example.com");
+    let thread3 = owned_event_id!("$thread3:example.com");
+
+    server
+        .mock_get_thread_subscriptions()
+        .match_from("from")
+        .match_to("to")
+        .add_subscription(room1.clone(), thread1.clone(), ThreadSubscription::new(true, uint!(42)))
+        .add_subscription(room2.clone(), thread2.clone(), ThreadSubscription::new(false, uint!(7)))
+        .add_unsubcription(room3.clone(), thread3.clone(), ThreadUnsubscription::new(uint!(13)))
+        .ok(Some("next_batch_token".to_owned()))
+        .mount()
+        .await;
+
+    let response = client
+        .fetch_thread_subscriptions(Some("from".to_owned()), Some("to".to_owned()), None)
+        .await
+        .unwrap();
+
+    assert_eq!(response.end.as_deref(), Some("next_batch_token"));
+
+    assert_eq!(response.subscribed.len(), 2);
+
+    let s1 = &response.subscribed[&room1][&thread1];
+    assert!(s1.automatic);
+    assert_eq!(s1.bump_stamp, uint!(42));
+
+    let s2 = &response.subscribed[&room2][&thread2];
+    assert!(s2.automatic.not());
+    assert_eq!(s2.bump_stamp, uint!(7));
+
+    assert_eq!(response.unsubscribed.len(), 1);
+
+    let u = &response.unsubscribed[&room3][&thread3];
+    assert_eq!(u.bump_stamp, uint!(13));
 }

--- a/crates/matrix-sdk/tests/integration/event_cache/threads.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads.rs
@@ -555,7 +555,7 @@ async fn test_auto_subscribe_thread_via_sync() {
     // (The endpoint will be called for the current thread, and with an automatic
     // subscription up to the given event ID.)
     s.server
-        .mock_put_thread_subscription()
+        .mock_room_put_thread_subscription()
         .match_automatic_event_id(&s.mention_event_id)
         .match_thread_id(s.thread_root.to_owned())
         .ok()
@@ -587,7 +587,7 @@ async fn test_dont_auto_subscribe_on_already_subscribed_thread() {
 
     // Given a thread I'm already subscribed to,
     s.server
-        .mock_get_thread_subscription()
+        .mock_room_get_thread_subscription()
         .match_thread_id(s.thread_root.to_owned())
         .ok(false)
         .mock_once()
@@ -595,7 +595,7 @@ async fn test_dont_auto_subscribe_on_already_subscribed_thread() {
         .await;
 
     // The PUT endpoint (to subscribe to the thread) shouldn't be called…
-    s.server.mock_put_thread_subscription().ok().expect(0).mount().await;
+    s.server.mock_room_put_thread_subscription().ok().expect(0).mount().await;
 
     // …when I receive a new in-thread mention for this thread.
     s.server
@@ -678,7 +678,7 @@ async fn test_auto_subscribe_on_thread_paginate() {
     // (The endpoint will be called for the current thread, and with an automatic
     // subscription up to the given event ID.)
     s.server
-        .mock_put_thread_subscription()
+        .mock_room_put_thread_subscription()
         .match_automatic_event_id(&s.mention_event_id)
         .match_thread_id(s.thread_root.to_owned())
         .ok()
@@ -764,7 +764,7 @@ async fn test_auto_subscribe_on_thread_paginate_root_event() {
     // (The endpoint will be called for the current thread, and with an automatic
     // subscription up to the given event ID.)
     s.server
-        .mock_put_thread_subscription()
+        .mock_room_put_thread_subscription()
         .match_automatic_event_id(thread_root_id)
         .match_thread_id(thread_root_id.to_owned())
         .ok()

--- a/crates/matrix-sdk/tests/integration/room/thread.rs
+++ b/crates/matrix-sdk/tests/integration/room/thread.rs
@@ -18,7 +18,7 @@ async fn test_subscribe_thread() {
     let root_id = owned_event_id!("$root");
 
     server
-        .mock_put_thread_subscription()
+        .mock_room_put_thread_subscription()
         .match_room_id(room_id.to_owned())
         .match_thread_id(root_id.clone())
         .ok()
@@ -30,7 +30,7 @@ async fn test_subscribe_thread() {
     room.subscribe_thread(root_id.clone(), Some(root_id.clone())).await.unwrap();
 
     server
-        .mock_get_thread_subscription()
+        .mock_room_get_thread_subscription()
         .match_room_id(room_id.to_owned())
         .match_thread_id(root_id.clone())
         .ok(true)
@@ -50,7 +50,7 @@ async fn test_subscribe_thread() {
 
     // I can also unsubscribe from a thread.
     server
-        .mock_delete_thread_subscription()
+        .mock_room_delete_thread_subscription()
         .match_room_id(room_id.to_owned())
         .match_thread_id(root_id.clone())
         .ok()
@@ -68,7 +68,7 @@ async fn test_subscribe_thread() {
     // Subscribing automatically to the thread may also return a `M_SKIPPED` error
     // that should be non-fatal.
     server
-        .mock_put_thread_subscription()
+        .mock_room_put_thread_subscription()
         .match_room_id(room_id.to_owned())
         .match_thread_id(root_id.clone())
         .conflicting_unsubscription()
@@ -99,7 +99,7 @@ async fn test_subscribe_thread_if_needed() {
         (owned_event_id!("$woot"), Some(owned_event_id!("$woot"))),
     ] {
         server
-            .mock_put_thread_subscription()
+            .mock_room_put_thread_subscription()
             .match_room_id(room_id.to_owned())
             .match_thread_id(root_id.clone())
             .ok()
@@ -117,7 +117,7 @@ async fn test_subscribe_thread_if_needed() {
         let root_id = owned_event_id!("$toot");
 
         server
-            .mock_get_thread_subscription()
+            .mock_room_get_thread_subscription()
             .match_room_id(room_id.to_owned())
             .match_thread_id(root_id.clone())
             .ok(true)
@@ -126,7 +126,7 @@ async fn test_subscribe_thread_if_needed() {
             .await;
 
         server
-            .mock_put_thread_subscription()
+            .mock_room_put_thread_subscription()
             .match_room_id(room_id.to_owned())
             .match_thread_id(root_id.clone())
             .ok()
@@ -142,7 +142,7 @@ async fn test_subscribe_thread_if_needed() {
         let root_id = owned_event_id!("$foot");
 
         server
-            .mock_get_thread_subscription()
+            .mock_room_get_thread_subscription()
             .match_room_id(room_id.to_owned())
             .match_thread_id(root_id.clone())
             .ok(true)
@@ -160,7 +160,7 @@ async fn test_subscribe_thread_if_needed() {
         (owned_event_id!("$woot"), Some(owned_event_id!("$woot"))),
     ] {
         server
-            .mock_get_thread_subscription()
+            .mock_room_get_thread_subscription()
             .match_room_id(room_id.to_owned())
             .match_thread_id(root_id.clone())
             .ok(false)
@@ -214,7 +214,7 @@ async fn test_thread_push_rule_is_triggered_for_subscribed_threads() {
     // Mock the thread subscriptions endpoint so the user is subscribed to the
     // thread.
     server
-        .mock_get_thread_subscription()
+        .mock_room_get_thread_subscription()
         .match_room_id(room_id.to_owned())
         .match_thread_id(thread_root_id.clone())
         .ok(true)
@@ -289,7 +289,7 @@ async fn test_thread_push_rules_and_notification_modes() {
     let thread_root_id = owned_event_id!("$root");
 
     server
-        .mock_get_thread_subscription()
+        .mock_room_get_thread_subscription()
         .match_room_id(room_id.to_owned())
         .match_thread_id(thread_root_id.clone())
         .ok(true)

--- a/crates/matrix-sdk/tests/integration/room/thread.rs
+++ b/crates/matrix-sdk/tests/integration/room/thread.rs
@@ -344,9 +344,7 @@ async fn test_thread_push_rules_and_notification_modes() {
 
     // The thread event will trigger a notification.
     let actions = room.push_context().await.unwrap().unwrap().traced_for_event(&event).await;
-    // TODO: unexpected! this should trigger a thread mention
-    //assert!(actions.iter().any(|action| action.should_notify()));
-    assert!(!actions.iter().any(|action| action.should_notify()));
+    assert!(actions.iter().any(|action| action.should_notify()));
 
     // If room mode = mute,
     settings.set_room_notification_mode(room_id, RoomNotificationMode::Mute).await.unwrap();
@@ -403,9 +401,7 @@ async fn test_thread_push_rules_and_notification_modes() {
 
     // The thread event will trigger a notification.
     let actions = room.push_context().await.unwrap().unwrap().traced_for_event(&event).await;
-    // TODO: unexpected! this should trigger a thread mention
-    //assert!(actions.iter().any(|action| action.should_notify()));
-    assert!(!actions.iter().any(|action| action.should_notify()));
+    assert!(actions.iter().any(|action| action.should_notify()));
 
     // If room mode = mute,
     settings.set_room_notification_mode(room_id, RoomNotificationMode::Mute).await.unwrap();

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -3747,7 +3747,7 @@ async fn test_sending_reply_in_thread_auto_subscribe() {
     server.mock_room_send().ok(event_id!("$reply")).mock_once().mount().await;
 
     server
-        .mock_put_thread_subscription()
+        .mock_room_put_thread_subscription()
         .match_room_id(room_id.to_owned())
         .match_thread_id(thread_root.to_owned())
         .ok()
@@ -3771,7 +3771,7 @@ async fn test_sending_reply_in_thread_auto_subscribe() {
 
     // Subscribed, automatically.
     server
-        .mock_get_thread_subscription()
+        .mock_room_get_thread_subscription()
         .match_room_id(room_id.to_owned())
         .match_thread_id(thread_root.to_owned())
         .ok(true)
@@ -3780,7 +3780,7 @@ async fn test_sending_reply_in_thread_auto_subscribe() {
 
     // I'll get one subscription.
     server
-        .mock_put_thread_subscription()
+        .mock_room_put_thread_subscription()
         .match_room_id(room_id.to_owned())
         .match_thread_id(thread_root.to_owned())
         .ok()
@@ -3805,7 +3805,7 @@ async fn test_sending_reply_in_thread_auto_subscribe() {
 
     // Subscribed, but manually.
     server
-        .mock_get_thread_subscription()
+        .mock_room_get_thread_subscription()
         .match_room_id(room_id.to_owned())
         .match_thread_id(thread_root.to_owned())
         .ok(false)
@@ -3813,7 +3813,7 @@ async fn test_sending_reply_in_thread_auto_subscribe() {
         .await;
 
     // I'll get zero subscription.
-    server.mock_put_thread_subscription().ok().expect(0).mount().await;
+    server.mock_room_put_thread_subscription().ok().expect(0).mount().await;
 
     server.mock_room_send().ok(event_id!("$reply")).mock_once().mount().await;
 


### PR DESCRIPTION
This bumps Ruma (to an unstable branch, because we need https://github.com/ruma/ruma/pull/2200 for tests, duh), which brings us a few documented test fixes.

In addition to this, this implements the support for the companion endpoint of MSC4308, which allows to back-paginate thread subscriptions, if the sync response contained only a small subset of the entire change set.

Part of #5038. 