### PR TITLE
feat(rtc): Remove deprecated CallNotify in favour of RtcNotification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4734,8 +4734,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b698b728bc3747f564a9115c83b4f2e229b52377f6a1cca2e6add9cf4a13be"
+source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
 dependencies = [
  "assign",
  "js_int",
@@ -4752,8 +4751,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54e56c591f9ad686defb0bacbebba5c8882eb0c9f8734f6a080345b4e3dd941"
+source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
 dependencies = [
  "as_variant",
  "assign",
@@ -4776,8 +4774,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac7f59b9f7639667d0d6ae3ae242c8912e9ed061cea1fbaf72710a402e83b53e"
+source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
 dependencies = [
  "as_variant",
  "base64",
@@ -4810,8 +4807,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fa815769ed4fe1ef5b50aa0ba6f350317c13b5a9f1e008b014f4a3ddf14204"
+source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4837,8 +4833,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbc887ba1292e48e6363b29e0dec4571b52d2b5102ebf60068105efadaa6e0a"
+source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
 dependencies = [
  "headers",
  "http",
@@ -4858,8 +4853,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6124d74847ea788601477c89a44485894432a806824cae93885c5825a8ae9dbc"
+source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4870,8 +4864,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a7b93ac1e571c585f8fa5cef09c07bb8a15529775fd56b9a3eac4f9233dff2"
+source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
 dependencies = [
  "js_int",
  "thiserror 2.0.16",
@@ -4880,8 +4873,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9911c7188517f28505d2d513339511d00e0f50cec5c2dde820cd0ec7e6a833"
+source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",
@@ -4896,8 +4888,7 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47cd146d56ae6e7a4a8d912a30dfe57c70e5bf18806fdf617527d4d4f2dd2a4"
+source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ rand = "0.8.5"
 regex = "1.11.2"
 reqwest = { version = "0.12.23", default-features = false }
 rmp-serde = "1.3.0"
-ruma = { version = "0.13.0", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "2f64faeabb85950de27e9829faeb389d2779ac57", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-arbitrary-length-ids",

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
   struct.
   ([#5635](https://github.com/matrix-org/matrix-rust-sdk/pull/5635))
 
+- Remove the deprecated `CallNotify` event (`org.matrix.msc4075.call.notify`) in favor of the new
+  `RtcNotification` event (`org.matrix.msc4075.rtc.notification`).
+
 ## [0.14.0] - 2025-09-04
 
 ### Features:

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -21,7 +21,6 @@ use mime::Mime;
 use ruma::{
     assign,
     events::{
-        call::notify,
         room::{
             avatar::ImageInfo as RumaAvatarImageInfo,
             history_visibility::HistoryVisibility as RumaHistoryVisibility,
@@ -1381,18 +1380,6 @@ impl TryFrom<ImageInfo> for RumaAvatarImageInfo {
             thumbnail_url: thumbnail_url,
             blurhash: value.blurhash,
         }))
-    }
-}
-
-#[derive(uniffi::Enum)]
-pub enum RtcApplicationType {
-    Call,
-}
-impl From<RtcApplicationType> for notify::ApplicationType {
-    fn from(value: RtcApplicationType) -> Self {
-        match value {
-            RtcApplicationType::Call => notify::ApplicationType::Call,
-        }
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -23,7 +23,6 @@ use matrix_sdk::attachment::{BaseAudioInfo, BaseFileInfo, BaseImageInfo, BaseVid
 use ruma::{
     assign,
     events::{
-        call::notify::NotifyType as RumaNotifyType,
         direct::DirectEventContent,
         fully_read::FullyReadEventContent,
         identity_server::IdentityServerEventContent,
@@ -57,6 +56,7 @@ use ruma::{
             ImageInfo as RumaImageInfo, MediaSource as RumaMediaSource,
             ThumbnailInfo as RumaThumbnailInfo,
         },
+        rtc::notification::NotificationType as RumaNotificationType,
         secret_storage::{
             default_key::SecretStorageDefaultKeyEventContent,
             key::{
@@ -487,25 +487,25 @@ impl TryFrom<RumaMessageType> for MessageType {
 }
 
 #[derive(Clone, uniffi::Enum)]
-pub enum NotifyType {
+pub enum RtcNotificationType {
     Ring,
     Notify,
 }
 
-impl From<RumaNotifyType> for NotifyType {
-    fn from(val: RumaNotifyType) -> Self {
+impl From<RumaNotificationType> for RtcNotificationType {
+    fn from(val: RumaNotificationType) -> Self {
         match val {
-            RumaNotifyType::Ring => Self::Ring,
+            RumaNotificationType::Ring => Self::Ring,
             _ => Self::Notify,
         }
     }
 }
 
-impl From<NotifyType> for RumaNotifyType {
-    fn from(value: NotifyType) -> Self {
+impl From<RtcNotificationType> for RumaNotificationType {
+    fn from(value: RtcNotificationType) -> Self {
         match value {
-            NotifyType::Ring => RumaNotifyType::Ring,
-            NotifyType::Notify => RumaNotifyType::Notify,
+            RtcNotificationType::Ring => RumaNotificationType::Ring,
+            RtcNotificationType::Notify => RumaNotificationType::Notification,
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -489,14 +489,14 @@ impl TryFrom<RumaMessageType> for MessageType {
 #[derive(Clone, uniffi::Enum)]
 pub enum RtcNotificationType {
     Ring,
-    Notify,
+    Notification,
 }
 
 impl From<RumaNotificationType> for RtcNotificationType {
     fn from(val: RumaNotificationType) -> Self {
         match val {
             RumaNotificationType::Ring => Self::Ring,
-            _ => Self::Notify,
+            _ => Self::Notification,
         }
     }
 }
@@ -505,7 +505,7 @@ impl From<RtcNotificationType> for RumaNotificationType {
     fn from(value: RtcNotificationType) -> Self {
         match value {
             RtcNotificationType::Ring => RumaNotificationType::Ring,
-            RtcNotificationType::Notify => RumaNotificationType::Notification,
+            RtcNotificationType::Notification => RumaNotificationType::Notification,
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -35,7 +35,7 @@ impl From<matrix_sdk_ui::timeline::TimelineItemContent> for TimelineItemContent 
 
             Content::CallInvite => TimelineItemContent::CallInvite,
 
-            Content::CallNotify => TimelineItemContent::CallNotify,
+            Content::RtcNotification => TimelineItemContent::RtcNotification,
 
             Content::MembershipChange(membership) => {
                 let reason = match membership.content() {
@@ -109,7 +109,7 @@ pub enum TimelineItemContent {
         content: MsgLikeContent,
     },
     CallInvite,
-    CallNotify,
+    RtcNotification,
     RoomMembership {
         user_id: String,
         user_display_name: Option<String>,

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -204,10 +204,12 @@ pub fn get_element_call_required_permissions(
         send: vec![
             // To notify other users that a call has started.
             WidgetEventFilter::MessageLikeWithType {
-                event_type: "org.matrix.msc4075.rtc.notification".to_owned(),
+                event_type: MessageLikeEventType::RtcNotification.to_string(),
             },
             // Also for call notifications, except this is the deprecated fallback type which
             // Element Call still sends.
+            // Deprecated for now, kept for backward compatibility as widgets will send both
+            // CallNotify and RtcNotification.
             WidgetEventFilter::MessageLikeWithType {
                 event_type: MessageLikeEventType::CallNotify.to_string(),
             },

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -570,7 +570,7 @@ fn marks_as_unread(event: &Raw<AnySyncTimelineEvent>, user_id: &UserId) -> bool 
             match event {
                 AnySyncMessageLikeEvent::CallAnswer(_)
                 | AnySyncMessageLikeEvent::CallInvite(_)
-                | AnySyncMessageLikeEvent::CallNotify(_)
+                | AnySyncMessageLikeEvent::RtcNotification(_)
                 | AnySyncMessageLikeEvent::CallHangup(_)
                 | AnySyncMessageLikeEvent::CallCandidates(_)
                 | AnySyncMessageLikeEvent::CallNegotiate(_)

--- a/crates/matrix-sdk-base/src/response_processors/latest_event.rs
+++ b/crates/matrix-sdk-base/src/response_processors/latest_event.rs
@@ -80,7 +80,7 @@ async fn find_suitable_and_decrypt(
                     PossibleLatestEvent::YesRoomMessage(_)
                     | PossibleLatestEvent::YesPoll(_)
                     | PossibleLatestEvent::YesCallInvite(_)
-                    | PossibleLatestEvent::YesCallNotify(_)
+                    | PossibleLatestEvent::YesRtcNotification(_)
                     | PossibleLatestEvent::YesSticker(_)
                     | PossibleLatestEvent::YesKnockedStateEvent(_) => {
                         return Some((Box::new(LatestEvent::new(decrypted)), i));

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -461,7 +461,7 @@ pub(crate) async fn cache_latest_events(
                 PossibleLatestEvent::YesRoomMessage(_)
                 | PossibleLatestEvent::YesPoll(_)
                 | PossibleLatestEvent::YesCallInvite(_)
-                | PossibleLatestEvent::YesCallNotify(_)
+                | PossibleLatestEvent::YesRtcNotification(_)
                 | PossibleLatestEvent::YesSticker(_)
                 | PossibleLatestEvent::YesKnockedStateEvent(_) => {
                     // We found a suitable latest event. Store it.

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -274,7 +274,7 @@ pub fn default_event_filter(event: &AnySyncTimelineEvent, rules: &RoomVersionRul
                             UnstablePollStartEventContent::New(_),
                         )
                         | AnyMessageLikeEventContent::CallInvite(_)
-                        | AnyMessageLikeEventContent::CallNotify(_)
+                        | AnyMessageLikeEventContent::RtcNotification(_)
                         | AnyMessageLikeEventContent::RoomEncrypted(_) => true,
 
                         _ => false,

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -340,8 +340,8 @@ impl TimelineAction {
                 Self::add_item(TimelineItemContent::CallInvite)
             }
 
-            AnyMessageLikeEventContent::CallNotify(_) => {
-                Self::add_item(TimelineItemContent::CallNotify)
+            AnyMessageLikeEventContent::RtcNotification(_) => {
+                Self::add_item(TimelineItemContent::RtcNotification)
             }
 
             AnyMessageLikeEventContent::Sticker(content) => {

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -616,7 +616,7 @@ impl EventTimelineItem {
             | TimelineItemContent::FailedToParseMessageLike { .. }
             | TimelineItemContent::FailedToParseState { .. }
             | TimelineItemContent::CallInvite
-            | TimelineItemContent::CallNotify => None,
+            | TimelineItemContent::RtcNotification => None,
         };
 
         if let Some(body) = body {

--- a/crates/matrix-sdk/src/latest_events/latest_event.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event.rs
@@ -996,7 +996,7 @@ mod tests_latest_event_content {
     use ruma::{
         event_id,
         events::{room::message::RoomMessageEventContent, rtc::notification::NotificationType},
-        user_id,
+        owned_user_id, user_id,
     };
 
     use super::filter_timeline_event;
@@ -1099,9 +1099,10 @@ mod tests_latest_event_content {
                 event_factory
                      .rtc_notification(
                         NotificationType::Ring,
-                        None,
-                        None,
                     )
+                    .mentions(vec![owned_user_id!("@alice:server.name")])
+                    .relates_to_membership_state_event(ruma::OwnedEventId::try_from("!1234").unwrap())
+                    .lifetime(60)
                     .into_event()
             }
             is a candidate

--- a/crates/matrix-sdk/src/latest_events/latest_event.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event.rs
@@ -1101,7 +1101,7 @@ mod tests_latest_event_content {
                         NotificationType::Ring,
                     )
                     .mentions(vec![owned_user_id!("@alice:server.name")])
-                    .relates_to_membership_state_event(ruma::OwnedEventId::try_from("!1234").unwrap())
+                    .relates_to_membership_state_event(ruma::OwnedEventId::try_from("$abc:server.name").unwrap())
                     .lifetime(60)
                     .into_event()
             }

--- a/crates/matrix-sdk/src/latest_events/latest_event.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event.rs
@@ -977,7 +977,7 @@ fn filter_any_message_like_event_content(event: AnyMessageLikeEventContent) -> b
 
         AnyMessageLikeEventContent::UnstablePollStart(_)
         | AnyMessageLikeEventContent::CallInvite(_)
-        | AnyMessageLikeEventContent::CallNotify(_)
+        | AnyMessageLikeEventContent::RtcNotification(_)
         | AnyMessageLikeEventContent::Sticker(_) => true,
 
         // Encrypted events are not suitable.
@@ -993,7 +993,11 @@ mod tests_latest_event_content {
     use std::ops::Not;
 
     use matrix_sdk_test::event_factory::EventFactory;
-    use ruma::{event_id, events::room::message::RoomMessageEventContent, user_id};
+    use ruma::{
+        event_id,
+        events::{room::message::RoomMessageEventContent, rtc::notification::NotificationType},
+        user_id,
+    };
 
     use super::filter_timeline_event;
 
@@ -1089,15 +1093,14 @@ mod tests_latest_event_content {
     }
 
     #[test]
-    fn test_call_notify() {
+    fn test_rtc_notification() {
         assert_latest_event_content!(
             event | event_factory | {
                 event_factory
-                    .call_notify(
-                        "call_id".to_owned(),
-                        ruma::events::call::notify::ApplicationType::Call,
-                        ruma::events::call::notify::NotifyType::Ring,
-                        ruma::events::Mentions::new(),
+                     .rtc_notification(
+                        NotificationType::Ring,
+                        None,
+                        None,
                     )
                     .into_event()
             }

--- a/crates/matrix-sdk/src/room/calls.rs
+++ b/crates/matrix-sdk/src/room/calls.rs
@@ -65,7 +65,7 @@ impl Room {
     /// The returned receiver will receive the sender UserID for each decline
     /// for the matching notify event.
     /// Example:
-    /// - A push is received for an `m.call.notify` event.
+    /// - A push is received for an `m.rtc.notification` event.
     /// - The app starts ringing on this device.
     /// - The app subscribes to decline events for that notify event and stops
     ///   ringing if another device declines the call.
@@ -80,7 +80,7 @@ impl Room {
     /// # async fn dismiss_incoming_call_ui() {}
     /// #
     /// # async fn on_push_for_call_notify(room: matrix_sdk::Room, notify_event_id: &ruma::EventId) {
-    ///     // 1) We just received a push for an `m.call.notify` in `room`.
+    ///     // 1) We just received a push for an `m.rtc.notification` in `room`.
     ///     show_incoming_call_ui().await;
     ///     start_ringing().await;
     ///
@@ -149,8 +149,10 @@ async fn make_call_decline_event(
 
     let event = target.raw().deserialize().map_err(CallError::Deserialize)?;
 
-    // The event must be CallNotify-like.
-    if let AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::CallNotify(notify)) = event {
+    // The event must be RtcNotification-like.
+    if let AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RtcNotification(notify)) =
+        event
+    {
         if notify.sender() == own_user_id {
             // Cannot decline own call.
             Err(CallError::DeclineOwnCall)

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -236,7 +236,8 @@ pub struct VirtualElementCallWidgetConfig {
 /// All these are required to start the widget in the first place.
 /// This is different from the `VirtualElementCallWidgetConfiguration` which
 /// configures the widgets behavior.
-#[derive(Debug, Default, uniffi::Record, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug, Default, Clone)]
 pub struct VirtualElementCallWidgetProperties {
     /// The url to the app.
     ///

--- a/crates/matrix-sdk/tests/integration/room/calls.rs
+++ b/crates/matrix-sdk/tests/integration/room/calls.rs
@@ -3,7 +3,9 @@ use std::sync::{Arc, Mutex};
 use assert_matches2::assert_matches;
 use matrix_sdk::{room::calls::CallError, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent};
-use ruma::{owned_event_id, room_id, user_id, OwnedUserId};
+use ruma::{
+    events::rtc::notification::NotificationType, owned_event_id, room_id, user_id, OwnedUserId,
+};
 use tokio::spawn;
 
 #[async_test]
@@ -23,14 +25,9 @@ async fn test_subscribe_to_decline_call_events() {
         .sync_room(
             &client,
             JoinedRoomBuilder::new(room_id).add_timeline_event(
-                f.call_notify(
-                    "call_id".to_owned(),
-                    ruma::events::call::notify::ApplicationType::Call,
-                    ruma::events::call::notify::NotifyType::Ring,
-                    ruma::events::Mentions::new(),
-                )
-                .sender(user_id!("@alice:matrix.org"))
-                .event_id(&notification_event_id),
+                f.rtc_notification(NotificationType::Ring, None, None)
+                    .sender(user_id!("@alice:matrix.org"))
+                    .event_id(&notification_event_id),
             ),
         )
         .await;
@@ -107,24 +104,14 @@ async fn test_decline_call() {
             JoinedRoomBuilder::new(room_id)
                 .add_state_event(StateTestEvent::Encryption)
                 .add_timeline_event(
-                    f.call_notify(
-                        "call_id".to_owned(),
-                        ruma::events::call::notify::ApplicationType::Call,
-                        ruma::events::call::notify::NotifyType::Ring,
-                        ruma::events::Mentions::new(),
-                    )
-                    .sender(user_id!("@alice:matrix.org"))
-                    .event_id(&notification_event_id),
+                    f.rtc_notification(NotificationType::Ring, None, None)
+                        .sender(user_id!("@alice:matrix.org"))
+                        .event_id(&notification_event_id),
                 )
                 .add_timeline_event(
-                    f.call_notify(
-                        "call_id_1".to_owned(),
-                        ruma::events::call::notify::ApplicationType::Call,
-                        ruma::events::call::notify::NotifyType::Ring,
-                        ruma::events::Mentions::new(),
-                    )
-                    .sender(user_id!("@example:localhost"))
-                    .event_id(&own_notification_event_id),
+                    f.rtc_notification(NotificationType::Ring, None, None)
+                        .sender(user_id!("@example:localhost"))
+                        .event_id(&own_notification_event_id),
                 )
                 .add_timeline_event(
                     f.text_msg("Hello, HRU? ")

--- a/crates/matrix-sdk/tests/integration/room/calls.rs
+++ b/crates/matrix-sdk/tests/integration/room/calls.rs
@@ -25,7 +25,7 @@ async fn test_subscribe_to_decline_call_events() {
         .sync_room(
             &client,
             JoinedRoomBuilder::new(room_id).add_timeline_event(
-                f.rtc_notification(NotificationType::Ring, None, None)
+                f.rtc_notification(NotificationType::Ring)
                     .sender(user_id!("@alice:matrix.org"))
                     .event_id(&notification_event_id),
             ),
@@ -104,12 +104,12 @@ async fn test_decline_call() {
             JoinedRoomBuilder::new(room_id)
                 .add_state_event(StateTestEvent::Encryption)
                 .add_timeline_event(
-                    f.rtc_notification(NotificationType::Ring, None, None)
+                    f.rtc_notification(NotificationType::Ring)
                         .sender(user_id!("@alice:matrix.org"))
                         .event_id(&notification_event_id),
                 )
                 .add_timeline_event(
-                    f.rtc_notification(NotificationType::Ring, None, None)
+                    f.rtc_notification(NotificationType::Ring)
                         .sender(user_id!("@example:localhost"))
                         .event_id(&own_notification_event_id),
                 )

--- a/labs/multiverse/src/widgets/room_view/timeline.rs
+++ b/labs/multiverse/src/widgets/room_view/timeline.rs
@@ -124,7 +124,7 @@ fn format_timeline_item(item: &Arc<TimelineItem>, is_thread: bool) -> Option<Lis
                     kind: MsgLikeKind::Poll(_), ..
                 })
                 | TimelineItemContent::CallInvite
-                | TimelineItemContent::CallNotify => {
+                | TimelineItemContent::RtcNotification => {
                     return None;
                 }
             }

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -1007,17 +1007,12 @@ impl EventFactory {
     pub fn rtc_notification(
         &self,
         notification_type: NotificationType,
-        mentions: Option<Mentions>,
-        rtc_membership_event_id: Option<OwnedEventId>,
     ) -> EventBuilder<RtcNotificationEventContent> {
-        let mut content = RtcNotificationEventContent::new(
+        self.event(RtcNotificationEventContent::new(
             MilliSecondsSinceUnixEpoch::now(),
-            Duration::new(20, 0),
+            Duration::new(30, 0),
             notification_type,
-        );
-        content.relates_to = rtc_membership_event_id.map(Reference::new);
-        content.mentions = mentions;
-        self.event(content)
+        ))
     }
 
     // Creates a new `org.matrix.msc4310.rtc.decline` event.
@@ -1196,6 +1191,23 @@ impl EventBuilder<RoomAvatarEventContent> {
     /// Defines the image info for the avatar.
     pub fn info(mut self, image: avatar::ImageInfo) -> Self {
         self.content.info = Some(Box::new(image));
+        self
+    }
+}
+
+impl EventBuilder<RtcNotificationEventContent> {
+    pub fn mentions(mut self, users: impl IntoIterator<Item = OwnedUserId>) -> Self {
+        self.content.mentions = Some(Mentions::with_user_ids(users));
+        self
+    }
+
+    pub fn relates_to_membership_state_event(mut self, event_id: OwnedEventId) -> Self {
+        self.content.relates_to = Some(Reference::new(event_id));
+        self
+    }
+
+    pub fn lifetime(mut self, time_in_seconds: u64) -> Self {
+        self.content.lifetime = Duration::from_secs(time_in_seconds);
         self
     }
 }

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -17,6 +17,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::atomic::{AtomicU64, Ordering::SeqCst},
+    time::Duration,
 };
 
 use as_variant::as_variant;
@@ -33,11 +34,7 @@ use ruma::{
         GlobalAccountDataEventContent, Mentions, RedactedMessageLikeEventContent,
         RedactedStateEventContent, StateEventContent, StaticEventContent,
         beacon::BeaconEventContent,
-        call::{
-            SessionDescription,
-            invite::CallInviteEventContent,
-            notify::{ApplicationType, CallNotifyEventContent, NotifyType},
-        },
+        call::{SessionDescription, invite::CallInviteEventContent},
         direct::{DirectEventContent, OwnedDirectUserIdentifier},
         ignored_user_list::IgnoredUserListEventContent,
         member_hints::MemberHintsEventContent,
@@ -52,7 +49,7 @@ use ruma::{
         push_rules::PushRulesEventContent,
         reaction::ReactionEventContent,
         receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
-        relation::{Annotation, BundledThread, InReplyTo, Replacement, Thread},
+        relation::{Annotation, BundledThread, InReplyTo, Reference, Replacement, Thread},
         room::{
             ImageInfo,
             avatar::{self, RoomAvatarEventContent},
@@ -73,7 +70,10 @@ use ruma::{
             tombstone::RoomTombstoneEventContent,
             topic::RoomTopicEventContent,
         },
-        rtc::decline::RtcDeclineEventContent,
+        rtc::{
+            decline::RtcDeclineEventContent,
+            notification::{NotificationType, RtcNotificationEventContent},
+        },
         space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
         sticker::StickerEventContent,
         typing::TypingEventContent,
@@ -1003,15 +1003,21 @@ impl EventFactory {
         self.event(CallInviteEventContent::new(call_id, lifetime, offer, version))
     }
 
-    /// Create a new `m.call.notify` event.
-    pub fn call_notify(
+    /// Create a new `m.rtc.notification` event.
+    pub fn rtc_notification(
         &self,
-        call_id: String,
-        application: ApplicationType,
-        notify_type: NotifyType,
-        mentions: Mentions,
-    ) -> EventBuilder<CallNotifyEventContent> {
-        self.event(CallNotifyEventContent::new(call_id, application, notify_type, mentions))
+        notification_type: NotificationType,
+        mentions: Option<Mentions>,
+        rtc_membership_event_id: Option<OwnedEventId>,
+    ) -> EventBuilder<RtcNotificationEventContent> {
+        let mut content = RtcNotificationEventContent::new(
+            MilliSecondsSinceUnixEpoch::now(),
+            Duration::new(20, 0),
+            notification_type,
+        );
+        content.relates_to = rtc_membership_event_id.map(Reference::new);
+        content.mentions = mentions;
+        self.event(content)
     }
 
     // Creates a new `org.matrix.msc4310.rtc.decline` event.


### PR DESCRIPTION
<!-- description of the changes in this PR -->

`CallNotify` event has been deprecated in favour of `RtcNotification` event https://github.com/ruma/ruma/pull/2199

Needs an update on ruma dependency


- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
