### PR TITLE
feat(ui): Add the new `latest_event` room list sorter, and update the `recency` sorter

### DIFF
--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -57,8 +57,8 @@ pub use once_cell;
 pub use room::{
     EncryptionState, InviteAcceptanceDetails, PredecessorRoom, Room,
     RoomCreateWithCreatorEventContent, RoomDisplayName, RoomHero, RoomInfo, RoomInfoNotableUpdate,
-    RoomInfoNotableUpdateReasons, RoomMember, RoomMembersUpdate, RoomMemberships, RoomState,
-    RoomStateFilter, SuccessorRoom, apply_redaction,
+    RoomInfoNotableUpdateReasons, RoomMember, RoomMembersUpdate, RoomMemberships, RoomRecencyStamp,
+    RoomState, RoomStateFilter, SuccessorRoom, apply_redaction,
 };
 pub use store::{
     ComposerDraft, ComposerDraftType, QueueWedgeError, StateChanges, StateStore, StateStoreDataKey,

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -399,7 +399,7 @@ fn properties(
     }
 
     if let Some(recency_stamp) = &room_response.bump_stamp {
-        let recency_stamp: u64 = (*recency_stamp).into();
+        let recency_stamp = u64::from(*recency_stamp).into();
 
         if room_info.recency_stamp.as_ref() != Some(&recency_stamp) {
             room_info.update_recency_stamp(recency_stamp);

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -45,7 +45,7 @@ pub use members::{RoomMember, RoomMembersUpdate, RoomMemberships};
 pub(crate) use room_info::SyncInfo;
 pub use room_info::{
     BaseRoomInfo, InviteAcceptanceDetails, RoomInfo, RoomInfoNotableUpdate,
-    RoomInfoNotableUpdateReasons, apply_redaction,
+    RoomInfoNotableUpdateReasons, RoomRecencyStamp, apply_redaction,
 };
 use ruma::{
     EventId, OwnedEventId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, RoomId,
@@ -479,7 +479,7 @@ impl Room {
     /// Returns the recency stamp of the room.
     ///
     /// Please read `RoomInfo::recency_stamp` to learn more.
-    pub fn recency_stamp(&self) -> Option<u64> {
+    pub fn recency_stamp(&self) -> Option<RoomRecencyStamp> {
         self.inner.read().recency_stamp
     }
 

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1051,7 +1051,7 @@ impl RoomInfo {
     /// Updates the recency stamp of this room.
     ///
     /// Please read [`Self::recency_stamp`] to learn more.
-    pub(crate) fn update_recency_stamp(&mut self, stamp: u64) {
+    pub fn update_recency_stamp(&mut self, stamp: u64) {
         self.recency_stamp = Some(stamp);
     }
 

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -495,7 +495,7 @@ pub struct RoomInfo {
     /// stamp of the room. Thus, using this `recency_stamp` value is
     /// more accurate than relying on the latest event.
     #[serde(default)]
-    pub(crate) recency_stamp: Option<u64>,
+    pub(crate) recency_stamp: Option<RoomRecencyStamp>,
 
     /// A timestamp remembering when we observed the user accepting an invite on
     /// this current device.
@@ -1051,7 +1051,7 @@ impl RoomInfo {
     /// Updates the recency stamp of this room.
     ///
     /// Please read `Self::recency_stamp` to learn more.
-    pub fn update_recency_stamp(&mut self, stamp: u64) {
+    pub fn update_recency_stamp(&mut self, stamp: RoomRecencyStamp) {
         self.recency_stamp = Some(stamp);
     }
 
@@ -1133,6 +1133,24 @@ impl RoomInfo {
         }
 
         migrated
+    }
+}
+
+/// Type to represent a `RoomInfo::recency_stamp`.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
+pub struct RoomRecencyStamp(u64);
+
+impl From<u64> for RoomRecencyStamp {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<RoomRecencyStamp> for u64 {
+    fn from(value: RoomRecencyStamp) -> Self {
+        value.0
     }
 }
 
@@ -1313,7 +1331,7 @@ mod tests {
             warned_about_unknown_room_version_rules: Arc::new(false.into()),
             cached_display_name: None,
             cached_user_defined_notification_mode: None,
-            recency_stamp: Some(42),
+            recency_stamp: Some(42.into()),
             invite_acceptance_details: None,
         };
 
@@ -1562,7 +1580,7 @@ mod tests {
             info.cached_user_defined_notification_mode.as_ref(),
             Some(&RoomNotificationMode::Mute)
         );
-        assert_eq!(info.recency_stamp.as_ref(), Some(&42));
+        assert_eq!(info.recency_stamp.as_ref(), Some(&42.into()));
     }
 
     // Ensure we can still deserialize RoomInfos before we added things to its

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -490,10 +490,20 @@ pub struct RoomInfo {
 
     /// The recency stamp of this room.
     ///
-    /// It's not to be confused with `origin_server_ts` of the latest event.
-    /// Sliding Sync might "ignore” some events when computing the recency
-    /// stamp of the room. Thus, using this `recency_stamp` value is
-    /// more accurate than relying on the latest event.
+    /// It's not to be confused with the `origin_server_ts` value of an event.
+    /// Sliding Sync might “ignore” some events when computing the recency
+    /// stamp of the room. The recency stamp must be considered as an opaque
+    /// unsigned integer value.
+    ///
+    /// # Sorting rooms
+    ///
+    /// The recency stamp is designed to _sort_ rooms between them. The room
+    /// with the highest stamp should be at the top of a room list. However, in
+    /// some situation, it might be inaccurate (for example if the server and
+    /// the client disagree on which events should increment the recency stamp).
+    /// The [`LatestEventValue`] might be a useful alternative to sort rooms
+    /// between them as it's all computed client-side. In this case, the recency
+    /// stamp nicely acts as a default fallback.
     #[serde(default)]
     pub(crate) recency_stamp: Option<RoomRecencyStamp>,
 

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1050,7 +1050,7 @@ impl RoomInfo {
 
     /// Updates the recency stamp of this room.
     ///
-    /// Please read [`Self::recency_stamp`] to learn more.
+    /// Please read `Self::recency_stamp` to learn more.
     pub fn update_recency_stamp(&mut self, stamp: u64) {
         self.recency_stamp = Some(stamp);
     }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -1794,7 +1794,7 @@ mod tests {
 
         // Then the room in the client has the recency stamp
         let client_room = client.get_room(room_id).expect("No room found");
-        assert_eq!(client_room.recency_stamp().expect("No recency stamp"), 42);
+        assert_eq!(client_room.recency_stamp().expect("No recency stamp"), 42.into());
     }
 
     #[async_test]
@@ -1816,7 +1816,7 @@ mod tests {
 
             // Then the room in the client has the recency stamp
             let client_room = client.get_room(room_id).expect("No room found");
-            assert_eq!(client_room.recency_stamp().expect("No recency stamp"), 42);
+            assert_eq!(client_room.recency_stamp().expect("No recency stamp"), 42.into());
         }
 
         {
@@ -1832,7 +1832,7 @@ mod tests {
 
             // Then the room in the client has the previous recency stamp
             let client_room = client.get_room(room_id).expect("No room found");
-            assert_eq!(client_room.recency_stamp().expect("No recency stamp"), 42);
+            assert_eq!(client_room.recency_stamp().expect("No recency stamp"), 42.into());
         }
 
         {
@@ -1849,7 +1849,7 @@ mod tests {
 
             // Then the room in the client has the recency stamp
             let client_room = client.get_room(room_id).expect("No room found");
-            assert_eq!(client_room.recency_stamp().expect("No recency stamp"), 153);
+            assert_eq!(client_room.recency_stamp().expect("No recency stamp"), 153.into());
         }
     }
 

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/category.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/category.rs
@@ -32,47 +32,36 @@ pub enum RoomCategory {
 
 type DirectTargetsLength = usize;
 
-struct CategoryRoomMatcher<F>
+/// _Direct targets_ mean the number of users in a direct room, except us.
+/// So if it returns 1, it means there are 2 users in the direct room.
+fn matches<F>(number_of_direct_targets: F, room: &Room, expected_kind: RoomCategory) -> bool
 where
     F: Fn(&Room) -> Option<DirectTargetsLength>,
 {
-    /// _Direct targets_ mean the number of users in a direct room, except us.
-    /// So if it returns 1, it means there are 2 users in the direct room.
-    number_of_direct_targets: F,
-}
+    let kind = match number_of_direct_targets(room) {
+        // If 1, we are sure it's a direct room between two users. It's the strict
+        // definition of the `People` category, all good.
+        Some(1) => RoomCategory::People,
 
-impl<F> CategoryRoomMatcher<F>
-where
-    F: Fn(&Room) -> Option<DirectTargetsLength>,
-{
-    fn matches(&self, room: &Room, expected_kind: RoomCategory) -> bool {
-        let kind = match (self.number_of_direct_targets)(room) {
-            // If 1, we are sure it's a direct room between two users. It's the strict
-            // definition of the `People` category, all good.
-            Some(1) => RoomCategory::People,
+        // If smaller than 1, we are not sure it's a direct room, it's then a `Group`.
+        // If greater than 1, we are sure it's a direct room but not between
+        // two users, so it's a `Group` based on our expectation.
+        Some(_) => RoomCategory::Group,
 
-            // If smaller than 1, we are not sure it's a direct room, it's then a `Group`.
-            // If greater than 1, we are sure it's a direct room but not between
-            // two users, so it's a `Group` based on our expectation.
-            Some(_) => RoomCategory::Group,
+        // Don't know.
+        None => return false,
+    };
 
-            // Don't know.
-            None => return false,
-        };
-
-        kind == expected_kind
-    }
+    kind == expected_kind
 }
 
 /// Create a new filter that will accept all rooms that fit in the
 /// `expected_category`. The category is defined by [`RoomCategory`], see this
 /// type to learn more.
 pub fn new_filter(expected_category: RoomCategory) -> impl Filter {
-    let matcher = CategoryRoomMatcher {
-        number_of_direct_targets: move |room| Some(room.direct_targets_length()),
-    };
+    let number_of_direct_targets = move |room: &Room| Some(room.direct_targets_length());
 
-    move |room| -> bool { matcher.matches(room, expected_category) }
+    move |room| -> bool { matches(number_of_direct_targets, room, expected_category) }
 }
 
 #[cfg(test)]
@@ -90,20 +79,20 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = CategoryRoomMatcher { number_of_direct_targets: |_| Some(42) };
+        let number_of_direct_targets = |_room: &Room| Some(42);
 
         // Expect `People`.
         {
             let expected_kind = RoomCategory::People;
 
-            assert!(matcher.matches(&room, expected_kind).not());
+            assert!(matches(number_of_direct_targets, &room, expected_kind).not());
         }
 
         // Expect `Group`.
         {
             let expected_kind = RoomCategory::Group;
 
-            assert!(matcher.matches(&room, expected_kind));
+            assert!(matches(number_of_direct_targets, &room, expected_kind));
         }
     }
 
@@ -112,20 +101,20 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = CategoryRoomMatcher { number_of_direct_targets: |_| Some(1) };
+        let number_of_direct_targets = |_room: &Room| Some(1);
 
         // Expect `People`.
         {
             let expected_kind = RoomCategory::People;
 
-            assert!(matcher.matches(&room, expected_kind));
+            assert!(matches(number_of_direct_targets, &room, expected_kind));
         }
 
         // Expect `Group`.
         {
             let expected_kind = RoomCategory::Group;
 
-            assert!(matcher.matches(&room, expected_kind).not());
+            assert!(matches(number_of_direct_targets, &room, expected_kind).not());
         }
     }
 
@@ -134,8 +123,8 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = CategoryRoomMatcher { number_of_direct_targets: |_| None };
+        let number_of_direct_targets = |_room: &Room| None;
 
-        assert!(matcher.matches(&room, RoomCategory::Group).not());
+        assert!(matches(number_of_direct_targets, &room, RoomCategory::Group).not());
     }
 }

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/deduplicate_versions.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/deduplicate_versions.rs
@@ -18,51 +18,39 @@ use super::{super::Room, Filter};
 
 type SuccessorRoomState = RoomState;
 
-struct VersionDeduplicationMatcher<F>
+fn matches<F>(state: F, room: &Room) -> bool
 where
     F: Fn(&Room) -> (RoomState, Option<SuccessorRoomState>),
 {
-    state: F,
-}
+    let (room_state, successor_room_state) = state(room);
 
-impl<F> VersionDeduplicationMatcher<F>
-where
-    F: Fn(&Room) -> (RoomState, Option<SuccessorRoomState>),
-{
-    fn matches(&self, room: &Room) -> bool {
-        let (room_state, successor_room_state) = (self.state)(room);
+    // Check if a room is one of the active versions.
+    match (room_state, successor_room_state) {
+        // This room is joined, and there is no successor. It is an active version.
+        (RoomState::Joined, None) => true,
 
-        // Check if a room is one of the active versions.
-        match (room_state, successor_room_state) {
-            // This room is joined, and there is no successor. It is an active version.
-            (RoomState::Joined, None) => true,
+        // This room is joined, and there is a successor room. This successor room is joined,
+        // left or banned, so this room is **not** the active version.
+        (RoomState::Joined, Some(RoomState::Joined | RoomState::Left | RoomState::Banned)) => false,
 
-            // This room is joined, and there is a successor room. This successor room is joined,
-            // left or banned, so this room is **not** the active version.
-            (RoomState::Joined, Some(RoomState::Joined | RoomState::Left | RoomState::Banned)) => {
-                false
-            }
+        // This room is joined, and there is a successor room. This successor room is invited or
+        // knocked, so this room **is** an active version.
+        (RoomState::Joined, Some(RoomState::Invited | RoomState::Knocked)) => true,
 
-            // This room is joined, and there is a successor room. This successor room is invited or
-            // knocked, so this room **is** an active version.
-            (RoomState::Joined, Some(RoomState::Invited | RoomState::Knocked)) => true,
+        // This room is not joined. It is either left, invited, banned or knocked. The user is
+        // not part of this room, but there is a successor room. This room is **not** the active
+        // version, and should be hidden.
+        (
+            RoomState::Left | RoomState::Invited | RoomState::Banned | RoomState::Knocked,
+            Some(_),
+        ) => false,
 
-            // This room is not joined. It is either left, invited, banned or knocked. The user is
-            // not part of this room, but there is a successor room. This room is **not** the active
-            // version, and should be hidden.
-            (
-                RoomState::Left | RoomState::Invited | RoomState::Banned | RoomState::Knocked,
-                Some(_),
-            ) => false,
-
-            // This room is not joined. It is either left, invited, banned or knocked. The user is
-            // not part of this room, and there may not be a successor. It should not be possible to
-            // know if this room is tombstoned. Consequently, this room **is** the active version,
-            // and should be visible.
-            (
-                RoomState::Left | RoomState::Invited | RoomState::Banned | RoomState::Knocked,
-                None,
-            ) => true,
+        // This room is not joined. It is either left, invited, banned or knocked. The user is
+        // not part of this room, and there may not be a successor. It should not be possible to
+        // know if this room is tombstoned. Consequently, this room **is** the active version,
+        // and should be visible.
+        (RoomState::Left | RoomState::Invited | RoomState::Banned | RoomState::Knocked, None) => {
+            true
         }
     }
 }
@@ -78,18 +66,16 @@ where
 ///
 /// All other rooms are filtered out.
 pub fn new_filter() -> impl Filter {
-    let matcher = VersionDeduplicationMatcher {
-        state: move |room| {
-            (
-                room.state(),
-                room.successor_room()
-                    .and_then(|successor_room| room.client().get_room(&successor_room.room_id))
-                    .map(|successor_room| successor_room.state()),
-            )
-        },
+    let state = |room: &Room| {
+        (
+            room.state(),
+            room.successor_room()
+                .and_then(|successor_room| room.client().get_room(&successor_room.room_id))
+                .map(|successor_room| successor_room.state()),
+        )
     };
 
-    move |room| -> bool { matcher.matches(room) }
+    move |room| -> bool { matches(state, room) }
 }
 
 #[cfg(test)]
@@ -108,8 +94,7 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = VersionDeduplicationMatcher { state: |_| (RoomState::Joined, None) };
-        assert!(matcher.matches(&room));
+        assert!(matches(|_room: &Room| (RoomState::Joined, None), &room));
     }
 
     #[async_test]
@@ -117,10 +102,7 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = VersionDeduplicationMatcher {
-            state: |_| (RoomState::Joined, Some(SuccessorRoomState::Joined)),
-        };
-        assert!(matcher.matches(&room).not());
+        assert!(matches(|_| (RoomState::Joined, Some(SuccessorRoomState::Joined)), &room).not());
     }
 
     #[async_test]
@@ -128,10 +110,7 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = VersionDeduplicationMatcher {
-            state: |_| (RoomState::Joined, Some(SuccessorRoomState::Left)),
-        };
-        assert!(matcher.matches(&room).not());
+        assert!(matches(|_| (RoomState::Joined, Some(SuccessorRoomState::Left)), &room).not());
     }
 
     #[async_test]
@@ -139,10 +118,7 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = VersionDeduplicationMatcher {
-            state: |_| (RoomState::Joined, Some(SuccessorRoomState::Banned)),
-        };
-        assert!(matcher.matches(&room).not());
+        assert!(matches(|_| (RoomState::Joined, Some(SuccessorRoomState::Banned)), &room).not());
     }
 
     #[async_test]
@@ -150,10 +126,7 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = VersionDeduplicationMatcher {
-            state: |_| (RoomState::Joined, Some(SuccessorRoomState::Invited)),
-        };
-        assert!(matcher.matches(&room));
+        assert!(matches(|_| (RoomState::Joined, Some(SuccessorRoomState::Invited)), &room));
     }
 
     #[async_test]
@@ -161,10 +134,7 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = VersionDeduplicationMatcher {
-            state: |_| (RoomState::Joined, Some(SuccessorRoomState::Knocked)),
-        };
-        assert!(matcher.matches(&room));
+        assert!(matches(|_| (RoomState::Joined, Some(SuccessorRoomState::Knocked)), &room));
     }
 
     #[async_test]
@@ -172,9 +142,7 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher =
-            VersionDeduplicationMatcher { state: |_| (RoomState::Left, Some(RoomState::Joined)) };
-        assert!(matcher.matches(&room).not());
+        assert!(matches(|_| (RoomState::Left, Some(RoomState::Joined)), &room).not());
     }
 
     #[async_test]
@@ -182,10 +150,7 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = VersionDeduplicationMatcher {
-            state: |_| (RoomState::Invited, Some(RoomState::Joined)),
-        };
-        assert!(matcher.matches(&room).not());
+        assert!(matches(|_| (RoomState::Invited, Some(RoomState::Joined)), &room).not());
     }
 
     #[async_test]
@@ -193,9 +158,7 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher =
-            VersionDeduplicationMatcher { state: |_| (RoomState::Banned, Some(RoomState::Joined)) };
-        assert!(matcher.matches(&room).not());
+        assert!(matches(|_| (RoomState::Banned, Some(RoomState::Joined)), &room).not());
     }
 
     #[async_test]
@@ -203,10 +166,7 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = VersionDeduplicationMatcher {
-            state: |_| (RoomState::Knocked, Some(RoomState::Joined)),
-        };
-        assert!(matcher.matches(&room).not());
+        assert!(matches(|_| (RoomState::Knocked, Some(RoomState::Joined)), &room).not());
     }
 
     #[async_test]
@@ -214,8 +174,8 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = VersionDeduplicationMatcher { state: |_| (RoomState::Left, None) };
-        assert!(matcher.matches(&room));
+        let state = |_: &Room| (RoomState::Left, None);
+        assert!(matches(state, &room));
     }
 
     #[async_test]
@@ -223,8 +183,8 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = VersionDeduplicationMatcher { state: |_| (RoomState::Invited, None) };
-        assert!(matcher.matches(&room));
+        let state = |_: &Room| (RoomState::Invited, None);
+        assert!(matches(state, &room));
     }
 
     #[async_test]
