### PR TITLE
Implement the redecryption logic in the event cache

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -941,6 +941,14 @@ impl TimelineEventKind {
             TimelineEventKind::PlainText { .. } => None,
         }
     }
+
+    /// Get the event type of this event.
+    ///
+    /// Returns `None` if there isn't an event type or if the event failed to be
+    /// deserialized.
+    pub fn event_type(&self) -> Option<String> {
+        self.raw().get_field("type").ok().flatten()
+    }
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/012_store_event_type.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/012_store_event_type.sql
@@ -1,0 +1,46 @@
+-- After the merge of https://github.com/matrix-org/matrix-rust-sdk/pull/5648,
+-- we want all events to get a `TimelineEvent::timestamp` value (extracted from
+-- `origin_server_ts`).
+--
+-- To accomplish that, we are emptying the event cache. New synced events will
+-- be built correctly, with a valid `TimelineEvent::timestamp`, allowing a
+-- clear, stable situation.
+
+DELETE from linked_chunks;
+DELETE from event_chunks; -- should be done by cascading
+DELETE from gap_chunks; -- should be done by cascading
+DELETE from events;
+
+DROP TABLE events;
+
+-- Events and their content.
+CREATE TABLE "events" (
+    -- The room in which the event is located.
+    "room_id" BLOB NOT NULL,
+
+    -- The `OwnedEventId` of this event.
+    "event_id" BLOB NOT NULL,
+
+    -- The event type of this event.
+    "event_type" BLOB NOT NULL,
+
+    -- The ID of the session that was used to encrypt this event, may be null if
+    -- the event wasn't encrypted.
+    "session_id" BLOB NULL,
+
+    -- JSON serialized `TimelineEvent` (encrypted value).
+    "content" BLOB NOT NULL,
+
+    -- If this event is an aggregation (related event), the event id of the event it relates to.
+    -- Can be null if this event isn't an aggregation.
+    "relates_to" BLOB,
+
+    -- If this event is an aggregation (related event), the kind of relation it has to the event it
+    -- relates to.
+    -- Can be null if this event isn't an aggregation.
+    "rel_type" BLOB,
+
+    -- Primary key is the event ID.
+    PRIMARY KEY (event_id)
+)
+WITHOUT ROWID;

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -1332,7 +1332,7 @@ impl EventCacheStore for SqliteEventCacheStore {
         let _timer = timer!("method");
 
         let Some(event_id) = event.event_id() else {
-            error!(%room_id, "Trying to save an event with no ID");
+            error!("Trying to save an event with no ID");
             return Ok(());
         };
 

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -53,6 +53,7 @@ use crate::{
 mod keys {
     // Tables
     pub const LINKED_CHUNKS: &str = "linked_chunks";
+    pub const EVENTS: &str = "events";
 }
 
 /// The database name.
@@ -63,7 +64,7 @@ const DATABASE_NAME: &str = "matrix-sdk-event-cache.sqlite3";
 /// This is used to figure whether the SQLite database requires a migration.
 /// Every new SQL migration should imply a bump of this number, and changes in
 /// the [`run_migrations`] function.
-const DATABASE_VERSION: u8 = 11;
+const DATABASE_VERSION: u8 = 12;
 
 /// The string used to identify a chunk of type events, in the `type` field in
 /// the database.
@@ -472,6 +473,16 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
         .await?;
     }
 
+    if version < 12 {
+        conn.with_transaction(|txn| {
+            txn.execute_batch(include_str!(
+                "../migrations/event_cache_store/012_store_event_type.sql"
+            ))?;
+            txn.set_db_version(12)
+        })
+        .await?;
+    }
+
     Ok(())
 }
 
@@ -632,7 +643,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                         // deduplicated and moved to another position; or because it was inserted
                         // outside the context of a linked chunk (e.g. pinned event).
                         let mut content_statement = txn.prepare(
-                            "INSERT OR REPLACE INTO events(room_id, event_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?)"
+                            "INSERT OR REPLACE INTO events(room_id, event_id, event_type, session_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?, ?, ?)"
                         )?;
 
                         let invalid_event = |event: TimelineEvent| {
@@ -641,20 +652,27 @@ impl EventCacheStore for SqliteEventCacheStore {
                                 return None;
                             };
 
-                            Some((event_id.to_string(), event))
+                            let Some(event_type) = event.kind.event_type() else {
+                                error!(%event_id, "Trying to save an event with no event type");
+                                return None;
+                            };
+
+                            Some((event_id.to_string(), event_type, event))
                         };
 
                         let room_id = linked_chunk_id.room_id();
                         let hashed_room_id = this.encode_key(keys::LINKED_CHUNKS, room_id);
 
