### PR TITLE
widget-driver: Add read/send capabilities for rtc decline event

### DIFF
--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -175,6 +175,13 @@ pub fn get_element_call_required_permissions(
         WidgetEventFilter::MessageLikeWithType {
             event_type: MessageLikeEventType::RoomRedaction.to_string(),
         },
+        // This allows declining an incoming call and detect if someone declines a call.
+        // Accepts both `org.matrix.msc4310.rtc.decline` and `m.rtc.decline` events to ease future
+        // transition.
+        WidgetEventFilter::MessageLikeWithType {
+            event_type: "org.matrix.msc4310.rtc.decline".to_owned(),
+        },
+        WidgetEventFilter::MessageLikeWithType { event_type: "m.rtc.decline".to_owned() },
     ];
 
     WidgetCapabilities {

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -535,5 +535,11 @@ mod tests {
         );
         cap_assert("org.matrix.msc2762.send.event:org.matrix.rageshake_request");
         cap_assert("org.matrix.msc2762.send.event:io.element.call.encryption_keys");
+
+        // RTC decline
+        cap_assert("org.matrix.msc2762.receive.event:org.matrix.msc4310.rtc.decline");
+        cap_assert("org.matrix.msc2762.receive.event:m.rtc.decline");
+        cap_assert("org.matrix.msc2762.send.event:org.matrix.msc4310.rtc.decline");
+        cap_assert("org.matrix.msc2762.send.event:m.rtc.decline");
     }
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Add capabilities for widgets to read/send rtc decline events.
- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