@@ -232,8 +192,8 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = VersionDeduplicationMatcher { state: |_| (RoomState::Banned, None) };
-        assert!(matcher.matches(&room));
+        let state = |_: &Room| (RoomState::Banned, None);
+        assert!(matches(state, &room));
     }
 
     #[async_test]
@@ -241,7 +201,7 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = VersionDeduplicationMatcher { state: |_| (RoomState::Knocked, None) };
-        assert!(matcher.matches(&room));
+        let state = |_: &Room| (RoomState::Knocked, None);
+        assert!(matches(state, &room));
     }
 }

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/invite.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/invite.rs
@@ -16,28 +16,19 @@ use matrix_sdk_base::RoomState;
 
 use super::{super::Room, Filter};
 
-struct InviteRoomMatcher<F>
+fn matches<F>(state: F, room: &Room) -> bool
 where
     F: Fn(&Room) -> RoomState,
 {
-    state: F,
-}
-
-impl<F> InviteRoomMatcher<F>
-where
-    F: Fn(&Room) -> RoomState,
-{
-    fn matches(&self, room: &Room) -> bool {
-        (self.state)(room) == RoomState::Invited
-    }
+    state(room) == RoomState::Invited
 }
 
 /// Create a new filter that will filter out rooms that are not invites (see
 /// [`matrix_sdk_base::RoomState::Invited`]).
 pub fn new_filter() -> impl Filter {
-    let matcher = InviteRoomMatcher { state: move |room| room.state() };
+    let state = |room: &Room| room.state();
 
-    move |room| -> bool { matcher.matches(room) }
+    move |room| -> bool { matches(state, room) }
 }
 
 #[cfg(test)]
