### PR TITLE
crypto: log message index for megolm sessions received over olm

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Log message index for Megolm sessions received over encrypted to-device messages. ([#5599](https://github.com/matrix-org/matrix-rust-sdk/pull/5599))
 - Add `RoomSettings::encrypt_state_events` flag. ([#5511](https://github.com/matrix-org/matrix-rust-sdk/pull/5511))
 - Make sure to accept historic room key bundles only if the sender is trusted
   enough.

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -897,7 +897,7 @@ impl OlmMachine {
         // This function is only ever called by add_room_key via
         // handle_decrypted_to_device_event, so sender, sender_key, and algorithm are
         // already recorded.
-        fields(room_id = ? content.room_id, session_id)
+        fields(room_id = ? content.room_id, session_id, message_index)
     )]
     async fn handle_key(
         &self,
@@ -911,6 +911,7 @@ impl OlmMachine {
         match session {
             Ok(mut session) => {
                 Span::current().record("session_id", session.session_id());
+                Span::current().record("message_index", session.first_known_index());
 
                 let sender_data =
                     SenderDataFinder::find_using_event(self.store(), sender_key, event, &session)


### PR DESCRIPTION
When we receive a to-device message that contains a megolm decryption key, log the ratchet index of the received key, for debugging.