### PR TITLE
refactor(timeline): some preparatory refactorings for in-thread permalinks

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -327,14 +327,10 @@ impl TimelineMetadata {
                 relations: ev.relations(),
                 bundled_edit_encryption_info,
             });
-            return self.process_content_relations(
-                &content,
-                remote_ctx,
-                timeline_items,
-                is_thread_focus,
-            );
+            self.process_content_relations(&content, remote_ctx, timeline_items, is_thread_focus)
+        } else {
+            (None, None)
         }
-        (None, None)
     }
 
     /// Extracts the in-reply-to details and thread root from the content of a

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -148,6 +148,17 @@ impl<P: RoomDataProvider> TimelineFocusKind<P> {
             TimelineFocusKind::PinnedEvents { .. } => ReceiptThread::Unthreaded,
         }
     }
+
+    /// Whether the focus is on a thread (from a live thread or a thread
+    /// permalink).
+    fn is_thread(&self) -> bool {
+        match self {
+            TimelineFocusKind::Live { hide_threaded_events: _ }
+            | TimelineFocusKind::Event { paginator: _, hide_threaded_events: _ }
+            | TimelineFocusKind::PinnedEvents { loader: _ } => false,
+            TimelineFocusKind::Thread { root_event_id: _ } => true,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -604,11 +604,18 @@ impl<P: RoomDataProvider> TimelineController<P> {
 
     /// Is this timeline focused on a thread?
     pub(super) fn is_threaded(&self) -> bool {
-        matches!(&*self.focus, TimelineFocusKind::Thread { .. })
+        self.focus.is_thread()
     }
 
+    /// The root of the current thread, for a live thread timeline or a
+    /// permalink to a thread message.
     pub(super) fn thread_root(&self) -> Option<OwnedEventId> {
-        as_variant!(&*self.focus, TimelineFocusKind::Thread { root_event_id } => root_event_id.clone())
+        match &*self.focus {
+            TimelineFocusKind::Live { hide_threaded_events: _ }
+            | TimelineFocusKind::Event { paginator: _, hide_threaded_events: _ }
+            | TimelineFocusKind::PinnedEvents { loader: _ } => None,
+            TimelineFocusKind::Thread { root_event_id } => Some(root_event_id.clone()),
+        }
     }
 
     /// Get a copy of the current items in the list.

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -160,7 +160,7 @@ impl<P: RoomDataProvider> TimelineState<P> {
 
         let mut date_divider_adjuster = DateDividerAdjuster::new(date_divider_mode);
 
-        let is_thread_focus = matches!(txn.focus, TimelineFocusKind::Thread { .. });
+        let is_thread_focus = txn.focus.is_thread();
         let (in_reply_to, thread_root) =
             txn.meta.process_content_relations(&content, None, &txn.items, is_thread_focus);
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -410,7 +410,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 room_data_provider.is_pinned_event(event.event_id())
             }
 
-            TimelineFocusKind::Event { hide_threaded_events, .. } => {
+            TimelineFocusKind::Event { hide_threaded_events, paginator: _ } => {
                 // If the timeline's filtering out in-thread events, don't add items for
                 // threaded events.
                 if thread_root.is_some() && *hide_threaded_events {

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -627,7 +627,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                     &raw,
                     bundled_edit_encryption_info,
                     &self.items,
-                    matches!(self.focus, TimelineFocusKind::Thread { .. }),
+                    self.focus.is_thread(),
                 );
 
                 let should_add = self.should_add_event_item(

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -868,6 +868,12 @@ impl Timeline {
     ) -> Result<Option<EmbeddedEvent>, Error> {
         self.controller.make_replied_to(event).await
     }
+
+    /// Returns whether this timeline is focused on a thread (be it live, or
+    /// from a permalink to a threaded event).
+    pub fn is_threaded(&self) -> bool {
+        self.controller.is_threaded()
+    }
 }
 
 /// Test helpers, likely not very useful in production.


### PR DESCRIPTION
In support of https://github.com/matrix-org/matrix-rust-sdk/issues/5535, this changes two things:

- centralize the decision whether a timeline is thread-focused or not, by using a `match` with fields explicitly named (so that when adding/changing a field, we have to consider those `match` statements).
- add a new `Timeline::is_threaded()` function that will return whether a timeline is on a thread or not. This will be useful in the `Events` case, to know if the permalinked message belonged to a thread or to the main timeline.