### PR TITLE
IndexedDB: add functionality for cleaning up `MediaStore`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3477,6 +3477,7 @@ dependencies = [
  "assert_matches2",
  "async-trait",
  "base64",
+ "futures-util",
  "getrandom 0.2.15",
  "gloo-timers",
  "gloo-utils",

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -27,6 +27,7 @@ experimental-encrypted-state-events = [
 [dependencies]
 async-trait.workspace = true
 base64.workspace = true
+futures-util.workspace = true
 gloo-utils = { version = "0.2.0", features = ["serde"] }
 growable-bloom-filter = { workspace = true, optional = true }
 hkdf.workspace = true

--- a/crates/matrix-sdk-indexeddb/src/media_store/builder.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/builder.rs
@@ -14,7 +14,7 @@
 
 use std::{rc::Rc, sync::Arc};
 
-use matrix_sdk_base::media::store::{MediaService, MemoryMediaStore};
+use matrix_sdk_base::media::store::MediaService;
 use matrix_sdk_store_encryption::StoreCipher;
 
 use crate::{
@@ -67,7 +67,6 @@ impl IndexeddbMediaStoreBuilder {
             inner: Rc::new(open_and_upgrade_db(&self.database_name).await?),
             serializer: IndexedTypeSerializer::new(SafeEncodeSerializer::new(self.store_cipher)),
             media_service: MediaService::new(),
-            memory_store: MemoryMediaStore::new(),
         })
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/media_store/error.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/error.rs
@@ -28,6 +28,8 @@ pub enum IndexeddbMediaStoreError {
     Transaction(#[from] TransactionError),
     #[error("DomException {name} ({code}): {message}")]
     DomException { name: String, message: String, code: u16 },
+    #[error("cache size too big, cannot exceed 'usize::MAX' ({})", usize::MAX)]
+    CacheSizeTooBig,
 }
 
 impl From<IndexeddbMediaStoreError> for MediaStoreError {
@@ -38,6 +40,7 @@ impl From<IndexeddbMediaStoreError> for MediaStoreError {
             UnableToOpenDatabase(e) => GenericError::from(e).into(),
             DomException { .. } => Self::InvalidData { details: value.to_string() },
             Transaction(inner) => inner.into(),
+            CacheSizeTooBig => GenericError::from(value.to_string()).into(),
             MemoryStore(error) => error,
         }
     }

--- a/crates/matrix-sdk-indexeddb/src/media_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/migrations.rs
@@ -113,6 +113,7 @@ pub mod v1 {
         pub const LEASES: &str = "leases";
         pub const LEASES_KEY_PATH: &str = "id";
         pub const MEDIA_RETENTION_POLICY_KEY: &str = "media_retention_policy";
+        pub const MEDIA_CLEANUP_TIME_KEY: &str = "media_cleanup_time";
         pub const MEDIA: &str = "media";
         pub const MEDIA_KEY_PATH: &str = "id";
         pub const MEDIA_URI: &str = "media_uri";

--- a/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
@@ -434,8 +434,8 @@ impl MediaStoreInner for IndexeddbMediaStore {
 #[cfg(all(test, target_family = "wasm"))]
 mod tests {
     use matrix_sdk_base::{
-        media::store::MediaStoreError, media_store_integration_tests,
-        media_store_integration_tests_time,
+        media::store::MediaStoreError, media_store_inner_integration_tests,
+        media_store_integration_tests, media_store_integration_tests_time,
     };
     use uuid::Uuid;
 
@@ -456,6 +456,9 @@ mod tests {
 
         #[cfg(target_family = "wasm")]
         media_store_integration_tests_time!();
+
+        #[cfg(target_family = "wasm")]
+        media_store_inner_integration_tests!(with_media_size_tests);
     }
 
     mod encrypted {
@@ -473,5 +476,8 @@ mod tests {
 
         #[cfg(target_family = "wasm")]
         media_store_integration_tests_time!();
+
+        #[cfg(target_family = "wasm")]
+        media_store_inner_integration_tests!();
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
@@ -33,7 +33,7 @@ use matrix_sdk_base::{
     media::{
         store::{
             IgnoreMediaRetentionPolicy, MediaRetentionPolicy, MediaService, MediaStore,
-            MediaStoreInner, MemoryMediaStore,
+            MediaStoreInner,
         },
         MediaRequestParameters,
     },
@@ -66,12 +66,6 @@ pub struct IndexeddbMediaStore {
     // A service for conveniently delegating media-related queries to an `MediaStoreInner`
     // implementation
     media_service: MediaService,
-    // An in-memory store for providing temporary implementations for
-    // functions of `MediaStore`.
-    //
-    // NOTE: This will be removed once we have IndexedDB-backed implementations for all
-    // functions in `MediaStore`.
-    memory_store: MemoryMediaStore,
 }
 
 impl IndexeddbMediaStore {

--- a/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
@@ -265,10 +265,11 @@ impl MediaStoreInner for IndexeddbMediaStore {
         policy: MediaRetentionPolicy,
     ) -> Result<(), IndexeddbMediaStoreError> {
         let _timer = timer!("method");
-        self.transaction(&[MediaRetentionPolicy::OBJECT_STORE], IdbTransactionMode::Readwrite)?
-            .put_item(&policy)
-            .await
-            .map_err(Into::into)
+
+        let transaction =
+            self.transaction(&[MediaRetentionPolicy::OBJECT_STORE], IdbTransactionMode::Readwrite)?;
+        transaction.put_item(&policy).await?;
+        transaction.commit().await.map_err(Into::into)
     }
 
     #[instrument(skip_all)]

--- a/crates/matrix-sdk-indexeddb/src/media_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/serializer/indexed_types.rs
@@ -385,6 +385,8 @@ impl IndexedMediaContentSizeKey {
 }
 
 impl IndexedKey<Media> for IndexedMediaContentSizeKey {
+    const INDEX: Option<&'static str> = Some(keys::MEDIA_CONTENT_SIZE);
+
     type KeyComponents<'a> = (IgnoreMediaRetentionPolicy, IndexedMediaContentSize);
 
     fn encode(
@@ -436,6 +438,8 @@ pub struct IndexedMediaLastAccessKey(
 );
 
 impl IndexedKey<Media> for IndexedMediaLastAccessKey {
+    const INDEX: Option<&'static str> = Some(keys::MEDIA_LAST_ACCESS);
+
     type KeyComponents<'a> = (IgnoreMediaRetentionPolicy, UnixTime);
 
     fn encode(
@@ -490,6 +494,8 @@ pub struct IndexedMediaRetentionMetadataKey(
 );
 
 impl IndexedKey<Media> for IndexedMediaRetentionMetadataKey {
+    const INDEX: Option<&'static str> = Some(keys::MEDIA_RETENTION_METADATA);
+
     type KeyComponents<'a> = (IgnoreMediaRetentionPolicy, UnixTime, IndexedMediaContentSize);
 
     fn encode(

--- a/crates/matrix-sdk-indexeddb/src/media_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/serializer/indexed_types.rs
@@ -46,7 +46,7 @@ use crate::{
             },
             foreign::{ignore_media_retention_policy, unix_time},
         },
-        types::{Lease, Media, UnixTime},
+        types::{Lease, Media, MediaCleanupTime, UnixTime},
     },
     serializer::{
         Indexed, IndexedKey, IndexedKeyComponentBounds, IndexedPrefixKeyComponentBounds,
@@ -66,6 +66,10 @@ pub type IndexedLeaseContent = MaybeEncrypted;
 
 /// A (possibly) encrypted representation of a [`MediaRetentionPolicy`]
 pub type IndexedMediaRetentionPolicyContent = MaybeEncrypted;
+
+/// A (possibly) encrypted representation of a the last time the store was
+/// cleaned - i.e., as a [`UnixTime`]
+pub type IndexedMediaCleanupTimeContent = MaybeEncrypted;
 
 /// A (possibly) encrypted representation of a [`MediaMetadata`][1]
 ///
@@ -186,6 +190,49 @@ impl IndexedKey<MediaRetentionPolicy> for IndexedCoreIdKey {
 
     fn encode(_components: Self::KeyComponents<'_>, serializer: &SafeEncodeSerializer) -> Self {
         serializer.encode_key_as_string(keys::CORE, keys::MEDIA_RETENTION_POLICY_KEY)
+    }
+}
+
+/// Represents the [`MediaCleanupTime`] record in the [`CORE`][1] object store.
+///
+/// [1]: crate::media_store::migrations::v1::create_core_object_store
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IndexedMediaCleanupTime {
+    /// The primary key of the object store.
+    pub id: IndexedCoreIdKey,
+    /// The (possibly) encrypted content - i.e., a [`MediaCleanupTime`]
+    pub content: IndexedMediaCleanupTimeContent,
+}
+
+impl Indexed for MediaCleanupTime {
+    const OBJECT_STORE: &'static str = keys::CORE;
+
+    type IndexedType = IndexedMediaCleanupTime;
+    type Error = CryptoStoreError;
+
+    fn to_indexed(
+        &self,
+        serializer: &SafeEncodeSerializer,
+    ) -> Result<Self::IndexedType, Self::Error> {
+        Ok(Self::IndexedType {
+            id: <IndexedCoreIdKey as IndexedKey<Self>>::encode((), serializer),
+            content: serializer.maybe_encrypt_value(self)?,
+        })
+    }
+
+    fn from_indexed(
+        indexed: Self::IndexedType,
+        serializer: &SafeEncodeSerializer,
+    ) -> Result<Self, Self::Error> {
+        serializer.maybe_decrypt_value(indexed.content)
+    }
+}
+
+impl IndexedKey<MediaCleanupTime> for IndexedCoreIdKey {
+    type KeyComponents<'a> = ();
+
+    fn encode(_components: Self::KeyComponents<'_>, serializer: &SafeEncodeSerializer) -> Self {
+        serializer.encode_key_as_string(keys::CORE, keys::MEDIA_CLEANUP_TIME_KEY)
     }
 }
 

--- a/crates/matrix-sdk-indexeddb/src/media_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/serializer/indexed_types.rs
@@ -374,8 +374,8 @@ pub struct IndexedMediaContentSizeKey(
 impl IndexedMediaContentSizeKey {
     /// Returns whether the associated [`IndexedMedia`] record should ignore the
     /// global [`MediaRetentionPolicy`]
-    pub fn ignore_policy(&self) -> bool {
-        self.0.is_yes()
+    pub fn ignore_policy(&self) -> IgnoreMediaRetentionPolicy {
+        self.0
     }
 
     /// Returns the size in bytes of the associated [`IndexedMedia::content`]

--- a/crates/matrix-sdk-indexeddb/src/media_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/serializer/indexed_types.rs
@@ -437,6 +437,20 @@ pub struct IndexedMediaLastAccessKey(
     #[serde(with = "unix_time")] UnixTime,
 );
 
+impl IndexedMediaLastAccessKey {
+    /// Returns whether the associated [`IndexedMedia`] record should ignore the
+    /// global [`MediaRetentionPolicy`]
+    pub fn ignore_policy(&self) -> IgnoreMediaRetentionPolicy {
+        self.0
+    }
+
+    /// Returns the last time the associated [`IndexedMedia`] record was
+    /// accessed as a [`UnixTime`]
+    pub fn last_access(&self) -> UnixTime {
+        self.1
+    }
+}
+
 impl IndexedKey<Media> for IndexedMediaLastAccessKey {
     const INDEX: Option<&'static str> = Some(keys::MEDIA_LAST_ACCESS);
 
@@ -492,6 +506,25 @@ pub struct IndexedMediaRetentionMetadataKey(
     #[serde(with = "unix_time")] UnixTime,
     IndexedMediaContentSize,
 );
+
+impl IndexedMediaRetentionMetadataKey {
+    /// Returns whether the associated [`IndexedMedia`] record should ignore the
+    /// global [`MediaRetentionPolicy`]
+    pub fn ignore_policy(&self) -> IgnoreMediaRetentionPolicy {
+        self.0
+    }
+
+    /// Returns the last time the associated [`IndexedMedia`] record was
+    /// accessed as a [`UnixTime`]
+    pub fn last_access(&self) -> UnixTime {
+        self.1
+    }
+
+    /// Returns the size in bytes of the associated [`IndexedMedia::content`]
+    pub fn content_size(&self) -> usize {
+        self.2
+    }
+}
 
 impl IndexedKey<Media> for IndexedMediaRetentionMetadataKey {
     const INDEX: Option<&'static str> = Some(keys::MEDIA_RETENTION_METADATA);

--- a/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
@@ -236,7 +236,7 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
         policy: MediaRetentionPolicy,
     ) -> Result<(), TransactionError> {
         self.put_item_if(media, |indexed| {
-            !indexed.content_size.ignore_policy()
+            !indexed.content_size.ignore_policy().is_yes()
                 && !policy.exceeds_max_file_size(indexed.content_size.content_size() as u64)
         })
         .await

--- a/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
@@ -23,7 +23,7 @@ use crate::{
         serializer::indexed_types::{
             IndexedCoreIdKey, IndexedLeaseIdKey, IndexedMediaIdKey, IndexedMediaUriKey,
         },
-        types::{Lease, Media, UnixTime},
+        types::{Lease, Media, MediaCleanupTime, UnixTime},
     },
     serializer::IndexedTypeSerializer,
     transaction::{Transaction, TransactionError},
@@ -78,6 +78,23 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
         self.transaction
             .get_item_by_key_components::<MediaRetentionPolicy, IndexedCoreIdKey>(())
             .await
+    }
+
+    /// Query IndexedDB for the stored [`MediaCleanupTime`]
+    pub async fn get_media_cleanup_time(
+        &self,
+    ) -> Result<Option<MediaCleanupTime>, TransactionError> {
+        self.transaction.get_item_by_key_components::<MediaCleanupTime, IndexedCoreIdKey>(()).await
+    }
+
+    /// Puts a media clean up time into IndexedDB. If one already exists, it
+    /// will be overwritten.
+    pub async fn put_media_cleanup_time(
+        &self,
+        time: impl Into<MediaCleanupTime>,
+    ) -> Result<(), TransactionError> {
+        let time: MediaCleanupTime = time.into();
+        self.transaction.put_item(&time).await
     }
 
     /// Query IndexedDB for [`Media`] that matches the given

--- a/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
@@ -225,6 +225,12 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
         self.add_item(media).await
     }
 
+    /// Puts [`Media`] in IndexedDB object. If an item with the same key already
+    /// exists, it will be overwritten.
+    pub async fn put_media(&self, media: &Media) -> Result<(), TransactionError> {
+        self.put_item(media).await
+    }
+
     /// Adds [`Media`] to IndexedDB if the size of [`IndexedMedia::content`][1]
     /// does not exceed [`MediaRetentionPolicy::max_file_size]. If an item with
     /// the same key already exists, it will be overwritten.

--- a/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
@@ -242,8 +242,9 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
         policy: MediaRetentionPolicy,
     ) -> Result<(), TransactionError> {
         self.put_item_if(media, |indexed| {
-            !indexed.content_size.ignore_policy().is_yes()
-                && !policy.exceeds_max_file_size(indexed.content_size.content_size() as u64)
+            indexed.content_size.ignore_policy().is_yes()
+                || (!indexed.content_size.ignore_policy().is_yes()
+                    && !policy.exceeds_max_file_size(indexed.content_size.content_size() as u64))
         })
         .await
     }

--- a/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
@@ -14,18 +14,22 @@
 
 use std::ops::Deref;
 
-use indexed_db_futures::transaction as inner;
-use matrix_sdk_base::media::{store::MediaRetentionPolicy, MediaRequestParameters};
+use indexed_db_futures::{cursor::CursorDirection, transaction as inner};
+use matrix_sdk_base::media::{
+    store::{IgnoreMediaRetentionPolicy, MediaRetentionPolicy},
+    MediaRequestParameters,
+};
 use ruma::MxcUri;
 
 use crate::{
     media_store::{
         serializer::indexed_types::{
-            IndexedCoreIdKey, IndexedLeaseIdKey, IndexedMediaIdKey, IndexedMediaUriKey,
+            IndexedCoreIdKey, IndexedLeaseIdKey, IndexedMediaContentSizeKey, IndexedMediaIdKey,
+            IndexedMediaRetentionMetadataKey, IndexedMediaUriKey,
         },
         types::{Lease, Media, MediaCleanupTime, UnixTime},
     },
-    serializer::IndexedTypeSerializer,
+    serializer::{IndexedKeyRange, IndexedTypeSerializer},
     transaction::{Transaction, TransactionError},
 };
 
@@ -151,6 +155,51 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
             medias.push(media);
         }
         Ok(medias)
+    }
+
+    /// Query IndexedDB for all [content size](IndexedMediaContentSizeKey) keys
+    /// whose associated [`Media`] matches the given
+    /// [`IgnoreMediaRetentionPolicy`].
+    pub async fn get_media_keys_by_content_size(
+        &self,
+        ignore_policy: IgnoreMediaRetentionPolicy,
+    ) -> Result<Vec<IndexedMediaContentSizeKey>, TransactionError> {
+        self.get_keys::<Media, IndexedMediaContentSizeKey>(IndexedKeyRange::all_with_prefix(
+            ignore_policy,
+            self.serializer().inner(),
+        ))
+        .await
+    }
+
+    /// Query IndexedDB for [retention metadata][1] keys that match the given
+    /// key range. Iterate over the keys in the given
+    /// [`direction`](CursorDirection) using a cursor and fold them into an
+    /// accumulator while the given function `f` returns [`Some`].
+    ///
+    /// This function returns the final value of the accumulator and the key, if
+    /// any, which caused the fold to short circuit.
+    ///
+    /// Note that the use of cursor means that keys are read lazily from
+    /// IndexedDB.
+    ///
+    /// [1]: IndexedMediaRetentionMetadataKey
+    pub async fn fold_media_keys_by_retention_metadata_while<B, F>(
+        &self,
+        direction: CursorDirection,
+        ignore_policy: IgnoreMediaRetentionPolicy,
+        init: B,
+        f: F,
+    ) -> Result<(B, Option<IndexedMediaRetentionMetadataKey>), TransactionError>
+    where
+        F: FnMut(&B, &IndexedMediaRetentionMetadataKey) -> Option<B>,
+    {
+        self.fold_keys_while::<Media, IndexedMediaRetentionMetadataKey, B, F>(
+            direction,
+            IndexedKeyRange::all_with_prefix(ignore_policy, self.serializer().inner()),
+            init,
+            f,
+        )
+        .await
     }
 
     /// Adds [`Media`] to IndexedDB. If an item with the same key already

--- a/crates/matrix-sdk-indexeddb/src/media_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/types.rs
@@ -13,7 +13,7 @@
 // limitations under the License
 
 use std::{
-    ops::{Add, Sub},
+    ops::{Add, Deref, Sub},
     time::Duration,
 };
 
@@ -145,5 +145,49 @@ impl Sub<Duration> for UnixTime {
                 Self::BeforeEpoch(duration + rhs)
             }
         }
+    }
+}
+
+/// A newtype-style wrapper around [`UnixTime`] which represents a time at which
+/// the media store was cleaned.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct MediaCleanupTime(UnixTime);
+
+impl Deref for MediaCleanupTime {
+    type Target = UnixTime;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<UnixTime> for MediaCleanupTime {
+    fn as_ref(&self) -> &UnixTime {
+        self.deref()
+    }
+}
+
+impl From<SystemTime> for MediaCleanupTime {
+    fn from(value: SystemTime) -> Self {
+        Self::from(UnixTime::from(value))
+    }
+}
+
+impl From<MediaCleanupTime> for SystemTime {
+    fn from(value: MediaCleanupTime) -> Self {
+        Self::from(UnixTime::from(value))
+    }
+}
+
+impl From<UnixTime> for MediaCleanupTime {
+    fn from(value: UnixTime) -> Self {
+        Self(value)
+    }
+}
+
+impl From<MediaCleanupTime> for UnixTime {
+    fn from(value: MediaCleanupTime) -> Self {
+        value.0
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/serializer/safe_encode/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/serializer/safe_encode/types.rs
@@ -89,6 +89,14 @@ impl SafeEncodeSerializer {
         Self { store_cipher }
     }
 
+    /// Returns whether this serializer contains a nested [`StoreCipher`]. If
+    /// so, values passed to the serializer will be encrypted when serialized
+    /// and decrypted when deserialized.
+    #[cfg(feature = "media-store")]
+    pub fn has_store_cipher(&self) -> bool {
+        self.store_cipher.is_some()
+    }
+
     /// Hash the given key securely for the given tablename using the store
     /// cipher.
     ///

--- a/crates/matrix-sdk-indexeddb/src/transaction/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/transaction/mod.rs
@@ -18,6 +18,7 @@
 // clean up any dead code.
 #![allow(dead_code)]
 
+use futures_util::TryStreamExt;
 use indexed_db_futures::{
     internals::SystemRepr, query_source::QuerySource, transaction as inner, BuildSerde,
 };
@@ -262,6 +263,85 @@ impl<'a> Transaction<'a> {
             }
         }
         Ok(None)
+    }
+
+    /// Query IndexedDB for keys that match the given key range.
+    pub async fn get_keys<T, K>(
+        &self,
+        range: impl Into<IndexedKeyRange<K>>,
+    ) -> Result<Vec<K>, TransactionError>
+    where
+        T: Indexed,
+        K: IndexedKey<T> + Serialize + DeserializeOwned,
+    {
+        let range = self.serializer.encode_key_range::<T, K>(range);
+        let object_store = self.transaction.object_store(T::OBJECT_STORE)?;
+        if let Some(index) = K::INDEX {
+            let index = object_store.index(index)?;
+            if let Some(cursor) = index.open_key_cursor().with_query(range).serde()?.await? {
+                return cursor.key_stream_ser().try_collect().await.map_err(Into::into);
+            }
+        } else if let Some(cursor) =
+            object_store.open_key_cursor().with_query(range).serde()?.await?
+        {
+            return cursor.key_stream_ser().try_collect().await.map_err(Into::into);
+        }
+        Ok(Vec::new())
+    }
+
+    /// Query IndexedDB for keys that match the given key range. Iterate over
+    /// the keys in the given [`direction`](CursorDirection) using a cursor and
+    /// fold them into an accumulator while the given function `f` returns
+    /// [`Some`].
+    ///
+    /// This function returns the final value of the accumulator and the key, if
+    /// any, which caused the fold to short circuit.
+    ///
+    /// Note that the use of cursor means that keys are read lazily from
+    /// IndexedDB.
+    pub async fn fold_keys_while<T, K, B, F>(
+        &self,
+        direction: IdbCursorDirection,
+        range: impl Into<IndexedKeyRange<K>>,
+        init: B,
+        mut f: F,
+    ) -> Result<(B, Option<K>), TransactionError>
+    where
+        T: Indexed,
+        K: IndexedKey<T> + Serialize + DeserializeOwned,
+        F: FnMut(&B, &K) -> Option<B>,
+    {
+        let range = self.serializer.encode_key_range::<T, K>(range);
+        let object_store = self.transaction.object_store(T::OBJECT_STORE)?;
+
+        let mut state = init;
+        if let Some(index) = K::INDEX {
+            let index = object_store.index(index)?;
+            if let Some(mut cursor) =
+                index.open_key_cursor().with_query(range).with_direction(direction).serde()?.await?
+            {
+                while let Some(key) = cursor.next_key_ser().await? {
+                    match f(&state, &key) {
+                        Some(s) => state = s,
+                        None => return Ok((state, Some(key))),
+                    }
+                }
+            }
+        } else if let Some(mut cursor) = object_store
+            .open_key_cursor()
+            .with_query(range)
+            .with_direction(direction)
+            .serde()?
+            .await?
+        {
+            while let Some(key) = cursor.next_key_ser().await? {
+                match f(&state, &key) {
+                    Some(s) => state = s,
+                    None => return Ok((state, Some(key))),
+                }
+            }
+        }
+        Ok((state, None))
     }
 
     /// Adds an item to the corresponding IndexedDB object

--- a/crates/matrix-sdk-indexeddb/src/transaction/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/transaction/mod.rs
@@ -20,7 +20,8 @@
 
 use futures_util::TryStreamExt;
 use indexed_db_futures::{
-    internals::SystemRepr, query_source::QuerySource, transaction as inner, BuildSerde,
+    cursor::CursorDirection, internals::SystemRepr, query_source::QuerySource,
+    transaction as inner, BuildSerde,
 };
 use serde::{
     de::{DeserializeOwned, Error},
@@ -28,7 +29,6 @@ use serde::{
 };
 use thiserror::Error;
 use wasm_bindgen::JsValue;
-use web_sys::IdbCursorDirection;
 
 use crate::{
     error::{AsyncErrorDeps, GenericError},
@@ -240,7 +240,7 @@ impl<'a> Transaction<'a> {
         K: IndexedKey<T> + Serialize,
     {
         let range = self.serializer.encode_key_range::<T, K>(range);
-        let direction = IdbCursorDirection::Prev;
+        let direction = CursorDirection::Prev;
         let object_store = self.transaction.object_store(T::OBJECT_STORE)?;
         if let Some(index) = K::INDEX {
             let index = object_store.index(index)?;
@@ -301,7 +301,7 @@ impl<'a> Transaction<'a> {
     /// IndexedDB.
     pub async fn fold_keys_while<T, K, B, F>(
         &self,
-        direction: IdbCursorDirection,
+        direction: CursorDirection,
         range: impl Into<IndexedKeyRange<K>>,
         init: B,
         mut f: F,


### PR DESCRIPTION
## Background

This pull request is part of a series of pull requests to add a full IndexedDB implementation of the `EventCacheStore` and  `MediaStore` (see #4617, #4996, #5090, #5138, #5226, #5274, #5343, #5384, #5406, #5414, #5497, #5506, #5540, #5574, #5603, #5676, #5682). This particular pull request adds IndexedDB-backed implementations for cleaning expired and over-sized media in IndexedDB via `MediaStore`.

## Changes

### IndexedDB implementations of top-level `MediaStore` functions

The overarching change is the removal of the nested `MemoryStore` and the addition of IndexedDB-backed implementations for the following functions.

- `MediaStoreInner::clean_inner`
- `MediaStoreInner::last_media_cleanup_time_inner`
- `MediaStoreInner::set_ignore_media_retention_policy`

Additionally, the following types, trait implementations, and functions were added to support the functions above.

**Types**
- `MediaCleanupTime` - a basic wrapper around `UnixTime` for representing the last time the `MediaStore` was cleaned. This also includes indexed versions of this type optimized for IndexedDB storage.

**Trait Implementations**
- `Add<Duration>` and `Sub<Duration>` for `UnixTime`
    - Helps calculate expiration times, etc. for `Media`

**Functions**
- `Transaction::get_keys`
- `Transaction::fold_keys_while`
- `IndexeddbMediaStoreTransaction::get_media_cleanup_time`
- `IndexeddbMediaStoreTransaction::put_media_cleanup_time`
- `IndexeddbMediaStoreTransaction::get_media_keys_by_content_size`
- `IndexeddbMediaStoreTransaction::fold_media_keys_by_retention_metadata_while`
- `IndexeddbMediaStoreTransaction::get_cache_size`
- `IndexeddbMediaStoreTransaction::put_media`
- `IndexeddbMediaStoreTransaction::delete_media_by_content_size`
- `IndexeddbMediaStoreTransaction::delete_media_by_content_size_greater_than`
- `IndexeddbMediaStoreTransaction::delete_media_by_last_access`
- `IndexeddbMediaStoreTransaction::delete_media_by_last_access_earlier_than`
- `IndexeddbMediaStoreTransaction::delete_media_by_retention_metadata`
- `IndexeddbMediaStoreTransaction::delete_media_by_retention_metadata_to`

## Bug Fixes

1. [`3a379e061a5d2266ae2be3d5e897d089d0e83df7`](https://github.com/matrix-org/matrix-rust-sdk/commit/3a379e061a5d2266ae2be3d5e897d089d0e83df7) - Integration tests for `MediaStore` that assure media size constraints are properly implemented expect that content will maintain its size after encoding. For this reason, these tests are recommended to be run against an unencrypted `MediaStore` only (see [documentation](https://github.com/matrix-org/matrix-rust-sdk/blob/68075b65fbbea5b34ea50ba27f68aea7d7129282/crates/matrix-sdk-base/src/media/store/integration_tests.rs#L969-L972)). Previously, unencrypted media contents were Base64 encoded, which increased the size of the contents, causing the tests to fail. Now, an unencrypted `MediaStore` does not modify the contents for serialization, but rather stores it as it is provided.
2. [`377271814a0284183be2c4cdb49c7ef31f189760`](https://github.com/matrix-org/matrix-rust-sdk/commit/377271814a0284183be2c4cdb49c7ef31f189760) - `MediaStoreInner::set_media_retention_policy_inner` previously failed to commit the transaction used to set the `MediaRetentionPolicy` and so the policy was not properly recorded. The transaction is now being commited.
3. [`870e1e26718c75e9bb71206fd4085a98557afd14`](https://github.com/matrix-org/matrix-rust-sdk/commit/870e1e26718c75e9bb71206fd4085a98557afd14) - `IndexeddbMediaStoreTransaction::put_media_if_policy_compliant` previously failed to put `Media` items in IndexedDB when the given `Media` was set to ignore the `MediaRetentionPolicy`. The condition for adding `Media` through this function was modified to correct the error.

## Caveats

IndexedDB does not seem to allow partial updates to existing objects. So, if one would like to update a single field on an object in IndexedDB, they must do the following.

1. Deserialize the object from the database.
2. Make the desired modifications to the deserialized object. 
3. Re-serialize the modified object.
4. Overwrite the old object with the modified object.

This can, of course, be very inefficient when an object store's schema contains large fields. 
And, unfortunately, this issue affects the existing schema for the `Media` object store.

The issue is that the `Media` object store stores metadata and content alongside each other in a single object. So, for instance, to set the `last_access` field of an object in IndexedDB, one has to deserialize and re-serialized the entire content of the `Media`, which might be very large.

The following functions are affected by this issue.

- [`MediaStore::replace_media_key`](https://github.com/mgoldenberg/matrix-rust-sdk/blob/a82a0db02350438cd78be2e73c18e437d4a47229/crates/matrix-sdk-indexeddb/src/media_store/mod.rs#L145)
- [`MediaStore::get_media_content`](https://github.com/mgoldenberg/matrix-rust-sdk/blob/a82a0db02350438cd78be2e73c18e437d4a47229/crates/matrix-sdk-indexeddb/src/media_store/mod.rs#L164)
    - Due to the use of [`IndexeddbMediaStoreTransaction::access_media_by_id`](https://github.com/mgoldenberg/matrix-rust-sdk/blob/68075b65fbbea5b34ea50ba27f68aea7d7129282/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs#L97) which sets the `last_access` field of a `Media` object
- [`MediaStore::get_media_content_for_uri`](https://github.com/mgoldenberg/matrix-rust-sdk/blob/a82a0db02350438cd78be2e73c18e437d4a47229/crates/matrix-sdk-indexeddb/src/media_store/mod.rs#L185)
    - Due to the use of [`IndexeddbMediaStoreTransaction::access_media_by_id`](https://github.com/mgoldenberg/matrix-rust-sdk/blob/68075b65fbbea5b34ea50ba27f68aea7d7129282/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs#L97) which sets the `last_access` field of a `Media` object
- [`MediaStore::set_ignore_media_retention_policy`](https://github.com/mgoldenberg/matrix-rust-sdk/blob/a82a0db02350438cd78be2e73c18e437d4a47229/crates/matrix-sdk-indexeddb/src/media_store/mod.rs#L221)

### Proposed Solution

I am currently working on a solution to this problem which separates the metadata and content of a `Media` object into two separate object stores. As a result, this would require that retrieving media contents would require two separate queries to IndexedDB, but I think this is preferable to the excessive (de)serialization described above.

## Future Work

- Separate metadata and contents in `Media` object store
- Refactor feature flags
    - The current feature flags are a bit convoluted and could be simplified and made more modular
- Expose `EventCacheStore` and `MediaStore` outside of the `matrix-sdk-indexeddb` 

---

- [ ] Public API changes documented in changelogs (optional)


Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>