### PR TITLE
fix(ui): `RoomListItem` refreshes its `cache_is_space`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -431,7 +431,7 @@ impl RoomListItem {
         self.cached_latest_event_is_local = self.inner.new_latest_event_is_local();
         self.cached_recency_stamp = self.inner.recency_stamp();
         self.cached_display_name = self.inner.cached_display_name().map(|name| name.to_string());
-        // no need to refresh `Self::is_space`.
+        self.cached_is_space = self.inner.is_space();
         self.cached_state = self.inner.state();
     }
 }


### PR DESCRIPTION
The `RoomListItem` caches some data. It's been introduced in #5684. When the cached data are refreshed, the `Room::is_space()` value wasn't refreshed because I thought it wasn't possible to change the type of a room. However, if the state is not fully loaded (because the `m.room.create` event isn't present), the result of `Room::is_space()`… can change. So this patch refreshes the `cached_is_space` value unconditionally.

---

* Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/5721