### PR TITLE
chore(common): Add log in `TimelineEvent::timestamp`

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -27,7 +27,7 @@ use ruma::{
     },
 };
 use serde::{Deserialize, Serialize};
-use tracing::warn;
+use tracing::{trace, warn};
 #[cfg(target_family = "wasm")]
 use wasm_bindgen::prelude::*;
 
@@ -777,7 +777,13 @@ impl TimelineEvent {
     /// [`MilliSecondsSinceUnixEpoch::now`]. It means that the returned value
     /// might not be constant.
     pub fn timestamp(&self) -> Option<MilliSecondsSinceUnixEpoch> {
-        self.timestamp.or_else(|| extract_timestamp(self.raw(), MilliSecondsSinceUnixEpoch::now()))
+        self.timestamp.or_else(|| {
+            trace!(
+                "`TimelineEvent::timestamp` is parsing the raw event to extract the `timestamp`"
+            );
+
+            extract_timestamp(self.raw(), MilliSecondsSinceUnixEpoch::now())
+        })
     }
 
     /// Get the timestamp value, without trying to backfill it if `None`.


### PR DESCRIPTION
This patch adds a log in `TimelineEvent::timestamp` when the `timestamp` has to be extracted. It can be a performance problem depending on when it's called.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4112