### PR TITLE
chore(ffi): expose the `SyncService.expire_sessions` so client can expire Sliding Sync positions on demand

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -90,6 +90,15 @@ impl SyncService {
             }
         })))
     }
+
+    /// Force expiring both sliding sync sessions.
+    ///
+    /// This ensures that the sync service is stopped before expiring both
+    /// sessions. It should be used sparingly, as it will cause a restart of
+    /// the sessions on the server as well.
+    pub async fn expire_sessions(&self) {
+        self.inner.expire_sessions().await;
+    }
 }
 
 #[derive(Clone, uniffi::Object)]


### PR DESCRIPTION
This is useful when changing the required sliding sync state in between position resets which Synapse doesn't handle well at the moment as per https://github.com/element-hq/synapse/issues/18844