### PR TITLE
chore(ffi): Define new log target for `deserialized_responses`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform.rs
@@ -275,6 +275,7 @@ enum LogTarget {
 
     // SDK common modules.
     MatrixSdkCommonCrossProcessLock,
+    MatrixSdkCommonDeserializedResponses,
 
     // SDK modules.
     MatrixSdk,
@@ -303,6 +304,9 @@ impl LogTarget {
             LogTarget::MatrixSdkBaseStoreAmbiguityMap => "matrix_sdk_base::store::ambiguity_map",
             LogTarget::MatrixSdkBaseResponseProcessors => "matrix_sdk_base::response_processors",
             LogTarget::MatrixSdkCommonCrossProcessLock => "matrix_sdk_common::cross_process_lock",
+            LogTarget::MatrixSdkCommonDeserializedResponses => {
+                "matrix_sdk_common::deserialized_responses"
+            }
             LogTarget::MatrixSdk => "matrix_sdk",
             LogTarget::MatrixSdkClient => "matrix_sdk::client",
             LogTarget::MatrixSdkCrypto => "matrix_sdk_crypto",
@@ -336,6 +340,7 @@ const DEFAULT_TARGET_LOG_LEVELS: &[(LogTarget, LogLevel)] = &[
     (LogTarget::MatrixSdkBaseEventCache, LogLevel::Info),
     (LogTarget::MatrixSdkEventCacheStore, LogLevel::Info),
     (LogTarget::MatrixSdkCommonCrossProcessLock, LogLevel::Warn),
+    (LogTarget::MatrixSdkCommonDeserializedResponses, LogLevel::Warn),
     (LogTarget::MatrixSdkBaseStoreAmbiguityMap, LogLevel::Warn),
     (LogTarget::MatrixSdkUiNotificationClient, LogLevel::Info),
     (LogTarget::MatrixSdkBaseResponseProcessors, LogLevel::Debug),
@@ -374,15 +379,21 @@ impl TraceLogPacks {
                 LogTarget::MatrixSdkEventCache,
                 LogTarget::MatrixSdkBaseEventCache,
                 LogTarget::MatrixSdkEventCacheStore,
+                LogTarget::MatrixSdkCommonCrossProcessLock,
+                LogTarget::MatrixSdkCommonDeserializedResponses,
             ],
             TraceLogPacks::SendQueue => &[LogTarget::MatrixSdkSendQueue],
-            TraceLogPacks::Timeline => &[LogTarget::MatrixSdkUiTimeline],
+            TraceLogPacks::Timeline => {
+                &[LogTarget::MatrixSdkUiTimeline, LogTarget::MatrixSdkCommonDeserializedResponses]
+            }
             TraceLogPacks::NotificationClient => &[LogTarget::MatrixSdkUiNotificationClient],
             TraceLogPacks::SyncProfiling => &[
                 LogTarget::MatrixSdkSlidingSync,
                 LogTarget::MatrixSdkBaseSlidingSync,
                 LogTarget::MatrixSdkBaseResponseProcessors,
                 LogTarget::MatrixSdkCrypto,
+                LogTarget::MatrixSdkCommonCrossProcessLock,
+                LogTarget::MatrixSdkCommonDeserializedResponses,
             ],
         }
     }
@@ -724,6 +735,7 @@ mod tests {
             matrix_sdk_base::event_cache=info,
             matrix_sdk_sqlite::event_cache_store=info,
             matrix_sdk_common::cross_process_lock=warn,
+            matrix_sdk_common::deserialized_responses=warn,
             matrix_sdk_base::store::ambiguity_map=warn,
             matrix_sdk_ui::notification_client=info,
             matrix_sdk_base::response_processors=debug,
@@ -768,6 +780,7 @@ mod tests {
             matrix_sdk_base::event_cache=trace,
             matrix_sdk_sqlite::event_cache_store=trace,
             matrix_sdk_common::cross_process_lock=warn,
+            matrix_sdk_common::deserialized_responses=trace,
             matrix_sdk_base::store::ambiguity_map=warn,
             matrix_sdk_ui::notification_client=trace,
             matrix_sdk_base::response_processors=trace,
@@ -813,6 +826,7 @@ mod tests {
             matrix_sdk_base::event_cache=trace,
             matrix_sdk_sqlite::event_cache_store=trace,
             matrix_sdk_common::cross_process_lock=warn,
+            matrix_sdk_common::deserialized_responses=trace,
             matrix_sdk_base::store::ambiguity_map=warn,
             matrix_sdk_ui::notification_client=info,
             matrix_sdk_base::response_processors=debug,

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -27,7 +27,7 @@ use ruma::{
     },
 };
 use serde::{Deserialize, Serialize};
-use tracing::{trace, warn};
+use tracing::warn;
 #[cfg(target_family = "wasm")]
 use wasm_bindgen::prelude::*;
 
@@ -778,9 +778,7 @@ impl TimelineEvent {
     /// might not be constant.
     pub fn timestamp(&self) -> Option<MilliSecondsSinceUnixEpoch> {
         self.timestamp.or_else(|| {
-            trace!(
-                "`TimelineEvent::timestamp` is parsing the raw event to extract the `timestamp`"
-            );
+            warn!("`TimelineEvent::timestamp` is parsing the raw event to extract the `timestamp`");
 
             extract_timestamp(self.raw(), MilliSecondsSinceUnixEpoch::now())
         })


### PR DESCRIPTION
This patch defines a new log target, `MatrixSdkCommonDeserializedResponses`. It is enabled by the `SyncProfiling`, `EventCache` or `Timeline` log packs.

This patch also changes the level of the log in `TimelineEvent::timestamp` from `trace` to `warn`.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4112