### PR TITLE
chore(base): don't log the same missing room info log line on every single sync

### DIFF
--- a/crates/matrix-sdk-base/src/response_processors/account_data/global.rs
+++ b/crates/matrix-sdk-base/src/response_processors/account_data/global.rs
@@ -172,7 +172,7 @@ fn map_info<F: FnOnce(&mut RoomInfo)>(
         let mut info = room.clone_info();
         f(&mut info);
         changes.add_room(info);
-    } else {
+    } else if store.already_logged_missing_room.lock().insert(room_id.to_owned()) {
         debug!(room = %room_id, "couldn't find room in state changes or store");
     }
 }


### PR DESCRIPTION
This should only happen when a room has been forgotten and was a room DMs before. Ideally, we'd clean up the room DM event data, but since this is slightly more involved, we don't do that here just quite yet.