### PR TITLE
fix(room service): enable the thread subscriptions extension based on server support

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -1,4 +1,4 @@
-use std::{ops::Not, sync::Arc};
+use std::{collections::BTreeMap, ops::Not, sync::Arc};
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
@@ -2892,4 +2892,197 @@ async fn test_multiple_timeline_init() {
 
     // A new timeline for the same room can still be constructed.
     room.timeline_builder().build().await.unwrap();
+}
+
+#[async_test]
+async fn test_thread_subscriptions_extension_enabled_only_if_server_advertises_it() {
+    let server = MatrixMockServer::new().await;
+
+    {
+        // The first time, don't advertise support for MSC4306; the extension will NOT
+        // enabled in this case, despite the client requesting it.
+        let features_map = BTreeMap::new();
+
+        server
+            .mock_versions()
+            .ok_custom(&["v1.11"], &features_map)
+            .named("/versions, first time")
+            .mock_once()
+            .mount()
+            .await;
+
+        let client = server
+            .client_builder()
+            .no_server_versions()
+            .on_builder(|b| {
+                b.with_threading_support(matrix_sdk::ThreadingSupport::Enabled {
+                    with_subscriptions: true,
+                })
+            })
+            .build()
+            .await;
+        let room_list = RoomListService::new(client.clone()).await.unwrap();
+
+        let sync = room_list.sync();
+        pin_mut!(sync);
+
+        let room_id = room_id!("!r0:bar.org");
+
+        let mock_server = server.server();
+        sync_then_assert_request_and_fake_response! {
+            [mock_server, room_list, sync]
+            assert request = {
+                "conn_id": "room-list",
+                "extensions": {
+                    "account_data": {
+                        "enabled": true,
+                    },
+                    "receipts": {
+                        "enabled": true,
+                        "rooms": ["*"],
+                    },
+                    "typing": {
+                        "enabled": true,
+                    },
+                },
+                "lists": {
+                    "all_rooms": {
+                        "filters": {},
+                        "ranges": [ [ 0, 19, ], ],
+                        "required_state": [
+                            [ "m.room.name", "" ],
+                            [ "m.room.encryption", "" ],
+                            [ "m.room.member", "$LAZY" ],
+                            [ "m.room.member", "$ME" ],
+                            [ "m.room.topic", "", ],
+                            [ "m.room.avatar", "", ],
+                            [ "m.room.canonical_alias", "", ],
+                            [ "m.room.power_levels", "", ],
+                            [ "org.matrix.msc3401.call.member", "*", ],
+                            [ "m.room.join_rules", "", ],
+                            [ "m.room.tombstone", "", ],
+                            [ "m.room.create", "", ],
+                            [ "m.room.history_visibility", "", ],
+                            [ "io.element.functional_members", "", ],
+                            [ "m.space.parent", "*", ],
+                            [ "m.space.child", "*", ],
+                        ],
+                        "timeline_limit": 1,
+                    },
+                },
+            },
+            respond with = {
+                "pos": "0",
+                "lists": {
+                    ALL_ROOMS: {
+                        "count": 2,
+                    },
+                },
+                "rooms": {
+                    room_id: {
+                        "initial": true,
+                        "timeline": [
+                            timeline_event!("$x0:bar.org" at 0 sec),
+                        ],
+                        "prev_batch": "prev-batch-token"
+                    },
+                },
+            },
+        };
+    }
+
+    // Then, advertise support with support for MSC4306; the extension will be
+    // enabled in this case.
+    let features_map = BTreeMap::from([("org.matrix.msc4306", true)]);
+
+    server
+        .mock_versions()
+        .ok_custom(&["v1.11"], &features_map)
+        .named("/versions, second time")
+        .mock_once()
+        .mount()
+        .await;
+
+    let client = server
+        .client_builder()
+        .no_server_versions()
+        .on_builder(|b| {
+            b.with_threading_support(matrix_sdk::ThreadingSupport::Enabled {
+                with_subscriptions: true,
+            })
+        })
+        .build()
+        .await;
+    let room_list = RoomListService::new(client.clone()).await.unwrap();
+
+    let sync = room_list.sync();
+    pin_mut!(sync);
+
+    let room_id = room_id!("!r0:bar.org");
+
+    let mock_server = server.server();
+    sync_then_assert_request_and_fake_response! {
+        [mock_server, room_list, sync]
+        assert request = {
+            "conn_id": "room-list",
+            "extensions": {
+                "account_data": {
+                    "enabled": true,
+                },
+                "receipts": {
+                    "enabled": true,
+                    "rooms": ["*"],
+                },
+                "typing": {
+                    "enabled": true,
+                },
+                "io.element.msc4308.thread_subscriptions": {
+                    "enabled": true,
+                    "limit": 10,
+                },
+            },
+            "lists": {
+                "all_rooms": {
+                    "filters": {},
+                    "ranges": [ [ 0, 19, ], ],
+                    "required_state": [
+                        [ "m.room.name", "" ],
+                        [ "m.room.encryption", "" ],
+                        [ "m.room.member", "$LAZY" ],
+                        [ "m.room.member", "$ME" ],
+                        [ "m.room.topic", "", ],
+                        [ "m.room.avatar", "", ],
+                        [ "m.room.canonical_alias", "", ],
+                        [ "m.room.power_levels", "", ],
+                        [ "org.matrix.msc3401.call.member", "*", ],
+                        [ "m.room.join_rules", "", ],
+                        [ "m.room.tombstone", "", ],
+                        [ "m.room.create", "", ],
+                        [ "m.room.history_visibility", "", ],
+                        [ "io.element.functional_members", "", ],
+                        [ "m.space.parent", "*", ],
+                        [ "m.space.child", "*", ],
+                    ],
+                    "timeline_limit": 1,
+                },
+            },
+        },
+        respond with = {
+            "pos": "0",
+            "lists": {
+                ALL_ROOMS: {
+                    "count": 2,
+                },
+            },
+            "rooms": {
+                room_id: {
+                    "initial": true,
+                    "timeline": [
+                        timeline_event!("$x0:bar.org" at 0 sec),
+                    ],
+                    "prev_batch": "prev-batch-token"
+                },
+            },
+        },
+    };
 }

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -54,7 +54,7 @@ impl MockClientBuilder {
         }
     }
 
-    /// Don't cache server versions in the client.
+    /// Don't use an initial, cached server versions list in the client.
     pub fn no_server_versions(mut self) -> Self {
         self.server_versions = ServerVersions::None;
         self


### PR DESCRIPTION
Otherwise, when running against a server that doesn't support thread subscriptions, the client may falsely think that its thread subscriptions are *not* outdated (when receiving an empty, defaulted `ThreadSubscriptions` section in the SSS response). As a result, it would always use the store, not find most thread subscriptions, and conclude "nope, you haven't subscribed to any thread", which is wrong.

(Looking for support of MSC4306 is _close_ to what we want, which would be support of MSC4308 itself, coming as part of https://github.com/element-hq/synapse/pull/18695, and that will land despite MSC4306 being already advertised, but that's good enough, since it's unlikely many servers have enabled it by default yet.)