### PR TITLE
feat(sqlite): `SqliteStateStore` has 1 write connection

### DIFF
--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -165,7 +165,7 @@ impl SqliteEventCacheStore {
         })
     }
 
-    // Acquire a connection for executing read operations.
+    /// Acquire a connection for executing read operations.
     #[instrument(skip_all)]
     async fn read(&self) -> Result<SqliteAsyncConn> {
         trace!("Taking a `read` connection");
@@ -182,7 +182,7 @@ impl SqliteEventCacheStore {
         Ok(connection)
     }
 
-    // Acquire a connection for executing write operations.
+    /// Acquire a connection for executing write operations.
     #[instrument(skip_all)]
     async fn write(&self) -> Result<OwnedMutexGuard<SqliteAsyncConn>> {
         trace!("Taking a `write` connection");


### PR DESCRIPTION
This patch introduces a write-only connection in `SqliteStateStore` _à la_ `SqliteEventCacheStore` (see https://github.com/matrix-org/matrix-rust-sdk/pull/5382 to learn more). The idea is to get many read-only connections, and a single write-only connections behind a lock, so that there is a single writer at a time.

This patch renames the `acquire` method to `read`, and it introduces a new `write` connection.

---

- Address https://github.com/element-hq/customer-success/issues/591
- May fix https://github.com/matrix-org/matrix-rust-sdk/issues/5362