### PR TITLE
feat(base): Add `get_room_events` to `EventCacheStore` trait and impls.

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -220,6 +220,15 @@ impl EventCacheStore for MemoryStore {
         Ok(related_events)
     }
 
+    async fn get_room_events(&self, room_id: &RoomId) -> Result<Vec<Event>, Self::Error> {
+        let inner = self.inner.read().unwrap();
+
+        let event: Vec<_> =
+            inner.events.items(room_id).map(|(event, _pos)| event.clone()).collect();
+
+        Ok(event)
+    }
+
     async fn save_event(&self, room_id: &RoomId, event: Event) -> Result<(), Self::Error> {
         if event.event_id().is_none() {
             error!(%room_id, "Trying to save an event with no ID");

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -154,6 +154,12 @@ pub trait EventCacheStore: AsyncTraitDeps {
         filter: Option<&[RelationType]>,
     ) -> Result<Vec<(Event, Option<Position>)>, Self::Error>;
 
+    /// Get all events in this room.
+    ///
+    /// This method must return events saved either in any linked chunks, *or*
+    /// events saved "out-of-band" with the [`Self::save_event`] method.
+    async fn get_room_events(&self, room_id: &RoomId) -> Result<Vec<Event>, Self::Error>;
+
     /// Save an event, that might or might not be part of an existing linked
     /// chunk.
     ///
@@ -256,6 +262,10 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
         filter: Option<&[RelationType]>,
     ) -> Result<Vec<(Event, Option<Position>)>, Self::Error> {
         self.0.find_event_relations(room_id, event_id, filter).await.map_err(Into::into)
+    }
+
+    async fn get_room_events(&self, room_id: &RoomId) -> Result<Vec<Event>, Self::Error> {
+        self.0.get_room_events(room_id).await.map_err(Into::into)
     }
 
     async fn save_event(&self, room_id: &RoomId, event: Event) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -469,6 +469,21 @@ impl EventCacheStore for IndexeddbEventCacheStore {
         Ok(related_events)
     }
 
+    #[instrument(skip(self))]
+    async fn get_room_events(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Vec<Event>, IndexeddbEventCacheStoreError> {
+        let _timer = timer!("method");
+
+        let transaction = self.transaction(&[keys::EVENTS], IdbTransactionMode::Readonly)?;
+        transaction
+            .get_room_events(room_id)
+            .await
+            .map(|vec| vec.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
     #[instrument(skip(self, event))]
     async fn save_event(
         &self,

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -32,7 +32,7 @@ use crate::event_cache_store::{
         types::{
             IndexedChunkIdKey, IndexedEventIdKey, IndexedEventPositionKey, IndexedEventRelationKey,
             IndexedEventRoomKey, IndexedGapIdKey, IndexedKeyRange, IndexedLeaseIdKey,
-            IndexedNextChunkIdKey,
+            IndexedNextChunkIdKey, IndexedRoomId,
         },
         IndexeddbEventCacheStoreSerializer,
     },
@@ -675,6 +675,15 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     ) -> Result<Option<Event>, IndexeddbEventCacheStoreTransactionError> {
         let key = self.serializer.encode_key((room_id, event_id));
         self.get_item_by_key::<Event, IndexedEventRoomKey>(key).await
+    }
+
+    /// Query IndexedDB for events that are in the given
+    /// room.
+    pub async fn get_room_events(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Vec<Event>, IndexeddbEventCacheStoreTransactionError> {
+        self.get_items_in_room::<Event, IndexedEventRoomKey>(room_id).await
     }
 
     /// Query IndexedDB for events in the given position range matching the


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Add a `get_room_events` function to the `EventCacheStore` trait and implement it for `MemoryStore`, `SqliteEventCacheStore` and `IndexeddbEventCacheStore`.

Also add a test `test_get_room_events` for this new function in `EventCacheStoreIntegrationTests`

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Shrey Patel shreyp@element.io
