### PR TITLE
Release prep for matrix-sdk-base 0.14.1

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -10,6 +10,7 @@ exclude = [
 version = 2
 ignore = [
     { id = "RUSTSEC-2024-0436", reason = "Unmaintained paste crate, not critical." },
+    { id = "RUSTSEC-2025-0056", reason = "Unmaintained adler crate, not a direct dependency" },
 ]
 
 [licenses]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-base"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "as_variant",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,6 +3202,7 @@ dependencies = [
  "matrix-sdk-test",
  "matrix-sdk-test-utils",
  "once_cell",
+ "proptest",
  "regex",
  "ruma",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ wiremock = "0.6.5"
 zeroize = "1.8.1"
 
 matrix-sdk = { path = "crates/matrix-sdk", version = "0.14.0", default-features = false }
-matrix-sdk-base = { path = "crates/matrix-sdk-base", version = "0.14.0" }
+matrix-sdk-base = { path = "crates/matrix-sdk-base", version = "0.14.1" }
 matrix-sdk-common = { path = "crates/matrix-sdk-common", version = "0.14.0" }
 matrix-sdk-crypto = { path = "crates/matrix-sdk-crypto", version = "0.14.0" }
 matrix-sdk-ffi-macros = { path = "bindings/matrix-sdk-ffi-macros", version = "0.7.0" }

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+## [0.14.1] - 2025-09-10
+
 ### Bug Fixes
 
 - Fix a panic in the `RoomMember::normalized_power_level` method.

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Bug Fixes
+
+- Fix a panic in the `RoomMember::normalized_power_level` method.
+  ([#5635](https://github.com/matrix-org/matrix-rust-sdk/pull/5635))
+
 ## [0.14.0] - 2025-09-04
 
 ### Features

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -9,7 +9,7 @@ name = "matrix-sdk-base"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version.workspace = true
-version = "0.14.0"
+version = "0.14.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -107,6 +107,7 @@ futures-executor.workspace = true
 http.workspace = true
 matrix-sdk-test.workspace = true
 matrix-sdk-test-utils.workspace = true
+proptest.workspace = true
 similar-asserts.workspace = true
 stream_assert.workspace = true
 

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -473,3 +473,40 @@ pub fn normalize_power_level(power_level: Int, max_power_level: i64) -> Int {
     power_level = (power_level * 100) / max_power_level;
     power_level.try_into().expect("normalized power level should fit in Int")
 }
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    prop_compose! {
+        fn arb_int()(id in any::<i64>()) -> Int {
+            id.try_into().unwrap_or_default()
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10_000))]
+        #[test]
+        fn test_power_level_normalization_with_min_max_level(power_level in arb_int()) {
+            let normalized = normalize_power_level(power_level, 1);
+            let normalized = i64::from(normalized);
+
+            assert!(normalized >= 0);
+            assert!(normalized <= 100);
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10_000))]
+        #[test]
+        fn test_power_level_normalization(power_level in arb_int(), max_level in 1i64..) {
+            let normalized = normalize_power_level(power_level, max_level);
+            let normalized = i64::from(normalized);
+
+            assert!(normalized >= 0);
+            assert!(normalized <= 100);
+        }
+    }
+}

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -509,4 +509,19 @@ mod tests {
             assert!(normalized <= 100);
         }
     }
+
+    #[test]
+    fn test_power_level_normalization_limits() {
+        let level = Int::MIN;
+        let normalized = normalize_power_level(level, 1);
+        let normalized = i64::from(normalized);
+        assert!(normalized >= 0);
+        assert!(normalized <= 100);
+
+        let level = Int::MAX;
+        let normalized = normalize_power_level(level, 1);
+        let normalized = i64::from(normalized);
+        assert!(normalized >= 0);
+        assert!(normalized <= 100);
+    }
 }

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -471,7 +471,9 @@ impl RoomMemberships {
 pub fn normalize_power_level(power_level: Int, max_power_level: i64) -> Int {
     let mut power_level = i64::from(power_level);
     power_level = (power_level * 100) / max_power_level;
-    power_level.try_into().expect("normalized power level should fit in Int")
+
+    Int::try_from(power_level.clamp(0, 100))
+        .expect("We clamped the normalized power level so they must fit into the Int")
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
   the MSC.
   ([#5590](https://github.com/matrix-org/matrix-rust-sdk/pull/5590))
 - Add a `Client::joined_space_rooms` method that allows retrieving the list of joined spaces.
+  ([#5592](https://github.com/matrix-org/matrix-rust-sdk/pull/5592))
 - `Room::enable_encryption` and `Room::enable_encryption_with_state_event_encryption` will poll
   the encryption state for up to 3 seconds, rather than checking once after a single sync has
   completed.
@@ -56,7 +57,9 @@ All notable changes to this project will be documented in this file.
   ([#5623](https://github.com/matrix-org/matrix-rust-sdk/pull/5623))
 - [**breaking**] `SyncSettings` token is now `SyncToken` enum type which has default behaviour of `SyncToken::ReusePrevious` token. This breaks `Client::sync_once`.
   For old behaviour, set the token to `SyncToken::NoToken` with the usual `SyncSettings::token` setter.
+  ([#5522](https://github.com/matrix-org/matrix-rust-sdk/pull/5522))
 - [**breaking**] Change the upload_encrypted_file and make it clone the client instead of owning it. The lifetime of the `UploadEncryptedFile` request returned by `Client::upload_encrypted_file()` only depends on the request lifetime now.
+  ([#5470](https://github.com/matrix-org/matrix-rust-sdk/pull/5470))
 - [**breaking**] Add an `IsPrefix = False` bound to the `account_data()` and
   `fetch_account_data_static()` methods of `Account`. These methods only worked
   for events where the full event type is statically-known, and this is now
@@ -78,6 +81,7 @@ All notable changes to this project will be documented in this file.
 - [**breaking**] The MSRV has been bumped to Rust 1.88.
   ([#5431](https://github.com/matrix-org/matrix-rust-sdk/pull/5431))
 - [**breaking**] `Room::send_call_notification` and `Room::send_call_notification_if_needed` have been removed, since the event type they send is outdated, and `Client` is not actually supposed to be able to join MatrixRTC sessions (yet). In practice, users of these methods probably already rely on another MatrixRTC implementation to participate in sessions, and such an implementation should be capable of sending notifications itself.
+  ([#5452](https://github.com/matrix-org/matrix-rust-sdk/pull/5452))
 
 ### Bugfix
 


### PR DESCRIPTION
This PR cherry picks a fix for a panic and prepares the 0.14.1 release of the matrix-sdk-base crate.

I forgot to develop the fix on the release branch, so we're doing cherry picks.