### PR TITLE
common: js_tracing: drop TRACE logs

### DIFF
--- a/crates/matrix-sdk-common/CHANGELOG.md
+++ b/crates/matrix-sdk-common/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Tracing subscribers created via [`matrix_sdk_common::js_tracing::MakeJsLogWriter`] or [`make_tracing_subscriber`] will now drop log events at the `TRACE` level. Previously `TRACE` logs were treated the same as `DEBUG` logs. ([#5590](https://github.com/matrix-org/matrix-rust-sdk/pull/5590)).
+
 - [**breaking**] Use `Raw<AnyTimelineEvent>` in place of `Raw<AnyMessageLikeEvent>`
   in `DecryptedRoomEvent::event`.
   ([#5512](https://github.com/matrix-org/matrix-rust-sdk/pull/5512/files)).

--- a/crates/matrix-sdk-common/src/js_tracing.rs
+++ b/crates/matrix-sdk-common/src/js_tracing.rs
@@ -186,7 +186,8 @@ impl io::Write for JsLogWriter {
 
 fn write_message_to_logger(level: Level, message: &JsValue, logger: &JsLogger) {
     match level {
-        Level::TRACE | Level::DEBUG => logger.debug(message),
+        Level::TRACE => (),
+        Level::DEBUG => logger.debug(message),
         Level::INFO => logger.info(message),
         Level::WARN => logger.warn(message),
         Level::ERROR => logger.error(message),
@@ -195,7 +196,8 @@ fn write_message_to_logger(level: Level, message: &JsValue, logger: &JsLogger) {
 
 fn write_message_to_console(level: Level, message: &JsValue) {
     match level {
-        Level::TRACE | Level::DEBUG => web_sys::console::debug_1(message),
+        Level::TRACE => (),
+        Level::DEBUG => web_sys::console::debug_1(message),
         Level::INFO => web_sys::console::info_1(message),
         Level::WARN => web_sys::console::warn_1(message),
         Level::ERROR => web_sys::console::error_1(message),
@@ -342,10 +344,11 @@ pub fn make_tracing_subscriber(logger: Option<JsLogger>) -> JsLoggingSubscriber 
     };
 
     tracing_subscriber::fmt()
-        .with_max_level(Level::TRACE)
-        .with_writer(make_writer)
+        // JsLogWriter drops Level::TRACE events, so there's no point formatting them.
+        .with_max_level(Level::DEBUG)
         .with_ansi(false)
         .event_format(JsEventFormatter::new())
+        .with_writer(make_writer)
         .finish()
 }
 


### PR DESCRIPTION
Now that (since https://github.com/matrix-org/matrix-js-sdk/pull/4918) Element Web uses separate subscribers for each OlmMachine, rather than a single global one with a separate LevelFilter, EW's logs are very verbose because they receive all the TRACE logs.

Dropping the TRACE logs on the floor isn't my favourite solution, but everything else seems to be a bit harder than I have time for right now:

* Sending TRACE logs up to the JS side in case it wants to print them would (a) increase overhead and (b) be an annoying breaking change in JsLogger

* Ideally we'd let the application configure its logging more precisely via an `EnvFilter` or something, but I'm not really sure what the API would look like for that.

So for now, we take the easy path.