### PR TITLE
fix(sqlite): Empty the cache after the introduction of `TimelineEvent::timestamp`

### DIFF
--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/011_empty_event_cache.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/011_empty_event_cache.sql
@@ -1,0 +1,12 @@
+-- After the merge of https://github.com/matrix-org/matrix-rust-sdk/pull/5648,
+-- we want all events to get a `TimelineEvent::timestamp` value (extracted from
+-- `origin_server_ts`).
+--
+-- To accomplish that, we are emptying the event cache. New synced events will
+-- be built correctly, with a valid `TimelineEvent::timestamp`, allowing a
+-- clear, stable situation.
+
+DELETE from linked_chunks;
+DELETE from event_chunks; -- should be done by cascading
+DELETE from gap_chunks; -- should be done by cascading
+DELETE from events;


### PR DESCRIPTION
After the merge of https://github.com/matrix-org/matrix-rust-sdk/pull/5648, we want all events to get a `TimelineEvent::timestamp` value (extracted from `origin_server_ts`).

To accomplish that, we are emptying the event cache. New synced events will be built correctly, with a valid `TimelineEvent::timestamp`, allowing a clear, stable situation.

This is required to also solve a performance problem. When using the new `room_list_service::sorter::recency`, the `TimelineEvent::timestamp()` method is called a lot (depending of the number of rooms). If the `TimelineEvent::timestamp` field is empty (`None`), `extract_timestamp` will be called to… extract the timestamp from the `origin_server_ts` value, which implies **parsing the event** every time. This value isn't kept in-memory at this step because `TimelineEvent::timestamp()` is a getter. The `timestamp` value is set during the sync. Hence the clearing of the cache: we restart from fresh, and we are sure all events will have a correct `timestamp` value.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4112#issuecomment-3273792412