### PR TITLE
fix: Make impl Stream return type not use any lifetime

### DIFF
--- a/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
+++ b/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
@@ -335,14 +335,14 @@ impl CryptoStoreWrapper {
     /// logged and items will be dropped.
     pub fn room_keys_withheld_received_stream(
         &self,
-    ) -> impl Stream<Item = Vec<RoomKeyWithheldInfo>> {
+    ) -> impl Stream<Item = Vec<RoomKeyWithheldInfo>> + use<> {
         let stream = BroadcastStream::new(self.room_keys_withheld_received_sender.subscribe());
         Self::filter_errors_out_of_stream(stream, "room_keys_withheld_received_stream")
     }
 
     /// Receive notifications of gossipped secrets being received and stored in
     /// the secret inbox as a [`Stream`].
-    pub fn secrets_stream(&self) -> impl Stream<Item = GossippedSecret> {
+    pub fn secrets_stream(&self) -> impl Stream<Item = GossippedSecret> + use<> {
         let stream = BroadcastStream::new(self.secrets_broadcaster.subscribe());
         Self::filter_errors_out_of_stream(stream, "secrets_stream")
     }
@@ -360,7 +360,8 @@ impl CryptoStoreWrapper {
     /// device and user identity streams.
     pub(super) fn identities_stream(
         &self,
-    ) -> impl Stream<Item = (Option<OwnUserIdentityData>, IdentityChanges, DeviceChanges)> {
+    ) -> impl Stream<Item = (Option<OwnUserIdentityData>, IdentityChanges, DeviceChanges)> + use<>
+    {
         let stream = BroadcastStream::new(self.identities_broadcaster.subscribe());
         Self::filter_errors_out_of_stream(stream, "identities_stream")
     }

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -1151,7 +1151,7 @@ impl Store {
     /// logged and items will be dropped.
     pub fn room_keys_withheld_received_stream(
         &self,
-    ) -> impl Stream<Item = Vec<RoomKeyWithheldInfo>> {
+    ) -> impl Stream<Item = Vec<RoomKeyWithheldInfo>> + use<> {
         self.inner.store.room_keys_withheld_received_stream()
     }
 
@@ -1185,7 +1185,7 @@ impl Store {
     /// }
     /// # });
     /// ```
-    pub fn user_identities_stream(&self) -> impl Stream<Item = IdentityUpdates> {
+    pub fn user_identities_stream(&self) -> impl Stream<Item = IdentityUpdates> + use<> {
         let verification_machine = self.inner.verification_machine.to_owned();
 
         let this = self.clone();
@@ -1243,7 +1243,7 @@ impl Store {
     /// }
     /// # });
     /// ```
-    pub fn devices_stream(&self) -> impl Stream<Item = DeviceUpdates> {
+    pub fn devices_stream(&self) -> impl Stream<Item = DeviceUpdates> + use<> {
         let verification_machine = self.inner.verification_machine.to_owned();
 
         self.inner.store.identities_stream().map(move |(own_identity, identities, devices)| {
@@ -1265,7 +1265,9 @@ impl Store {
     ///
     /// The stream will terminate once all references to the underlying
     /// `CryptoStoreWrapper` are dropped.
-    pub fn identities_stream_raw(&self) -> impl Stream<Item = (IdentityChanges, DeviceChanges)> {
+    pub fn identities_stream_raw(
+        &self,
+    ) -> impl Stream<Item = (IdentityChanges, DeviceChanges)> + use<> {
         self.inner.store.identities_stream().map(|(_, identities, devices)| (identities, devices))
     }
 
@@ -1318,7 +1320,7 @@ impl Store {
     /// }
     /// # });
     /// ```
-    pub fn secrets_stream(&self) -> impl Stream<Item = GossippedSecret> {
+    pub fn secrets_stream(&self) -> impl Stream<Item = GossippedSecret> + use<> {
         self.inner.store.secrets_stream()
     }
 

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -681,7 +681,7 @@ impl QrVerification {
     /// Listen for changes in the QrCode verification process.
     ///
     /// The changes are presented as a stream of [`QrVerificationState`] values.
-    pub fn changes(&self) -> impl Stream<Item = QrVerificationState> {
+    pub fn changes(&self) -> impl Stream<Item = QrVerificationState> + use<> {
         self.state.subscribe().map(|s| (&s).into())
     }
 

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -881,7 +881,7 @@ impl VerificationRequest {
     ///
     /// The changes are presented as a stream of [`VerificationRequestState`]
     /// values.
-    pub fn changes(&self) -> impl Stream<Item = VerificationRequestState> {
+    pub fn changes(&self) -> impl Stream<Item = VerificationRequestState> + use<> {
         self.inner.subscribe().map(|s| (&s).into())
     }
 

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -745,7 +745,7 @@ impl Sas {
     /// }
     /// # anyhow::Ok(()) };
     /// ```
-    pub fn changes(&self) -> impl Stream<Item = SasState> {
+    pub fn changes(&self) -> impl Stream<Item = SasState> + use<> {
         self.inner.subscribe().map(|s| (&s).into())
     }
 

--- a/crates/matrix-sdk/src/encryption/verification/qrcode.rs
+++ b/crates/matrix-sdk/src/encryption/verification/qrcode.rs
@@ -207,7 +207,7 @@ impl QrVerification {
     /// }
     /// # anyhow::Ok(()) };
     /// ```
-    pub fn changes(&self) -> impl Stream<Item = QrVerificationState> {
+    pub fn changes(&self) -> impl Stream<Item = QrVerificationState> + use<> {
         self.inner.changes()
     }
 

--- a/crates/matrix-sdk/src/encryption/verification/requests.rs
+++ b/crates/matrix-sdk/src/encryption/verification/requests.rs
@@ -247,7 +247,7 @@ impl VerificationRequest {
     ///
     /// The changes are presented as a stream of [`VerificationRequestState`]
     /// values.
-    pub fn changes(&self) -> impl Stream<Item = VerificationRequestState> {
+    pub fn changes(&self) -> impl Stream<Item = VerificationRequestState> + use<> {
         let client = self.client.to_owned();
 
         self.inner.changes().map(move |s| Self::convert_state(client.to_owned(), s))

--- a/crates/matrix-sdk/src/encryption/verification/sas.rs
+++ b/crates/matrix-sdk/src/encryption/verification/sas.rs
@@ -317,7 +317,7 @@ impl SasVerification {
     /// }
     /// # anyhow::Ok(()) };
     /// ```
-    pub fn changes(&self) -> impl Stream<Item = SasState> {
+    pub fn changes(&self) -> impl Stream<Item = SasState> + use<> {
         self.inner.changes()
     }
 

--- a/crates/matrix-sdk/src/live_location_share.rs
+++ b/crates/matrix-sdk/src/live_location_share.rs
@@ -41,7 +41,7 @@ impl ObservableLiveLocation {
     }
 
     /// Get a stream of [`LiveLocationShare`].
-    pub fn subscribe(&self) -> impl Stream<Item = LiveLocationShare> {
+    pub fn subscribe(&self) -> impl Stream<Item = LiveLocationShare> + use<> {
         let stream = self.observable_room_events.subscribe();
 
         stream! {


### PR DESCRIPTION
With Rust 2024, by default `impl Trait` return types use any hidden generic parameter that is in scope, so in these cases the lifetime of `self`.

But since the return type is actually owned, the returned `impl Stream` shouldn't use any lifetime, which is what `use<>` does.

For more details: https://blog.rust-lang.org/2024/09/05/impl-trait-capture-rules/.