@@ -55,15 +46,12 @@ mod tests {
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         // When a room has been left, it doesn't match.
-        let matcher = InviteRoomMatcher { state: |_| RoomState::Left };
-        assert!(!matcher.matches(&room));
+        assert!(!matches(|_| RoomState::Left, &room));
 
         // When a room has been joined, it doesn't match.
-        let matcher = InviteRoomMatcher { state: |_| RoomState::Joined };
-        assert!(!matcher.matches(&room));
+        assert!(!matches(|_| RoomState::Joined, &room));
 
         // When a room is an invite, it does match (unless it's empty).
-        let matcher = InviteRoomMatcher { state: |_| RoomState::Invited };
-        assert!(matcher.matches(&room));
+        assert!(matches(|_| RoomState::Invited, &room));
     }
 }

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/joined.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/joined.rs
@@ -16,28 +16,19 @@ use matrix_sdk_base::RoomState;
 
 use super::{super::Room, Filter};
 
-struct JoinedRoomMatcher<F>
+fn matches<F>(state: F, room: &Room) -> bool
 where
     F: Fn(&Room) -> RoomState,
 {
-    state: F,
-}
-
-impl<F> JoinedRoomMatcher<F>
-where
-    F: Fn(&Room) -> RoomState,
-{
-    fn matches(&self, room: &Room) -> bool {
-        (self.state)(room) == RoomState::Joined
-    }
+    state(room) == RoomState::Joined
 }
 
 /// Create a new filter that will filter out rooms that are not joined (see
 /// [`matrix_sdk_base::RoomState::Joined`]).
 pub fn new_filter() -> impl Filter {
-    let matcher = JoinedRoomMatcher { state: move |room| room.state() };
+    let state = |room: &Room| room.state();
 
-    move |room| -> bool { matcher.matches(room) }
+    move |room| -> bool { matches(state, room) }
 }
 
 #[cfg(test)]
