### PR TITLE
fix(ffi): `ffi::Room::load_or_fetch_event` fails with missing room_id

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -27,7 +27,7 @@ use ruma::{
             join_rules::JoinRule as RumaJoinRule, message::RoomMessageEventContentWithoutRelation,
             MediaSource,
         },
-        AnyMessageLikeEventContent, AnySyncTimelineEvent, AnyTimelineEvent,
+        AnyMessageLikeEventContent, AnySyncTimelineEvent,
     },
     EventId, Int, OwnedDeviceId, OwnedRoomOrAliasId, OwnedServerName, OwnedUserId, RoomAliasId,
     ServerName, UserId,
@@ -1188,7 +1188,12 @@ impl Room {
     ) -> Result<TimelineEvent, ClientError> {
         let event_id = EventId::parse(event_id)?;
         let timeline_event = self.inner.load_or_fetch_event(&event_id, None).await?;
-        Ok(timeline_event.kind.into_raw().deserialize_as_unchecked::<AnyTimelineEvent>()?.into())
+        Ok(timeline_event
+            .kind
+            .into_raw()
+            .deserialize()?
+            .into_full_event(self.inner.room_id().to_owned())
+            .into())
     }
 }
 


### PR DESCRIPTION
The raw event was being deserialized in a wrong way and it could have a missing room id in some cases, returning an error even when the event was found.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
