### PR TITLE
refactor(stores): get rid of the temporary `compute_filter_strings` now that Ruma has been updated

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -28,9 +28,7 @@ use matrix_sdk_common::{
 use ruma::{EventId, OwnedEventId, RoomId, events::relation::RelationType, time::Instant};
 use tracing::error;
 
-use super::{
-    EventCacheStore, EventCacheStoreError, Result, compute_filters_string, extract_event_relation,
-};
+use super::{EventCacheStore, EventCacheStoreError, Result, extract_event_relation};
 use crate::event_cache::{Event, Gap};
 
 /// In-memory, non-persistent implementation of the `EventCacheStore`.
@@ -194,14 +192,13 @@ impl EventCacheStore for MemoryStore {
     ) -> Result<Vec<(Event, Option<Position>)>, Self::Error> {
         let inner = self.inner.read().unwrap();
 
-        let filters = compute_filters_string(filters);
-
         let related_events = inner
             .events
             .items(room_id)
             .filter_map(|(event, pos)| {
                 // Must have a relation.
                 let (related_to, rel_type) = extract_event_relation(event.raw())?;
+                let rel_type = RelationType::from(rel_type.as_str());
 
                 // Must relate to the target item.
                 if related_to != event_id {

--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -31,11 +31,7 @@ use matrix_sdk_common::cross_process_lock::{
     CrossProcessLock, CrossProcessLockError, CrossProcessLockGuard, TryLock,
 };
 pub use matrix_sdk_store_encryption::Error as StoreEncryptionError;
-use ruma::{
-    OwnedEventId,
-    events::{AnySyncTimelineEvent, relation::RelationType},
-    serde::Raw,
-};
+use ruma::{OwnedEventId, events::AnySyncTimelineEvent, serde::Raw};
 use tracing::trace;
 
 #[cfg(any(test, feature = "testing"))]
@@ -224,19 +220,4 @@ pub fn extract_event_relation(event: &Raw<AnySyncTimelineEvent>) -> Option<(Owne
             None
         }
     }
-}
-
-/// Compute the list of string filters to be applied when looking for an event's
-/// relations.
-// TODO: get Ruma fix from https://github.com/ruma/ruma/pull/2052, and get rid of this function
-// then.
-pub fn compute_filters_string(filters: Option<&[RelationType]>) -> Option<Vec<String>> {
-    filters.map(|filter| {
-        filter
-            .iter()
-            .map(|f| {
-                if *f == RelationType::Replacement { "m.replace".to_owned() } else { f.to_string() }
-            })
-            .collect()
-    })
 }


### PR DESCRIPTION
This was a local fix for a bug in Ruma, that has been fixed upstream since then, so we can get rid of the workaround now.