@@ -55,15 +46,12 @@ mod tests {
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         // When a room has been left, it doesn't match.
-        let matcher = JoinedRoomMatcher { state: |_| RoomState::Left };
-        assert!(!matcher.matches(&room));
+        assert!(!matches(|_| RoomState::Left, &room));
 
         // When a room is an invite, it doesn't match.
-        let matcher = JoinedRoomMatcher { state: |_| RoomState::Invited };
-        assert!(!matcher.matches(&room));
+        assert!(!matches(|_| RoomState::Invited, &room));
 
         // When a room has been joined, it does match (unless it's empty).
-        let matcher = JoinedRoomMatcher { state: |_| RoomState::Joined };
-        assert!(matcher.matches(&room));
+        assert!(matches(|_| RoomState::Joined, &room));
     }
 }

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/space.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/space.rs
@@ -14,28 +14,19 @@
 
 use super::{super::Room, Filter};
 
-struct SpaceRoomMatcher<F>
+fn matches<F>(is_space: F, room: &Room) -> bool
 where
     F: Fn(&Room) -> bool,
 {
-    is_space: F,
-}
-
-impl<F> SpaceRoomMatcher<F>
-where
-    F: Fn(&Room) -> bool,
-{
-    fn matches(&self, room: &Room) -> bool {
-        (self.is_space)(room)
-    }
+    is_space(room)
 }
 
 /// Create a new filter that will filter out rooms that are spaces, i.e.
 /// room with a `room_type` of `m.space` as defined in <https://spec.matrix.org/latest/client-server-api/#spaces>
 pub fn new_filter() -> impl Filter {
-    let matcher = SpaceRoomMatcher { is_space: move |room| room.is_space() };
+    let is_space = |room: &Room| room.is_space();
 
-    move |room| -> bool { matcher.matches(room) }
+    move |room| -> bool { matches(is_space, room) }
 }
 
 #[cfg(test)]
