### PR TITLE
IndexedDB: Add initial types and database migrations for `EventCacheStoreMedia` backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,6 +3400,7 @@ dependencies = [
  "matrix-sdk-store-encryption",
  "matrix-sdk-test",
  "rand 0.8.5",
+ "rmp-serde",
  "ruma",
  "serde",
  "serde-wasm-bindgen",

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -32,6 +32,7 @@ js-sys.workspace = true
 matrix-sdk-base = { workspace = true, features = ["js"], optional = true }
 matrix-sdk-crypto = { workspace = true, features = ["js"], optional = true }
 matrix-sdk-store-encryption.workspace = true
+rmp-serde.workspace = true
 ruma.workspace = true
 serde.workspace = true
 serde-wasm-bindgen = "0.6.5"

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -133,6 +133,8 @@ pub mod v1 {
         pub const MEDIA_RETENTION_POLICY_KEY: &str = "media_retention_policy";
         pub const MEDIA: &str = "media";
         pub const MEDIA_KEY_PATH: &str = "id";
+        pub const MEDIA_SOURCE: &str = "media_source";
+        pub const MEDIA_SOURCE_KEY_PATH: &str = "source";
         pub const MEDIA_CONTENT_SIZE: &str = "media_content_size";
         pub const MEDIA_CONTENT_SIZE_KEY_PATH: &str = "content_size";
     }
@@ -227,14 +229,18 @@ pub mod v1 {
     /// Create an object store for tracking information about media.
     ///
     /// * Primary Key - `id`
+    /// * Index - `source` - tracks the [`MediaSource`][1] of the associated
+    ///   media
     /// * Index - `content_size` - tracks the size of the media content and
-    ///   whether to ignore the [`MediaRetentionPolicy`][1]
+    ///   whether to ignore the [`MediaRetentionPolicy`][2]
     ///
-    /// [1]: matrix_sdk_base::event_cache::store::media::MediaRetentionPolicy
+    /// [1]: ruma::events::room::MediaSource
+    /// [2]: matrix_sdk_base::event_cache::store::media::MediaRetentionPolicy
     fn create_media_object_store(db: &IdbDatabase) -> Result<(), DomException> {
         let mut object_store_params = IdbObjectStoreParameters::new();
         object_store_params.key_path(Some(&keys::MEDIA_KEY_PATH.into()));
         let media = db.create_object_store_with_params(keys::MEDIA, &object_store_params)?;
+        media.create_index(keys::MEDIA_SOURCE, &keys::MEDIA_SOURCE_KEY_PATH.into())?;
         media.create_index(keys::MEDIA_CONTENT_SIZE, &keys::MEDIA_CONTENT_SIZE_KEY_PATH.into())?;
         Ok(())
     }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -139,6 +139,8 @@ pub mod v1 {
         pub const MEDIA_CONTENT_SIZE_KEY_PATH: &str = "content_size";
         pub const MEDIA_LAST_ACCESS: &str = "media_last_access";
         pub const MEDIA_LAST_ACCESS_KEY_PATH: &str = "last_access";
+        pub const MEDIA_RETENTION_METADATA: &str = "media_retention_metadata";
+        pub const MEDIA_RETENTION_METADATA_KEY_PATH: &str = "retention_metadata";
     }
 
     /// Create all object stores and indices for v1 database
@@ -237,6 +239,8 @@ pub mod v1 {
     ///   whether to ignore the [`MediaRetentionPolicy`][2]
     /// * Index - `last_access` - tracks the last time the associated media was
     ///   accessed
+    /// * Index - `retention_metadata` - tracks all retention metadata - i.e.,
+    ///   joins `content_size` and `last_access`
     ///
     /// [1]: ruma::events::room::MediaSource
     /// [2]: matrix_sdk_base::event_cache::store::media::MediaRetentionPolicy
@@ -247,6 +251,10 @@ pub mod v1 {
         media.create_index(keys::MEDIA_SOURCE, &keys::MEDIA_SOURCE_KEY_PATH.into())?;
         media.create_index(keys::MEDIA_CONTENT_SIZE, &keys::MEDIA_CONTENT_SIZE_KEY_PATH.into())?;
         media.create_index(keys::MEDIA_LAST_ACCESS, &keys::MEDIA_LAST_ACCESS_KEY_PATH.into())?;
+        media.create_index(
+            keys::MEDIA_RETENTION_METADATA,
+            &keys::MEDIA_RETENTION_METADATA_KEY_PATH.into(),
+        )?;
         Ok(())
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -133,6 +133,8 @@ pub mod v1 {
         pub const MEDIA_RETENTION_POLICY_KEY: &str = "media_retention_policy";
         pub const MEDIA: &str = "media";
         pub const MEDIA_KEY_PATH: &str = "id";
+        pub const MEDIA_CONTENT_SIZE: &str = "media_content_size";
+        pub const MEDIA_CONTENT_SIZE_KEY_PATH: &str = "content_size";
     }
 
     /// Create all object stores and indices for v1 database
@@ -225,10 +227,15 @@ pub mod v1 {
     /// Create an object store for tracking information about media.
     ///
     /// * Primary Key - `id`
+    /// * Index - `content_size` - tracks the size of the media content and
+    ///   whether to ignore the [`MediaRetentionPolicy`][1]
+    ///
+    /// [1]: matrix_sdk_base::event_cache::store::media::MediaRetentionPolicy
     fn create_media_object_store(db: &IdbDatabase) -> Result<(), DomException> {
         let mut object_store_params = IdbObjectStoreParameters::new();
         object_store_params.key_path(Some(&keys::MEDIA_KEY_PATH.into()));
-        let _ = db.create_object_store_with_params(keys::MEDIA, &object_store_params)?;
+        let media = db.create_object_store_with_params(keys::MEDIA, &object_store_params)?;
+        media.create_index(keys::MEDIA_CONTENT_SIZE, &keys::MEDIA_CONTENT_SIZE_KEY_PATH.into())?;
         Ok(())
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -131,6 +131,8 @@ pub mod v1 {
         pub const GAPS: &str = "gaps";
         pub const GAPS_KEY_PATH: &str = "id";
         pub const MEDIA_RETENTION_POLICY_KEY: &str = "media_retention_policy";
+        pub const MEDIA: &str = "media";
+        pub const MEDIA_KEY_PATH: &str = "id";
     }
 
     /// Create all object stores and indices for v1 database
@@ -140,6 +142,7 @@ pub mod v1 {
         create_linked_chunks_object_store(db)?;
         create_events_object_store(db)?;
         create_gaps_object_store(db)?;
+        create_media_object_store(db)?;
         Ok(())
     }
 
@@ -216,6 +219,16 @@ pub mod v1 {
         let mut object_store_params = IdbObjectStoreParameters::new();
         object_store_params.key_path(Some(&keys::GAPS_KEY_PATH.into()));
         let _ = db.create_object_store_with_params(keys::GAPS, &object_store_params)?;
+        Ok(())
+    }
+
+    /// Create an object store for tracking information about media.
+    ///
+    /// * Primary Key - `id`
+    fn create_media_object_store(db: &IdbDatabase) -> Result<(), DomException> {
+        let mut object_store_params = IdbObjectStoreParameters::new();
+        object_store_params.key_path(Some(&keys::MEDIA_KEY_PATH.into()));
+        let _ = db.create_object_store_with_params(keys::MEDIA, &object_store_params)?;
         Ok(())
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -137,6 +137,8 @@ pub mod v1 {
         pub const MEDIA_SOURCE_KEY_PATH: &str = "source";
         pub const MEDIA_CONTENT_SIZE: &str = "media_content_size";
         pub const MEDIA_CONTENT_SIZE_KEY_PATH: &str = "content_size";
+        pub const MEDIA_LAST_ACCESS: &str = "media_last_access";
+        pub const MEDIA_LAST_ACCESS_KEY_PATH: &str = "last_access";
     }
 
     /// Create all object stores and indices for v1 database
@@ -233,6 +235,8 @@ pub mod v1 {
     ///   media
     /// * Index - `content_size` - tracks the size of the media content and
     ///   whether to ignore the [`MediaRetentionPolicy`][2]
+    /// * Index - `last_access` - tracks the last time the associated media was
+    ///   accessed
     ///
     /// [1]: ruma::events::room::MediaSource
     /// [2]: matrix_sdk_base::event_cache::store::media::MediaRetentionPolicy
@@ -242,6 +246,7 @@ pub mod v1 {
         let media = db.create_object_store_with_params(keys::MEDIA, &object_store_params)?;
         media.create_index(keys::MEDIA_SOURCE, &keys::MEDIA_SOURCE_KEY_PATH.into())?;
         media.create_index(keys::MEDIA_CONTENT_SIZE, &keys::MEDIA_CONTENT_SIZE_KEY_PATH.into())?;
+        media.create_index(keys::MEDIA_LAST_ACCESS, &keys::MEDIA_LAST_ACCESS_KEY_PATH.into())?;
         Ok(())
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/foreign.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/foreign.rs
@@ -1,0 +1,55 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+pub mod ignore_media_retention_policy {
+    //! This module contains a foreign implementation of [`serde::Serialize`]
+    //! and [`serde::Deserialize`] for [`IgnoreMediaRetentionPolicy`]. These
+    //! implementations can be injected with the proper macros, i.e.,
+    //! `#[serde(with = "path::to::this::module")]`.
+    //!
+    //! This is necessary, as [`IgnoreMediaRetentionPolicy`] does not implement
+    //! these traits directly.
+
+    use matrix_sdk_base::event_cache::store::media::IgnoreMediaRetentionPolicy;
+    use serde::{Deserializer, Serializer};
+
+    /// Serializes an [`IgnoreMediaRetentionPolicy`] as a `u8`, where
+    /// [`IgnoreMediaRetentionPolicy::No`] is `0`
+    /// and [`IgnoreMediaRetentionPolicy::Yes`] is `1`.
+    ///
+    /// Note that this is not serialized as a `bool` because boolean values are
+    /// not supported as IndexedDB keys.
+    pub fn serialize<S>(ignore_policy: &IgnoreMediaRetentionPolicy, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        s.serialize_u8(match ignore_policy {
+            IgnoreMediaRetentionPolicy::Yes => 1,
+            IgnoreMediaRetentionPolicy::No => 0,
+        })
+    }
+
+    /// Deserializes a `u8` into an [`IgnoreMediaRetentionPolicy`] where `0` is
+    /// [`IgnoreMediaRetentionPolicy::No`] and anything else is
+    /// [`IgnoreMediaRetentionPolicy::Yes`].
+    pub fn deserialize<'de, D>(d: D) -> Result<IgnoreMediaRetentionPolicy, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(match serde::de::Deserialize::deserialize(d)? {
+            0u8 => IgnoreMediaRetentionPolicy::No,
+            _ => IgnoreMediaRetentionPolicy::Yes,
+        })
+    }
+}

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/mod.rs
@@ -28,6 +28,7 @@ use crate::{
     serializer::IndexeddbSerializer,
 };
 
+pub mod foreign;
 pub mod traits;
 pub mod types;
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -16,8 +16,9 @@ use std::time::Duration;
 
 use matrix_sdk_base::{
     deserialized_responses::TimelineEvent,
-    event_cache::store::extract_event_relation,
+    event_cache::store::{extract_event_relation, media::IgnoreMediaRetentionPolicy},
     linked_chunk::{ChunkIdentifier, LinkedChunkId, OwnedLinkedChunkId},
+    media::MediaRequestParameters,
 };
 use ruma::{OwnedEventId, OwnedRoomId, RoomId};
 use serde::{Deserialize, Serialize};
@@ -220,4 +221,28 @@ pub struct Gap {
     /// The token to use in the query, extracted from a previous "from" /
     /// "end" field of a `/messages` response.
     pub prev_token: String,
+}
+
+/// A representation of media data which can be stored in IndexedDB.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Media {
+    /// The metadata associated with [`Media::content`]
+    pub metadata: MediaMetadata,
+    /// The content of the media
+    pub content: Vec<u8>,
+}
+
+/// A representation of media metadata which can be stored in IndexedDB.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MediaMetadata {
+    /// The parameters specifying the type and source of the media contained in
+    /// [`Media::content`]
+    pub request_parameters: MediaRequestParameters,
+    /// The last time the media was accessed in IndexedDB
+    pub last_access: Duration,
+    /// Whether to ignore the [`MediaRetentionPolicy`][1] stored in IndexedDB
+    ///
+    /// [1]: matrix_sdk_base::event_cache::store::media::MediaRetentionPolicy
+    #[serde(with = "crate::event_cache_store::serializer::foreign::ignore_media_retention_policy")]
+    pub ignore_policy: IgnoreMediaRetentionPolicy,
 }


### PR DESCRIPTION
## Background

This pull request is part of a series of pull requests to add a full IndexedDB implementation of the `EventCacheStore` (see #4617, #4996, #5090, #5138, #5226, #5274, #5343, #5384, #5406, #5414, #5497, #5506, #5540, #5574). This particular pull request adds types and migrations that will support storing media in IndexedDB via `EventCacheStoreMedia`.

## Changes

### Queries

Based on the SQLite-backed implementation of `EventCacheStoreMedia`, the following queries for interacting with stored media should be supported.

1. Operate on media by [`MediaRequestParameters`](https://docs.rs/matrix-sdk/latest/matrix_sdk/media/struct.MediaRequestParameters.html)
2. Operate on media by [`MediaSource`](https://docs.rs/matrix-sdk/latest/matrix_sdk/ruma/events/room/enum.MediaSource.html#)
3. Operate on media by last time it was accessed and whether it obeys the [`MediaRetentionPolicy`](https://docs.rs/matrix-sdk/latest/matrix_sdk/media/struct.MediaRetentionPolicy.html). 
4. Operate on media by the size of its contents and whether it obeys the [`MediaRetentionPolicy`](https://docs.rs/matrix-sdk/latest/matrix_sdk/media/struct.MediaRetentionPolicy.html).
5. Operate on media by the last time it was accessed, the size of its contents, and whether it obeys the [`MediaRetentionPolicy`](https://docs.rs/matrix-sdk/latest/matrix_sdk/media/struct.MediaRetentionPolicy.html).

### Types

Two types have been added - `Media` and `MediaMetadata` to represent each media object in the database.

```rust
pub struct Media {
    pub metadata: MediaMetadata,
    pub content: Vec<u8>,
}

pub struct MediaMetadata {
    pub request_parameters: MediaRequestParameters,
    pub last_access: Duration,
    pub ignore_policy: IgnoreMediaRetentionPolicy,
}
```

The fields in `MediaMetadata` along with the size of `Media::content` after it is serialized, are used to derive keys for indexing `Media` in service of the queries above.

### Schema

In order to support the queries above, the following object stores and indices have been created.

- `MEDIA` - Object Store
    - Key - `id` - derived from [`MediaRequestParameters::unique_key()`](https://docs.rs/matrix-sdk/latest/matrix_sdk/media/struct.MediaRequestParameters.html#impl-UniqueKey-for-MediaRequestParameters)
        - Supports query (1)
    - Value - `Media`
- `MEDIA_SOURCE` - Index on `MEDIA`
    - Key - `source` - derived from [`MediaSource::unique_key()`](https://docs.rs/matrix-sdk/latest/matrix_sdk/ruma/events/room/enum.MediaSource.html#impl-UniqueKey-for-MediaSource)
        - Supports query (2)
- `MEDIA_LAST_ACCESS` - Index on `MEDIA`
    - Key - `last_access` - derived from `Media.ignore_policy` and `Media.last_access`
        - Supports query (3)
- `MEDIA_CONTENT_SIZE` - Index on `MEDIA`
    - Key - `content_size` - derived from `Media.ignore_policy` and `Media.content`
        - Supports query (4)
- `MEDIA_RETENTION_METADATA` - Index on `MEDIA`
    - Key - `retention_metadata`  - derived from `Media.ignore_policy`, `Media.last_access`, and `Media.content`
        - Supports query (5)


## Future Work

- Add implementation of remaining functions in `EventCacheStoreMedia`

---

- [ ] Public API changes documented in changelogs (optional)


Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
