### PR TITLE
chore(ffi): rejigger recent emoji code around so as to work with defaut features disabled

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1745,37 +1745,42 @@ impl Client {
             }
         }))))
     }
-
-    /// Adds a recently used emoji to the list and uploads the updated
-    /// `io.element.recent_emoji` content to the global account data.
-    #[cfg(feature = "experimental-element-recent-emojis")]
-    pub async fn add_recent_emoji(&self, emoji: String) -> Result<(), ClientError> {
-        Ok(self.inner.account().add_recent_emoji(&emoji).await?)
-    }
-
-    /// Gets the list of recently used emojis from the `io.element.recent_emoji`
-    /// global account data.
-    #[cfg(feature = "experimental-element-recent-emojis")]
-    pub async fn get_recent_emojis(&self) -> Result<Vec<RecentEmoji>, ClientError> {
-        Ok(self
-            .inner
-            .account()
-            .get_recent_emojis(false)
-            .await?
-            .into_iter()
-            .map(|(emoji, count)| RecentEmoji { emoji, count: count.into() })
-            .collect::<Vec<RecentEmoji>>())
-    }
 }
 
-/// Represents an emoji recently used for reactions.
 #[cfg(feature = "experimental-element-recent-emojis")]
-#[derive(Debug, uniffi::Record)]
-pub struct RecentEmoji {
-    /// The actual emoji text representation.
-    pub emoji: String,
-    /// The number of times this emoji has been used for reactions.
-    pub count: u64,
+mod recent_emoji {
+    use crate::{client::Client, error::ClientError};
+
+    /// Represents an emoji recently used for reactions.
+    #[derive(Debug, uniffi::Record)]
+    pub struct RecentEmoji {
+        /// The actual emoji text representation.
+        pub emoji: String,
+        /// The number of times this emoji has been used for reactions.
+        pub count: u64,
+    }
+
+    #[matrix_sdk_ffi_macros::export]
+    impl Client {
+        /// Adds a recently used emoji to the list and uploads the updated
+        /// `io.element.recent_emoji` content to the global account data.
+        pub async fn add_recent_emoji(&self, emoji: String) -> Result<(), ClientError> {
+            Ok(self.inner.account().add_recent_emoji(&emoji).await?)
+        }
+
+        /// Gets the list of recently used emojis from the
+        /// `io.element.recent_emoji` global account data.
+        pub async fn get_recent_emojis(&self) -> Result<Vec<RecentEmoji>, ClientError> {
+            Ok(self
+                .inner
+                .account()
+                .get_recent_emojis(false)
+                .await?
+                .into_iter()
+                .map(|(emoji, count)| RecentEmoji { emoji, count: count.into() })
+                .collect::<Vec<RecentEmoji>>())
+        }
+    }
 }
 
 #[matrix_sdk_ffi_macros::export(callback_interface)]


### PR DESCRIPTION
For some reason, running `cargo xtask ci clippy` locally would now fail, complaining that the recent emoji functions didn't exist, in the FFI layer. I suspect it's because some of the uniffi derive macro to export functions incorrectly propagates the `cfg` guards; so a solution is to move all this code under a new mod, that's enabled if and only if the feature's enabled.

@jmartinesp can you try it around and confirm the emoji functions are still available for you, when the experimental feature's enabled, please?