### PR TITLE
Merge release-0.14 back to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-base"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "as_variant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ wiremock = "0.6.5"
 zeroize = "1.8.1"
 
 matrix-sdk = { path = "crates/matrix-sdk", version = "0.14.0", default-features = false }
-matrix-sdk-base = { path = "crates/matrix-sdk-base", version = "0.14.0" }
+matrix-sdk-base = { path = "crates/matrix-sdk-base", version = "0.14.1" }
 matrix-sdk-common = { path = "crates/matrix-sdk-common", version = "0.14.0" }
 matrix-sdk-crypto = { path = "crates/matrix-sdk-crypto", version = "0.14.0" }
 matrix-sdk-ffi-macros = { path = "bindings/matrix-sdk-ffi-macros", version = "0.7.0" }

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+## [0.14.1] - 2025-09-10
+
 ### Bug Fixes
 
 - Fix a panic in the `RoomMember::normalized_power_level` method.

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -9,7 +9,7 @@ name = "matrix-sdk-base"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version.workspace = true
-version = "0.14.0"
+version = "0.14.1"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Now that we have a patch release, we need to bring the changelog changes and version bumps back to main.