### PR TITLE
feat(ui): `sync_service::TerminationReport` and `State` contain the error

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -45,7 +45,7 @@ impl From<MatrixSyncServiceState> for SyncServiceState {
             MatrixSyncServiceState::Idle => Self::Idle,
             MatrixSyncServiceState::Running => Self::Running,
             MatrixSyncServiceState::Terminated => Self::Terminated,
-            MatrixSyncServiceState::Error => Self::Error,
+            MatrixSyncServiceState::Error(_error) => Self::Error,
             MatrixSyncServiceState::Offline => Self::Offline,
         }
     }

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -58,16 +58,20 @@ use crate::{
 /// [`State::Error`] (in case any of the underlying syncs ran into an error).
 ///
 /// This can be observed with [`SyncService::state`].
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum State {
     /// The service hasn't ever been started yet, or has been stopped.
     Idle,
+
     /// The underlying syncs are properly running in the background.
     Running,
+
     /// Any of the underlying syncs has terminated gracefully (i.e. be stopped).
     Terminated,
+
     /// Any of the underlying syncs has ran into an error.
     Error,
+
     /// The service has entered offline mode. This state will only be entered if
     /// the [`SyncService`] has been built with the
     /// [`SyncServiceBuilder::with_offline_mode`] setting.

--- a/crates/matrix-sdk/src/test_utils/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mod.rs
@@ -158,6 +158,9 @@ macro_rules! assert_next_matches_with_timeout {
     ($stream:expr, $pat:pat => $arm:expr) => {
         $crate::assert_next_matches_with_timeout!($stream, 100, $pat => $arm)
     };
+    ($stream:expr, $timeout_ms:expr, $pat:pat) => {
+        $crate::assert_next_matches_with_timeout!($stream, $timeout_ms, $pat => {})
+    };
     ($stream:expr, $timeout_ms:expr, $pat:pat => $arm:expr) => {
         match $crate::assert_next_with_timeout!(&mut $stream, $timeout_ms) {
             $pat => $arm,

--- a/examples/oauth_cli/src/main.rs
+++ b/examples/oauth_cli/src/main.rs
@@ -463,7 +463,7 @@ impl OAuthCli {
                                     }
                                 }
 
-                                matrix_sdk_ui::sync_service::State::Error | matrix_sdk_ui::sync_service::State::Offline => {
+                                matrix_sdk_ui::sync_service::State::Error(_) | matrix_sdk_ui::sync_service::State::Offline => {
                                     num_errors += 1;
                                     num_running = 0;
 

--- a/labs/multiverse/src/widgets/settings/developer.rs
+++ b/labs/multiverse/src/widgets/settings/developer.rs
@@ -59,7 +59,7 @@ impl DeveloperSettingsView {
                                 sync_service::State::Running => sync_service.stop().await,
                                 sync_service::State::Idle
                                 | sync_service::State::Terminated
-                                | sync_service::State::Error
+                                | sync_service::State::Error(_)
                                 | sync_service::State::Offline => sync_service.start().await,
                             }
                         }
@@ -86,7 +86,7 @@ impl Widget for &mut DeveloperSettingsView {
             sync_service::State::Running => ListItem::new("Sync [x]"),
             sync_service::State::Idle
             | sync_service::State::Terminated
-            | sync_service::State::Error
+            | sync_service::State::Error(_)
             | sync_service::State::Offline => ListItem::new("Sync [ ]"),
         };
 


### PR DESCRIPTION
This set of patches makes `TerminationReport` and `State::Error` to contain the error leading to this state.

So far, this is not yet mapped to new error type in FFI land because it's unclear what we want for the moment. However, things are here, ready to be used, for any other Rust consumers.

It's best to review this set patch after patch.

---

* Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/2822#issuecomment-3248280281