### PR TITLE
chore: Update `eyeball-im`, `eyeball-im-util` and `imbl`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,9 +1741,9 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e8e9d31591be508826b875d8fe6056aebcaec3281ac0e45434ff303686c566"
+checksum = "4790c03df183c2b46665c1a58118c04fd3e3976ec2fe16a0aa00e00c9eea7754"
 dependencies = [
  "futures-core",
  "imbl",
@@ -1753,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im-util"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda2d08a8fa99050bdb84d077193a371e9abd29696921971aa26ae076adb6023"
+checksum = "809fa2e8e59c25a41f5b2440aa937f1e84df6ae48b707e65f69ce259b1c44bda"
 dependencies = [
  "arrayvec",
  "eyeball-im",
@@ -2598,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "imbl"
-version = "5.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4308a675e4cfc1920f36a8f4d8fb62d5533b7da106844bd1ec51c6f1fa94a0c"
+checksum = "0fade8ae6828627ad1fa094a891eccfb25150b383047190a3648d66d06186501"
 dependencies = [
  "archery",
  "bitmaps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ clap = "4.5.46"
 chrono = "0.4.41"
 dirs = "6.0.0"
 eyeball = { version = "0.8.8", features = ["tracing"] }
-eyeball-im = { version = "0.7.0", features = ["tracing"] }
-eyeball-im-util = "0.9.0"
+eyeball-im = { version = "0.8.0", features = ["tracing"] }
+eyeball-im-util = "0.10.0"
 futures-core = "0.3.31"
 futures-executor = "0.3.31"
 futures-util = "0.3.31"
@@ -50,7 +50,7 @@ growable-bloom-filter = "2.1.1"
 hkdf = "0.12.4"
 hmac = "0.12.1"
 http = "1.3.1"
-imbl = "5.0.0"
+imbl = "6.1.0"
 indexmap = "2.11.0"
 insta = { version = "1.43.1", features = ["json", "redactions"] }
 itertools = "0.14.0"

--- a/crates/matrix-sdk-ui/src/room_list_service/sorters/recency.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/sorters/recency.rs
@@ -20,27 +20,6 @@ fn cmp<F>(ranks: F, left: &RoomListItem, right: &RoomListItem) -> Ordering
 where
     F: Fn(&RoomListItem, &RoomListItem) -> (Option<Rank>, Option<Rank>),
 {
-    if left.room_id() == right.room_id() {
-        // `left` and `right` are the same room. We are comparing the same
-        // `LatestEvent`!
-        //
-        // The way our `Room` types are implemented makes it so they are sharing the
-        // same data, because they are all built from the same store. They can be seen
-        // as shallow clones of each others. In practice it's really great: a `Room` can
-        // never be outdated. However, for the case of sorting rooms, it breaks the
-        // search algorithm. `left` and `right` will have the exact same recency
-        // stamp, so `left` and `right` will always be `Ordering::Equal`. This is
-        // wrong: if `left` is compared with `right` and if they are both the same room,
-        // it means that one of them (either `left`, or `right`, it's not important) has
-        // received an update. The room position is very likely to change. But if they
-        // compare to `Equal`, the position may not change. It actually depends of the
-        // search algorithm used by [`eyeball_im_util::SortBy`].
-        //
-        // Since this room received an update, it is more recent than the previous one
-        // we matched against, so return `Ordering::Greater`.
-        return Ordering::Greater;
-    }
-
     match ranks(left, right) {
         (Some(left_rank), Some(right_rank)) => left_rank.cmp(&right_rank).reverse(),
 

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -1735,7 +1735,7 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
     assert_entries_batch! {
         [dynamic_entries_stream]
         pop back;
-        insert [ 0 ] [ "!r0:bar.org" ];
+        push front [ "!r0:bar.org" ];
         end;
     };
     assert_pending!(dynamic_entries_stream);
@@ -1906,7 +1906,7 @@ async fn test_room_sorting() -> Result<(), Error> {
     assert_entries_batch! {
         [stream]
         remove [ 3 ];
-        insert [ 0 ] [ "!r0:bar.org" ];
+        push front [ "!r0:bar.org" ];
         end;
     };
 
@@ -1940,7 +1940,7 @@ async fn test_room_sorting() -> Result<(), Error> {
     assert_entries_batch! {
         [stream]
         remove [ 4 ];
-        insert [ 0 ] [ "!r2:bar.org" ];
+        push front [ "!r2:bar.org" ];
         end;
     };
 
@@ -2006,7 +2006,7 @@ async fn test_room_sorting() -> Result<(), Error> {
     assert_entries_batch! {
         [stream]
         remove [ 5 ];
-        insert [ 0 ] [ "!r3:bar.org" ];
+        push front [ "!r3:bar.org" ];
         end;
     };
 


### PR DESCRIPTION
This patch updates `eyeball-im` to 0.8.0, `eyeball-im-util` to 0.10.0 and `imbl` to 6.1.0.

The idea is to fix this bug https://github.com/jplatte/eyeball/pull/80.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4112