### PR TITLE
sqlite: Drop media table from event cache store

### DIFF
--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/010_drop_media.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/010_drop_media.sql
@@ -1,0 +1,2 @@
+-- The media cache is separate now.
+DROP TABLE "media";


### PR DESCRIPTION
Since the media store was split into a separate database in #5568.

