### PR TITLE
perf: make room notification caching up to 4000% faster

### DIFF
--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -510,7 +510,7 @@ pub struct RoomInfo {
     /// A timestamp remembering when we observed the user accepting an invite on
     /// this current device.
     ///
-    /// This is useful to remember if the user accepted this a join on this
+    /// This is useful to remember if the user accepted this join on this
     /// specific client.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) invite_acceptance_details: Option<InviteAcceptanceDetails>,

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -180,7 +180,11 @@ impl RoomListService {
         }
 
         if share_pos {
-            // We don't deal with encryption device messages here so this is safe
+            // The e2ee extensions aren't enabled in this sliding sync instance, and this is
+            // the only one that could be used from a different process. So it's
+            // fine to enable position sharing (i.e. reloading it from disk),
+            // since it's always exclusively owned by the current process.
+            debug!("Enabling `share_pos` for the room list sliding sync");
             builder = builder.share_pos();
         }
 

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -14,7 +14,7 @@
 
 //! High-level push notification settings API
 
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
 use indexmap::IndexSet;
 use ruma::{
@@ -568,6 +568,11 @@ impl NotificationSettings {
     /// [`NotificationSettings`] instance.
     pub async fn ruleset(&self) -> Ruleset {
         self.rules.read().await.ruleset.clone()
+    }
+
+    /// Returns the inner [`Rules`] object currently known by this instance.
+    pub(crate) async fn rules(&self) -> impl Deref<Target = Rules> + '_ {
+        self.rules.read().await
     }
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -212,7 +212,7 @@ impl SlidingSyncResponseProcessor {
 
         handle_receipts_extension(&self.client, response, &mut sync_response).await?;
 
-        update_in_memory_caches(&self.client, &previously_joined_rooms, &sync_response).await?;
+        update_in_memory_caches(&self.client, &previously_joined_rooms, &sync_response).await;
 
         self.response = Some(sync_response);
 
@@ -256,7 +256,7 @@ async fn update_in_memory_caches(
     client: &Client,
     previously_joined_rooms: &BTreeSet<OwnedRoomId>,
     response: &SyncResponse,
-) -> Result<()> {
+) {
     let _timer = timer!(tracing::Level::TRACE, "update_in_memory_caches");
 
     // If the push rules have changed, update the cached notification mode for *all*
@@ -308,8 +308,6 @@ async fn update_in_memory_caches(
             }
         }
     }
-
-    Ok(())
 }
 
 /// Update the receipts extension and compute the read receipt accordingly.


### PR DESCRIPTION
The room notification modes will only change when the push rules have changed; otherwise, recomputing them is a no-op, and only wastes time.

Here's a distribution of the worst processing times under this method, as measured in `multiverse` with some big test account running (fresh, i.e. after an initial response) for a few minutes:

Before:
0.036192141s
0.037368775s
0.039177686s
0.039883797s
0.041679405s

After:
0.000000249s
0.000000397s
0.000000899s
0.001080307s
0.001340611s

The new distribution makes sense: the push rules event comes only once, in the initial response, so they're processed only once. Then, there's no need to process it ever again (in my session I've never changed the processing times), so it's almost instantaneous the subsequent times.

Found thanks to https://github.com/matrix-org/matrix-rust-sdk/pull/5612