### PR TITLE
fix: Stop `ClientBuilder::build` from requesting the server info indefinitely

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1628,7 +1628,7 @@ impl Client {
     /// This method retrieves information about the server's name and version
     /// by calling the `/_matrix/federation/v1/version` endpoint.
     pub async fn server_vendor_info(&self) -> Result<matrix_sdk::ServerVendorInfo, ClientError> {
-        Ok(self.inner.server_vendor_info().await?)
+        Ok(self.inner.server_vendor_info(None).await?)
     }
 
     /// Subscribe to changes in the media preview configuration.

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -574,8 +574,12 @@ impl ClientBuilder {
 
         let sdk_client = inner_builder.build().await?;
 
+        // Disable retries for this request to prevent it from being retried
+        // indefinitely
+        let config = sdk_client.request_config().disable_retry();
+
         // Log server version information at info level.
-        if let Ok(server_info) = sdk_client.server_vendor_info().await {
+        if let Ok(server_info) = sdk_client.server_vendor_info(Some(config)).await {
             tracing::info!(
                 server_name = %server_info.server_name,
                 version = %server_info.version,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -575,15 +575,20 @@ impl Client {
     /// # let homeserver = Url::parse("http://example.com")?;
     /// let client = Client::new(homeserver).await?;
     ///
-    /// let server_info = client.server_vendor_info().await?;
+    /// let server_info = client.server_vendor_info(None).await?;
     /// println!(
     ///     "Server: {}, Version: {}",
     ///     server_info.server_name, server_info.version
     /// );
     /// # anyhow::Ok(()) };
     /// ```
-    pub async fn server_vendor_info(&self) -> HttpResult<ServerVendorInfo> {
-        let res = self.send(get_server_version::v1::Request::new()).await?;
+    pub async fn server_vendor_info(
+        &self,
+        request_config: Option<RequestConfig>,
+    ) -> HttpResult<ServerVendorInfo> {
+        let res = self
+            .send_inner(get_server_version::v1::Request::new(), request_config, Default::default())
+            .await?;
 
         // Extract server info, using defaults if fields are missing.
         let server = res.server.unwrap_or_default();

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -1522,7 +1522,7 @@ async fn test_server_vendor_info() {
     // Mock the federation version endpoint
     server.mock_federation_version().ok("Synapse", "1.70.0").mount().await;
 
-    let server_info = client.server_vendor_info().await.unwrap();
+    let server_info = client.server_vendor_info(None).await.unwrap();
 
     assert_eq!(server_info.server_name, "Synapse");
     assert_eq!(server_info.version, "1.70.0");
@@ -1536,7 +1536,7 @@ async fn test_server_vendor_info_with_missing_fields() {
     // Mock the federation version endpoint with missing fields
     server.mock_federation_version().ok_empty().mount().await;
 
-    let server_info = client.server_vendor_info().await.unwrap();
+    let server_info = client.server_vendor_info(None).await.unwrap();
 
     // Should use defaults for missing fields
     assert_eq!(server_info.server_name, "unknown");


### PR DESCRIPTION
If no custom request config is passed to `ClientBuilder`, it'll use the default one with no retry limit.

On Element X Android, this caused the `Client` to never be built and the logs to get stuck like this:

```
...
09-03 10:55:12.059 26932 27032 D org.matrix.rust.sdk: matrix_sdk::http_client::native: Sending request num_attempt=7 | crates/matrix-sdk/src/http_client/native.rs:78 | spans: send{request_id="REQ-0" method=GET uri="https://matrix-client.matrix.org/_matrix/federation/v1/version" status=429 response_size="56B" request_duration=4.144895311s status=429 response_size="56B" request_duration=3.6975288s status=429 response_size="56B" request_duration=3.40915854s status=429 response_size="56B" request_duration=3.254537239s status=429 response_size="56B" request_duration=3.750466093s status=429 response_size="56B" request_duration=3.46515052s}
09-03 10:55:47.783 26932 26984 D org.matrix.rust.sdk: matrix_sdk::http_client::native: Sending request num_attempt=8 | crates/matrix-sdk/src/http_client/native.rs:78 | spans: send{request_id="REQ-0" method=GET uri="https://matrix-client.matrix.org/_matrix/federation/v1/version" status=429 response_size="56B" request_duration=4.144895311s status=429 response_size="56B" request_duration=3.6975288s status=429 response_size="56B" request_duration=3.40915854s status=429 response_size="56B" request_duration=3.254537239s status=429 response_size="56B" request_duration=3.750466093s status=429 response_size="56B" request_duration=3.46515052s status=429 response_size="56B" request_duration=3.722156144s}
09-03 10:56:51.296 26932 26984 D org.matrix.rust.sdk: matrix_sdk::http_client::native: Sending request num_attempt=9 | crates/matrix-sdk/src/http_client/native.rs:78 | spans: send{request_id="REQ-0" method=GET uri="https://matrix-client.matrix.org/_matrix/federation/v1/version" status=429 response_size="56B" request_duration=4.144895311s status=429 response_size="56B" request_duration=3.6975288s status=429 response_size="56B" request_duration=3.40915854s status=429 response_size="56B" request_duration=3.254537239s status=429 response_size="56B" request_duration=3.750466093s status=429 response_size="56B" request_duration=3.46515052s status=429 response_size="56B" request_duration=3.722156144s status=429 response_size="56B" request_duration=3.511499165s}
09-03 10:57:54.612 26932 26984 D org.matrix.rust.sdk: matrix_sdk::http_client::native: Sending request num_attempt=10 | crates/matrix-sdk/src/http_client/native.rs:78 | spans: send{request_id="REQ-0" method=GET uri="https://matrix-client.matrix.org/_matrix/federation/v1/version" status=429 response_size="56B" request_duration=4.144895311s status=429 response_size="56B" request_duration=3.6975288s status=429 response_size="56B" request_duration=3.40915854s status=429 response_size="56B" request_duration=3.254537239s status=429 response_size="56B" request_duration=3.750466093s status=429 response_size="56B" request_duration=3.46515052s status=429 response_size="56B" request_duration=3.722156144s status=429 response_size="56B" request_duration=3.511499165s status=429 response_size="56B" request_duration=3.31307927s}
09-03 10:58:57.984 26932 27032 D org.matrix.rust.sdk: matrix_sdk::http_client::native: Sending request num_attempt=11 | crates/matrix-sdk/src/http_client/native.rs:78 | spans: send{request_id="REQ-0" method=GET uri="https://matrix-client.matrix.org/_matrix/federation/v1/version" status=429 response_size="56B" request_duration=4.144895311s status=429 response_size="56B" request_duration=3.6975288s status=429 response_size="56B" request_duration=3.40915854s status=429 response_size="56B" request_duration=3.254537239s status=429 response_size="56B" request_duration=3.750466093s status=429 response_size="56B" request_duration=3.46515052s status=429 response_size="56B" request_duration=3.722156144s status=429 response_size="56B" request_duration=3.511499165s status=429 response_size="56B" request_duration=3.31307927s status=429 response_size="56B" request_duration=3.369202655s}
09-03 11:00:01.531 26932 27032 D org.matrix.rust.sdk: matrix_sdk::http_client::native: Sending request num_attempt=12 | crates/matrix-sdk/src/http_client/native.rs:78 | spans: send{request_id="REQ-0" method=GET uri="https://matrix-client.matrix.org/_matrix/federation/v1/version" status=429 response_size="56B" request_duration=4.144895311s status=429 response_size="56B" request_duration=3.6975288s status=429 response_size="56B" request_duration=3.40915854s status=429 response_size="56B" request_duration=3.254537239s status=429 response_size="56B" request_duration=3.750466093s status=429 response_size="56B" request_duration=3.46515052s status=429 response_size="56B" request_duration=3.722156144s status=429 response_size="56B" request_duration=3.511499165s status=429 response_size="56B" request_duration=3.31307927s status=429 response_size="56B" request_duration=3.369202655s status=429 response_size="56B" request_duration=3.539915259s}
...
```

And since the `Client` was never built, the app was stuck with a loading UI.

We *could* solve this by passing that custom request config, but that sets the default request config for *all* requests, and that seems a bit excessive when we just want to make sure the builder can finish.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
