### PR TITLE
feat: implement msc4308 + automatic background catchup of thread subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4639,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.6"
-source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
+source = "git+https://github.com/ruma/ruma?rev=51fb51a560027fd330b43398a278922cacbc825c#51fb51a560027fd330b43398a278922cacbc825c"
 dependencies = [
  "assign",
  "js_int",
@@ -4656,7 +4656,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.4"
-source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
+source = "git+https://github.com/ruma/ruma?rev=51fb51a560027fd330b43398a278922cacbc825c#51fb51a560027fd330b43398a278922cacbc825c"
 dependencies = [
  "as_variant",
  "assign",
@@ -4679,7 +4679,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.4"
-source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
+source = "git+https://github.com/ruma/ruma?rev=51fb51a560027fd330b43398a278922cacbc825c#51fb51a560027fd330b43398a278922cacbc825c"
 dependencies = [
  "as_variant",
  "base64",
@@ -4712,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.5"
-source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
+source = "git+https://github.com/ruma/ruma?rev=51fb51a560027fd330b43398a278922cacbc825c#51fb51a560027fd330b43398a278922cacbc825c"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4738,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.11.2"
-source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
+source = "git+https://github.com/ruma/ruma?rev=51fb51a560027fd330b43398a278922cacbc825c#51fb51a560027fd330b43398a278922cacbc825c"
 dependencies = [
  "headers",
  "http",
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.1"
-source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
+source = "git+https://github.com/ruma/ruma?rev=51fb51a560027fd330b43398a278922cacbc825c#51fb51a560027fd330b43398a278922cacbc825c"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4769,7 +4769,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
+source = "git+https://github.com/ruma/ruma?rev=51fb51a560027fd330b43398a278922cacbc825c#51fb51a560027fd330b43398a278922cacbc825c"
 dependencies = [
  "js_int",
  "thiserror 2.0.11",
@@ -4778,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.2"
-source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
+source = "git+https://github.com/ruma/ruma?rev=51fb51a560027fd330b43398a278922cacbc825c#51fb51a560027fd330b43398a278922cacbc825c"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",
@@ -4793,7 +4793,7 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.17.1"
-source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
+source = "git+https://github.com/ruma/ruma?rev=51fb51a560027fd330b43398a278922cacbc825c#51fb51a560027fd330b43398a278922cacbc825c"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 rand = "0.8.5"
 reqwest = { version = "0.12.12", default-features = false }
 rmp-serde = "1.3.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "57049282e3a74f67f86e4eb2382a3e649b57cc2b", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "51fb51a560027fd330b43398a278922cacbc825c", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-arbitrary-length-ids",

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -62,7 +62,7 @@ pub use room::{
 };
 pub use store::{
     ComposerDraft, ComposerDraftType, QueueWedgeError, StateChanges, StateStore, StateStoreDataKey,
-    StateStoreDataValue, StoreError,
+    StateStoreDataValue, StoreError, ThreadSubscriptionCatchupToken,
 };
 pub use utils::{
     MinimalRoomMemberEvent, MinimalStateEvent, OriginalMinimalStateEvent, RedactedMinimalStateEvent,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -93,7 +93,8 @@ pub use self::{
     },
     traits::{
         ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, ServerInfo, StateStore,
-        StateStoreDataKey, StateStoreDataValue, StateStoreExt, WellKnownResponse,
+        StateStoreDataKey, StateStoreDataValue, StateStoreExt, ThreadSubscriptionCatchupToken,
+        WellKnownResponse,
     },
 };
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -1164,8 +1164,10 @@ pub enum StateStoreDataValue {
 /// These tokens are created when the client receives some thread subscriptions
 /// from sync, but the sync indicates that there are more thread subscriptions
 /// available on the server. In this case, it's expected that the client will
-/// call the MSC4308 companion endpoint to catch up (back-paginate) on previous
-/// thread subscriptions.
+/// call the [MSC4308] companion endpoint to catch up (back-paginate) on
+/// previous thread subscriptions.
+///
+/// [MSC4308]: https://github.com/matrix-org/matrix-spec-proposals/pull/4308
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ThreadSubscriptionCatchupToken {
     /// The token to use as the lower bound when fetching new threads

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -32,7 +32,7 @@ use matrix_sdk_base::{
         StateStore, StoreError, StoredThreadSubscription, ThreadSubscriptionStatus,
     },
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, StateStoreDataKey, StateStoreDataValue,
-    ROOM_VERSION_FALLBACK, ROOM_VERSION_RULES_FALLBACK,
+    ThreadSubscriptionCatchupToken, ROOM_VERSION_FALLBACK, ROOM_VERSION_RULES_FALLBACK,
 };
 use matrix_sdk_store_encryption::{Error as EncryptionError, StoreCipher};
 use ruma::{
@@ -439,6 +439,9 @@ impl IndexeddbStateStore {
             StateStoreDataKey::SeenKnockRequests(room_id) => {
                 self.encode_key(keys::KV, (StateStoreDataKey::SEEN_KNOCK_REQUESTS, room_id))
             }
+            StateStoreDataKey::ThreadSubscriptionsCatchupTokens => {
+                self.encode_key(keys::KV, StateStoreDataKey::THREAD_SUBSCRIPTIONS_CATCHUP_TOKENS)
+            }
         }
     }
 }
@@ -591,6 +594,10 @@ impl_state_store!({
                 .map(|f| self.deserialize_value::<BTreeMap<OwnedEventId, OwnedUserId>>(&f))
                 .transpose()?
                 .map(StateStoreDataValue::SeenKnockRequests),
+            StateStoreDataKey::ThreadSubscriptionsCatchupTokens => value
+                .map(|f| self.deserialize_value::<Vec<ThreadSubscriptionCatchupToken>>(&f))
+                .transpose()?
+                .map(StateStoreDataValue::ThreadSubscriptionsCatchupTokens),
         };
 
         Ok(value)
@@ -631,6 +638,11 @@ impl_state_store!({
                 &value
                     .into_seen_knock_requests()
                     .expect("Session data is not a set of seen knock request ids"),
+            ),
+            StateStoreDataKey::ThreadSubscriptionsCatchupTokens => self.serialize_value(
+                &value
+                    .into_thread_subscriptions_catchup_tokens()
+                    .expect("Session data is not a list of thread subscription catchup tokens"),
             ),
         };
 

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -155,6 +155,15 @@ impl RoomListService {
                 enabled: Some(true),
             }));
 
+        if client.enabled_thread_subscriptions() {
+            builder = builder.with_thread_subscriptions_extension(
+                assign!(http::request::ThreadSubscriptions::default(), {
+                    enabled: Some(true),
+                    limit: Some(ruma::uint!(10))
+                }),
+            );
+        }
+
         if share_pos {
             // We don't deal with encryption device messages here so this is safe
             builder = builder.share_pos();

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -608,6 +608,7 @@ impl ClientBuilder {
 
         let event_cache = OnceCell::new();
         let latest_events = OnceCell::new();
+        let thread_subscriptions_catchup = OnceCell::new();
 
         #[cfg(feature = "experimental-search")]
         let search_index =
@@ -632,6 +633,7 @@ impl ClientBuilder {
             self.cross_process_store_locks_holder_name,
             #[cfg(feature = "experimental-search")]
             search_index,
+            thread_subscriptions_catchup,
         )
         .await;
 

--- a/crates/matrix-sdk/src/client/thread_subscriptions.rs
+++ b/crates/matrix-sdk/src/client/thread_subscriptions.rs
@@ -1,0 +1,441 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::BTreeMap,
+    sync::{
+        atomic::{self, AtomicBool},
+        Arc,
+    },
+};
+
+use matrix_sdk_base::{
+    executor::AbortOnDrop,
+    store::{StoredThreadSubscription, ThreadSubscriptionStatus},
+    StateStoreDataKey, StateStoreDataValue, ThreadSubscriptionCatchupToken,
+};
+use matrix_sdk_common::executor::spawn;
+use once_cell::sync::OnceCell;
+use ruma::{
+    api::client::threads::get_thread_subscriptions_changes::unstable::{
+        ThreadSubscription, ThreadUnsubscription,
+    },
+    assign, OwnedEventId, OwnedRoomId,
+};
+use tokio::sync::{
+    mpsc::{channel, Receiver, Sender},
+    Mutex, OwnedMutexGuard,
+};
+use tracing::{instrument, trace, warn};
+
+use crate::{client::WeakClient, Client, Result};
+
+struct GuardedStoreAccess {
+    _mutex: OwnedMutexGuard<()>,
+    client: Client,
+    is_outdated: Arc<AtomicBool>,
+}
+
+impl GuardedStoreAccess {
+    /// Return the current list of catchup tokens, if any.
+    ///
+    /// It is guaranteed that if the list is set, then it's non-empty.
+    async fn load_catchup_tokens(&self) -> Result<Option<Vec<ThreadSubscriptionCatchupToken>>> {
+        let loaded = self
+            .client
+            .state_store()
+            .get_kv_data(StateStoreDataKey::ThreadSubscriptionsCatchupTokens)
+            .await?;
+
+        match loaded {
+            Some(data) => {
+                if let Some(tokens) = data.into_thread_subscriptions_catchup_tokens() {
+                    // If the tokens list is empty, automatically clean it up.
+                    if tokens.is_empty() {
+                        self.save_catchup_tokens(tokens).await?;
+                        Ok(None)
+                    } else {
+                        Ok(Some(tokens))
+                    }
+                } else {
+                    warn!(
+                        "invalid data in thread subscriptions catchup tokens state store k/v entry"
+                    );
+                    Ok(None)
+                }
+            }
+
+            None => Ok(None),
+        }
+    }
+
+    /// Saves the tokens in the database.
+    ///
+    /// Returns whether the list of tokens is empty or not.
+    #[instrument(skip_all, fields(num_tokens = tokens.len()))]
+    async fn save_catchup_tokens(
+        &self,
+        tokens: Vec<ThreadSubscriptionCatchupToken>,
+    ) -> Result<bool> {
+        let store = self.client.state_store();
+        let is_empty = if tokens.is_empty() {
+            store.remove_kv_data(StateStoreDataKey::ThreadSubscriptionsCatchupTokens).await?;
+
+            trace!("Marking thread subscriptions as not outdated \\o/");
+            self.is_outdated.store(false, atomic::Ordering::SeqCst);
+            true
+        } else {
+            store
+                .set_kv_data(
+                    StateStoreDataKey::ThreadSubscriptionsCatchupTokens,
+                    StateStoreDataValue::ThreadSubscriptionsCatchupTokens(tokens),
+                )
+                .await?;
+
+            trace!("Marking thread subscriptions as outdated.");
+            self.is_outdated.store(true, atomic::Ordering::SeqCst);
+            false
+        };
+        Ok(is_empty)
+    }
+}
+
+pub struct ThreadSubscriptionCatchup {
+    /// The task catching up thread subscriptions in the background.
+    _task: OnceCell<AbortOnDrop<()>>,
+
+    /// Whether the known list of thread subscriptions is outdated or not, i.e.
+    /// all thread subscriptions have been caught up
+    is_outdated: Arc<AtomicBool>,
+
+    /// A weak reference to the parent [`Client`] instance.
+    client: WeakClient,
+
+    /// A sender to wake up the catchup task when new catchup tokens are
+    /// available.
+    ping_sender: Sender<()>,
+
+    /// A mutex to ensure there's only one writer on the thread subscriptions
+    /// catchup tokens at a time.
+    uniq_mutex: Arc<Mutex<()>>,
+}
+
+impl ThreadSubscriptionCatchup {
+    pub fn new(client: Client) -> Arc<Self> {
+        let is_outdated = Arc::new(AtomicBool::new(true));
+
+        let weak_client = WeakClient::from_client(&client);
+
+        let (ping_sender, ping_receiver) = channel(8);
+
+        let uniq_mutex = Arc::new(Mutex::new(()));
+
+        let this = Arc::new(Self {
+            _task: OnceCell::new(),
+            is_outdated,
+            client: weak_client,
+            ping_sender,
+            uniq_mutex,
+        });
+
+        // Create the task only if the client is configured to handle thread
+        // subscriptions.
+        if client.enabled_thread_subscriptions() {
+            let _ = this._task.get_or_init(|| {
+                AbortOnDrop::new(spawn(Self::thread_subscriptions_catchup_task(
+                    this.clone(),
+                    ping_receiver,
+                )))
+            });
+        }
+
+        this
+    }
+
+    /// Returns whether the known list of thread subscriptions is outdated or
+    /// more thread subscriptions need to be caught up.
+    pub(crate) fn is_outdated(&self) -> bool {
+        self.is_outdated.load(atomic::Ordering::SeqCst)
+    }
+
+    /// Store the new subscriptions changes, received via the sync response or
+    /// from the msc4308 companion endpoint.
+    #[instrument(skip_all)]
+    pub(crate) async fn sync_subscriptions(
+        &self,
+        subscribed: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, ThreadSubscription>>,
+        unsubscribed: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, ThreadUnsubscription>>,
+        token: Option<ThreadSubscriptionCatchupToken>,
+    ) -> Result<()> {
+        let Some(guard) = self.lock().await else {
+            // Client is shutting down.
+            return Ok(());
+        };
+        self.save_catchup_token(&guard, token).await?;
+        self.store_subscriptions(&guard, subscribed, unsubscribed).await?;
+        Ok(())
+    }
+
+    async fn store_subscriptions(
+        &self,
+        guard: &GuardedStoreAccess,
+        subscribed: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, ThreadSubscription>>,
+        unsubscribed: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, ThreadUnsubscription>>,
+    ) -> Result<()> {
+        if subscribed.is_empty() && unsubscribed.is_empty() {
+            // Nothing to do.
+            return Ok(());
+        }
+
+        trace!(
+            "saving {} new subscriptions and {} unsubscriptions",
+            subscribed.values().map(|by_room| by_room.len()).sum::<usize>(),
+            unsubscribed.values().map(|by_room| by_room.len()).sum::<usize>(),
+        );
+
+        // Take into account the new unsubscriptions.
+        for (room_id, room_map) in unsubscribed {
+            for (event_id, thread_sub) in room_map {
+                guard
+                    .client
+                    .state_store()
+                    .upsert_thread_subscription(
+                        &room_id,
+                        &event_id,
+                        StoredThreadSubscription {
+                            status: ThreadSubscriptionStatus::Unsubscribed,
+                            bump_stamp: Some(thread_sub.bump_stamp.into()),
+                        },
+                    )
+                    .await?;
+            }
+        }
+
+        // Take into account the new subscriptions.
+        for (room_id, room_map) in subscribed {
+            for (event_id, thread_sub) in room_map {
+                guard
+                    .client
+                    .state_store()
+                    .upsert_thread_subscription(
+                        &room_id,
+                        &event_id,
+                        StoredThreadSubscription {
+                            status: ThreadSubscriptionStatus::Subscribed {
+                                automatic: thread_sub.automatic,
+                            },
+                            bump_stamp: Some(thread_sub.bump_stamp.into()),
+                        },
+                    )
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Internal helper to lock writes to the thread subscriptions catchup
+    /// tokens list.
+    async fn lock(&self) -> Option<GuardedStoreAccess> {
+        let client = self.client.get()?;
+        let mutex_guard = self.uniq_mutex.clone().lock_owned().await;
+        Some(GuardedStoreAccess {
+            _mutex: mutex_guard,
+            client,
+            is_outdated: self.is_outdated.clone(),
+        })
+    }
+
+    /// Save a new catchup token (or absence thereof) in the state store.
+    async fn save_catchup_token(
+        &self,
+        guard: &GuardedStoreAccess,
+        token: Option<ThreadSubscriptionCatchupToken>,
+    ) -> Result<()> {
+        // Note: saving an empty tokens list will mark the thread subscriptions list as
+        // not outdated.
+        let mut tokens = guard.load_catchup_tokens().await?.unwrap_or_default();
+
+        if let Some(token) = token {
+            trace!(?token, "Saving catchup token");
+            tokens.push(token);
+        } else {
+            trace!("No catchup token to save");
+        }
+
+        let is_token_list_empty = guard.save_catchup_tokens(tokens).await?;
+
+        // Wake up the catchup task, in case it's waiting.
+        if !is_token_list_empty {
+            let _ = self.ping_sender.send(()).await;
+        }
+
+        Ok(())
+    }
+
+    /// The background task listening to new catchup tokens, and using them to
+    /// catch up the thread subscriptions via the [MSC4308] companion
+    /// endpoint.
+    ///
+    /// It will continue to process catchup tokens until there are none, and
+    /// then wait for a new one to be available and inserted in the
+    /// database.
+    ///
+    /// It always processes catch up tokens from the newest to the oldest, since
+    /// newest tokens are more interesting than older ones. Indeed, they're
+    /// more likely to include entries with higher bump-stamps, i.e. to include
+    /// more recent thread subscriptions statuses for each thread, so more
+    /// relevant information.
+    ///
+    /// [MSC4308]: https://github.com/matrix-org/matrix-spec-proposals/pull/4308
+    #[instrument(skip_all)]
+    async fn thread_subscriptions_catchup_task(this: Arc<Self>, mut ping_receiver: Receiver<()>) {
+        loop {
+            // Load the current catchup token.
+            let Some(guard) = this.lock().await else {
+                // Client is shutting down.
+                return;
+            };
+
+            let store_tokens = match guard.load_catchup_tokens().await {
+                Ok(tokens) => tokens,
+                Err(err) => {
+                    warn!("Failed to load thread subscriptions catchup tokens: {err}");
+                    continue;
+                }
+            };
+
+            let Some(mut tokens) = store_tokens else {
+                // Release the mutex.
+                drop(guard);
+
+                // Wait for a wake up.
+                trace!("Waiting for an explicit wake up to process future thread subscriptions");
+
+                if let Some(()) = ping_receiver.recv().await {
+                    trace!("Woke up!");
+                    continue;
+                }
+
+                // Channel closed, the client is shutting down.
+                break;
+            };
+
+            // We do have a tokens. Pop the last value, and use it to catch up!
+            let last = tokens.pop().expect("must be set per `load_catchup_tokens` contract");
+
+            // Release the mutex before running the network request.
+            let client = guard.client.clone();
+            drop(guard);
+
+            // Start the actual catchup!
+            let req = assign!(ruma::api::client::threads::get_thread_subscriptions_changes::unstable::Request::new(), {
+                from: Some(last.from.clone()),
+                to: last.to.clone(),
+            });
+
+            match client.send(req).await {
+                Ok(resp) => {
+                    let guard = this
+                        .lock()
+                        .await
+                        .expect("a client instance is alive, so the locking should not fail");
+
+                    if let Err(err) =
+                        this.store_subscriptions(&guard, resp.subscribed, resp.unsubscribed).await
+                    {
+                        warn!("Failed to store caught up thread subscriptions: {err}");
+                        continue;
+                    }
+
+                    // Refresh the tokens, as the list might have changed while we sent the
+                    // request.
+                    let mut tokens = match guard.load_catchup_tokens().await {
+                        Ok(tokens) => tokens.unwrap_or_default(),
+                        Err(err) => {
+                            warn!("Failed to load thread subscriptions catchup tokens: {err}");
+                            continue;
+                        }
+                    };
+
+                    let Some(index) = tokens.iter().position(|t| *t == last) else {
+                        warn!("Thread subscriptions catchup token disappeared while processing it");
+                        continue;
+                    };
+
+                    if let Some(next_batch) = resp.end {
+                        // If the response contained a next batch token, reuse the same catchup
+                        // token entry, so the `to` value remains the same.
+                        tokens[index] =
+                            ThreadSubscriptionCatchupToken { from: next_batch, to: last.to };
+                    } else {
+                        // No next batch, we can remove this token from the list.
+                        tokens.remove(index);
+                    }
+
+                    if let Err(err) = guard.save_catchup_tokens(tokens).await {
+                        warn!("Failed to save updated thread subscriptions catchup tokens: {err}");
+                    }
+                }
+
+                Err(err) => {
+                    warn!("Failed to catch up thread subscriptions: {err}");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Not as _;
+
+    use matrix_sdk_base::ThreadSubscriptionCatchupToken;
+    use matrix_sdk_test::async_test;
+
+    use crate::test_utils::client::MockClientBuilder;
+
+    #[async_test]
+    async fn test_load_save_catchup_tokens() {
+        let client = MockClientBuilder::new(None).build().await;
+
+        let tsc = client.thread_subscription_catchup();
+
+        // At first there are no catchup tokens, and we are outdated.
+        let guard = tsc.lock().await.unwrap();
+        assert!(guard.load_catchup_tokens().await.unwrap().is_none());
+        assert!(tsc.is_outdated());
+
+        // When I save a token,
+        let token =
+            ThreadSubscriptionCatchupToken { from: "from".to_owned(), to: Some("to".to_owned()) };
+        guard.save_catchup_tokens(vec![token.clone()]).await.unwrap();
+
+        // Well, it is saved,
+        let tokens = guard.load_catchup_tokens().await.unwrap();
+        assert_eq!(tokens, Some(vec![token]));
+
+        // And we are still outdated.
+        assert!(tsc.is_outdated());
+
+        // When I remove the token,
+        guard.save_catchup_tokens(vec![]).await.unwrap();
+
+        // It is gone,
+        assert!(guard.load_catchup_tokens().await.unwrap().is_none());
+
+        // And we are not outdated anymore!
+        assert!(tsc.is_outdated().not());
+    }
+}

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -183,6 +183,23 @@ impl SlidingSyncBuilder {
         self
     }
 
+    /// Set the Threads subscriptions extension configuration.
+    pub fn with_thread_subscriptions_extension(
+        mut self,
+        thread_subscriptions: http::request::ThreadSubscriptions,
+    ) -> Self {
+        self.extensions.get_or_insert_with(Default::default).thread_subscriptions =
+            thread_subscriptions;
+        self
+    }
+
+    /// Unset the Threads subscriptions extension configuration.
+    pub fn without_thread_subscriptions_extension(mut self) -> Self {
+        self.extensions.get_or_insert_with(Default::default).thread_subscriptions =
+            Default::default();
+        self
+    }
+
     /// Sets a custom timeout duration for the sliding sync polling endpoint.
     ///
     /// This is the maximum time to wait before the sliding sync server returns

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -211,7 +211,16 @@ impl SlidingSyncResponseProcessor {
         previous_pos: Option<&str>,
         thread_subs: response::ThreadSubscriptions,
     ) -> Result<()> {
-        // TODO
+        let catchup_token =
+            thread_subs.prev_batch.map(|prev_batch| ThreadSubscriptionCatchupToken {
+                from: prev_batch,
+                to: previous_pos.map(|s| s.to_owned()),
+            });
+
+        self.client
+            .thread_subscription_catchup()
+            .sync_subscriptions(thread_subs.subscribed, thread_subs.unsubscribed, catchup_token)
+            .await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -1,8 +1,13 @@
 use std::collections::BTreeSet;
 
-use matrix_sdk_base::{sync::SyncResponse, RequestedRequiredStates};
+use matrix_sdk_base::{
+    sync::SyncResponse, RequestedRequiredStates, ThreadSubscriptionCatchupToken,
+};
 use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
-use ruma::api::{client::sync::sync_events::v5 as http, FeatureFlag, SupportedVersions};
+use ruma::api::{
+    client::sync::sync_events::v5::{self as http, response},
+    FeatureFlag, SupportedVersions,
+};
 use tracing::error;
 
 use super::{SlidingSync, SlidingSyncBuilder};
@@ -160,10 +165,7 @@ impl SlidingSyncResponseProcessor {
     }
 
     #[cfg(feature = "e2e-encryption")]
-    pub async fn handle_encryption(
-        &mut self,
-        extensions: &http::response::Extensions,
-    ) -> Result<()> {
+    pub async fn handle_encryption(&mut self, extensions: &response::Extensions) -> Result<()> {
         // This is an internal API misuse if this is triggered (calling
         // `handle_room_response` before this function), so panic is fine.
         assert!(self.response.is_none());
@@ -200,6 +202,16 @@ impl SlidingSyncResponseProcessor {
         update_in_memory_caches(&self.client, &sync_response).await?;
 
         self.response = Some(sync_response);
+
+        Ok(())
+    }
+
+    pub async fn handle_thread_subscriptions(
+        &mut self,
+        previous_pos: Option<&str>,
+        thread_subs: response::ThreadSubscriptions,
+    ) -> Result<()> {
+        // TODO
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -659,15 +659,19 @@ impl SlidingSync {
             || !self.inner.lists.read().await.is_empty()
     }
 
+    /// Send a single sliding sync request, and returns the response summary.
+    ///
+    /// Public for testing purposes only.
+    #[doc(hidden)]
     #[instrument(skip_all, fields(pos, conn_id = self.inner.id))]
-    async fn sync_once(&self) -> Result<UpdateSummary> {
+    pub async fn sync_once(&self) -> Result<UpdateSummary> {
         let (request, request_config, position_guard) =
             self.generate_sync_request(&mut LazyTransactionId::new()).await?;
 
-        // Send the request, kaboom.
+        // Send the request.
         let summaries = self.send_sync_request(request, request_config, position_guard).await?;
 
-        // Notify a new sync was received
+        // Notify a new sync was received.
         self.inner.client.inner.sync_beat.notify(usize::MAX);
 
         Ok(summaries)

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -36,6 +36,9 @@ use ruma::{
             get_public_rooms,
             get_public_rooms_filtered::{self, v3::Request as PublicRoomsFilterRequest},
         },
+        threads::get_thread_subscriptions_changes::unstable::{
+            ThreadSubscription, ThreadUnsubscription,
+        },
         uiaa,
     },
     assign, device_id,
@@ -1511,8 +1514,6 @@ async fn test_room_sync_state_after() {
 
 #[async_test]
 async fn test_server_vendor_info() {
-    use matrix_sdk::test_utils::mocks::MatrixMockServer;
-
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
 
@@ -1527,8 +1528,6 @@ async fn test_server_vendor_info() {
 
 #[async_test]
 async fn test_server_vendor_info_with_missing_fields() {
-    use matrix_sdk::test_utils::mocks::MatrixMockServer;
-
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
 
@@ -1544,10 +1543,6 @@ async fn test_server_vendor_info_with_missing_fields() {
 
 #[async_test]
 async fn test_fetch_thread_subscriptions() {
-    use ruma::api::client::threads::get_thread_subscriptions_changes::unstable::{
-        ThreadSubscription, ThreadUnsubscription,
-    };
-
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
 

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -522,7 +522,7 @@ impl RoomView {
     async fn print_thread_subscription_status(&mut self) {
         if let TimelineKind::Thread { thread_root, .. } = &self.kind {
             self.call_with_room(async |room, status_handle| {
-                match room.fetch_thread_subscription(thread_root.clone()).await {
+                match room.load_or_fetch_thread_subscription(thread_root).await {
                     Ok(Some(subscription)) => {
                         status_handle.set_message(format!(
                             "Thread subscription status: {}",


### PR DESCRIPTION
This adds support for:

- msc4308 sliding sync extension: receiving new changes to thread subscriptions over sync, as well as the `prev_batch` token that indicates if there are more subscriptions to catch up with the companion endpoint.
- saving such catchup tokens in the state store
- automatically catch up for extra thread subscriptions in a background task
- in `Room::load_or_fetch_thread_subscriptions()`, use network if we haven't caught up yet, or the local store only, if we have.

I've tested this in isolation, with a few sliding sync tests (using the `MatrixMockServer`; this adds quite a bit of code to it, expanding the PR's size), as well as against the Synapse impl from https://github.com/element-hq/synapse/pull/18695, and it works great in both cases.

Fixes #5038.