### PR TITLE
fix(ci): Fix cargo-codspeed command

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -32,7 +32,7 @@ jobs:
           bins: cargo-codspeed
 
       - name: Build the benchmark target(s)
-        run: cargo codspeed build -p benchmarks ${{ matrix.benchmark }} --features codspeed
+        run: cargo codspeed build -p benchmarks --bench ${{ matrix.benchmark }} --features codspeed
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@653fdc30e6c40ffd9739e40c8a0576f4f4523ca1


### PR DESCRIPTION
A new release occurred which has a breaking change in the syntax used to select a benchmark.

