### PR TITLE
Upgrade Ruma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,16 +2307,13 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.29.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e15626aaf9c351bc696217cbe29cb9b5e86c43f8a46b5e2f5c6c5cf7cb904ce"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
 dependencies = [
  "log",
- "mac",
  "markup5ever",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "match_token",
 ]
 
 [[package]]
@@ -2914,11 +2911,11 @@ dependencies = [
 
 [[package]]
 name = "js_option"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68421373957a1593a767013698dbf206e2b221eefe97a44d98d18672ff38423c"
+checksum = "c7dd3e281add16813cf673bf74a32249b0aa0d1c8117519a17b3ada5e8552b3c"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3137,16 +3134,24 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.14.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c88c6129bd24319e62a0359cb6b958fa7e8be6e19bb1663bc396b90883aca5"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
 dependencies = [
  "log",
- "phf 0.11.2",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
  "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "match_token"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4214,18 +4219,8 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
 dependencies = [
- "phf_generator 0.11.2",
+ "phf_generator",
  "phf_shared 0.11.2",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
-dependencies = [
- "phf_shared 0.10.0",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -4236,15 +4231,6 @@ checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
  "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -4834,7 +4820,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=8544b61f249c42ba58108f1cae4179ddbd312378#8544b61f249c42ba58108f1cae4179ddbd312378"
 dependencies = [
  "assign",
  "js_int",
@@ -4851,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.21.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=8544b61f249c42ba58108f1cae4179ddbd312378#8544b61f249c42ba58108f1cae4179ddbd312378"
 dependencies = [
  "as_variant",
  "assign",
@@ -4874,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.16.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=8544b61f249c42ba58108f1cae4179ddbd312378#8544b61f249c42ba58108f1cae4179ddbd312378"
 dependencies = [
  "as_variant",
  "base64",
@@ -4907,7 +4893,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.31.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=8544b61f249c42ba58108f1cae4179ddbd312378#8544b61f249c42ba58108f1cae4179ddbd312378"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4933,7 +4919,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.12.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=8544b61f249c42ba58108f1cae4179ddbd312378#8544b61f249c42ba58108f1cae4179ddbd312378"
 dependencies = [
  "headers",
  "http",
@@ -4953,7 +4939,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.5.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=8544b61f249c42ba58108f1cae4179ddbd312378#8544b61f249c42ba58108f1cae4179ddbd312378"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4964,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.11.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=8544b61f249c42ba58108f1cae4179ddbd312378#8544b61f249c42ba58108f1cae4179ddbd312378"
 dependencies = [
  "js_int",
  "thiserror 2.0.16",
@@ -4973,7 +4959,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.16.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=8544b61f249c42ba58108f1cae4179ddbd312378#8544b61f249c42ba58108f1cae4179ddbd312378"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",
@@ -4982,13 +4968,13 @@ dependencies = [
  "ruma-identifiers-validation",
  "serde",
  "syn 2.0.101",
- "toml 0.8.15",
+ "toml 0.9.7",
 ]
 
 [[package]]
 name = "ruma-signatures"
 version = "0.18.0"
-source = "git+https://github.com/ruma/ruma?rev=2f64faeabb85950de27e9829faeb389d2779ac57#2f64faeabb85950de27e9829faeb389d2779ac57"
+source = "git+https://github.com/ruma/ruma?rev=8544b61f249c42ba58108f1cae4179ddbd312378#8544b61f249c42ba58108f1cae4179ddbd312378"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5337,10 +5323,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -5365,10 +5352,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5412,11 +5408,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5635,26 +5631,25 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "once_cell",
  "parking_lot",
- "phf_shared 0.10.0",
+ "phf_shared 0.11.2",
  "precomputed-hash",
  "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
+ "phf_generator",
+ "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
 ]
@@ -6164,14 +6159,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.15"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
+checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
 dependencies = [
- "serde",
+ "serde_core",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.7.2",
+ "toml_parser",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -6179,8 +6175,14 @@ name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -6190,10 +6192,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
+ "toml_datetime 0.6.8",
+ "winnow 0.6.20",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -6993,6 +7002,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf 0.11.2",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7341,6 +7362,12 @@ checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ rand = "0.8.5"
 regex = "1.11.2"
 reqwest = { version = "0.12.23", default-features = false }
 rmp-serde = "1.3.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "2f64faeabb85950de27e9829faeb389d2779ac57", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "8544b61f249c42ba58108f1cae4179ddbd312378", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-arbitrary-length-ids",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -59,7 +59,7 @@ matrix-sdk-ffi-macros.workspace = true
 matrix-sdk-ui = { workspace = true, features = ["uniffi"] }
 mime = "0.3.16"
 once_cell.workspace = true
-ruma = { workspace = true, features = ["html", "unstable-msc3488", "compat-unset-avatar", "unstable-msc3245-v1-compat", "unstable-msc4278", "unstable-hydra"] }
+ruma = { workspace = true, features = ["html", "unstable-msc3488", "compat-unset-avatar", "unstable-msc3245-v1-compat", "unstable-msc4278"] }
 serde.workspace = true
 serde_json.workspace = true
 sentry = { workspace = true, optional = true, default-features = false, features = [

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2083,24 +2083,24 @@ impl TryFrom<CreateRoomParameters> for create_room::v3::Request {
         if value.is_encrypted {
             let content =
                 RoomEncryptionEventContent::new(EventEncryptionAlgorithm::MegolmV1AesSha2);
-            initial_state.push(InitialStateEvent::new(content).to_raw_any());
+            initial_state.push(InitialStateEvent::with_empty_state_key(content).to_raw_any());
         }
 
         if let Some(url) = value.avatar {
             let mut content = RoomAvatarEventContent::new();
             content.url = Some(url.into());
-            initial_state.push(InitialStateEvent::new(content).to_raw_any());
+            initial_state.push(InitialStateEvent::with_empty_state_key(content).to_raw_any());
         }
 
         if let Some(join_rule_override) = value.join_rule_override {
             let content = RoomJoinRulesEventContent::new(join_rule_override.try_into()?);
-            initial_state.push(InitialStateEvent::new(content).to_raw_any());
+            initial_state.push(InitialStateEvent::with_empty_state_key(content).to_raw_any());
         }
 
         if let Some(history_visibility_override) = value.history_visibility_override {
             let content =
                 RoomHistoryVisibilityEventContent::new(history_visibility_override.try_into()?);
-            initial_state.push(InitialStateEvent::new(content).to_raw_any());
+            initial_state.push(InitialStateEvent::with_empty_state_key(content).to_raw_any());
         }
 
         request.initial_state = initial_state;

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -58,7 +58,7 @@ futures-util.workspace = true
 hkdf.workspace = true
 hmac.workspace = true
 itertools.workspace = true
-js_option = "0.1.1"
+js_option = "0.2"
 matrix-sdk-common.workspace = true
 matrix-sdk-qrcode = { workspace = true, optional = true }
 matrix-sdk-test = { workspace = true, optional = true }  # feature = testing only

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1910,14 +1910,14 @@ mod tests {
 
         alice_machine.inner.store.save_sessions(&[alice_session]).await.unwrap();
 
-        let event = RumaToDeviceEvent {
-            sender: bob_account.user_id().to_owned(),
-            content: ToDeviceSecretRequestEventContent::new(
+        let event = RumaToDeviceEvent::new(
+            bob_account.user_id().to_owned(),
+            ToDeviceSecretRequestEventContent::new(
                 RequestAction::Request(SecretName::CrossSigningMasterKey),
                 bob_account.device_id().to_owned(),
                 "request_id".into(),
             ),
-        };
+        );
 
         // No secret found
         assert!(alice_machine.inner.outgoing_requests.read().is_empty());
@@ -1948,14 +1948,14 @@ mod tests {
         }
         assert!(alice_machine.inner.outgoing_requests.read().is_empty());
 
-        let event = RumaToDeviceEvent {
-            sender: alice_id().to_owned(),
-            content: ToDeviceSecretRequestEventContent::new(
+        let event = RumaToDeviceEvent::new(
+            alice_id().to_owned(),
+            ToDeviceSecretRequestEventContent::new(
                 RequestAction::Request(SecretName::CrossSigningMasterKey),
                 second_account.device_id().into(),
                 "request_id".into(),
             ),
-        };
+        );
 
         // The device isn't trusted
         alice_machine.receive_incoming_secret_request(&event);
@@ -2010,14 +2010,14 @@ mod tests {
                 .unwrap();
         }
 
-        let event = RumaToDeviceEvent {
-            sender: alice_machine.user_id().to_owned(),
-            content: ToDeviceSecretRequestEventContent::new(
+        let event = RumaToDeviceEvent::new(
+            alice_machine.user_id().to_owned(),
+            ToDeviceSecretRequestEventContent::new(
                 RequestAction::Request(SecretName::RecoveryKey),
                 bob_machine.device_id().to_owned(),
                 request_id,
             ),
-        };
+        );
 
         let bob_device = alice_machine
             .get_device(alice_id, bob_machine.device_id(), None)

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -255,7 +255,7 @@ impl VerificationMachine {
         for request in requests {
             if let Ok(OutgoingContent::ToDevice(to_device)) = request.clone().try_into() {
                 if let AnyToDeviceEventContent::KeyVerificationCancel(content) = *to_device {
-                    let event = ToDeviceEvent { content, sender: self.own_user_id().to_owned() };
+                    let event = ToDeviceEvent::new(self.own_user_id().to_owned(), content);
 
                     events.push(
                         Raw::new(&event)

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -786,25 +786,25 @@ pub(crate) mod tests {
 
         match *content {
             AnyToDeviceEventContent::KeyVerificationRequest(c) => {
-                ToDeviceEvents::KeyVerificationRequest(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationRequest(ToDeviceEvent::new(sender, c))
             }
             AnyToDeviceEventContent::KeyVerificationReady(c) => {
-                ToDeviceEvents::KeyVerificationReady(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationReady(ToDeviceEvent::new(sender, c))
             }
             AnyToDeviceEventContent::KeyVerificationKey(c) => {
-                ToDeviceEvents::KeyVerificationKey(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationKey(ToDeviceEvent::new(sender, c))
             }
             AnyToDeviceEventContent::KeyVerificationStart(c) => {
-                ToDeviceEvents::KeyVerificationStart(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationStart(ToDeviceEvent::new(sender, c))
             }
             AnyToDeviceEventContent::KeyVerificationAccept(c) => {
-                ToDeviceEvents::KeyVerificationAccept(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationAccept(ToDeviceEvent::new(sender, c))
             }
             AnyToDeviceEventContent::KeyVerificationMac(c) => {
-                ToDeviceEvents::KeyVerificationMac(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationMac(ToDeviceEvent::new(sender, c))
             }
             AnyToDeviceEventContent::KeyVerificationDone(c) => {
-                ToDeviceEvents::KeyVerificationDone(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationDone(ToDeviceEvent::new(sender, c))
             }
 
             _ => unreachable!(),

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1765,8 +1765,10 @@ impl Client {
     pub async fn create_dm(&self, user_id: &UserId) -> Result<Room> {
         #[cfg(feature = "e2e-encryption")]
         let initial_state = vec![
-            InitialStateEvent::new(RoomEncryptionEventContent::with_recommended_defaults())
-                .to_raw_any(),
+            InitialStateEvent::with_empty_state_key(
+                RoomEncryptionEventContent::with_recommended_defaults(),
+            )
+            .to_raw_any(),
         ];
 
         #[cfg(not(feature = "e2e-encryption"))]

--- a/testing/matrix-sdk-integration-testing/src/tests/room_privacy.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room_privacy.rs
@@ -56,7 +56,7 @@ async fn test_publishing_room_alias() -> anyhow::Result<()> {
     // The room can only be visible in the public room directory later if its join
     // rule is one of  [public, knock, knock_restricted] or its history
     // visibility is `world_readable`. Let's use this last option.
-    let room_history_visibility = InitialRoomHistoryVisibilityEvent::new(
+    let room_history_visibility = InitialRoomHistoryVisibilityEvent::with_empty_state_key(
         RoomHistoryVisibilityEventContent::new(HistoryVisibility::WorldReadable),
     )
     .to_raw_any();
@@ -181,11 +181,11 @@ async fn test_removing_published_room_alias() -> anyhow::Result<()> {
     // visibility is `world_readable`. Let's use this last option.
     // This room will be created with a room alias and being visible in the public
     // room directory.
-    let room_history_visibility = InitialRoomHistoryVisibilityEvent::new(
+    let room_history_visibility = InitialRoomHistoryVisibilityEvent::with_empty_state_key(
         RoomHistoryVisibilityEventContent::new(HistoryVisibility::WorldReadable),
     )
     .to_raw_any();
-    let canonical_alias = InitialRoomCanonicalAliasEvent::new(
+    let canonical_alias = InitialRoomCanonicalAliasEvent::with_empty_state_key(
         assign!(RoomCanonicalAliasEventContent::new(), { alias: Some(room_alias.clone()) }),
     )
     .to_raw_any();

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -1072,8 +1072,8 @@ async fn test_room_preview() -> Result<()> {
             topic: Some("Discussing Alice's Topic".to_owned()),
             room_alias_name: Some(room_alias.clone()),
             initial_state: vec![
-                InitialStateEvent::new(RoomHistoryVisibilityEventContent::new(HistoryVisibility::WorldReadable)).to_raw_any(),
-                InitialStateEvent::new(RoomJoinRulesEventContent::new(JoinRule::Invite)).to_raw_any(),
+                InitialStateEvent::with_empty_state_key(RoomHistoryVisibilityEventContent::new(HistoryVisibility::WorldReadable)).to_raw_any(),
+                InitialStateEvent::with_empty_state_key(RoomJoinRulesEventContent::new(JoinRule::Invite)).to_raw_any(),
             ],
         }))
         .await?;
@@ -1085,8 +1085,8 @@ async fn test_room_preview() -> Result<()> {
         .create_room(assign!(CreateRoomRequest::new(), {
             name: Some("Alice's Room 2".to_owned()),
             initial_state: vec![
-                InitialStateEvent::new(RoomHistoryVisibilityEventContent::new(HistoryVisibility::Shared)).to_raw_any(),
-                InitialStateEvent::new(RoomJoinRulesEventContent::new(JoinRule::Public)).to_raw_any(),
+                InitialStateEvent::with_empty_state_key(RoomHistoryVisibilityEventContent::new(HistoryVisibility::Shared)).to_raw_any(),
+                InitialStateEvent::with_empty_state_key(RoomJoinRulesEventContent::new(JoinRule::Public)).to_raw_any(),
             ],
         }))
         .await?;

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -410,8 +410,10 @@ async fn test_enabling_backups_retries_decryption() {
     debug!("Creating room…");
 
     let initial_state = vec![
-        InitialStateEvent::new(RoomEncryptionEventContent::with_recommended_defaults())
-            .to_raw_any(),
+        InitialStateEvent::with_empty_state_key(
+            RoomEncryptionEventContent::with_recommended_defaults(),
+        )
+        .to_raw_any(),
     ];
 
     let room = alice
@@ -548,8 +550,10 @@ async fn test_room_keys_received_on_notification_client_trigger_redecryption() {
 
     // The room needs to be encrypted.
     let initial_state = vec![
-        InitialStateEvent::new(RoomEncryptionEventContent::with_recommended_defaults())
-            .to_raw_any(),
+        InitialStateEvent::with_empty_state_key(
+            RoomEncryptionEventContent::with_recommended_defaults(),
+        )
+        .to_raw_any(),
     ];
 
     let alice_room = alice
@@ -805,7 +809,7 @@ async fn test_new_users_first_messages_dont_warn_about_insecure_device_if_it_is_
         .create_room(assign!(CreateRoomRequest::new(), {
             is_direct: true,
             initial_state: vec![
-                InitialStateEvent::new(RoomEncryptionEventContent::with_recommended_defaults()).to_raw_any()
+                InitialStateEvent::with_empty_state_key(RoomEncryptionEventContent::with_recommended_defaults()).to_raw_any()
             ],
             preset: Some(RoomPreset::PrivateChat)
         }))


### PR DESCRIPTION
Brings a breaking change with event structs being non-exhaustive now, so they need to be constructed with methods rather than with a struct declaration.

A few other crates are also upgraded, to avoid having two versions of the same crate in the dependency tree if possible.
