### PR TITLE
Create a separate error variant to indicate a failure importing a secret.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -79,9 +79,14 @@ pub enum RecoveryError {
     #[error(transparent)]
     Client { source: crate::ClientError },
 
-    /// Error in the secret storage subsystem.
+    /// Error in the secret storage subsystem, except for when importing a
+    /// secret.
     #[error("Error in the secret-storage subsystem: {error_message}")]
     SecretStorage { error_message: String },
+
+    /// Error when importing a secret from secret storage.
+    #[error("Error importing a secret: {error_message}")]
+    Import { error_message: String },
 }
 
 impl From<matrix_sdk::encryption::recovery::RecoveryError> for RecoveryError {
@@ -89,6 +94,9 @@ impl From<matrix_sdk::encryption::recovery::RecoveryError> for RecoveryError {
         match value {
             recovery::RecoveryError::BackupExistsOnServer => Self::BackupExistsOnServer,
             recovery::RecoveryError::Sdk(e) => Self::Client { source: ClientError::from(e) },
+            recovery::RecoveryError::SecretStorage(
+                matrix_sdk::encryption::secret_storage::SecretStorageError::ImportError(e),
+            ) => Self::Import { error_message: e.to_string() },
             recovery::RecoveryError::SecretStorage(e) => {
                 Self::SecretStorage { error_message: e.to_string() }
             }

--- a/crates/matrix-sdk/src/encryption/secret_storage/mod.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/mod.rs
@@ -90,6 +90,27 @@ pub use secret_store::SecretStore;
 /// Convenicence type alias for the secret-storage specific results.
 pub type Result<T, E = SecretStorageError> = std::result::Result<T, E>;
 
+/// Error type for errors when importing a secret from secret storage.
+#[derive(Debug, Error)]
+pub enum ImportError {
+    /// A typical SDK error.
+    #[error(transparent)]
+    Sdk(#[from] crate::Error),
+
+    /// Error when deserializing account data events.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    /// A secret could not be imported from the secret store into the local
+    /// store.
+    #[error(transparent)]
+    SecretImportError(#[from] SecretImportError),
+
+    /// Error describing a decryption failure of a secret.
+    #[error(transparent)]
+    Decryption(#[from] DecryptionError),
+}
+
 /// Error type for the secret-storage subsystem.
 #[derive(Debug, Error)]
 pub enum SecretStorageError {
@@ -120,10 +141,9 @@ pub enum SecretStorageError {
         key_id: Option<String>,
     },
 
-    /// A secret could not have been imported from the secret store into the
-    /// local store.
+    /// An error when importing from the secret store into the local store.
     #[error(transparent)]
-    SecretImportError(#[from] SecretImportError),
+    ImportError(#[from] ImportError),
 
     /// A general storage error.
     #[error(transparent)]


### PR DESCRIPTION
Part of the fix to https://github.com/element-hq/element-x-android/issues/5099

Allows applications to distinguish between errors that occur when unlocking Secret Storage, or errors that occur when importing a secret, so that they can display appropriate feedback (or not) to the user.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