@@ -51,10 +42,7 @@ mod tests {
         let (client, server) = logged_in_client_with_server().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let matcher = SpaceRoomMatcher { is_space: |_| false };
-        assert!(!matcher.matches(&room));
-
-        let matcher = SpaceRoomMatcher { is_space: |_| true };
-        assert!(matcher.matches(&room));
+        assert!(!matches(|_| false, &room));
+        assert!(matches(|_| true, &room));
     }
 }

--- a/crates/matrix-sdk-ui/src/room_list_service/sorters/latest_event.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/sorters/latest_event.rs
@@ -1,0 +1,267 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+
+use matrix_sdk::latest_events::LatestEventValue;
+
+use super::{Room, Sorter};
+
+struct LatestEventMatcher<F>
+where
+    F: Fn(&Room, &Room) -> (LatestEventValue, LatestEventValue),
+{
+    latest_events: F,
+}
+
+impl<F> LatestEventMatcher<F>
+where
+    F: Fn(&Room, &Room) -> (LatestEventValue, LatestEventValue),
+{
+    fn matches(&self, left: &Room, right: &Room) -> Ordering {
+        // We want local latest event to come first. When there is a remote latest event
+        // or no latest event, we don't want to sort them.
+        match (self.latest_events)(left, right) {
+            // `None` == `None`.
+            // `None` == `Remote`.
+            // `Remote` == `None`.
+            // `Remote` == `Remote`.
+            (
+                LatestEventValue::None | LatestEventValue::Remote(_),
+                LatestEventValue::None | LatestEventValue::Remote(_),
+            ) => Ordering::Equal,
+
+            // `None` > `Local*`.
+            // `Remote` > `Local*`.
+            (
+                LatestEventValue::None | LatestEventValue::Remote(_),
+                LatestEventValue::LocalIsSending(_) | LatestEventValue::LocalCannotBeSent(_),
+            ) => Ordering::Greater,
+
+            // `Local*` < `None`.
+            // `Local*` < `Remote`.
+            (
+                LatestEventValue::LocalIsSending(_) | LatestEventValue::LocalCannotBeSent(_),
+                LatestEventValue::None | LatestEventValue::Remote(_),
+            ) => Ordering::Less,
+
+            // `Local*` == `Local*`
+            (
+                LatestEventValue::LocalIsSending(_) | LatestEventValue::LocalCannotBeSent(_),
+                LatestEventValue::LocalIsSending(_) | LatestEventValue::LocalCannotBeSent(_),
+            ) => Ordering::Equal,
+        }
+    }
+}
+
+/// Create a new sorter that will sort two [`Room`] by their latest events'
+/// state: latest events representing a local event
+/// ([`LatestEventValue::LocalIsSending`] or
+/// [`LatestEventValue::LocalCannotBeSent`]) come first, and latest event
+/// representing a remote event ([`LatestEventValue::Remote`]) come last.
+pub fn new_sorter() -> impl Sorter {
+    let matcher = LatestEventMatcher {
+        latest_events: move |left, right| (left.new_latest_event(), right.new_latest_event()),
+    };
+
+    move |left, right| -> Ordering { matcher.matches(left, right) }
+}
+
+#[cfg(test)]
+mod tests {
+    use matrix_sdk::{
+        latest_events::{LocalLatestEventValue, RemoteLatestEventValue},
+        store::SerializableEventContent,
+        test_utils::logged_in_client_with_server,
+    };
+    use matrix_sdk_test::async_test;
+    use ruma::{
+        MilliSecondsSinceUnixEpoch,
+        events::{AnyMessageLikeEventContent, room::message::RoomMessageEventContent},
+        room_id,
+        serde::Raw,
+        uint,
+    };
+    use serde_json::json;
+
+    use super::{super::super::filters::new_rooms, *};
+
+    fn none() -> LatestEventValue {
+        LatestEventValue::None
+    }
+
+    fn remote() -> LatestEventValue {
+        LatestEventValue::Remote(RemoteLatestEventValue::from_plaintext(
+            Raw::from_json_string(
+                json!({
+                    "content": RoomMessageEventContent::text_plain("raclette"),
+                    "type": "m.room.message",
+                    "event_id": "$ev0",
+                    "room_id": "!r0",
+                    "origin_server_ts": 42,
+                    "sender": "@mnt_io:matrix.org",
+                })
+                .to_string(),
+            )
+            .unwrap(),
+        ))
+    }
+
+    fn local_is_sending() -> LatestEventValue {
+        LatestEventValue::LocalIsSending(LocalLatestEventValue {
+            timestamp: MilliSecondsSinceUnixEpoch(uint!(42)),
+            content: SerializableEventContent::from_raw(
+                Raw::new(&AnyMessageLikeEventContent::RoomMessage(
+                    RoomMessageEventContent::text_plain("raclette"),
+                ))
+                .unwrap(),
+                "m.room.message".to_owned(),
+            ),
+        })
+    }
+
+    fn local_cannot_be_sent() -> LatestEventValue {
+        LatestEventValue::LocalCannotBeSent(LocalLatestEventValue {
+            timestamp: MilliSecondsSinceUnixEpoch(uint!(42)),
+            content: SerializableEventContent::from_raw(
+                Raw::new(&AnyMessageLikeEventContent::RoomMessage(
+                    RoomMessageEventContent::text_plain("raclette"),
+                ))
+                .unwrap(),
+                "m.room.message".to_owned(),
+            ),
+        })
+    }
+
+    #[async_test]
+    async fn test_none_or_remote_and_none_or_remote() {
+        let (client, server) = logged_in_client_with_server().await;
+
+        let [room_a, room_b] =
+            new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
+
+        // `None` and `None`.
+        {
+            let matcher = LatestEventMatcher { latest_events: |_, _| (none(), none()) };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Equal);
+        }
+
+        // `None` and `Remote`.
+        {
+            let matcher = LatestEventMatcher { latest_events: |_, _| (none(), remote()) };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Equal);
+        }
+
+        // `Remote` and `None`.
+        {
+            let matcher = LatestEventMatcher { latest_events: |_, _| (remote(), none()) };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Equal);
+        }
+
+        // `Remote` and `None`.
+        {
+            let matcher = LatestEventMatcher { latest_events: |_, _| (remote(), remote()) };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Equal);
+        }
+    }
+
+    #[async_test]
+    async fn test_none_or_remote_and_local() {
+        let (client, server) = logged_in_client_with_server().await;
+
+        let [room_a, room_b] =
+            new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
+
+        // `None` and `Local*`.
+        {
+            let matcher = LatestEventMatcher { latest_events: |_, _| (none(), local_is_sending()) };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Greater);
+
+            let matcher =
+                LatestEventMatcher { latest_events: |_, _| (none(), local_cannot_be_sent()) };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Greater);
+        }
+
+        // `Remote` and `Local*`.
+        {
+            let matcher =
+                LatestEventMatcher { latest_events: |_, _| (remote(), local_is_sending()) };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Greater);
+
+            let matcher =
+                LatestEventMatcher { latest_events: |_, _| (remote(), local_cannot_be_sent()) };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Greater);
+        }
+    }
+
+    #[async_test]
+    async fn test_local_and_none_or_remote() {
+        let (client, server) = logged_in_client_with_server().await;
+
+        let [room_a, room_b] =
+            new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
+
+        // `Local*` and `None`.
+        {
+            let matcher = LatestEventMatcher { latest_events: |_, _| (local_is_sending(), none()) };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Less);
+
+            let matcher =
+                LatestEventMatcher { latest_events: |_, _| (local_cannot_be_sent(), none()) };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Less);
+        }
+
+        // `Local*` and `Remote`.
+        {
+            let matcher =
+                LatestEventMatcher { latest_events: |_, _| (local_is_sending(), remote()) };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Less);
+
+            let matcher =
+                LatestEventMatcher { latest_events: |_, _| (local_cannot_be_sent(), remote()) };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Less);
+        }
+    }
+
+    #[async_test]
+    async fn test_local_and_local() {
+        let (client, server) = logged_in_client_with_server().await;
+
+        let [room_a, room_b] =
+            new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
+
+        // `Local*` and `Local*`.
+        {
+            let matcher = LatestEventMatcher {
+                latest_events: |_, _| (local_is_sending(), local_is_sending()),
+            };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Equal);
+
+            let matcher = LatestEventMatcher {
+                latest_events: |_, _| (local_is_sending(), local_cannot_be_sent()),
+            };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Equal);
+
+            let matcher = LatestEventMatcher {
+                latest_events: |_, _| (local_cannot_be_sent(), local_is_sending()),
+            };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Equal);
+
+            let matcher = LatestEventMatcher {
+                latest_events: |_, _| (local_cannot_be_sent(), local_cannot_be_sent()),
+            };
+            assert_eq!(matcher.matches(&room_a, &room_b), Ordering::Equal);
+        }
+    }
+}

