### PR TITLE
fix(multiverse): Define the color of the placeholder text of the input line

### DIFF
--- a/labs/multiverse/src/widgets/room_view/input.rs
+++ b/labs/multiverse/src/widgets/room_view/input.rs
@@ -35,7 +35,7 @@ pub struct Input {
 impl Input {
     /// Create a new empty [`Input`] widget.
     pub fn new() -> Self {
-        let textarea = TextArea::default();
+        let textarea = Self::text_area();
 
         Self { textarea }
     }
@@ -71,7 +71,14 @@ impl Input {
 
     /// Clear the text from the input area.
     pub fn clear(&mut self) {
-        self.textarea = TextArea::default();
+        self.textarea = Self::text_area();
+    }
+
+    fn text_area() -> TextArea<'static> {
+        let mut area = TextArea::default();
+        area.set_placeholder_style(Style::new().fg(tailwind::GRAY.c50));
+
+        area
     }
 }
 


### PR DESCRIPTION
This ensures that we're using the same color despite what your color scheme of your terminal is. Some color schemes might produce unreadable combinations of foreground color and background color.

Reported by @dkasak.