### PR TITLE
feat(ffi): Add `NotificationSettings::get_raw_push_rules`

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 - Add `Room::load_or_fetch_event` so we can get a `TimelineEvent` given its event id ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678)).
 - Add `TimelineEvent::thread_root_event_id` to expose the thread root event id for this type too ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678)).
+- Add `NotificationSettings::get_raw_push_rules` so clients can fetch the raw JSON content of the push rules of the current user and include it in bug reports ([#5706](https://github.com/matrix-org/matrix-rust-sdk/pull/5706)).
 
 ## [0.14.0] - 2025-09-04
 

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -11,6 +11,7 @@ use matrix_sdk::{
 };
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
 use ruma::{
+    events::push_rules::PushRulesEventContent,
     push::{
         Action as SdkAction, ComparisonOperator as SdkComparisonOperator, PredefinedOverrideRuleId,
         PredefinedUnderrideRuleId, PushCondition as SdkPushCondition, RoomMemberCountIs,
@@ -20,7 +21,7 @@ use ruma::{
 };
 use tokio::sync::RwLock as AsyncRwLock;
 
-use crate::error::NotificationSettingsError;
+use crate::error::{ClientError, NotificationSettingsError};
 
 #[derive(Clone, Default, uniffi::Enum)]
 pub enum ComparisonOperator {
@@ -769,5 +770,12 @@ impl NotificationSettings {
             .unmute_room(&parsed_room_id, is_encrypted.into(), is_one_to_one.into())
             .await?;
         Ok(())
+    }
+
+    /// Returns the raw push rules in JSON format.
+    pub async fn get_raw_push_rules(&self) -> Result<Option<String>, ClientError> {
+        let raw_push_rules =
+            self.sdk_client.account().account_data::<PushRulesEventContent>().await?;
+        Ok(raw_push_rules.map(|raw| serde_json::to_string(&raw)).transpose()?)
     }
 }


### PR DESCRIPTION
This allows clients to get the raw push rules so they can be added to bug reports if needed.

<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
