### PR TITLE
Fix adding both final and dev id doesn't work with ruma alias

### DIFF
--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -177,12 +177,9 @@ pub fn get_element_call_required_permissions(
             event_type: MessageLikeEventType::RoomRedaction.to_string(),
         },
         // This allows declining an incoming call and detect if someone declines a call.
-        // Accepts both `org.matrix.msc4310.rtc.decline` and `m.rtc.decline` events to ease future
-        // transition.
         WidgetEventFilter::MessageLikeWithType {
-            event_type: "org.matrix.msc4310.rtc.decline".to_owned(),
+            event_type: MessageLikeEventType::RtcDecline.to_string(),
         },
-        WidgetEventFilter::MessageLikeWithType { event_type: "m.rtc.decline".to_owned() },
     ];
 
     WidgetCapabilities {
@@ -539,8 +536,6 @@ mod tests {
 
         // RTC decline
         cap_assert("org.matrix.msc2762.receive.event:org.matrix.msc4310.rtc.decline");
-        cap_assert("org.matrix.msc2762.receive.event:m.rtc.decline");
         cap_assert("org.matrix.msc2762.send.event:org.matrix.msc4310.rtc.decline");
-        cap_assert("org.matrix.msc2762.send.event:m.rtc.decline");
     }
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Disable adding both final `m.rtc.notification` and dev id `org.matrix.mscxxx.rtc.notification` as it is not working as expected with the ser/deser and serde alias. (They both are turned into RtcDecline at the end so ends up with duplicating the same cap)

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
