### PR TITLE
feat(sdk): `LatestEvents` auto-listens from the sync

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -806,7 +806,11 @@ impl BaseClient {
         .await;
 
         // Save the new display name updates if any.
-        processors::changes::save_only(context, &self.state_store).await?;
+        {
+            let _sync_lock = self.sync_lock().lock().await;
+
+            processors::changes::save_only(context, &self.state_store).await?;
+        }
 
         for (room_id, member_ids) in updated_members_in_room {
             if let Some(room) = self.get_room(&room_id) {

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -931,18 +931,21 @@ impl BaseClient {
 
         context.state_changes.ambiguity_maps.insert(room_id.to_owned(), ambiguity_map);
 
-        let _sync_lock = self.sync_lock().lock().await;
-        let mut room_info = room.clone_info();
-        room_info.mark_members_synced();
-        context.state_changes.add_room(room_info);
+        {
+            let _sync_lock = self.sync_lock().lock().await;
 
-        processors::changes::save_and_apply(
-            context,
-            &self.state_store,
-            &self.ignore_user_list_changes,
-            None,
-        )
-        .await?;
+            let mut room_info = room.clone_info();
+            room_info.mark_members_synced();
+            context.state_changes.add_room(room_info);
+
+            processors::changes::save_and_apply(
+                context,
+                &self.state_store,
+                &self.ignore_user_list_changes,
+                None,
+            )
+            .await?;
+        }
 
         let _ = room.room_member_updates_sender.send(RoomMembersUpdate::FullReload);
 

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -465,13 +465,15 @@ impl RoomListService {
 
         // Before subscribing, let's listen these rooms to calculate their latest
         // events.
-        let latest_events = self.client.latest_events().await;
+        if self.client.event_cache().has_subscribed() {
+            let latest_events = self.client.latest_events().await;
 
-        for room_id in room_ids {
-            if let Err(error) = latest_events.listen_to_room(room_id).await {
-                // Let's not fail the room subscription. Instead, emit a log because it's very
-                // unlikely to happen.
-                error!(?error, ?room_id, "Failed to listen to the latest event for this room");
+            for room_id in room_ids {
+                if let Err(error) = latest_events.listen_to_room(room_id).await {
+                    // Let's not fail the room subscription. Instead, emit a log because it's very
+                    // unlikely to happen.
+                    error!(?error, ?room_id, "Failed to listen to the latest event for this room");
+                }
             }
         }
 

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -408,6 +408,11 @@ impl EventCache {
         info!("Auto-shrink linked chunk task has been closed, exiting");
     }
 
+    /// Check whether [`EventCache::subscribe`] has been called.
+    pub fn has_subscribed(&self) -> bool {
+        self.inner.drop_handles.get().is_some()
+    }
+
     /// Return a room-specific view over the [`EventCache`].
     pub(crate) async fn for_room(
         &self,

--- a/crates/matrix-sdk/src/latest_events/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/mod.rs
@@ -48,6 +48,7 @@
 
 mod error;
 mod latest_event;
+mod room_latest_events;
 
 use std::{
     collections::{HashMap, HashSet},
@@ -61,19 +62,17 @@ use futures_util::FutureExt;
 use latest_event::LatestEvent;
 pub use latest_event::{LatestEventValue, LocalLatestEventValue, RemoteLatestEventValue};
 use matrix_sdk_common::executor::{AbortOnDrop, JoinHandleExt as _, spawn};
-use ruma::{EventId, OwnedEventId, OwnedRoomId, RoomId};
+use room_latest_events::RoomLatestEvents;
+use ruma::{EventId, OwnedRoomId, RoomId};
 use tokio::{
     select,
-    sync::{
-        OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
-        broadcast, mpsc,
-    },
+    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard, broadcast, mpsc},
 };
 use tracing::{error, warn};
 
 use crate::{
     client::WeakClient,
-    event_cache::{EventCache, EventCacheError, RoomEventCache, RoomEventCacheGenericUpdate},
+    event_cache::{EventCache, RoomEventCacheGenericUpdate},
     room::WeakRoom,
     send_queue::{RoomSendQueueUpdate, SendQueue, SendQueueUpdate},
 };
@@ -447,200 +446,6 @@ enum LatestEventQueueUpdate {
     },
 }
 
-/// Type holding the [`LatestEvent`] for a room and for all its threads.
-#[derive(Debug)]
-struct RoomLatestEvents {
-    /// The state of this type.
-    state: Arc<RwLock<RoomLatestEventsState>>,
-}
-
-impl RoomLatestEvents {
-    /// Create a new [`RoomLatestEvents`].
-    async fn new(
-        weak_room: WeakRoom,
-        event_cache: &EventCache,
-    ) -> Result<Option<Self>, LatestEventsError> {
-        let room_id = weak_room.room_id();
-        let room_event_cache = match event_cache.for_room(room_id).await {
-            // It's fine to drop the `EventCacheDropHandles` here as the caller
-            // (`LatestEventState`) owns a clone of the `EventCache`.
-            Ok((room_event_cache, _drop_handles)) => room_event_cache,
-            Err(EventCacheError::RoomNotFound { .. }) => return Ok(None),
-            Err(err) => return Err(LatestEventsError::EventCache(err)),
-        };
-
-        Ok(Some(Self {
-            state: Arc::new(RwLock::new(RoomLatestEventsState {
-                for_the_room: Self::create_latest_event_for_inner(
-                    &weak_room,
-                    None,
-                    &room_event_cache,
-                )
-                .await,
-                per_thread: HashMap::new(),
-                weak_room,
-                room_event_cache,
-            })),
-        }))
-    }
-
-    async fn create_latest_event_for_inner(
-        weak_room: &WeakRoom,
-        thread_id: Option<&EventId>,
-        room_event_cache: &RoomEventCache,
-    ) -> LatestEvent {
-        LatestEvent::new(weak_room, thread_id, room_event_cache).await
-    }
-
-    /// Lock this type with shared read access, and return an owned lock guard.
-    async fn read(&self) -> RoomLatestEventsReadGuard {
-        RoomLatestEventsReadGuard { inner: self.state.clone().read_owned().await }
-    }
-
-    /// Lock this type with exclusive write access, and return an owned lock
-    /// guard.
-    async fn write(&self) -> RoomLatestEventsWriteGuard {
-        RoomLatestEventsWriteGuard { inner: self.state.clone().write_owned().await }
-    }
-}
-
-/// The state of [`RoomLatestEvents`].
-#[derive(Debug)]
-struct RoomLatestEventsState {
-    /// The latest event of the room.
-    for_the_room: LatestEvent,
-
-    /// The latest events for each thread.
-    per_thread: HashMap<OwnedEventId, LatestEvent>,
-
-    /// The room event cache associated to this room.
-    room_event_cache: RoomEventCache,
-
-    /// The (weak) room.
-    ///
-    /// It used to to get the power-levels of the user for this room when
-    /// computing the latest events.
-    weak_room: WeakRoom,
-}
-
-/// The owned lock guard returned by [`RoomLatestEvents::read`].
-struct RoomLatestEventsReadGuard {
-    inner: OwnedRwLockReadGuard<RoomLatestEventsState>,
-}
-
-impl RoomLatestEventsReadGuard {
-    /// Get the [`LatestEvent`] for the room.
-    fn for_room(&self) -> &LatestEvent {
-        &self.inner.for_the_room
-    }
-
-    /// Get the [`LatestEvent`] for the thread if it exists.
-    fn for_thread(&self, thread_id: &EventId) -> Option<&LatestEvent> {
-        self.inner.per_thread.get(thread_id)
-    }
-}
-
-/// The owned lock guard returned by [`RoomLatestEvents::write`].
-struct RoomLatestEventsWriteGuard {
-    inner: OwnedRwLockWriteGuard<RoomLatestEventsState>,
-}
-
-impl RoomLatestEventsWriteGuard {
-    async fn create_latest_event_for(&self, thread_id: Option<&EventId>) -> LatestEvent {
-        RoomLatestEvents::create_latest_event_for_inner(
-            &self.inner.weak_room,
-            thread_id,
-            &self.inner.room_event_cache,
-        )
-        .await
-    }
-
-    /// Check whether this [`RoomLatestEvents`] has a latest event for a
-    /// particular thread.
-    fn has_thread(&self, thread_id: &EventId) -> bool {
-        self.inner.per_thread.contains_key(thread_id)
-    }
-
-    /// Create the [`LatestEvent`] for thread `thread_id` and insert it in this
-    /// [`RoomLatestEvents`].
-    async fn create_and_insert_latest_event_for_thread(&mut self, thread_id: &EventId) {
-        let latest_event = self.create_latest_event_for(Some(thread_id)).await;
-
-        self.inner.per_thread.insert(thread_id.to_owned(), latest_event);
-    }
-
-    /// Forget the thread `thread_id`.
-    fn forget_thread(&mut self, thread_id: &EventId) {
-        self.inner.per_thread.remove(thread_id);
-    }
-
-    /// Update the latest events for the room and its threads, based on the
-    /// event cache data.
-    async fn update_with_event_cache(&mut self) {
-        // Get the power levels of the user for the current room if the `WeakRoom` is
-        // still valid.
-        //
-        // Get it once for all the updates of all the latest events for this room (be
-        // the room and its threads).
-        let room = self.inner.weak_room.get();
-        let power_levels = match &room {
-            Some(room) => {
-                let power_levels = room.power_levels().await.ok();
-
-                Some(room.own_user_id()).zip(power_levels)
-            }
-
-            None => None,
-        };
-
-        let inner = &mut *self.inner;
-        let for_the_room = &mut inner.for_the_room;
-        let per_thread = &mut inner.per_thread;
-        let room_event_cache = &inner.room_event_cache;
-
-        for_the_room.update_with_event_cache(room_event_cache, &power_levels).await;
-
-        for latest_event in per_thread.values_mut() {
-            latest_event.update_with_event_cache(room_event_cache, &power_levels).await;
-        }
-    }
-
-    /// Update the latest events for the room and its threads, based on the
-    /// send queue update.
-    async fn update_with_send_queue(&mut self, send_queue_update: &RoomSendQueueUpdate) {
-        // Get the power levels of the user for the current room if the `WeakRoom` is
-        // still valid.
-        //
-        // Get it once for all the updates of all the latest events for this room (be
-        // the room and its threads).
-        let room = self.inner.weak_room.get();
-        let power_levels = match &room {
-            Some(room) => {
-                let power_levels = room.power_levels().await.ok();
-
-                Some(room.own_user_id()).zip(power_levels)
-            }
-
-            None => None,
-        };
-
-        let inner = &mut *self.inner;
-        let for_the_room = &mut inner.for_the_room;
-        let per_thread = &mut inner.per_thread;
-        let room_event_cache = &inner.room_event_cache;
-
-        for_the_room
-            .update_with_send_queue(send_queue_update, room_event_cache, &power_levels)
-            .await;
-
-        for latest_event in per_thread.values_mut() {
-            latest_event
-                .update_with_send_queue(send_queue_update, room_event_cache, &power_levels)
-                .await;
-        }
-    }
-}
-
 /// The task responsible to listen to the [`EventCache`] and the [`SendQueue`].
 /// When an update is received and is considered relevant, a message is sent to
 /// the [`compute_latest_events_task`] to compute a new [`LatestEvent`].
@@ -880,9 +685,9 @@ mod tests {
             assert!(rooms.contains_key(room_id_1));
 
             // Room 0 contains zero thread latest events.
-            assert!(rooms.get(room_id_0).unwrap().read().await.inner.per_thread.is_empty());
+            assert!(rooms.get(room_id_0).unwrap().read().await.per_thread().is_empty());
             // Room 1 contains zero thread latest events.
-            assert!(rooms.get(room_id_1).unwrap().read().await.inner.per_thread.is_empty());
+            assert!(rooms.get(room_id_1).unwrap().read().await.per_thread().is_empty());
         }
 
         // Now let's listen to one thread respectively for two rooms.
@@ -899,17 +704,17 @@ mod tests {
             assert!(rooms.contains_key(room_id_2));
 
             // Room 0 contains zero thread latest events.
-            assert!(rooms.get(room_id_0).unwrap().read().await.inner.per_thread.is_empty());
+            assert!(rooms.get(room_id_0).unwrap().read().await.per_thread().is_empty());
             // Room 1 contains one thread latest event…
             let room_1 = rooms.get(room_id_1).unwrap().read().await;
-            assert_eq!(room_1.inner.per_thread.len(), 1);
+            assert_eq!(room_1.per_thread().len(), 1);
             // … which is thread 1.0.
-            assert!(room_1.inner.per_thread.contains_key(thread_id_1_0));
+            assert!(room_1.per_thread().contains_key(thread_id_1_0));
             // Room 2 contains one thread latest event…
             let room_2 = rooms.get(room_id_2).unwrap().read().await;
-            assert_eq!(room_2.inner.per_thread.len(), 1);
+            assert_eq!(room_2.per_thread().len(), 1);
             // … which is thread 2.0.
-            assert!(room_2.inner.per_thread.contains_key(thread_id_2_0));
+            assert!(room_2.per_thread().contains_key(thread_id_2_0));
         }
     }
 
@@ -939,7 +744,7 @@ mod tests {
             assert!(rooms.contains_key(room_id_0));
 
             // Room 0 contains zero thread latest events.
-            assert!(rooms.get(room_id_0).unwrap().read().await.inner.per_thread.is_empty());
+            assert!(rooms.get(room_id_0).unwrap().read().await.per_thread().is_empty());
         }
 
         // Now let's forget about room 0.
@@ -980,9 +785,9 @@ mod tests {
 
             // Room 0 contains one thread latest event…
             let room_0 = rooms.get(room_id_0).unwrap().read().await;
-            assert_eq!(room_0.inner.per_thread.len(), 1);
+            assert_eq!(room_0.per_thread().len(), 1);
             // … which is thread 0.0.
-            assert!(room_0.inner.per_thread.contains_key(thread_id_0_0));
+            assert!(room_0.per_thread().contains_key(thread_id_0_0));
         }
 
         // Now let's forget about the thread.
@@ -996,7 +801,7 @@ mod tests {
             assert!(rooms.contains_key(room_id_0));
 
             // But the thread has been removed.
-            assert!(rooms.get(room_id_0).unwrap().read().await.inner.per_thread.is_empty());
+            assert!(rooms.get(room_id_0).unwrap().read().await.per_thread().is_empty());
         }
     }
 

--- a/crates/matrix-sdk/src/latest_events/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/mod.rs
@@ -141,6 +141,14 @@ impl LatestEvents {
         Ok(self.state.registered_rooms.for_room(room_id).await?.is_some())
     }
 
+    /// Check whether the system listens to a particular room.
+    ///
+    /// Note: It's a test only method.
+    #[cfg(test)]
+    pub async fn is_listening_to_room(&self, room_id: &RoomId) -> bool {
+        self.state.registered_rooms.rooms.read().await.contains_key(room_id)
+    }
+
     /// Start listening to updates (if not already) for a particular room, and
     /// return a [`Subscriber`] to get the current and future
     /// [`LatestEventValue`]s.

--- a/crates/matrix-sdk/src/latest_events/room_latest_events.rs
+++ b/crates/matrix-sdk/src/latest_events/room_latest_events.rs
@@ -1,0 +1,224 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::HashMap, sync::Arc};
+
+use ruma::{EventId, OwnedEventId};
+use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
+
+use super::{LatestEvent, LatestEventsError};
+use crate::{
+    event_cache::{EventCache, EventCacheError, RoomEventCache},
+    room::WeakRoom,
+    send_queue::RoomSendQueueUpdate,
+};
+
+/// Type holding the [`LatestEvent`] for a room and for all its threads.
+#[derive(Debug)]
+pub(super) struct RoomLatestEvents {
+    /// The state of this type.
+    state: Arc<RwLock<RoomLatestEventsState>>,
+}
+
+impl RoomLatestEvents {
+    /// Create a new [`RoomLatestEvents`].
+    pub async fn new(
+        weak_room: WeakRoom,
+        event_cache: &EventCache,
+    ) -> Result<Option<Self>, LatestEventsError> {
+        let room_id = weak_room.room_id();
+        let room_event_cache = match event_cache.for_room(room_id).await {
+            // It's fine to drop the `EventCacheDropHandles` here as the caller
+            // (`LatestEventState`) owns a clone of the `EventCache`.
+            Ok((room_event_cache, _drop_handles)) => room_event_cache,
+            Err(EventCacheError::RoomNotFound { .. }) => return Ok(None),
+            Err(err) => return Err(LatestEventsError::EventCache(err)),
+        };
+
+        Ok(Some(Self {
+            state: Arc::new(RwLock::new(RoomLatestEventsState {
+                for_the_room: Self::create_latest_event_for_inner(
+                    &weak_room,
+                    None,
+                    &room_event_cache,
+                )
+                .await,
+                per_thread: HashMap::new(),
+                weak_room,
+                room_event_cache,
+            })),
+        }))
+    }
+
+    async fn create_latest_event_for_inner(
+        weak_room: &WeakRoom,
+        thread_id: Option<&EventId>,
+        room_event_cache: &RoomEventCache,
+    ) -> LatestEvent {
+        LatestEvent::new(weak_room, thread_id, room_event_cache).await
+    }
+
+    /// Lock this type with shared read access, and return an owned lock guard.
+    pub async fn read(&self) -> RoomLatestEventsReadGuard {
+        RoomLatestEventsReadGuard { inner: self.state.clone().read_owned().await }
+    }
+
+    /// Lock this type with exclusive write access, and return an owned lock
+    /// guard.
+    pub async fn write(&self) -> RoomLatestEventsWriteGuard {
+        RoomLatestEventsWriteGuard { inner: self.state.clone().write_owned().await }
+    }
+}
+
+/// The state of [`RoomLatestEvents`].
+#[derive(Debug)]
+struct RoomLatestEventsState {
+    /// The latest event of the room.
+    for_the_room: LatestEvent,
+
+    /// The latest events for each thread.
+    per_thread: HashMap<OwnedEventId, LatestEvent>,
+
+    /// The room event cache associated to this room.
+    room_event_cache: RoomEventCache,
+
+    /// The (weak) room.
+    ///
+    /// It used to to get the power-levels of the user for this room when
+    /// computing the latest events.
+    weak_room: WeakRoom,
+}
+
+/// The owned lock guard returned by [`RoomLatestEvents::read`].
+pub(super) struct RoomLatestEventsReadGuard {
+    inner: OwnedRwLockReadGuard<RoomLatestEventsState>,
+}
+
+impl RoomLatestEventsReadGuard {
+    /// Get the [`LatestEvent`] for the room.
+    pub fn for_room(&self) -> &LatestEvent {
+        &self.inner.for_the_room
+    }
+
+    /// Get the [`LatestEvent`] for the thread if it exists.
+    pub fn for_thread(&self, thread_id: &EventId) -> Option<&LatestEvent> {
+        self.inner.per_thread.get(thread_id)
+    }
+
+    #[cfg(test)]
+    pub fn per_thread(&self) -> &HashMap<OwnedEventId, LatestEvent> {
+        &self.inner.per_thread
+    }
+}
+
+/// The owned lock guard returned by [`RoomLatestEvents::write`].
+pub(super) struct RoomLatestEventsWriteGuard {
+    inner: OwnedRwLockWriteGuard<RoomLatestEventsState>,
+}
+
+impl RoomLatestEventsWriteGuard {
+    async fn create_latest_event_for(&self, thread_id: Option<&EventId>) -> LatestEvent {
+        RoomLatestEvents::create_latest_event_for_inner(
+            &self.inner.weak_room,
+            thread_id,
+            &self.inner.room_event_cache,
+        )
+        .await
+    }
+
+    /// Check whether this [`RoomLatestEvents`] has a latest event for a
+    /// particular thread.
+    pub fn has_thread(&self, thread_id: &EventId) -> bool {
+        self.inner.per_thread.contains_key(thread_id)
+    }
+
+    /// Create the [`LatestEvent`] for thread `thread_id` and insert it in this
+    /// [`RoomLatestEvents`].
+    pub async fn create_and_insert_latest_event_for_thread(&mut self, thread_id: &EventId) {
+        let latest_event = self.create_latest_event_for(Some(thread_id)).await;
+
+        self.inner.per_thread.insert(thread_id.to_owned(), latest_event);
+    }
+
+    /// Forget the thread `thread_id`.
+    pub fn forget_thread(&mut self, thread_id: &EventId) {
+        self.inner.per_thread.remove(thread_id);
+    }
+
+    /// Update the latest events for the room and its threads, based on the
+    /// event cache data.
+    pub async fn update_with_event_cache(&mut self) {
+        // Get the power levels of the user for the current room if the `WeakRoom` is
+        // still valid.
+        //
+        // Get it once for all the updates of all the latest events for this room (be
+        // the room and its threads).
+        let room = self.inner.weak_room.get();
+        let power_levels = match &room {
+            Some(room) => {
+                let power_levels = room.power_levels().await.ok();
+
+                Some(room.own_user_id()).zip(power_levels)
+            }
+
+            None => None,
+        };
+
+        let inner = &mut *self.inner;
+        let for_the_room = &mut inner.for_the_room;
+        let per_thread = &mut inner.per_thread;
+        let room_event_cache = &inner.room_event_cache;
+
+        for_the_room.update_with_event_cache(room_event_cache, &power_levels).await;
+
+        for latest_event in per_thread.values_mut() {
+            latest_event.update_with_event_cache(room_event_cache, &power_levels).await;
+        }
+    }
+
+    /// Update the latest events for the room and its threads, based on the
+    /// send queue update.
+    pub async fn update_with_send_queue(&mut self, send_queue_update: &RoomSendQueueUpdate) {
+        // Get the power levels of the user for the current room if the `WeakRoom` is
+        // still valid.
+        //
+        // Get it once for all the updates of all the latest events for this room (be
+        // the room and its threads).
+        let room = self.inner.weak_room.get();
+        let power_levels = match &room {
+            Some(room) => {
+                let power_levels = room.power_levels().await.ok();
+
+                Some(room.own_user_id()).zip(power_levels)
+            }
+
+            None => None,
+        };
+
+        let inner = &mut *self.inner;
+        let for_the_room = &mut inner.for_the_room;
+        let per_thread = &mut inner.per_thread;
+        let room_event_cache = &inner.room_event_cache;
+
+        for_the_room
+            .update_with_send_queue(send_queue_update, room_event_cache, &power_levels)
+            .await;
+
+        for latest_event in per_thread.values_mut() {
+            latest_event
+                .update_with_send_queue(send_queue_update, room_event_cache, &power_levels)
+                .await;
+        }
+    }
+}

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -359,6 +359,10 @@ pub(crate) async fn subscribe_to_room_latest_events<'a, R>(client: &'a Client, r
 where
     R: Iterator<Item = &'a OwnedRoomId>,
 {
+    if !client.event_cache().has_subscribed() {
+        return;
+    }
+
     let latest_events = client.latest_events().await;
 
     for room_id in room_ids {


### PR DESCRIPTION
This patch updates `SlidingSyncResponseProcessor::handle_room_response` to automatically call `LatestEvents::listen_to_room` based on `http::Response`'s `rooms`.

Why? Because when a sync is received, we want its `LatestEventValue` to be computed, so that it can trigger a `RoomInfoNotableUpdate`, which will update the `RoomList`, which will re-sort the rooms. So far, `LatestEvents::listen_to_room` was called by `RoomListService::subscribe_to_rooms`, but it's possible to receive a room update via the sync for a room that is not subscribed, i.e. out of the viewport of the room list in Matrix clients (it's recommended to subscribe to rooms that “enter” the viewport). Without this patch, rooms are receiving updates but the room list is not entirely refreshed/recalculated.

Other patches also solve a dead lock found by Complement Crypto. Read the patches' description to learn more. 

---

* https://github.com/matrix-org/matrix-rust-sdk/issues/4112