### PR TITLE
feat(ffi): add bindings for listening to room send queue updates

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 - Add `QrLoginProgress::SyncingSecrets` to indicate that secrets are being synced between the two
   devices.
   ([#5760](https://github.com/matrix-org/matrix-rust-sdk/pull/5760))
+- Add `Room::subscribe_to_send_queue_updates` to observe room send queue updates.
+  ([#5761](https://github.com/matrix-org/matrix-rust-sdk/pull/5761))
 
 ### Features:
 


### PR DESCRIPTION
This allows users of the FFI bindings to listen for updates on a room's send queue.

<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)