--- a/crates/matrix-sdk-ui/src/room_list_service/sorters/lexicographic.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/sorters/lexicographic.rs
@@ -17,7 +17,7 @@ use std::cmp::Ordering;
 use super::{BoxedSorterFn, Sorter};
 
 /// Create a new sorter that will run multiple sorters. When the nth sorter
-/// returns [`Ordering::Equal`], the next sorter is called. It stops at soon as
+/// returns [`Ordering::Equal`], the next sorter is called. It stops as soon as
 /// a sorter return [`Ordering::Greater`] or [`Ordering::Less`].
 ///
 /// This is an implementation of a lexicographic order as defined for cartesian

--- a/crates/matrix-sdk-ui/src/room_list_service/sorters/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/sorters/mod.rs
@@ -14,12 +14,14 @@
 
 //! A collection of room sorters.
 
+mod latest_event;
 mod lexicographic;
 mod name;
 mod recency;
 
 use std::cmp::Ordering;
 
+pub use latest_event::new_sorter as new_sorter_latest_event;
 pub use lexicographic::new_sorter as new_sorter_lexicographic;
 pub use name::new_sorter as new_sorter_name;
 pub use recency::new_sorter as new_sorter_recency;

--- a/crates/matrix-sdk-ui/src/room_list_service/sorters/recency.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/sorters/recency.rs
@@ -18,48 +18,39 @@ use matrix_sdk::latest_events::LatestEventValue;
 
 use super::{Room, Sorter};
 
