### PR TITLE
feat(push): add experimental support for applying "Do not Disturb" notification settings as per MSC4359

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,16 +2253,13 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.29.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e15626aaf9c351bc696217cbe29cb9b5e86c43f8a46b5e2f5c6c5cf7cb904ce"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
 dependencies = [
  "log",
- "mac",
  "markup5ever",
- "proc-macro2",
- "quote",
- "syn",
+ "match_token",
 ]
 
 [[package]]
@@ -2837,6 +2834,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js_option"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7dd3e281add16813cf673bf74a32249b0aa0d1c8117519a17b3ada5e8552b3c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "json-structural-diff"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,16 +3057,24 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.14.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c88c6129bd24319e62a0359cb6b958fa7e8be6e19bb1663bc396b90883aca5"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
 dependencies = [
  "log",
- "phf 0.11.2",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
  "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "match_token"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3277,7 +3291,7 @@ dependencies = [
  "indoc",
  "insta",
  "itertools 0.14.0",
- "js_option",
+ "js_option 0.1.1",
  "matrix-sdk-common",
  "matrix-sdk-qrcode",
  "matrix-sdk-test",
@@ -3593,6 +3607,7 @@ dependencies = [
  "async-stream",
  "async_cell",
  "bitflags",
+ "cfg-if",
  "chrono",
  "emojis",
  "eyeball",
@@ -4129,18 +4144,8 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
 dependencies = [
- "phf_generator 0.11.2",
+ "phf_generator",
  "phf_shared 0.11.2",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
-dependencies = [
- "phf_shared 0.10.0",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -4151,15 +4156,6 @@ checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
  "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -4749,11 +4745,11 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=de227ef5c5b2d2ecff89ab021ebe53c5d565577d#de227ef5c5b2d2ecff89ab021ebe53c5d565577d"
 dependencies = [
  "assign",
  "js_int",
- "js_option",
+ "js_option 0.2.0",
  "ruma-client-api",
  "ruma-common",
  "ruma-events",
@@ -4766,7 +4762,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.21.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=de227ef5c5b2d2ecff89ab021ebe53c5d565577d#de227ef5c5b2d2ecff89ab021ebe53c5d565577d"
 dependencies = [
  "as_variant",
  "assign",
@@ -4774,7 +4770,7 @@ dependencies = [
  "date_header",
  "http",
  "js_int",
- "js_option",
+ "js_option 0.2.0",
  "maplit",
  "ruma-common",
  "ruma-events",
@@ -4789,7 +4785,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.16.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=de227ef5c5b2d2ecff89ab021ebe53c5d565577d#de227ef5c5b2d2ecff89ab021ebe53c5d565577d"
 dependencies = [
  "as_variant",
  "base64",
@@ -4822,12 +4818,12 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.31.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=de227ef5c5b2d2ecff89ab021ebe53c5d565577d#de227ef5c5b2d2ecff89ab021ebe53c5d565577d"
 dependencies = [
  "as_variant",
  "indexmap",
  "js_int",
- "js_option",
+ "js_option 0.2.0",
  "percent-encoding",
  "pulldown-cmark",
  "regex",
@@ -4848,7 +4844,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.12.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=de227ef5c5b2d2ecff89ab021ebe53c5d565577d#de227ef5c5b2d2ecff89ab021ebe53c5d565577d"
 dependencies = [
  "headers",
  "http",
@@ -4868,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.5.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=de227ef5c5b2d2ecff89ab021ebe53c5d565577d#de227ef5c5b2d2ecff89ab021ebe53c5d565577d"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4879,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.11.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=de227ef5c5b2d2ecff89ab021ebe53c5d565577d#de227ef5c5b2d2ecff89ab021ebe53c5d565577d"
 dependencies = [
  "js_int",
  "thiserror 2.0.16",
@@ -4888,7 +4884,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.16.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=de227ef5c5b2d2ecff89ab021ebe53c5d565577d#de227ef5c5b2d2ecff89ab021ebe53c5d565577d"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",
@@ -4897,13 +4893,13 @@ dependencies = [
  "ruma-identifiers-validation",
  "serde",
  "syn",
- "toml 0.8.15",
+ "toml 0.9.6",
 ]
 
 [[package]]
 name = "ruma-signatures"
 version = "0.18.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=de227ef5c5b2d2ecff89ab021ebe53c5d565577d#de227ef5c5b2d2ecff89ab021ebe53c5d565577d"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5241,10 +5237,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -5269,10 +5266,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5316,11 +5322,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5536,26 +5542,25 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "once_cell",
  "parking_lot",
- "phf_shared 0.10.0",
+ "phf_shared 0.11.2",
  "precomputed-hash",
  "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
+ "phf_generator",
+ "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
 ]
@@ -6054,14 +6059,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.15"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
+checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
 dependencies = [
- "serde",
+ "serde_core",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.7.1",
+ "toml_parser",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -6069,8 +6075,14 @@ name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a197c0ec7d131bfc6f7e82c8442ba1595aeab35da7adbf05b6b73cd06a16b6be"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -6080,10 +6092,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
+ "toml_datetime 0.6.8",
+ "winnow 0.6.20",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -6858,6 +6877,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf 0.11.2",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7206,6 +7237,12 @@ checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ rand = "0.8.5"
 regex = "1.11.2"
 reqwest = { version = "0.12.23", default-features = false }
 rmp-serde = "1.3.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "2f64faeabb85950de27e9829faeb389d2779ac57", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "de227ef5c5b2d2ecff89ab021ebe53c5d565577d", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-arbitrary-length-ids",
@@ -85,11 +85,12 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "2f64faeabb85950de27e9829fa
     "unstable-msc4286",
     "unstable-msc4306",
     "unstable-msc4308",
-    "unstable-msc4310"
+    "unstable-msc4310",
+    "unstable-msc4359"
 ] }
 sentry = { version = "0.42.0", default-features = false }
 sentry-tracing = "0.42.0"
-serde = { version = "1.0.219", features = ["rc"] }
+serde = { version = "1.0.221", features = ["rc"] }
 serde_html_form = "0.2.7"
 serde_json = "1.0.143"
 sha2 = "0.10.9"

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 - Add `Room::load_or_fetch_event` so we can get a `TimelineEvent` given its event id ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678)).
 - Add `TimelineEvent::thread_root_event_id` to expose the thread root event id for this type too ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678)).
+- Add support for "Do not Disturb" room list in account data as per MSC4359 ([#5687](https://github.com/matrix-org/matrix-rust-sdk/pull/5687))
 
 ## [0.14.0] - 2025-09-04
 

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -27,6 +27,7 @@ crate-type = [
 default = ["bundled-sqlite", "unstable-msc4274", "experimental-element-recent-emojis"]
 bundled-sqlite = ["matrix-sdk/bundled-sqlite"]
 unstable-msc4274 = ["matrix-sdk-ui/unstable-msc4274"]
+unstable-msc4359 = ["matrix-sdk-ui/unstable-msc4359"]
 # Required when targeting a Javascript environment, like Wasm in a browser.
 js = ["matrix-sdk-ui/js"]
 # Use the TLS implementation provided by the host system, necessary on iOS and Wasm platforms.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -61,6 +61,7 @@ use ruma::{
     },
     events::{
         direct::DirectEventContent,
+        do_not_disturb::DoNotDisturbEventContent,
         fully_read::FullyReadEventContent,
         identity_server::IdentityServerEventContent,
         ignored_user_list::IgnoredUserListEventContent,
@@ -698,6 +699,9 @@ impl Client {
         match event_type {
             AccountDataEventType::Direct => {
                 observe!(DirectEventContent)
+            }
+            AccountDataEventType::DoNotDisturbRoomList => {
+                observe!(DoNotDisturbEventContent)
             }
             AccountDataEventType::IdentityServer => {
                 observe!(IdentityServerEventContent)

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -65,6 +65,9 @@ testing = [
 # Add support for inline media galleries via msgtypes
 unstable-msc4274 = []
 
+# "Do not Disturb" notification settings
+unstable-msc4359 = ["ruma/unstable-msc4359"]
+
 experimental-element-recent-emojis = []
 
 [dependencies]

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
   `RoomListItem`.
   ([#5684](https://github.com/matrix-org/matrix-rust-sdk/pull/5684))
 
+### Features
+
+- Apply "Do not Disturb" room list when filtering notifications as
+  per MSC4359
+  ([#5687](https://github.com/matrix-org/matrix-rust-sdk/pull/5687))
+
 ## [0.14.0] - 2025-09-04
 
 ### Features

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -25,6 +25,9 @@ unstable-msc3956 = ["ruma/unstable-msc3956"]
 # Add support for inline media galleries via msgtypes
 unstable-msc4274 = ["matrix-sdk/unstable-msc4274"]
 
+# "Do not Disturb" notification settings
+unstable-msc4359 = ["matrix-sdk/unstable-msc4359"]
+
 # Enable experimental support for encrypting state events; see
 # https://github.com/matrix-org/matrix-rust-sdk/issues/5397.
 experimental-encrypted-state-events = [
@@ -38,6 +41,7 @@ async-rx.workspace = true
 async-stream.workspace = true
 async_cell = "0.2.3"
 bitflags.workspace = true
+cfg-if.workspace = true
 chrono.workspace = true
 eyeball.workspace = true
 eyeball-im.workspace = true

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -71,6 +71,9 @@ docsrs = ["e2e-encryption", "sqlite", "indexeddb", "sso-login", "qrcode"]
 # Add support for inline media galleries via msgtypes
 unstable-msc4274 = ["ruma/unstable-msc4274", "matrix-sdk-base/unstable-msc4274"]
 
+# "Do not Disturb" notification settings
+unstable-msc4359 = ["matrix-sdk-base/unstable-msc4359"]
+
 experimental-search = ["matrix-sdk-search"]
 
 experimental-element-recent-emojis = ["matrix-sdk-base/experimental-element-recent-emojis"]

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2860,6 +2860,13 @@ impl Client {
         self.base_client().is_user_ignored(user_id).await
     }
 
+    /// Checks whether the provided `room_id` belongs to a room in "Do not
+    /// Disturb" mode.
+    #[cfg(feature = "unstable-msc4359")]
+    pub async fn is_room_in_do_not_disturb_mode(&self, room_id: &RoomId) -> bool {
+        self.base_client().is_room_in_do_not_disturb_mode(room_id).await
+    }
+
     /// Gets the `max_upload_size` value from the homeserver, getting either a
     /// cached value or with a `/_matrix/client/v1/media/config` request if it's
     /// missing.

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -36,6 +36,7 @@ use ruma::{
         beacon::BeaconEventContent,
         call::{SessionDescription, invite::CallInviteEventContent},
         direct::{DirectEventContent, OwnedDirectUserIdentifier},
+        do_not_disturb::DoNotDisturbEventContent,
         ignored_user_list::IgnoredUserListEventContent,
         macros::EventContent,
         member_hints::MemberHintsEventContent,
@@ -1042,6 +1043,16 @@ impl EventFactory {
         users: impl IntoIterator<Item = OwnedUserId>,
     ) -> EventBuilder<IgnoredUserListEventContent> {
         let mut builder = self.event(IgnoredUserListEventContent::users(users));
+        builder.is_global = true;
+        builder
+    }
+
+    /// Create a new `dm.filament.do_not_disturb` global account data event.
+    pub fn do_not_disturb_room_list(
+        &self,
+        rooms: impl IntoIterator<Item = OwnedRoomId>,
+    ) -> EventBuilder<DoNotDisturbEventContent> {
+        let mut builder = self.event(rooms.into_iter().collect());
         builder.is_global = true;
         builder
     }


### PR DESCRIPTION
This adds partial support for https://github.com/matrix-org/matrix-spec-proposals/pull/4359 and suppresses push notifications when a room is set to "Do not Disturb" (DnD). The DnD setting is sourced from a dedicated global account data event.

<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->

