### PR TITLE
chore(ui): Add a temporary `RoomList::entries_with_dynamic_adapters_with` method

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -169,6 +169,15 @@ impl RoomList {
         page_size: u32,
         listener: Box<dyn RoomListEntriesListener>,
     ) -> Arc<RoomListEntriesWithDynamicAdaptersResult> {
+        self.entries_with_dynamic_adapters_with(page_size, false, listener)
+    }
+
+    fn entries_with_dynamic_adapters_with(
+        self: Arc<Self>,
+        page_size: u32,
+        enable_latest_event_sorter: bool,
+        listener: Box<dyn RoomListEntriesListener>,
+    ) -> Arc<RoomListEntriesWithDynamicAdaptersResult> {
         let this = self;
 
         // The following code deserves a bit of explanation.
@@ -216,7 +225,10 @@ impl RoomList {
         // borrowing `this`, which is going to live long enough since it will live as
         // long as `entries_stream` and `dynamic_entries_controller`.
         let (entries_stream, dynamic_entries_controller) =
-            this.inner.entries_with_dynamic_adapters(page_size.try_into().unwrap());
+            this.inner.entries_with_dynamic_adapters_with(
+                page_size.try_into().unwrap(),
+                enable_latest_event_sorter,
+            );
 
         // FFI dance to make those values consumable by foreign language, nothing fancy
         // here, that's the real code for this method.


### PR DESCRIPTION
This patch adds a temporary
`RoomList::entries_with_dynamic_adapters_with` method to help debug an issue in Element X.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4112