### PR TITLE
feat(spaces): automatically subscribe to `SpaceRoomList` "parent" space room info updates 

### DIFF
--- a/crates/matrix-sdk-ui/src/spaces/room_list.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room_list.rs
@@ -180,10 +180,8 @@ impl SpaceRoomList {
                 let space_id = space_id.clone();
                 let space_observable = space_observable.clone();
                 async move {
-                    loop {
-                        if subscriber.next().await.is_some()
-                            && let Some(room) = client.get_room(&space_id)
-                        {
+                    while subscriber.next().await.is_some() {
+                        if let Some(room) = client.get_room(&space_id) {
                             space_observable
                                 .set(Some(SpaceRoom::new_from_known(&room, children_count)));
                         }


### PR DESCRIPTION
… when known to the client and forward updates through the existing `subscribe_to_space_updates` mechanisms.

This allows clients to listen to updates without having to resort to a separate room info subscription on their side.
