### PR TITLE
chore: define `FrozenSlidingSyncPos` only if the e2e-encryption feature is enabled

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -42,7 +42,6 @@ use ruma::{
     api::client::{error::ErrorKind, sync::sync_events::v5 as http},
     assign,
 };
-use serde::{Deserialize, Serialize};
 use tokio::{
     select,
     sync::{Mutex as AsyncMutex, OwnedMutexGuard, RwLock as AsyncRwLock, broadcast::Sender},
@@ -855,12 +854,6 @@ impl SlidingSync {
 pub(super) struct SlidingSyncPositionMarkers {
     /// An ephemeral position in the current stream, as received from the
     /// previous `/sync` response, or `None` for the first request.
-    pos: Option<String>,
-}
-
-#[derive(Serialize, Deserialize)]
-struct FrozenSlidingSyncPos {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pos: Option<String>,
 }
 


### PR DESCRIPTION
This caused compilation errors in other PRs, since the introduction of Rust 1.90, which was able to detect this was unused otherwise.

Also avoids reading the OlmMachine twice when deserializing the to-device token and the persisted `pos` marker.