### PR TITLE
refactor(timeline): don't require an `ExactSizeIterator` on `replace_with_initial_remote_events`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/tasks.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tasks.rs
@@ -55,10 +55,7 @@ pub(in crate::timeline) async fn pinned_events_task<S>(
             Ok(Some(events)) => {
                 trace!("successfully reloaded pinned events");
                 timeline_controller
-                    .replace_with_initial_remote_events(
-                        events.into_iter(),
-                        RemoteEventOrigin::Pagination,
-                    )
+                    .replace_with_initial_remote_events(events, RemoteEventOrigin::Pagination)
                     .await;
             }
 
@@ -99,10 +96,7 @@ pub(in crate::timeline) async fn thread_updates_task(
                 let (initial_events, _) = room_event_cache.subscribe_to_thread(root.clone()).await;
 
                 timeline_controller
-                    .replace_with_initial_remote_events(
-                        initial_events.into_iter(),
-                        RemoteEventOrigin::Cache,
-                    )
+                    .replace_with_initial_remote_events(initial_events, RemoteEventOrigin::Cache)
                     .await;
 
                 continue;
@@ -154,10 +148,7 @@ pub(in crate::timeline) async fn room_event_cache_updates_task(
                 let initial_events = room_event_cache.events().await;
 
                 timeline_controller
-                    .replace_with_initial_remote_events(
-                        initial_events.into_iter(),
-                        RemoteEventOrigin::Cache,
-                    )
+                    .replace_with_initial_remote_events(initial_events, RemoteEventOrigin::Cache)
                     .await;
 
                 continue;

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -116,10 +116,7 @@ async fn test_replace_with_initial_events_and_read_marker() {
     assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "hey");
 
     let ev = f.text_msg("yo").sender(*BOB).into_event();
-    timeline
-        .controller
-        .replace_with_initial_remote_events([ev].into_iter(), RemoteEventOrigin::Sync)
-        .await;
+    timeline.controller.replace_with_initial_remote_events([ev], RemoteEventOrigin::Sync).await;
 
     let items = timeline.controller.items().await;
     assert_eq!(items.len(), 2);
@@ -489,10 +486,7 @@ async fn test_replace_with_initial_events_when_batched() {
     assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "hey");
 
     let ev = f.text_msg("yo").sender(*BOB).into_event();
-    timeline
-        .controller
-        .replace_with_initial_remote_events([ev].into_iter(), RemoteEventOrigin::Sync)
-        .await;
+    timeline.controller.replace_with_initial_remote_events([ev], RemoteEventOrigin::Sync).await;
 
     // Assert there are more than a single Clear diff in the next batch:
     // Clear + PushBack (event) + PushFront (date divider)

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -253,8 +253,7 @@ async fn test_no_read_marker_with_local_echo() {
                 .sender(user_id!("@a:b.c"))
                 .event_id(event_id)
                 .server_ts(MilliSecondsSinceUnixEpoch::now())
-                .into_event()]
-            .into_iter(),
+                .into_event()],
             RemoteEventOrigin::Sync,
         )
         .await;


### PR DESCRIPTION
This is only used to know if the new events list is empty or not, which we can figure thanks to a peekable iterator. It avoids the requirement of an explicit `.into_iter()` on all call sites, which is also nice for readability.

Spotted while reviewing #5678.