### PR TITLE
refactor(base): Rename `sync_lock` to `state_store_lock`

### DIFF
--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Refactor
+
+- `Client::sync_lock` has been renamed `Client::state_store_lock`.
+  ([#5707](https://github.com/matrix-org/matrix-rust-sdk/pull/5707))
+
 ## [0.14.1] - 2025-09-10
 
 ### Security Fixes

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -184,7 +184,7 @@ pub(crate) struct BaseStateStore {
     rooms: Arc<StdRwLock<ObservableMap<OwnedRoomId, Room>>>,
     /// A lock to synchronize access to the store, such that data by the sync is
     /// never overwritten.
-    sync_lock: Arc<Mutex<()>>,
+    lock: Arc<Mutex<()>>,
 }
 
 impl BaseStateStore {
@@ -196,13 +196,13 @@ impl BaseStateStore {
             room_load_settings: Default::default(),
             sync_token: Default::default(),
             rooms: Arc::new(StdRwLock::new(ObservableMap::new())),
-            sync_lock: Default::default(),
+            lock: Default::default(),
         }
     }
 
     /// Get access to the syncing lock.
-    pub fn sync_lock(&self) -> &Mutex<()> {
-        &self.sync_lock
+    pub fn lock(&self) -> &Mutex<()> {
+        &self.lock
     }
 
     /// Set the [`SessionMeta`] into [`BaseStateStore::session_meta`].

--- a/crates/matrix-sdk/src/latest_events/latest_event.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event.rs
@@ -153,8 +153,8 @@ impl LatestEvent {
 
         let client = room.client();
 
-        // Take the sync lock.
-        let _sync_lock = client.base_client().sync_lock().lock().await;
+        // Take the state store lock.
+        let _state_store_lock = client.base_client().state_store_lock().lock().await;
 
         // Update the `RoomInfo` in the state store.
         if let Err(error) = client.state_store().save_changes(&state_changes).await {

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -949,7 +949,7 @@ impl Room {
                     Err(err) => return Err(err.into()),
                 };
 
-                let _sync_lock = self.client.base_client().sync_lock().lock().await;
+                let _state_store_lock = self.client.base_client().state_store_lock().lock().await;
 
                 // Persist the event and the fact that we requested it from the server in
                 // `RoomInfo`.
@@ -2073,7 +2073,9 @@ impl Room {
                     loop {
                         // Listen for sync events, then check if the encryption state is known.
                         self.client.inner.sync_beat.listen().await;
-                        let _sync_lock = self.client.base_client().sync_lock().lock().await;
+                        let _state_store_lock =
+                            self.client.base_client().state_store_lock().lock().await;
+
                         if !self.inner.encryption_state().is_unknown() {
                             break;
                         }
@@ -2083,7 +2085,7 @@ impl Room {
             )
             .await;
 
-            let _sync_lock = self.client.base_client().sync_lock().lock().await;
+            let _state_store_lock = self.client.base_client().state_store_lock().lock().await;
 
             // If encryption was enabled, return.
             #[cfg(not(feature = "experimental-encrypted-state-events"))]

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -261,12 +261,12 @@ impl SlidingSync {
             let _timer = timer!("response processor");
 
             let response_processor = {
-                // Take the lock to avoid concurrent sliding syncs overwriting each other's room
-                // infos.
-                let _sync_lock = {
-                    let _timer = timer!("acquiring the `sync_lock`");
+                // Take the lock to synchronise accesses to the state store, to avoid concurrent
+                // sliding syncs overwriting each other's room infos.
+                let _state_store_lock = {
+                    let _timer = timer!("acquiring the `state_store_lock`");
 
-                    self.inner.client.base_client().sync_lock().lock().await
+                    self.inner.client.base_client().state_store_lock().lock().await
                 };
 
                 let mut response_processor =
@@ -2843,7 +2843,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_sync_lock_is_released_before_calling_handlers() -> Result<()> {
+    async fn test_state_store_lock_is_released_before_calling_handlers() -> Result<()> {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let room_id = room_id!("!mu5hr00m:example.org");


### PR DESCRIPTION
This patch renames the `sync_lock` to `state_store_lock` because it is what it is. It's not about the sync, it's about the state store.
