### PR TITLE
perf: process read receipts concurrently

### DIFF
--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
@@ -51,12 +51,10 @@ pub fn dispatch_receipt_ephemeral_event_for_room(
     context: &mut Context,
     room_id: &RoomId,
     receipt: &Raw<SyncEphemeralRoomEvent<ReceiptEventContent>>,
-    joined_room_update: &mut JoinedRoomUpdate,
 ) {
     let receipt: Raw<AnySyncEphemeralRoomEvent> = receipt.cast_ref().clone();
 
     dispatch_receipt(context, &receipt, room_id);
-    joined_room_update.ephemeral.push(receipt);
 }
 
 pub fn room_account_data(


### PR DESCRIPTION
By slightly changing the shape of the function used to process read receipts, we can make it so that it's trivial to run concurrently, which gives some nice speedups locally.

While not a benchmark (and so not super accurate), I've got the distribution of the 6 worst case processing time, for an initial response of my personal account, in multiverse:

Before:
0.172524963s
0.216173016s
0.252289760s
0.257619156s
0.275838632s
0.280295891s

After:
0.083094692s
0.117074046s
0.130246646s
0.132577343s
0.138685246s
0.170287945s

---

I think we could even do better:  finally move the read receipt processing to the event cache, since it can know about the order of events, it won't have to rebuild it from scratch on every new event/read receipt, for every room. I could look into this later.

Found thanks to #5612