### PR TITLE
refactor(search): Move event processing out of search crate.

### DIFF
--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -16,7 +16,7 @@ features = ["docsrs"]
 rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [features]
-default = ["e2e-encryption", "automatic-room-key-forwarding", "sqlite", "native-tls"]
+default = ["e2e-encryption", "automatic-room-key-forwarding", "sqlite", "native-tls", "experimental-search"]
 testing = [
     "matrix-sdk-sqlite?/testing",
     "matrix-sdk-indexeddb?/testing",

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -742,14 +742,12 @@ impl EventCache {
                     let mut search_index_guard = client.search_index().lock().await;
 
                     for event in timeline_events {
-                        if let Some(message_event) =
-                            search::parse_timeline_event(&room_cache, &event).await
+                        if let Some(index_operation) =
+                            search::parse_timeline_event(&room_cache, &event, &redaction_rules)
+                                .await
                         {
-                            if let Err(err) = search_index_guard.handle_event(
-                                message_event,
-                                &room_id,
-                                &redaction_rules,
-                            ) {
+                            if let Err(err) = search_index_guard.execute(index_operation, &room_id)
+                            {
                                 warn!("Failed to handle event for indexing: {err}")
                             }
                         }

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -62,8 +62,9 @@ use ruma::{
             member::{MembershipState, RoomMemberEventContent},
             message::{
                 FormattedBody, GalleryItemType, GalleryMessageEventContent,
-                ImageMessageEventContent, MessageType, Relation, RelationWithoutReplacement,
-                RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
+                ImageMessageEventContent, MessageType, OriginalSyncRoomMessageEvent, Relation,
+                RelationWithoutReplacement, RoomMessageEventContent,
+                RoomMessageEventContentWithoutRelation,
             },
             name::RoomNameEventContent,
             power_levels::RoomPowerLevelsEventContent,
@@ -327,6 +328,10 @@ where
 
     pub fn into_any_sync_message_like_event(self) -> AnySyncMessageLikeEvent {
         self.into_raw().deserialize().expect("expected message like event")
+    }
+
+    pub fn into_original_sync_room_message_event(self) -> OriginalSyncRoomMessageEvent {
+        self.into_raw().deserialize().expect("expected original sync room message event")
     }
 
     pub fn into_raw_sync(self) -> Raw<AnySyncTimelineEvent> {


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Clean up the search crate integration by moving event processing out and having a new 
`RoomIndex::execute(op: RoomIndexOperation)` api.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Shrey Patel shreyp@element.io