-struct RecencySorter<F>
+fn cmp<F>(ranks: F, left: &Room, right: &Room) -> Ordering
 where
     F: Fn(&Room, &Room) -> (Option<Rank>, Option<Rank>),
 {
-    ranks: F,
-}
+    if left.room_id() == right.room_id() {
+        // `left` and `right` are the same room. We are comparing the same
+        // `LatestEvent`!
+        //
+        // The way our `Room` types are implemented makes it so they are sharing the
+        // same data, because they are all built from the same store. They can be seen
+        // as shallow clones of each others. In practice it's really great: a `Room` can
+        // never be outdated. However, for the case of sorting rooms, it breaks the
+        // search algorithm. `left` and `right` will have the exact same recency
+        // stamp, so `left` and `right` will always be `Ordering::Equal`. This is
+        // wrong: if `left` is compared with `right` and if they are both the same room,
+        // it means that one of them (either `left`, or `right`, it's not important) has
+        // received an update. The room position is very likely to change. But if they
+        // compare to `Equal`, the position may not change. It actually depends of the
+        // search algorithm used by [`eyeball_im_util::SortBy`].
+        //
+        // Since this room received an update, it is more recent than the previous one
+        // we matched against, so return `Ordering::Greater`.
+        return Ordering::Greater;
+    }
 
