### PR TITLE
refactor(sdk): Use TextMessageEventContent to send a caption

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/futures.rs
+++ b/crates/matrix-sdk-ui/src/timeline/futures.rs
@@ -79,7 +79,6 @@ impl<'a> IntoFuture for SendAttachment<'a> {
                 info: config.info,
                 thumbnail: config.thumbnail,
                 caption: config.caption,
-                formatted_caption: config.formatted_caption,
                 mentions: config.mentions,
                 reply,
             };
@@ -153,11 +152,7 @@ mod galleries {
                     config = config.add_item(item.try_into()?);
                 }
 
-                config = config
-                    .caption(gallery.caption)
-                    .formatted_caption(gallery.formatted_caption)
-                    .mentions(gallery.mentions)
-                    .reply(reply);
+                config = config.caption(gallery.caption).mentions(gallery.mentions).reply(reply);
 
                 timeline
                     .room()

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -50,8 +50,8 @@ use ruma::{
         relation::Thread,
         room::{
             message::{
-                FormattedBody, Relation, RelationWithoutReplacement, ReplyWithinThread,
-                RoomMessageEventContentWithoutRelation,
+                Relation, RelationWithoutReplacement, ReplyWithinThread,
+                RoomMessageEventContentWithoutRelation, TextMessageEventContent,
             },
             pinned_events::RoomPinnedEventsEventContent,
         },
@@ -185,8 +185,7 @@ pub struct AttachmentConfig {
     pub txn_id: Option<OwnedTransactionId>,
     pub info: Option<AttachmentInfo>,
     pub thumbnail: Option<Thumbnail>,
-    pub caption: Option<String>,
-    pub formatted_caption: Option<FormattedBody>,
+    pub caption: Option<TextMessageEventContent>,
     pub mentions: Option<Mentions>,
     pub in_reply_to: Option<OwnedEventId>,
 }
@@ -985,8 +984,7 @@ where
 pub struct GalleryConfig {
     pub(crate) txn_id: Option<OwnedTransactionId>,
     pub(crate) items: Vec<GalleryItemInfo>,
-    pub(crate) caption: Option<String>,
-    pub(crate) formatted_caption: Option<FormattedBody>,
+    pub(crate) caption: Option<TextMessageEventContent>,
     pub(crate) mentions: Option<Mentions>,
     pub(crate) in_reply_to: Option<OwnedEventId>,
 }
@@ -1027,18 +1025,8 @@ impl GalleryConfig {
     /// # Arguments
     ///
     /// * `caption` - The optional caption.
-    pub fn caption(mut self, caption: Option<String>) -> Self {
+    pub fn caption(mut self, caption: Option<TextMessageEventContent>) -> Self {
         self.caption = caption;
-        self
-    }
-
-    /// Set the optional formatted caption.
-    ///
-    /// # Arguments
-    ///
-    /// * `formatted_caption` - The optional formatted caption.
-    pub fn formatted_caption(mut self, formatted_caption: Option<FormattedBody>) -> Self {
-        self.formatted_caption = formatted_caption;
         self
     }
 
@@ -1084,9 +1072,7 @@ pub struct GalleryItemInfo {
     /// The attachment info.
     pub attachment_info: AttachmentInfo,
     /// The caption.
-    pub caption: Option<String>,
-    /// The formatted caption.
-    pub formatted_caption: Option<FormattedBody>,
+    pub caption: Option<TextMessageEventContent>,
     /// The thumbnail.
     pub thumbnail: Option<Thumbnail>,
 }
@@ -1103,7 +1089,6 @@ impl TryFrom<GalleryItemInfo> for matrix_sdk::attachment::GalleryItemInfo {
             data,
             attachment_info: value.attachment_info,
             caption: value.caption,
-            formatted_caption: value.formatted_caption,
             thumbnail: value.thumbnail,
         })
     }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
@@ -37,7 +37,10 @@ use ruma::events::room::message::GalleryItemType;
 use ruma::owned_mxc_uri;
 use ruma::{
     event_id,
-    events::room::{MediaSource, message::MessageType},
+    events::room::{
+        MediaSource,
+        message::{MessageType, TextMessageEventContent},
+    },
     room_id,
 };
 use serde_json::json;
@@ -119,7 +122,10 @@ async fn test_send_attachment_from_file() -> TestResult {
         .with_focus(TimelineFocus::Thread { root_event_id: event_id.to_owned() })
         .build()
         .await?;
-    let config = AttachmentConfig { caption: Some("caption".to_owned()), ..Default::default() };
+    let config = AttachmentConfig {
+        caption: Some(TextMessageEventContent::plain("caption")),
+        ..Default::default()
+    };
     thread_timeline.send_attachment(&file_path, mime::TEXT_PLAIN, config).use_send_queue().await?;
 
     {
@@ -256,7 +262,10 @@ async fn test_send_attachment_from_bytes() -> TestResult {
     mock.mock_room_send().ok(event_id!("$media")).mock_once().mount().await;
 
     // Queue sending of an attachment.
-    let config = AttachmentConfig { caption: Some("caption".to_owned()), ..Default::default() };
+    let config = AttachmentConfig {
+        caption: Some(TextMessageEventContent::plain("caption")),
+        ..Default::default()
+    };
     timeline.send_attachment(source, mime::TEXT_PLAIN, config).use_send_queue().await?;
 
     {
@@ -392,13 +401,13 @@ async fn test_send_gallery_from_bytes() -> TestResult {
     mock.mock_room_send().ok(event_id!("$media")).mock_once().mount().await;
 
     // Queue sending of a gallery.
-    let gallery =
-        GalleryConfig::new().caption(Some("caption".to_owned())).add_item(GalleryItemInfo {
+    let gallery = GalleryConfig::new()
+        .caption(Some(TextMessageEventContent::plain("caption")))
+        .add_item(GalleryItemInfo {
             source: AttachmentSource::Data { bytes: data, filename: filename.to_owned() },
             content_type: mime::TEXT_PLAIN,
             attachment_info: AttachmentInfo::File(BaseFileInfo { size: None }),
-            caption: Some("item caption".to_owned()),
-            formatted_caption: None,
+            caption: Some(TextMessageEventContent::plain("item caption")),
             thumbnail: None,
         });
     timeline.send_gallery(gallery).await?;

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 ### Refactor
+
+- [**breaking**] The `caption` and `formatted_caption` fields and methods of `AttachmentConfig`,
+  `GalleryConfig` and `GalleryItemInfo` have been merged into a single field that uses
+  `TextMessageEventContent`.
+  ([#5733](https://github.com/matrix-org/matrix-rust-sdk/pull/5733))
 - The Matrix SDK crate now uses the 2024 edition of Rust.
   ([#5677](https://github.com/matrix-org/matrix-rust-sdk/pull/5677))
 
@@ -60,9 +65,9 @@ All notable changes to this project will be documented in this file.
 
 - [**breaking**] `OAuth::login` now allows requesting additional scopes for the authorization code grant.
   ([#5395](https://github.com/matrix-org/matrix-rust-sdk/pull/5395))
-- [**breaking**] `ThreadedEventsLoader::new` now takes optional `tokens` parameter to customise where the pagination 
+- [**breaking**] `ThreadedEventsLoader::new` now takes optional `tokens` parameter to customise where the pagination
   begins ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678).
-- Make `PaginationTokens` `pub`, as well as its `previous` and `next` tokens so they can be assigned from other files 
+- Make `PaginationTokens` `pub`, as well as its `previous` and `next` tokens so they can be assigned from other files
   ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678).
 
 ### Refactor

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -22,7 +22,7 @@ use ruma::{
         Mentions,
         room::{
             ImageInfo, ThumbnailInfo,
-            message::{AudioInfo, FileInfo, FormattedBody, VideoInfo},
+            message::{AudioInfo, FileInfo, TextMessageEventContent, VideoInfo},
         },
     },
 };
@@ -195,10 +195,7 @@ pub struct AttachmentConfig {
     pub thumbnail: Option<Thumbnail>,
 
     /// An optional caption for the attachment.
-    pub caption: Option<String>,
-
-    /// An optional formatted caption for the attachment.
-    pub formatted_caption: Option<FormattedBody>,
+    pub caption: Option<TextMessageEventContent>,
 
     /// Intentional mentions to be included in the media event.
     pub mentions: Option<Mentions>,
@@ -256,18 +253,8 @@ impl AttachmentConfig {
     /// # Arguments
     ///
     /// * `caption` - The optional caption.
-    pub fn caption(mut self, caption: Option<String>) -> Self {
+    pub fn caption(mut self, caption: Option<TextMessageEventContent>) -> Self {
         self.caption = caption;
-        self
-    }
-
-    /// Set the optional formatted caption.
-    ///
-    /// # Arguments
-    ///
-    /// * `formatted_caption` - The optional formatted caption.
-    pub fn formatted_caption(mut self, formatted_caption: Option<FormattedBody>) -> Self {
-        self.formatted_caption = formatted_caption;
         self
     }
 
@@ -298,8 +285,7 @@ impl AttachmentConfig {
 pub struct GalleryConfig {
     pub(crate) txn_id: Option<OwnedTransactionId>,
     pub(crate) items: Vec<GalleryItemInfo>,
-    pub(crate) caption: Option<String>,
-    pub(crate) formatted_caption: Option<FormattedBody>,
+    pub(crate) caption: Option<TextMessageEventContent>,
     pub(crate) mentions: Option<Mentions>,
     pub(crate) reply: Option<Reply>,
 }
@@ -340,18 +326,8 @@ impl GalleryConfig {
     /// # Arguments
     ///
     /// * `caption` - The optional caption.
-    pub fn caption(mut self, caption: Option<String>) -> Self {
+    pub fn caption(mut self, caption: Option<TextMessageEventContent>) -> Self {
         self.caption = caption;
-        self
-    }
-
-    /// Set the optional formatted caption.
-    ///
-    /// # Arguments
-    ///
-    /// * `formatted_caption` - The optional formatted caption.
-    pub fn formatted_caption(mut self, formatted_caption: Option<FormattedBody>) -> Self {
-        self.formatted_caption = formatted_caption;
         self
     }
 
@@ -399,9 +375,7 @@ pub struct GalleryItemInfo {
     /// The attachment info.
     pub attachment_info: AttachmentInfo,
     /// The caption.
-    pub caption: Option<String>,
-    /// The formatted caption.
-    pub formatted_caption: Option<FormattedBody>,
+    pub caption: Option<TextMessageEventContent>,
     /// The thumbnail.
     pub thumbnail: Option<Thumbnail>,
 }

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -229,7 +229,6 @@ impl RoomSendQueue {
                     filename,
                     file_media_request.source.clone(),
                     config.caption,
-                    config.formatted_caption,
                     config.info,
                     event_thumbnail_info,
                 ),
@@ -346,7 +345,6 @@ impl RoomSendQueue {
                 filename,
                 file_media_request.source.clone(),
                 item_info.caption,
-                item_info.formatted_caption,
                 Some(item_info.attachment_info),
                 event_thumbnail_info,
             ));
@@ -362,13 +360,11 @@ impl RoomSendQueue {
         }
 
         // Create the content for the gallery event.
+        let (body, formatted) =
+            gallery.caption.map(|caption| (caption.body, caption.formatted)).unwrap_or_default();
         let event_content = room
             .make_media_event(
-                MessageType::Gallery(GalleryMessageEventContent::new(
-                    gallery.caption.unwrap_or_default(),
-                    gallery.formatted_caption,
-                    item_types,
-                )),
+                MessageType::Gallery(GalleryMessageEventContent::new(body, formatted, item_types)),
                 gallery.mentions,
                 gallery.reply,
             )

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -11,7 +11,10 @@ use ruma::{
     event_id,
     events::{
         Mentions,
-        room::{MediaSource, message::ReplyWithinThread},
+        room::{
+            MediaSource,
+            message::{ReplyWithinThread, TextMessageEventContent},
+        },
     },
     mxc_uri, owned_mxc_uri, owned_user_id, uint,
 };
@@ -135,7 +138,7 @@ async fn test_room_attachment_send_info() {
             width: Some(uint!(800)),
             ..Default::default()
         }))
-        .caption(Some("image caption".to_owned()));
+        .caption(Some(TextMessageEventContent::plain("image caption")));
 
     let response = room
         .send_attachment("image.jpg", &mime::IMAGE_JPEG, b"Hello world".to_vec(), config)
@@ -188,7 +191,7 @@ async fn test_room_attachment_send_wrong_info() {
             duration: Some(Duration::from_millis(3600)),
             ..Default::default()
         }))
-        .caption(Some("image caption".to_owned()));
+        .caption(Some(TextMessageEventContent::plain("image caption")));
 
     // But here, using `image/jpeg`.
     let response =
@@ -652,7 +655,7 @@ async fn test_room_attachment_send_is_animated() {
             is_animated: Some(false),
             ..Default::default()
         }))
-        .caption(Some("image caption".to_owned()));
+        .caption(Some(TextMessageEventContent::plain("image caption")));
 
     let response = room
         .send_attachment("image.jpg", &mime::IMAGE_JPEG, b"Hello world".to_vec(), config)

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -35,7 +35,7 @@ use ruma::{
             MediaSource,
             message::{
                 ImageMessageEventContent, MessageType, Relation, ReplyWithinThread,
-                RoomMessageEventContent,
+                RoomMessageEventContent, TextMessageEventContent,
             },
         },
     },
@@ -1936,7 +1936,7 @@ async fn test_media_uploads() {
     let config = AttachmentConfig::new()
         .thumbnail(Some(thumbnail))
         .txn_id(transaction_id.clone())
-        .caption(Some("caption".to_owned()))
+        .caption(Some(TextMessageEventContent::plain("caption")))
         .mentions(Some(mentions.clone()))
         .reply(Some(Reply {
             event_id: replied_to_event_id.into(),
@@ -2230,8 +2230,7 @@ async fn test_gallery_uploads() {
             filename: filename1.into(),
             data: data1,
             thumbnail: Some(thumbnail1),
-            caption: Some("caption1".to_owned()),
-            formatted_caption: None,
+            caption: Some(TextMessageEventContent::plain("caption1")),
         })
         .add_item(GalleryItemInfo {
             attachment_info: attachment_info2,
@@ -2239,10 +2238,9 @@ async fn test_gallery_uploads() {
             filename: filename2.into(),
             data: data2,
             thumbnail: Some(thumbnail2),
-            caption: Some("caption2".to_owned()),
-            formatted_caption: None,
+            caption: Some(TextMessageEventContent::plain("caption2")),
         })
-        .caption(Some("caption".to_owned()))
+        .caption(Some(TextMessageEventContent::plain("caption")))
         .mentions(Some(mentions.clone()))
         .reply(Some(Reply {
             event_id: replied_to_event_id.into(),

--- a/examples/image_bot/src/main.rs
+++ b/examples/image_bot/src/main.rs
@@ -4,7 +4,9 @@ use matrix_sdk::{
     Client, Room, RoomState,
     attachment::AttachmentConfig,
     config::SyncSettings,
-    ruma::events::room::message::{MessageType, OriginalSyncRoomMessageEvent},
+    ruma::events::room::message::{
+        MessageType, OriginalSyncRoomMessageEvent, TextMessageEventContent,
+    },
 };
 use url::Url;
 
@@ -20,7 +22,7 @@ async fn on_room_message(event: OriginalSyncRoomMessageEvent, room: Room, image:
             "cat.jpg",
             &mime::IMAGE_JPEG,
             image,
-            AttachmentConfig::new().caption(Some("my pretty cat".to_owned())),
+            AttachmentConfig::new().caption(Some(TextMessageEventContent::plain("my pretty cat"))),
         )
         .await
         .unwrap();


### PR DESCRIPTION
It doesn't make sense to send a formatted caption without a plain text caption so using TextMessageEventContent forces the latter to be present.

This also allows to use the helpful constructors of TextMessageEventContent.
