### PR TITLE
IndexedDB: upgrade `indexed_db_futures` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,14 @@ version = 4
 
 [[package]]
 name = "accessory"
-version = "1.3.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87537f9ae7cfa78d5b8ebd1a1db25959f5e737126be4d8eb44a5452fc4b63cde"
+checksum = "28e416a3ab45838bac2ab2d81b1088d738d7b2d2c5272a54d39366565a29bd80"
 dependencies = [
  "macroific",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -179,7 +179,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -238,7 +238,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -350,7 +350,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -361,7 +361,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -594,7 +594,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -852,7 +852,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1153,7 +1153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1190,7 +1190,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1224,7 +1224,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1238,7 +1238,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1249,7 +1249,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1260,7 +1260,7 @@ checksum = "2b5be8a7a562d315a5b92a630c30cec6bcf663e6673f00fbb69cca66a6f521b9"
 dependencies = [
  "darling_core 0.21.1",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1331,14 +1331,16 @@ dependencies = [
 
 [[package]]
 name = "delegate-display"
-version = "2.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a85201f233142ac819bbf6226e36d0b5e129a47bd325084674261c82d4cd66"
+checksum = "9926686c832494164c33a36bf65118f4bd6e704000b58c94681bf62e9ad67a74"
 dependencies = [
+ "impartial-ord",
+ "itoa",
  "macroific",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1363,6 +1365,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,7 +1393,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1390,7 +1403,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1439,7 +1493,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1722,7 +1776,7 @@ checksum = "dd65f1b59dd22d680c7a626cc4a000c1e03d241c51c3e034d2bc9f1e90734f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1789,14 +1843,14 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy_constructor"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b19d0e43eae2bfbafe4931b5e79c73fb1a849ca15cd41a761a7b8587f9a1a2"
+checksum = "28a27643a5d05f3a22f5afd6e0d0e6e354f92d37907006f97b84b9cb79082198"
 dependencies = [
  "macroific",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1966,7 +2020,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2262,7 +2316,7 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2554,7 +2608,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2621,6 +2675,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "impartial-ord"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab604ee7085efba6efc65e4ebca0e9533e3aff6cb501d7d77b211e3a781c6d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,19 +2712,39 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexed_db_futures"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43315957678a70eb21fb0d2384fe86dde0d6c859a01e24ce127eb65a0143d28c"
+version = "0.6.4"
+source = "git+https://github.com/mgoldenberg/rust-indexed-db?rev=2ac8f0bc1c53f8d8654efcdf9e32b6d359457398#2ac8f0bc1c53f8d8654efcdf9e32b6d359457398"
 dependencies = [
  "accessory",
  "cfg-if",
  "delegate-display",
+ "derive_more 2.0.1",
  "fancy_constructor",
+ "futures-core",
+ "indexed_db_futures_macros_internal",
  "js-sys",
- "uuid",
+ "sealed",
+ "serde",
+ "serde-wasm-bindgen",
+ "smallvec",
+ "thiserror 2.0.16",
+ "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm_evt_listener",
  "web-sys",
+ "web-time",
+]
+
+[[package]]
+name = "indexed_db_futures_macros_internal"
+version = "1.0.0"
+source = "git+https://github.com/mgoldenberg/rust-indexed-db?rev=2ac8f0bc1c53f8d8654efcdf9e32b6d359457398#2ac8f0bc1c53f8d8654efcdf9e32b6d359457398"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2713,7 +2798,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2998,9 +3083,9 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "macroific"
-version = "1.3.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05c00ac596022625d01047c421a0d97d7f09a18e429187b341c201cb631b9dd"
+checksum = "89f276537b4b8f981bf1c13d79470980f71134b7bdcc5e6e911e910e556b0285"
 dependencies = [
  "macroific_attr_parse",
  "macroific_core",
@@ -3009,38 +3094,39 @@ dependencies = [
 
 [[package]]
 name = "macroific_attr_parse"
-version = "1.3.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94d5da95b30ae6e10621ad02340909346ad91661f3f8c0f2b62345e46a2f67"
+checksum = "ad4023761b45fcd36abed8fb7ae6a80456b0a38102d55e89a57d9a594a236be9"
 dependencies = [
- "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "sealed",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "macroific_core"
-version = "1.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13198c120864097a565ccb3ff947672d969932b7975ebd4085732c9f09435e55"
+checksum = "d0a7594d3c14916fa55bef7e9d18c5daa9ed410dd37504251e4b75bbdeec33e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "sealed",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "macroific_macro"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c9853143cbed7f1e41dc39fee95f9b361bec65c8dc2a01bf609be01b61f5ae"
+checksum = "4da6f2ed796261b0a74e2b52b42c693bb6dee1effba3a482c49592659f824b3b"
 dependencies = [
  "macroific_attr_parse",
  "macroific_core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3098,7 +3184,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3380,7 +3466,7 @@ version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3569,7 +3655,7 @@ name = "matrix-sdk-test-macros"
 version = "0.14.0"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3933,7 +4019,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4091,7 +4177,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4278,7 +4364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4356,7 +4442,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4896,7 +4982,7 @@ dependencies = [
  "quote",
  "ruma-identifiers-validation",
  "serde",
- "syn",
+ "syn 2.0.101",
  "toml 0.8.15",
 ]
 
@@ -5096,7 +5182,18 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "sealed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5276,7 +5373,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5466,6 +5563,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smawk"
@@ -5594,7 +5694,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5607,7 +5707,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5615,6 +5715,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -5644,7 +5755,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5854,7 +5965,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5865,7 +5976,7 @@ checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5981,7 +6092,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6161,7 +6272,7 @@ source = "git+https://github.com/tokio-rs/tracing.git?rev=20f5b3d8ba057ca9c4ae00
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6363,6 +6474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "uniffi"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6426,7 +6543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6458,7 +6575,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.101",
  "toml 0.5.11",
  "uniffi_meta",
 ]
@@ -6751,7 +6868,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -6786,7 +6903,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6821,7 +6938,7 @@ checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6834,6 +6951,24 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm_evt_listener"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc92d6378b411ed94839112a36d9dbc77143451d85b05dfb0cce93a78dab1963"
+dependencies = [
+ "accessory",
+ "derivative",
+ "derive_more 1.0.0",
+ "fancy_constructor",
+ "futures-core",
+ "js-sys",
+ "smallvec",
+ "tokio",
+ "wasm-bindgen",
  "web-sys",
 ]
 
@@ -6854,6 +6989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -6993,7 +7129,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7004,7 +7140,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7317,7 +7453,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -7338,7 +7474,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7358,7 +7494,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -7379,7 +7515,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7401,7 +7537,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ hkdf = "0.12.4"
 hmac = "0.12.1"
 http = "1.3.1"
 imbl = "6.1.0"
+indexed_db_futures = "0.5.0"
 indexmap = "2.11.0"
 insta = { version = "1.43.1", features = ["json", "redactions"] }
 itertools = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ hkdf = "0.12.4"
 hmac = "0.12.1"
 http = "1.3.1"
 imbl = "6.1.0"
-indexed_db_futures = "0.5.0"
+indexed_db_futures = "0.6.4"
 indexmap = "2.11.0"
 insta = { version = "1.43.1", features = ["json", "redactions"] }
 itertools = "0.14.0"
@@ -201,6 +201,7 @@ lto = false
 [patch.crates-io]
 async-compat = { git = "https://github.com/element-hq/async-compat", rev = "5a27c8b290f1f1dcfc0c4ec22c464e38528aa591" }
 const_panic = { git = "https://github.com/jplatte/const_panic", rev = "9024a4cb3eac45c1d2d980f17aaee287b17be498" }
+indexed_db_futures = { git = "https://github.com/mgoldenberg/rust-indexed-db", rev = "2ac8f0bc1c53f8d8654efcdf9e32b6d359457398" }
 # Needed to fix rotation log issue on Android (https://github.com/tokio-rs/tracing/issues/2937)
 tracing = { git = "https://github.com/tokio-rs/tracing.git", rev = "20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05" }
 tracing-core = { git = "https://github.com/tokio-rs/tracing.git", rev = "20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05" }

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -31,7 +31,12 @@ base64.workspace = true
 gloo-utils = { version = "0.2.0", features = ["serde"] }
 growable-bloom-filter = { workspace = true, optional = true }
 hkdf.workspace = true
-indexed_db_futures.workspace = true
+indexed_db_futures = { workspace = true, features = [
+    "serde",
+    "cursors",
+    "indices",
+    "streams",
+]}
 js-sys.workspace = true
 matrix-sdk-base = { workspace = true, features = ["js"], optional = true }
 matrix-sdk-crypto = { workspace = true, features = ["js"], optional = true }

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -31,7 +31,7 @@ base64.workspace = true
 gloo-utils = { version = "0.2.0", features = ["serde"] }
 growable-bloom-filter = { workspace = true, optional = true }
 hkdf.workspace = true
-indexed_db_futures = "0.5.0"
+indexed_db_futures.workspace = true
 js-sys.workspace = true
 matrix-sdk-base = { workspace = true, features = ["js"], optional = true }
 matrix-sdk-crypto = { workspace = true, features = ["js"], optional = true }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
@@ -14,9 +14,16 @@
 
 use std::ops::Deref;
 
-use indexed_db_futures::{prelude::*, web_sys::DomException};
+use indexed_db_futures::{
+    database::Database,
+    error::{Error, OpenDbError},
+    index::Index,
+    internals::SystemRepr,
+    object_store::ObjectStore,
+    prelude::*,
+    transaction::Transaction,
+};
 use tracing::info;
-use wasm_bindgen::JsValue;
 
 use crate::{crypto_store::Result, serializer::SafeEncodeSerializer, IndexeddbCryptoStoreError};
 
@@ -32,7 +39,7 @@ mod v7_to_v8;
 mod v8_to_v10;
 
 struct MigrationDb {
-    db: IdbDatabase,
+    db: Database,
     next_version: u32,
 }
 
@@ -42,12 +49,12 @@ impl MigrationDb {
     /// closing the DB when this object is dropped.
     async fn new(name: &str, next_version: u32) -> Result<Self> {
         info!("IndexeddbCryptoStore migrate data before v{next_version} starting");
-        Ok(Self { db: IdbDatabase::open(name)?.await?, next_version })
+        Ok(Self { db: Database::open(name).await?, next_version })
     }
 }
 
 impl Deref for MigrationDb {
-    type Target = IdbDatabase;
+    type Target = Database;
 
     fn deref(&self) -> &Self::Target {
         &self.db
@@ -58,7 +65,7 @@ impl Drop for MigrationDb {
     fn drop(&mut self) {
         let version = self.next_version;
         info!("IndexeddbCryptoStore migrate data before v{version} finished");
-        self.db.close();
+        self.db.as_sys().close();
     }
 }
 
@@ -101,7 +108,7 @@ const MAX_SUPPORTED_SCHEMA_VERSION: u32 = 99;
 pub async fn open_and_upgrade_db(
     name: &str,
     serializer: &SafeEncodeSerializer,
-) -> Result<IdbDatabase, IndexeddbCryptoStoreError> {
+) -> Result<Database, IndexeddbCryptoStoreError> {
     // Move the DB version up from where it is to the latest version.
     //
     // Schema changes need to be separate from data migrations, so we often
@@ -177,11 +184,11 @@ pub async fn open_and_upgrade_db(
     // `MAX_SUPPORTED_SCHEMA_VERSION` itself to the next multiple of 10).
 
     // Open and return the DB (we know it's at the latest version)
-    Ok(IdbDatabase::open(name)?.await?)
+    Ok(Database::open(name).await?)
 }
 
 async fn db_version(name: &str) -> Result<u32, IndexeddbCryptoStoreError> {
-    let db = IdbDatabase::open(name)?.await?;
+    let db = Database::open(name).await?;
     let old_version = db.version() as u32;
     db.close();
     Ok(old_version)
@@ -197,50 +204,45 @@ type OldVersion = u32;
 /// * `version` - version we are upgrading to.
 /// * `f` - closure which will be called if the database is below the version
 ///   given. It will be called with three arguments `(db, txn, oldver)`, where:
-///   * `db` - the [`IdbDatabase`]
-///   * `txn` - the database transaction: a [`IdbTransaction`]
+///   * `db` - the [`Database`]
+///   * `txn` - the database transaction: a [`Transaction`]
 ///   * `oldver` - the version number before the upgrade.
-async fn do_schema_upgrade<F>(name: &str, version: u32, f: F) -> Result<(), DomException>
+async fn do_schema_upgrade<F>(name: &str, version: u32, f: F) -> Result<(), OpenDbError>
 where
-    F: Fn(&IdbDatabase, IdbTransaction<'_>, OldVersion) -> Result<(), JsValue> + 'static,
+    F: Fn(&Transaction<'_>, OldVersion) -> Result<(), Error> + 'static,
 {
     info!("IndexeddbCryptoStore upgrade schema -> v{version} starting");
-    let mut db_req: OpenDbRequest = IdbDatabase::open_u32(name, version)?;
+    let db = Database::open(name)
+        .with_version(version)
+        .with_on_upgrade_needed(move |evt, tx| {
+            // Even if the web-sys bindings expose the version as a f64, the IndexedDB API
+            // works with an unsigned integer.
+            // See <https://github.com/rustwasm/wasm-bindgen/issues/1149>
+            let old_version = evt.old_version() as u32;
 
-    db_req.set_on_upgrade_needed(Some(move |evt: &IdbVersionChangeEvent| {
-        // Even if the web-sys bindings expose the version as a f64, the IndexedDB API
-        // works with an unsigned integer.
-        // See <https://github.com/rustwasm/wasm-bindgen/issues/1149>
-        let old_version = evt.old_version() as u32;
-
-        // Run the upgrade code we were supplied
-        f(evt.db(), evt.transaction(), old_version)
-    }));
-
-    let db = db_req.await?;
+            // Run the upgrade code we were supplied
+            f(tx, old_version)
+        })
+        .await?;
     db.close();
     info!("IndexeddbCryptoStore upgrade schema -> v{version} complete");
     Ok(())
 }
 
 fn add_nonunique_index<'a>(
-    object_store: &'a IdbObjectStore<'a>,
+    object_store: &'a ObjectStore<'a>,
     name: &str,
     key_path: &str,
-) -> Result<IdbIndex<'a>, DomException> {
-    let params = IdbIndexParameters::new();
-    params.set_unique(false);
-    object_store.create_index_with_params(name, &IdbKeyPath::str(key_path), &params)
+) -> Result<Index<'a>, Error> {
+    object_store.create_index(name, key_path.into()).with_unique(false).build()
 }
 
 fn add_unique_index<'a>(
-    object_store: &'a IdbObjectStore<'a>,
+    object_store: &'a ObjectStore<'a>,
     name: &str,
     key_path: &str,
-) -> Result<IdbIndex<'a>, DomException> {
-    let params = IdbIndexParameters::new();
-    params.set_unique(true);
-    object_store.create_index_with_params(name, &IdbKeyPath::str(key_path), &params)
+) -> Result<Index<'a>, Error> {
+    object_store.create_index(name, key_path.into()).with_unique(true).build()
 }
 
 #[cfg(all(test, target_family = "wasm"))]
@@ -249,7 +251,9 @@ mod tests {
 
     use assert_matches::assert_matches;
     use gloo_utils::format::JsValueSerdeExt;
-    use indexed_db_futures::prelude::*;
+    use indexed_db_futures::{
+        database::VersionChangeEvent, prelude::*, transaction::TransactionMode,
+    };
     use matrix_sdk_common::js_tracing::make_tracing_subscriber;
     use matrix_sdk_crypto::{
         olm::{InboundGroupSession, SenderData, SessionKey},
@@ -262,6 +266,7 @@ mod tests {
     use ruma::{room_id, OwnedRoomId, RoomId};
     use serde::Serialize;
     use tracing_subscriber::util::SubscriberInitExt;
+    use wasm_bindgen::JsValue;
     use web_sys::console;
 
     use super::{v0_to_v5, v7::InboundGroupSessionIndexedDbObject2};
@@ -304,14 +309,21 @@ mod tests {
         // Check how long it takes to insert these records
         measure_performance("Inserting", "v8", NUM_RECORDS_FOR_PERF, || async {
             for (key, session_js) in objects.iter() {
-                store.add_key_val(key, session_js).unwrap().await.unwrap();
+                store
+                    .add(session_js)
+                    .with_key(key)
+                    .without_key_type()
+                    .build()
+                    .unwrap()
+                    .await
+                    .unwrap();
             }
         })
         .await;
 
         // Check how long it takes to count these records
         measure_performance("Counting", "v8", NUM_RECORDS_FOR_PERF, || async {
-            store.count().unwrap().await.unwrap();
+            store.count().await.unwrap();
         })
         .await;
     }
@@ -340,40 +352,51 @@ mod tests {
         // Check how long it takes to insert these records
         measure_performance("Inserting", "v10", NUM_RECORDS_FOR_PERF, || async {
             for (key, session_js) in objects.iter() {
-                store.add_key_val(key, session_js).unwrap().await.unwrap();
+                store
+                    .add(session_js)
+                    .with_key(key)
+                    .without_key_type()
+                    .build()
+                    .unwrap()
+                    .await
+                    .unwrap();
             }
         })
         .await;
 
         // Check how long it takes to count these records
         measure_performance("Counting", "v10", NUM_RECORDS_FOR_PERF, || async {
-            store.count().unwrap().await.unwrap();
+            store.count().await.unwrap();
         })
         .await;
     }
 
-    async fn create_db(db_prefix: &str) -> IdbDatabase {
+    async fn create_db(db_prefix: &str) -> Database {
         let db_name = format!("{db_prefix}::matrix-sdk-crypto");
         let store_name = format!("{db_prefix}_store");
-        let mut db_req: OpenDbRequest = IdbDatabase::open_u32(&db_name, 1).unwrap();
-        db_req.set_on_upgrade_needed(Some(
-            move |evt: &IdbVersionChangeEvent| -> Result<(), JsValue> {
-                evt.db().create_object_store(&store_name)?;
-                Ok(())
-            },
-        ));
-        db_req.await.unwrap()
+        Database::open(&db_name)
+            .with_version(1u32)
+            .with_on_upgrade_needed(
+                move |_: VersionChangeEvent, tx: &Transaction<'_>| -> Result<(), Error> {
+                    tx.db().create_object_store(&store_name).build()?;
+                    Ok(())
+                },
+            )
+            .build()
+            .unwrap()
+            .await
+            .unwrap()
     }
 
-    async fn create_transaction<'a>(db: &'a IdbDatabase, db_prefix: &str) -> IdbTransaction<'a> {
+    async fn create_transaction<'a>(db: &'a Database, db_prefix: &str) -> Transaction<'a> {
         let store_name = format!("{db_prefix}_store");
-        db.transaction_on_one_with_mode(&store_name, IdbTransactionMode::Readwrite).unwrap()
+        db.transaction(&store_name).with_mode(TransactionMode::Readwrite).build().unwrap()
     }
 
     async fn create_store<'a>(
-        transaction: &'a IdbTransaction<'a>,
+        transaction: &'a Transaction<'a>,
         db_prefix: &str,
-    ) -> IdbObjectStore<'a> {
+    ) -> ObjectStore<'a> {
         let store_name = format!("{db_prefix}_store");
         transaction.object_store(&store_name).unwrap()
     }
@@ -520,7 +543,7 @@ mod tests {
         let db_name = format!("{db_prefix:0}::matrix-sdk-crypto");
 
         // delete the db in case it was used in a previous run
-        let _ = IdbDatabase::delete_by_name(&db_name);
+        let _ = Database::delete_by_name(&db_name);
 
         // Given a DB with data in it as it was at v5
         let room_id = room_id!("!test:localhost");
@@ -568,21 +591,21 @@ mod tests {
         store: &IndexeddbCryptoStore,
         fetched_backed_up_session: &InboundGroupSession,
     ) {
-        let db = IdbDatabase::open(&db_name).unwrap().await.unwrap();
+        let db = Database::open(&db_name).build().unwrap().await.unwrap();
         assert!(db.version() >= 10.0);
-        let transaction = db.transaction_on_one("inbound_group_sessions3").unwrap();
+        let transaction = db.transaction("inbound_group_sessions3").build().unwrap();
         let raw_store = transaction.object_store("inbound_group_sessions3").unwrap();
         let key = store.serializer.encode_key(
             keys::INBOUND_GROUP_SESSIONS_V3,
             (fetched_backed_up_session.room_id(), fetched_backed_up_session.session_id()),
         );
         let idb_object: InboundGroupSessionIndexedDbObject =
-            serde_wasm_bindgen::from_value(raw_store.get(&key).unwrap().await.unwrap().unwrap())
-                .unwrap();
+            serde_wasm_bindgen::from_value(raw_store.get(&key).await.unwrap().unwrap()).unwrap();
 
         assert_eq!(idb_object.backed_up_to, -1);
         assert!(raw_store.index_names().find(|idx| idx == "backed_up_to").is_some());
 
+        transaction.commit().await.unwrap();
         db.close();
     }
 
@@ -591,16 +614,15 @@ mod tests {
         store: &IndexeddbCryptoStore,
         session: &InboundGroupSession,
     ) {
-        let db = IdbDatabase::open(&db_name).unwrap().await.unwrap();
+        let db = Database::open(&db_name).build().unwrap().await.unwrap();
         assert!(db.version() >= 12.0);
-        let transaction = db.transaction_on_one("inbound_group_sessions3").unwrap();
+        let transaction = db.transaction("inbound_group_sessions3").build().unwrap();
         let raw_store = transaction.object_store("inbound_group_sessions3").unwrap();
         let key = store
             .serializer
             .encode_key(keys::INBOUND_GROUP_SESSIONS_V3, (session.room_id(), session.session_id()));
         let idb_object: InboundGroupSessionIndexedDbObject =
-            serde_wasm_bindgen::from_value(raw_store.get(&key).unwrap().await.unwrap().unwrap())
-                .unwrap();
+            serde_wasm_bindgen::from_value(raw_store.get(&key).await.unwrap().unwrap()).unwrap();
 
         assert_eq!(
             idb_object.session_id,
@@ -623,6 +645,7 @@ mod tests {
             .find(|idx| idx == "inbound_group_session_sender_key_sender_data_type_idx")
             .is_some());
 
+        transaction.commit().await.unwrap();
         db.close();
     }
 
@@ -685,10 +708,9 @@ mod tests {
         let serializer = SafeEncodeSerializer::new(store_cipher.clone());
 
         let txn = db
-            .transaction_on_one_with_mode(
-                old_keys::INBOUND_GROUP_SESSIONS_V1,
-                IdbTransactionMode::Readwrite,
-            )
+            .transaction(old_keys::INBOUND_GROUP_SESSIONS_V1)
+            .with_mode(TransactionMode::Readwrite)
+            .build()
             .unwrap();
         let sessions = txn.object_store(old_keys::INBOUND_GROUP_SESSIONS_V1).unwrap();
         for session in session_entries {
@@ -701,9 +723,9 @@ mod tests {
             // Serialize the session with the old style of serialization, since that's what
             // we used at the time.
             let serialized_session = serialize_value_as_legacy(&store_cipher, &pickle);
-            sessions.put_key_val(&key, &serialized_session).unwrap();
+            sessions.put(&serialized_session).with_key(key).build().unwrap();
         }
-        txn.await.into_result().unwrap();
+        txn.commit().await.unwrap();
 
         // now close our DB, reopen it properly, and check that we can still read our
         // data.
@@ -736,21 +758,23 @@ mod tests {
         let db_name = format!("{db_prefix:0}::matrix-sdk-crypto");
 
         // delete the db in case it was used in a previous run
-        let _ = IdbDatabase::delete_by_name(&db_name);
+        let _ = Database::delete_by_name(&db_name).unwrap().await.unwrap();
 
         // Given a DB with data in it as it was at v5
         let db = create_v5_db(&db_name).await.unwrap();
 
         let txn = db
-            .transaction_on_one_with_mode(keys::BACKUP_KEYS, IdbTransactionMode::Readwrite)
+            .transaction(keys::BACKUP_KEYS)
+            .with_mode(TransactionMode::Readwrite)
+            .build()
             .unwrap();
         let store = txn.object_store(keys::BACKUP_KEYS).unwrap();
         store
-            .put_key_val(
-                &JsValue::from_str(old_keys::BACKUP_KEY_V1),
-                &serialize_value_as_legacy(&store_cipher, &"1".to_owned()),
-            )
+            .put(&serialize_value_as_legacy(&store_cipher, &"1".to_owned()))
+            .with_key(JsValue::from_str(old_keys::BACKUP_KEY_V1))
+            .build()
             .unwrap();
+        txn.commit().await.unwrap();
         db.close();
 
         // When I open a store based on that DB, triggering an upgrade
@@ -762,9 +786,9 @@ mod tests {
         assert_eq!(backup_data.backup_version, Some("1".to_owned()));
     }
 
-    async fn create_v5_db(name: &str) -> std::result::Result<IdbDatabase, DomException> {
+    async fn create_v5_db(name: &str) -> std::result::Result<Database, OpenDbError> {
         v0_to_v5::schema_add(name).await?;
-        IdbDatabase::open_u32(name, 5)?.await
+        Database::open(name).with_version(5u32).build()?.await
     }
 
     /// Opening a db that has been upgraded to MAX_SUPPORTED_SCHEMA_VERSION
@@ -811,23 +835,27 @@ mod tests {
         let db_name = format!("{db_prefix}::matrix-sdk-crypto");
 
         // delete the db in case it was used in a previous run
-        let _ = IdbDatabase::delete_by_name(&db_name);
+        let _ = Database::delete_by_name(&db_name);
 
         // Open, and close, the store at the regular version.
         IndexeddbCryptoStore::open_with_store_cipher(&db_prefix, None).await.unwrap();
 
         // Now upgrade to the given version, keeping a record of the previous version so
         // that we can double-check it.
-        let mut db_req: OpenDbRequest = IdbDatabase::open_u32(&db_name, version).unwrap();
-
         let old_version: Rc<Cell<Option<u32>>> = Rc::new(Cell::new(None));
         let old_version2 = old_version.clone();
-        db_req.set_on_upgrade_needed(Some(move |evt: &IdbVersionChangeEvent| {
-            old_version2.set(Some(evt.old_version() as u32));
-            Ok(())
-        }));
 
-        let db = db_req.await.unwrap();
+        let db = Database::open(&db_name)
+            .with_version(version)
+            .with_on_upgrade_needed(move |evt: VersionChangeEvent, _: &Transaction<'_>| {
+                old_version2.set(Some(evt.old_version() as u32));
+                Ok(())
+            })
+            .build()
+            .unwrap()
+            .await
+            .unwrap();
+
         assert_eq!(
             old_version.get(),
             Some(EXPECTED_SCHEMA_VERSION),

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v10_to_v11.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v10_to_v11.rs
@@ -15,9 +15,10 @@
 //! Migration code that moves from `backup_keys.backup_key_v1` to
 //! `backup_keys.backup_version_v1`, switching to a new serialization format.
 
-use indexed_db_futures::IdbQuerySource;
+use indexed_db_futures::{
+    error::OpenDbError, query_source::QuerySource, transaction::TransactionMode, Build,
+};
 use wasm_bindgen::JsValue;
-use web_sys::{DomException, IdbTransactionMode};
 
 use crate::{
     crypto_store::{
@@ -34,10 +35,10 @@ pub(crate) async fn data_migrate(
     serializer: &SafeEncodeSerializer,
 ) -> crate::crypto_store::Result<()> {
     let db = MigrationDb::new(name, 11).await?;
-    let txn = db.transaction_on_one_with_mode(keys::BACKUP_KEYS, IdbTransactionMode::Readwrite)?;
+    let txn = db.transaction(keys::BACKUP_KEYS).with_mode(TransactionMode::Readwrite).build()?;
     let store = txn.object_store(keys::BACKUP_KEYS)?;
 
-    let bv = store.get(&JsValue::from_str(old_keys::BACKUP_KEY_V1))?.await?;
+    let bv = store.get(&JsValue::from_str(old_keys::BACKUP_KEY_V1)).await?;
 
     let Some(bv) = bv else {
         return Ok(());
@@ -50,14 +51,15 @@ pub(crate) async fn data_migrate(
 
     // Re-serialize as new format, then store in the new field.
     let serialized = serializer.serialize_value(&bv)?;
-    store.put_key_val(&JsValue::from_str(keys::BACKUP_VERSION_V1), &serialized)?.await?;
-    store.delete(&JsValue::from_str(old_keys::BACKUP_KEY_V1))?.await?;
+    store.put(&serialized).with_key(JsValue::from_str(keys::BACKUP_VERSION_V1)).await?;
+    store.delete(&JsValue::from_str(old_keys::BACKUP_KEY_V1)).await?;
+    txn.commit().await?;
     Ok(())
 }
 
 /// Perform the schema upgrade v10 to v11, just bumping the schema version.
-pub(crate) async fn schema_bump(name: &str) -> crate::crypto_store::Result<(), DomException> {
+pub(crate) async fn schema_bump(name: &str) -> crate::crypto_store::Result<(), OpenDbError> {
     // Just bump the version number to 11 to demonstrate that we have run the data
     // changes from data_migrate.
-    do_schema_upgrade(name, 11, |_, _, _| Ok(())).await
+    do_schema_upgrade(name, 11, |_, _| Ok(())).await
 }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v12_to_v13.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v12_to_v13.rs
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use web_sys::DomException;
+use indexed_db_futures::{error::OpenDbError, Build};
 
 use crate::crypto_store::{keys, migrations::do_schema_upgrade, Result};
 
 /// Perform the schema upgrade v12 to v13, adding the
 /// `received_room_key_bundles` store.
-pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 13, |db, _, _| {
-        db.create_object_store(keys::RECEIVED_ROOM_KEY_BUNDLES)?;
+pub(crate) async fn schema_add(name: &str) -> Result<(), OpenDbError> {
+    do_schema_upgrade(name, 13, |tx, _| {
+        tx.db().create_object_store(keys::RECEIVED_ROOM_KEY_BUNDLES).build()?;
         Ok(())
     })
     .await

--- a/crates/matrix-sdk-indexeddb/src/error.rs
+++ b/crates/matrix-sdk-indexeddb/src/error.rs
@@ -12,7 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License
 
+#[cfg(feature = "event-cache-store")]
+use matrix_sdk_base::event_cache::store::EventCacheStoreError;
+#[cfg(feature = "media-store")]
+use matrix_sdk_base::media::store::MediaStoreError;
+#[cfg(feature = "state-store")]
+use matrix_sdk_base::StoreError;
 use matrix_sdk_base::{SendOutsideWasm, SyncOutsideWasm};
+#[cfg(feature = "e2e-encryption")]
+use matrix_sdk_crypto::CryptoStoreError;
+use thiserror::Error;
 
 /// A trait that combines the necessary traits needed for asynchronous runtimes,
 /// but excludes them when running in a web environment - i.e., when
@@ -21,3 +30,45 @@ pub trait AsyncErrorDeps: std::error::Error + SendOutsideWasm + SyncOutsideWasm 
 
 impl<T> AsyncErrorDeps for T where T: std::error::Error + SendOutsideWasm + SyncOutsideWasm + 'static
 {}
+
+/// A wrapper around [`String`] that derives [`Error`](std::error::Error).
+/// This is useful when a particular error is not [`Send`] or [`Sync`] but
+/// must be mapped into a higher-level error that requires those constraints,
+/// e.g. [`StoreError::Backend`], [`CryptStoreError::Backend`], etc.
+#[derive(Debug, Error)]
+#[error("{0}")]
+pub struct GenericError(String);
+
+impl<S: AsRef<str>> From<S> for GenericError {
+    fn from(value: S) -> Self {
+        Self(value.as_ref().to_owned())
+    }
+}
+
+#[cfg(feature = "e2e-encryption")]
+impl From<GenericError> for CryptoStoreError {
+    fn from(value: GenericError) -> Self {
+        Self::backend(value)
+    }
+}
+
+#[cfg(feature = "event-cache-store")]
+impl From<GenericError> for EventCacheStoreError {
+    fn from(value: GenericError) -> Self {
+        Self::backend(value)
+    }
+}
+
+#[cfg(feature = "media-store")]
+impl From<GenericError> for MediaStoreError {
+    fn from(value: GenericError) -> Self {
+        Self::backend(value)
+    }
+}
+
+#[cfg(feature = "state-store")]
+impl From<GenericError> for StoreError {
+    fn from(value: GenericError) -> Self {
+        Self::backend(value)
+    }
+}

--- a/crates/matrix-sdk-indexeddb/src/error.rs
+++ b/crates/matrix-sdk-indexeddb/src/error.rs
@@ -18,6 +18,7 @@ use matrix_sdk_base::event_cache::store::EventCacheStoreError;
 use matrix_sdk_base::media::store::MediaStoreError;
 #[cfg(feature = "state-store")]
 use matrix_sdk_base::StoreError;
+#[cfg(any(feature = "event-cache-store", feature = "media-store"))]
 use matrix_sdk_base::{SendOutsideWasm, SyncOutsideWasm};
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_crypto::CryptoStoreError;
@@ -26,8 +27,10 @@ use thiserror::Error;
 /// A trait that combines the necessary traits needed for asynchronous runtimes,
 /// but excludes them when running in a web environment - i.e., when
 /// `#[cfg(target_family = "wasm")]`.
+#[cfg(any(feature = "event-cache-store", feature = "media-store"))]
 pub trait AsyncErrorDeps: std::error::Error + SendOutsideWasm + SyncOutsideWasm + 'static {}
 
+#[cfg(any(feature = "event-cache-store", feature = "media-store"))]
 impl<T> AsyncErrorDeps for T where T: std::error::Error + SendOutsideWasm + SyncOutsideWasm + 'static
 {}
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -16,7 +16,7 @@
 
 use std::{rc::Rc, time::Duration};
 
-use indexed_db_futures::IdbDatabase;
+use indexed_db_futures::{database::Database, Build};
 use matrix_sdk_base::{
     event_cache::{store::EventCacheStore, Event, Gap},
     linked_chunk::{
@@ -61,7 +61,7 @@ pub use error::IndexeddbEventCacheStoreError;
 #[derive(Debug, Clone)]
 pub struct IndexeddbEventCacheStore {
     // A handle to the IndexedDB database
-    inner: Rc<IdbDatabase>,
+    inner: Rc<Database>,
     // A serializer with functionality tailored to `IndexeddbEventCacheStore`
     serializer: IndexedTypeSerializer,
 }
@@ -82,7 +82,11 @@ impl IndexeddbEventCacheStore {
         mode: IdbTransactionMode,
     ) -> Result<IndexeddbEventCacheStoreTransaction<'a>, IndexeddbEventCacheStoreError> {
         Ok(IndexeddbEventCacheStoreTransaction::new(
-            self.inner.transaction_on_multi_with_mode(stores, mode)?,
+            self.inner
+                .transaction(stores)
+                .with_mode(mode)
+                .build()
+                .map_err(TransactionError::from)?,
             &self.serializer,
         ))
     }
@@ -120,7 +124,7 @@ impl EventCacheStore for IndexeddbEventCacheStore {
                 expiration: now + Duration::from_millis(lease_duration_ms.into()),
             })
             .await?;
-
+        transaction.commit().await?;
         Ok(true)
     }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -14,7 +14,7 @@
 
 use std::ops::Deref;
 
-use indexed_db_futures::prelude::IdbTransaction;
+use indexed_db_futures::transaction as inner;
 use matrix_sdk_base::{
     event_cache::{Event as RawEvent, Gap as RawGap},
     linked_chunk::{ChunkContent, ChunkIdentifier, LinkedChunkId, RawChunk},
@@ -54,7 +54,7 @@ impl<'a> Deref for IndexeddbEventCacheStoreTransaction<'a> {
 }
 
 impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
-    pub fn new(transaction: IdbTransaction<'a>, serializer: &'a IndexedTypeSerializer) -> Self {
+    pub fn new(transaction: inner::Transaction<'a>, serializer: &'a IndexedTypeSerializer) -> Self {
         Self { transaction: Transaction::new(transaction, serializer) }
     }
 

--- a/crates/matrix-sdk-indexeddb/src/lib.rs
+++ b/crates/matrix-sdk-indexeddb/src/lib.rs
@@ -6,7 +6,6 @@ use thiserror::Error;
 
 #[cfg(feature = "e2e-encryption")]
 mod crypto_store;
-#[cfg(any(feature = "event-cache-store", feature = "media-store"))]
 mod error;
 #[cfg(feature = "event-cache-store")]
 mod event_cache_store;

--- a/crates/matrix-sdk-indexeddb/src/media_store/error.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/error.rs
@@ -16,16 +16,16 @@ use matrix_sdk_base::media::store::{MediaStore, MediaStoreError, MemoryMediaStor
 use serde::de::Error;
 use thiserror::Error;
 
-use crate::transaction::TransactionError;
+use crate::{error::GenericError, transaction::TransactionError};
 
 #[derive(Debug, Error)]
 pub enum IndexeddbMediaStoreError {
+    #[error("unable to open database: {0}")]
+    UnableToOpenDatabase(String),
     #[error("media store: {0}")]
     MemoryStore(<MemoryMediaStore as MediaStore>::Error),
-
     #[error("transaction: {0}")]
     Transaction(#[from] TransactionError),
-
     #[error("DomException {name} ({code}): {message}")]
     DomException { name: String, message: String, code: u16 },
 }
@@ -35,6 +35,7 @@ impl From<IndexeddbMediaStoreError> for MediaStoreError {
         use IndexeddbMediaStoreError::*;
 
         match value {
+            UnableToOpenDatabase(e) => GenericError::from(e).into(),
             DomException { .. } => Self::InvalidData { details: value.to_string() },
             Transaction(inner) => inner.into(),
             MemoryStore(error) => error,
@@ -48,6 +49,18 @@ impl From<web_sys::DomException> for IndexeddbMediaStoreError {
     }
 }
 
+impl From<indexed_db_futures::error::OpenDbError> for IndexeddbMediaStoreError {
+    fn from(value: indexed_db_futures::error::OpenDbError) -> Self {
+        use indexed_db_futures::error::OpenDbError::*;
+        match value {
+            VersionZero | UnsupportedEnvironment | NullFactory => {
+                Self::UnableToOpenDatabase(value.to_string())
+            }
+            Base(e) => TransactionError::from(e).into(),
+        }
+    }
+}
+
 impl From<TransactionError> for MediaStoreError {
     fn from(value: TransactionError) -> Self {
         use TransactionError::*;
@@ -56,6 +69,7 @@ impl From<TransactionError> for MediaStoreError {
             DomException { .. } => Self::InvalidData { details: value.to_string() },
             Serialization(e) => Self::Serialization(serde_json::Error::custom(e.to_string())),
             ItemIsNotUnique | ItemNotFound => Self::InvalidData { details: value.to_string() },
+            Backend(e) => GenericError::from(e.to_string()).into(),
         }
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
@@ -14,7 +14,7 @@
 
 use std::ops::Deref;
 
-use indexed_db_futures::prelude::IdbTransaction;
+use indexed_db_futures::transaction as inner;
 use matrix_sdk_base::media::{store::MediaRetentionPolicy, MediaRequestParameters};
 use ruma::MxcUri;
 
@@ -45,7 +45,7 @@ impl<'a> Deref for IndexeddbMediaStoreTransaction<'a> {
 }
 
 impl<'a> IndexeddbMediaStoreTransaction<'a> {
-    pub fn new(transaction: IdbTransaction<'a>, serializer: &'a IndexedTypeSerializer) -> Self {
+    pub fn new(transaction: inner::Transaction<'a>, serializer: &'a IndexedTypeSerializer) -> Self {
         Self { transaction: Transaction::new(transaction, serializer) }
     }
 

--- a/crates/matrix-sdk-indexeddb/src/serializer/safe_encode/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/serializer/safe_encode/types.rs
@@ -20,11 +20,11 @@ use base64::{
     Engine,
 };
 use gloo_utils::format::JsValueSerdeExt;
+use indexed_db_futures::KeyRange;
 use matrix_sdk_crypto::CryptoStoreError;
 use matrix_sdk_store_encryption::{EncryptedValueBase64, StoreCipher};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use wasm_bindgen::JsValue;
-use web_sys::IdbKeyRange;
 use zeroize::Zeroizing;
 
 use crate::serializer::safe_encode::traits::SafeEncode;
@@ -146,11 +146,7 @@ impl SafeEncodeSerializer {
         }
     }
 
-    pub fn encode_to_range<T>(
-        &self,
-        table_name: &str,
-        key: T,
-    ) -> Result<IdbKeyRange, SafeEncodeSerializerError>
+    pub fn encode_to_range<T>(&self, table_name: &str, key: T) -> KeyRange<JsValue>
     where
         T: SafeEncode,
     {
@@ -158,11 +154,6 @@ impl SafeEncodeSerializer {
             Some(cipher) => key.encode_to_range_secure(table_name, cipher),
             None => key.encode_to_range(),
         }
-        .map_err(|e| SafeEncodeSerializerError::DomException {
-            code: 0,
-            name: "IdbKeyRangeMakeError".to_owned(),
-            message: e,
-        })
     }
 
     /// Encode the value for storage as a value in indexeddb.

--- a/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
@@ -18,7 +18,14 @@ use std::{
 };
 
 use gloo_utils::format::JsValueSerdeExt;
-use indexed_db_futures::{prelude::*, request::OpenDbRequest, IdbDatabase, IdbVersionChangeEvent};
+use indexed_db_futures::{
+    database::{Database, VersionChangeEvent},
+    error::Error,
+    future::OpenDbRequest,
+    object_store::ObjectStore,
+    prelude::*,
+    transaction::{Transaction, TransactionMode},
+};
 use js_sys::Date as JsDate;
 use matrix_sdk_base::{
     deserialized_responses::SyncOrStrippedState, store::migration_helpers::RoomInfoV1,
@@ -38,7 +45,6 @@ use ruma::{
 use serde::{Deserialize, Serialize};
 use serde_json::value::{RawValue as RawJsonValue, Value as JsonValue};
 use wasm_bindgen::JsValue;
-use web_sys::IdbTransactionMode;
 
 use super::{
     deserialize_value, encode_key, encode_to_range, keys, serialize_value, Result, RoomMember,
@@ -82,35 +88,41 @@ mod old_keys {
 pub async fn upgrade_meta_db(
     meta_name: &str,
     passphrase: Option<&str>,
-) -> Result<(IdbDatabase, Option<Arc<StoreCipher>>)> {
+) -> Result<(Database, Option<Arc<StoreCipher>>)> {
     // Meta database.
-    let mut db_req: OpenDbRequest = IdbDatabase::open_u32(meta_name, CURRENT_META_DB_VERSION)?;
-    db_req.set_on_upgrade_needed(Some(|evt: &IdbVersionChangeEvent| -> Result<(), JsValue> {
-        let db = evt.db();
-        let old_version = evt.old_version() as u32;
+    let db_req: OpenDbRequest = Database::open(meta_name)
+        .with_version(CURRENT_META_DB_VERSION)
+        .with_on_upgrade_needed(
+            |evt: VersionChangeEvent, tx: &Transaction<'_>| -> Result<(), Error> {
+                let db = tx.db();
+                let old_version = evt.old_version() as u32;
 
-        if old_version < 1 {
-            db.create_object_store(keys::INTERNAL_STATE)?;
-        }
+                if old_version < 1 {
+                    db.create_object_store(keys::INTERNAL_STATE).build()?;
+                }
 
-        if old_version < 2 {
-            db.create_object_store(keys::BACKUPS_META)?;
-        }
+                if old_version < 2 {
+                    db.create_object_store(keys::BACKUPS_META).build()?;
+                }
 
-        Ok(())
-    }));
+                Ok(())
+            },
+        )
+        .build()?;
 
-    let meta_db: IdbDatabase = db_req.await?;
+    let meta_db: Database = db_req.await?;
 
     let store_cipher = if let Some(passphrase) = passphrase {
-        let tx: IdbTransaction<'_> = meta_db
-            .transaction_on_one_with_mode(keys::INTERNAL_STATE, IdbTransactionMode::Readwrite)?;
+        let tx: Transaction<'_> = meta_db
+            .transaction(keys::INTERNAL_STATE)
+            .with_mode(TransactionMode::Readwrite)
+            .build()?;
         let ob = tx.object_store(keys::INTERNAL_STATE)?;
 
         let cipher = if let Some(StoreKeyWrapper(inner)) = ob
-            .get(&JsValue::from_str(keys::STORE_KEY))?
+            .get(&JsValue::from_str(keys::STORE_KEY))
             .await?
-            .map(|v| v.into_serde())
+            .map(|v: JsValue| v.into_serde())
             .transpose()?
         {
             StoreCipher::import(passphrase, &inner)?
@@ -120,14 +132,11 @@ pub async fn upgrade_meta_db(
             let export = cipher.export(passphrase)?;
             #[cfg(test)]
             let export = cipher._insecure_export_fast_for_testing(passphrase)?;
-            ob.put_key_val(
-                &JsValue::from_str(keys::STORE_KEY),
-                &JsValue::from_serde(&StoreKeyWrapper(export))?,
-            )?;
+            ob.put(&StoreKeyWrapper(export)).with_key(keys::STORE_KEY.to_owned()).serde()?.await?;
             cipher
         };
 
-        tx.await.into_result()?;
+        tx.commit().await?;
         Some(Arc::new(cipher))
     } else {
         None
@@ -151,9 +160,9 @@ pub async fn upgrade_inner_db(
     name: &str,
     store_cipher: Option<&StoreCipher>,
     migration_strategy: MigrationConflictStrategy,
-    meta_db: &IdbDatabase,
-) -> Result<IdbDatabase> {
-    let mut db = IdbDatabase::open(name)?.await?;
+    meta_db: &Database,
+) -> Result<Database> {
+    let mut db = Database::open(name).await?;
 
     // Even if the web-sys bindings expose the version as a f64, the IndexedDB API
     // works with an unsigned integer.
@@ -247,19 +256,21 @@ pub async fn upgrade_inner_db(
 
         db.close();
 
-        let mut db_req: OpenDbRequest = IdbDatabase::open_u32(name, CURRENT_DB_VERSION)?;
-        db_req.set_on_upgrade_needed(Some(
-            move |evt: &IdbVersionChangeEvent| -> Result<(), JsValue> {
-                // Sanity check.
-                // There should be no upgrade needed since the database should have already been
-                // upgraded to the latest version.
-                panic!(
-                    "Opening database that was not fully upgraded: \
+        let db_req: OpenDbRequest = Database::open(name)
+            .with_version(CURRENT_DB_VERSION)
+            .with_on_upgrade_needed(
+                move |evt: VersionChangeEvent, _: &Transaction<'_>| -> Result<(), Error> {
+                    // Sanity check.
+                    // There should be no upgrade needed since the database should have already been
+                    // upgraded to the latest version.
+                    panic!(
+                        "Opening database that was not fully upgraded: \
                      DB version: {}; latest version: {CURRENT_DB_VERSION}",
-                    evt.old_version()
-                )
-            },
-        ));
+                        evt.old_version()
+                    )
+                },
+            )
+            .build()?;
         db = db_req.await?;
     }
 
@@ -269,41 +280,45 @@ pub async fn upgrade_inner_db(
 /// Apply the given migration by upgrading the database with the given name to
 /// the given version.
 async fn apply_migration(
-    db: IdbDatabase,
+    db: Database,
     version: u32,
     migration: OngoingMigration,
-) -> Result<IdbDatabase> {
+) -> Result<Database> {
     let name = db.name();
     db.close();
 
-    let mut db_req: OpenDbRequest = IdbDatabase::open_u32(&name, version)?;
-    db_req.set_on_upgrade_needed(Some(move |evt: &IdbVersionChangeEvent| -> Result<(), JsValue> {
-        // Changing the format can only happen in the upgrade procedure
-        for store in &migration.drop_stores {
-            evt.db().delete_object_store(store)?;
-        }
-        for store in &migration.create_stores {
-            evt.db().create_object_store(store)?;
-        }
+    let db_req: OpenDbRequest = Database::open(&name)
+        .with_version(version)
+        .with_on_upgrade_needed(
+            move |_: VersionChangeEvent, tx: &Transaction<'_>| -> Result<(), Error> {
+                // Changing the format can only happen in the upgrade procedure
+                for store in &migration.drop_stores {
+                    tx.db().delete_object_store(store)?;
+                }
+                for store in &migration.create_stores {
+                    tx.db().create_object_store(store).build()?;
+                }
 
-        Ok(())
-    }));
+                Ok(())
+            },
+        )
+        .build()?;
 
     let db = db_req.await?;
 
     // Finally, we can add data to the newly created tables if needed.
     if !migration.data.is_empty() {
         let stores: Vec<_> = migration.data.keys().copied().collect();
-        let tx = db.transaction_on_multi_with_mode(&stores, IdbTransactionMode::Readwrite)?;
+        let tx = db.transaction(stores).with_mode(TransactionMode::Readwrite).build()?;
 
         for (name, data) in migration.data {
             let store = tx.object_store(name)?;
             for (key, value) in data {
-                store.put_key_val(&key, &value)?;
+                store.put(&value).with_key(key).await?;
             }
         }
 
-        tx.await.into_result()?;
+        tx.commit().await?;
     }
 
     Ok(db)
@@ -333,57 +348,61 @@ pub const V1_STORES: &[&str] = &[
     old_keys::SYNC_TOKEN,
 ];
 
-async fn backup_v1(source: &IdbDatabase, meta: &IdbDatabase) -> Result<()> {
+async fn backup_v1(source: &Database, meta: &Database) -> Result<()> {
     let now = JsDate::now();
     let backup_name = format!("backup-{}-{now}", source.name());
 
-    let mut db_req: OpenDbRequest = IdbDatabase::open_f64(&backup_name, source.version())?;
-    db_req.set_on_upgrade_needed(Some(move |evt: &IdbVersionChangeEvent| -> Result<(), JsValue> {
-        // migrating to version 1
-        let db = evt.db();
-        for name in V1_STORES {
-            db.create_object_store(name)?;
-        }
-        Ok(())
-    }));
+    let db_req: OpenDbRequest = Database::open(&backup_name)
+        .with_version(source.version())
+        .with_on_upgrade_needed(
+            move |_: VersionChangeEvent, tx: &Transaction<'_>| -> Result<(), Error> {
+                // migrating to version 1
+                let db = tx.db();
+                for name in V1_STORES {
+                    db.create_object_store(name).build()?;
+                }
+                Ok(())
+            },
+        )
+        .build()?;
     let target = db_req.await?;
 
     for name in V1_STORES {
-        let source_tx = source.transaction_on_one_with_mode(name, IdbTransactionMode::Readonly)?;
+        let source_tx = source.transaction(*name).with_mode(TransactionMode::Readonly).build()?;
         let source_obj = source_tx.object_store(name)?;
-        let Some(curs) = source_obj.open_cursor()?.await? else {
+        let Some(mut curs) = source_obj.open_cursor().await? else {
             continue;
         };
 
-        let data = curs.into_vec(0).await?;
-
-        let target_tx = target.transaction_on_one_with_mode(name, IdbTransactionMode::Readwrite)?;
-        let target_obj = target_tx.object_store(name)?;
-
-        for kv in data {
-            target_obj.put_key_val(kv.key(), kv.value())?;
+        let mut data = vec![];
+        while let Some(value) = curs.next_record::<JsValue>().await? {
+            if let Some(key) = curs.key::<JsValue>()? {
+                data.push((key, value));
+            }
         }
 
-        target_tx.await.into_result()?;
+        let target_tx = target.transaction(*name).with_mode(TransactionMode::Readwrite).build()?;
+        let target_obj = target_tx.object_store(name)?;
+
+        for (key, value) in data {
+            target_obj.put(value).with_key(key).await?;
+        }
+
+        target_tx.commit().await?;
     }
 
-    let tx =
-        meta.transaction_on_one_with_mode(keys::BACKUPS_META, IdbTransactionMode::Readwrite)?;
+    let tx = meta.transaction(keys::BACKUPS_META).with_mode(TransactionMode::Readwrite).build()?;
     let backup_store = tx.object_store(keys::BACKUPS_META)?;
-    backup_store.put_key_val(&JsValue::from_f64(now), &JsValue::from_str(&backup_name))?;
+    backup_store.put(&backup_name).with_key(now).await?;
 
-    tx.await;
+    tx.commit().await?;
 
-    source.close();
     target.close();
 
     Ok(())
 }
 
-async fn v3_fix_store(
-    store: &IdbObjectStore<'_>,
-    store_cipher: Option<&StoreCipher>,
-) -> Result<()> {
+async fn v3_fix_store(store: &ObjectStore<'_>, store_cipher: Option<&StoreCipher>) -> Result<()> {
     fn maybe_fix_json(raw_json: &RawJsonValue) -> Result<Option<JsonValue>> {
         let json = raw_json.get();
 
@@ -400,18 +419,14 @@ async fn v3_fix_store(
         Ok(None)
     }
 
-    let cursor = store.open_cursor()?.await?;
+    let cursor = store.open_cursor().await?;
 
-    if let Some(cursor) = cursor {
-        loop {
-            let raw_json: Box<RawJsonValue> = deserialize_value(store_cipher, &cursor.value())?;
+    if let Some(mut cursor) = cursor {
+        while let Some(value) = cursor.next_record().await? {
+            let raw_json: Box<RawJsonValue> = deserialize_value(store_cipher, &value)?;
 
             if let Some(fixed_json) = maybe_fix_json(&raw_json)? {
-                cursor.update(&serialize_value(store_cipher, &fixed_json)?)?.await?;
-            }
-
-            if !cursor.continue_cursor()?.await? {
-                break;
+                cursor.update(&serialize_value(store_cipher, &fixed_json)?).await?;
             }
         }
     }
@@ -420,35 +435,35 @@ async fn v3_fix_store(
 }
 
 /// Fix serialized redacted state events.
-async fn migrate_to_v3(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> Result<IdbDatabase> {
-    let tx = db.transaction_on_multi_with_mode(
-        &[keys::ROOM_STATE, keys::ROOM_INFOS],
-        IdbTransactionMode::Readwrite,
-    )?;
+async fn migrate_to_v3(db: Database, store_cipher: Option<&StoreCipher>) -> Result<Database> {
+    let tx = db
+        .transaction([keys::ROOM_STATE, keys::ROOM_INFOS])
+        .with_mode(TransactionMode::Readwrite)
+        .build()?;
 
     v3_fix_store(&tx.object_store(keys::ROOM_STATE)?, store_cipher).await?;
     v3_fix_store(&tx.object_store(keys::ROOM_INFOS)?, store_cipher).await?;
 
-    tx.await.into_result()?;
+    tx.commit().await?;
 
     let name = db.name();
     db.close();
 
     // Update the version of the database.
-    Ok(IdbDatabase::open_u32(&name, 3)?.await?)
+    Ok(Database::open(&name).with_version(3u32).await?)
 }
 
 /// Move the content of the SYNC_TOKEN and SESSION stores to the new KV store.
-async fn migrate_to_v4(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> Result<IdbDatabase> {
-    let tx = db.transaction_on_multi_with_mode(
-        &[old_keys::SYNC_TOKEN, old_keys::SESSION],
-        IdbTransactionMode::Readonly,
-    )?;
+async fn migrate_to_v4(db: Database, store_cipher: Option<&StoreCipher>) -> Result<Database> {
+    let tx = db
+        .transaction([old_keys::SYNC_TOKEN, old_keys::SESSION])
+        .with_mode(TransactionMode::Readonly)
+        .build()?;
     let mut values = Vec::new();
 
     // Sync token
     let sync_token_store = tx.object_store(old_keys::SYNC_TOKEN)?;
-    let sync_token = sync_token_store.get(&JsValue::from_str(old_keys::SYNC_TOKEN))?.await?;
+    let sync_token = sync_token_store.get(&JsValue::from_str(old_keys::SYNC_TOKEN)).await?;
 
     if let Some(sync_token) = sync_token {
         values.push((
@@ -459,17 +474,17 @@ async fn migrate_to_v4(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
 
     // Filters
     let session_store = tx.object_store(old_keys::SESSION)?;
-    let range =
-        encode_to_range(store_cipher, StateStoreDataKey::FILTER, StateStoreDataKey::FILTER)?;
-    if let Some(cursor) = session_store.open_cursor_with_range(&range)?.await? {
-        while let Some(key) = cursor.key() {
-            let value = cursor.value();
+    let range = encode_to_range(store_cipher, StateStoreDataKey::FILTER, StateStoreDataKey::FILTER);
+    if let Some(mut cursor) = session_store.open_cursor().with_query(&range).await? {
+        while let Some(value) = cursor.next_record().await? {
+            let Some(key) = cursor.key()? else {
+                break;
+            };
             values.push((key, value));
-            cursor.continue_cursor()?.await?;
         }
     }
 
-    tx.await.into_result()?;
+    tx.commit().await?;
 
     let mut data = HashMap::new();
     if !values.is_empty() {
@@ -485,33 +500,34 @@ async fn migrate_to_v4(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
 }
 
 /// Move the member events with other state events.
-async fn migrate_to_v5(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> Result<IdbDatabase> {
-    let tx = db.transaction_on_multi_with_mode(
-        &[
+async fn migrate_to_v5(db: Database, store_cipher: Option<&StoreCipher>) -> Result<Database> {
+    let tx = db
+        .transaction([
             old_keys::MEMBERS,
             old_keys::STRIPPED_MEMBERS,
             keys::ROOM_STATE,
             keys::STRIPPED_ROOM_STATE,
             keys::ROOM_INFOS,
             old_keys::STRIPPED_ROOM_INFOS,
-        ],
-        IdbTransactionMode::Readwrite,
-    )?;
+        ])
+        .with_mode(TransactionMode::Readwrite)
+        .build()?;
 
     let members_store = tx.object_store(old_keys::MEMBERS)?;
     let state_store = tx.object_store(keys::ROOM_STATE)?;
     let room_infos = tx
         .object_store(keys::ROOM_INFOS)?
-        .get_all()?
+        .get_all()
         .await?
-        .iter()
+        .filter_map(Result::ok)
         .filter_map(|f| deserialize_value::<RoomInfoV1>(store_cipher, &f).ok())
         .collect::<Vec<_>>();
 
     for room_info in room_infos {
         let room_id = room_info.room_id();
-        let range = encode_to_range(store_cipher, old_keys::MEMBERS, room_id)?;
-        for value in members_store.get_all_with_key(&range)?.await?.iter() {
+        let range = encode_to_range(store_cipher, old_keys::MEMBERS, room_id);
+        for result in members_store.get_all().with_query(&range).await? {
+            let value = result?;
             let raw_member_event =
                 deserialize_value::<Raw<SyncRoomMemberEvent>>(store_cipher, &value)?;
             let state_key = raw_member_event.get_field::<String>("state_key")?.unwrap_or_default();
@@ -521,7 +537,7 @@ async fn migrate_to_v5(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
                 (room_id, StateEventType::RoomMember, state_key),
             );
 
-            state_store.add_key_val(&key, &value)?;
+            state_store.add(&value).with_key(key).build()?.await?;
         }
     }
 
@@ -529,16 +545,17 @@ async fn migrate_to_v5(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
     let stripped_state_store = tx.object_store(keys::STRIPPED_ROOM_STATE)?;
     let stripped_room_infos = tx
         .object_store(old_keys::STRIPPED_ROOM_INFOS)?
-        .get_all()?
+        .get_all()
         .await?
-        .iter()
+        .filter_map(Result::ok)
         .filter_map(|f| deserialize_value::<RoomInfoV1>(store_cipher, &f).ok())
         .collect::<Vec<_>>();
 
     for room_info in stripped_room_infos {
         let room_id = room_info.room_id();
-        let range = encode_to_range(store_cipher, old_keys::STRIPPED_MEMBERS, room_id)?;
-        for value in stripped_members_store.get_all_with_key(&range)?.await?.iter() {
+        let range = encode_to_range(store_cipher, old_keys::STRIPPED_MEMBERS, room_id);
+        for result in stripped_members_store.get_all().with_query(&range).await? {
+            let value = result?;
             let raw_member_event =
                 deserialize_value::<Raw<StrippedRoomMemberEvent>>(store_cipher, &value)?;
             let state_key = raw_member_event.get_field::<String>("state_key")?.unwrap_or_default();
@@ -548,11 +565,11 @@ async fn migrate_to_v5(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
                 (room_id, StateEventType::RoomMember, state_key),
             );
 
-            stripped_state_store.add_key_val(&key, &value)?;
+            stripped_state_store.add(&value).with_key(key).build()?.await?;
         }
     }
 
-    tx.await.into_result()?;
+    tx.commit().await?;
 
     let migration = OngoingMigration {
         drop_stores: [old_keys::MEMBERS, old_keys::STRIPPED_MEMBERS].into_iter().collect(),
@@ -563,25 +580,25 @@ async fn migrate_to_v5(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
 }
 
 /// Remove the old user IDs stores and populate the new ones.
-async fn migrate_to_v6(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> Result<IdbDatabase> {
+async fn migrate_to_v6(db: Database, store_cipher: Option<&StoreCipher>) -> Result<Database> {
     // We only have joined and invited user IDs in the old store, so instead we will
     // use the room member events to populate the new store.
-    let tx = db.transaction_on_multi_with_mode(
-        &[
+    let tx = db
+        .transaction([
             keys::ROOM_STATE,
             keys::ROOM_INFOS,
             keys::STRIPPED_ROOM_STATE,
             old_keys::STRIPPED_ROOM_INFOS,
-        ],
-        IdbTransactionMode::Readonly,
-    )?;
+        ])
+        .with_mode(TransactionMode::Readonly)
+        .build()?;
 
     let state_store = tx.object_store(keys::ROOM_STATE)?;
     let room_infos = tx
         .object_store(keys::ROOM_INFOS)?
-        .get_all()?
+        .get_all()
         .await?
-        .iter()
+        .filter_map(Result::ok)
         .filter_map(|f| deserialize_value::<RoomInfoV1>(store_cipher, &f).ok())
         .collect::<Vec<_>>();
     let mut values = Vec::new();
@@ -589,8 +606,9 @@ async fn migrate_to_v6(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
     for room_info in room_infos {
         let room_id = room_info.room_id();
         let range =
-            encode_to_range(store_cipher, keys::ROOM_STATE, (room_id, StateEventType::RoomMember))?;
-        for value in state_store.get_all_with_key(&range)?.await?.iter() {
+            encode_to_range(store_cipher, keys::ROOM_STATE, (room_id, StateEventType::RoomMember));
+        for result in state_store.get_all().with_query(&range).await? {
+            let value = result?;
             let member_event = deserialize_value::<Raw<SyncRoomMemberEvent>>(store_cipher, &value)?
                 .deserialize()?;
             let key = encode_key(store_cipher, keys::USER_IDS, (room_id, member_event.state_key()));
@@ -603,9 +621,9 @@ async fn migrate_to_v6(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
     let stripped_state_store = tx.object_store(keys::STRIPPED_ROOM_STATE)?;
     let stripped_room_infos = tx
         .object_store(old_keys::STRIPPED_ROOM_INFOS)?
-        .get_all()?
+        .get_all()
         .await?
-        .iter()
+        .filter_map(Result::ok)
         .filter_map(|f| deserialize_value::<RoomInfoV1>(store_cipher, &f).ok())
         .collect::<Vec<_>>();
     let mut stripped_values = Vec::new();
@@ -616,8 +634,9 @@ async fn migrate_to_v6(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
             store_cipher,
             keys::STRIPPED_ROOM_STATE,
             (room_id, StateEventType::RoomMember),
-        )?;
-        for value in stripped_state_store.get_all_with_key(&range)?.await?.iter() {
+        );
+        for result in stripped_state_store.get_all().with_query(&range).await? {
+            let value = result?;
             let stripped_member_event =
                 deserialize_value::<Raw<StrippedRoomMemberEvent>>(store_cipher, &value)?
                     .deserialize()?;
@@ -632,7 +651,7 @@ async fn migrate_to_v6(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         }
     }
 
-    tx.await.into_result()?;
+    tx.commit().await?;
 
     let mut data = HashMap::new();
     if !values.is_empty() {
@@ -657,17 +676,17 @@ async fn migrate_to_v6(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
 
 /// Remove the stripped room infos store and migrate the data with the other
 /// room infos, as well as .
-async fn migrate_to_v7(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> Result<IdbDatabase> {
-    let tx = db.transaction_on_multi_with_mode(
-        &[old_keys::STRIPPED_ROOM_INFOS],
-        IdbTransactionMode::Readonly,
-    )?;
+async fn migrate_to_v7(db: Database, store_cipher: Option<&StoreCipher>) -> Result<Database> {
+    let tx = db
+        .transaction([old_keys::STRIPPED_ROOM_INFOS])
+        .with_mode(TransactionMode::Readonly)
+        .build()?;
 
     let room_infos = tx
         .object_store(old_keys::STRIPPED_ROOM_INFOS)?
-        .get_all()?
+        .get_all()
         .await?
-        .iter()
+        .filter_map(Result::ok)
         .filter_map(|value| {
             deserialize_value::<RoomInfoV1>(store_cipher, &value)
                 .ok()
@@ -675,7 +694,7 @@ async fn migrate_to_v7(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         })
         .collect::<Vec<_>>();
 
-    tx.await.into_result()?;
+    tx.commit().await?;
 
     let mut data = HashMap::new();
     if !room_infos.is_empty() {
@@ -691,21 +710,21 @@ async fn migrate_to_v7(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
 }
 
 /// Change the format of the room infos.
-async fn migrate_to_v8(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> Result<IdbDatabase> {
-    let tx = db.transaction_on_multi_with_mode(
-        &[keys::ROOM_STATE, keys::STRIPPED_ROOM_STATE, keys::ROOM_INFOS],
-        IdbTransactionMode::Readwrite,
-    )?;
+async fn migrate_to_v8(db: Database, store_cipher: Option<&StoreCipher>) -> Result<Database> {
+    let tx = db
+        .transaction([keys::ROOM_STATE, keys::STRIPPED_ROOM_STATE, keys::ROOM_INFOS])
+        .with_mode(TransactionMode::Readwrite)
+        .build()?;
 
     let room_state_store = tx.object_store(keys::ROOM_STATE)?;
     let stripped_room_state_store = tx.object_store(keys::STRIPPED_ROOM_STATE)?;
     let room_infos_store = tx.object_store(keys::ROOM_INFOS)?;
 
     let room_infos_v1 = room_infos_store
-        .get_all()?
+        .get_all()
+        .build()?
         .await?
-        .iter()
-        .map(|value| deserialize_value::<RoomInfoV1>(store_cipher, &value))
+        .map(|value| deserialize_value::<RoomInfoV1>(store_cipher, &value?))
         .collect::<Result<Vec<_>, _>>()?;
 
     for room_info_v1 in room_infos_v1 {
@@ -714,7 +733,7 @@ async fn migrate_to_v8(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
                 store_cipher,
                 keys::STRIPPED_ROOM_STATE,
                 (room_info_v1.room_id(), &StateEventType::RoomCreate, ""),
-            ))?
+            ))
             .await?
             .map(|f| deserialize_value(store_cipher, &f))
             .transpose()?
@@ -726,7 +745,7 @@ async fn migrate_to_v8(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
                     store_cipher,
                     keys::ROOM_STATE,
                     (room_info_v1.room_id(), &StateEventType::RoomCreate, ""),
-                ))?
+                ))
                 .await?
                 .map(|f| deserialize_value(store_cipher, &f))
                 .transpose()?
@@ -734,23 +753,23 @@ async fn migrate_to_v8(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         };
 
         let room_info = room_info_v1.migrate(create.as_ref());
-        room_infos_store.put_key_val(
-            &encode_key(store_cipher, keys::ROOM_INFOS, room_info.room_id()),
-            &serialize_value(store_cipher, &room_info)?,
-        )?;
+        room_infos_store
+            .put(&serialize_value(store_cipher, &room_info)?)
+            .with_key(encode_key(store_cipher, keys::ROOM_INFOS, room_info.room_id()))
+            .build()?;
     }
 
-    tx.await.into_result()?;
+    tx.commit().await?;
 
     let name = db.name();
     db.close();
 
     // Update the version of the database.
-    Ok(IdbDatabase::open_u32(&name, 8)?.await?)
+    Ok(Database::open(&name).with_version(8u32).build()?.await?)
 }
 
 /// Add the new [`keys::ROOM_SEND_QUEUE`] table.
-async fn migrate_to_v9(db: IdbDatabase) -> Result<IdbDatabase> {
+async fn migrate_to_v9(db: Database) -> Result<Database> {
     let migration = OngoingMigration {
         drop_stores: [].into(),
         create_stores: [keys::ROOM_SEND_QUEUE].into_iter().collect(),
@@ -760,7 +779,7 @@ async fn migrate_to_v9(db: IdbDatabase) -> Result<IdbDatabase> {
 }
 
 /// Add the new [`keys::DEPENDENT_SEND_QUEUE`] table.
-async fn migrate_to_v10(db: IdbDatabase) -> Result<IdbDatabase> {
+async fn migrate_to_v10(db: Database) -> Result<Database> {
     let migration = OngoingMigration {
         drop_stores: [].into(),
         create_stores: [keys::DEPENDENT_SEND_QUEUE].into_iter().collect(),
@@ -770,7 +789,7 @@ async fn migrate_to_v10(db: IdbDatabase) -> Result<IdbDatabase> {
 }
 
 /// Drop the [`old_keys::MEDIA`] table.
-async fn migrate_to_v11(db: IdbDatabase) -> Result<IdbDatabase> {
+async fn migrate_to_v11(db: Database) -> Result<Database> {
     let migration = OngoingMigration {
         drop_stores: [old_keys::MEDIA].into(),
         create_stores: Default::default(),
@@ -781,26 +800,26 @@ async fn migrate_to_v11(db: IdbDatabase) -> Result<IdbDatabase> {
 
 /// The format of data serialized into the send queue and dependent send queue
 /// tables have changed, clear both.
-async fn migrate_to_v12(db: IdbDatabase) -> Result<IdbDatabase> {
-    let store_keys = &[keys::DEPENDENT_SEND_QUEUE, keys::ROOM_SEND_QUEUE];
-    let tx = db.transaction_on_multi_with_mode(store_keys, IdbTransactionMode::Readwrite)?;
+async fn migrate_to_v12(db: Database) -> Result<Database> {
+    let store_keys = [keys::DEPENDENT_SEND_QUEUE, keys::ROOM_SEND_QUEUE];
+    let tx = db.transaction(store_keys).with_mode(TransactionMode::Readwrite).build()?;
 
     for store_name in store_keys {
         let store = tx.object_store(store_name)?;
         store.clear()?;
     }
 
-    tx.await.into_result()?;
+    tx.commit().await?;
 
     let name = db.name();
     db.close();
 
     // Update the version of the database.
-    Ok(IdbDatabase::open_u32(&name, 12)?.await?)
+    Ok(Database::open(&name).with_version(12u32).build()?.await?)
 }
 
 /// Add the thread subscriptions table.
-async fn migrate_to_v13(db: IdbDatabase) -> Result<IdbDatabase> {
+async fn migrate_to_v13(db: Database) -> Result<Database> {
     let migration = OngoingMigration {
         drop_stores: [].into(),
         create_stores: [keys::THREAD_SUBSCRIPTIONS].into_iter().collect(),
@@ -812,7 +831,7 @@ async fn migrate_to_v13(db: IdbDatabase) -> Result<IdbDatabase> {
 /// Empty the thread subscriptions table, because the serialized format has
 /// changed (from storing only the subscription to storing the
 /// `StoredThreadSubscription`).
-async fn migrate_to_v14(db: IdbDatabase) -> Result<IdbDatabase> {
+async fn migrate_to_v14(db: Database) -> Result<Database> {
     let migration = OngoingMigration {
         drop_stores: [keys::THREAD_SUBSCRIPTIONS].into_iter().collect(),
         create_stores: [keys::THREAD_SUBSCRIPTIONS].into_iter().collect(),
@@ -827,7 +846,13 @@ mod tests {
 
     use assert_matches::assert_matches;
     use assert_matches2::assert_let;
-    use indexed_db_futures::prelude::*;
+    use indexed_db_futures::{
+        database::{Database, VersionChangeEvent},
+        error::Error,
+        object_store::ObjectStore,
+        prelude::*,
+        transaction::{Transaction, TransactionMode},
+    };
     use matrix_sdk_base::{
         deserialized_responses::RawMemberEvent,
         store::{RoomLoadSettings, StateStoreExt},
@@ -861,70 +886,73 @@ mod tests {
     const CUSTOM_DATA_KEY: &[u8] = b"custom_data_key";
     const CUSTOM_DATA: &[u8] = b"some_custom_data";
 
-    pub async fn create_fake_db(name: &str, version: u32) -> Result<IdbDatabase> {
-        let mut db_req: OpenDbRequest = IdbDatabase::open_u32(name, version)?;
-        db_req.set_on_upgrade_needed(Some(
-            move |evt: &IdbVersionChangeEvent| -> Result<(), JsValue> {
-                let db = evt.db();
+    pub async fn create_fake_db(name: &str, version: u32) -> Result<Database> {
+        Database::open(name)
+            .with_version(version)
+            .with_on_upgrade_needed(
+                move |_: VersionChangeEvent, tx: &Transaction<'_>| -> Result<(), Error> {
+                    let db = tx.db();
 
-                // Stores common to all versions.
-                let common_stores = &[
-                    keys::ACCOUNT_DATA,
-                    keys::PROFILES,
-                    keys::DISPLAY_NAMES,
-                    keys::ROOM_STATE,
-                    keys::ROOM_INFOS,
-                    keys::PRESENCE,
-                    keys::ROOM_ACCOUNT_DATA,
-                    keys::STRIPPED_ROOM_STATE,
-                    keys::ROOM_USER_RECEIPTS,
-                    keys::ROOM_EVENT_RECEIPTS,
-                    keys::CUSTOM,
-                ];
+                    // Stores common to all versions.
+                    let common_stores = &[
+                        keys::ACCOUNT_DATA,
+                        keys::PROFILES,
+                        keys::DISPLAY_NAMES,
+                        keys::ROOM_STATE,
+                        keys::ROOM_INFOS,
+                        keys::PRESENCE,
+                        keys::ROOM_ACCOUNT_DATA,
+                        keys::STRIPPED_ROOM_STATE,
+                        keys::ROOM_USER_RECEIPTS,
+                        keys::ROOM_EVENT_RECEIPTS,
+                        keys::CUSTOM,
+                    ];
 
-                for name in common_stores {
-                    db.create_object_store(name)?;
-                }
+                    for name in common_stores {
+                        db.create_object_store(name).build()?;
+                    }
 
-                if version < 4 {
-                    for name in [old_keys::SYNC_TOKEN, old_keys::SESSION] {
-                        db.create_object_store(name)?;
+                    if version < 4 {
+                        for name in [old_keys::SYNC_TOKEN, old_keys::SESSION] {
+                            db.create_object_store(name).build()?;
+                        }
                     }
-                }
-                if version >= 4 {
-                    db.create_object_store(keys::KV)?;
-                }
-                if version < 5 {
-                    for name in [old_keys::MEMBERS, old_keys::STRIPPED_MEMBERS] {
-                        db.create_object_store(name)?;
+                    if version >= 4 {
+                        db.create_object_store(keys::KV).build()?;
                     }
-                }
-                if version < 6 {
-                    for name in [
-                        old_keys::INVITED_USER_IDS,
-                        old_keys::JOINED_USER_IDS,
-                        old_keys::STRIPPED_INVITED_USER_IDS,
-                        old_keys::STRIPPED_JOINED_USER_IDS,
-                    ] {
-                        db.create_object_store(name)?;
+                    if version < 5 {
+                        for name in [old_keys::MEMBERS, old_keys::STRIPPED_MEMBERS] {
+                            db.create_object_store(name).build()?;
+                        }
                     }
-                }
-                if version >= 6 {
-                    for name in [keys::USER_IDS, keys::STRIPPED_USER_IDS] {
-                        db.create_object_store(name)?;
+                    if version < 6 {
+                        for name in [
+                            old_keys::INVITED_USER_IDS,
+                            old_keys::JOINED_USER_IDS,
+                            old_keys::STRIPPED_INVITED_USER_IDS,
+                            old_keys::STRIPPED_JOINED_USER_IDS,
+                        ] {
+                            db.create_object_store(name).build()?;
+                        }
                     }
-                }
-                if version < 7 {
-                    db.create_object_store(old_keys::STRIPPED_ROOM_INFOS)?;
-                }
-                if version < 11 {
-                    db.create_object_store(old_keys::MEDIA)?;
-                }
+                    if version >= 6 {
+                        for name in [keys::USER_IDS, keys::STRIPPED_USER_IDS] {
+                            db.create_object_store(name).build()?;
+                        }
+                    }
+                    if version < 7 {
+                        db.create_object_store(old_keys::STRIPPED_ROOM_INFOS).build()?;
+                    }
+                    if version < 11 {
+                        db.create_object_store(old_keys::MEDIA).build()?;
+                    }
 
-                Ok(())
-            },
-        ));
-        db_req.await.map_err(Into::into)
+                    Ok(())
+                },
+            )
+            .build()?
+            .await
+            .map_err(Into::into)
     }
 
     fn room_info_v1_json(
@@ -996,14 +1024,13 @@ mod tests {
         // Create and populate db.
         {
             let db = create_fake_db(&name, 1).await?;
-            let tx =
-                db.transaction_on_one_with_mode(keys::CUSTOM, IdbTransactionMode::Readwrite)?;
+            let tx = db.transaction(keys::CUSTOM).with_mode(TransactionMode::Readwrite).build()?;
             let custom = tx.object_store(keys::CUSTOM)?;
             let jskey = JsValue::from_str(
                 core::str::from_utf8(CUSTOM_DATA_KEY).map_err(StoreError::Codec)?,
             );
-            custom.put_key_val(&jskey, &serialize_value(None, &CUSTOM_DATA)?)?;
-            tx.await.into_result()?;
+            custom.put(&serialize_value(None, &CUSTOM_DATA)?).with_key(jskey).await?;
+            tx.commit().await?;
             db.close();
         }
 
@@ -1031,14 +1058,13 @@ mod tests {
         // Create and populate db.
         {
             let db = create_fake_db(&name, 1).await?;
-            let tx =
-                db.transaction_on_one_with_mode(keys::CUSTOM, IdbTransactionMode::Readwrite)?;
+            let tx = db.transaction(keys::CUSTOM).with_mode(TransactionMode::Readwrite).build()?;
             let custom = tx.object_store(keys::CUSTOM)?;
             let jskey = JsValue::from_str(
                 core::str::from_utf8(CUSTOM_DATA_KEY).map_err(StoreError::Codec)?,
             );
-            custom.put_key_val(&jskey, &serialize_value(None, &CUSTOM_DATA)?)?;
-            tx.await.into_result()?;
+            custom.put(&serialize_value(None, &CUSTOM_DATA)?).with_key(jskey).await?;
+            tx.commit().await?;
             db.close();
         }
 
@@ -1069,14 +1095,13 @@ mod tests {
         // Create and populate db.
         {
             let db = create_fake_db(&name, 1).await?;
-            let tx =
-                db.transaction_on_one_with_mode(keys::CUSTOM, IdbTransactionMode::Readwrite)?;
+            let tx = db.transaction(keys::CUSTOM).with_mode(TransactionMode::Readwrite).build()?;
             let custom = tx.object_store(keys::CUSTOM)?;
             let jskey = JsValue::from_str(
                 core::str::from_utf8(CUSTOM_DATA_KEY).map_err(StoreError::Codec)?,
             );
-            custom.put_key_val(&jskey, &serialize_value(None, &CUSTOM_DATA)?)?;
-            tx.await.into_result()?;
+            custom.put(&serialize_value(None, &CUSTOM_DATA)?).with_key(jskey).await?;
+            tx.commit().await?;
             db.close();
         }
 
@@ -1110,14 +1135,13 @@ mod tests {
         // Create and populate db.
         {
             let db = create_fake_db(&name, 1).await?;
-            let tx =
-                db.transaction_on_one_with_mode(keys::CUSTOM, IdbTransactionMode::Readwrite)?;
+            let tx = db.transaction(keys::CUSTOM).with_mode(TransactionMode::Readwrite).build()?;
             let custom = tx.object_store(keys::CUSTOM)?;
             let jskey = JsValue::from_str(
                 core::str::from_utf8(CUSTOM_DATA_KEY).map_err(StoreError::Codec)?,
             );
-            custom.put_key_val(&jskey, &serialize_value(None, &CUSTOM_DATA)?)?;
-            tx.await.into_result()?;
+            custom.put(&serialize_value(None, &CUSTOM_DATA)?).with_key(jskey).await?;
+            tx.commit().await?;
             db.close();
         }
 
@@ -1167,11 +1191,11 @@ mod tests {
         {
             let db = create_fake_db(&name, 2).await?;
             let tx =
-                db.transaction_on_one_with_mode(keys::ROOM_STATE, IdbTransactionMode::Readwrite)?;
+                db.transaction(keys::ROOM_STATE).with_mode(TransactionMode::Readwrite).build()?;
             let state = tx.object_store(keys::ROOM_STATE)?;
             let key: JsValue = (room_id, StateEventType::RoomTopic, "").as_encoded_string().into();
-            state.put_key_val(&key, &serialize_value(None, &wrong_redacted_state_event)?)?;
-            tx.await.into_result()?;
+            state.put(&serialize_value(None, &wrong_redacted_state_event)?).with_key(key).await?;
+            tx.commit().await?;
             db.close();
         }
 
@@ -1201,28 +1225,36 @@ mod tests {
         // Populate DB with old table.
         {
             let db = create_fake_db(&name, 3).await?;
-            let tx = db.transaction_on_multi_with_mode(
-                &[old_keys::SYNC_TOKEN, old_keys::SESSION],
-                IdbTransactionMode::Readwrite,
-            )?;
+            let tx = db
+                .transaction([old_keys::SYNC_TOKEN, old_keys::SESSION])
+                .with_mode(TransactionMode::Readwrite)
+                .build()?;
 
             let sync_token_store = tx.object_store(old_keys::SYNC_TOKEN)?;
-            sync_token_store.put_key_val(
-                &JsValue::from_str(old_keys::SYNC_TOKEN),
-                &serialize_value(None, &sync_token)?,
-            )?;
+            sync_token_store
+                .put(&serialize_value(None, &sync_token)?)
+                .with_key(JsValue::from_str(old_keys::SYNC_TOKEN))
+                .build()?;
 
             let session_store = tx.object_store(old_keys::SESSION)?;
-            session_store.put_key_val(
-                &encode_key(None, StateStoreDataKey::FILTER, (StateStoreDataKey::FILTER, filter_1)),
-                &serialize_value(None, &filter_1_id)?,
-            )?;
-            session_store.put_key_val(
-                &encode_key(None, StateStoreDataKey::FILTER, (StateStoreDataKey::FILTER, filter_2)),
-                &serialize_value(None, &filter_2_id)?,
-            )?;
+            session_store
+                .put(&serialize_value(None, &filter_1_id)?)
+                .with_key(encode_key(
+                    None,
+                    StateStoreDataKey::FILTER,
+                    (StateStoreDataKey::FILTER, filter_1),
+                ))
+                .build()?;
+            session_store
+                .put(&serialize_value(None, &filter_2_id)?)
+                .with_key(encode_key(
+                    None,
+                    StateStoreDataKey::FILTER,
+                    (StateStoreDataKey::FILTER, filter_2),
+                ))
+                .build()?;
 
-            tx.await.into_result()?;
+            tx.commit().await?;
             db.close();
         }
 
@@ -1274,42 +1306,46 @@ mod tests {
         // Populate DB with old table.
         {
             let db = create_fake_db(&name, 4).await?;
-            let tx = db.transaction_on_multi_with_mode(
-                &[
+            let tx = db
+                .transaction([
                     old_keys::MEMBERS,
                     keys::ROOM_INFOS,
                     old_keys::STRIPPED_MEMBERS,
                     old_keys::STRIPPED_ROOM_INFOS,
-                ],
-                IdbTransactionMode::Readwrite,
-            )?;
+                ])
+                .with_mode(TransactionMode::Readwrite)
+                .build()?;
 
             let members_store = tx.object_store(old_keys::MEMBERS)?;
-            members_store.put_key_val(
-                &encode_key(None, old_keys::MEMBERS, (room_id, user_id)),
-                &serialize_value(None, &member_event)?,
-            )?;
+            members_store
+                .put(&serialize_value(None, &member_event)?)
+                .with_key(encode_key(None, old_keys::MEMBERS, (room_id, user_id)))
+                .build()?;
             let room_infos_store = tx.object_store(keys::ROOM_INFOS)?;
             let room_info = room_info_v1_json(room_id, RoomState::Joined, None, None);
-            room_infos_store.put_key_val(
-                &encode_key(None, keys::ROOM_INFOS, room_id),
-                &serialize_value(None, &room_info)?,
-            )?;
+            room_infos_store
+                .put(&serialize_value(None, &room_info)?)
+                .with_key(encode_key(None, keys::ROOM_INFOS, room_id))
+                .build()?;
 
             let stripped_members_store = tx.object_store(old_keys::STRIPPED_MEMBERS)?;
-            stripped_members_store.put_key_val(
-                &encode_key(None, old_keys::STRIPPED_MEMBERS, (stripped_room_id, stripped_user_id)),
-                &serialize_value(None, &stripped_member_event)?,
-            )?;
+            stripped_members_store
+                .put(&serialize_value(None, &stripped_member_event)?)
+                .with_key(encode_key(
+                    None,
+                    old_keys::STRIPPED_MEMBERS,
+                    (stripped_room_id, stripped_user_id),
+                ))
+                .build()?;
             let stripped_room_infos_store = tx.object_store(old_keys::STRIPPED_ROOM_INFOS)?;
             let stripped_room_info =
                 room_info_v1_json(stripped_room_id, RoomState::Invited, None, None);
-            stripped_room_infos_store.put_key_val(
-                &encode_key(None, old_keys::STRIPPED_ROOM_INFOS, stripped_room_id),
-                &serialize_value(None, &stripped_room_info)?,
-            )?;
+            stripped_room_infos_store
+                .put(&serialize_value(None, &stripped_room_info)?)
+                .with_key(encode_key(None, old_keys::STRIPPED_ROOM_INFOS, stripped_room_id))
+                .build()?;
 
-            tx.await.into_result()?;
+            tx.commit().await?;
             db.close();
         }
 
@@ -1352,8 +1388,8 @@ mod tests {
         // Populate DB with old table.
         {
             let db = create_fake_db(&name, 5).await?;
-            let tx = db.transaction_on_multi_with_mode(
-                &[
+            let tx = db
+                .transaction([
                     keys::ROOM_STATE,
                     keys::ROOM_INFOS,
                     keys::STRIPPED_ROOM_STATE,
@@ -1362,82 +1398,82 @@ mod tests {
                     old_keys::JOINED_USER_IDS,
                     old_keys::STRIPPED_INVITED_USER_IDS,
                     old_keys::STRIPPED_JOINED_USER_IDS,
-                ],
-                IdbTransactionMode::Readwrite,
-            )?;
+                ])
+                .with_mode(TransactionMode::Readwrite)
+                .build()?;
 
             let state_store = tx.object_store(keys::ROOM_STATE)?;
-            state_store.put_key_val(
-                &encode_key(
+            state_store
+                .put(&serialize_value(None, &invite_member_event)?)
+                .with_key(encode_key(
                     None,
                     keys::ROOM_STATE,
                     (room_id, StateEventType::RoomMember, invite_user_id),
-                ),
-                &serialize_value(None, &invite_member_event)?,
-            )?;
-            state_store.put_key_val(
-                &encode_key(
+                ))
+                .build()?;
+            state_store
+                .put(&serialize_value(None, &ban_member_event)?)
+                .with_key(encode_key(
                     None,
                     keys::ROOM_STATE,
                     (room_id, StateEventType::RoomMember, ban_user_id),
-                ),
-                &serialize_value(None, &ban_member_event)?,
-            )?;
+                ))
+                .build()?;
             let room_infos_store = tx.object_store(keys::ROOM_INFOS)?;
             let room_info = room_info_v1_json(room_id, RoomState::Joined, None, None);
-            room_infos_store.put_key_val(
-                &encode_key(None, keys::ROOM_INFOS, room_id),
-                &serialize_value(None, &room_info)?,
-            )?;
+            room_infos_store
+                .put(&serialize_value(None, &room_info)?)
+                .with_key(encode_key(None, keys::ROOM_INFOS, room_id))
+                .build()?;
 
             let stripped_state_store = tx.object_store(keys::STRIPPED_ROOM_STATE)?;
-            stripped_state_store.put_key_val(
-                &encode_key(
+            stripped_state_store
+                .put(&serialize_value(None, &stripped_member_event)?)
+                .with_key(encode_key(
                     None,
                     keys::STRIPPED_ROOM_STATE,
                     (stripped_room_id, StateEventType::RoomMember, stripped_user_id),
-                ),
-                &serialize_value(None, &stripped_member_event)?,
-            )?;
+                ))
+                .build()?;
             let stripped_room_infos_store = tx.object_store(old_keys::STRIPPED_ROOM_INFOS)?;
             let stripped_room_info =
                 room_info_v1_json(stripped_room_id, RoomState::Invited, None, None);
-            stripped_room_infos_store.put_key_val(
-                &encode_key(None, old_keys::STRIPPED_ROOM_INFOS, stripped_room_id),
-                &serialize_value(None, &stripped_room_info)?,
-            )?;
+            stripped_room_infos_store
+                .put(&serialize_value(None, &stripped_room_info)?)
+                .with_key(encode_key(None, old_keys::STRIPPED_ROOM_INFOS, stripped_room_id))
+                .build()?;
 
             // Populate the old user IDs stores to check the data is not reused.
             let joined_user_id = user_id!("@joined_user:localhost");
-            tx.object_store(old_keys::JOINED_USER_IDS)?.put_key_val(
-                &encode_key(None, old_keys::JOINED_USER_IDS, (room_id, joined_user_id)),
-                &serialize_value(None, &joined_user_id)?,
-            )?;
+            tx.object_store(old_keys::JOINED_USER_IDS)?
+                .put(&serialize_value(None, &joined_user_id)?)
+                .with_key(encode_key(None, old_keys::JOINED_USER_IDS, (room_id, joined_user_id)))
+                .build()?;
             let invited_user_id = user_id!("@invited_user:localhost");
-            tx.object_store(old_keys::INVITED_USER_IDS)?.put_key_val(
-                &encode_key(None, old_keys::INVITED_USER_IDS, (room_id, invited_user_id)),
-                &serialize_value(None, &invited_user_id)?,
-            )?;
+            tx.object_store(old_keys::INVITED_USER_IDS)?
+                .put(&serialize_value(None, &invited_user_id)?)
+                .with_key(encode_key(None, old_keys::INVITED_USER_IDS, (room_id, invited_user_id)))
+                .build()?;
             let stripped_joined_user_id = user_id!("@stripped_joined_user:localhost");
-            tx.object_store(old_keys::STRIPPED_JOINED_USER_IDS)?.put_key_val(
-                &encode_key(
+            tx.object_store(old_keys::STRIPPED_JOINED_USER_IDS)?
+                .put(&serialize_value(None, &stripped_joined_user_id)?)
+                .with_key(encode_key(
                     None,
                     old_keys::STRIPPED_JOINED_USER_IDS,
                     (room_id, stripped_joined_user_id),
-                ),
-                &serialize_value(None, &stripped_joined_user_id)?,
-            )?;
+                ))
+                .build()?;
             let stripped_invited_user_id = user_id!("@stripped_invited_user:localhost");
-            tx.object_store(old_keys::STRIPPED_INVITED_USER_IDS)?.put_key_val(
-                &encode_key(
+            tx.object_store(old_keys::STRIPPED_INVITED_USER_IDS)?
+                .put(&serialize_value(None, &stripped_invited_user_id)?)
+                .with_key(encode_key(
                     None,
                     old_keys::STRIPPED_INVITED_USER_IDS,
                     (room_id, stripped_invited_user_id),
-                ),
-                &serialize_value(None, &stripped_invited_user_id)?,
-            )?;
+                ))
+                .build()?;
 
-            tx.await.into_result()?;
+            tx.commit().await?;
             db.close();
         }
 
@@ -1484,27 +1520,27 @@ mod tests {
         // Populate DB with old table.
         {
             let db = create_fake_db(&name, 6).await?;
-            let tx = db.transaction_on_multi_with_mode(
-                &[keys::ROOM_INFOS, old_keys::STRIPPED_ROOM_INFOS],
-                IdbTransactionMode::Readwrite,
-            )?;
+            let tx = db
+                .transaction([keys::ROOM_INFOS, old_keys::STRIPPED_ROOM_INFOS])
+                .with_mode(TransactionMode::Readwrite)
+                .build()?;
 
             let room_infos_store = tx.object_store(keys::ROOM_INFOS)?;
             let room_info = room_info_v1_json(room_id, RoomState::Joined, None, None);
-            room_infos_store.put_key_val(
-                &encode_key(None, keys::ROOM_INFOS, room_id),
-                &serialize_value(None, &room_info)?,
-            )?;
+            room_infos_store
+                .put(&serialize_value(None, &room_info)?)
+                .with_key(encode_key(None, keys::ROOM_INFOS, room_id))
+                .build()?;
 
             let stripped_room_infos_store = tx.object_store(old_keys::STRIPPED_ROOM_INFOS)?;
             let stripped_room_info =
                 room_info_v1_json(stripped_room_id, RoomState::Invited, None, None);
-            stripped_room_infos_store.put_key_val(
-                &encode_key(None, old_keys::STRIPPED_ROOM_INFOS, stripped_room_id),
-                &serialize_value(None, &stripped_room_info)?,
-            )?;
+            stripped_room_infos_store
+                .put(&serialize_value(None, &stripped_room_info)?)
+                .with_key(encode_key(None, old_keys::STRIPPED_ROOM_INFOS, stripped_room_id))
+                .build()?;
 
-            tx.await.into_result()?;
+            tx.commit().await?;
             db.close();
         }
 
@@ -1518,8 +1554,8 @@ mod tests {
 
     // Add a room in version 7 format of the state store.
     fn add_room_v7(
-        room_infos_store: &IdbObjectStore<'_>,
-        room_state_store: &IdbObjectStore<'_>,
+        room_infos_store: &ObjectStore<'_>,
+        room_state_store: &ObjectStore<'_>,
         room_id: &RoomId,
         name: Option<&str>,
         create_creator: Option<OwnedUserId>,
@@ -1528,10 +1564,10 @@ mod tests {
         let room_info_json =
             room_info_v1_json(room_id, RoomState::Joined, name, create_creator.as_deref());
 
-        room_infos_store.put_key_val(
-            &encode_key(None, keys::ROOM_INFOS, room_id),
-            &serialize_value(None, &room_info_json)?,
-        )?;
+        room_infos_store
+            .put(&serialize_value(None, &room_info_json)?)
+            .with_key(encode_key(None, keys::ROOM_INFOS, room_id))
+            .build()?;
 
         // Test with or without `m.room.create` event in the room state.
         let Some(create_sender) = create_sender else {
@@ -1554,10 +1590,14 @@ mod tests {
             "unsigned": {},
         });
 
-        room_state_store.put_key_val(
-            &encode_key(None, keys::ROOM_STATE, (room_id, &StateEventType::RoomCreate, "")),
-            &serialize_value(None, &create_event)?,
-        )?;
+        room_state_store
+            .put(&serialize_value(None, &create_event)?)
+            .with_key(encode_key(
+                None,
+                keys::ROOM_STATE,
+                (room_id, &StateEventType::RoomCreate, ""),
+            ))
+            .build()?;
 
         Ok(())
     }
@@ -1584,10 +1624,10 @@ mod tests {
         // Create and populate db.
         {
             let db = create_fake_db(&name, 6).await?;
-            let tx = db.transaction_on_multi_with_mode(
-                &[keys::ROOM_INFOS, keys::ROOM_STATE],
-                IdbTransactionMode::Readwrite,
-            )?;
+            let tx = db
+                .transaction([keys::ROOM_INFOS, keys::ROOM_STATE])
+                .with_mode(TransactionMode::Readwrite)
+                .build()?;
 
             let room_infos_store = tx.object_store(keys::ROOM_INFOS)?;
             let room_state_store = tx.object_store(keys::ROOM_STATE)?;
@@ -1610,7 +1650,7 @@ mod tests {
                 Some(&room_c_create_sender),
             )?;
 
-            tx.await.into_result()?;
+            tx.commit().await?;
             db.close();
         }
 

--- a/crates/matrix-sdk-indexeddb/src/transaction/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/transaction/mod.rs
@@ -18,16 +18,19 @@
 // clean up any dead code.
 #![allow(dead_code)]
 
-use indexed_db_futures::{prelude::IdbTransaction, IdbQuerySource};
+use indexed_db_futures::{
+    internals::SystemRepr, query_source::QuerySource, transaction as inner, BuildSerde,
+};
 use serde::{
     de::{DeserializeOwned, Error},
     Serialize,
 };
 use thiserror::Error;
+use wasm_bindgen::JsValue;
 use web_sys::IdbCursorDirection;
 
 use crate::{
-    error::AsyncErrorDeps,
+    error::{AsyncErrorDeps, GenericError},
     serializer::{Indexed, IndexedKey, IndexedKeyRange, IndexedTypeSerializer},
 };
 
@@ -41,6 +44,8 @@ pub enum TransactionError {
     ItemIsNotUnique,
     #[error("item not found")]
     ItemNotFound,
+    #[error("backend: {0}")]
+    Backend(Box<dyn AsyncErrorDeps>),
 }
 
 impl From<web_sys::DomException> for TransactionError {
@@ -55,16 +60,40 @@ impl From<serde_wasm_bindgen::Error> for TransactionError {
     }
 }
 
+impl From<indexed_db_futures::error::SerialisationError> for TransactionError {
+    fn from(e: indexed_db_futures::error::SerialisationError) -> Self {
+        Self::Serialization(Box::new(serde_json::Error::custom(e.to_string())))
+    }
+}
+
+impl From<indexed_db_futures::error::JSError> for TransactionError {
+    fn from(value: indexed_db_futures::error::JSError) -> Self {
+        Self::Backend(Box::new(GenericError::from(value.to_string())))
+    }
+}
+
+impl From<indexed_db_futures::error::Error> for TransactionError {
+    fn from(value: indexed_db_futures::error::Error) -> Self {
+        use indexed_db_futures::error::Error;
+        match value {
+            Error::DomException(e) => e.into_sys().into(),
+            Error::Serialisation(e) => e.into(),
+            Error::MissingData(e) => Self::Backend(Box::new(e)),
+            Error::Unknown(e) => e.into(),
+        }
+    }
+}
+
 /// Represents an IndexedDB transaction, but provides a convenient interface for
 /// performing operations on types that implement [`Indexed`] and related
 /// traits.
 pub struct Transaction<'a> {
-    transaction: IdbTransaction<'a>,
+    transaction: inner::Transaction<'a>,
     serializer: &'a IndexedTypeSerializer,
 }
 
 impl<'a> Transaction<'a> {
-    pub fn new(transaction: IdbTransaction<'a>, serializer: &'a IndexedTypeSerializer) -> Self {
+    pub fn new(transaction: inner::Transaction<'a>, serializer: &'a IndexedTypeSerializer) -> Self {
         Self { transaction, serializer }
     }
 
@@ -75,13 +104,13 @@ impl<'a> Transaction<'a> {
     }
 
     /// Returns the underlying IndexedDB transaction.
-    pub fn into_inner(self) -> IdbTransaction<'a> {
+    pub fn into_inner(self) -> inner::Transaction<'a> {
         self.transaction
     }
 
     /// Commit all operations tracked in this transaction to IndexedDB.
     pub async fn commit(self) -> Result<(), TransactionError> {
-        self.transaction.await.into_result().map_err(Into::into)
+        self.transaction.commit().await.map_err(Into::into)
     }
 
     /// Query IndexedDB for items that match the given key range
@@ -95,18 +124,16 @@ impl<'a> Transaction<'a> {
         T::Error: AsyncErrorDeps,
         K: IndexedKey<T> + Serialize,
     {
-        let range = self.serializer.encode_key_range::<T, K>(range)?;
+        let range = self.serializer.encode_key_range::<T, K>(range);
         let object_store = self.transaction.object_store(T::OBJECT_STORE)?;
         let array = if let Some(index) = K::INDEX {
-            object_store.index(index)?.get_all_with_key(&range)?.await?
+            object_store.index(index)?.get_all().with_query(range).serde()?.await?
         } else {
-            object_store.get_all_with_key(&range)?.await?
+            object_store.get_all().with_query(range).serde()?.await?
         };
-        let mut items = Vec::with_capacity(array.length() as usize);
+        let mut items = Vec::with_capacity(array.len());
         for value in array {
-            let item = self
-                .serializer
-                .deserialize(value)
+            let item = T::from_indexed(value?, self.serializer.inner())
                 .map_err(|e| TransactionError::Serialization(Box::new(e)))?;
             items.push(item);
         }
@@ -174,12 +201,12 @@ impl<'a> Transaction<'a> {
         T::Error: AsyncErrorDeps,
         K: IndexedKey<T> + Serialize,
     {
-        let range = self.serializer.encode_key_range::<T, K>(range)?;
+        let range = self.serializer.encode_key_range::<T, K>(range);
         let object_store = self.transaction.object_store(T::OBJECT_STORE)?;
         let count = if let Some(index) = K::INDEX {
-            object_store.index(index)?.count_with_key(&range)?.await?
+            object_store.index(index)?.count().with_query(range).serde()?.await?
         } else {
-            object_store.count_with_key(&range)?.await?
+            object_store.count().with_query(range).serde()?.await?
         };
         Ok(count as usize)
     }
@@ -211,25 +238,30 @@ impl<'a> Transaction<'a> {
         T::Error: AsyncErrorDeps,
         K: IndexedKey<T> + Serialize,
     {
-        let range = self.serializer.encode_key_range::<T, K>(range)?;
+        let range = self.serializer.encode_key_range::<T, K>(range);
         let direction = IdbCursorDirection::Prev;
         let object_store = self.transaction.object_store(T::OBJECT_STORE)?;
         if let Some(index) = K::INDEX {
-            object_store
-                .index(index)?
-                .open_cursor_with_range_and_direction(&range, direction)?
-                .await?
-                .map(|cursor| self.serializer.deserialize(cursor.value()))
-                .transpose()
-                .map_err(|e| TransactionError::Serialization(Box::new(e)))
-        } else {
-            object_store
-                .open_cursor_with_range_and_direction(&range, direction)?
-                .await?
-                .map(|cursor| self.serializer.deserialize(cursor.value()))
-                .transpose()
-                .map_err(|e| TransactionError::Serialization(Box::new(e)))
+            let index = object_store.index(index)?;
+            if let Some(mut cursor) =
+                index.open_cursor().with_query(range).with_direction(direction).serde()?.await?
+            {
+                if let Some(record) = cursor.next_record_ser().await? {
+                    return T::from_indexed(record, self.serializer.inner())
+                        .map(Some)
+                        .map_err(|e| TransactionError::Serialization(Box::new(e)));
+                }
+            }
+        } else if let Some(mut cursor) =
+            object_store.open_cursor().with_query(range).with_direction(direction).serde()?.await?
+        {
+            if let Some(record) = cursor.next_record_ser().await? {
+                return T::from_indexed(record, self.serializer.inner())
+                    .map(Some)
+                    .map_err(|e| TransactionError::Serialization(Box::new(e)));
+            }
         }
+        Ok(None)
     }
 
     /// Adds an item to the corresponding IndexedDB object
@@ -243,11 +275,11 @@ impl<'a> Transaction<'a> {
     {
         self.transaction
             .object_store(T::OBJECT_STORE)?
-            .add_val_owned(
+            .add(
                 self.serializer
                     .serialize(item)
                     .map_err(|e| TransactionError::Serialization(Box::new(e)))?,
-            )?
+            )
             .await
             .map_err(Into::into)
     }
@@ -263,11 +295,11 @@ impl<'a> Transaction<'a> {
     {
         self.transaction
             .object_store(T::OBJECT_STORE)?
-            .put_val_owned(
+            .put(
                 self.serializer
                     .serialize(item)
                     .map_err(|e| TransactionError::Serialization(Box::new(e)))?,
-            )?
+            )
             .await
             .map_err(Into::into)
     }
@@ -291,7 +323,7 @@ impl<'a> Transaction<'a> {
             .serialize_if(item, f)
             .map_err(|e| TransactionError::Serialization(Box::new(e)))?;
         if let Some(value) = option {
-            self.transaction.object_store(T::OBJECT_STORE)?.put_val_owned(value)?.await?;
+            self.transaction.object_store(T::OBJECT_STORE)?.put(value).await?;
         }
         Ok(())
     }
@@ -305,18 +337,20 @@ impl<'a> Transaction<'a> {
         T: Indexed,
         K: IndexedKey<T> + Serialize,
     {
-        let range = self.serializer.encode_key_range::<T, K>(range)?;
+        let range = self.serializer.encode_key_range::<T, K>(range);
         let object_store = self.transaction.object_store(T::OBJECT_STORE)?;
         if let Some(index) = K::INDEX {
             let index = object_store.index(index)?;
-            if let Some(cursor) = index.open_cursor_with_range(&range)?.await? {
-                while cursor.key().is_some() {
-                    cursor.delete()?.await?;
-                    cursor.continue_cursor()?.await?;
+            if let Some(mut cursor) = index.open_cursor().with_query(range).serde()?.await? {
+                loop {
+                    cursor.delete()?;
+                    if cursor.next_record::<JsValue>().await?.is_none() {
+                        break;
+                    }
                 }
             }
         } else {
-            object_store.delete_owned(&range)?.await?;
+            object_store.delete(range).serde()?.await?;
         }
         Ok(())
     }

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -442,6 +442,10 @@ fn run_wasm_pack_tests(cmd: Option<WasmFeatureSet>) -> Result<()> {
         cmd!(sh, "wasm-pack test --firefox --headless --")
             .args(arg_set.split_whitespace())
             .env(WASM_TIMEOUT_ENV_KEY, WASM_TIMEOUT_VALUE)
+            .run()?;
+        cmd!(sh, "wasm-pack test --chrome --headless --")
+            .args(arg_set.split_whitespace())
+            .env(WASM_TIMEOUT_ENV_KEY, WASM_TIMEOUT_VALUE)
             .run()
     };
 


### PR DESCRIPTION
**NOTE:** _this should not be merged until matrix-org/rust-indexed-db#1 is merged! The `[patch]` in this branch should point to the official `matrix-org` fork of `rust-indexed_db`, but is currently pointed at my personal fork._

## Background

This pull request makes updates [`indexed_db_futures`](https://docs.rs/indexed_db_futures/latest/indexed_db_futures/index.html) in the `matrix-sdk-indexeddb` crate. The reason we'd like to update this dependency is because the version currently used does not fully support the Chrome browser (see #5420).

The latest version of `indexed_db_futures` has significant changes. Many of these changes can be integrated without issue. There is, however, a single change which is incompatible with the `matrix-sdk-indexeddb` crate. Namely, one cannot access the active transaction in the callback to update the database (for details, see Alorel/rust-indexed-db#66).

### An Updated Proposal

Originally, new migrations were implemented in order to work around this issue (see #5467). However, the proposal was ultimately rejected (see @andybalaam's [comment](https://github.com/matrix-org/matrix-rust-sdk/pull/5467#issuecomment-3149550617)).

For this reason, the dependency has instead been `[patch]`ed in the top-level `Cargo.toml` with a modified version of `indexed_db_futures` (see matrix-org/rust-indexed-db#1). Furthermore, these changes have been proposed to the maintainer and are awaiting feedback (see Alorel/rust-indexed-db#72).

### Why do we need the active transaction in our migrations?

The `crypto_store` module provides access to the active transaction to its migrations (see [here](https://github.com/matrix-org/matrix-rust-sdk/blob/ca89700dfe9f29dcd823bb10861807f9d75e0634/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs#L211)). Furthermore, there is a single migration (`v11_to_v12`) in the `crypto_store` module which actually makes use of the active transaction (see [here](https://github.com/matrix-org/matrix-rust-sdk/blob/ca89700dfe9f29dcd823bb10861807f9d75e0634/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs#L23)).

For clarity, the reason `v11_to_v12` is problematic in the latest versions of `indexed_db_futures` is because it is simply adding an index to an object store which was created in a different migration and this requires access to the active transaction. All the other migrations create object stores and indices in the same migration, which does not suffer from the same issue.

## Changes

- Move `indexed_db_futures` to the workspace `Cargo.toml` and add a `[patch]` so that it points to a modified version.
- Add `GenericError` type and conversions in order to more easily map `indexed_db_futures` errors into `matrix-sdk-*` errors.
- Update all IndexedDB interactions so that they use the upgraded interface provided by `indexed_db_futures`
- Add functionality for running `wasm-pack` tests against Chrome


---
Closes #5420.

---

- [ ] Public API changes documented in changelogs (optional)


Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>