-                        for (i, (event_id, event)) in items.into_iter().filter_map(invalid_event).enumerate() {
+                        for (i, (event_id, event_type, event)) in items.into_iter().filter_map(invalid_event).enumerate() {
                             // Insert the location information into the database.
                             let index = at.index() + i;
                             chunk_statement.execute((chunk_id, &hashed_linked_chunk_id, &event_id, index))?;
 
+                            let session_id = event.kind.session_id().map(|s| this.encode_key(keys::EVENTS, s));
+
                             // Now, insert the event content into the database.
                             let encoded_event = this.encode_event(&event)?;
-                            content_statement.execute((&hashed_room_id, event_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
+                            content_statement.execute((&hashed_room_id, event_id, event_type, session_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
                         }
                     }
 
@@ -671,6 +689,13 @@ impl EventCacheStore for SqliteEventCacheStore {
                             continue;
                         };
 
+                        let Some(event_type) = event.kind.event_type() else {
+                            error!(%event_id, "Trying to save an event with no event type");
+                            continue;
+                        };
+
+                        let session_id = event.kind.session_id().map(|s| this.encode_key(keys::EVENTS, s));
+
                         // Replace the event's content. Really we'd like to update, but in case the
                         // event id changed, we are a bit lenient here and will allow an insertion
                         // of the new event.
@@ -678,8 +703,8 @@ impl EventCacheStore for SqliteEventCacheStore {
                         let room_id = linked_chunk_id.room_id();
                         let hashed_room_id = this.encode_key(keys::LINKED_CHUNKS, room_id);
                         txn.execute(
-                            "INSERT OR REPLACE INTO events(room_id, event_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?)"
-                        , (&hashed_room_id, &event_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
+                            "INSERT OR REPLACE INTO events(room_id, event_id, event_type, session_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                            (&hashed_room_id, &event_id, event_type, session_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
 
                         // Replace the event id in the linked chunk, in case it changed.
                         txn.execute(
@@ -1336,6 +1361,14 @@ impl EventCacheStore for SqliteEventCacheStore {
             return Ok(());
         };
 
+        let Some(event_type) = event.kind.event_type() else {
+            error!(%event_id, "Trying to save an event with no event type");
+            return Ok(());
+        };
+
+        let event_type = self.encode_key(keys::EVENTS, event_type);
+        let session_id = event.kind.session_id().map(|s| self.encode_key(keys::EVENTS, s));
+
         let hashed_room_id = self.encode_key(keys::LINKED_CHUNKS, room_id);
         let event_id = event_id.to_string();
         let encoded_event = self.encode_event(&event)?;
@@ -1344,8 +1377,8 @@ impl EventCacheStore for SqliteEventCacheStore {
             .await?
             .with_transaction(move |txn| -> Result<_> {
                 txn.execute(
-                    "INSERT OR REPLACE INTO events(room_id, event_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?)"
-                    , (&hashed_room_id, &event_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
+                    "INSERT OR REPLACE INTO events(room_id, event_id, event_type, session_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (&hashed_room_id, &event_id, event_type, session_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
 
                 Ok(())
             })

--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -300,42 +300,43 @@ async fn decryption_task<P: RoomDataProvider, D: Decryptor>(
 ) {
     debug!("Decryption task starting.");
 
-    while let Some(request) = receiver.recv().await {
-        let should_retry = |session_id: &str| {
-            if let Some(session_ids) = &request.session_ids {
-                session_ids.contains(session_id)
-            } else {
-                true
-            }
-        };
-
-        // Find the indices of events that are in the supplied sessions, distinguishing
-        // between UTDs which we need to decrypt, and already-decrypted events where we
-        // only need to re-fetch encryption info.
-        let mut state = state.write().await;
-        let (retry_decryption_indices, retry_info_indices) =
-            compute_event_indices_to_retry_decryption(&state.items, should_retry);
-
-        // Retry fetching encryption info for events that are already decrypted
-        if !retry_info_indices.is_empty() {
-            debug!("Retrying fetching encryption info");
-            retry_fetch_encryption_info(&mut state, retry_info_indices, &room_data_provider).await;
-        }
-
-        // Retry decrypting any unable-to-decrypt messages
-        if !retry_decryption_indices.is_empty() {
-            debug!("Retrying decryption");
-            decrypt_by_index(
-                &mut state,
-                &request.settings,
-                &room_data_provider,
-                request.decryptor,
-                should_retry,
-                retry_decryption_indices,
-            )
-            .await
-        }
-    }
+    // while let Some(request) = receiver.recv().await {
+    //     let should_retry = |session_id: &str| {
+    //         if let Some(session_ids) = &request.session_ids {
+    //             session_ids.contains(session_id)
+    //         } else {
+    //             true
+    //         }
+    //     };
+    //
+    //     // Find the indices of events that are in the supplied sessions,
+    // distinguishing     // between UTDs which we need to decrypt, and
+    // already-decrypted events where we     // only need to re-fetch encryption
+    // info.     let mut state = state.write().await;
+    //     let (retry_decryption_indices, retry_info_indices) =
+    //         compute_event_indices_to_retry_decryption(&state.items,
+    // should_retry);
+    //
+    //     // Retry fetching encryption info for events that are already decrypted
+    //     if !retry_info_indices.is_empty() {
+    //         debug!("Retrying fetching encryption info");
+    //         retry_fetch_encryption_info(&mut state, retry_info_indices,
+    // &room_data_provider).await;     }
+    //
+    //     // Retry decrypting any unable-to-decrypt messages
+    //     if !retry_decryption_indices.is_empty() {
+    //         debug!("Retrying decryption");
+    //         decrypt_by_index(
+    //             &mut state,
+    //             &request.settings,
+    //             &room_data_provider,
+    //             request.decryptor,
+    //             should_retry,
+    //             retry_decryption_indices,
+    //         )
+    //         .await
+    //     }
+    // }
 
     debug!("Decryption task stopping.");
 }

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -935,7 +935,7 @@ impl EventCacheInner {
             self.multiple_room_updates_lock.lock().await
         };
 
-        // Note: bnjbvr tried to make this concurrent at some point, but it turned out
+        // NOTE: bnjbvr tried to make this concurrent at some point, but it turned out
         // to be a performance regression, even for large sync updates. Lacking
         // time to investigate, this code remains sequential for now. See also
         // https://github.com/matrix-org/matrix-rust-sdk/pull/5426.

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -74,6 +74,7 @@ use crate::{
 
 mod deduplicator;
 mod pagination;
+mod redecryptor;
 mod room;
 
 pub use pagination::{RoomPagination, RoomPaginationStatus};

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -152,7 +152,7 @@ pub struct EventCacheDropHandles {
     auto_shrink_linked_chunk_task: JoinHandle<()>,
 
     /// The task used to automatically redecrypt UTDs.
-    redecryption_task: JoinHandle<()>,
+    redecryptor: Redecryptor,
 }
 
 impl fmt::Debug for EventCacheDropHandles {
@@ -166,7 +166,6 @@ impl Drop for EventCacheDropHandles {
         self.listen_updates_task.abort();
         self.ignore_user_list_update_task.abort();
         self.auto_shrink_linked_chunk_task.abort();
-        self.redecryption_task.abort();
     }
 }
 
@@ -263,13 +262,13 @@ impl EventCache {
                 auto_shrink_receiver,
             ));
 
-            let redecryption_task = Redecryptor::new(client, Arc::downgrade(&self.inner));
+            let redecryptor = Redecryptor::new(client, Arc::downgrade(&self.inner));
 
             Arc::new(EventCacheDropHandles {
                 listen_updates_task,
                 ignore_user_list_update_task,
                 auto_shrink_linked_chunk_task,
-                redecryption_task,
+                redecryptor,
             })
         });
 

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -262,7 +262,7 @@ impl EventCache {
                 auto_shrink_receiver,
             ));
 
-            let redecryptor = Redecryptor::new(client, Arc::downgrade(&self.inner));
+            let redecryptor = Redecryptor::new(Arc::downgrade(&self.inner));
 
             Arc::new(EventCacheDropHandles {
                 listen_updates_task,

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -206,3 +206,177 @@ impl Redecryptor {
         info!("Shutting down the event cache redecryptor");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use assert_matches2::assert_matches;
+    use eyeball_im::VectorDiff;
+    use matrix_sdk_base::deserialized_responses::TimelineEventKind;
+    use matrix_sdk_test::{
+        JoinedRoomBuilder, StateTestEvent, async_test, event_factory::EventFactory,
+    };
+    use ruma::{device_id, event_id, room_id, user_id};
+    use serde_json::json;
+
+    use crate::{
+        assert_let_timeout, encryption::EncryptionSettings, event_cache::RoomEventCacheUpdate,
+        test_utils::mocks::MatrixMockServer,
+    };
+
+    #[async_test]
+    async fn test_redecryptor() {
+        let room_id = room_id!("!test:localhost");
+
+        let alice_user_id = user_id!("@alice:localhost");
+        let alice_device_id = device_id!("ALICEDEVICE");
+        let bob_user_id = user_id!("@bob:localhost");
+        let bob_device_id = device_id!("BOBDEVICE");
+
+        let matrix_mock_server = MatrixMockServer::new().await;
+        matrix_mock_server.mock_crypto_endpoints_preset().await;
+
+        let encryption_settings =
+            EncryptionSettings { auto_enable_cross_signing: true, ..Default::default() };
+
+        // Create some clients for Alice and Bob.
+
+        let alice = matrix_mock_server
+            .client_builder_for_crypto_end_to_end(alice_user_id, alice_device_id)
+            .on_builder(|builder| {
+                builder
+                    .with_enable_share_history_on_invite(true)
+                    .with_encryption_settings(encryption_settings)
+            })
+            .build()
+            .await;
+
+        let bob = matrix_mock_server
+            .client_builder_for_crypto_end_to_end(bob_user_id, bob_device_id)
+            .on_builder(|builder| {
+                builder
+                    .with_enable_share_history_on_invite(true)
+                    .with_encryption_settings(encryption_settings)
+            })
+            .build()
+            .await;
+
+        bob.event_cache().subscribe().expect("Bob should be able to enable the event cache");
+
+        // Ensure that Alice and Bob are aware of their devices and identities.
+        matrix_mock_server.exchange_e2ee_identities(&alice, &bob).await;
+
+        let event_factory = EventFactory::new().room(room_id);
+        let alice_member_event = event_factory.member(alice_user_id).into_raw();
+        let bob_member_event = event_factory.member(bob_user_id).into_raw();
+
+        // Let us now create a room for them.
+        let room_builder = JoinedRoomBuilder::new(room_id)
+            .add_state_event(StateTestEvent::Create)
+            .add_state_event(StateTestEvent::Encryption);
+
+        matrix_mock_server
+            .mock_sync()
+            .ok_and_run(&alice, |builder| {
+                builder.add_joined_room(room_builder.clone());
+            })
+            .await;
+
+        matrix_mock_server
+            .mock_sync()
+            .ok_and_run(&bob, |builder| {
+                builder.add_joined_room(room_builder);
+            })
+            .await;
+
+        let room = alice
+            .get_room(room_id)
+            .expect("Alice should have access to the room now that we synced");
+
+        // Alice will send a single event to the room, but this will trigger a to-device
+        // message containing the room key to be sent as well. We capture both the event
+        // and the to-device message.
+
+        let event_type = "m.room.message";
+        let content = json!({"body": "It's a secret to everybody", "msgtype": "m.text"});
+
+        let event_id = event_id!("$some_id");
+        let (event_receiver, mock) =
+            matrix_mock_server.mock_room_send().ok_with_capture(event_id, alice_user_id);
+        let (_guard, room_key) = matrix_mock_server.mock_capture_put_to_device(alice_user_id).await;
+
+        {
+            let _guard = mock.mock_once().mount_as_scoped().await;
+
+            matrix_mock_server
+                .mock_get_members()
+                .ok(vec![alice_member_event.clone(), bob_member_event.clone()])
+                .mock_once()
+                .mount()
+                .await;
+
+            room.send_raw(event_type, content)
+                .await
+                .expect("We should be able to send an initial message");
+        };
+
+        // Let's now see what Bob's event cache does.
+
+        let (room_cache, _) = bob
+            .event_cache()
+            .for_room(room_id)
+            .await
+            .expect("We should be able to get to the event cache for a specific room");
+
+        let (_, mut subscriber) = room_cache.subscribe().await;
+
+        // Let us retrieve the captured event and to-device message.
+        let event = event_receiver.await.expect("Alice should have sent the event by now");
+        let room_key = room_key.await;
+
+        // Let us forward the event to Bob.
+        matrix_mock_server
+            .mock_sync()
+            .ok_and_run(&bob, |builder| {
+                builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(event));
+            })
+            .await;
+
+        // Alright, Bob has received an update from the cache.
+
+        assert_let_timeout!(
+            Ok(RoomEventCacheUpdate::UpdateTimelineEvents { diffs, .. }) = subscriber.recv()
+        );
+
+        // There should be a single new event, and it should be a UTD as we did not
+        // receive the room key yet.
+        assert_eq!(diffs.len(), 1);
+        assert_matches!(&diffs[0], VectorDiff::Append { values });
+        assert_matches!(&values[0].kind, TimelineEventKind::UnableToDecrypt { .. });
+
+        // Now we send the room key to Bob.
+        matrix_mock_server
+            .mock_sync()
+            .ok_and_run(&bob, |builder| {
+                builder.add_to_device_event(
+                    room_key
+                        .deserialize_as()
+                        .expect("We should be able to deserialize the room key"),
+                );
+            })
+            .await;
+
+        // Bob should receive a new update from the cache.
+        assert_let_timeout!(
+            Duration::from_secs(1),
+            Ok(RoomEventCacheUpdate::UpdateTimelineEvents { diffs, .. }) = subscriber.recv()
+        );
+
+        // It should replace the UTD with a decrypted event.
+        assert_eq!(diffs.len(), 1);
+        assert_matches!(&diffs[0], VectorDiff::Set { index, value });
+        assert_eq!(*index, 0);
+        assert_matches!(&value.kind, TimelineEventKind::Decrypted { .. });
+    }
+}

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -12,14 +12,62 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The REDECRYPTOR is a layer that handles redecryption of events in case we
-//! couldn't decrypt them imediatelly
+//! The Redecryptor (Rd) is a layer and long-running background task which
+//! handles redecryption of events in case we couldn't decrypt them imediatelly.
+//!
+//! Rd listens to the OlmMachine for received room keys. If a new room key has
+//! been received it attempts to find any UTDs in the [`EventCache`]. If Rd
+//! decrypts any UTDs from the event cache it will replace the events in the
+//! cache and send out new [`RoomEventCacheUpdates`] to any of its listeners.
+//!
+//! There's an additional gotcha, the [`OlmMachine`] might get recreated by
+//! calls to [`BaseClient::regenerate_olm()`]. When this happens we will receive
+//! a `None` on the room keys stream and we need to re-listen to it.
+//!
+//! Another gotcha is that room keys might be received on another process if the
+//! Client is operating on a iOS device. A separate process is used in this case
+//! to receive push notifications. In this case the room key will be received
+//! and Rd won't get notified about it. To work around this decryption requests
+//! can be explicitly sent to Rd.
+//!
+//!                              ┌─────────────┐
+//!                              │             │
+//!                  ┌───────────┤  Timeline   │
+//!                  │           │             │
+//!                  │           └─────▲───────┘
+//!                  │                 │
+//!                  │                 │
+//!                  │                 │
+//!              Decryption            │
+//!                request             │
+//!                  │       RoomEventCacheUpdates
+//!                  │                 │
+//!                  │                 │
+//!                  │      ┌──────────┴────────────┐
+//!                  │      │                       │
+//!                  └──────►      Redecryptor      │
+//!                         │                       │
+//!                         └───────────▲───────────┘
+//!                                     │
+//!                                     │
+//!                                     │
+//!                         Received room keys stream
+//!                                     │
+//!                                     │
+//!                                     │
+//!                             ┌───────┴──────┐
+//!                             │              │
+//!                             │  OlmMachine  │
+//!                             │              │
+//!                             └──────────────┘
 
 use std::{collections::BTreeSet, pin::Pin, sync::Weak};
 
 use as_variant::as_variant;
 use futures_core::Stream;
 use futures_util::{StreamExt, pin_mut};
+#[cfg(doc)]
+use matrix_sdk_base::{BaseClient, crypto::OlmMachine};
 use matrix_sdk_base::{
     crypto::{store::types::RoomKeyInfo, types::events::room::encrypted::EncryptedEvent},
     deserialized_responses::{DecryptedRoomEvent, TimelineEvent, TimelineEventKind},
@@ -44,6 +92,13 @@ pub struct DecryptionRetryRequest {
 type SessionId<'a> = &'a str;
 
 impl EventCache {
+    /// Retrieve a set of events that we weren't able to decrypt.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The ID of the room where the events were sent to.
+    /// * `session_id` - The unique ID of the room key that was used to encrypt
+    ///   the event.
     async fn get_utds(
         &self,
         room_id: &RoomId,
@@ -76,6 +131,17 @@ impl EventCache {
         Ok(events.into_iter().filter_map(filter_non_utds).collect())
     }
 
+    /// Handle a chunk of events that we were previously unable to decrypt but
+    /// have now successfully decrypted.
+    ///
+    /// This function will replace the existing UTD events in memory and the
+    /// store and send out a [`RoomEventCacheUpdate`] for the newly
+    /// decrypted events.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The ID of the room where the events were sent to.
+    /// * `events` - A chunk of events that were successfully decrypted.
     #[instrument(skip_all, fields(room_id))]
     async fn on_resolved_utds(
         &self,
@@ -113,12 +179,17 @@ impl EventCache {
         Ok(())
     }
 
+    /// Attempt to decrypt a single event.
     async fn decrypt_event(
         &self,
         room_id: &RoomId,
         event: &Raw<EncryptedEvent>,
     ) -> Option<DecryptedRoomEvent> {
         let client = self.inner.client().ok()?;
+        // TODO: Do we need to use the `Room` object to decrypt these events so we can
+        // calculate if the event should count as a notification, i.e. get the push
+        // actions. I thing we do, what happens if the room can't be found? We fallback
+        // to this?
         let machine = client.olm_machine().await;
         let machine = machine.as_ref()?;
 
@@ -141,7 +212,10 @@ impl EventCache {
     ) -> Result<(), EventCacheError> {
         trace!("Retrying to decrypt");
 
+        // Get all the relevant UTDs.
         let events = self.get_utds(room_id, session_id).await?;
+
+        // Let's attempt to decrypt them them.
         let mut decrypted_events = Vec::with_capacity(events.len());
 
         for (event_id, event) in events {
@@ -152,6 +226,8 @@ impl EventCache {
             }
         }
 
+        // Replace the events and notify listeners that UTDs have been replaced with
+        // decrypted events.
         self.on_resolved_utds(room_id, decrypted_events).await?;
 
         Ok(())
@@ -170,6 +246,10 @@ impl Drop for Redecryptor {
 }
 
 impl Redecryptor {
+    /// Create a new [`Redecryptor`].
+    ///
+    /// This creates a task that listens to various streams and attempts to
+    /// redecrypt UTDs that can be found inside the [`EventCache`].
     pub(super) fn new(cache: Weak<EventCacheInner>) -> Self {
         let (request_decryption_sender, receiver) = tokio::sync::mpsc::unbounded_channel();
 
@@ -189,6 +269,10 @@ impl Redecryptor {
         });
     }
 
+    /// (Re)-subscribe to the room key stream from the [`OlmMachine`].
+    ///
+    /// This needs to happen any time this stream returns a `None` meaning that
+    /// the sending part of the stream has been dropped.
     async fn subscribe_to_room_key_stream(
         cache: &Weak<EventCacheInner>,
     ) -> Option<impl Stream<Item = Result<Vec<RoomKeyInfo>, BroadcastStreamRecvError>>> {
@@ -215,6 +299,8 @@ impl Redecryptor {
 
         loop {
             tokio::select! {
+                // An explicit request, presumably from the timeline, has been received to decrypt
+                // events that were encrypted with a certain room key.
                 Some(request) = decryption_request_stream.next() => {
                         let Some(cache) = Self::upgrade_event_cache(cache) else {
                             break false;
@@ -227,6 +313,8 @@ impl Redecryptor {
                                 .inspect_err(|e| warn!("Error redecrypting {e:?}"));
                         }
                 }
+                // The room key stream from the OlmMachine. Needs to be recreated every time we
+                // receive a `None` from the stream.
                 room_keys = room_key_stream.next() => {
                     match room_keys {
                         Some(Ok(room_keys)) => {
@@ -244,6 +332,8 @@ impl Redecryptor {
                         Some(Err(_)) => {
                             todo!("Handle lagging here, how?")
                         },
+                        // The stream got closed, this could mean that our OlmMachine got
+                        // regenerated, let's return true and try to recreate the stream.
                         None => {
                             break true
                         }
@@ -258,6 +348,9 @@ impl Redecryptor {
         cache: Weak<EventCacheInner>,
         decryption_request_stream: UnboundedReceiverStream<DecryptionRetryRequest>,
     ) {
+        // We pin the decryption request stream here since that one doesn't need to be
+        // recreated and we don't want to miss messages coming from the stream
+        // while recreating it unnecessarily.
         pin_mut!(decryption_request_stream);
 
         while Self::redecryption_loop(&cache, &mut decryption_request_stream).await {

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -1,0 +1,116 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The REDECRYPTOR is a layer that handles redecryption of events in case we
+//! couldn't decrypt them imediatelly
+
+use std::sync::{Arc, Weak};
+
+use futures_core::Stream;
+use futures_util::{StreamExt, pin_mut};
+use matrix_sdk_base::{
+    crypto::{OlmMachine, store::types::RoomKeyInfo},
+    deserialized_responses::{DecryptedRoomEvent, TimelineEvent, TimelineEventKind},
+    event_cache::store::{EventCacheStoreError, EventCacheStoreLock},
+};
+use matrix_sdk_common::executor::JoinHandle;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+use tracing::warn;
+
+use crate::event_cache::{EventCacheError, RoomEventCacheState};
+
+pub(crate) struct Redecryptor {
+    redecryption_task: JoinHandle<()>,
+    inner: Arc<InnerRedecryptor>,
+}
+
+impl Drop for Redecryptor {
+    fn drop(&mut self) {
+        self.redecryption_task.abort();
+    }
+}
+
+pub(crate) struct InnerRedecryptor {
+    store: EventCacheStoreLock,
+    olm_machine: OlmMachine,
+}
+
+impl InnerRedecryptor {
+    /// Attempt to redecrypt events after a room key with the given session ID
+    /// has been received.
+    pub async fn retry_decryption(
+        &self,
+        room_key_info: RoomKeyInfo,
+    ) -> Result<(), EventCacheError> {
+        let event_cache: RoomEventCacheState = unimplemented!();
+
+        // Load the relevant events from the event cache store and attempt to redecrypt
+        // things.
+        // TODO: Do we want to have this method on the [`RoomEventCacheState`]?
+        let store = self.store.lock().await.unwrap();
+
+        // TODO: We can't load **all** events all the time.
+        let events = store.get_room_events(&room_key_info.room_id).await?;
+
+        for event in events.into_iter().filter(|e| !e.kind.is_utd()) {
+            let Some(event_id) = event.event_id() else {
+                continue;
+            };
+
+            let Some((location, mut target_event)) = event_cache.find_event(&event_id).await?
+            else {
+                continue;
+            };
+
+            let decrypted = self.decrypt_event(event).await?;
+            target_event.kind = TimelineEventKind::Decrypted(decrypted);
+
+            event_cache.replace_event_at(location, target_event).await?
+        }
+
+        Ok(())
+    }
+
+    pub async fn decrypt_event(
+        &self,
+        event: TimelineEvent,
+    ) -> Result<DecryptedRoomEvent, EventCacheStoreError> {
+        todo!();
+    }
+
+    pub async fn listen_for_room_keys_task(
+        weak_redecryptor: Weak<InnerRedecryptor>,
+        received_stream: impl Stream<Item = Result<Vec<RoomKeyInfo>, BroadcastStreamRecvError>>,
+    ) {
+        pin_mut!(received_stream);
+
+        // TODO: We need to relisten to this stream if it dies.
+        while let Some(update) = received_stream.next().await {
+            let Some(decryptor) = weak_redecryptor.upgrade() else {
+                break;
+            };
+
+            if let Ok(room_keys) = update {
+                for key in room_keys {
+                    let _ = decryptor
+                        .retry_decryption(key)
+                        .await
+                        .inspect_err(|e| warn!("Error redecrypting {e:?}"));
+                }
+            } else {
+                todo!("Redecrypt all visible events?")
+            }
+        }
+    }
+}

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -37,28 +37,11 @@ use crate::{
     },
 };
 
-pub(crate) trait RedecryptorCtx {
-    type Error;
-
+impl EventCache {
     async fn get_utds(
         &self,
         room_key_info: &RoomKeyInfo,
-    ) -> Result<Vec<(OwnedEventId, Raw<AnySyncTimelineEvent>)>, Self::Error>;
-
-    async fn on_resolved_utds(
-        &self,
-        room_id: &RoomId,
-        events: Vec<(OwnedEventId, DecryptedRoomEvent)>,
-    ) -> Result<(), Self::Error>;
-}
-
-impl RedecryptorCtx for EventCache {
-    type Error = EventCacheError;
-
-    async fn get_utds(
-        &self,
-        room_key_info: &RoomKeyInfo,
-    ) -> Result<Vec<(OwnedEventId, Raw<AnySyncTimelineEvent>)>, Self::Error> {
+    ) -> Result<Vec<(OwnedEventId, Raw<AnySyncTimelineEvent>)>, EventCacheError> {
         let filter_non_utds = |event: TimelineEvent| {
             let event_id = event.event_id();
             // We only care about events fort his particular room key, identified by the
@@ -92,7 +75,7 @@ impl RedecryptorCtx for EventCache {
         &self,
         room_id: &RoomId,
         events: Vec<(OwnedEventId, DecryptedRoomEvent)>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), EventCacheError> {
         // Get the cache for this particular room and lock the state for the duration of
         // the decryption.
         let (room_cache, _) = self.for_room(room_id).await?;

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -25,15 +25,86 @@ use matrix_sdk_base::{
     deserialized_responses::{DecryptedRoomEvent, TimelineEvent, TimelineEventKind},
 };
 use matrix_sdk_common::executor::spawn;
-use ruma::{RoomId, serde::Raw};
+use ruma::{OwnedEventId, RoomId, events::AnySyncTimelineEvent, serde::Raw};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
-use tracing::{instrument, trace, warn};
+use tracing::{info, instrument, trace, warn};
 
 use crate::{
     Client,
     event_cache::{EventCache, EventCacheError, EventCacheInner},
 };
+
+pub(crate) trait RedecryptorCtx {
+    type Error;
+
+    async fn get_utds(
+        &self,
+        room_key_info: &RoomKeyInfo,
+    ) -> Result<Vec<(OwnedEventId, Raw<AnySyncTimelineEvent>)>, Self::Error>;
+
+    async fn on_resolved_utds(
+        &self,
+        room_id: &RoomId,
+        events: Vec<(OwnedEventId, DecryptedRoomEvent)>,
+    ) -> Result<(), Self::Error>;
+}
+
+impl RedecryptorCtx for EventCache {
+    type Error = EventCacheError;
+
+    async fn get_utds(
+        &self,
+        room_key_info: &RoomKeyInfo,
+    ) -> Result<Vec<(OwnedEventId, Raw<AnySyncTimelineEvent>)>, Self::Error> {
+        let only_utd_events = |event: TimelineEvent| {
+            // We need the event ID to be able to replace the event.
+            let event_id = event.event_id();
+            // We only care about events fort his particular room key, identified by the
+            // session ID.
+            let session_id = event.kind.session_id();
+
+            if session_id == Some(&room_key_info.session_id) {
+                // Only pick out events that are UTDs.
+                let event = as_variant!(event.kind, TimelineEventKind::UnableToDecrypt { event, .. } => event);
+                event_id.zip(event)
+            } else {
+                None
+            }
+        };
+
+        // Load the relevant events from the event cache store and attempt to redecrypt
+        // things.
+        //
+        // TODO: We can't load **all** events all the time.
+        let store = self.inner.store.lock().await?;
+        let events = store.get_room_events(&room_key_info.room_id).await?;
+
+        Ok(events.into_iter().filter_map(only_utd_events).collect())
+    }
+
+    async fn on_resolved_utds(
+        &self,
+        room_id: &RoomId,
+        events: Vec<(OwnedEventId, DecryptedRoomEvent)>,
+    ) -> Result<(), Self::Error> {
+        // Get the cache for this particular room and lock the state for the duration of
+        // the decryption.
+        let (room_cache, _) = self.for_room(room_id).await?;
+        let mut state = room_cache.inner.state.write().await;
+
+        for (event_id, decrypted) in events {
+            // The event isn't in the cache, nothing to replace. Realistically this can't
+            // happen since we retrieved the list of events from the cache itself.
+            if let Some((location, mut target_event)) = state.find_event(&event_id).await? {
+                target_event.kind = TimelineEventKind::Decrypted(decrypted);
+                state.replace_event_at(location, target_event).await?
+            }
+        }
+
+        Ok(())
+    }
+}
 
 pub(crate) struct Redecryptor {
     cache: Weak<EventCacheInner>,
@@ -66,57 +137,20 @@ impl Redecryptor {
     ) -> Result<(), EventCacheError> {
         trace!("Retrying to decrypt");
 
-        // Load the relevant events from the event cache store and attempt to redecrypt
-        // things.
-        let events = {
-            // TODO: We can't load **all** events all the time.
-            let store = cache.inner.store.lock().await?;
-            let events = store.get_room_events(&room_key_info.room_id).await?;
+        let events = cache.get_utds(&room_key_info).await?;
+        let mut decrypted_events = Vec::with_capacity(events.len());
 
-            events
-        };
-
-        let only_utd_events = |event: TimelineEvent| {
-            // We need the event ID to be able to replace the event.
-            let event_id = event.event_id();
-            // We only care about events fort his particular room key, identified by the
-            // session ID.
-            let session_id = event.kind.session_id();
-
-            if session_id == Some(&room_key_info.session_id) {
-                // Only pick out events that are UTDs.
-                let event = as_variant!(event.kind, TimelineEventKind::UnableToDecrypt { event, .. } => event);
-                event.zip(event_id)
-            } else {
-                None
-            }
-        };
-
-        // Get the cache for this particular room and lock the state for the duration of
-        // the decryption.
-        // TODO: Do we want to first decrypt and then do the locking and replacement,
-        // would be an additional loop but the lock would be free for the
-        // duration of the "slow" decryption attempts.
-        let (room_cache, _) = cache.for_room(&room_key_info.room_id).await?;
-        let mut state = room_cache.inner.state.write().await;
-
-        for (event, event_id) in events.into_iter().filter_map(only_utd_events) {
-            // The event isn't in the cache, nothing to replace. Realistically this can't
-            // happen since we retrieved the list of events from the cache itself.
-            let Some((location, mut target_event)) = state.find_event(&event_id).await? else {
-                continue;
-            };
-
+        for (event_id, event) in events {
             // If we managed to decrypt the event, and we should have to since we received
             // the room key for this specific event, then replace the event.
             if let Some(decrypted) =
                 self.decrypt_event(&cache, &room_key_info.room_id, event.cast_ref_unchecked()).await
             {
-                target_event.kind = TimelineEventKind::Decrypted(decrypted);
-
-                state.replace_event_at(location, target_event).await?
+                decrypted_events.push((event_id, decrypted));
             }
         }
+
+        cache.on_resolved_utds(&room_key_info.room_id, decrypted_events).await?;
 
         Ok(())
     }
@@ -166,5 +200,7 @@ impl Redecryptor {
                 todo!("Redecrypt all visible events?")
             }
         }
+
+        info!("Shutting down the event cache redecryptor");
     }
 }

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1582,7 +1582,7 @@ mod private {
         /// observers that a single item has been replaced. Otherwise,
         /// such a notification is not emitted, because observers are
         /// unlikely to observe the store updates directly.
-        async fn replace_event_at(
+        pub(crate) async fn replace_event_at(
             &mut self,
             location: EventLocation,
             event: Event,

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -2266,7 +2266,7 @@ mod timed_tests {
 
         let event_cache = client.event_cache();
 
-        // Don't forget to subscribe and like^W enable storage!
+        // Don't forget to subscribe and like.
         event_cache.subscribe().unwrap();
 
         client.base_client().get_or_create_room(room_id, matrix_sdk_base::RoomState::Joined);
@@ -2343,7 +2343,7 @@ mod timed_tests {
 
         let event_cache = client.event_cache();
 
-        // Don't forget to subscribe and like^W enable storage!
+        // Don't forget to subscribe and like.
         event_cache.subscribe().unwrap();
 
         client.base_client().get_or_create_room(room_id, matrix_sdk_base::RoomState::Joined);
@@ -2485,7 +2485,7 @@ mod timed_tests {
 
         let event_cache = client.event_cache();
 
-        // Don't forget to subscribe and like^W enable storage!
+        // Don't forget to subscribe and like.
         event_cache.subscribe().unwrap();
 
         client.base_client().get_or_create_room(room_id, matrix_sdk_base::RoomState::Joined);
@@ -2633,7 +2633,7 @@ mod timed_tests {
 
         let event_cache = client.event_cache();
 
-        // Don't forget to subscribe and like^W enable storage!
+        // Don't forget to subscribe and like.
         event_cache.subscribe().unwrap();
 
         // Let's check whether the generic updates are received for the initialisation.
@@ -2757,7 +2757,7 @@ mod timed_tests {
 
         let event_cache = client.event_cache();
 
-        // Don't forget to subscribe and like^W enable storage!
+        // Don't forget to subscribe and like.
         event_cache.subscribe().unwrap();
 
         client.base_client().get_or_create_room(room_id, matrix_sdk_base::RoomState::Joined);

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1321,6 +1321,11 @@ mod private {
             &self.room_linked_chunk
         }
 
+        /// Returns a mutable reference to the underlying room linked chunk.
+        pub(in crate::event_cache) fn room_linked_chunk_mut(&mut self) -> &mut EventLinkedChunk {
+            &mut self.room_linked_chunk
+        }
+
         //// Find a single event in this room, starting from the most recent event.
         ///
         /// **Warning**! It looks into the loaded events from the in-memory

--- a/crates/matrix-sdk/src/test_utils/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mod.rs
@@ -138,6 +138,10 @@ macro_rules! assert_next_with_timeout {
 /// milliseconds.
 #[macro_export]
 macro_rules! assert_recv_with_timeout {
+    ($receiver:expr) => {
+        $crate::assert_recv_with_timeout!($receiver, 1000)
+    };
+
     ($receiver:expr, $timeout_ms:expr) => {{
         tokio::time::timeout(std::time::Duration::from_millis($timeout_ms), $receiver.recv())
             .await


### PR DESCRIPTION
This is very much a WIP PR. Eventually it will get split into different smaller PRs.

Things that still need to be addressed:

* [ ] Don't load all events for a certain room when attempting to redecrypt events.
* [ ] Decide what to do when the room key stream has lagged.
* [ ] Connect the UTD hook to the new redecryptor
* [ ] Completely remove the timeline redecryption logic