-impl<F> RecencySorter<F>
-where
-    F: Fn(&Room, &Room) -> (Option<Rank>, Option<Rank>),
-{
-    fn cmp(&self, left: &Room, right: &Room) -> Ordering {
-        if left.room_id() == right.room_id() {
-            // `left` and `right` are the same room. We are comparing the same
-            // `LatestEvent`!
-            //
-            // The way our `Room` types are implemented makes it so they are sharing the
-            // same data, because they are all built from the same store. They can be seen
-            // as shallow clones of each others. In practice it's really great: a `Room` can
-            // never be outdated. However, for the case of sorting rooms, it breaks the
-            // search algorithm. `left` and `right` will have the exact same recency
-            // stamp, so `left` and `right` will always be `Ordering::Equal`. This is
-            // wrong: if `left` is compared with `right` and if they are both the same room,
-            // it means that one of them (either `left`, or `right`, it's not important) has
-            // received an update. The room position is very likely to change. But if they
-            // compare to `Equal`, the position may not change. It actually depends of the
-            // search algorithm used by [`eyeball_im_util::SortBy`].
-            //
-            // Since this room received an update, it is more recent than the previous one
-            // we matched against, so return `Ordering::Greater`.
-            return Ordering::Greater;
-        }
+    match ranks(left, right) {
+        (Some(left_rank), Some(right_rank)) => left_rank.cmp(&right_rank).reverse(),
 
-        match (self.ranks)(left, right) {
-            (Some(left_rank), Some(right_rank)) => left_rank.cmp(&right_rank).reverse(),
+        (Some(_), None) => Ordering::Less,
 
-            (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
 
-            (None, Some(_)) => Ordering::Greater,
-
-            (None, None) => Ordering::Equal,
-        }
+        (None, None) => Ordering::Equal,
     }
 }
 
@@ -72,9 +63,9 @@ where
 /// [`RoomInfo::recency_stamp`]: matrix_sdk_base::RoomInfo::recency_stamp
 /// [`RoomInfo::new_latest_event`]: matrix_sdk_base::RoomInfo::new_latest_event
 pub fn new_sorter() -> impl Sorter {
-    let sorter = RecencySorter { ranks: move |left, right| extract_rank(left, right) };
+    let ranks = |left: &Room, right: &Room| extract_rank(left, right);
 
-    move |left, right| -> Ordering { sorter.cmp(left, right) }
+    move |left, right| -> Ordering { cmp(ranks, left, right) }
 }
 
 /// The term _rank_ is used here to avoid any confusion with a _timestamp_ (a
@@ -257,25 +248,22 @@ mod tests {
 
         // `room_a` has an older recency stamp than `room_b`.
         {
-            let sorter = RecencySorter { ranks: |_left, _right| (Some(1), Some(2)) };
-
             // `room_a` is greater than `room_b`, i.e. it must come after `room_b`.
-            assert_eq!(sorter.cmp(&room_a, &room_b), Ordering::Greater);
+            assert_eq!(
+                cmp(|_left, _right| (Some(1), Some(2)), &room_a, &room_b),
+                Ordering::Greater
+            );
         }
 
         // `room_b` has an older recency stamp than `room_a`.
         {
-            let sorter = RecencySorter { ranks: |_left, _right| (Some(2), Some(1)) };
-
             // `room_a` is less than `room_b`, i.e. it must come before `room_b`.
-            assert_eq!(sorter.cmp(&room_a, &room_b), Ordering::Less);
+            assert_eq!(cmp(|_left, _right| (Some(2), Some(1)), &room_a, &room_b), Ordering::Less);
         }
 
         // `room_a` has an equally old recency stamp than `room_b`.
         {
-            let sorter = RecencySorter { ranks: |_left, _right| (Some(1), Some(1)) };
-
-            assert_eq!(sorter.cmp(&room_a, &room_b), Ordering::Equal);
+            assert_eq!(cmp(|_left, _right| (Some(1), Some(1)), &room_a, &room_b), Ordering::Equal);
         }
     }
 
@@ -287,16 +275,12 @@ mod tests {
 
         // `room_a` has a recency stamp, `room_b` has no recency stamp.
         {
-            let sorter = RecencySorter { ranks: |_left, _right| (Some(1), None) };
-
-            assert_eq!(sorter.cmp(&room_a, &room_b), Ordering::Less);
+            assert_eq!(cmp(|_left, _right| (Some(1), None), &room_a, &room_b), Ordering::Less);
         }
 
         // `room_a` has no recency stamp, `room_b` has a recency stamp.
         {
-            let sorter = RecencySorter { ranks: |_left, _right| (None, Some(1)) };
-
-            assert_eq!(sorter.cmp(&room_a, &room_b), Ordering::Greater);
+            assert_eq!(cmp(|_left, _right| (None, Some(1)), &room_a, &room_b), Ordering::Greater);
         }
     }
 
@@ -308,9 +292,7 @@ mod tests {
 
         // `room_a` and `room_b` has no recency stamp.
         {
-            let sorter = RecencySorter { ranks: |_left, _right| (None, None) };
-
-            assert_eq!(sorter.cmp(&room_a, &room_b), Ordering::Equal);
+            assert_eq!(cmp(|_left, _right| (None, None), &room_a, &room_b), Ordering::Equal);
         }
     }
 }

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -27,8 +27,8 @@ pub use matrix_sdk_base::{
     store::{self, DynStateStore, MemoryStore, StateStoreExt},
     ComposerDraft, ComposerDraftType, EncryptionState, PredecessorRoom, QueueWedgeError,
     Room as BaseRoom, RoomCreateWithCreatorEventContent, RoomDisplayName, RoomHero, RoomInfo,
-    RoomMember as BaseRoomMember, RoomMemberships, RoomState, SessionMeta, StateChanges,
-    StateStore, StoreError, SuccessorRoom, ThreadingSupport,
+    RoomMember as BaseRoomMember, RoomMemberships, RoomRecencyStamp, RoomState, SessionMeta,
+    StateChanges, StateStore, StoreError, SuccessorRoom, ThreadingSupport,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;


### PR DESCRIPTION
This set of patches updates the room list to sort rooms by their “latest event”. What does it mean?

- We want a room with a **local** latest event to be at the top of the room list,
- We want a room to have an accurate position in the room list, which means we want to rely on the latest event instead of the room `recency_stamp` (also known as the `bump_stamp` in sliding sync terminology):
  - Why was `recency_stamp` inaccurate? Because the server might _bump_ a room based on certain events, so the room will _bump_ in the room list, but the latest event won't change because the event causing the bump is **not** a latest event candidate. Because the latest event is used by som apps to display the room “last updated time” in the room, the user might see unordered rooms!
  - One may argue that we should keep the list of events triggering a bump on the server in-sync with the list of latest event candidates on the client side. I would happily counter-argue that it's server-dependent and client-dependent. Not all servers and not all clients want the same behaviour. The list on the server is “best-effort”. Also, it's not configurable anymore with Simplified Sliding Sync (MSC4186).
  - One may also argue that sorting by latest event's timestamp means we use [the famous `origin_server_rs` value](https://spec.matrix.org/v1.15/client-server-api/), which is a mistake because it _can_ be forged by malicious servers! Yes, that's true, but:
    - There is no security risk involved here. At worst, a room is _sticked_ at the top or the bottom of the room list, that's it.
    - We were using this value in the past and we agreed it was fine (happy to re-discuss that if needed).
    - Some homeservers can use the `origin_server_ts` value of the last event in the room as the value for `bump_stamp`. We can't control this, it's an opaque value.

All-in-all, this set of patches creates a new `latest_event` sorter for the room list. Then it updates the `recency` sorter to be “latest-event aware”. Finally, it installs the new `latest_event` sorter.