### PR TITLE
Document `--proxy` option in the `multiverse` client to inspect network requests

### DIFF
--- a/labs/README.md
+++ b/labs/README.md
@@ -14,8 +14,10 @@ Rust SDK can evolve, feel free to propose an experiment.
 ## Current experiments
 
 - multiverse: a TUI client mostly for quick development iteration of SDK features and debugging.
-  Run with `cargo run --bin multiverse matrix.org ~/.cache/multiverse-cache`.
-
+  - Run with `cargo run --bin multiverse matrix.org ~/.cache/multiverse-cache`.
+  - To inspect network requests, there is a `--proxy` option which can use in
+    combination with [mitmproxy](https://www.mitmproxy.org/):
+    `cargo run --bin multiverse -- --proxy http://localhost:8080 matrix.org ~/.cache/multiverse-cache`
 
 ## Archived experiments
 


### PR DESCRIPTION
Document `--proxy` option in the `multiverse` client to be able to inspect network requests flying around as you interact.

Spawning from https://github.com/matrix-org/matrix-rust-sdk/issues/5600#issuecomment-3238128112 as pointed out by @poljar 

<!-- description of the changes in this PR -->

- [ ] ~~Public API changes documented in changelogs (optional)~~ N/A

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: erice@element.io
