### PR TITLE
fix(timeline): avoid replacing timeline items when the encryption info is unchanged

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -294,7 +294,7 @@ pub enum ShieldStateCode {
 }
 
 /// The algorithm specific information of a decrypted event.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum AlgorithmInfo {
     /// The info if the event was encrypted using m.megolm.v1.aes-sha2
     MegolmV1AesSha2 {
@@ -320,7 +320,7 @@ pub enum AlgorithmInfo {
 }
 
 /// Struct containing information on how an event was decrypted.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct EncryptionInfo {
     /// The user ID of the event sender, note this is untrusted data unless the
     /// `verification_state` is `Verified` as well.

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Bug Fixes
+
+- Avoid replacing timeline items when the encryption info is unchanged.
+  ([#5660](https://github.com/matrix-org/matrix-rust-sdk/pull/5660))
+
 ## [0.14.0] - 2025-09-04
 
 ### Features


### PR DESCRIPTION
`make_replacement_for` is intended to update the `EncryptionInfo` on `TimelineItem`s. However, it also creates replacements when the info is unchanged from before which can cause massive, unbatched timeline updates. This change avoids creating replacements and triggering timeline updates when the encryption info is unchanged.

- [x] Public API changes documented in changelogs (optional)

