### PR TITLE
chore: bump `matrix-sdk` to the 2024 edition

### DIFF
--- a/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
+++ b/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
@@ -321,7 +321,7 @@ impl CryptoStoreWrapper {
     /// the reader.
     pub fn room_keys_received_stream(
         &self,
-    ) -> impl Stream<Item = Result<Vec<RoomKeyInfo>, BroadcastStreamRecvError>> {
+    ) -> impl Stream<Item = Result<Vec<RoomKeyInfo>, BroadcastStreamRecvError>> + use<> {
         BroadcastStream::new(self.room_keys_received_sender.subscribe())
     }
 
@@ -349,7 +349,7 @@ impl CryptoStoreWrapper {
 
     /// Receive notifications of historic room key bundles being received and
     /// stored in the store as a [`Stream`].
-    pub fn historic_room_key_stream(&self) -> impl Stream<Item = RoomKeyBundleInfo> {
+    pub fn historic_room_key_stream(&self) -> impl Stream<Item = RoomKeyBundleInfo> + use<> {
         let stream = BroadcastStream::new(self.historic_room_key_bundles_broadcaster.subscribe());
         Self::filter_errors_out_of_stream(stream, "bundle_stream")
     }

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -1129,7 +1129,7 @@ impl Store {
     /// `CryptoStoreWrapper` are dropped.
     pub fn room_keys_received_stream(
         &self,
-    ) -> impl Stream<Item = Result<Vec<RoomKeyInfo>, BroadcastStreamRecvError>> {
+    ) -> impl Stream<Item = Result<Vec<RoomKeyInfo>, BroadcastStreamRecvError>> + use<> {
         self.inner.store.room_keys_received_stream()
     }
 
@@ -1353,7 +1353,7 @@ impl Store {
     /// }
     /// # anyhow::Ok(()) };
     /// ```
-    pub fn historic_room_key_stream(&self) -> impl Stream<Item = RoomKeyBundleInfo> {
+    pub fn historic_room_key_stream(&self) -> impl Stream<Item = RoomKeyBundleInfo> + use<> {
         self.inner.store.historic_room_key_stream()
     }
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+### Refactor
+- The Matrix SDK crate now uses the 2024 edition of Rust.
+  ([#5677](https://github.com/matrix-org/matrix-rust-sdk/pull/5677))
+
+### Bugfix
+
 ## [0.14.0] - 2025-09-04
 
 ### Features

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 description = "A high level Matrix client-server library."
-edition = "2021"
+edition = "2024"
 homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ruma", "nio"]
 license = "Apache-2.0"

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 use futures_core::Stream;
-use futures_util::{stream, StreamExt};
+use futures_util::{StreamExt, stream};
 #[cfg(feature = "experimental-element-recent-emojis")]
 use itertools::Itertools;
 #[cfg(feature = "experimental-element-recent-emojis")]
@@ -23,14 +23,15 @@ use js_int::uint;
 #[cfg(feature = "experimental-element-recent-emojis")]
 use matrix_sdk_base::recent_emojis::RecentEmojisContent;
 use matrix_sdk_base::{
+    StateStoreDataKey, StateStoreDataValue,
     media::{MediaFormat, MediaRequestParameters},
     store::StateStoreExt,
-    StateStoreDataKey, StateStoreDataValue,
 };
 use mime::Mime;
 #[cfg(feature = "experimental-element-recent-emojis")]
 use ruma::api::client::config::set_global_account_data::v3::Request as UpdateGlobalAccountDataRequest;
 use ruma::{
+    ClientSecret, MxcUri, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomId, SessionId, UInt, UserId,
     api::client::{
         account::{
             add_3pid, change_password, deactivate, delete_3pid, get_3pids,
@@ -45,6 +46,8 @@ use ruma::{
     },
     assign,
     events::{
+        AnyGlobalAccountDataEventContent, GlobalAccountDataEvent, GlobalAccountDataEventContent,
+        GlobalAccountDataEventType, StaticEventContent,
         ignored_user_list::{IgnoredUser, IgnoredUserListEventContent},
         media_preview_config::{
             InviteAvatars, MediaPreviewConfigEventContent, MediaPreviews,
@@ -52,18 +55,15 @@ use ruma::{
         },
         push_rules::PushRulesEventContent,
         room::MediaSource,
-        AnyGlobalAccountDataEventContent, GlobalAccountDataEvent, GlobalAccountDataEventContent,
-        GlobalAccountDataEventType, StaticEventContent,
     },
     push::Ruleset,
     serde::Raw,
     thirdparty::Medium,
-    ClientSecret, MxcUri, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomId, SessionId, UInt, UserId,
 };
 use serde::Deserialize;
 use tracing::error;
 
-use crate::{config::RequestConfig, Client, Error, Result};
+use crate::{Client, Error, Result, config::RequestConfig};
 
 /// A high-level API to manage the client owner's account.
 ///
@@ -780,11 +780,7 @@ impl Account {
             Ok(r) => Ok(Some(r.account_data)),
             Err(e) => {
                 if let Some(kind) = e.client_api_error_kind() {
-                    if kind == &ErrorKind::NotFound {
-                        Ok(None)
-                    } else {
-                        Err(e.into())
-                    }
+                    if kind == &ErrorKind::NotFound { Ok(None) } else { Err(e.into()) }
                 } else {
                     Err(e.into())
                 }
@@ -1055,7 +1051,7 @@ impl Account {
     ) -> Result<
         (
             Option<MediaPreviewConfigEventContent>,
-            impl Stream<Item = MediaPreviewConfigEventContent>,
+            impl Stream<Item = MediaPreviewConfigEventContent> + use<>,
         ),
         Error,
     > {
@@ -1266,7 +1262,7 @@ mod tests {
     use assert_matches::assert_matches;
     use matrix_sdk_test::async_test;
 
-    use crate::{test_utils::client::MockClientBuilder, Error};
+    use crate::{Error, test_utils::client::MockClientBuilder};
 
     #[async_test]
     async fn test_dont_ignore_oneself() {

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -17,15 +17,14 @@
 use std::time::Duration;
 
 use ruma::{
-    assign,
+    OwnedTransactionId, UInt, assign,
     events::{
-        room::{
-            message::{AudioInfo, FileInfo, FormattedBody, VideoInfo},
-            ImageInfo, ThumbnailInfo,
-        },
         Mentions,
+        room::{
+            ImageInfo, ThumbnailInfo,
+            message::{AudioInfo, FileInfo, FormattedBody, VideoInfo},
+        },
     },
-    OwnedTransactionId, UInt,
 };
 
 use crate::room::reply::Reply;

--- a/crates/matrix-sdk/src/authentication/matrix/login_builder.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/login_builder.rs
@@ -29,7 +29,7 @@ use tracing::{info, instrument};
 use super::MatrixAuth;
 #[cfg(feature = "sso-login")]
 use crate::utils::local_server::LocalServerBuilder;
-use crate::{config::RequestConfig, Result};
+use crate::{Result, config::RequestConfig};
 
 /// The login method.
 ///

--- a/crates/matrix-sdk/src/authentication/matrix/mod.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/mod.rs
@@ -20,9 +20,10 @@ use std::fmt;
 #[cfg(feature = "sso-login")]
 use std::future::Future;
 
-use matrix_sdk_base::{store::RoomLoadSettings, SessionMeta};
+use matrix_sdk_base::{SessionMeta, store::RoomLoadSettings};
 use ruma::{
     api::{
+        OutgoingRequest, SendAccessToken,
         client::{
             account::register,
             session::{
@@ -30,7 +31,6 @@ use ruma::{
             },
             uiaa::UserIdentifier,
         },
-        OutgoingRequest, SendAccessToken,
     },
     serde::JsonObject,
 };
@@ -40,10 +40,10 @@ use tracing::{debug, error, info, instrument};
 use url::Url;
 
 use crate::{
+    Client, Error, RefreshTokenError, Result,
     authentication::AuthData,
     client::SessionChange,
     error::{HttpError, HttpResult},
-    Client, Error, RefreshTokenError, Result,
 };
 
 mod login_builder;
@@ -572,10 +572,10 @@ impl MatrixAuth {
     ///
     /// ```no_run
     /// use matrix_sdk::{
+    ///     Client,
     ///     ruma::api::client::{
     ///         account::register::v3::Request as RegistrationRequest, uiaa,
     ///     },
-    ///     Client,
     /// };
     /// # use url::Url;
     /// # let homeserver = Url::parse("http://example.com").unwrap();
@@ -662,9 +662,9 @@ impl MatrixAuth {
     ///
     /// ```no_run
     /// use matrix_sdk::{
+    ///     Client, SessionMeta, SessionTokens,
     ///     authentication::matrix::MatrixSession,
     ///     ruma::{device_id, user_id},
-    ///     Client, SessionMeta, SessionTokens,
     /// };
     /// # use url::Url;
     /// # async {
@@ -691,7 +691,7 @@ impl MatrixAuth {
     /// [`LoginBuilder::send()`] method returns:
     ///
     /// ```no_run
-    /// use matrix_sdk::{store::RoomLoadSettings, Client};
+    /// use matrix_sdk::{Client, store::RoomLoadSettings};
     /// use url::Url;
     /// # async {
     ///
@@ -815,7 +815,7 @@ impl MatrixAuth {
 ///
 /// ```
 /// use matrix_sdk::{
-///     authentication::matrix::MatrixSession, SessionMeta, SessionTokens,
+///     SessionMeta, SessionTokens, authentication::matrix::MatrixSession,
 /// };
 /// use ruma::{device_id, user_id};
 ///

--- a/crates/matrix-sdk/src/authentication/matrix/mod.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/mod.rs
@@ -536,10 +536,9 @@ impl MatrixAuth {
 
                 if let Some(save_session_callback) =
                     self.client.inner.auth_ctx.save_session_callback.get()
+                    && let Err(err) = save_session_callback(self.client.clone())
                 {
-                    if let Err(err) = save_session_callback(self.client.clone()) {
-                        error!("when saving session after refresh: {err}");
-                    }
+                    error!("when saving session after refresh: {err}");
                 }
 
                 _ = self

--- a/crates/matrix-sdk/src/authentication/mod.rs
+++ b/crates/matrix-sdk/src/authentication/mod.rs
@@ -16,9 +16,9 @@
 
 use std::{fmt, sync::Arc};
 
-use matrix_sdk_base::{locks::Mutex, SessionMeta};
+use matrix_sdk_base::{SessionMeta, locks::Mutex};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{broadcast, Mutex as AsyncMutex, OnceCell};
+use tokio::sync::{Mutex as AsyncMutex, OnceCell, broadcast};
 
 pub mod matrix;
 pub mod oauth;

--- a/crates/matrix-sdk/src/authentication/oauth/account_management_url.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/account_management_url.rs
@@ -17,8 +17,8 @@
 //! This is a Matrix extension introduced in [MSC4191](https://github.com/matrix-org/matrix-spec-proposals/pull/4191).
 
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::v1::AccountManagementAction,
     OwnedDeviceId,
+    api::client::discovery::get_authorization_server_metadata::v1::AccountManagementAction,
 };
 use url::Url;
 

--- a/crates/matrix-sdk/src/authentication/oauth/auth_code_builder.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/auth_code_builder.rs
@@ -15,16 +15,16 @@
 use std::borrow::Cow;
 
 use oauth2::{
-    basic::BasicClient as OAuthClient, AuthUrl, CsrfToken, PkceCodeChallenge, RedirectUrl, Scope,
+    AuthUrl, CsrfToken, PkceCodeChallenge, RedirectUrl, Scope, basic::BasicClient as OAuthClient,
 };
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::v1::Prompt, OwnedDeviceId, UserId,
+    OwnedDeviceId, UserId, api::client::discovery::get_authorization_server_metadata::v1::Prompt,
 };
 use tracing::{info, instrument};
 use url::Url;
 
 use super::{ClientRegistrationData, OAuth, OAuthError};
-use crate::{authentication::oauth::AuthorizationValidationData, Result};
+use crate::{Result, authentication::oauth::AuthorizationValidationData};
 
 /// Builder type used to configure optional settings for authorization with an
 /// OAuth 2.0 authorization server via the Authorization Code flow.

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -193,14 +193,14 @@ impl CrossProcessRefreshLockGuard {
         let new_hash = compute_session_hash(trusted_tokens);
         trace!("Trusted OAuth 2.0 tokens have hash {new_hash:?}; db had {:?}", self.db_hash);
 
-        if let Some(db_hash) = &self.db_hash {
-            if new_hash != *db_hash {
-                // That should never happen, unless we got into an impossible situation!
-                // In this case, we assume the value returned by the callback is always
-                // correct, so override that in the database too.
-                tracing::error!("error: DB and trusted disagree. Overriding in DB.");
-                self.save_in_database(&new_hash).await?;
-            }
+        if let Some(db_hash) = &self.db_hash
+            && new_hash != *db_hash
+        {
+            // That should never happen, unless we got into an impossible situation!
+            // In this case, we assume the value returned by the callback is always
+            // correct, so override that in the database too.
+            tracing::error!("error: DB and trusted disagree. Overriding in DB.");
+            self.save_in_database(&new_hash).await?;
         }
 
         self.save_in_memory(new_hash);

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::{
-    store::{LockableCryptoStore, Store},
     CryptoStoreError,
+    store::{LockableCryptoStore, Store},
 };
 use matrix_sdk_common::cross_process_lock::{
     CrossProcessLock, CrossProcessLockError, CrossProcessLockGuard,
@@ -247,21 +247,21 @@ mod tests {
 
     use anyhow::Context as _;
     use futures_util::future::join_all;
-    use matrix_sdk_base::{store::RoomLoadSettings, SessionMeta};
+    use matrix_sdk_base::{SessionMeta, store::RoomLoadSettings};
     use matrix_sdk_test::async_test;
     use ruma::{owned_device_id, owned_user_id};
 
     use super::compute_session_hash;
     use crate::{
+        Error,
         authentication::oauth::cross_process::SessionHash,
         test_utils::{
             client::{
-                mock_prev_session_tokens_with_refresh, mock_session_tokens_with_refresh,
-                oauth::mock_session, MockClientBuilder,
+                MockClientBuilder, mock_prev_session_tokens_with_refresh,
+                mock_session_tokens_with_refresh, oauth::mock_session,
             },
             mocks::MatrixMockServer,
         },
-        Error,
     };
 
     #[async_test]

--- a/crates/matrix-sdk/src/authentication/oauth/error.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/error.rs
@@ -17,12 +17,12 @@
 use matrix_sdk_base::deserialized_responses::PrivOwnedStr;
 use oauth2::ErrorResponseType;
 pub use oauth2::{
+    ConfigurationError, HttpClientError, RequestTokenError, RevocationErrorResponseType,
+    StandardErrorResponse,
     basic::{
         BasicErrorResponse, BasicErrorResponseType, BasicRequestTokenError,
         BasicRevocationErrorResponse,
     },
-    ConfigurationError, HttpClientError, RequestTokenError, RevocationErrorResponseType,
-    StandardErrorResponse,
 };
 use ruma::{
     api::client::discovery::get_authorization_server_metadata::v1::AuthorizationServerMetadataUrlError,

--- a/crates/matrix-sdk/src/authentication/oauth/http_client.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/http_client.rs
@@ -108,7 +108,7 @@ pub(super) fn check_http_response_json_content_type<T: ErrorResponse + 'static>(
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use oauth2::{basic::BasicErrorResponse, RequestTokenError};
+    use oauth2::{RequestTokenError, basic::BasicErrorResponse};
 
     use super::{check_http_response_json_content_type, check_http_response_status_code};
 

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -178,19 +178,20 @@ use error::{
 use matrix_sdk_base::crypto::types::qr_login::QrCodeData;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::once_cell::sync::OnceCell;
-use matrix_sdk_base::{store::RoomLoadSettings, SessionMeta};
+use matrix_sdk_base::{SessionMeta, store::RoomLoadSettings};
 use oauth2::{
-    basic::BasicClient as OAuthClient, AccessToken, PkceCodeVerifier, RedirectUrl, RefreshToken,
-    RevocationUrl, Scope, StandardErrorResponse, StandardRevocableToken, TokenResponse, TokenUrl,
+    AccessToken, PkceCodeVerifier, RedirectUrl, RefreshToken, RevocationUrl, Scope,
+    StandardErrorResponse, StandardRevocableToken, TokenResponse, TokenUrl,
+    basic::BasicClient as OAuthClient,
 };
 pub use oauth2::{ClientId, CsrfToken};
 use ruma::{
+    DeviceId, OwnedDeviceId,
     api::client::discovery::get_authorization_server_metadata::{
         self,
         v1::{AccountManagementAction, AuthorizationServerMetadata},
     },
     serde::Raw,
-    DeviceId, OwnedDeviceId,
 };
 use serde::{Deserialize, Serialize};
 use sha2::Digest as _;
@@ -221,10 +222,10 @@ pub use self::{
 };
 use self::{
     http_client::OAuthHttpClient,
-    registration::{register_client, ClientMetadata, ClientRegistrationResponse},
+    registration::{ClientMetadata, ClientRegistrationResponse, register_client},
 };
 use super::{AuthData, SessionTokens};
-use crate::{client::SessionChange, executor::spawn, Client, HttpError, RefreshTokenError, Result};
+use crate::{Client, HttpError, RefreshTokenError, Result, client::SessionChange, executor::spawn};
 
 pub(crate) struct OAuthCtx {
     /// Lock and state when multiple processes may refresh an OAuth 2.0 session.

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
@@ -17,29 +17,28 @@ use std::future::IntoFuture;
 use eyeball::SharedObservable;
 use futures_core::Stream;
 use matrix_sdk_base::{
-    boxed_into_future,
+    SessionMeta, boxed_into_future,
     crypto::types::qr_login::{QrCodeData, QrCodeMode},
     store::RoomLoadSettings,
-    SessionMeta,
 };
 use oauth2::{DeviceCodeErrorResponseType, StandardDeviceAuthorizationResponse};
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::v1::AuthorizationServerMetadata,
     OwnedDeviceId,
+    api::client::discovery::get_authorization_server_metadata::v1::AuthorizationServerMetadata,
 };
 use tracing::trace;
-use vodozemac::{ecies::CheckCode, Curve25519PublicKey};
+use vodozemac::{Curve25519PublicKey, ecies::CheckCode};
 
 use super::{
+    DeviceAuthorizationOAuthError, QRCodeLoginError, SecureChannelError,
     messages::{LoginFailureReason, QrAuthMessage},
     secure_channel::EstablishedSecureChannel,
-    DeviceAuthorizationOAuthError, QRCodeLoginError, SecureChannelError,
 };
 #[cfg(doc)]
 use crate::authentication::oauth::OAuth;
 use crate::{
-    authentication::oauth::{ClientRegistrationData, OAuthError},
     Client,
+    authentication::oauth::{ClientRegistrationData, OAuthError},
 };
 
 async fn send_unexpected_message_error(
@@ -94,7 +93,7 @@ impl LoginWithQrCode<'_> {
     /// It's usually necessary to subscribe to this to let the existing device
     /// know about the [`CheckCode`] which is used to verify that the two
     /// devices are communicating in a secure manner.
-    pub fn subscribe_to_progress(&self) -> impl Stream<Item = LoginProgress> {
+    pub fn subscribe_to_progress(&self) -> impl Stream<Item = LoginProgress> + use<> {
         self.state.subscribe()
     }
 }
@@ -330,8 +329,8 @@ impl<'a> LoginWithQrCode<'a> {
 #[cfg(all(test, not(target_family = "wasm")))]
 mod test {
     use assert_matches2::{assert_let, assert_matches};
-    use futures_util::{join, StreamExt};
-    use matrix_sdk_base::crypto::types::{qr_login::QrCodeModeData, SecretsBundle};
+    use futures_util::{StreamExt, join};
+    use matrix_sdk_base::crypto::types::{SecretsBundle, qr_login::QrCodeModeData};
     use matrix_sdk_common::executor::spawn;
     use matrix_sdk_test::async_test;
     use serde_json::json;
@@ -340,7 +339,7 @@ mod test {
     use crate::{
         authentication::oauth::qrcode::{
             messages::LoginProtocolType,
-            secure_channel::{test::MockedRendezvousServer, SecureChannel},
+            secure_channel::{SecureChannel, test::MockedRendezvousServer},
         },
         config::RequestConfig,
         http_client::HttpClient,

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
@@ -22,14 +22,14 @@
 //! [`OAuth::login_with_qr_code()`] method.
 
 use as_variant::as_variant;
+use matrix_sdk_base::crypto::SecretImportError;
 pub use matrix_sdk_base::crypto::types::qr_login::{
     LoginQrCodeDecodeError, QrCodeData, QrCodeMode, QrCodeModeData,
 };
-use matrix_sdk_base::crypto::SecretImportError;
 pub use oauth2::{
-    basic::{BasicErrorResponse, BasicRequestTokenError},
     ConfigurationError, DeviceCodeErrorResponse, DeviceCodeErrorResponseType, HttpClientError,
     RequestTokenError, StandardErrorResponse,
+    basic::{BasicErrorResponse, BasicRequestTokenError},
 };
 use thiserror::Error;
 use url::Url;

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel.rs
@@ -15,18 +15,18 @@
 use std::time::Duration;
 
 use http::{
-    header::{CONTENT_TYPE, ETAG, EXPIRES, IF_MATCH, IF_NONE_MATCH, LAST_MODIFIED},
     HeaderMap, HeaderName, Method, StatusCode,
+    header::{CONTENT_TYPE, ETAG, EXPIRES, IF_MATCH, IF_NONE_MATCH, LAST_MODIFIED},
 };
 use matrix_sdk_base::sleep;
 use ruma::api::{
-    error::{FromHttpResponseError, HeaderDeserializationError, IntoHttpError, MatrixError},
     EndpointError,
+    error::{FromHttpResponseError, HeaderDeserializationError, IntoHttpError, MatrixError},
 };
 use tracing::{debug, instrument, trace};
 use url::Url;
 
-use crate::{http_client::HttpClient, HttpError, RumaApiError};
+use crate::{HttpError, RumaApiError, http_client::HttpClient};
 
 const TEXT_PLAIN_CONTENT_TYPE: &str = "text/plain";
 #[cfg(test)]
@@ -114,7 +114,7 @@ impl RendezvousChannel {
         client: HttpClient,
         rendezvous_server: &Url,
     ) -> Result<Self, HttpError> {
-        use ruma::api::{client::rendezvous::create_rendezvous_session, SupportedVersions};
+        use ruma::api::{SupportedVersions, client::rendezvous::create_rendezvous_session};
 
         let request = create_rendezvous_session::unstable::Request::default();
         let response = client
@@ -298,8 +298,8 @@ mod test {
     use serde_json::json;
     use similar_asserts::assert_eq;
     use wiremock::{
-        matchers::{header, method, path},
         Mock, MockServer, ResponseTemplate,
+        matchers::{header, method, path},
     };
 
     use super::*;

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/secure_channel.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/secure_channel.rs
@@ -15,7 +15,7 @@
 #[cfg(test)]
 use matrix_sdk_base::crypto::types::qr_login::QrCodeModeData;
 use matrix_sdk_base::crypto::types::qr_login::{QrCodeData, QrCodeMode};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use tracing::{instrument, trace};
 #[cfg(test)]
 use url::Url;
@@ -24,8 +24,8 @@ use vodozemac::ecies::{CheckCode, Ecies, EstablishedEcies, Message, OutboundCrea
 use vodozemac::ecies::{InboundCreationResult, InitialMessage};
 
 use super::{
-    rendezvous_channel::{InboundChannelCreationResult, RendezvousChannel},
     SecureChannelError as Error,
+    rendezvous_channel::{InboundChannelCreationResult, RendezvousChannel},
 };
 use crate::{config::RequestConfig, http_client::HttpClient};
 
@@ -229,8 +229,8 @@ impl EstablishedSecureChannel {
 #[cfg(all(test, not(target_family = "wasm")))]
 pub(super) mod test {
     use std::sync::{
-        atomic::{AtomicU8, Ordering},
         Arc, Mutex,
+        atomic::{AtomicU8, Ordering},
     };
 
     use matrix_sdk_base::crypto::types::qr_login::QrCodeMode;
@@ -240,8 +240,8 @@ pub(super) mod test {
     use similar_asserts::assert_eq;
     use url::Url;
     use wiremock::{
-        matchers::{method, path},
         Mock, MockGuard, MockServer, ResponseTemplate,
+        matchers::{method, path},
     };
 
     use super::{EstablishedSecureChannel, SecureChannel};

--- a/crates/matrix-sdk/src/authentication/oauth/registration.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/registration.rs
@@ -23,17 +23,17 @@ use language_tags::LanguageTag;
 use matrix_sdk_base::deserialized_responses::PrivOwnedStr;
 use oauth2::{AsyncHttpClient, ClientId, HttpClientError, RequestTokenError};
 use ruma::{
+    SecondsSinceUnixEpoch,
     api::client::discovery::get_authorization_server_metadata::v1::{GrantType, ResponseType},
     serde::{PartialEqAsRefStr, Raw, StringEnum},
-    SecondsSinceUnixEpoch,
 };
-use serde::{ser::SerializeMap, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, ser::SerializeMap};
 use url::Url;
 
 use super::{
+    OAuthHttpClient,
     error::OAuthClientRegistrationError,
     http_client::{check_http_response_json_content_type, check_http_response_status_code},
-    OAuthHttpClient,
 };
 
 /// Register a client with an OAuth 2.0 authorization server.

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -4,8 +4,8 @@ use matrix_sdk_base::store::RoomLoadSettings;
 use matrix_sdk_test::async_test;
 use oauth2::{ClientId, CsrfToken, PkceCodeChallenge, RedirectUrl, Scope};
 use ruma::{
-    api::client::discovery::get_authorization_server_metadata::v1::Prompt, device_id,
-    owned_device_id, user_id, DeviceId, ServerName,
+    DeviceId, ServerName, api::client::discovery::get_authorization_server_metadata::v1::Prompt,
+    device_id, owned_device_id, user_id,
 };
 use tokio::sync::broadcast::error::TryRecvError;
 use url::Url;
@@ -15,19 +15,19 @@ use super::{
     OAuthError, RedirectUriQueryParseError, UrlOrQuery,
 };
 use crate::{
+    Client, Error, SessionChange,
     authentication::oauth::{
-        error::{AuthorizationCodeErrorResponseType, OAuthClientRegistrationError},
         AuthorizationValidationData, ClientRegistrationData, OAuthAuthorizationCodeError,
+        error::{AuthorizationCodeErrorResponseType, OAuthClientRegistrationError},
     },
     test_utils::{
         client::{
-            mock_prev_session_tokens_with_refresh, mock_session_tokens_with_refresh,
+            MockClientBuilder, mock_prev_session_tokens_with_refresh,
+            mock_session_tokens_with_refresh,
             oauth::{mock_client_id, mock_client_metadata, mock_redirect_uri, mock_session},
-            MockClientBuilder,
         },
         mocks::MatrixMockServer,
     },
-    Client, Error, SessionChange,
 };
 
 const REDIRECT_URI_STRING: &str = "http://127.0.0.1:6778/oauth/callback";

--- a/crates/matrix-sdk/src/client/builder/homeserver_config.rs
+++ b/crates/matrix-sdk/src/client/builder/homeserver_config.rs
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 use ruma::{
-    api::{
-        client::discovery::{discover_homeserver, get_supported_versions},
-        MatrixVersion, SupportedVersions,
-    },
     OwnedServerName, ServerName,
+    api::{
+        MatrixVersion, SupportedVersions,
+        client::discovery::{discover_homeserver, get_supported_versions},
+    },
 };
 use tracing::debug;
 use url::Url;
 
 use crate::{
-    config::RequestConfig, http_client::HttpClient, sanitize_server_name, ClientBuildError,
-    HttpError,
+    ClientBuildError, HttpError, config::RequestConfig, http_client::HttpClient,
+    sanitize_server_name,
 };
 
 /// Configuration for the homeserver.
@@ -227,8 +227,8 @@ mod tests {
     use ruma::OwnedServerName;
     use serde_json::json;
     use wiremock::{
-        matchers::{method, path},
         Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
     };
 
     use super::*;

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -26,16 +26,16 @@ use std::{collections::BTreeSet, fmt, sync::Arc};
 use homeserver_config::*;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::DecryptionSettings;
-use matrix_sdk_base::{store::StoreConfig, BaseClient, ThreadingSupport};
+use matrix_sdk_base::{BaseClient, ThreadingSupport, store::StoreConfig};
 #[cfg(feature = "sqlite")]
 use matrix_sdk_sqlite::SqliteStoreConfig;
 use ruma::{
-    api::{error::FromHttpResponseError, MatrixVersion, SupportedVersions},
     OwnedServerName, ServerName,
+    api::{MatrixVersion, SupportedVersions, error::FromHttpResponseError},
 };
 use thiserror::Error;
-use tokio::sync::{broadcast, Mutex, OnceCell};
-use tracing::{debug, field::debug, instrument, Span};
+use tokio::sync::{Mutex, OnceCell, broadcast};
+use tracing::{Span, debug, field::debug, instrument};
 
 use super::{Client, ClientInner};
 #[cfg(feature = "experimental-search")]
@@ -49,7 +49,8 @@ use crate::encryption::EncryptionSettings;
 #[cfg(not(target_family = "wasm"))]
 use crate::http_client::HttpSettings;
 use crate::{
-    authentication::{oauth::OAuthCtx, AuthCtx},
+    HttpError, IdParseError,
+    authentication::{AuthCtx, oauth::OAuthCtx},
     client::{
         CachedValue::{Cached, NotSet},
         ClientServerInfo,
@@ -59,7 +60,6 @@ use crate::{
     http_client::HttpClient,
     send_queue::SendQueueData,
     sliding_sync::VersionBuilder as SlidingSyncVersionBuilder,
-    HttpError, IdParseError,
 };
 
 /// Builder that allows creating and configuring various parts of a [`Client`].
@@ -299,7 +299,7 @@ impl ClientBuilder {
     /// ```
     /// # use matrix_sdk_base::store::MemoryStore;
     /// # let custom_state_store = MemoryStore::new();
-    /// use matrix_sdk::{config::StoreConfig, Client};
+    /// use matrix_sdk::{Client, config::StoreConfig};
     ///
     /// let store_config =
     ///     StoreConfig::new("cross-process-store-locks-holder-name".to_owned())
@@ -866,10 +866,10 @@ pub enum ClientBuildError {
 pub(crate) mod tests {
     use assert_matches::assert_matches;
     use matrix_sdk_test::{async_test, test_json};
-    use serde_json::{json_internal, Value as JsonValue};
+    use serde_json::{Value as JsonValue, json_internal};
     use wiremock::{
-        matchers::{method, path},
         Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
     };
 
     use super::*;

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -18,22 +18,22 @@ use std::{fmt::Debug, future::IntoFuture};
 
 use eyeball::{SharedObservable, Subscriber};
 use js_int::UInt;
-use matrix_sdk_common::{boxed_into_future, SendOutsideWasm, SyncOutsideWasm};
-use oauth2::{basic::BasicErrorResponseType, RequestTokenError};
+use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm, boxed_into_future};
+use oauth2::{RequestTokenError, basic::BasicErrorResponseType};
 use ruma::api::{
+    OutgoingRequest,
     client::{error::ErrorKind, media},
     error::FromHttpResponseError,
-    OutgoingRequest,
 };
 use tracing::{error, trace};
 
 use super::super::Client;
 use crate::{
+    Error, RefreshTokenError, TransmissionProgress,
     authentication::oauth::OAuthError,
     config::RequestConfig,
     error::{HttpError, HttpResult},
     media::MediaError,
-    Error, RefreshTokenError, TransmissionProgress,
 };
 
 /// `IntoFuture` returned by [`Client::send`].

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1362,12 +1362,11 @@ impl Client {
     /// * `login_well_known` - The `well_known` field from a successful login
     ///   response.
     pub(crate) fn maybe_update_login_well_known(&self, login_well_known: Option<&DiscoveryInfo>) {
-        if self.inner.respect_login_well_known {
-            if let Some(well_known) = login_well_known {
-                if let Ok(homeserver) = Url::parse(&well_known.homeserver.base_url) {
-                    self.set_homeserver(homeserver);
-                }
-            }
+        if self.inner.respect_login_well_known
+            && let Some(well_known) = login_well_known
+            && let Ok(homeserver) = Url::parse(&well_known.homeserver.base_url)
+        {
+            self.set_homeserver(homeserver);
         }
     }
 
@@ -1576,13 +1575,12 @@ impl Client {
         }
 
         #[cfg(feature = "e2e-encryption")]
-        if self.inner.enable_share_history_on_invite {
-            if let Some(inviter) =
+        if self.inner.enable_share_history_on_invite
+            && let Some(inviter) =
                 pre_join_room_info.as_ref().and_then(|info| info.inviter.as_ref())
-            {
-                crate::room::shared_room_history::maybe_accept_key_bundle(&room, inviter.user_id())
-                    .await?;
-            }
+        {
+            crate::room::shared_room_history::maybe_accept_key_bundle(&room, inviter.user_id())
+                .await?;
         }
 
         // Suppress "unused variable" and "unused field" lints
@@ -1726,13 +1724,13 @@ impl Client {
 
         let joined_room = Room::new(self.clone(), base_room);
 
-        if is_direct_room && !invite.is_empty() {
-            if let Err(error) =
+        if is_direct_room
+            && !invite.is_empty()
+            && let Err(error) =
                 self.account().mark_as_dm(joined_room.room_id(), invite.as_slice()).await
-            {
-                // FIXME: Retry in the background
-                error!("Failed to mark room as DM: {error}");
-            }
+        {
+            // FIXME: Retry in the background
+            error!("Failed to mark room as DM: {error}");
         }
 
         Ok(joined_room)

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -883,7 +883,7 @@ impl Client {
     ///     expires_at: MilliSecondsSinceUnixEpoch,
     /// }
     ///
-    /// client.add_event_handler(|ev: SyncTokenEvent, room: Room| async move {
+    /// client.add_event_handler(async |ev: SyncTokenEvent, room: Room| -> () {
     ///     todo!("Display the token");
     /// });
     ///

--- a/crates/matrix-sdk/src/client/search.rs
+++ b/crates/matrix-sdk/src/client/search.rs
@@ -142,7 +142,7 @@ impl SearchIndexGuard<'_> {
 
 #[cfg(test)]
 mod tests {
-    use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder};
+    use matrix_sdk_test::{JoinedRoomBuilder, async_test, event_factory::EventFactory};
     use ruma::{
         event_id, events::room::message::RoomMessageEventContentWithoutRelation, room_id, user_id,
     };
@@ -165,11 +165,13 @@ mod tests {
         let room = mock_server
             .sync_room(
                 &client,
-                JoinedRoomBuilder::new(room_id).add_timeline_bulk(vec![event_factory
-                    .text_msg("this is a sentence")
-                    .event_id(event_id)
-                    .sender(user_id)
-                    .into_raw_sync()]),
+                JoinedRoomBuilder::new(room_id).add_timeline_bulk(vec![
+                    event_factory
+                        .text_msg("this is a sentence")
+                        .event_id(event_id)
+                        .sender(user_id)
+                        .into_raw_sync(),
+                ]),
             )
             .await;
 

--- a/crates/matrix-sdk/src/client/thread_subscriptions.rs
+++ b/crates/matrix-sdk/src/client/thread_subscriptions.rs
@@ -15,31 +15,32 @@
 use std::{
     collections::BTreeMap,
     sync::{
-        atomic::{self, AtomicBool},
         Arc,
+        atomic::{self, AtomicBool},
     },
 };
 
 use matrix_sdk_base::{
+    StateStoreDataKey, StateStoreDataValue, ThreadSubscriptionCatchupToken,
     executor::AbortOnDrop,
     store::{StoredThreadSubscription, ThreadSubscriptionStatus},
-    StateStoreDataKey, StateStoreDataValue, ThreadSubscriptionCatchupToken,
 };
 use matrix_sdk_common::executor::spawn;
 use once_cell::sync::OnceCell;
 use ruma::{
+    OwnedEventId, OwnedRoomId,
     api::client::threads::get_thread_subscriptions_changes::unstable::{
         ThreadSubscription, ThreadUnsubscription,
     },
-    assign, OwnedEventId, OwnedRoomId,
+    assign,
 };
 use tokio::sync::{
-    mpsc::{channel, Receiver, Sender},
     Mutex, OwnedMutexGuard,
+    mpsc::{Receiver, Sender, channel},
 };
 use tracing::{instrument, trace, warn};
 
-use crate::{client::WeakClient, Client, Result};
+use crate::{Client, Result, client::WeakClient};
 
 struct GuardedStoreAccess {
     _mutex: OwnedMutexGuard<()>,

--- a/crates/matrix-sdk/src/encryption/backups/futures.rs
+++ b/crates/matrix-sdk/src/encryption/backups/futures.rs
@@ -65,7 +65,7 @@ impl WaitForSteadyState<'_> {
     /// to settle down.
     pub fn subscribe_to_progress(
         &self,
-    ) -> impl Stream<Item = Result<UploadState, BroadcastStreamRecvError>> {
+    ) -> impl Stream<Item = Result<UploadState, BroadcastStreamRecvError>> + use<> {
         self.progress.subscribe()
     }
 

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -27,18 +27,19 @@ use futures_util::StreamExt;
 #[cfg(feature = "experimental-encrypted-state-events")]
 use matrix_sdk_base::crypto::types::events::room::encrypted::EncryptedEvent;
 use matrix_sdk_base::crypto::{
+    OlmMachine, RoomKeyImportResult,
     backups::MegolmV1BackupKey,
     store::types::BackupDecryptionKey,
-    types::{requests::KeysBackupRequest, RoomKeyBackupInfo},
-    OlmMachine, RoomKeyImportResult,
+    types::{RoomKeyBackupInfo, requests::KeysBackupRequest},
 };
 #[cfg(feature = "experimental-encrypted-state-events")]
 use ruma::serde::JsonCastable;
 use ruma::{
+    OwnedRoomId, RoomId, TransactionId,
     api::client::{
         backup::{
-            add_backup_keys, create_backup_version, get_backup_keys, get_backup_keys_for_room,
-            get_backup_keys_for_session, get_latest_backup_info, RoomKeyBackup,
+            RoomKeyBackup, add_backup_keys, create_backup_version, get_backup_keys,
+            get_backup_keys_for_room, get_backup_keys_for_session, get_latest_backup_info,
         },
         error::ErrorKind,
     },
@@ -47,10 +48,9 @@ use ruma::{
         secret::{request::SecretName, send::ToDeviceSecretSendEvent},
     },
     serde::Raw,
-    OwnedRoomId, RoomId, TransactionId,
 };
-use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
-use tracing::{error, info, instrument, trace, warn, Span};
+use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
+use tracing::{Span, error, info, instrument, trace, warn};
 
 pub mod futures;
 pub(crate) mod types;
@@ -59,7 +59,7 @@ pub use types::{BackupState, UploadState};
 
 use self::futures::WaitForSteadyState;
 use crate::{
-    crypto::olm::ExportedRoomKey, encryption::BackupDownloadStrategy, Client, Error, Room,
+    Client, Error, Room, crypto::olm::ExportedRoomKey, encryption::BackupDownloadStrategy,
 };
 
 /// The backups manager for the [`Client`].
@@ -364,7 +364,7 @@ impl Backups {
     /// ```
     pub fn state_stream(
         &self,
-    ) -> impl Stream<Item = Result<BackupState, BroadcastStreamRecvError>> {
+    ) -> impl Stream<Item = Result<BackupState, BroadcastStreamRecvError>> + use<> {
         self.client.inner.e2ee.backup_state.global_state.subscribe()
     }
 
@@ -423,7 +423,7 @@ impl Backups {
     pub fn room_keys_for_room_stream(
         &self,
         room_id: &RoomId,
-    ) -> impl Stream<Item = Result<BTreeMap<String, BTreeSet<String>>, BroadcastStreamRecvError>>
+    ) -> impl Stream<Item = Result<BTreeMap<String, BTreeSet<String>>, BroadcastStreamRecvError>> + use<>
     {
         let room_id = room_id.to_owned();
 
@@ -620,7 +620,7 @@ impl Backups {
 
     fn room_keys_stream(
         &self,
-    ) -> impl Stream<Item = Result<RoomKeyImportResult, BroadcastStreamRecvError>> {
+    ) -> impl Stream<Item = Result<RoomKeyImportResult, BroadcastStreamRecvError>> + use<> {
         BroadcastStream::new(self.client.inner.e2ee.backup_state.room_keys_broadcaster.subscribe())
     }
 
@@ -634,11 +634,7 @@ impl Backups {
             Ok(r) => Ok(Some(r)),
             Err(e) => {
                 if let Some(kind) = e.client_api_error_kind() {
-                    if kind == &ErrorKind::NotFound {
-                        Ok(None)
-                    } else {
-                        Err(e.into())
-                    }
+                    if kind == &ErrorKind::NotFound { Ok(None) } else { Err(e.into()) }
                 } else {
                     Err(e.into())
                 }
@@ -653,11 +649,7 @@ impl Backups {
             Ok(_) => Ok(()),
             Err(e) => {
                 if let Some(kind) = e.client_api_error_kind() {
-                    if kind == &ErrorKind::NotFound {
-                        Ok(())
-                    } else {
-                        Err(e.into())
-                    }
+                    if kind == &ErrorKind::NotFound { Ok(()) } else { Err(e.into()) }
                 } else {
                     Err(e.into())
                 }
@@ -1059,8 +1051,8 @@ mod test {
     use matrix_sdk_test::async_test;
     use serde_json::json;
     use wiremock::{
-        matchers::{header, method, path},
         Mock, MockServer, ResponseTemplate,
+        matchers::{header, method, path},
     };
 
     use super::*;

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -454,21 +454,21 @@ impl Backups {
 
         let backup_keys = olm_machine.store().load_backup_keys().await?;
 
-        if let Some(decryption_key) = backup_keys.decryption_key {
-            if let Some(version) = backup_keys.backup_version {
-                let request =
-                    get_backup_keys_for_room::v3::Request::new(version.clone(), room_id.to_owned());
-                let response = self.client.send(request).await?;
+        if let Some(decryption_key) = backup_keys.decryption_key
+            && let Some(version) = backup_keys.backup_version
+        {
+            let request =
+                get_backup_keys_for_room::v3::Request::new(version.clone(), room_id.to_owned());
+            let response = self.client.send(request).await?;
 
-                // Transform response to standard format (map of room ID -> room key).
-                let response = get_backup_keys::v3::Response::new(BTreeMap::from([(
-                    room_id.to_owned(),
-                    RoomKeyBackup::new(response.sessions),
-                )]));
+            // Transform response to standard format (map of room ID -> room key).
+            let response = get_backup_keys::v3::Response::new(BTreeMap::from([(
+                room_id.to_owned(),
+                RoomKeyBackup::new(response.sessions),
+            )]));
 
-                self.handle_downloaded_room_keys(response, decryption_key, &version, olm_machine)
-                    .await?;
-            }
+            self.handle_downloaded_room_keys(response, decryption_key, &version, olm_machine)
+                .await?;
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/encryption/backups/types.rs
+++ b/crates/matrix-sdk/src/encryption/backups/types.rs
@@ -17,14 +17,14 @@ use std::{
     time::Duration,
 };
 
-use matrix_sdk_base::crypto::{store::types::RoomKeyCounts, RoomKeyImportResult};
+use matrix_sdk_base::crypto::{RoomKeyImportResult, store::types::RoomKeyCounts};
 use tokio::sync::broadcast;
 
 use crate::utils::ChannelObservable;
 #[cfg(doc)]
 use crate::{
-    encryption::{backups::Backups, secret_storage::SecretStore},
     Client,
+    encryption::{backups::Backups, secret_storage::SecretStore},
 };
 
 /// The states the upload task can be in.

--- a/crates/matrix-sdk/src/encryption/futures.rs
+++ b/crates/matrix-sdk/src/encryption/futures.rs
@@ -23,7 +23,7 @@ use eyeball::{SharedObservable, Subscriber};
 use matrix_sdk_common::boxed_into_future;
 use ruma::events::room::{EncryptedFile, EncryptedFileInit};
 
-use crate::{config::RequestConfig, Client, Media, Result, TransmissionProgress};
+use crate::{Client, Media, Result, TransmissionProgress, config::RequestConfig};
 
 /// Future returned by [`Client::upload_encrypted_file`].
 #[allow(missing_debug_implementations)]

--- a/crates/matrix-sdk/src/encryption/identities/devices.rs
+++ b/crates/matrix-sdk/src/encryption/identities/devices.rs
@@ -15,16 +15,16 @@
 use std::{collections::BTreeMap, ops::Deref};
 
 use matrix_sdk_base::crypto::{
-    store::CryptoStoreError, Device as BaseDevice, DeviceData, LocalTrust,
-    UserDevices as BaseUserDevices,
+    Device as BaseDevice, DeviceData, LocalTrust, UserDevices as BaseUserDevices,
+    store::CryptoStoreError,
 };
-use ruma::{events::key::verification::VerificationMethod, DeviceId, OwnedDeviceId, OwnedUserId};
+use ruma::{DeviceId, OwnedDeviceId, OwnedUserId, events::key::verification::VerificationMethod};
 
 use super::ManualVerifyError;
 use crate::{
+    Client,
     encryption::verification::{SasVerification, VerificationRequest},
     error::Result,
-    Client,
 };
 
 /// Updates about [`Device`]s which got received over the `/keys/query`

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -15,16 +15,16 @@
 use std::collections::BTreeMap;
 
 use matrix_sdk_base::{
-    crypto::{types::MasterPubkey, CryptoStoreError, UserIdentity as CryptoUserIdentity},
     RoomMemberships,
+    crypto::{CryptoStoreError, UserIdentity as CryptoUserIdentity, types::MasterPubkey},
 };
 use ruma::{
-    events::{key::verification::VerificationMethod, room::message::RoomMessageEventContent},
     OwnedUserId, UserId,
+    events::{key::verification::VerificationMethod, room::message::RoomMessageEventContent},
 };
 
 use super::{ManualVerifyError, RequestVerificationError};
-use crate::{encryption::verification::VerificationRequest, Client};
+use crate::{Client, encryption::verification::VerificationRequest};
 
 /// Updates about [`UserIdentity`]s which got received over the `/keys/query`
 /// endpoint.

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1830,10 +1830,10 @@ impl Encryption {
             // network requests
             this.update_verification_state().await;
 
-            if this.settings().auto_enable_cross_signing {
-                if let Err(e) = this.bootstrap_cross_signing_if_needed(auth_data).await {
-                    error!("Couldn't bootstrap cross signing {e:?}");
-                }
+            if this.settings().auto_enable_cross_signing
+                && let Err(e) = this.bootstrap_cross_signing_if_needed(auth_data).await
+            {
+                error!("Couldn't bootstrap cross signing {e:?}");
             }
 
             if let Err(e) = this.backups().setup_and_resume().await {
@@ -1852,10 +1852,10 @@ impl Encryption {
     pub async fn wait_for_e2ee_initialization_tasks(&self) {
         let task = self.client.inner.e2ee.tasks.lock().setup_e2ee.take();
 
-        if let Some(task) = task {
-            if let Err(err) = task.await {
-                warn!("Error when initializing backups: {err}");
-            }
+        if let Some(task) = task
+            && let Err(err) = task.await
+        {
+            warn!("Error when initializing backups: {err}");
         }
     }
 

--- a/crates/matrix-sdk/src/encryption/recovery/futures.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/futures.rs
@@ -17,10 +17,10 @@
 use std::future::IntoFuture;
 
 use futures_core::Stream;
-use futures_util::{pin_mut, StreamExt};
+use futures_util::{StreamExt, pin_mut};
 use matrix_sdk_common::boxed_into_future;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
-use tracing::{warn, Instrument, Span};
+use tracing::{Instrument, Span, warn};
 
 use super::{EnableProgress, Recovery, RecoveryError, Result};
 use crate::{
@@ -52,7 +52,7 @@ impl<'a> Enable<'a> {
     /// Subscribe to updates to the recovery enabling progress.
     pub fn subscribe_to_progress(
         &self,
-    ) -> impl Stream<Item = Result<EnableProgress, BroadcastStreamRecvError>> {
+    ) -> impl Stream<Item = Result<EnableProgress, BroadcastStreamRecvError>> + use<> {
         self.progress.subscribe()
     }
 

--- a/crates/matrix-sdk/src/encryption/recovery/mod.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/mod.rs
@@ -32,7 +32,7 @@
 //! doesn't exist, as well:
 //!
 //! ```no_run
-//! use matrix_sdk::{encryption::EncryptionSettings, Client};
+//! use matrix_sdk::{Client, encryption::EncryptionSettings};
 //!
 //! # async {
 //! # let homeserver = "http://example.org";
@@ -95,9 +95,9 @@ use futures_util::StreamExt as _;
 use ruma::{
     api::client::keys::get_keys,
     events::{
+        GlobalAccountDataEventType,
         secret::{request::SecretName, send::ToDeviceSecretSendEvent},
         secret_storage::{default_key::SecretStorageDefaultKeyEvent, secret::SecretEventContent},
-        GlobalAccountDataEventType,
     },
     serde::Raw,
 };
@@ -109,7 +109,7 @@ use crate::encryption::{
     backups::Backups,
     secret_storage::{SecretStorage, SecretStore},
 };
-use crate::{client::WeakClient, encryption::backups::BackupState, Client};
+use crate::{Client, client::WeakClient, encryption::backups::BackupState};
 
 pub mod futures;
 mod types;
@@ -169,7 +169,7 @@ impl Recovery {
     /// }
     /// # anyhow::Ok(()) };
     /// ```
-    pub fn state_stream(&self) -> impl Stream<Item = RecoveryState> {
+    pub fn state_stream(&self) -> impl Stream<Item = RecoveryState> + use<> {
         self.client.inner.e2ee.recovery_state.subscribe_reset()
     }
 
@@ -653,7 +653,7 @@ impl Recovery {
     /// task which is always listening for updates in the [`BackupState`].
     pub(crate) fn update_state_after_backup_state_change(
         client: &Client,
-    ) -> impl Future<Output = ()> {
+    ) -> impl Future<Output = ()> + use<> {
         let mut stream = client.encryption().backups().state_stream();
         let weak = WeakClient::from_client(client);
 

--- a/crates/matrix-sdk/src/encryption/recovery/types.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/types.rs
@@ -21,7 +21,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 #[cfg(doc)]
 use crate::encryption::{
     backups::Backups,
-    recovery::{futures::Enable, Recovery},
+    recovery::{Recovery, futures::Enable},
 };
 
 /// Result type alias for the [`Recovery`] subsystem.

--- a/crates/matrix-sdk/src/encryption/secret_storage/mod.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/mod.rs
@@ -63,15 +63,15 @@
 use std::string::FromUtf8Error;
 
 use matrix_sdk_base::crypto::{
-    secret_storage::{DecodeError, MacError, SecretStorageKey},
     CryptoStoreError, SecretImportError,
+    secret_storage::{DecodeError, MacError, SecretStorageKey},
 };
 use ruma::{
     events::{
+        EventContentFromType, GlobalAccountDataEventType,
         secret_storage::{
             default_key::SecretStorageDefaultKeyEventContent, key::SecretStorageKeyEventContent,
         },
-        EventContentFromType, GlobalAccountDataEventType,
     },
     serde::Raw,
 };

--- a/crates/matrix-sdk/src/encryption/secret_storage/secret_store.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/secret_store.rs
@@ -14,19 +14,19 @@
 
 use std::fmt;
 
-use matrix_sdk_base::crypto::{secret_storage::SecretStorageKey, CrossSigningKeyExport};
+use matrix_sdk_base::crypto::{CrossSigningKeyExport, secret_storage::SecretStorageKey};
 use ruma::{
     events::{
-        secret::request::SecretName, secret_storage::secret::SecretEventContent,
-        GlobalAccountDataEventType,
+        GlobalAccountDataEventType, secret::request::SecretName,
+        secret_storage::secret::SecretEventContent,
     },
     serde::Raw,
 };
 use serde_json::value::to_raw_value;
 use tracing::{
-    error,
+    Span, error,
     field::{debug, display},
-    info, instrument, warn, Span,
+    info, instrument, warn,
 };
 use zeroize::Zeroize;
 

--- a/crates/matrix-sdk/src/encryption/tasks.rs
+++ b/crates/matrix-sdk/src/encryption/tasks.rs
@@ -15,29 +15,29 @@
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use futures_core::Stream;
-use futures_util::{pin_mut, StreamExt};
+use futures_util::{StreamExt, pin_mut};
 #[cfg(feature = "experimental-encrypted-state-events")]
 use matrix_sdk_base::crypto::types::events::room::encrypted::{
     EncryptedEvent, RoomEventEncryptionScheme,
 };
 use matrix_sdk_base::{
-    crypto::store::types::RoomKeyBundleInfo, InviteAcceptanceDetails, RoomState,
+    InviteAcceptanceDetails, RoomState, crypto::store::types::RoomKeyBundleInfo,
 };
 use matrix_sdk_common::failures_cache::FailuresCache;
 #[cfg(not(feature = "experimental-encrypted-state-events"))]
 use ruma::events::room::encrypted::{EncryptedEventScheme, OriginalSyncRoomEncryptedEvent};
 #[cfg(feature = "experimental-encrypted-state-events")]
 use ruma::serde::JsonCastable;
-use ruma::{serde::Raw, OwnedEventId, OwnedRoomId};
-use tokio::sync::{mpsc, Mutex};
+use ruma::{OwnedEventId, OwnedRoomId, serde::Raw};
+use tokio::sync::{Mutex, mpsc};
 use tracing::{debug, info, instrument, trace, warn};
 
 use crate::{
+    Client, Room,
     client::WeakClient,
     encryption::backups::UploadState,
-    executor::{spawn, JoinHandle},
+    executor::{JoinHandle, spawn},
     room::shared_room_history,
-    Client, Room,
 };
 
 /// A cache of room keys we already downloaded.
@@ -515,7 +515,7 @@ impl BundleReceiverTask {
 #[cfg(all(test, not(target_family = "wasm")))]
 mod test {
     use matrix_sdk_test::{
-        async_test, event_factory::EventFactory, InvitedRoomBuilder, JoinedRoomBuilder,
+        InvitedRoomBuilder, JoinedRoomBuilder, async_test, event_factory::EventFactory,
     };
     #[cfg(not(feature = "experimental-encrypted-state-events"))]
     use ruma::events::room::encrypted::OriginalSyncRoomEncryptedEvent;

--- a/crates/matrix-sdk/src/encryption/tasks.rs
+++ b/crates/matrix-sdk/src/encryption/tasks.rs
@@ -170,15 +170,15 @@ impl BackupDownloadTask {
         room_id: OwnedRoomId,
         event: Raw<OriginalSyncRoomEncryptedEvent>,
     ) {
-        if let Ok(deserialized_event) = event.deserialize() {
-            if let EncryptedEventScheme::MegolmV1AesSha2(c) = deserialized_event.content.scheme {
-                let _ = self.sender.send(RoomKeyDownloadRequest {
-                    room_id,
-                    event_id: deserialized_event.event_id,
-                    event,
-                    megolm_session_id: c.session_id,
-                });
-            }
+        if let Ok(deserialized_event) = event.deserialize()
+            && let EncryptedEventScheme::MegolmV1AesSha2(c) = deserialized_event.content.scheme
+        {
+            let _ = self.sender.send(RoomKeyDownloadRequest {
+                room_id,
+                event_id: deserialized_event.event_id,
+                event,
+                megolm_session_id: c.session_id,
+            });
         }
     }
 

--- a/crates/matrix-sdk/src/encryption/verification/mod.rs
+++ b/crates/matrix-sdk/src/encryption/verification/mod.rs
@@ -36,13 +36,13 @@ mod sas;
 
 use as_variant::as_variant;
 pub use matrix_sdk_base::crypto::{
-    format_emojis, AcceptSettings, AcceptedProtocols, CancelInfo, Emoji, EmojiShortAuthString,
-    SasState,
+    AcceptSettings, AcceptedProtocols, CancelInfo, Emoji, EmojiShortAuthString, SasState,
+    format_emojis,
 };
 #[cfg(feature = "qrcode")]
 pub use matrix_sdk_base::crypto::{
-    matrix_sdk_qrcode::{DecodingError, EncodingError, QrVerificationData},
     QrVerificationState, ScanError,
+    matrix_sdk_qrcode::{DecodingError, EncodingError, QrVerificationData},
 };
 #[cfg(feature = "qrcode")]
 pub use qrcode::QrVerification;

--- a/crates/matrix-sdk/src/encryption/verification/qrcode.rs
+++ b/crates/matrix-sdk/src/encryption/verification/qrcode.rs
@@ -14,8 +14,8 @@
 
 use futures_core::Stream;
 use matrix_sdk_base::crypto::{
-    matrix_sdk_qrcode::{qrcode::QrCode, EncodingError},
     CancelInfo, DeviceData, QrVerification as BaseQrVerification, QrVerificationState,
+    matrix_sdk_qrcode::{EncodingError, qrcode::QrCode},
 };
 use ruma::{RoomId, UserId};
 

--- a/crates/matrix-sdk/src/encryption/verification/requests.rs
+++ b/crates/matrix-sdk/src/encryption/verification/requests.rs
@@ -16,7 +16,7 @@ use futures_util::{Stream, StreamExt};
 use matrix_sdk_base::crypto::{
     CancelInfo, DeviceData, VerificationRequest as BaseVerificationRequest,
 };
-use ruma::{events::key::verification::VerificationMethod, RoomId};
+use ruma::{RoomId, events::key::verification::VerificationMethod};
 
 #[cfg(feature = "qrcode")]
 use super::{QrVerification, QrVerificationData};

--- a/crates/matrix-sdk/src/encryption/verification/sas.rs
+++ b/crates/matrix-sdk/src/encryption/verification/sas.rs
@@ -16,9 +16,9 @@ use futures_core::Stream;
 use matrix_sdk_base::crypto::{
     AcceptSettings, CancelInfo, DeviceData, Emoji, Sas as BaseSas, SasState,
 };
-use ruma::{events::key::verification::cancel::CancelCode, RoomId, UserId};
+use ruma::{RoomId, UserId, events::key::verification::cancel::CancelCode};
 
-use crate::{error::Result, Client};
+use crate::{Client, error::Result};
 
 /// An object controlling the short auth string verification flow.
 #[derive(Debug, Clone)]

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -25,11 +25,12 @@ use matrix_sdk_base::crypto::{
     CryptoStoreError, DecryptorError, KeyExportError, MegolmError, OlmError,
 };
 use matrix_sdk_base::{
-    event_cache::store::EventCacheStoreError, media::store::MediaStoreError, Error as SdkBaseError,
-    QueueWedgeError, RoomState, StoreError,
+    Error as SdkBaseError, QueueWedgeError, RoomState, StoreError,
+    event_cache::store::EventCacheStoreError, media::store::MediaStoreError,
 };
 use reqwest::Error as ReqwestError;
 use ruma::{
+    IdParseError,
     api::{
         client::{
             error::{ErrorBody, ErrorKind, RetryAfter},
@@ -39,7 +40,6 @@ use ruma::{
     },
     events::{room::power_levels::PowerLevelsError, tag::InvalidUserTagName},
     push::{InsertPushRuleError, RemovePushRuleError},
-    IdParseError,
 };
 use serde_json::Error as JsonError;
 use thiserror::Error;

--- a/crates/matrix-sdk/src/event_cache/deduplicator.rs
+++ b/crates/matrix-sdk/src/event_cache/deduplicator.rs
@@ -24,8 +24,8 @@ use matrix_sdk_base::{
 use ruma::OwnedEventId;
 
 use super::{
-    room::events::{Event, EventLinkedChunk},
     EventCacheError,
+    room::events::{Event, EventLinkedChunk},
 };
 
 /// Find duplicates in the given collection of new events, and return relevant
@@ -150,7 +150,7 @@ mod tests {
 
     use matrix_sdk_base::{deserialized_responses::TimelineEvent, linked_chunk::ChunkIdentifier};
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
-    use ruma::{owned_event_id, serde::Raw, user_id, EventId};
+    use ruma::{EventId, owned_event_id, serde::Raw, user_id};
 
     use super::*;
 

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -747,11 +747,9 @@ impl EventCache {
                         if let Some(index_operation) =
                             search::parse_timeline_event(&room_cache, &event, &redaction_rules)
                                 .await
+                            && let Err(err) = search_index_guard.execute(index_operation, &room_id)
                         {
-                            if let Err(err) = search_index_guard.execute(index_operation, &room_id)
-                            {
-                                warn!("Failed to handle event for indexing: {err}")
-                            }
+                            warn!("Failed to handle event for indexing: {err}")
                         }
                     }
                 }

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -37,37 +37,39 @@ use eyeball::{SharedObservable, Subscriber};
 use eyeball_im::VectorDiff;
 use futures_util::future::{join_all, try_join_all};
 use matrix_sdk_base::{
+    ThreadingSupport,
     cross_process_lock::CrossProcessLockError,
     deserialized_responses::{AmbiguityChange, TimelineEvent},
     event_cache::{
-        store::{EventCacheStoreError, EventCacheStoreLock},
         Gap,
+        store::{EventCacheStoreError, EventCacheStoreLock},
     },
     executor::AbortOnDrop,
-    linked_chunk::{self, lazy_loader::LazyLoaderError, OwnedLinkedChunkId},
+    linked_chunk::{self, OwnedLinkedChunkId, lazy_loader::LazyLoaderError},
     serde_helpers::extract_thread_root_from_content,
     sync::RoomUpdates,
-    timer, ThreadingSupport,
+    timer,
 };
-use matrix_sdk_common::executor::{spawn, JoinHandle};
+use matrix_sdk_common::executor::{JoinHandle, spawn};
 use room::RoomEventCacheState;
 use ruma::{
-    events::AnySyncEphemeralRoomEvent, serde::Raw, OwnedEventId, OwnedRoomId, OwnedTransactionId,
-    RoomId,
+    OwnedEventId, OwnedRoomId, OwnedTransactionId, RoomId, events::AnySyncEphemeralRoomEvent,
+    serde::Raw,
 };
 use tokio::{
     select,
     sync::{
-        broadcast::{channel, error::RecvError, Receiver, Sender},
-        mpsc, Mutex, RwLock,
+        Mutex, RwLock,
+        broadcast::{Receiver, Sender, channel, error::RecvError},
+        mpsc,
     },
 };
-use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument as _, Span};
+use tracing::{Instrument as _, Span, debug, error, info, info_span, instrument, trace, warn};
 
 use crate::{
+    Client,
     client::WeakClient,
     send_queue::{LocalEchoContent, RoomSendQueueUpdate, SendQueueUpdate},
-    Client,
 };
 
 mod deduplicator;
@@ -754,7 +756,9 @@ impl EventCache {
                     }
                 }
                 Err(RecvError::Closed) => {
-                    debug!("Linked chunk update channel has been closed, exiting thread subscriber task");
+                    debug!(
+                        "Linked chunk update channel has been closed, exiting thread subscriber task"
+                    );
                     break;
                 }
                 Err(RecvError::Lagged(num_skipped)) => {
@@ -1163,12 +1167,12 @@ mod tests {
     use assert_matches::assert_matches;
     use futures_util::FutureExt as _;
     use matrix_sdk_base::{
+        RoomState,
         linked_chunk::{ChunkIdentifier, LinkedChunkId, Position, Update},
         sync::{JoinedRoomUpdate, RoomUpdates, Timeline},
-        RoomState,
     };
     use matrix_sdk_test::{
-        async_test, event_factory::EventFactory, JoinedRoomBuilder, SyncResponseBuilder,
+        JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
     };
     use ruma::{event_id, room_id, serde::Raw, user_id};
     use serde_json::json;
@@ -1357,11 +1361,13 @@ mod tests {
                     },
                     Update::PushItems {
                         at: Position::new(ChunkIdentifier::new(0), 0),
-                        items: vec![event_factory
-                            .text_msg("hello")
-                            .sender(user)
-                            .event_id(event_id!("$ev0"))
-                            .into_event()],
+                        items: vec![
+                            event_factory
+                                .text_msg("hello")
+                                .sender(user)
+                                .event_id(event_id!("$ev0"))
+                                .into_event(),
+                        ],
                     },
                 ],
             )
@@ -1432,11 +1438,13 @@ mod tests {
                     },
                     Update::PushItems {
                         at: Position::new(ChunkIdentifier::new(2), 0),
-                        items: vec![event_factory
-                            .text_msg("hello")
-                            .sender(user)
-                            .event_id(event_id!("$ev0"))
-                            .into_event()],
+                        items: vec![
+                            event_factory
+                                .text_msg("hello")
+                                .sender(user)
+                                .event_id(event_id!("$ev0"))
+                                .into_event(),
+                        ],
                     },
                     // Non-empty items chunk.
                     Update::NewItemsChunk {
@@ -1446,11 +1454,13 @@ mod tests {
                     },
                     Update::PushItems {
                         at: Position::new(ChunkIdentifier::new(3), 0),
-                        items: vec![event_factory
-                            .text_msg("world")
-                            .sender(user)
-                            .event_id(event_id!("$ev1"))
-                            .into_event()],
+                        items: vec![
+                            event_factory
+                                .text_msg("world")
+                                .sender(user)
+                                .event_id(event_id!("$ev1"))
+                                .into_event(),
+                        ],
                     },
                 ],
             )

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -22,8 +22,8 @@ use ruma::api::Direction;
 use tracing::{debug, instrument, trace};
 
 use super::{
-    room::{LoadMoreEventsBackwardsOutcome, RoomEventCacheInner},
     BackPaginationOutcome, EventsOrigin, Result, RoomEventCacheUpdate,
+    room::{LoadMoreEventsBackwardsOutcome, RoomEventCacheInner},
 };
 use crate::{
     event_cache::{EventCacheError, RoomEventCacheGenericUpdate},

--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -18,8 +18,8 @@ pub use matrix_sdk_base::event_cache::{Event, Gap};
 use matrix_sdk_base::{
     event_cache::store::DEFAULT_CHUNK_CAPACITY,
     linked_chunk::{
-        lazy_loader::{self, LazyLoaderError},
         ChunkContent, ChunkIdentifierGenerator, ChunkMetadata, OrderTracker, RawChunk,
+        lazy_loader::{self, LazyLoaderError},
     },
 };
 use matrix_sdk_common::linked_chunk::{
@@ -508,8 +508,8 @@ pub(super) fn sort_positions_descending(positions: &mut [Position]) {
 mod tests {
     use assert_matches::assert_matches;
     use assert_matches2::assert_let;
-    use matrix_sdk_test::{event_factory::EventFactory, ALICE, DEFAULT_TEST_ROOM_ID};
-    use ruma::{event_id, user_id, EventId, OwnedEventId};
+    use matrix_sdk_test::{ALICE, DEFAULT_TEST_ROOM_ID, event_factory::EventFactory};
+    use ruma::{EventId, OwnedEventId, event_id, user_id};
 
     use super::*;
 

--- a/crates/matrix-sdk/src/event_cache/room/threads.rs
+++ b/crates/matrix-sdk/src/event_cache/room/threads.rs
@@ -26,9 +26,9 @@ use tokio::sync::broadcast::{Receiver, Sender};
 use tracing::trace;
 
 use crate::event_cache::{
-    deduplicator::DeduplicationOutcome,
-    room::{events::EventLinkedChunk, LoadMoreEventsBackwardsOutcome},
     BackPaginationOutcome, EventsOrigin, RoomEventCacheLinkedChunkUpdate,
+    deduplicator::DeduplicationOutcome,
+    room::{LoadMoreEventsBackwardsOutcome, events::EventLinkedChunk},
 };
 
 /// An update coming from a thread event cache.
@@ -253,7 +253,7 @@ impl ThreadEventCache {
             // If the gap id is missing, it means that the gap disappeared during
             // pagination; in this case, early return to the caller.
             let gap_id = self.chunk.chunk_identifier(|chunk| {
-                    matches!(chunk.content(), ChunkContent::Gap(Gap { ref prev_token }) if *prev_token == token)
+                    matches!(chunk.content(), ChunkContent::Gap(Gap { prev_token }) if *prev_token == token)
                 })?;
 
             Some(gap_id)

--- a/crates/matrix-sdk/src/event_cache/search.rs
+++ b/crates/matrix-sdk/src/event_cache/search.rs
@@ -93,19 +93,16 @@ async fn handle_room_redaction(
     cache: &RoomEventCache,
     rules: &RedactionRules,
 ) -> Option<RoomIndexOperation> {
-    if let Some(redacted_event_id) = event.redacts(rules) {
-        if let Some(redacted_event) = cache.find_event(redacted_event_id).await {
-            if let Ok(AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
-                redacted_event,
-            ))) = redacted_event.raw().deserialize()
-            {
-                if let Some(redacted_event) = redacted_event.as_original() {
-                    return handle_possible_edit(redacted_event, cache)
-                        .await
-                        .or(Some(RoomIndexOperation::Remove(redacted_event.event_id.clone())));
-                }
-            }
-        }
+    if let Some(redacted_event_id) = event.redacts(rules)
+        && let Some(redacted_event) = cache.find_event(redacted_event_id).await
+        && let Ok(AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
+            redacted_event,
+        ))) = redacted_event.raw().deserialize()
+        && let Some(redacted_event) = redacted_event.as_original()
+    {
+        return handle_possible_edit(redacted_event, cache)
+            .await
+            .or(Some(RoomIndexOperation::Remove(redacted_event.event_id.clone())));
     }
     None
 }

--- a/crates/matrix-sdk/src/event_cache/search.rs
+++ b/crates/matrix-sdk/src/event_cache/search.rs
@@ -15,15 +15,15 @@
 use matrix_sdk_base::deserialized_responses::TimelineEvent;
 use matrix_sdk_search::index::RoomIndexOperation;
 use ruma::{
+    EventId,
     events::{
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
         room::{
             message::{OriginalSyncRoomMessageEvent, Relation, SyncRoomMessageEvent},
             redaction::SyncRoomRedactionEvent,
         },
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
     },
     room_version_rules::RedactionRules,
-    EventId,
 };
 use tracing::warn;
 
@@ -35,7 +35,7 @@ async fn get_most_recent_edit(
     cache: &RoomEventCache,
     original: &EventId,
 ) -> Option<OriginalSyncRoomMessageEvent> {
-    use ruma::events::{relation::RelationType, AnySyncTimelineEvent};
+    use ruma::events::{AnySyncTimelineEvent, relation::RelationType};
 
     let Some((original_ev, related)) =
         cache.find_event_with_relations(original, Some(vec![RelationType::Replacement])).await

--- a/crates/matrix-sdk/src/event_handler/maps.rs
+++ b/crates/matrix-sdk/src/event_handler/maps.rs
@@ -14,7 +14,7 @@
 
 use std::{
     borrow::Borrow,
-    collections::{btree_map, BTreeMap},
+    collections::{BTreeMap, btree_map},
 };
 
 use ruma::{OwnedRoomId, RoomId};

--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -884,7 +884,6 @@ mod tests {
     }
 
     #[async_test]
-    #[allow(dependency_on_unit_never_type_fallback)]
     async fn test_add_to_device_event_handler() -> crate::Result<()> {
         let client = logged_in_client(None).await;
 
@@ -923,7 +922,6 @@ mod tests {
     }
 
     #[async_test]
-    #[allow(dependency_on_unit_never_type_fallback)]
     async fn test_add_room_event_handler() -> crate::Result<()> {
         let client = logged_in_client(None).await;
 
@@ -959,9 +957,15 @@ mod tests {
         });
 
         // Room name event handler for room name events in room B
-        client.add_room_event_handler(room_id_b, move |_ev: OriginalSyncRoomNameEvent| async {
-            unreachable!("No room event in room B")
-        });
+        client.add_room_event_handler(
+            room_id_b,
+            // lint is buggy: rustc wants the explicit conversion from ! to () here, but clippy
+            // thinks it's useless.
+            #[allow(clippy::unused_unit)]
+            async move |_ev: OriginalSyncRoomNameEvent| -> () {
+                unreachable!("No room event in room B")
+            },
+        );
 
         let response = SyncResponseBuilder::default()
             .add_joined_room(
@@ -985,7 +989,6 @@ mod tests {
     }
 
     #[async_test]
-    #[allow(dependency_on_unit_never_type_fallback)]
     async fn test_add_event_handler_with_tuples() -> crate::Result<()> {
         let client = logged_in_client(None).await;
 
@@ -999,7 +1002,6 @@ mod tests {
     }
 
     #[async_test]
-    #[allow(dependency_on_unit_never_type_fallback)]
     async fn test_remove_event_handler() -> crate::Result<()> {
         let client = logged_in_client(None).await;
 
@@ -1012,13 +1014,21 @@ mod tests {
             }
         });
 
-        let handle_a = client.add_event_handler(move |_ev: OriginalSyncRoomMemberEvent| async {
-            panic!("handler should have been removed");
-        });
+        let handle_a = client.add_event_handler(
+            // lint is buggy: rustc wants the explicit conversion from ! to () here, but clippy
+            // thinks it's useless.
+            #[allow(clippy::unused_unit)]
+            async move |_ev: OriginalSyncRoomMemberEvent| -> () {
+                panic!("handler should have been removed");
+            },
+        );
         let handle_b = client.add_room_event_handler(
             #[allow(unknown_lints, clippy::explicit_auto_deref)] // lint is buggy
             *DEFAULT_TEST_ROOM_ID,
-            move |_ev: OriginalSyncRoomMemberEvent| async {
+            // lint is buggy: rustc wants the explicit conversion from ! to () here, but clippy
+            // thinks it's useless.
+            #[allow(clippy::unused_unit)]
+            async move |_ev: OriginalSyncRoomMemberEvent| -> () {
                 panic!("handler should have been removed");
             },
         );
@@ -1117,7 +1127,6 @@ mod tests {
     }
 
     #[async_test]
-    #[allow(dependency_on_unit_never_type_fallback)]
     async fn test_observe_events() -> crate::Result<()> {
         let client = logged_in_client(None).await;
 
@@ -1192,7 +1201,6 @@ mod tests {
     }
 
     #[async_test]
-    #[allow(dependency_on_unit_never_type_fallback)]
     async fn test_observe_room_events() -> crate::Result<()> {
         let client = logged_in_client(None).await;
 
@@ -1339,7 +1347,6 @@ mod tests {
     }
 
     #[async_test]
-    #[allow(dependency_on_unit_never_type_fallback)]
     async fn test_observe_events_with_type_prefix() -> crate::Result<()> {
         let client = logged_in_client(None).await;
 
@@ -1380,7 +1387,6 @@ mod tests {
     }
 
     #[async_test]
-    #[allow(dependency_on_unit_never_type_fallback)]
     async fn test_observe_room_events_with_type_prefix() -> crate::Result<()> {
         // To create an event handler for a room account data event type with prefix, we
         // need to create a custom event type, none exist in the Matrix specification

--- a/crates/matrix-sdk/src/event_handler/static_events.rs
+++ b/crates/matrix-sdk/src/event_handler/static_events.rs
@@ -16,13 +16,13 @@
 
 use ruma::{
     events::{
-        self, presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
-        AnyStrippedStateEvent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
-        AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent, EphemeralRoomEventContent,
-        False, GlobalAccountDataEventContent, MessageLikeEventContent,
-        PossiblyRedactedStateEventContent, RedactContent, RedactedMessageLikeEventContent,
-        RedactedStateEventContent, RoomAccountDataEventContent, StaticEventContent,
-        StaticStateEventContent, ToDeviceEventContent,
+        self, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
+        AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent, AnySyncStateEvent,
+        AnySyncTimelineEvent, AnyToDeviceEvent, EphemeralRoomEventContent, False,
+        GlobalAccountDataEventContent, MessageLikeEventContent, PossiblyRedactedStateEventContent,
+        RedactContent, RedactedMessageLikeEventContent, RedactedStateEventContent,
+        RoomAccountDataEventContent, StaticEventContent, StaticStateEventContent,
+        ToDeviceEventContent, presence::PresenceEvent,
     },
     serde::Raw,
 };

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -17,8 +17,8 @@ use std::{
     fmt::Debug,
     num::NonZeroUsize,
     sync::{
-        atomic::{AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicU64, Ordering},
     },
     time::Duration,
 };
@@ -28,8 +28,8 @@ use bytesize::ByteSize;
 use eyeball::SharedObservable;
 use http::Method;
 use ruma::api::{
-    error::{FromHttpResponseError, IntoHttpError},
     AuthScheme, OutgoingRequest, SendAccessToken, SupportedVersions,
+    error::{FromHttpResponseError, IntoHttpError},
 };
 use tokio::sync::{Semaphore, SemaphorePermit};
 use tracing::{debug, field::debug, instrument, trace};
@@ -259,8 +259,8 @@ mod tests {
     use std::{
         num::NonZeroUsize,
         sync::{
-            atomic::{AtomicU8, Ordering},
             Arc,
+            atomic::{AtomicU8, Ordering},
         },
         time::Duration,
     };
@@ -268,8 +268,8 @@ mod tests {
     use matrix_sdk_common::executor::spawn;
     use matrix_sdk_test::{async_test, test_json};
     use wiremock::{
-        matchers::{method, path},
         Mock, Request, ResponseTemplate,
+        matchers::{method, path},
     };
 
     use crate::{

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -24,11 +24,11 @@ use bytes::Bytes;
 use bytesize::ByteSize;
 use eyeball::SharedObservable;
 use http::header::CONTENT_LENGTH;
-use reqwest::{tls, Certificate};
-use ruma::api::{error::FromHttpResponseError, IncomingResponse, OutgoingRequest};
+use reqwest::{Certificate, tls};
+use ruma::api::{IncomingResponse, OutgoingRequest, error::FromHttpResponseError};
 use tracing::{debug, info, warn};
 
-use super::{response_to_http_response, HttpClient, TransmissionProgress, DEFAULT_REQUEST_TIMEOUT};
+use super::{DEFAULT_REQUEST_TIMEOUT, HttpClient, TransmissionProgress, response_to_http_response};
 use crate::{
     config::RequestConfig,
     error::{HttpError, RetryKind},
@@ -131,11 +131,7 @@ impl HttpClient {
                         // If we ran into a network failure, only retry if there's some retry limit
                         // associated to this request's configuration; otherwise, we would end up
                         // running an infinite loop of network requests in offline mode.
-                        if has_retry_limit {
-                            default_timeout
-                        } else {
-                            None
-                        }
+                        if has_retry_limit { default_timeout } else { None }
                     }
                 }
             })

--- a/crates/matrix-sdk/src/http_client/wasm.rs
+++ b/crates/matrix-sdk/src/http_client/wasm.rs
@@ -17,9 +17,9 @@ use std::fmt::Debug;
 use bytes::Bytes;
 use bytesize::ByteSize;
 use eyeball::SharedObservable;
-use ruma::api::{error::FromHttpResponseError, IncomingResponse, OutgoingRequest};
+use ruma::api::{IncomingResponse, OutgoingRequest, error::FromHttpResponseError};
 
-use super::{response_to_http_response, HttpClient, TransmissionProgress};
+use super::{HttpClient, TransmissionProgress, response_to_http_response};
 use crate::{config::RequestConfig, error::HttpError};
 
 impl HttpClient {

--- a/crates/matrix-sdk/src/latest_events/latest_event.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event.rs
@@ -931,23 +931,23 @@ fn filter_timeline_event(
         AnySyncTimelineEvent::State(state) => {
             // … but we make an exception for knocked state events _if_ the current user
             // can either accept or decline them.
-            if let AnySyncStateEvent::RoomMember(member) = state {
-                if matches!(member.membership(), MembershipState::Knock) {
-                    let can_accept_or_decline_knocks = match power_levels {
-                        Some((own_user_id, room_power_levels)) => {
-                            room_power_levels.user_can_invite(own_user_id)
-                                || room_power_levels.user_can_kick(own_user_id)
-                        }
-                        _ => false,
-                    };
-
-                    // The current user can act on the knock changes, so they should be
-                    // displayed
-                    if can_accept_or_decline_knocks {
-                        // We can only decide whether the user can accept or decline knocks if the
-                        // event isn't redacted.
-                        return matches!(member, SyncStateEvent::Original(_));
+            if let AnySyncStateEvent::RoomMember(member) = state
+                && matches!(member.membership(), MembershipState::Knock)
+            {
+                let can_accept_or_decline_knocks = match power_levels {
+                    Some((own_user_id, room_power_levels)) => {
+                        room_power_levels.user_can_invite(own_user_id)
+                            || room_power_levels.user_can_kick(own_user_id)
                     }
+                    _ => false,
+                };
+
+                // The current user can act on the knock changes, so they should be
+                // displayed
+                if can_accept_or_decline_knocks {
+                    // We can only decide whether the user can accept or decline knocks if the
+                    // event isn't redacted.
+                    return matches!(member, SyncStateEvent::Original(_));
                 }
             }
 

--- a/crates/matrix-sdk/src/latest_events/latest_event.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event.rs
@@ -19,16 +19,16 @@ pub use matrix_sdk_base::latest_event::{
     LatestEventValue, LocalLatestEventValue, RemoteLatestEventValue,
 };
 use matrix_sdk_base::{
-    deserialized_responses::TimelineEvent, store::SerializableEventContent,
-    RoomInfoNotableUpdateReasons, StateChanges,
+    RoomInfoNotableUpdateReasons, StateChanges, deserialized_responses::TimelineEvent,
+    store::SerializableEventContent,
 };
 use ruma::{
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, TransactionId, UserId,
     events::{
+        AnyMessageLikeEventContent, AnySyncStateEvent, AnySyncTimelineEvent, SyncStateEvent,
         relation::RelationType,
         room::{member::MembershipState, message::MessageType, power_levels::RoomPowerLevels},
-        AnyMessageLikeEventContent, AnySyncStateEvent, AnySyncTimelineEvent, SyncStateEvent,
     },
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, TransactionId, UserId,
 };
 use tracing::{error, instrument, warn};
 
@@ -170,17 +170,17 @@ impl LatestEvent {
 mod tests_latest_event {
     use assert_matches::assert_matches;
     use matrix_sdk_base::{
+        RoomInfoNotableUpdateReasons, RoomState,
         linked_chunk::{ChunkIdentifier, LinkedChunkId, Position, Update},
         store::StoreConfig,
-        RoomInfoNotableUpdateReasons, RoomState,
     };
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
     use ruma::{
-        event_id,
-        events::{room::message::RoomMessageEventContent, AnyMessageLikeEventContent},
+        MilliSecondsSinceUnixEpoch, OwnedTransactionId, event_id,
+        events::{AnyMessageLikeEventContent, room::message::RoomMessageEventContent},
         room_id,
         serde::Raw,
-        user_id, MilliSecondsSinceUnixEpoch, OwnedTransactionId,
+        user_id,
     };
 
     use super::{LatestEvent, LatestEventValue, LocalLatestEventValue, SerializableEventContent};
@@ -412,10 +412,9 @@ mod tests_latest_event {
                         },
                         Update::PushItems {
                             at: Position::new(ChunkIdentifier::new(0), 0),
-                            items: vec![event_factory
-                                .text_msg("A")
-                                .event_id(event_id!("$ev0"))
-                                .into()],
+                            items: vec![
+                                event_factory.text_msg("A").event_id(event_id!("$ev0")).into(),
+                            ],
                         },
                     ],
                 )
@@ -552,7 +551,10 @@ impl LatestEventValueBuilder {
                         }
 
                         Err(error) => {
-                            error!(?error, "Failed to deserialize an event from `RoomSendQueueUpdate::NewLocalEvent`");
+                            error!(
+                                ?error,
+                                "Failed to deserialize an event from `RoomSendQueueUpdate::NewLocalEvent`"
+                            );
 
                             LatestEventValue::None
                         }
@@ -639,7 +641,10 @@ impl LatestEventValueBuilder {
                         }
 
                         Err(error) => {
-                            error!(?error, "Failed to deserialize an event from `RoomSendQueueUpdate::ReplacedLocalEvent`");
+                            error!(
+                                ?error,
+                                "Failed to deserialize an event from `RoomSendQueueUpdate::ReplacedLocalEvent`"
+                            );
 
                             return LatestEventValue::None;
                         }
@@ -1244,7 +1249,7 @@ mod tests_latest_event_content {
 
     #[test]
     fn test_room_message_verification_request() {
-        use ruma::{events::room::message, OwnedDeviceId};
+        use ruma::{OwnedDeviceId, events::room::message};
 
         assert_latest_event_content!(
             event | event_factory | {
@@ -1268,9 +1273,9 @@ mod tests_latest_event_content {
 mod tests_latest_event_values_for_local_events {
     use assert_matches::assert_matches;
     use ruma::{
-        events::{room::message::RoomMessageEventContent, AnyMessageLikeEventContent},
-        serde::Raw,
         MilliSecondsSinceUnixEpoch, OwnedTransactionId,
+        events::{AnyMessageLikeEventContent, room::message::RoomMessageEventContent},
+        serde::Raw,
     };
     use serde_json::json;
 
@@ -1510,20 +1515,20 @@ mod tests_latest_event_value_builder {
 
     use assert_matches::assert_matches;
     use matrix_sdk_base::{
+        RoomState,
         deserialized_responses::TimelineEventKind,
         linked_chunk::{ChunkIdentifier, LinkedChunkId, Position, Update},
         store::SerializableEventContent,
-        RoomState,
     };
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
     use ruma::{
-        event_id,
+        MilliSecondsSinceUnixEpoch, OwnedRoomId, OwnedTransactionId, event_id,
         events::{
-            reaction::ReactionEventContent, relation::Annotation,
-            room::message::RoomMessageEventContent, AnyMessageLikeEventContent,
-            AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent,
+            AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+            SyncMessageLikeEvent, reaction::ReactionEventContent, relation::Annotation,
+            room::message::RoomMessageEventContent,
         },
-        room_id, user_id, MilliSecondsSinceUnixEpoch, OwnedRoomId, OwnedTransactionId,
+        room_id, user_id,
     };
 
     use super::{
@@ -1531,11 +1536,11 @@ mod tests_latest_event_value_builder {
         RemoteLatestEventValue, RoomEventCache, RoomSendQueueUpdate,
     };
     use crate::{
+        Client, Error,
         client::WeakClient,
         room::WeakRoom,
         send_queue::{AbstractProgress, LocalEcho, LocalEchoContent, RoomSendQueue, SendHandle},
         test_utils::mocks::MatrixMockServer,
-        Client, Error,
     };
 
     macro_rules! assert_remote_value_matches_room_message_with_body {
@@ -2212,10 +2217,9 @@ mod tests_latest_event_value_builder {
                         },
                         Update::PushItems {
                             at: Position::new(ChunkIdentifier::new(0), 0),
-                            items: vec![event_factory
-                                .text_msg("hello")
-                                .event_id(event_id_0)
-                                .into()],
+                            items: vec![
+                                event_factory.text_msg("hello").event_id(event_id_0).into(),
+                            ],
                         },
                     ],
                 )

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -23,12 +23,11 @@ pub use bytes;
 #[cfg(feature = "e2e-encryption")]
 pub use matrix_sdk_base::crypto;
 pub use matrix_sdk_base::{
-    deserialized_responses,
-    store::{self, DynStateStore, MemoryStore, StateStoreExt},
     ComposerDraft, ComposerDraftType, EncryptionState, PredecessorRoom, QueueWedgeError,
     Room as BaseRoom, RoomCreateWithCreatorEventContent, RoomDisplayName, RoomHero, RoomInfo,
     RoomMember as BaseRoomMember, RoomMemberships, RoomRecencyStamp, RoomState, SessionMeta,
-    StateChanges, StateStore, StoreError, SuccessorRoom, ThreadingSupport,
+    StateChanges, StateStore, StoreError, SuccessorRoom, ThreadingSupport, deserialized_responses,
+    store::{self, DynStateStore, MemoryStore, StateStoreExt},
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;
@@ -70,8 +69,8 @@ pub use authentication::{AuthApi, AuthSession, SessionTokens};
 #[cfg(feature = "experimental-search")]
 pub use client::search::SearchIndexStoreKind;
 pub use client::{
-    sanitize_server_name, Client, ClientBuildError, ClientBuilder, LoopCtrl, ServerVendorInfo,
-    SessionChange,
+    Client, ClientBuildError, ClientBuilder, LoopCtrl, ServerVendorInfo, SessionChange,
+    sanitize_server_name,
 };
 pub use error::{
     Error, HttpError, HttpResult, NotificationSettingsError, RefreshTokenError, Result,
@@ -82,8 +81,8 @@ pub use http_client::TransmissionProgress;
 pub use matrix_sdk_sqlite::SqliteCryptoStore;
 #[cfg(feature = "sqlite")]
 pub use matrix_sdk_sqlite::{
-    SqliteEventCacheStore, SqliteMediaStore, SqliteStateStore, SqliteStoreConfig,
-    STATE_STORE_DATABASE_NAME,
+    STATE_STORE_DATABASE_NAME, SqliteEventCacheStore, SqliteMediaStore, SqliteStateStore,
+    SqliteStoreConfig,
 };
 pub use media::Media;
 pub use pusher::Pusher;

--- a/crates/matrix-sdk/src/live_location_share.rs
+++ b/crates/matrix-sdk/src/live_location_share.rs
@@ -19,14 +19,14 @@
 use async_stream::stream;
 use futures_util::Stream;
 use ruma::{
+    MilliSecondsSinceUnixEpoch, OwnedUserId, RoomId,
     events::{
         beacon::OriginalSyncBeaconEvent, beacon_info::BeaconInfoEventContent,
         location::LocationContent,
     },
-    MilliSecondsSinceUnixEpoch, OwnedUserId, RoomId,
 };
 
-use crate::{event_handler::ObservableEventHandler, Client, Room};
+use crate::{Client, Room, event_handler::ObservableEventHandler};
 
 /// An observable live location.
 #[derive(Debug)]

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -276,10 +276,10 @@ impl Media {
     ) -> Result<()> {
         // Do a best-effort at reporting an expired MXC URI here; otherwise the server
         // may complain about it later.
-        if let Some(expire_date) = uri.expire_date {
-            if MilliSecondsSinceUnixEpoch::now() >= expire_date {
-                return Err(Error::Media(MediaError::ExpiredPreallocatedMxcUri));
-            }
+        if let Some(expire_date) = uri.expire_date
+            && MilliSecondsSinceUnixEpoch::now() >= expire_date
+        {
+            return Err(Error::Media(MediaError::ExpiredPreallocatedMxcUri));
         }
 
         let timeout = std::cmp::max(
@@ -426,12 +426,11 @@ impl Media {
         }
 
         // Read from the cache.
-        if use_cache {
-            if let Some(content) =
+        if use_cache
+            && let Some(content) =
                 self.client.media_store().lock().await?.get_media_content(request).await?
-            {
-                return Ok(content);
-            }
+        {
+            return Ok(content);
         }
 
         let request_config = self

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -27,13 +27,13 @@ use matrix_sdk_base::media::store::IgnoreMediaRetentionPolicy;
 pub use matrix_sdk_base::media::{store::MediaRetentionPolicy, *};
 use mime::Mime;
 use ruma::{
+    MilliSecondsSinceUnixEpoch, MxcUri, OwnedMxcUri, TransactionId, UInt,
     api::{
-        client::{authenticated_media, error::ErrorKind, media},
         OutgoingRequest,
+        client::{authenticated_media, error::ErrorKind, media},
     },
     assign,
     events::room::{MediaSource, ThumbnailInfo},
-    MilliSecondsSinceUnixEpoch, MxcUri, OwnedMxcUri, TransactionId, UInt,
 };
 #[cfg(not(target_family = "wasm"))]
 use tempfile::{Builder as TempFileBuilder, NamedTempFile, TempDir};
@@ -41,8 +41,8 @@ use tempfile::{Builder as TempFileBuilder, NamedTempFile, TempDir};
 use tokio::{fs::File as TokioFile, io::AsyncWriteExt};
 
 use crate::{
-    attachment::Thumbnail, client::futures::SendMediaUploadRequest, config::RequestConfig, Client,
-    Error, Result, TransmissionProgress,
+    Client, Error, Result, TransmissionProgress, attachment::Thumbnail,
+    client::futures::SendMediaUploadRequest, config::RequestConfig,
 };
 
 /// A conservative upload speed of 1Mbps
@@ -808,8 +808,9 @@ impl Media {
 mod tests {
     use assert_matches2::assert_matches;
     use ruma::{
+        MxcUri,
         events::room::{EncryptedFile, MediaSource},
-        mxc_uri, owned_mxc_uri, uint, MxcUri,
+        mxc_uri, owned_mxc_uri, uint,
     };
     use serde_json::json;
 

--- a/crates/matrix-sdk/src/notification_settings/command.rs
+++ b/crates/matrix-sdk/src/notification_settings/command.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 
 use ruma::{
+    OwnedRoomId,
     push::{
         Action, NewConditionalPushRule, NewPatternedPushRule, NewPushRule, NewSimplePushRule,
         PushCondition, RuleKind, Tweak,
     },
-    OwnedRoomId,
 };
 
 use crate::NotificationSettingsError;

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -18,16 +18,16 @@ use std::sync::Arc;
 
 use indexmap::IndexSet;
 use ruma::{
+    RoomId,
     api::client::push::{
         delete_pushrule, set_pushrule, set_pushrule_actions, set_pushrule_enabled,
     },
     events::push_rules::PushRulesEvent,
     push::{Action, NewPushRule, PredefinedUnderrideRuleId, RuleKind, Ruleset, Tweak},
-    RoomId,
 };
 use tokio::sync::{
-    broadcast::{self, Receiver},
     RwLock,
+    broadcast::{self, Receiver},
 };
 use tracing::{debug, error};
 
@@ -40,8 +40,8 @@ mod rules;
 pub use matrix_sdk_base::notification_settings::RoomNotificationMode;
 
 use crate::{
-    config::RequestConfig, error::NotificationSettingsError, event_handler::EventHandlerDropGuard,
-    Client, Result,
+    Client, Result, config::RequestConfig, error::NotificationSettingsError,
+    event_handler::EventHandlerDropGuard,
 };
 
 /// Whether or not a room is encrypted
@@ -55,11 +55,7 @@ pub enum IsEncrypted {
 
 impl From<bool> for IsEncrypted {
     fn from(value: bool) -> Self {
-        if value {
-            Self::Yes
-        } else {
-            Self::No
-        }
+        if value { Self::Yes } else { Self::No }
     }
 }
 
@@ -74,11 +70,7 @@ pub enum IsOneToOne {
 
 impl From<bool> for IsOneToOne {
     fn from(value: bool) -> Self {
-        if value {
-            Self::Yes
-        } else {
-            Self::No
-        }
+        if value { Self::Yes } else { Self::No }
     }
 }
 
@@ -583,39 +575,37 @@ impl NotificationSettings {
 #[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     };
 
     use assert_matches::assert_matches;
     use matrix_sdk_test::{
-        async_test,
+        TestResult, async_test,
         event_factory::EventFactory,
         notification_settings::{build_ruleset, get_server_default_ruleset},
-        TestResult,
     };
     use ruma::{
-        owned_room_id,
+        OwnedRoomId, RoomId, owned_room_id,
         push::{
             Action, AnyPushRuleRef, NewPatternedPushRule, NewPushRule, PredefinedContentRuleId,
             PredefinedOverrideRuleId, PredefinedUnderrideRuleId, RuleKind, Ruleset,
         },
-        OwnedRoomId, RoomId,
     };
     use stream_assert::{assert_next_eq, assert_pending};
     use tokio_stream::wrappers::BroadcastStream;
     use wiremock::{
-        matchers::{method, path, path_regex},
         Mock, MockServer, ResponseTemplate,
+        matchers::{method, path, path_regex},
     };
 
     use crate::{
+        Client,
         error::NotificationSettingsError,
         notification_settings::{
             IsEncrypted, IsOneToOne, NotificationSettings, RoomNotificationMode,
         },
         test_utils::{logged_in_client, mocks::MatrixMockServer},
-        Client,
     };
 
     fn get_test_room_id() -> OwnedRoomId {

--- a/crates/matrix-sdk/src/notification_settings/rule_commands.rs
+++ b/crates/matrix-sdk/src/notification_settings/rule_commands.rs
@@ -1,9 +1,9 @@
 use ruma::{
+    RoomId,
     push::{
         Action, NewPushRule, PredefinedContentRuleId, PredefinedOverrideRuleId,
         RemovePushRuleError, RuleKind, Ruleset,
     },
-    RoomId,
 };
 
 use super::command::Command;
@@ -219,12 +219,12 @@ mod tests {
     use assert_matches::assert_matches;
     use matrix_sdk_test::async_test;
     use ruma::{
+        OwnedRoomId, RoomId, UserId,
         push::{
             Action, NewPushRule, NewSimplePushRule, PredefinedContentRuleId,
             PredefinedOverrideRuleId, PredefinedUnderrideRuleId, RemovePushRuleError, RuleKind,
             Ruleset, Tweak,
         },
-        OwnedRoomId, RoomId, UserId,
     };
 
     use super::RuleCommands;
@@ -421,23 +421,29 @@ mod tests {
             .unwrap();
 
         // The ruleset must have been updated.
-        assert!(rule_commands
-            .rules
-            .get(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention)
-            .unwrap()
-            .enabled());
+        assert!(
+            rule_commands
+                .rules
+                .get(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention)
+                .unwrap()
+                .enabled()
+        );
         #[allow(deprecated)]
         {
-            assert!(rule_commands
-                .rules
-                .get(RuleKind::Override, PredefinedOverrideRuleId::ContainsDisplayName)
-                .unwrap()
-                .enabled());
-            assert!(rule_commands
-                .rules
-                .get(RuleKind::Content, PredefinedContentRuleId::ContainsUserName)
-                .unwrap()
-                .enabled());
+            assert!(
+                rule_commands
+                    .rules
+                    .get(RuleKind::Override, PredefinedOverrideRuleId::ContainsDisplayName)
+                    .unwrap()
+                    .enabled()
+            );
+            assert!(
+                rule_commands
+                    .rules
+                    .get(RuleKind::Content, PredefinedContentRuleId::ContainsUserName)
+                    .unwrap()
+                    .enabled()
+            );
         }
 
         // Three commands are expected.
@@ -496,18 +502,22 @@ mod tests {
             .unwrap();
 
         // The ruleset must have been updated.
-        assert!(rule_commands
-            .rules
-            .get(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention)
-            .unwrap()
-            .enabled());
+        assert!(
+            rule_commands
+                .rules
+                .get(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention)
+                .unwrap()
+                .enabled()
+        );
         #[allow(deprecated)]
         {
-            assert!(rule_commands
-                .rules
-                .get(RuleKind::Override, PredefinedOverrideRuleId::RoomNotif)
-                .unwrap()
-                .enabled());
+            assert!(
+                rule_commands
+                    .rules
+                    .get(RuleKind::Override, PredefinedOverrideRuleId::RoomNotif)
+                    .unwrap()
+                    .enabled()
+            );
         }
 
         // Two commands are expected.

--- a/crates/matrix-sdk/src/notification_settings/rules.rs
+++ b/crates/matrix-sdk/src/notification_settings/rules.rs
@@ -3,14 +3,14 @@
 use imbl::HashSet;
 use indexmap::IndexSet;
 use ruma::{
+    RoomId,
     push::{
         AnyPushRuleRef, PatternedPushRule, PredefinedContentRuleId, PredefinedOverrideRuleId,
         PredefinedUnderrideRuleId, PushCondition, RuleKind, Ruleset,
     },
-    RoomId,
 };
 
-use super::{command::Command, rule_commands::RuleCommands, RoomNotificationMode};
+use super::{RoomNotificationMode, command::Command, rule_commands::RuleCommands};
 use crate::{
     error::NotificationSettingsError,
     notification_settings::{IsEncrypted, IsOneToOne},
@@ -319,19 +319,19 @@ pub(crate) mod tests {
         notification_settings::{build_ruleset, get_server_default_ruleset},
     };
     use ruma::{
+        OwnedRoomId, RoomId,
         push::{
             Action, NewConditionalPushRule, NewPushRule, PredefinedContentRuleId,
             PredefinedOverrideRuleId, PredefinedUnderrideRuleId, PushCondition, RuleKind,
         },
-        OwnedRoomId, RoomId,
     };
 
     use super::RuleCommands;
     use crate::{
         error::NotificationSettingsError,
         notification_settings::{
-            rules::{self, Rules},
             IsEncrypted, IsOneToOne, RoomNotificationMode,
+            rules::{self, Rules},
         },
     };
 
@@ -505,9 +505,11 @@ pub(crate) mod tests {
         assert!(rules.is_user_mention_enabled());
         // is_enabled() should also return `true` for
         // PredefinedOverrideRuleId::IsUserMention
-        assert!(rules
-            .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention.as_str())
-            .unwrap());
+        assert!(
+            rules
+                .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention.as_str())
+                .unwrap()
+        );
 
         // If `IsUserMention` is disabled, then is_user_mention_enabled() should return
         // `false` even if the deprecated rules are enabled
@@ -536,9 +538,11 @@ pub(crate) mod tests {
         assert!(!rules.is_user_mention_enabled());
         // is_enabled() should also return `false` for
         // PredefinedOverrideRuleId::IsUserMention
-        assert!(!rules
-            .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention.as_str())
-            .unwrap());
+        assert!(
+            !rules
+                .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention.as_str())
+                .unwrap()
+        );
     }
 
     #[async_test]
@@ -558,9 +562,11 @@ pub(crate) mod tests {
         assert!(rules.is_room_mention_enabled());
         // is_enabled() should also return `true` for
         // PredefinedOverrideRuleId::IsRoomMention
-        assert!(rules
-            .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention.as_str())
-            .unwrap());
+        assert!(
+            rules
+                .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention.as_str())
+                .unwrap()
+        );
 
         // If `IsRoomMention` is present and disabled then is_room_mention_enabled()
         // should return `false` even if the deprecated rule is enabled
@@ -575,9 +581,11 @@ pub(crate) mod tests {
         assert!(!rules.is_room_mention_enabled());
         // is_enabled() should also return `false` for
         // PredefinedOverrideRuleId::IsRoomMention
-        assert!(!rules
-            .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention.as_str())
-            .unwrap());
+        assert!(
+            !rules
+                .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention.as_str())
+                .unwrap()
+        );
     }
 
     #[async_test]
@@ -644,9 +652,11 @@ pub(crate) mod tests {
         rules.apply(rules_commands);
 
         // The rule must have been disabled in the updated rules
-        assert!(!rules
-            .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::Reaction.as_str())
-            .unwrap());
+        assert!(
+            !rules
+                .is_enabled(RuleKind::Override, PredefinedOverrideRuleId::Reaction.as_str())
+                .unwrap()
+        );
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/notification_settings/rules.rs
+++ b/crates/matrix-sdk/src/notification_settings/rules.rs
@@ -142,11 +142,11 @@ impl Rules {
             match rule {
                 AnyPushRuleRef::Override(r) | AnyPushRuleRef::Underride(r) => {
                     for condition in &r.conditions {
-                        if let PushCondition::EventMatch { key, pattern } = condition {
-                            if key == "room_id" {
-                                room_ids.insert(pattern.clone());
-                                break;
-                            }
+                        if let PushCondition::EventMatch { key, pattern } = condition
+                            && key == "room_id"
+                        {
+                            room_ids.insert(pattern.clone());
+                            break;
                         }
                     }
                 }
@@ -173,19 +173,19 @@ impl Rules {
         #[allow(deprecated)]
         if let Some(rule) =
             self.ruleset.get(RuleKind::Override, PredefinedOverrideRuleId::ContainsDisplayName)
+            && rule.enabled()
+            && rule.triggers_notification()
         {
-            if rule.enabled() && rule.triggers_notification() {
-                return true;
-            }
+            return true;
         }
 
         #[allow(deprecated)]
         if let Some(rule) =
             self.ruleset.get(RuleKind::Content, PredefinedContentRuleId::ContainsUserName)
+            && rule.enabled()
+            && rule.triggers_notification()
         {
-            if rule.enabled() && rule.triggers_notification() {
-                return true;
-            }
+            return true;
         }
 
         false

--- a/crates/matrix-sdk/src/paginators/room.rs
+++ b/crates/matrix-sdk/src/paginators/room.rs
@@ -389,11 +389,11 @@ impl PaginableRoom for Room {
                     // If the error was a 404, then the event wasn't found on the server;
                     // special case this to make it easy to react to
                     // such an error.
-                    if let Some(error) = err.as_client_api_error() {
-                        if error.status_code == 404 {
-                            // Event not found
-                            return Err(PaginatorError::EventNotFound(event_id.to_owned()));
-                        }
+                    if let Some(error) = err.as_client_api_error()
+                        && error.status_code == 404
+                    {
+                        // Event not found
+                        return Err(PaginatorError::EventNotFound(event_id.to_owned()));
                     }
 
                     // Otherwise, just return a wrapped error.

--- a/crates/matrix-sdk/src/paginators/room.rs
+++ b/crates/matrix-sdk/src/paginators/room.rs
@@ -20,13 +20,13 @@
 use std::{future::Future, sync::Mutex};
 
 use eyeball::{SharedObservable, Subscriber};
-use matrix_sdk_base::{deserialized_responses::TimelineEvent, SendOutsideWasm, SyncOutsideWasm};
-use ruma::{api::Direction, EventId, UInt};
+use matrix_sdk_base::{SendOutsideWasm, SyncOutsideWasm, deserialized_responses::TimelineEvent};
+use ruma::{EventId, UInt, api::Direction};
 
 use crate::{
+    Room,
     paginators::{PaginationResult, PaginationToken, PaginatorError},
     room::{EventWithContextResponse, Messages, MessagesOptions},
-    Room,
 };
 
 /// Current state of a [`Paginator`].
@@ -419,7 +419,7 @@ mod tests {
     use matrix_sdk_base::deserialized_responses::TimelineEvent;
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
     use once_cell::sync::Lazy;
-    use ruma::{api::Direction, event_id, room_id, uint, user_id, EventId, RoomId, UInt, UserId};
+    use ruma::{EventId, RoomId, UInt, UserId, api::Direction, event_id, room_id, uint, user_id};
     use tokio::{
         spawn,
         sync::{Mutex, Notify},

--- a/crates/matrix-sdk/src/paginators/thread.rs
+++ b/crates/matrix-sdk/src/paginators/thread.rs
@@ -18,13 +18,13 @@
 
 use std::{fmt::Formatter, future::Future, sync::Mutex};
 
-use matrix_sdk_base::{deserialized_responses::TimelineEvent, SendOutsideWasm, SyncOutsideWasm};
-use ruma::{api::Direction, OwnedEventId, UInt};
+use matrix_sdk_base::{SendOutsideWasm, SyncOutsideWasm, deserialized_responses::TimelineEvent};
+use ruma::{OwnedEventId, UInt, api::Direction};
 
 use crate::{
+    Error, Room,
     paginators::{PaginationResult, PaginationToken, PaginatorError},
     room::{IncludeRelations, Relations, RelationsOptions},
-    Error, Room,
 };
 
 /// A paginable thread interface, useful for testing purposes.

--- a/crates/matrix-sdk/src/pusher.rs
+++ b/crates/matrix-sdk/src/pusher.rs
@@ -15,7 +15,7 @@
 
 //! High-level pusher API.
 
-use ruma::api::client::push::{set_pusher, PusherIds};
+use ruma::api::client::push::{PusherIds, set_pusher};
 
 use crate::{Client, Result};
 
@@ -57,8 +57,8 @@ mod tests {
         push::HttpPusherData,
     };
     use wiremock::{
-        matchers::{method, path},
         Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
     };
 
     use crate::test_utils::logged_in_client;

--- a/crates/matrix-sdk/src/room/calls.rs
+++ b/crates/matrix-sdk/src/room/calls.rs
@@ -125,10 +125,9 @@ impl Room {
                     // Ignore decline for other unrelated notification events.
                     if let Some(declined_event_id) =
                         event.as_original().map(|ev| ev.content.relates_to.event_id.clone())
+                        && declined_event_id == own_notification_event_id
                     {
-                        if declined_event_id == own_notification_event_id {
-                            let _ = sender.send(event.sender().to_owned());
-                        }
+                        let _ = sender.send(event.sender().to_owned());
                     }
                 }
             });

--- a/crates/matrix-sdk/src/room/calls.rs
+++ b/crates/matrix-sdk/src/room/calls.rs
@@ -15,17 +15,17 @@
 //!  Facilities to handle incoming calls.
 
 use ruma::{
-    events::{
-        rtc::decline::{RtcDeclineEventContent, SyncRtcDeclineEvent},
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
-    },
     EventId, OwnedUserId, UserId,
+    events::{
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+        rtc::decline::{RtcDeclineEventContent, SyncRtcDeclineEvent},
+    },
 };
 use thiserror::Error;
 use tokio::sync::broadcast;
 use tracing::instrument;
 
-use crate::{event_handler::EventHandlerDropGuard, room::EventSource, Room};
+use crate::{Room, event_handler::EventHandlerDropGuard, room::EventSource};
 
 /// An error occurring while interacting with a call/rtc event.
 #[derive(Debug, Error)]

--- a/crates/matrix-sdk/src/room/edit.rs
+++ b/crates/matrix-sdk/src/room/edit.rs
@@ -15,7 +15,10 @@
 //! Facilities to edit existing events.
 
 use ruma::{
+    EventId, UserId,
     events::{
+        AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent, Mentions,
+        SyncMessageLikeEvent,
         poll::unstable_start::{
             ReplacementUnstablePollStartEventContent, UnstablePollStartContentBlock,
             UnstablePollStartEventContent,
@@ -24,10 +27,7 @@ use ruma::{
             FormattedBody, MessageType, ReplacementMetadata, RoomMessageEventContent,
             RoomMessageEventContentWithoutRelation,
         },
-        AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent, Mentions,
-        SyncMessageLikeEvent,
     },
-    EventId, UserId,
 };
 use thiserror::Error;
 use tracing::instrument;
@@ -290,16 +290,16 @@ mod tests {
     use matrix_sdk_base::deserialized_responses::TimelineEvent;
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
     use ruma::{
-        event_id,
+        EventId, OwnedEventId, event_id,
         events::{
-            room::message::{MessageType, Relation, RoomMessageEventContentWithoutRelation},
             AnyMessageLikeEventContent, AnySyncTimelineEvent, Mentions,
+            room::message::{MessageType, Relation, RoomMessageEventContentWithoutRelation},
         },
-        owned_mxc_uri, owned_user_id, user_id, EventId, OwnedEventId,
+        owned_mxc_uri, owned_user_id, user_id,
     };
 
-    use super::{make_edit_event, EditError, EventSource};
-    use crate::{room::edit::EditedContent, Error};
+    use super::{EditError, EventSource, make_edit_event};
+    use crate::{Error, room::edit::EditedContent};
 
     #[derive(Default)]
     struct TestEventCache {

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -26,25 +26,25 @@ use mime::Mime;
 #[cfg(doc)]
 use ruma::events::{MessageLikeUnsigned, SyncMessageLikeEvent};
 use ruma::{
+    OwnedTransactionId, TransactionId,
     api::client::message::send_message_event,
     assign,
     events::{AnyMessageLikeEventContent, MessageLikeEventContent},
     serde::Raw,
-    OwnedTransactionId, TransactionId,
 };
 #[cfg(feature = "experimental-encrypted-state-events")]
 use ruma::{
     api::client::state::send_state_event,
     events::{AnyStateEventContent, StateEventContent},
 };
-use tracing::{info, trace, Instrument, Span};
+use tracing::{Instrument, Span, info, trace};
 
 use super::Room;
 #[cfg(feature = "experimental-encrypted-state-events")]
 use crate::utils::IntoRawStateEventContent;
 use crate::{
-    attachment::AttachmentConfig, config::RequestConfig, utils::IntoRawMessageLikeEventContent,
-    Result, TransmissionProgress,
+    Result, TransmissionProgress, attachment::AttachmentConfig, config::RequestConfig,
+    utils::IntoRawMessageLikeEventContent,
 };
 
 /// Future returned by [`Room::send`].

--- a/crates/matrix-sdk/src/room/identity_status_changes.rs
+++ b/crates/matrix-sdk/src/room/identity_status_changes.rs
@@ -858,7 +858,7 @@ mod tests {
                     (_, Some(m)) => {
                         assert_eq!(*m.membership(), new_state);
                     }
-                };
+                }
             }
 
             async fn bob_is_pinned(&self) -> bool {

--- a/crates/matrix-sdk/src/room/identity_status_changes.rs
+++ b/crates/matrix-sdk/src/room/identity_status_changes.rs
@@ -19,19 +19,19 @@ use std::collections::BTreeMap;
 
 use async_stream::stream;
 use futures_core::Stream;
-use futures_util::{stream_select, StreamExt};
+use futures_util::{StreamExt, stream_select};
 use matrix_sdk_base::crypto::{
     IdentityState, IdentityStatusChange, RoomIdentityChange, RoomIdentityState,
 };
-use ruma::{events::room::member::SyncRoomMemberEvent, OwnedUserId, UserId};
+use ruma::{OwnedUserId, UserId, events::room::member::SyncRoomMemberEvent};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
 use super::Room;
 use crate::{
+    Client, Error, Result,
     encryption::identities::{IdentityUpdates, UserIdentity},
     event_handler::EventHandlerDropGuard,
-    Client, Error, Result,
 };
 
 /// Support for creating a stream of batches of [`IdentityStatusChange`].
@@ -153,7 +153,9 @@ fn combine_streams(
     stream_select!(identity_updates, room_member_events)
 }
 
-async fn wrap_identity_updates(client: &Client) -> Result<impl Stream<Item = RoomIdentityChange>> {
+async fn wrap_identity_updates(
+    client: &Client,
+) -> Result<impl Stream<Item = RoomIdentityChange> + use<>> {
     Ok(client
         .encryption()
         .user_identities_stream()
@@ -179,7 +181,7 @@ fn to_base_identities(
 
 fn wrap_room_member_events(
     room: &Room,
-) -> (EventHandlerDropGuard, impl Stream<Item = RoomIdentityChange>) {
+) -> (EventHandlerDropGuard, impl Stream<Item = RoomIdentityChange> + use<>) {
     let own_user_id = room.own_user_id().to_owned();
     let room_id = room.room_id();
     let (sender, receiver) = mpsc::channel(16);
@@ -199,7 +201,7 @@ fn wrap_room_member_events(
 mod tests {
     use std::time::Duration;
 
-    use futures_util::{pin_mut, FutureExt as _, StreamExt as _};
+    use futures_util::{FutureExt as _, StreamExt as _, pin_mut};
     use matrix_sdk_base::crypto::IdentityState;
     use matrix_sdk_test::{async_test, test_json::keys_query_sets::IdentityChangeDataSet};
     use test_setup::TestSetup;
@@ -591,29 +593,30 @@ mod tests {
 
         use futures_core::Stream;
         use matrix_sdk_base::{
-            crypto::{
-                testing::simulate_key_query_response_for_verification, IdentityStatusChange,
-                OtherUserIdentity,
-            },
             RoomState,
+            crypto::{
+                IdentityStatusChange, OtherUserIdentity,
+                testing::simulate_key_query_response_for_verification,
+            },
         };
         use matrix_sdk_test::{
-            test_json, test_json::keys_query_sets::IdentityChangeDataSet, JoinedRoomBuilder,
-            StateTestEvent, SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
+            DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder,
+            test_json, test_json::keys_query_sets::IdentityChangeDataSet,
         };
         use ruma::{
+            OwnedUserId, TransactionId, UserId,
             api::client::keys::{get_keys, get_keys::v3::Response as KeyQueryResponse},
             events::room::member::MembershipState,
-            owned_user_id, OwnedUserId, TransactionId, UserId,
+            owned_user_id,
         };
         use serde_json::json;
         use wiremock::{
-            matchers::{header, method, path_regex},
             Mock, MockServer, ResponseTemplate,
+            matchers::{header, method, path_regex},
         };
 
         use crate::{
-            encryption::identities::UserIdentity, test_utils::logged_in_client, Client, Room,
+            Client, Room, encryption::identities::UserIdentity, test_utils::logged_in_client,
         };
 
         /// Sets up a client and a room and allows changing user identities and
@@ -787,7 +790,7 @@ mod tests {
 
             pub(super) async fn subscribe_to_identity_status_changes(
                 &self,
-            ) -> impl Stream<Item = Vec<IdentityStatusChange>> {
+            ) -> impl Stream<Item = Vec<IdentityStatusChange>> + use<> {
                 self.room
                     .subscribe_to_identity_status_changes()
                     .await

--- a/crates/matrix-sdk/src/room/knock_requests.rs
+++ b/crates/matrix-sdk/src/room/knock_requests.rs
@@ -15,7 +15,7 @@
 use js_int::UInt;
 use ruma::{EventId, OwnedEventId, OwnedMxcUri, OwnedUserId, RoomId};
 
-use crate::{room::RoomMember, Error, Room};
+use crate::{Error, Room, room::RoomMember};
 
 /// A request to join a room with `knock` join rule.
 #[derive(Debug, Clone)]
@@ -105,15 +105,15 @@ impl KnockRequestMemberInfo {
 // The http mocking library is not supported for wasm32
 #[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
-    use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder};
+    use matrix_sdk_test::{JoinedRoomBuilder, async_test, event_factory::EventFactory};
     use ruma::{
-        event_id, events::room::member::MembershipState, owned_user_id, room_id, user_id, EventId,
+        EventId, event_id, events::room::member::MembershipState, owned_user_id, room_id, user_id,
     };
 
     use crate::{
+        Room,
         room::knock_requests::{KnockRequest, KnockRequestMemberInfo},
         test_utils::mocks::MatrixMockServer,
-        Room,
     };
 
     #[async_test]
@@ -125,11 +125,9 @@ mod tests {
         let user_id = user_id!("@alice:b.c");
 
         let f = EventFactory::new().room(room_id);
-        let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f
-            .member(user_id)
-            .membership(MembershipState::Knock)
-            .event_id(event_id)
-            .into_raw()]);
+        let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![
+            f.member(user_id).membership(MembershipState::Knock).event_id(event_id).into_raw(),
+        ]);
         let room = server.sync_room(&client, joined_room_builder).await;
 
         let knock_request = make_knock_request(&room, Some(event_id));

--- a/crates/matrix-sdk/src/room/member.rs
+++ b/crates/matrix-sdk/src/room/member.rs
@@ -1,13 +1,13 @@
 use std::ops::Deref;
 
 use ruma::{
-    events::room::{power_levels::UserPowerLevel, MediaSource},
+    events::room::{MediaSource, power_levels::UserPowerLevel},
     int,
 };
 
 use crate::{
-    media::{MediaFormat, MediaRequestParameters},
     BaseRoomMember, Client, Result,
+    media::{MediaFormat, MediaRequestParameters},
 };
 
 /// The high-level `RoomMember` representation
@@ -44,8 +44,8 @@ impl RoomMember {
     ///
     /// ```no_run
     /// use matrix_sdk::{
-    ///     media::MediaFormat, room::RoomMember, ruma::room_id, Client,
-    ///     RoomMemberships,
+    ///     Client, RoomMemberships, media::MediaFormat, room::RoomMember,
+    ///     ruma::room_id,
     /// };
     /// # use url::Url;
     /// # let homeserver = Url::parse("http://example.com").unwrap();

--- a/crates/matrix-sdk/src/room/messages.rs
+++ b/crates/matrix-sdk/src/room/messages.rs
@@ -17,19 +17,20 @@ use std::fmt;
 use futures_util::future::join_all;
 use matrix_sdk_common::{debug::DebugStructExt as _, deserialized_responses::TimelineEvent};
 use ruma::{
+    OwnedEventId, RoomId, UInt,
     api::{
+        Direction,
         client::{
             filter::RoomEventFilter,
             message::get_message_events,
             relations,
             threads::get_threads::{self, v1::IncludeThreads},
         },
-        Direction,
     },
     assign,
-    events::{relation::RelationType, AnyStateEvent, TimelineEventType},
+    events::{AnyStateEvent, TimelineEventType, relation::RelationType},
     serde::Raw,
-    uint, OwnedEventId, RoomId, UInt,
+    uint,
 };
 
 use super::Room;

--- a/crates/matrix-sdk/src/room/power_levels.rs
+++ b/crates/matrix-sdk/src/room/power_levels.rs
@@ -3,14 +3,14 @@
 use std::collections::HashMap;
 
 use ruma::{
+    OwnedUserId,
     events::{
+        StateEventType,
         room::power_levels::{
             PossiblyRedactedRoomPowerLevelsEventContent, RoomPowerLevels,
             RoomPowerLevelsEventContent,
         },
-        StateEventType,
     },
-    OwnedUserId,
 };
 
 use crate::Result;

--- a/crates/matrix-sdk/src/room/privacy_settings.rs
+++ b/crates/matrix-sdk/src/room/privacy_settings.rs
@@ -1,5 +1,6 @@
 use matrix_sdk_base::Room as BaseRoom;
 use ruma::{
+    OwnedRoomAliasId, RoomAliasId,
     api::client::{
         directory::{get_room_visibility, set_room_visibility},
         room::Visibility,
@@ -7,14 +8,13 @@ use ruma::{
     },
     assign,
     events::{
+        EmptyStateKey,
         room::{
             canonical_alias::RoomCanonicalAliasEventContent,
             history_visibility::{HistoryVisibility, RoomHistoryVisibilityEventContent},
             join_rules::{JoinRule, RoomJoinRulesEventContent},
         },
-        EmptyStateKey,
     },
-    OwnedRoomAliasId, RoomAliasId,
 };
 
 use crate::{Client, Result};
@@ -165,13 +165,13 @@ impl<'a> RoomPrivacySettings<'a> {
 mod tests {
     use std::ops::Not;
 
-    use matrix_sdk_test::{async_test, JoinedRoomBuilder, StateTestEvent};
+    use matrix_sdk_test::{JoinedRoomBuilder, StateTestEvent, async_test};
     use ruma::{
         api::client::room::Visibility,
         event_id,
         events::{
-            room::{history_visibility::HistoryVisibility, join_rules::JoinRule},
             StateEventType,
+            room::{history_visibility::HistoryVisibility, join_rules::JoinRule},
         },
         owned_room_alias_id, room_id,
     };

--- a/crates/matrix-sdk/src/room/reply.rs
+++ b/crates/matrix-sdk/src/room/reply.rs
@@ -16,7 +16,9 @@
 
 use as_variant::as_variant;
 use ruma::{
+    OwnedEventId, UserId,
     events::{
+        AnySyncTimelineEvent,
         room::{
             encrypted::Relation as EncryptedRelation,
             message::{
@@ -24,9 +26,7 @@ use ruma::{
                 RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
             },
         },
-        AnySyncTimelineEvent,
     },
-    OwnedEventId, UserId,
 };
 use thiserror::Error;
 use tracing::{error, instrument};
@@ -150,18 +150,18 @@ mod tests {
     use matrix_sdk_base::deserialized_responses::TimelineEvent;
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
     use ruma::{
-        event_id,
+        EventId, OwnedEventId, event_id,
         events::{
-            room::message::{Relation, ReplyWithinThread, RoomMessageEventContentWithoutRelation},
             AnySyncTimelineEvent,
+            room::message::{Relation, ReplyWithinThread, RoomMessageEventContentWithoutRelation},
         },
         serde::Raw,
-        user_id, EventId, OwnedEventId,
+        user_id,
     };
     use serde_json::json;
 
-    use super::{make_reply_event, EnforceThread, EventSource, Reply, ReplyError};
-    use crate::{event_cache::EventCacheError, Error};
+    use super::{EnforceThread, EventSource, Reply, ReplyError, make_reply_event};
+    use crate::{Error, event_cache::EventCacheError};
 
     #[derive(Default)]
     struct TestEventCache {

--- a/crates/matrix-sdk/src/room/shared_room_history.rs
+++ b/crates/matrix-sdk/src/room/shared_room_history.rs
@@ -15,10 +15,10 @@
 use std::iter;
 
 use matrix_sdk_base::media::{MediaFormat, MediaRequestParameters};
-use ruma::{events::room::MediaSource, OwnedUserId, UserId};
+use ruma::{OwnedUserId, UserId, events::room::MediaSource};
 use tracing::{info, instrument, warn};
 
-use crate::{crypto::types::events::room_key_bundle::RoomKeyBundleContent, Error, Result, Room};
+use crate::{Error, Result, Room, crypto::types::events::room_key_bundle::RoomKeyBundleContent};
 
 /// Share any shareable E2EE history in the given room with the given recipient,
 /// as per [MSC4268].

--- a/crates/matrix-sdk/src/room_directory_search.rs
+++ b/crates/matrix-sdk/src/room_directory_search.rs
@@ -19,8 +19,9 @@ use eyeball_im::{ObservableVector, VectorDiff};
 use futures_core::Stream;
 use imbl::Vector;
 use ruma::{
+    OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
     api::client::directory::get_public_rooms_filtered::v3::Request as PublicRoomsFilterRequest,
-    directory::Filter, room::JoinRuleKind, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
+    directory::Filter, room::JoinRuleKind,
 };
 
 use crate::{Client, OwnedServerName, Result};
@@ -77,11 +78,7 @@ enum SearchState {
 
 impl SearchState {
     fn next_token(&self) -> Option<&str> {
-        if let Self::Next(next_token) = &self {
-            Some(next_token)
-        } else {
-            None
-        }
+        if let Self::Next(next_token) = &self { Some(next_token) } else { None }
     }
 
     fn is_at_end(&self) -> bool {
@@ -100,7 +97,7 @@ impl SearchState {
 /// # Example
 ///
 /// ```no_run
-/// use matrix_sdk::{room_directory_search::RoomDirectorySearch, Client};
+/// use matrix_sdk::{Client, room_directory_search::RoomDirectorySearch};
 /// use url::Url;
 ///
 /// async {
@@ -195,7 +192,8 @@ impl RoomDirectorySearch {
     /// search, and a stream of updates for them.
     pub fn results(
         &self,
-    ) -> (Vector<RoomDescription>, impl Stream<Item = Vec<VectorDiff<RoomDescription>>>) {
+    ) -> (Vector<RoomDescription>, impl Stream<Item = Vec<VectorDiff<RoomDescription>>> + use<>)
+    {
         self.results.subscribe().into_values_and_batched_stream()
     }
 
@@ -220,19 +218,19 @@ mod tests {
     use futures_util::StreamExt;
     use matrix_sdk_test::{async_test, test_json};
     use ruma::{
-        directory::Filter, owned_server_name, room::JoinRuleKind, serde::Raw, RoomAliasId, RoomId,
+        RoomAliasId, RoomId, directory::Filter, owned_server_name, room::JoinRuleKind, serde::Raw,
     };
     use serde_json::Value as JsonValue;
     use stream_assert::assert_pending;
     use wiremock::{
-        matchers::{method, path_regex},
         Match, Mock, MockServer, Request, ResponseTemplate,
+        matchers::{method, path_regex},
     };
 
     use crate::{
+        Client,
         room_directory_search::{RoomDescription, RoomDirectorySearch},
         test_utils::logged_in_client,
-        Client,
     };
 
     struct RoomDirectorySearchMatcher {

--- a/crates/matrix-sdk/src/room_preview.rs
+++ b/crates/matrix-sdk/src/room_preview.rs
@@ -21,15 +21,15 @@
 use futures_util::future::join_all;
 use matrix_sdk_base::{RoomHero, RoomInfo, RoomState};
 use ruma::{
+    OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedServerName, RoomId, RoomOrAliasId, ServerName,
     api::client::{membership::joined_members, state::get_state_events},
     events::room::history_visibility::HistoryVisibility,
     room::{JoinRuleSummary, RoomType},
-    OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedServerName, RoomId, RoomOrAliasId, ServerName,
 };
 use tokio::try_join;
 use tracing::{instrument, warn};
 
-use crate::{room_directory_search::RoomDirectorySearch, Client, Error, Room};
+use crate::{Client, Error, Room, room_directory_search::RoomDirectorySearch};
 
 /// The preview of a room, be it invited/joined/left, or not.
 #[derive(Debug, Clone)]
@@ -394,7 +394,7 @@ fn ensure_server_names_is_not_empty(
 
 #[cfg(test)]
 mod tests {
-    use ruma::{owned_server_name, room_alias_id, room_id, server_name, RoomOrAliasId, ServerName};
+    use ruma::{RoomOrAliasId, ServerName, owned_server_name, room_alias_id, room_id, server_name};
 
     use crate::room_preview::ensure_server_names_is_not_empty;
 

--- a/crates/matrix-sdk/src/room_preview.rs
+++ b/crates/matrix-sdk/src/room_preview.rs
@@ -383,10 +383,11 @@ fn ensure_server_names_is_not_empty(
 ) -> Vec<OwnedServerName> {
     let mut server_names = server_names;
 
-    if let Some((own_server, alias_server)) = own_server_name.zip(room_or_alias_id.server_name()) {
-        if server_names.is_empty() && own_server != alias_server {
-            server_names.push(alias_server.to_owned());
-        }
+    if let Some((own_server, alias_server)) = own_server_name.zip(room_or_alias_id.server_name())
+        && server_names.is_empty()
+        && own_server != alias_server
+    {
+        server_names.push(alias_server.to_owned());
     }
 
     server_names

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -132,8 +132,8 @@ use std::{
     collections::{BTreeMap, HashMap},
     str::FromStr as _,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, RwLock,
+        atomic::{AtomicBool, Ordering},
     },
 };
 
@@ -141,46 +141,46 @@ use eyeball::SharedObservable;
 #[cfg(feature = "unstable-msc4274")]
 use matrix_sdk_base::store::FinishGalleryItemInfo;
 use matrix_sdk_base::{
+    RoomState, StoreError,
     cross_process_lock::CrossProcessLockError,
     event_cache::store::EventCacheStoreError,
-    media::{store::MediaStoreError, MediaRequestParameters},
+    media::{MediaRequestParameters, store::MediaStoreError},
     store::{
         ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind, DynStateStore,
         FinishUploadThumbnailInfo, QueueWedgeError, QueuedRequest, QueuedRequestKind,
         SentMediaInfo, SentRequestKey, SerializableEventContent,
     },
-    RoomState, StoreError,
 };
 use matrix_sdk_common::{
-    executor::{spawn, JoinHandle},
+    executor::{JoinHandle, spawn},
     locks::Mutex as SyncMutex,
 };
 use mime::Mime;
 use ruma::{
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId, RoomId,
+    TransactionId,
     events::{
+        AnyMessageLikeEventContent, Mentions, MessageLikeEventContent as _,
         reaction::ReactionEventContent,
         relation::Annotation,
         room::{
-            message::{FormattedBody, RoomMessageEventContent},
             MediaSource,
+            message::{FormattedBody, RoomMessageEventContent},
         },
-        AnyMessageLikeEventContent, Mentions, MessageLikeEventContent as _,
     },
     serde::Raw,
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId, RoomId,
-    TransactionId,
 };
-use tokio::sync::{broadcast, oneshot, Mutex, Notify, OwnedMutexGuard};
+use tokio::sync::{Mutex, Notify, OwnedMutexGuard, broadcast, oneshot};
 use tracing::{debug, error, info, instrument, trace, warn};
 
 #[cfg(feature = "e2e-encryption")]
 use crate::crypto::{OlmError, SessionRecipientCollectionError};
 use crate::{
+    Client, Media, Room, TransmissionProgress,
     client::WeakClient,
     config::RequestConfig,
     error::RetryKind,
-    room::{edit::EditedContent, WeakRoom},
-    Client, Media, Room, TransmissionProgress,
+    room::{WeakRoom, edit::EditedContent},
 };
 
 mod progress;
@@ -2744,10 +2744,11 @@ mod tests {
         ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind,
         SerializableEventContent,
     };
-    use matrix_sdk_test::{async_test, JoinedRoomBuilder, SyncResponseBuilder};
+    use matrix_sdk_test::{JoinedRoomBuilder, SyncResponseBuilder, async_test};
     use ruma::{
-        events::{room::message::RoomMessageEventContent, AnyMessageLikeEventContent},
-        room_id, MilliSecondsSinceUnixEpoch, TransactionId,
+        MilliSecondsSinceUnixEpoch, TransactionId,
+        events::{AnyMessageLikeEventContent, room::message::RoomMessageEventContent},
+        room_id,
     };
 
     use super::canonicalize_dependent_requests;

--- a/crates/matrix-sdk/src/send_queue/progress.rs
+++ b/crates/matrix-sdk/src/send_queue/progress.rs
@@ -21,13 +21,13 @@ use eyeball::SharedObservable;
 use matrix_sdk_base::store::AccumulatedSentMediaInfo;
 use matrix_sdk_base::{media::MediaRequestParameters, store::DependentQueuedRequestKind};
 use matrix_sdk_common::executor::spawn;
-use ruma::{events::room::MediaSource, TransactionId};
+use ruma::{TransactionId, events::room::MediaSource};
 use tokio::sync::broadcast;
 use tracing::warn;
 
 use crate::{
-    send_queue::{QueueStorage, RoomSendQueue, RoomSendQueueStorageError, RoomSendQueueUpdate},
     Room, TransmissionProgress,
+    send_queue::{QueueStorage, RoomSendQueue, RoomSendQueueStorageError, RoomSendQueueUpdate},
 };
 
 /// Progress of an operation in abstract units.
@@ -132,17 +132,19 @@ impl RoomSendQueue {
             // it, from the database. This will account in the total progress of the
             // file+thumbnail upload (we're currently uploading the thumbnail,
             // in the first step).
-            let pending_file_bytes =
-                match RoomSendQueue::get_dependent_pending_file_upload_size(own_txn_id, room).await
-                {
-                    Ok(maybe_size) => maybe_size.unwrap_or(0),
-                    Err(err) => {
-                        warn!(
+            let pending_file_bytes = match RoomSendQueue::get_dependent_pending_file_upload_size(
+                own_txn_id, room,
+            )
+            .await
+            {
+                Ok(maybe_size) => maybe_size.unwrap_or(0),
+                Err(err) => {
+                    warn!(
                         "error when getting pending file upload size: {err}; using 0 as fallback"
                     );
-                        0
-                    }
-                };
+                    0
+                }
+            };
 
             // In nominal cases where the send queue is used correctly, only one of these
             // two values will be non-zero.

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -17,43 +17,43 @@
 #[cfg(feature = "unstable-msc4274")]
 use std::{collections::HashMap, iter::zip};
 
+use matrix_sdk_base::{
+    RoomState,
+    media::{MediaFormat, MediaRequestParameters, store::IgnoreMediaRetentionPolicy},
+    store::{
+        ChildTransactionId, DependentQueuedRequestKind, FinishUploadThumbnailInfo,
+        QueuedRequestKind, SentMediaInfo, SentRequestKey, SerializableEventContent,
+    },
+};
 #[cfg(feature = "unstable-msc4274")]
 use matrix_sdk_base::{
     media::UniqueKey,
     store::{AccumulatedSentMediaInfo, FinishGalleryItemInfo},
 };
-use matrix_sdk_base::{
-    media::{store::IgnoreMediaRetentionPolicy, MediaFormat, MediaRequestParameters},
-    store::{
-        ChildTransactionId, DependentQueuedRequestKind, FinishUploadThumbnailInfo,
-        QueuedRequestKind, SentMediaInfo, SentRequestKey, SerializableEventContent,
-    },
-    RoomState,
-};
 use mime::Mime;
 #[cfg(feature = "unstable-msc4274")]
 use ruma::events::room::message::{GalleryItemType, GalleryMessageEventContent};
 use ruma::{
-    events::{
-        room::{
-            message::{FormattedBody, MessageType, RoomMessageEventContent},
-            MediaSource, ThumbnailInfo,
-        },
-        AnyMessageLikeEventContent, Mentions,
-    },
     MilliSecondsSinceUnixEpoch, OwnedTransactionId, TransactionId,
+    events::{
+        AnyMessageLikeEventContent, Mentions,
+        room::{
+            MediaSource, ThumbnailInfo,
+            message::{FormattedBody, MessageType, RoomMessageEventContent},
+        },
+    },
 };
-use tracing::{debug, error, instrument, trace, warn, Span};
+use tracing::{Span, debug, error, instrument, trace, warn};
 
 use super::{QueueStorage, QueueThumbnailInfo, RoomSendQueue, RoomSendQueueError};
 use crate::{
+    Client, Media, Room,
     attachment::{AttachmentConfig, Thumbnail},
     room::edit::update_media_caption,
     send_queue::{
         LocalEcho, LocalEchoContent, MediaHandles, RoomSendQueueStorageError, RoomSendQueueUpdate,
         SendHandle,
     },
-    Client, Media, Room,
 };
 #[cfg(feature = "unstable-msc4274")]
 use crate::{

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -7,14 +7,14 @@ use std::{
 
 use cfg_if::cfg_if;
 use matrix_sdk_common::timer;
-use ruma::{api::client::sync::sync_events::v5 as http, OwnedRoomId};
-use tokio::sync::{broadcast::channel, Mutex as AsyncMutex, RwLock as AsyncRwLock};
+use ruma::{OwnedRoomId, api::client::sync::sync_events::v5 as http};
+use tokio::sync::{Mutex as AsyncMutex, RwLock as AsyncRwLock, broadcast::channel};
 
 use super::{
-    cache::format_storage_key_prefix, sticky_parameters::SlidingSyncStickyManager, Error,
-    SlidingSync, SlidingSyncInner, SlidingSyncListBuilder, SlidingSyncPositionMarkers, Version,
+    Error, SlidingSync, SlidingSyncInner, SlidingSyncListBuilder, SlidingSyncPositionMarkers,
+    Version, cache::format_storage_key_prefix, sticky_parameters::SlidingSyncStickyManager,
 };
-use crate::{sliding_sync::SlidingSyncStickyParameters, Client, Result};
+use crate::{Client, Result, sliding_sync::SlidingSyncStickyParameters};
 
 /// Configuration for a Sliding Sync instance.
 ///

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -14,7 +14,7 @@ use super::{FrozenSlidingSyncList, SlidingSync, SlidingSyncPositionMarkers};
 use crate::sliding_sync::FrozenSlidingSyncPos;
 #[cfg(doc)]
 use crate::sliding_sync::SlidingSyncList;
-use crate::{sliding_sync::SlidingSyncListCachePolicy, Client, Result};
+use crate::{Client, Result, sliding_sync::SlidingSyncListCachePolicy};
 
 /// Be careful: as this is used as a storage key; changing it requires migrating
 /// data!
@@ -202,7 +202,7 @@ mod tests {
         super::SlidingSyncList, format_storage_key_for_sliding_sync_list,
         format_storage_key_prefix, restore_sliding_sync_state, store_sliding_sync_state,
     };
-    use crate::{test_utils::logged_in_client, Result};
+    use crate::{Result, test_utils::logged_in_client};
 
     #[allow(clippy::await_holding_lock)]
     #[async_test]
@@ -215,19 +215,23 @@ mod tests {
         let storage_key = format_storage_key_prefix(sync_id, client.user_id().unwrap());
 
         // Store entries don't exist.
-        assert!(store
-            .get_custom_value(
-                format_storage_key_for_sliding_sync_list(&storage_key, "list_foo").as_bytes()
-            )
-            .await?
-            .is_none());
+        assert!(
+            store
+                .get_custom_value(
+                    format_storage_key_for_sliding_sync_list(&storage_key, "list_foo").as_bytes()
+                )
+                .await?
+                .is_none()
+        );
 
-        assert!(store
-            .get_custom_value(
-                format_storage_key_for_sliding_sync_list(&storage_key, "list_bar").as_bytes()
-            )
-            .await?
-            .is_none());
+        assert!(
+            store
+                .get_custom_value(
+                    format_storage_key_for_sliding_sync_list(&storage_key, "list_bar").as_bytes()
+                )
+                .await?
+                .is_none()
+        );
 
         // Create a new `SlidingSync` instance, and store it.
         let storage_key = {
@@ -257,20 +261,24 @@ mod tests {
         };
 
         // Store entries now exist for `list_foo`.
-        assert!(store
-            .get_custom_value(
-                format_storage_key_for_sliding_sync_list(&storage_key, "list_foo").as_bytes()
-            )
-            .await?
-            .is_some());
+        assert!(
+            store
+                .get_custom_value(
+                    format_storage_key_for_sliding_sync_list(&storage_key, "list_foo").as_bytes()
+                )
+                .await?
+                .is_some()
+        );
 
         // But not for `list_bar`.
-        assert!(store
-            .get_custom_value(
-                format_storage_key_for_sliding_sync_list(&storage_key, "list_bar").as_bytes()
-            )
-            .await?
-            .is_none());
+        assert!(
+            store
+                .get_custom_value(
+                    format_storage_key_for_sliding_sync_list(&storage_key, "list_bar").as_bytes()
+                )
+                .await?
+                .is_none()
+        );
 
         // Create a new `SlidingSync`, and it should be read from the cache.
         let max_number_of_room_stream = Arc::new(RwLock::new(None));

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -179,11 +179,11 @@ pub(super) async fn restore_sliding_sync_state(
     if let Some(olm_machine) = &*_client.olm_machine().await {
         let instance_storage_key = format_storage_key_for_sliding_sync(storage_key);
 
-        if let Ok(Some(blob)) = olm_machine.store().get_custom_value(&instance_storage_key).await {
-            if let Ok(frozen_pos) = serde_json::from_slice::<FrozenSlidingSyncPos>(&blob) {
-                trace!("Successfully read the `Sliding Sync` pos from the crypto store cache");
-                restored_fields.pos = frozen_pos.pos;
-            }
+        if let Ok(Some(blob)) = olm_machine.store().get_custom_value(&instance_storage_key).await
+            && let Ok(frozen_pos) = serde_json::from_slice::<FrozenSlidingSyncPos>(&blob)
+        {
+            trace!("Successfully read the `Sliding Sync` pos from the crypto store cache");
+            restored_fields.pos = frozen_pos.pos;
         }
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -2,12 +2,12 @@ use std::collections::BTreeSet;
 
 use futures_util::future::try_join_all;
 use matrix_sdk_base::{
-    sync::SyncResponse, timer, RequestedRequiredStates, ThreadSubscriptionCatchupToken,
+    RequestedRequiredStates, ThreadSubscriptionCatchupToken, sync::SyncResponse, timer,
 };
 use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
 use ruma::api::{
-    client::sync::sync_events::v5::{self as http, response},
     FeatureFlag, SupportedVersions,
+    client::sync::sync_events::v5::{self as http, response},
 };
 use tracing::error;
 
@@ -329,8 +329,8 @@ mod tests {
 
     use assert_matches::assert_matches;
     use matrix_sdk_base::{
-        notification_settings::RoomNotificationMode, RequestedRequiredStates,
-        RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons,
+        RequestedRequiredStates, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons,
+        notification_settings::RoomNotificationMode,
     };
     use matrix_sdk_test::async_test;
     use ruma::{
@@ -341,10 +341,10 @@ mod tests {
 
     use super::{Version, VersionBuilder};
     use crate::{
-        error::Result,
-        sliding_sync::{client::SlidingSyncResponseProcessor, http, VersionBuilderError},
-        test_utils::{client::MockClientBuilder, mocks::MatrixMockServer},
         SlidingSyncList, SlidingSyncMode,
+        error::Result,
+        sliding_sync::{VersionBuilderError, client::SlidingSyncResponseProcessor, http},
+        test_utils::{client::MockClientBuilder, mocks::MatrixMockServer},
     };
 
     #[test]

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -16,8 +16,8 @@ use super::{
     SlidingSyncListStickyParameters, SlidingSyncMode,
 };
 use crate::{
-    sliding_sync::{cache::restore_sliding_sync_list, sticky_parameters::SlidingSyncStickyManager},
     Client,
+    sliding_sync::{cache::restore_sliding_sync_list, sticky_parameters::SlidingSyncStickyManager},
 };
 
 /// Data that might have been read from the cache.

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -11,7 +11,7 @@ use std::{
 
 use eyeball::{Observable, SharedObservable, Subscriber};
 use futures_core::Stream;
-use ruma::{api::client::sync::sync_events::v5 as http, assign, TransactionId};
+use ruma::{TransactionId, api::client::sync::sync_events::v5 as http, assign};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::Sender;
 use tracing::{instrument, warn};
@@ -20,8 +20,8 @@ pub use self::builder::*;
 use self::sticky::SlidingSyncListStickyParameters;
 pub(super) use self::{frozen::FrozenSlidingSyncList, request_generator::*};
 use super::{
-    sticky_parameters::{LazyTransactionId, SlidingSyncStickyManager},
     Error, SlidingSyncInternalMessage,
+    sticky_parameters::{LazyTransactionId, SlidingSyncStickyManager},
 };
 use crate::Result;
 
@@ -533,7 +533,7 @@ mod tests {
     use tokio::sync::broadcast::{channel, error::TryRecvError};
 
     use super::{SlidingSyncList, SlidingSyncListLoadingState, SlidingSyncMode};
-    use crate::sliding_sync::{sticky_parameters::LazyTransactionId, SlidingSyncInternalMessage};
+    use crate::sliding_sync::{SlidingSyncInternalMessage, sticky_parameters::LazyTransactionId};
 
     macro_rules! assert_json_roundtrip {
         (from $type:ty: $rust_value:expr => $json_value:expr) => {
@@ -1089,7 +1089,7 @@ mod tests {
         list.set_sync_mode(SlidingSyncMode::new_selective());
 
         assert_eq!(list.state(), SlidingSyncListLoadingState::PartiallyLoaded); // we had some partial state, but we can't be sure it's fully loaded until the
-                                                                                // next request
+        // next request
 
         // We need to update the ranges, of course, as they are not managed
         // automatically anymore.

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -31,7 +31,7 @@
 use std::cmp::min;
 
 use super::{Range, Ranges, SlidingSyncMode};
-use crate::{sliding_sync::Error, SlidingSyncListLoadingState};
+use crate::{SlidingSyncListLoadingState, sliding_sync::Error};
 
 /// The kind of request generator.
 #[derive(Debug, PartialEq)]
@@ -336,9 +336,9 @@ mod tests {
     use assert_matches::assert_matches;
 
     use super::{
-        create_range, SlidingSyncListRequestGenerator, SlidingSyncListRequestGeneratorKind,
+        SlidingSyncListRequestGenerator, SlidingSyncListRequestGeneratorKind, create_range,
     };
-    use crate::{sliding_sync::Error, SlidingSyncMode};
+    use crate::{SlidingSyncMode, sliding_sync::Error};
 
     #[test]
     fn test_create_range_from() {

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -15,7 +15,7 @@
 //! The SDK's representation of the result of a `/sync` request.
 
 use std::{
-    collections::{btree_map, BTreeMap},
+    collections::{BTreeMap, btree_map},
     fmt,
     time::Duration,
 };
@@ -32,18 +32,18 @@ use matrix_sdk_base::{
 };
 use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
 use ruma::{
+    OwnedRoomId, RoomId,
     api::client::sync::sync_events::{
         self,
         v3::{InvitedRoom, KnockedRoom},
     },
-    events::{presence::PresenceEvent, AnyGlobalAccountDataEvent},
+    events::{AnyGlobalAccountDataEvent, presence::PresenceEvent},
     serde::Raw,
     time::Instant,
-    OwnedRoomId, RoomId,
 };
 use tracing::{debug, error, warn};
 
-use crate::{event_handler::HandlerKind, Client, Result, Room};
+use crate::{Client, Result, Room, event_handler::HandlerKind};
 
 /// The processed response of a `/sync` request.
 #[derive(Clone, Default)]

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -334,10 +334,10 @@ impl Client {
         // If the last sync happened less than a second ago, sleep for a
         // while to not hammer out requests if the server doesn't respect
         // the sync timeout.
-        if let Some(t) = last_sync_time {
-            if now - *t <= Duration::from_secs(1) {
-                Self::sleep().await;
-            }
+        if let Some(t) = last_sync_time
+            && now - *t <= Duration::from_secs(1)
+        {
+            Self::sleep().await;
         }
 
         *last_sync_time = Some(now);

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -14,12 +14,12 @@
 
 //! Augmented [`ClientBuilder`] that can set up an already logged-in user.
 
-use matrix_sdk_base::{store::RoomLoadSettings, SessionMeta};
-use ruma::{api::MatrixVersion, owned_device_id, owned_user_id, OwnedDeviceId, OwnedUserId};
+use matrix_sdk_base::{SessionMeta, store::RoomLoadSettings};
+use ruma::{OwnedDeviceId, OwnedUserId, api::MatrixVersion, owned_device_id, owned_user_id};
 
 use crate::{
-    authentication::matrix::MatrixSession, config::RequestConfig, Client, ClientBuilder,
-    SessionTokens,
+    Client, ClientBuilder, SessionTokens, authentication::matrix::MatrixSession,
+    config::RequestConfig,
 };
 
 /// An augmented [`ClientBuilder`] that also allows for handling session login.
@@ -261,11 +261,11 @@ pub mod oauth {
     use url::Url;
 
     use crate::{
-        authentication::oauth::{
-            registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
-            ClientId, OAuthSession, UserSession,
-        },
         SessionTokens,
+        authentication::oauth::{
+            ClientId, OAuthSession, UserSession,
+            registration::{ApplicationType, ClientMetadata, Localized, OAuthGrantType},
+        },
     };
 
     /// An OAuth 2.0 `ClientId`, for unit or integration tests.

--- a/crates/matrix-sdk/src/test_utils/mocks/encryption.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/encryption.rs
@@ -18,12 +18,14 @@
 use std::{
     collections::BTreeMap,
     future::Future,
-    sync::{atomic::Ordering, Arc, Mutex},
+    sync::{Arc, Mutex, atomic::Ordering},
 };
 
 use assert_matches2::assert_let;
 use matrix_sdk_test::test_json;
 use ruma::{
+    CrossSigningKeyId, DeviceId, MilliSecondsSinceUnixEpoch, OneTimeKeyAlgorithm, OwnedDeviceId,
+    OwnedOneTimeKeyId, OwnedUserId, UserId,
     api::client::{
         keys::upload_signatures::v3::SignedKeys, to_device::send_event_to_device::v3::Messages,
     },
@@ -32,22 +34,20 @@ use ruma::{
     owned_device_id, owned_user_id,
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
-    CrossSigningKeyId, DeviceId, MilliSecondsSinceUnixEpoch, OneTimeKeyAlgorithm, OwnedDeviceId,
-    OwnedOneTimeKeyId, OwnedUserId, UserId,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{method, path_regex},
     Mock, MockGuard, Request, ResponseTemplate,
+    matchers::{method, path_regex},
 };
 
 use crate::{
+    Client,
     crypto::types::events::room::encrypted::EncryptedToDeviceEvent,
     test_utils::{
         client::MockClientBuilder,
         mocks::{Keys, MatrixMockServer},
     },
-    Client,
 };
 
 /// Stores pending to-device messages for each user and device.
@@ -339,7 +339,7 @@ impl MatrixMockServer {
     pub async fn mock_capture_put_to_device(
         &self,
         sender_user_id: &UserId,
-    ) -> (MockGuard, impl Future<Output = Raw<EncryptedToDeviceEvent>>) {
+    ) -> (MockGuard, impl Future<Output = Raw<EncryptedToDeviceEvent>> + use<>) {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let tx = Arc::new(Mutex::new(Some(tx)));
 

--- a/crates/matrix-sdk/src/test_utils/mocks/encryption.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/encryption.rs
@@ -365,10 +365,10 @@ impl MatrixMockServer {
                 });
                 let event: Raw<EncryptedToDeviceEvent> = serde_json::from_value(event).unwrap();
 
-                if let Ok(mut guard) = tx.lock() {
-                    if let Some(tx) = guard.take() {
-                        let _ = tx.send(event);
-                    }
+                if let Ok(mut guard) = tx.lock()
+                    && let Some(tx) = guard.take()
+                {
+                    let _ = tx.send(event);
                 }
 
                 ResponseTemplate::new(200).set_body_json(&*test_json::EMPTY)

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -19,17 +19,19 @@
 
 use std::{
     collections::BTreeMap,
-    sync::{atomic::AtomicU32, Arc, Mutex},
+    sync::{Arc, Mutex, atomic::AtomicU32},
 };
 
 use js_int::UInt;
 use matrix_sdk_base::deserialized_responses::TimelineEvent;
 use matrix_sdk_test::{
-    test_json, InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, LeftRoomBuilder,
-    SyncResponseBuilder,
+    InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, LeftRoomBuilder,
+    SyncResponseBuilder, test_json,
 };
 use percent_encoding::{AsciiSet, CONTROLS};
 use ruma::{
+    DeviceId, EventId, MilliSecondsSinceUnixEpoch, MxcUri, OwnedDeviceId, OwnedEventId,
+    OwnedOneTimeKeyId, OwnedRoomId, OwnedUserId, RoomId, ServerName, UserId,
     api::client::{
         receipt::create_receipt::v3::ReceiptType,
         room::Visibility,
@@ -42,26 +44,24 @@ use ruma::{
     directory::PublicRoomsChunk,
     encryption::{CrossSigningKey, DeviceKeys, OneTimeKey},
     events::{
-        receipt::ReceiptThread, room::member::RoomMemberEvent, AnyStateEvent, AnySyncTimelineEvent,
-        AnyTimelineEvent, GlobalAccountDataEventType, MessageLikeEventType,
-        RoomAccountDataEventType, StateEventType,
+        AnyStateEvent, AnySyncTimelineEvent, AnyTimelineEvent, GlobalAccountDataEventType,
+        MessageLikeEventType, RoomAccountDataEventType, StateEventType, receipt::ReceiptThread,
+        room::member::RoomMemberEvent,
     },
     media::Method,
     push::RuleKind,
     serde::Raw,
     time::Duration,
-    DeviceId, EventId, MilliSecondsSinceUnixEpoch, MxcUri, OwnedDeviceId, OwnedEventId,
-    OwnedOneTimeKeyId, OwnedRoomId, OwnedUserId, RoomId, ServerName, UserId,
 };
 use serde::Deserialize;
-use serde_json::{from_value, json, Value};
+use serde_json::{Value, from_value, json};
 use tokio::sync::oneshot::{self, Receiver};
 use wiremock::{
+    Mock, MockBuilder, MockGuard, MockServer, Request, Respond, ResponseTemplate, Times,
     matchers::{
         body_json, body_partial_json, header, method, path, path_regex, query_param,
         query_param_is_missing,
     },
-    Mock, MockBuilder, MockGuard, MockServer, Request, Respond, ResponseTemplate, Times,
 };
 
 #[cfg(feature = "e2e-encryption")]
@@ -69,7 +69,7 @@ pub mod encryption;
 pub mod oauth;
 
 use super::client::MockClientBuilder;
-use crate::{room::IncludeRelations, Client, OwnedServerName, Room, SlidingSyncBuilder};
+use crate::{Client, OwnedServerName, Room, SlidingSyncBuilder, room::IncludeRelations};
 
 /// Structure used to store the crypto keys uploaded to the server.
 /// They will be served back to clients when requested.

--- a/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
@@ -21,8 +21,8 @@ use ruma::{
 use serde_json::json;
 use url::Url;
 use wiremock::{
-    matchers::{method, path_regex},
     Mock, MockBuilder, ResponseTemplate,
+    matchers::{method, path_regex},
 };
 
 use super::{MatrixMock, MatrixMockServer, MockEndpoint};

--- a/crates/matrix-sdk/src/test_utils/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mod.rs
@@ -6,7 +6,7 @@ use assert_matches2::assert_let;
 use matrix_sdk_base::{deserialized_responses::TimelineEvent, store::RoomLoadSettings};
 use ruma::{
     api::MatrixVersion,
-    events::{room::message::MessageType, AnySyncMessageLikeEvent, AnySyncTimelineEvent},
+    events::{AnySyncMessageLikeEvent, AnySyncTimelineEvent, room::message::MessageType},
 };
 use url::Url;
 
@@ -15,7 +15,7 @@ pub mod client;
 pub mod mocks;
 
 use self::client::mock_matrix_session;
-use crate::{config::RequestConfig, Client, ClientBuilder};
+use crate::{Client, ClientBuilder, config::RequestConfig};
 
 /// Checks that an event is a message-like text event with the given text.
 #[track_caller]

--- a/crates/matrix-sdk/src/utils/local_server.rs
+++ b/crates/matrix-sdk/src/utils/local_server.rs
@@ -45,10 +45,10 @@ use std::{
 };
 
 use axum::{body::Body, response::IntoResponse, routing::any_service};
-use http::{header, HeaderValue, Method, Request, StatusCode};
+use http::{HeaderValue, Method, Request, StatusCode, header};
 use matrix_sdk_base::{boxed_into_future, locks::Mutex};
 use matrix_sdk_common::executor::spawn;
-use rand::{thread_rng, Rng};
+use rand::{Rng, thread_rng};
 use tokio::{net::TcpListener, sync::oneshot};
 use tower::service_fn;
 use url::Url;

--- a/crates/matrix-sdk/src/utils/mod.rs
+++ b/crates/matrix-sdk/src/utils/mod.rs
@@ -24,15 +24,15 @@ use futures_util::StreamExt;
 #[cfg(feature = "markdown")]
 use ruma::events::room::message::FormattedBody;
 use ruma::{
+    RoomAliasId,
     events::{AnyMessageLikeEventContent, AnyStateEventContent},
     serde::Raw,
-    RoomAliasId,
 };
 use serde_json::value::{RawValue as RawJsonValue, Value as JsonValue};
 #[cfg(feature = "e2e-encryption")]
 use tokio::sync::broadcast;
 #[cfg(feature = "e2e-encryption")]
-use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
+use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 
 #[cfg(feature = "local-server")]
 pub mod local_server;
@@ -73,7 +73,9 @@ impl<T: 'static + Send + Clone> ChannelObservable<T> {
     ///
     /// The current value will always be emitted as the first item in the
     /// stream.
-    pub(crate) fn subscribe(&self) -> impl Stream<Item = Result<T, BroadcastStreamRecvError>> {
+    pub(crate) fn subscribe(
+        &self,
+    ) -> impl Stream<Item = Result<T, BroadcastStreamRecvError>> + use<T> {
         let current_value = self.value.read().unwrap().to_owned();
         let initial_stream = tokio_stream::once(Ok(current_value));
         let broadcast_stream = BroadcastStream::new(self.channel.subscribe());
@@ -233,11 +235,7 @@ pub fn formatted_body_from(
     body: Option<&str>,
     formatted_body: Option<FormattedBody>,
 ) -> Option<FormattedBody> {
-    if formatted_body.is_some() {
-        formatted_body
-    } else {
-        body.and_then(FormattedBody::markdown)
-    }
+    if formatted_body.is_some() { formatted_body } else { body.and_then(FormattedBody::markdown) }
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk/src/widget/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/capabilities.rs
@@ -18,12 +18,12 @@
 use std::{fmt, future::Future};
 
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
-use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::SerializeSeq};
 use tracing::{debug, warn};
 
 use super::{
-    filter::{Filter, FilterInput, ToDeviceEventFilter},
     MessageLikeEventFilter, StateEventFilter,
+    filter::{Filter, FilterInput, ToDeviceEventFilter},
 };
 
 /// Must be implemented by a component that provides functionality of deciding

--- a/crates/matrix-sdk/src/widget/filter.rs
+++ b/crates/matrix-sdk/src/widget/filter.rs
@@ -330,8 +330,10 @@ mod tests {
 
     #[test]
     fn test_text_event_filter_does_not_match_image_event() {
-        assert!(!room_message_text_event_filter()
-            .matches(&FilterInput::message_with_msgtype("m.image")));
+        assert!(
+            !room_message_text_event_filter()
+                .matches(&FilterInput::message_with_msgtype("m.image"))
+        );
     }
 
     #[test]
@@ -351,8 +353,10 @@ mod tests {
 
     #[test]
     fn test_reaction_event_filter_matches_reaction() {
-        assert!(reaction_event_filter()
-            .matches(&message_event(&MessageLikeEventType::Reaction.to_string())));
+        assert!(
+            reaction_event_filter()
+                .matches(&message_event(&MessageLikeEventType::Reaction.to_string()))
+        );
     }
 
     #[test]
@@ -391,20 +395,26 @@ mod tests {
 
     #[test]
     fn self_member_event_filter_does_not_match_unrelated_state_event_with_same_state_key() {
-        assert!(!self_member_event_filter()
-            .matches(&FilterInput::state("io.element.test_state_event", "@self.example.me")));
+        assert!(
+            !self_member_event_filter()
+                .matches(&FilterInput::state("io.element.test_state_event", "@self.example.me"))
+        );
     }
 
     #[test]
     fn test_self_member_event_filter_does_not_match_reaction_event() {
-        assert!(!self_member_event_filter()
-            .matches(&message_event(&MessageLikeEventType::Reaction.to_string())));
+        assert!(
+            !self_member_event_filter()
+                .matches(&message_event(&MessageLikeEventType::Reaction.to_string()))
+        );
     }
 
     #[test]
     fn test_self_member_event_filter_only_matches_specific_state_key() {
-        assert!(!self_member_event_filter()
-            .matches(&FilterInput::state(&StateEventType::RoomMember.to_string(), "")));
+        assert!(
+            !self_member_event_filter()
+                .matches(&FilterInput::state(&StateEventType::RoomMember.to_string(), ""))
+        );
     }
 
     // Tests against an `m.room.member` filter with any `state_key`.
@@ -422,20 +432,26 @@ mod tests {
 
     #[test]
     fn test_member_event_filter_does_not_match_room_name_event() {
-        assert!(!member_event_filter()
-            .matches(&FilterInput::state(&TimelineEventType::RoomName.to_string(), "")));
+        assert!(
+            !member_event_filter()
+                .matches(&FilterInput::state(&TimelineEventType::RoomName.to_string(), ""))
+        );
     }
 
     #[test]
     fn test_member_event_filter_does_not_match_reaction_event() {
-        assert!(!member_event_filter()
-            .matches(&message_event(&MessageLikeEventType::Reaction.to_string())));
+        assert!(
+            !member_event_filter()
+                .matches(&message_event(&MessageLikeEventType::Reaction.to_string()))
+        );
     }
 
     #[test]
     fn test_member_event_filter_matches_any_state_key() {
-        assert!(member_event_filter()
-            .matches(&FilterInput::state(&StateEventType::RoomMember.to_string(), "")));
+        assert!(
+            member_event_filter()
+                .matches(&FilterInput::state(&StateEventType::RoomMember.to_string(), ""))
+        );
     }
 
     // Tests against an `m.room.topic` filter with `state_key = ""`
@@ -448,8 +464,10 @@ mod tests {
 
     #[test]
     fn test_topic_event_filter_does_match() {
-        assert!(topic_event_filter()
-            .matches(&FilterInput::state(&StateEventType::RoomTopic.to_string(), "")));
+        assert!(
+            topic_event_filter()
+                .matches(&FilterInput::state(&StateEventType::RoomTopic.to_string(), ""))
+        );
     }
 
     // Tests against an `m.room.message` filter with `msgtype = m.custom`
@@ -464,32 +482,44 @@ mod tests {
 
     #[test]
     fn test_reaction_event_type_does_not_match_room_message_text_event_filter() {
-        assert!(!room_message_text_event_filter()
-            .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string())));
+        assert!(
+            !room_message_text_event_filter()
+                .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string()))
+        );
     }
 
     #[test]
     fn test_room_message_event_without_msgtype_does_not_match_custom_msgtype_filter() {
-        assert!(!room_message_custom_event_filter()
-            .matches(&FilterInput::message_like(&MessageLikeEventType::RoomMessage.to_string())));
+        assert!(
+            !room_message_custom_event_filter().matches(&FilterInput::message_like(
+                &MessageLikeEventType::RoomMessage.to_string()
+            ))
+        );
     }
 
     #[test]
     fn test_reaction_event_type_does_not_match_room_message_custom_event_filter() {
-        assert!(!room_message_custom_event_filter()
-            .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string())));
+        assert!(
+            !room_message_custom_event_filter()
+                .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string()))
+        );
     }
 
     #[test]
     fn test_room_message_event_type_matches_room_message_event_filter() {
-        assert!(room_message_filter()
-            .matches(&FilterInput::message_like(&MessageLikeEventType::RoomMessage.to_string())));
+        assert!(
+            room_message_filter().matches(&FilterInput::message_like(
+                &MessageLikeEventType::RoomMessage.to_string()
+            ))
+        );
     }
 
     #[test]
     fn test_reaction_event_type_does_not_match_room_message_event_filter() {
-        assert!(!room_message_filter()
-            .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string())));
+        assert!(
+            !room_message_filter()
+                .matches(&FilterInput::message_like(&MessageLikeEventType::Reaction.to_string()))
+        );
     }
     #[test]
     fn test_convert_raw_event_into_message_like_filter_input() {

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -17,19 +17,19 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
 use ruma::{
+    OwnedUserId,
     api::client::{account::request_openid_token, delayed_events::update_delayed_event},
     events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEventContent},
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
-    OwnedUserId,
 };
 use serde::Deserialize;
 use serde_json::value::RawValue as RawJsonValue;
 use tracing::error;
 
 use super::{
-    from_widget::SendEventResponse, incoming::MatrixDriverResponse, Action,
-    MatrixDriverRequestMeta, SendToDeviceEventResponse, WidgetMachine,
+    Action, MatrixDriverRequestMeta, SendToDeviceEventResponse, WidgetMachine,
+    from_widget::SendEventResponse, incoming::MatrixDriverResponse,
 };
 use crate::widget::{Capabilities, StateKeySelector};
 
@@ -80,8 +80,8 @@ where
     pub(crate) fn add_response_handler(
         self,
         response_handler: impl FnOnce(Result<T, crate::Error>, &mut WidgetMachine) -> Vec<Action>
-            + Send
-            + 'static,
+        + Send
+        + 'static,
     ) {
         self.request_meta.response_fn = Some(Box::new(move |response, machine| {
             if let Some(response_data) = response.map(T::from_response).transpose() {

--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -16,24 +16,24 @@ use std::collections::BTreeMap;
 
 use as_variant::as_variant;
 use ruma::{
+    OwnedEventId, OwnedRoomId,
     api::client::{
         delayed_events::{delayed_message_event, delayed_state_event, update_delayed_event},
         error::{ErrorBody, StandardErrorBody},
     },
     events::AnyTimelineEvent,
     serde::Raw,
-    OwnedEventId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
 use super::{
-    driver_req::SendToDeviceRequest, MatrixDriverResponse, SendEventRequest,
-    UpdateDelayedEventRequest,
+    MatrixDriverResponse, SendEventRequest, UpdateDelayedEventRequest,
+    driver_req::SendToDeviceRequest,
 };
 use crate::{
-    widget::{machine::driver_req::FromMatrixDriverResponse, StateKeySelector},
     Error, HttpError, RumaApiError,
+    widget::{StateKeySelector, machine::driver_req::FromMatrixDriverResponse},
 };
 
 #[derive(Deserialize, Debug)]

--- a/crates/matrix-sdk/src/widget/machine/incoming.rs
+++ b/crates/matrix-sdk/src/widget/machine/incoming.rs
@@ -17,16 +17,16 @@ use ruma::{
     events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEvent},
     serde::Raw,
 };
-use serde::{de, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, de};
 use serde_json::value::RawValue as RawJsonValue;
 use uuid::Uuid;
 
 #[cfg(doc)]
 use super::MatrixDriverRequestData;
 use super::{
+    SendToDeviceEventResponse,
     from_widget::{FromWidgetRequest, SendEventResponse},
     to_widget::ToWidgetResponse,
-    SendToDeviceEventResponse,
 };
 use crate::widget::Capabilities;
 

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -20,9 +20,9 @@ use driver_req::{ReadStateRequest, UpdateDelayedEventRequest};
 use from_widget::UpdateDelayedEventResponse;
 use indexmap::IndexMap;
 use ruma::{
+    OwnedRoomId,
     events::{AnyStateEvent, AnyTimelineEvent},
     serde::{JsonObject, Raw},
-    OwnedRoomId,
 };
 use serde::Serialize;
 use serde_json::value::RawValue as RawJsonValue;
@@ -49,11 +49,11 @@ use self::{
 #[cfg(doc)]
 use super::WidgetDriver;
 use super::{
+    Capabilities, StateEventFilter, StateKeySelector,
     capabilities::{SEND_DELAYED_EVENT, UPDATE_DELAYED_EVENT},
     filter::FilterInput,
-    Capabilities, StateEventFilter, StateKeySelector,
 };
-use crate::{widget::Filter, Error, Result};
+use crate::{Error, Result, widget::Filter};
 
 mod driver_req;
 mod from_widget;

--- a/crates/matrix-sdk/src/widget/machine/openid.rs
+++ b/crates/matrix-sdk/src/widget/machine/openid.rs
@@ -15,7 +15,7 @@
 use std::time::Duration;
 
 use ruma::{
-    api::client::account::request_openid_token, authentication::TokenType, OwnedServerName,
+    OwnedServerName, api::client::account::request_openid_token, authentication::TokenType,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/matrix-sdk/src/widget/machine/pending.rs
+++ b/crates/matrix-sdk/src/widget/machine/pending.rs
@@ -15,7 +15,7 @@
 //! A wrapper around a hash map that tracks pending requests and makes sure
 //! that expired requests are removed.
 
-use indexmap::{map::Entry, IndexMap};
+use indexmap::{IndexMap, map::Entry};
 use ruma::time::{Duration, Instant};
 use tracing::warn;
 use uuid::Uuid;

--- a/crates/matrix-sdk/src/widget/machine/tests/api_versions.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/api_versions.rs
@@ -14,7 +14,7 @@
 
 use assert_matches2::assert_let;
 use ruma::owned_room_id;
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 
 use super::WIDGET_ID;
 use crate::widget::machine::{Action, IncomingMessage, WidgetMachine};

--- a/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
@@ -17,12 +17,12 @@ use assert_matches2::assert_let;
 use ruma::owned_room_id;
 use serde_json::{from_value, json};
 
-use super::{parse_msg, WIDGET_ID};
+use super::{WIDGET_ID, parse_msg};
 use crate::widget::{
     capabilities::{READ_EVENT, READ_STATE, READ_TODEVICE},
     machine::{
-        incoming::MatrixDriverResponse, Action, IncomingMessage, MatrixDriverRequestData,
-        WidgetMachine,
+        Action, IncomingMessage, MatrixDriverRequestData, WidgetMachine,
+        incoming::MatrixDriverResponse,
     },
 };
 

--- a/crates/matrix-sdk/src/widget/machine/tests/error.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/error.rs
@@ -16,7 +16,7 @@ use assert_matches2::assert_let;
 use ruma::owned_room_id;
 use serde_json::json;
 
-use super::{capabilities::assert_capabilities_dance, parse_msg, WIDGET_ID};
+use super::{WIDGET_ID, capabilities::assert_capabilities_dance, parse_msg};
 use crate::widget::machine::{Action, IncomingMessage, WidgetMachine};
 
 #[test]

--- a/crates/matrix-sdk/src/widget/machine/tests/openid.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/openid.rs
@@ -16,12 +16,12 @@ use std::time::Duration;
 
 use assert_matches2::assert_let;
 use ruma::{
-    api::client::account::request_openid_token, authentication::TokenType, owned_room_id,
-    ServerName,
+    ServerName, api::client::account::request_openid_token, authentication::TokenType,
+    owned_room_id,
 };
 use serde_json::json;
 
-use super::{parse_msg, WIDGET_ID};
+use super::{WIDGET_ID, parse_msg};
 use crate::widget::machine::{
     Action, IncomingMessage, MatrixDriverRequestData, MatrixDriverResponse, WidgetMachine,
 };

--- a/crates/matrix-sdk/src/widget/machine/to_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/to_widget.rs
@@ -18,11 +18,11 @@ use ruma::{
     events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEvent},
     serde::Raw,
 };
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::value::RawValue as RawJsonValue;
 use tracing::error;
 
-use super::{openid::OpenIdResponse, Action, ToWidgetRequestMeta, WidgetMachine};
+use super::{Action, ToWidgetRequestMeta, WidgetMachine, openid::OpenIdResponse};
 use crate::widget::Capabilities;
 
 /// A handle to a pending `toWidget` request.

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -24,6 +24,7 @@ use matrix_sdk_base::{
     sync::State,
 };
 use ruma::{
+    EventId, OwnedDeviceId, OwnedUserId, RoomId, TransactionId,
     api::client::{
         account::request_openid_token::v3::{Request as OpenIdRequest, Response as OpenIdResponse},
         delayed_events::{self, update_delayed_event::unstable::UpdateAction},
@@ -36,22 +37,21 @@ use ruma::{
         AnySyncTimelineEvent, AnyTimelineEvent, AnyToDeviceEvent, AnyToDeviceEventContent,
         MessageLikeEventType, StateEventType, TimelineEventType, ToDeviceEventType,
     },
-    serde::{from_raw_json_value, Raw},
+    serde::{Raw, from_raw_json_value},
     to_device::DeviceIdOrAllDevices,
-    EventId, OwnedDeviceId, OwnedUserId, RoomId, TransactionId,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::{value::RawValue as RawJsonValue, Value};
+use serde_json::{Value, value::RawValue as RawJsonValue};
 use tokio::sync::{
-    broadcast::{error::RecvError, Receiver},
-    mpsc::{unbounded_channel, UnboundedReceiver},
+    broadcast::{Receiver, error::RecvError},
+    mpsc::{UnboundedReceiver, unbounded_channel},
 };
 use tracing::{error, trace, warn};
 
-use super::{machine::SendEventResponse, StateKeySelector};
+use super::{StateKeySelector, machine::SendEventResponse};
 use crate::{
-    event_handler::EventHandlerDropGuard, room::MessagesOptions, sync::RoomUpdate,
-    widget::machine::SendToDeviceEventResponse, Client, Error, Result, Room,
+    Client, Error, Result, Room, event_handler::EventHandlerDropGuard, room::MessagesOptions,
+    sync::RoomUpdate, widget::machine::SendToDeviceEventResponse,
 };
 
 /// Thin wrapper around a [`Room`] that provides functionality relevant for
@@ -449,7 +449,9 @@ impl MatrixDriver {
                 let devices: Vec<_> = user_devices.devices().collect();
                 // TODO: What to do if the user has no devices?
                 if devices.is_empty() {
-                    warn!("Recipient list contains `AllDevices` but no devices found for user {user_id}.")
+                    warn!(
+                        "Recipient list contains `AllDevices` but no devices found for user {user_id}."
+                    )
                 }
                 // TODO: What if the `recipient_device_ids` has both
                 // `AllDevices` and other devices but one of the  other devices is not found.
@@ -571,7 +573,7 @@ fn attach_room_id_state(raw_ev: &Raw<AnySyncStateEvent>, room_id: &RoomId) -> Ra
 mod tests {
     use insta;
     use ruma::{events::AnyTimelineEvent, room_id, serde::Raw};
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     use super::attach_room_id;
 

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -22,7 +22,7 @@ use futures_util::StreamExt;
 use matrix_sdk_common::executor::spawn;
 use ruma::api::client::delayed_events::DelayParameters;
 use serde::de::{self, Deserialize, Deserializer, Visitor};
-use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::{CancellationToken, DropGuard};
 
@@ -33,7 +33,7 @@ use self::{
     },
     matrix::MatrixDriver,
 };
-use crate::{room::Room, Result};
+use crate::{Result, room::Room};
 
 mod capabilities;
 mod filter;

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -22,7 +22,7 @@
 use serde::Serialize;
 use url::Url;
 
-use super::{url_params, WidgetSettings};
+use super::{WidgetSettings, url_params};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -398,8 +398,8 @@ mod tests {
     use url::Url;
 
     use crate::widget::{
-        settings::element_call::{HeaderStyle, VirtualElementCallWidgetConfig},
         ClientProperties, Intent, WidgetSettings,
+        settings::element_call::{HeaderStyle, VirtualElementCallWidgetConfig},
     };
 
     const WIDGET_ID: &str = "1/@#w23";
@@ -494,16 +494,17 @@ mod tests {
                 &controlledAudioDevices=false\
         ";
 
-        let mut url = get_element_call_widget_settings(None, false, false, false, None, false)
-            .raw_url()
-            .clone();
-        let mut gen = Url::parse(CONVERTED_URL).unwrap();
-        assert_eq!(get_query_sets(&url).unwrap(), get_query_sets(&gen).unwrap());
-        url.set_fragment(None);
-        url.set_query(None);
-        gen.set_fragment(None);
-        gen.set_query(None);
-        assert_eq!(url, gen);
+        let mut generated_url =
+            get_element_call_widget_settings(None, false, false, false, None, false)
+                .raw_url()
+                .clone();
+        let mut expected_url = Url::parse(CONVERTED_URL).unwrap();
+        assert_eq!(get_query_sets(&generated_url).unwrap(), get_query_sets(&expected_url).unwrap());
+        generated_url.set_fragment(None);
+        generated_url.set_query(None);
+        expected_url.set_fragment(None);
+        expected_url.set_query(None);
+        assert_eq!(generated_url, expected_url);
     }
 
     #[test]
@@ -556,18 +557,17 @@ mod tests {
                 &hideScreensharing=false\
                 &controlledAudioDevices=false\
         ";
-        let gen = build_url_from_widget_settings(get_element_call_widget_settings(
-            None, false, false, false, None, false,
-        ));
-
-        let mut url = Url::parse(&gen).unwrap();
-        let mut gen = Url::parse(CONVERTED_URL).unwrap();
-        assert_eq!(get_query_sets(&url).unwrap(), get_query_sets(&gen).unwrap());
-        url.set_fragment(None);
-        url.set_query(None);
-        gen.set_fragment(None);
-        gen.set_query(None);
-        assert_eq!(url, gen);
+        let mut generated_url = Url::parse(&build_url_from_widget_settings(
+            get_element_call_widget_settings(None, false, false, false, None, false),
+        ))
+        .unwrap();
+        let mut expected_url = Url::parse(CONVERTED_URL).unwrap();
+        assert_eq!(get_query_sets(&generated_url).unwrap(), get_query_sets(&expected_url).unwrap());
+        generated_url.set_fragment(None);
+        generated_url.set_query(None);
+        expected_url.set_fragment(None);
+        expected_url.set_query(None);
+        assert_eq!(generated_url, expected_url);
     }
 
     #[test]
@@ -597,18 +597,17 @@ mod tests {
                 &sentryEnvironment=SENTRY_ENV\
                 &controlledAudioDevices=false\
         ";
-        let gen = build_url_from_widget_settings(get_element_call_widget_settings(
-            None, true, true, true, None, false,
-        ));
-
-        let mut url = Url::parse(&gen).unwrap();
-        let mut gen = Url::parse(CONVERTED_URL).unwrap();
-        assert_eq!(get_query_sets(&url).unwrap(), get_query_sets(&gen).unwrap());
-        url.set_fragment(None);
-        url.set_query(None);
-        gen.set_fragment(None);
-        gen.set_query(None);
-        assert_eq!(url, gen);
+        let mut generated_url = Url::parse(&build_url_from_widget_settings(
+            get_element_call_widget_settings(None, true, true, true, None, false),
+        ))
+        .unwrap();
+        let mut original_url = Url::parse(CONVERTED_URL).unwrap();
+        assert_eq!(get_query_sets(&generated_url).unwrap(), get_query_sets(&original_url).unwrap());
+        generated_url.set_fragment(None);
+        generated_url.set_query(None);
+        original_url.set_fragment(None);
+        original_url.set_query(None);
+        assert_eq!(generated_url, original_url);
     }
 
     #[test]

--- a/crates/matrix-sdk/src/widget/settings/mod.rs
+++ b/crates/matrix-sdk/src/widget/settings/mod.rs
@@ -14,8 +14,8 @@
 
 use language_tags::LanguageTag;
 use ruma::{
-    api::client::profile::{get_profile, AvatarUrl, DisplayName},
     DeviceId, RoomId, UserId,
+    api::client::profile::{AvatarUrl, DisplayName, get_profile},
 };
 use url::Url;
 

--- a/crates/matrix-sdk/src/widget/settings/url_params.rs
+++ b/crates/matrix-sdk/src/widget/settings/url_params.rs
@@ -87,7 +87,7 @@ pub fn replace_properties(url: &mut Url, props: QueryProperties) {
 mod tests {
     use url::Url;
 
-    use super::{replace_properties, QueryProperties};
+    use super::{QueryProperties, replace_properties};
 
     const EXAMPLE_URL: &str = "\
         https://my.widget.org/custom/path/using/$matrix_display_name/in/it\

--- a/crates/matrix-sdk/tests/integration/account.rs
+++ b/crates/matrix-sdk/tests/integration/account.rs
@@ -1,8 +1,8 @@
 use matrix_sdk_test::async_test;
 use serde_json::json;
 use wiremock::{
-    matchers::{method, path},
     Mock, Request, ResponseTemplate,
+    matchers::{method, path},
 };
 
 use crate::logged_in_client_with_server;
@@ -33,11 +33,9 @@ async fn test_account_deactivation() {
             .mount_as_scoped(&server)
             .await;
 
-        assert!(client
-            .account()
-            .deactivate(Some("FirstIdentityServer"), None, false)
-            .await
-            .is_ok());
+        assert!(
+            client.account().deactivate(Some("FirstIdentityServer"), None, false).await.is_ok()
+        );
     }
 
     {

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -136,28 +136,28 @@ async fn test_delete_devices() {
 
     let devices = &[device_id!("DEVICEID").to_owned()];
 
-    if let Err(e) = client.delete_devices(devices, None).await {
-        if let Some(info) = e.as_uiaa_response() {
-            let mut auth_parameters = BTreeMap::new();
+    if let Err(e) = client.delete_devices(devices, None).await
+        && let Some(info) = e.as_uiaa_response()
+    {
+        let mut auth_parameters = BTreeMap::new();
 
-            let identifier = json!({
-                "type": "m.id.user",
-                "user": "example",
-            });
-            auth_parameters.insert("identifier".to_owned(), identifier);
-            auth_parameters.insert("password".to_owned(), "wordpass".into());
+        let identifier = json!({
+            "type": "m.id.user",
+            "user": "example",
+        });
+        auth_parameters.insert("identifier".to_owned(), identifier);
+        auth_parameters.insert("password".to_owned(), "wordpass".into());
 
-            let auth_data = uiaa::AuthData::Password(assign!(
-                uiaa::Password::new(
-                    uiaa::UserIdentifier::UserIdOrLocalpart("example".to_owned()),
-                    "wordpass".to_owned(),
-                ), {
-                    session: info.session.clone(),
-                }
-            ));
+        let auth_data = uiaa::AuthData::Password(assign!(
+            uiaa::Password::new(
+                uiaa::UserIdentifier::UserIdOrLocalpart("example".to_owned()),
+                "wordpass".to_owned(),
+            ), {
+                session: info.session.clone(),
+            }
+        ));
 
-            client.delete_devices(devices, Some(auth_data)).await.unwrap();
-        }
+        client.delete_devices(devices, Some(auth_data)).await.unwrap();
     }
 }
 

--- a/crates/matrix-sdk/tests/integration/encryption.rs
+++ b/crates/matrix-sdk/tests/integration/encryption.rs
@@ -19,8 +19,8 @@ async fn mock_secret_store_with_backup_key(
 ) {
     use serde_json::json;
     use wiremock::{
-        matchers::{header, method, path},
         Mock, ResponseTemplate,
+        matchers::{header, method, path},
     };
 
     Mock::given(method("GET"))

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -16,8 +16,9 @@ use std::{fs::File, io::Write, sync::Arc, time::Duration};
 
 use anyhow::Result;
 use assert_matches::assert_matches;
-use futures_util::{pin_mut, FutureExt, StreamExt};
+use futures_util::{FutureExt, StreamExt, pin_mut};
 use matrix_sdk::{
+    Client, SessionMeta,
     authentication::matrix::MatrixSession,
     config::RequestConfig,
     crypto::{
@@ -26,38 +27,38 @@ use matrix_sdk::{
         types::EventEncryptionAlgorithm,
     },
     encryption::{
-        backups::{futures::SteadyStateError, BackupState, UploadState},
-        secret_storage::SecretStore,
         BackupDownloadStrategy, EncryptionSettings,
+        backups::{BackupState, UploadState, futures::SteadyStateError},
+        secret_storage::SecretStore,
     },
     test_utils::{
         client::mock_session_tokens, no_retry_test_client_with_server,
         test_client_builder_with_server,
     },
-    Client, SessionMeta,
 };
 use matrix_sdk_base::crypto::olm::OutboundGroupSession;
 use matrix_sdk_common::timeout::timeout;
-use matrix_sdk_test::{async_test, JoinedRoomBuilder, SyncResponseBuilder, TestResult};
+use matrix_sdk_test::{JoinedRoomBuilder, SyncResponseBuilder, TestResult, async_test};
 use ruma::{
+    EventId, RoomId, TransactionId,
     api::client::room::create_room::v3::Request as CreateRoomRequest,
     assign, device_id, event_id,
     events::room::message::{RoomMessageEvent, RoomMessageEventContent},
-    owned_device_id, owned_user_id, room_id, user_id, EventId, RoomId, TransactionId,
+    owned_device_id, owned_user_id, room_id, user_id,
 };
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tempfile::tempdir;
 use tokio::spawn;
 use vodozemac::{
-    olm::IdentityKeys, Curve25519PublicKey, Curve25519SecretKey, Ed25519PublicKey, Ed25519SecretKey,
+    Curve25519PublicKey, Curve25519SecretKey, Ed25519PublicKey, Ed25519SecretKey, olm::IdentityKeys,
 };
 use wiremock::{
-    matchers::{header, method, path, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path, path_regex},
 };
 
 use crate::{
-    encryption::{mock_secret_store_with_backup_key, BACKUP_DECRYPTION_KEY_BASE64},
+    encryption::{BACKUP_DECRYPTION_KEY_BASE64, mock_secret_store_with_backup_key},
     mock_sync,
 };
 
@@ -1384,8 +1385,8 @@ async fn test_enable_from_secret_storage_and_download_after_utd() -> TestResult 
 /// Even if we have a key to the session, we should still attempt a backup
 /// download if the UTD message has a lower megolm ratchet index than we have.
 #[async_test]
-async fn test_enable_from_secret_storage_and_download_after_utd_from_old_message_index(
-) -> TestResult {
+async fn test_enable_from_secret_storage_and_download_after_utd_from_old_message_index()
+-> TestResult {
     let room_id = room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost");
     let event_id = event_id!("$JbFHtZpEJiH8uaajZjPLz0QUZc1xtBR9rPGBOjF6WFM");
 

--- a/crates/matrix-sdk/tests/integration/encryption/recovery.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/recovery.rs
@@ -17,28 +17,28 @@ use std::sync::{Arc, Mutex};
 use assert_matches2::assert_let;
 use futures_util::StreamExt;
 use matrix_sdk::{
+    Client,
     authentication::matrix::MatrixSession,
     config::RequestConfig,
     encryption::{
+        BackupDownloadStrategy, CrossSigningResetAuthType,
         backups::BackupState,
         recovery::{EnableProgress, RecoveryState},
-        BackupDownloadStrategy, CrossSigningResetAuthType,
     },
     test_utils::{
         client::mock_session_tokens, no_retry_test_client_with_server,
         test_client_builder_with_server,
     },
-    Client,
 };
 use matrix_sdk_base::SessionMeta;
 use matrix_sdk_test::async_test;
-use ruma::{api::client::uiaa, device_id, user_id, UserId};
+use ruma::{UserId, api::client::uiaa, device_id, user_id};
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio::spawn;
 use wiremock::{
-    matchers::{header, method, path, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path, path_regex},
 };
 
 use crate::{encryption::mock_secret_store_with_backup_key, logged_in_client_with_server};

--- a/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
@@ -9,19 +9,19 @@ use matrix_sdk::{
 use matrix_sdk_base::SessionMeta;
 use matrix_sdk_test::async_test;
 use ruma::{
-    device_id,
+    UserId, device_id,
     events::{
         secret::request::SecretName,
         secret_storage::{
             default_key::SecretStorageDefaultKeyEventContent, secret::SecretEventContent,
         },
     },
-    user_id, UserId,
+    user_id,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path, path_regex},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path, path_regex},
 };
 
 use crate::logged_in_client_with_server;

--- a/crates/matrix-sdk/tests/integration/encryption/shared_history.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/shared_history.rs
@@ -6,7 +6,7 @@ use matrix_sdk::{
     test_utils::mocks::MatrixMockServer,
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, InvitedRoomBuilder, JoinedRoomBuilder, StateTestEvent,
+    InvitedRoomBuilder, JoinedRoomBuilder, StateTestEvent, async_test, event_factory::EventFactory,
 };
 use ruma::{
     device_id, event_id, events::room::message::RoomMessageEventContent, mxc_uri, room_id, user_id,

--- a/crates/matrix-sdk/tests/integration/encryption/state_events.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/state_events.rs
@@ -1,8 +1,8 @@
 use matrix_sdk::{encryption::EncryptionSettings, test_utils::mocks::MatrixMockServer};
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent};
+use matrix_sdk_test::{JoinedRoomBuilder, StateTestEvent, async_test, event_factory::EventFactory};
 use ruma::{
     device_id, event_id,
-    events::{room::topic::RoomTopicEventContent, StateEventType},
+    events::{StateEventType, room::topic::RoomTopicEventContent},
     room_id, user_id,
 };
 use serde_json::json;

--- a/crates/matrix-sdk/tests/integration/encryption/to_device.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/to_device.rs
@@ -14,8 +14,8 @@ use matrix_sdk_test::{async_test, test_json};
 use ruma::{events::AnyToDeviceEvent, serde::Raw};
 use serde_json::json;
 use wiremock::{
-    matchers::{method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{method, path_regex},
 };
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/encryption/verification.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/verification.rs
@@ -1,16 +1,16 @@
 use assert_matches2::assert_matches;
 use futures_util::FutureExt;
 use matrix_sdk::{
+    Client,
     encryption::VerificationState,
     test_utils::{logged_in_client_with_server, mocks::MatrixMockServer},
-    Client,
 };
 use matrix_sdk_test::async_test;
 use ruma::{owned_device_id, owned_user_id, user_id};
 use serde_json::json;
 use wiremock::{
-    matchers::{body_json, method, path},
     Mock, ResponseTemplate,
+    matchers::{body_json, method, path},
 };
 
 async fn bootstrap_cross_signing(client: &Client) {

--- a/crates/matrix-sdk/tests/integration/event_cache/mod.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/mod.rs
@@ -19,19 +19,19 @@ use matrix_sdk::{
     },
 };
 use matrix_sdk_base::event_cache::{
-    store::{EventCacheStore, MemoryStore},
     Gap,
+    store::{EventCacheStore, MemoryStore},
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE, BOB};
+use matrix_sdk_test::{ALICE, BOB, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use ruma::{
-    event_id,
+    EventId, event_id,
     events::{
-        room::message::RoomMessageEventContentWithoutRelation, AnySyncMessageLikeEvent,
-        AnySyncTimelineEvent, TimelineEventType,
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, TimelineEventType,
+        room::message::RoomMessageEventContentWithoutRelation,
     },
     room_id,
     room_version_rules::RedactionRules,
-    user_id, EventId,
+    user_id,
 };
 use tokio::{spawn, sync::broadcast, time::sleep};
 
@@ -1329,10 +1329,9 @@ async fn test_dont_delete_gap_that_wasnt_inserted() {
     server
         .sync_room(
             &client,
-            JoinedRoomBuilder::new(room_id).add_timeline_bulk(vec![f
-                .text_msg("sup")
-                .event_id(event_id!("$3"))
-                .into_raw_sync()]),
+            JoinedRoomBuilder::new(room_id).add_timeline_bulk(vec![
+                f.text_msg("sup").event_id(event_id!("$3")).into_raw_sync(),
+            ]),
         )
         .await;
 
@@ -1483,10 +1482,9 @@ async fn test_apply_redaction_on_an_in_store_event() {
                     // … and its item
                     Update::PushItems {
                         at: Position::new(ChunkIdentifier::new(0), 0),
-                        items: vec![event_factory
-                            .text_msg("foo")
-                            .event_id(event_id!("$ev0"))
-                            .into_event()],
+                        items: vec![
+                            event_factory.text_msg("foo").event_id(event_id!("$ev0")).into_event(),
+                        ],
                     },
                     // chunk #2
                     Update::NewItemsChunk {
@@ -1497,10 +1495,9 @@ async fn test_apply_redaction_on_an_in_store_event() {
                     // … and its item
                     Update::PushItems {
                         at: Position::new(ChunkIdentifier::new(1), 0),
-                        items: vec![event_factory
-                            .text_msg("foo")
-                            .event_id(event_id!("$ev1"))
-                            .into_event()],
+                        items: vec![
+                            event_factory.text_msg("foo").event_id(event_id!("$ev1")).into_event(),
+                        ],
                     },
                 ],
             )

--- a/crates/matrix-sdk/tests/integration/event_cache/threads.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads.rs
@@ -4,7 +4,7 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use imbl::Vector;
 use matrix_sdk::{
-    assert_let_timeout,
+    Client, ThreadingSupport, assert_let_timeout,
     deserialized_responses::{ThreadSummaryStatus, TimelineEvent},
     event_cache::{RoomEventCacheSubscriber, RoomEventCacheUpdate, ThreadEventCacheUpdate},
     sleep::sleep,
@@ -12,16 +12,15 @@ use matrix_sdk::{
         assert_event_matches_msg,
         mocks::{MatrixMockServer, RoomRelationsResponseTemplate},
     },
-    Client, ThreadingSupport,
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE};
+use matrix_sdk_test::{ALICE, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use ruma::{
-    event_id,
+    OwnedEventId, OwnedRoomId, event_id,
     events::{AnySyncTimelineEvent, Mentions},
     push::{ConditionalPushRule, Ruleset},
     room_id,
     serde::Raw,
-    user_id, OwnedEventId, OwnedRoomId,
+    user_id,
 };
 use tokio::sync::broadcast;
 
@@ -415,11 +414,12 @@ async fn test_deduplication() {
     server
         .sync_room(
             &client,
-            JoinedRoomBuilder::new(room_id).add_timeline_bulk(vec![f
-                .text_msg("hoy!")
-                .in_thread(thread_root, first_reply_event_id)
-                .event_id(second_reply_event_id)
-                .into_raw_sync()]),
+            JoinedRoomBuilder::new(room_id).add_timeline_bulk(vec![
+                f.text_msg("hoy!")
+                    .in_thread(thread_root, first_reply_event_id)
+                    .event_id(second_reply_event_id)
+                    .into_raw_sync(),
+            ]),
         )
         .await;
 

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -3,8 +3,8 @@
 use matrix_sdk::test_utils::logged_in_client_with_server;
 use serde::Serialize;
 use wiremock::{
-    matchers::{header, method, path, query_param, query_param_is_missing},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path, query_param, query_param_is_missing},
 };
 
 mod account;

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -2,34 +2,35 @@ use std::{collections::BTreeMap, sync::Mutex};
 
 use assert_matches::assert_matches;
 use matrix_sdk::{
+    AuthApi, AuthSession, Client, RumaApiError, SessionTokens,
     authentication::matrix::MatrixSession,
     config::RequestConfig,
     test_utils::{logged_in_client_with_server, no_retry_test_client_with_server},
-    AuthApi, AuthSession, Client, RumaApiError, SessionTokens,
 };
 use matrix_sdk_base::SessionMeta;
 use matrix_sdk_test::{async_test, test_json};
 use ruma::{
+    OwnedUserId,
     api::{
+        MatrixVersion,
         client::{
             self as client_api,
-            account::register::{v3::Request as RegistrationRequest, RegistrationKind},
+            account::register::{RegistrationKind, v3::Request as RegistrationRequest},
             keys::upload_signatures::v3::SignedKeys,
             session::get_login_types::v3::LoginType,
             uiaa::{self, AuthData, UserIdentifier},
         },
-        MatrixVersion,
     },
     assign, device_id,
     encryption::CrossSigningKey,
     serde::Raw,
-    user_id, OwnedUserId,
+    user_id,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 use url::Url;
 use wiremock::{
-    matchers::{method, path},
     Mock, MockServer, Request, ResponseTemplate,
+    matchers::{method, path},
 };
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -6,7 +6,7 @@ use matrix_sdk_test::async_test;
 use ruma::{
     api::client::media::get_content_thumbnail::v3::Method,
     assign,
-    events::room::{message::ImageMessageEventContent, ImageInfo, MediaSource},
+    events::room::{ImageInfo, MediaSource, message::ImageMessageEventContent},
     mxc_uri, owned_mxc_uri, uint,
 };
 

--- a/crates/matrix-sdk/tests/integration/notification.rs
+++ b/crates/matrix-sdk/tests/integration/notification.rs
@@ -5,10 +5,10 @@ use matrix_sdk::{
 };
 use matrix_sdk_base::deserialized_responses::RawAnySyncOrStrippedTimelineEvent;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, stripped_state_event, sync_state_event, test_json,
-    InvitedRoomBuilder, JoinedRoomBuilder, SyncResponseBuilder,
+    InvitedRoomBuilder, JoinedRoomBuilder, SyncResponseBuilder, async_test,
+    event_factory::EventFactory, stripped_state_event, sync_state_event, test_json,
 };
-use ruma::{event_id, events::StateEventType, room_id, serde::Raw, user_id, OwnedRoomId};
+use ruma::{OwnedRoomId, event_id, events::StateEventType, room_id, serde::Raw, user_id};
 use stream_assert::{assert_pending, assert_ready};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -6,6 +6,7 @@ use std::{
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use matrix_sdk::{
+    HttpError, RefreshTokenError, SessionChange, SessionTokens,
     authentication::matrix::MatrixSession,
     config::RequestConfig,
     executor::spawn,
@@ -16,21 +17,20 @@ use matrix_sdk::{
         mocks::{LoginResponseTemplate200, MatrixMockServer},
         no_retry_test_client_with_server, test_client_builder_with_server,
     },
-    HttpError, RefreshTokenError, SessionChange, SessionTokens,
 };
 use matrix_sdk_test::{async_test, test_json};
 use ruma::{
     api::{
-        client::{account::register, error::ErrorKind},
         MatrixVersion,
+        client::{account::register, error::ErrorKind},
     },
     assign, owned_device_id, owned_user_id,
 };
 use serde_json::json;
 use tokio::sync::{broadcast::error::TryRecvError, mpsc};
 use wiremock::{
-    matchers::{body_partial_json, header, method, path},
     Mock, ResponseTemplate,
+    matchers::{body_partial_json, header, method, path},
 };
 
 fn session() -> MatrixSession {

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -6,12 +6,12 @@ use matrix_sdk::{
     room::reply::{EnforceThread, Reply},
     test_utils::mocks::MatrixMockServer,
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, ALICE, DEFAULT_TEST_ROOM_ID};
+use matrix_sdk_test::{ALICE, DEFAULT_TEST_ROOM_ID, async_test, event_factory::EventFactory};
 use ruma::{
     event_id,
     events::{
-        room::{message::ReplyWithinThread, MediaSource},
         Mentions,
+        room::{MediaSource, message::ReplyWithinThread},
     },
     mxc_uri, owned_mxc_uri, owned_user_id, uint,
 };

--- a/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, UNIX_EPOCH};
 
-use futures_util::{pin_mut, FutureExt, StreamExt as _};
+use futures_util::{FutureExt, StreamExt as _, pin_mut};
 use js_int::uint;
 use matrix_sdk::{
     config::{SyncSettings, SyncToken},
@@ -8,22 +8,22 @@ use matrix_sdk::{
     test_utils::mocks::MatrixMockServer,
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, mocks::mock_encryption_state, test_json,
-    JoinedRoomBuilder, SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
+    DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, SyncResponseBuilder, async_test,
+    event_factory::EventFactory, mocks::mock_encryption_state, test_json,
 };
 use ruma::{
-    event_id,
+    EventId, MilliSecondsSinceUnixEpoch, event_id,
     events::{
         beacon::BeaconEventContent, beacon_info::BeaconInfoEventContent, location::AssetType,
     },
     owned_event_id, room_id,
     time::SystemTime,
-    user_id, EventId, MilliSecondsSinceUnixEpoch,
+    user_id,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{body_partial_json, header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{body_partial_json, header, method, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};
@@ -395,12 +395,13 @@ async fn test_observing_live_location_does_not_return_own_beacon_updates() {
 
     let f = EventFactory::new().room(room_id);
 
-    let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![f
-        .event(BeaconInfoEventContent::new(None, Duration::from_secs(60), false, None))
-        .event_id(event_id)
-        .sender(user_id)
-        .state_key(user_id)
-        .into_raw()]);
+    let joined_room_builder = JoinedRoomBuilder::new(room_id).add_state_bulk(vec![
+        f.event(BeaconInfoEventContent::new(None, Duration::from_secs(60), false, None))
+            .event_id(event_id)
+            .sender(user_id)
+            .state_key(user_id)
+            .into_raw(),
+    ]);
 
     let room = server.sync_room(&client, joined_room_builder).await;
 

--- a/crates/matrix-sdk/tests/integration/room/beacon_info/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon_info/mod.rs
@@ -2,16 +2,15 @@ use std::time::Duration;
 
 use js_int::uint;
 use matrix_sdk::config::{SyncSettings, SyncToken};
-use matrix_sdk_test::{async_test, test_json, DEFAULT_TEST_ROOM_ID};
+use matrix_sdk_test::{DEFAULT_TEST_ROOM_ID, async_test, test_json};
 use ruma::{
-    event_id,
-    events::{location::AssetType, AnySyncStateEvent, StateEventType},
-    MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch, event_id,
+    events::{AnySyncStateEvent, StateEventType, location::AssetType},
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{body_partial_json, header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{body_partial_json, header, method, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};

--- a/crates/matrix-sdk/tests/integration/room/calls.rs
+++ b/crates/matrix-sdk/tests/integration/room/calls.rs
@@ -2,9 +2,9 @@ use std::sync::{Arc, Mutex};
 
 use assert_matches2::assert_matches;
 use matrix_sdk::{room::calls::CallError, test_utils::mocks::MatrixMockServer};
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent};
+use matrix_sdk_test::{JoinedRoomBuilder, StateTestEvent, async_test, event_factory::EventFactory};
 use ruma::{
-    events::rtc::notification::NotificationType, owned_event_id, room_id, user_id, OwnedUserId,
+    OwnedUserId, events::rtc::notification::NotificationType, owned_event_id, room_id, user_id,
 };
 use tokio::spawn;
 

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -3,29 +3,29 @@ use std::{collections::BTreeMap, iter, time::Duration};
 use assert_matches2::{assert_let, assert_matches};
 use js_int::uint;
 use matrix_sdk::{
+    RoomDisplayName, RoomMemberships,
     config::{SyncSettings, SyncToken},
     room::RoomMember,
     test_utils::mocks::MatrixMockServer,
-    RoomDisplayName, RoomMemberships,
 };
 use matrix_sdk_test::{
-    async_test, bulk_room_members, event_factory::EventFactory, sync_state_event, test_json,
-    JoinedRoomBuilder, LeftRoomBuilder, StateTestEvent, SyncResponseBuilder, BOB,
-    DEFAULT_TEST_ROOM_ID,
+    BOB, DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, LeftRoomBuilder, StateTestEvent,
+    SyncResponseBuilder, async_test, bulk_room_members, event_factory::EventFactory,
+    sync_state_event, test_json,
 };
 use ruma::{
     event_id,
     events::{
+        AnySyncStateEvent, AnySyncTimelineEvent, StateEventType,
         direct::DirectUserIdentifier,
         room::{avatar, member::MembershipState, message::RoomMessageEventContent},
-        AnySyncStateEvent, AnySyncTimelineEvent, StateEventType,
     },
     mxc_uri, owned_room_alias_id, room_id, room_version_id, user_id,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{body_json, header, method, path, path_regex},
     Mock, ResponseTemplate,
+    matchers::{body_json, header, method, path, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -10,43 +10,42 @@ use futures_util::{future::join_all, pin_mut};
 use matrix_sdk::{
     assert_next_with_timeout, assert_recv_with_timeout,
     config::SyncSettings,
-    room::{edit::EditedContent, Receipts, ReportedContentScore, RoomMemberRole},
+    room::{Receipts, ReportedContentScore, RoomMemberRole, edit::EditedContent},
     test_utils::mocks::MatrixMockServer,
 };
 use matrix_sdk_base::{EncryptionState, RoomMembersUpdate, RoomState};
 use matrix_sdk_common::executor::spawn;
 use matrix_sdk_test::{
-    async_test,
+    DEFAULT_TEST_ROOM_ID, InvitedRoomBuilder, JoinedRoomBuilder, RoomAccountDataTestEvent,
+    SyncResponseBuilder, async_test,
     event_factory::EventFactory,
     mocks::mock_encryption_state,
     test_json::{self, sync::CUSTOM_ROOM_POWER_LEVELS},
-    InvitedRoomBuilder, JoinedRoomBuilder, RoomAccountDataTestEvent, SyncResponseBuilder,
-    DEFAULT_TEST_ROOM_ID,
 };
 use ruma::{
+    OwnedUserId, RoomVersionId, TransactionId,
     api::client::{
         membership::Invite3pidInit, receipt::create_receipt::v3::ReceiptType,
         room::upgrade_room::v3::Request as UpgradeRoomRequest,
     },
     assign, event_id,
     events::{
+        RoomAccountDataEventType, TimelineEventType,
         direct::DirectUserIdentifier,
         receipt::ReceiptThread,
         room::{
             member::MembershipState,
             message::{RoomMessageEventContent, RoomMessageEventContentWithoutRelation},
         },
-        RoomAccountDataEventType, TimelineEventType,
     },
-    int, mxc_uri, owned_event_id, room_id, thirdparty, user_id, OwnedUserId, RoomVersionId,
-    TransactionId,
+    int, mxc_uri, owned_event_id, room_id, thirdparty, user_id,
 };
 use serde_json::json;
 use stream_assert::assert_pending;
 use tokio::time::sleep;
 use wiremock::{
-    matchers::{body_json, body_partial_json, header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{body_json, body_partial_json, header, method, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};

--- a/crates/matrix-sdk/tests/integration/room/left.rs
+++ b/crates/matrix-sdk/tests/integration/room/left.rs
@@ -4,18 +4,19 @@ use assert_matches2::assert_matches;
 use matrix_sdk::{config::SyncSettings, linked_chunk::LinkedChunkId};
 use matrix_sdk_base::{RoomInfoNotableUpdateReasons, RoomState};
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, test_json, LeftRoomBuilder, SyncResponseBuilder,
-    DEFAULT_TEST_ROOM_ID,
+    DEFAULT_TEST_ROOM_ID, LeftRoomBuilder, SyncResponseBuilder, async_test,
+    event_factory::EventFactory, test_json,
 };
 use ruma::{
+    OwnedRoomOrAliasId,
     events::direct::{DirectEventContent, DirectUserIdentifier},
-    user_id, OwnedRoomOrAliasId,
+    user_id,
 };
 use serde_json::json;
 use tokio::task::yield_now;
 use wiremock::{
-    matchers::{header, method, path, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};

--- a/crates/matrix-sdk/tests/integration/room/notification_mode.rs
+++ b/crates/matrix-sdk/tests/integration/room/notification_mode.rs
@@ -4,8 +4,8 @@ use assert_matches::assert_matches;
 use matrix_sdk::{config::SyncSettings, notification_settings::RoomNotificationMode};
 use matrix_sdk_base::RoomState;
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, InvitedRoomBuilder, JoinedRoomBuilder,
-    SyncResponseBuilder, DEFAULT_TEST_ROOM_ID,
+    DEFAULT_TEST_ROOM_ID, InvitedRoomBuilder, JoinedRoomBuilder, SyncResponseBuilder, async_test,
+    event_factory::EventFactory,
 };
 use ruma::{
     push::{Action, ConditionalPushRule, NewSimplePushRule, PatternedPushRule, Ruleset, Tweak},
@@ -13,8 +13,8 @@ use ruma::{
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};

--- a/crates/matrix-sdk/tests/integration/room/spaces.rs
+++ b/crates/matrix-sdk/tests/integration/room/spaces.rs
@@ -2,17 +2,17 @@ use std::time::Duration;
 
 use assert_matches2::assert_let;
 use futures_util::StreamExt;
-use matrix_sdk::{config::SyncSettings, room::ParentSpace, Client};
-use matrix_sdk_test::{async_test, test_json, DEFAULT_TEST_ROOM_ID};
+use matrix_sdk::{Client, config::SyncSettings, room::ParentSpace};
+use matrix_sdk_test::{DEFAULT_TEST_ROOM_ID, async_test, test_json};
 use once_cell::sync::Lazy;
-use ruma::{room_id, RoomId};
-use serde_json::{json, Value as JsonValue};
+use ruma::{RoomId, room_id};
+use serde_json::{Value as JsonValue, json};
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
-use crate::{logged_in_client_with_server, mock_sync, MockServer};
+use crate::{MockServer, logged_in_client_with_server, mock_sync};
 
 pub static DEFAULT_TEST_SPACE_ID: Lazy<&RoomId> =
     Lazy::new(|| room_id!("!hIMjEx205EXNyjVPCV:localhost"));
@@ -173,8 +173,8 @@ async fn test_parent_space_undeserializable() {
     let (client, server) = logged_in_client_with_server().await;
 
     let mut sync = PARENT_SPACE_SYNC.clone();
-    sync["rooms"]["join"][DEFAULT_TEST_ROOM_ID.as_str()]["timeline"]["events"][0]["content"]
-        ["canonical"] = JsonValue::from("true"); // invalid, must be a boolean
+    sync["rooms"]["join"][DEFAULT_TEST_ROOM_ID.as_str()]["timeline"]["events"][0]["content"]["canonical"] =
+        JsonValue::from("true"); // invalid, must be a boolean
     initial_sync_with_m_space_parent(&client, &server, &sync).await;
 
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();

--- a/crates/matrix-sdk/tests/integration/room/tags.rs
+++ b/crates/matrix-sdk/tests/integration/room/tags.rs
@@ -1,20 +1,21 @@
 use std::{collections::BTreeMap, ops::Not, time::Duration};
 
 use matrix_sdk::{
-    config::{SyncSettings, SyncToken},
     Client, Room,
+    config::{SyncSettings, SyncToken},
 };
 use matrix_sdk_test::{
-    async_test, test_json, JoinedRoomBuilder, RoomAccountDataTestEvent, SyncResponseBuilder,
+    JoinedRoomBuilder, RoomAccountDataTestEvent, SyncResponseBuilder, async_test, test_json,
 };
 use ruma::{
+    RoomId,
     events::tag::{TagInfo, TagName, Tags},
-    room_id, RoomId,
+    room_id,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
 use crate::{logged_in_client_with_server, mock_sync};

--- a/crates/matrix-sdk/tests/integration/room/thread.rs
+++ b/crates/matrix-sdk/tests/integration/room/thread.rs
@@ -4,7 +4,7 @@ use matrix_sdk::{
     room::ThreadSubscription,
     test_utils::mocks::{MatrixMockServer, PushRuleIdSpec},
 };
-use matrix_sdk_test::{async_test, event_factory::EventFactory, JoinedRoomBuilder, ALICE};
+use matrix_sdk_test::{ALICE, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use ruma::{event_id, owned_event_id, push::RuleKind, room_id};
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/room_preview.rs
+++ b/crates/matrix-sdk/tests/integration/room_preview.rs
@@ -6,20 +6,21 @@ use matrix_sdk::{
 };
 use matrix_sdk_base::{RequestedRequiredStates, RoomState};
 use matrix_sdk_test::{
-    async_test, InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, SyncResponseBuilder,
+    InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, SyncResponseBuilder, async_test,
 };
 use ruma::{
+    RoomId,
     api::client::sync::sync_events::v5::{self as sliding_sync_http, response::Hero},
     assign,
     events::room::member::MembershipState,
     owned_user_id,
     room::JoinRuleKind,
-    room_id, RoomId,
+    room_id,
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path_regex},
     Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path_regex},
 };
 
 use crate::mock_sync;

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -5,7 +5,7 @@ use assert_matches2::{assert_let, assert_matches};
 #[cfg(feature = "unstable-msc4274")]
 use matrix_sdk::attachment::{GalleryConfig, GalleryItemInfo};
 use matrix_sdk::{
-    assert_let_timeout,
+    Client, MemoryStore, ThreadingSupport, assert_let_timeout,
     attachment::{AttachmentConfig, AttachmentInfo, BaseImageInfo, Thumbnail},
     config::StoreConfig,
     media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings},
@@ -15,38 +15,37 @@ use matrix_sdk::{
         RoomSendQueueStorageError, RoomSendQueueUpdate, SendHandle, SendQueueUpdate,
     },
     test_utils::mocks::{MatrixMock, MatrixMockServer},
-    Client, MemoryStore, ThreadingSupport,
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, InvitedRoomBuilder, KnockedRoomBuilder,
-    LeftRoomBuilder, ALICE,
+    ALICE, InvitedRoomBuilder, KnockedRoomBuilder, LeftRoomBuilder, async_test,
+    event_factory::EventFactory,
 };
 #[cfg(feature = "unstable-msc4274")]
 use ruma::events::room::message::GalleryItemType;
 use ruma::{
-    event_id,
+    MxcUri, OwnedEventId, OwnedTransactionId, TransactionId, event_id,
     events::{
+        AnyMessageLikeEventContent, Mentions, MessageLikeEventContent as _,
         poll::unstable_start::{
             NewUnstablePollStartEventContent, UnstablePollAnswer, UnstablePollAnswers,
             UnstablePollStartContentBlock, UnstablePollStartEventContent,
         },
         relation::Thread,
         room::{
+            MediaSource,
             message::{
                 ImageMessageEventContent, MessageType, Relation, ReplyWithinThread,
                 RoomMessageEventContent,
             },
-            MediaSource,
         },
-        AnyMessageLikeEventContent, Mentions, MessageLikeEventContent as _,
     },
     mxc_uri, owned_mxc_uri, owned_user_id, room_id,
     serde::Raw,
-    uint, MxcUri, OwnedEventId, OwnedTransactionId, TransactionId,
+    uint,
 };
 use serde_json::json;
 use tokio::{
-    sync::{broadcast::Receiver, Mutex},
+    sync::{Mutex, broadcast::Receiver},
     task::yield_now,
     time::{sleep, timeout},
 };
@@ -993,18 +992,22 @@ async fn test_edit() {
 
     // While the first item is being sent, the system remembers the intent to edit
     // it, and will send it later.
-    assert!(handle1
-        .edit(RoomMessageEventContent::text_plain("it's never too late!").into())
-        .await
-        .unwrap());
+    assert!(
+        handle1
+            .edit(RoomMessageEventContent::text_plain("it's never too late!").into())
+            .await
+            .unwrap()
+    );
     assert_update!((global_watch, watch) => edit { body = "it's never too late!", txn = txn1 });
 
     // The second item is pending, so we can edit it, using the handle returned by
     // `send()`.
-    assert!(handle2
-        .edit(RoomMessageEventContent::text_plain("new content, who diz").into())
-        .await
-        .unwrap());
+    assert!(
+        handle2
+            .edit(RoomMessageEventContent::text_plain("new content, who diz").into())
+            .await
+            .unwrap()
+    );
     assert_update!((global_watch, watch) => edit { body = "new content, who diz", txn = txn2 });
     assert!(watch.is_empty());
 
@@ -1214,10 +1217,12 @@ async fn test_edit_while_being_sent_and_fails() {
 
     // While the first item is being sent, the system remembers the intent to edit
     // it, and will send it later.
-    assert!(handle
-        .edit(RoomMessageEventContent::text_plain("it's never too late!").into())
-        .await
-        .unwrap());
+    assert!(
+        handle
+            .edit(RoomMessageEventContent::text_plain("it's never too late!").into())
+            .await
+            .unwrap()
+    );
     assert_update!((global_watch, watch) => edit { body = "it's never too late!", txn = txn1 });
 
     // Let the server process the responses.
@@ -1390,11 +1395,16 @@ async fn test_abort_or_edit_after_send() {
     assert_update!((global_watch, watch) => sent { txn = txn, });
 
     // Editing shouldn't work anymore.
-    assert!(handle
-        .edit(RoomMessageEventContent::text_plain("i meant something completely different").into())
-        .await
-        .unwrap()
-        .not());
+    assert!(
+        handle
+            .edit(
+                RoomMessageEventContent::text_plain("i meant something completely different")
+                    .into()
+            )
+            .await
+            .unwrap()
+            .not()
+    );
     // Neither will aborting.
     assert!(handle.abort().await.unwrap().not());
     // Or sending a reaction.

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -18,40 +18,41 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use futures_util::FutureExt;
 use matrix_sdk::{
+    Client,
     test_utils::mocks::{
-        encryption::PendingToDeviceMessages, MatrixMockServer, RoomMessagesResponseTemplate,
+        MatrixMockServer, RoomMessagesResponseTemplate, encryption::PendingToDeviceMessages,
     },
     widget::{
         Capabilities, CapabilitiesProvider, WidgetDriver, WidgetDriverHandle, WidgetSettings,
     },
-    Client,
 };
 use matrix_sdk_base::crypto::CollectStrategy;
 use matrix_sdk_common::{
     deserialized_responses::EncryptionInfo, executor::spawn, locks::Mutex, timeout::timeout,
 };
 use matrix_sdk_test::{
-    async_test, event_factory::EventFactory, JoinedRoomBuilder, StateTestEvent, ALICE, BOB,
+    ALICE, BOB, JoinedRoomBuilder, StateTestEvent, async_test, event_factory::EventFactory,
 };
 use once_cell::sync::Lazy;
 use ruma::{
+    OwnedRoomId,
     api::client::to_device::send_event_to_device::v3::Messages,
     device_id, event_id,
     events::{
-        room::{member::MembershipState, message::RoomMessageEventContent},
         AnySyncStateEvent, AnyToDeviceEvent, MessageLikeEventType, StateEventType,
+        room::{member::MembershipState, message::RoomMessageEventContent},
     },
     owned_room_id, room_id,
     serde::{JsonObject, Raw},
     to_device::DeviceIdOrAllDevices,
-    user_id, OwnedRoomId,
+    user_id,
 };
 use serde::Serialize;
-use serde_json::{json, Value as JsonValue, Value};
+use serde_json::{Value as JsonValue, Value, json};
 use tracing::error;
 use wiremock::{
-    matchers::{method, path_regex},
     Mock, Request, ResponseTemplate,
+    matchers::{method, path_regex},
 };
 
 /// Create a JSON string from a [`json!`][serde_json::json] "literal".
@@ -1437,12 +1438,16 @@ async fn test_send_encrypted_to_device_event_wildcard() {
             assert_eq!(params.messages.len(), 1);
             let for_bob = params.messages.get(bob.user_id().unwrap()).unwrap();
             assert_eq!(for_bob.len(), 2);
-            assert!(for_bob
-                .get(&DeviceIdOrAllDevices::DeviceId(bob.device_id().unwrap().to_owned()))
-                .is_some());
-            assert!(for_bob
-                .get(&DeviceIdOrAllDevices::DeviceId(bob_2.device_id().unwrap().to_owned()))
-                .is_some());
+            assert!(
+                for_bob
+                    .get(&DeviceIdOrAllDevices::DeviceId(bob.device_id().unwrap().to_owned()))
+                    .is_some()
+            );
+            assert!(
+                for_bob
+                    .get(&DeviceIdOrAllDevices::DeviceId(bob_2.device_id().unwrap().to_owned()))
+                    .is_some()
+            );
 
             ResponseTemplate::new(200)
         })
@@ -1518,12 +1523,16 @@ async fn test_send_encrypted_to_device_event_wildcard_edge_cases() {
             assert_eq!(params.messages.len(), 1);
             let for_bob = params.messages.get(bob.user_id().unwrap()).unwrap();
             assert_eq!(for_bob.len(), 2);
-            assert!(for_bob
-                .get(&DeviceIdOrAllDevices::DeviceId(bob.device_id().unwrap().to_owned()))
-                .is_some());
-            assert!(for_bob
-                .get(&DeviceIdOrAllDevices::DeviceId(bob_2.device_id().unwrap().to_owned()))
-                .is_some());
+            assert!(
+                for_bob
+                    .get(&DeviceIdOrAllDevices::DeviceId(bob.device_id().unwrap().to_owned()))
+                    .is_some()
+            );
+            assert!(
+                for_bob
+                    .get(&DeviceIdOrAllDevices::DeviceId(bob_2.device_id().unwrap().to_owned()))
+                    .is_some()
+            );
 
             ResponseTemplate::new(200)
         })


### PR DESCRIPTION
It all started with me noticing that `cargo nextest` warned about usage of the never type fallback in the SDK crate… and then it escalated a bit. This bumps the Rust edition of the matrix-sdk crate to 2024.

### Some notes

- Sorry that some commits include some reformatting changes. I should've started with that, and started to address the compilation errors first, then auto-format-on-save kicked in and included some `use` formatting changes in the mix. With some extra effort I could put them back into the `rustfmt` commit, tell me if you think it's worth it.
- I wonder if I can use the Rust edition 2024 in the `matrix-sdk` crate while some of its dependencies aren't using the 2024 edition (but some idioms that seem 2024-y to me, like `use<>` etc.). Let's see what CI thinks of it.