### PR TITLE
chore: Remove the matrix-sdk-crypto re-export in the matrix-sdk crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3439,6 +3439,7 @@ dependencies = [
  "language-tags",
  "log-panics",
  "matrix-sdk",
+ "matrix-sdk-base",
  "matrix-sdk-common",
  "matrix-sdk-ffi-macros",
  "matrix-sdk-ui",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -54,6 +54,7 @@ matrix-sdk = { workspace = true, features = [
     "sqlite",
     "uniffi",
 ] }
+matrix-sdk-base.workspace = true
 matrix-sdk-common.workspace = true
 matrix-sdk-ffi-macros.workspace = true
 matrix-sdk-ui = { workspace = true, features = ["uniffi"] }

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -3,7 +3,6 @@ use std::{fs, num::NonZeroUsize, path::Path, sync::Arc, time::Duration};
 #[cfg(not(target_family = "wasm"))]
 use matrix_sdk::reqwest::Certificate;
 use matrix_sdk::{
-    crypto::{CollectStrategy, DecryptionSettings, TrustRequirement},
     encryption::{BackupDownloadStrategy, EncryptionSettings},
     event_cache::EventCacheError,
     ruma::{ServerName, UserId},
@@ -14,6 +13,7 @@ use matrix_sdk::{
     Client as MatrixClient, ClientBuildError as MatrixClientBuildError, HttpError, IdParseError,
     RumaApiError, SqliteStoreConfig, ThreadingSupport,
 };
+use matrix_sdk_base::crypto::{CollectStrategy, DecryptionSettings, TrustRequirement};
 use ruma::api::error::{DeserializationError, FromHttpResponseError};
 use tracing::debug;
 use zeroize::Zeroizing;

--- a/bindings/matrix-sdk-ffi/src/identity_status_change.rs
+++ b/bindings/matrix-sdk-ffi/src/identity_status_change.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use matrix_sdk::crypto::IdentityState;
+use matrix_sdk_base::crypto::IdentityState;
 
 #[derive(uniffi::Record)]
 pub struct IdentityStatusChange {

--- a/bindings/matrix-sdk-ffi/src/qr_code.rs
+++ b/bindings/matrix-sdk-ffi/src/qr_code.rs
@@ -1,14 +1,11 @@
 use std::sync::Arc;
 
-use matrix_sdk::{
-    authentication::oauth::{
-        qrcode::{
-            self, CheckCodeSender as SdkCheckCodeSender, CheckCodeSenderError,
-            DeviceCodeErrorResponseType, GeneratedQrProgress, LoginFailureReason, QrProgress,
-        },
-        OAuth,
+use matrix_sdk::authentication::oauth::{
+    qrcode::{
+        self, CheckCodeSender as SdkCheckCodeSender, CheckCodeSenderError,
+        DeviceCodeErrorResponseType, GeneratedQrProgress, LoginFailureReason, QrProgress,
     },
-    crypto::types::qr_login::{LoginQrCodeDecodeError, QrCodeModeData},
+    OAuth,
 };
 use matrix_sdk_common::{stream::StreamExt, SendOutsideWasm, SyncOutsideWasm};
 
@@ -152,8 +149,8 @@ impl QrCodeData {
     /// will return `None`.
     pub fn server_name(&self) -> Option<String> {
         match &self.inner.mode_data {
-            QrCodeModeData::Reciprocate { server_name } => Some(server_name.to_owned()),
-            QrCodeModeData::Login => None,
+            qrcode::QrCodeModeData::Reciprocate { server_name } => Some(server_name.to_owned()),
+            qrcode::QrCodeModeData::Login => None,
         }
     }
 }
@@ -165,7 +162,7 @@ pub enum QrCodeDecodeError {
     #[error("Error decoding QR code: {error:?}")]
     Crypto {
         #[from]
-        error: LoginQrCodeDecodeError,
+        error: qrcode::LoginQrCodeDecodeError,
     },
 }
 

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fs, path::PathBuf, pin::pin, sync::Arc};
 use anyhow::{Context, Result};
 use futures_util::{pin_mut, StreamExt};
 use matrix_sdk::{
-    crypto::LocalTrust,
+    encryption::LocalTrust,
     room::{
         edit::EditedContent, power_levels::RoomPowerLevelChanges, Room as SdkRoom, RoomMemberRole,
         TryFromReportedContentScoreError,

--- a/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
@@ -14,7 +14,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use matrix_sdk::crypto::types::events::UtdCause;
+use matrix_sdk_base::crypto::types::events::UtdCause;
 use ruma::events::{room::MediaSource as RumaMediaSource, MessageLikeEventContent};
 
 use super::{

--- a/bindings/matrix-sdk-ffi/src/utd.rs
+++ b/bindings/matrix-sdk-ffi/src/utd.rs
@@ -14,7 +14,7 @@
 
 use std::{fmt::Debug, sync::Arc, time::Duration};
 
-use matrix_sdk::crypto::types::events::UtdCause;
+use matrix_sdk_base::crypto::types::events::UtdCause;
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
 use matrix_sdk_ui::unable_to_decrypt_hook::{
     UnableToDecryptHook, UnableToDecryptInfo as SdkUnableToDecryptInfo,

--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -23,12 +23,12 @@ use imbl::Vector;
 use itertools::{Either, Itertools as _};
 use matrix_sdk::{
     Client, Room,
-    crypto::store::types::RoomKeyInfo,
     deserialized_responses::TimelineEventKind as SdkTimelineEventKind,
     encryption::backups::BackupState,
     event_handler::EventHandlerHandle,
     executor::{JoinHandle, spawn},
 };
+use matrix_sdk_base::crypto::store::types::RoomKeyInfo;
 use tokio::sync::{
     RwLock,
     mpsc::{self, Receiver, Sender},
@@ -516,10 +516,8 @@ mod tests {
     use std::{collections::BTreeMap, sync::Arc, time::SystemTime};
 
     use imbl::vector;
-    use matrix_sdk::{
-        crypto::types::events::UtdCause,
-        deserialized_responses::{AlgorithmInfo, EncryptionInfo, VerificationState},
-    };
+    use matrix_sdk::deserialized_responses::{AlgorithmInfo, EncryptionInfo, VerificationState};
+    use matrix_sdk_base::crypto::types::events::UtdCause;
     use ruma::{
         MilliSecondsSinceUnixEpoch, OwnedTransactionId,
         events::room::{

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -17,10 +17,10 @@ use std::{borrow::Cow, sync::Arc};
 use as_variant::as_variant;
 use indexmap::IndexMap;
 use matrix_sdk::{
-    crypto::types::events::UtdCause,
     deserialized_responses::{EncryptionInfo, UnableToDecryptInfo},
     send_queue::SendHandle,
 };
+use matrix_sdk_base::crypto::types::events::UtdCause;
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
     TransactionId,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -15,8 +15,10 @@
 use std::sync::Arc;
 
 use as_variant::as_variant;
-use matrix_sdk::crypto::types::events::UtdCause;
-use matrix_sdk_base::latest_event::{PossibleLatestEvent, is_suitable_for_latest_event};
+use matrix_sdk_base::{
+    crypto::types::events::UtdCause,
+    latest_event::{PossibleLatestEvent, is_suitable_for_latest_event},
+};
 use ruma::{
     OwnedDeviceId, OwnedEventId, OwnedMxcUri, OwnedUserId, UserId,
     events::{

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -27,13 +27,15 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use matrix_sdk::{
     self, Client, assert_next_matches_with_timeout, assert_next_with_timeout,
-    crypto::{OlmMachine, decrypt_room_key_export, types::events::UtdCause},
     deserialized_responses::{
         AlgorithmInfo, DecryptedRoomEvent, EncryptionInfo, VerificationLevel, VerificationState,
     },
     test_utils::mocks::MatrixMockServer,
 };
-use matrix_sdk_base::deserialized_responses::{TimelineEvent, UnableToDecryptReason};
+use matrix_sdk_base::{
+    crypto::{OlmMachine, decrypt_room_key_export, types::events::UtdCause},
+    deserialized_responses::{TimelineEvent, UnableToDecryptReason},
+};
 use matrix_sdk_test::{ALICE, BOB, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use ruma::{
     RoomId, UserId, assign, event_id,

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -29,14 +29,18 @@ use indexmap::IndexMap;
 use matrix_sdk::{
     BoxFuture,
     config::RequestConfig,
-    crypto::{DecryptionSettings, OlmMachine, RoomEventDecryptionResult, TrustRequirement},
     deserialized_responses::{EncryptionInfo, TimelineEvent},
     paginators::{PaginableRoom, PaginatorError, thread::PaginableThread},
     room::{EventWithContextResponse, Messages, MessagesOptions, PushContext, Relations},
     send_queue::RoomSendQueueUpdate,
 };
 use matrix_sdk_base::{
-    RoomInfo, RoomState, crypto::types::events::CryptoContextInfo, latest_event::LatestEvent,
+    RoomInfo, RoomState,
+    crypto::{
+        DecryptionSettings, OlmMachine, RoomEventDecryptionResult, TrustRequirement,
+        types::events::CryptoContextInfo,
+    },
+    latest_event::LatestEvent,
 };
 use matrix_sdk_test::{ALICE, DEFAULT_TEST_ROOM_ID, event_factory::EventFactory};
 use ruma::{

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -18,12 +18,13 @@ use eyeball::Subscriber;
 use indexmap::IndexMap;
 use matrix_sdk::{
     AsyncTraitDeps, Result, Room, SendOutsideWasm,
-    crypto::types::events::CryptoContextInfo,
     deserialized_responses::{EncryptionInfo, TimelineEvent},
     paginators::{PaginableRoom, thread::PaginableThread},
     room::PushContext,
 };
-use matrix_sdk_base::{RoomInfo, latest_event::LatestEvent};
+use matrix_sdk_base::{
+    RoomInfo, crypto::types::events::CryptoContextInfo, latest_event::LatestEvent,
+};
 use ruma::{
     EventId, OwnedEventId, OwnedTransactionId, OwnedUserId, UserId,
     events::{

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -26,12 +26,12 @@ use std::{
 use growable_bloom_filter::{GrowableBloom, GrowableBloomBuilder};
 use matrix_sdk::{
     Client,
-    crypto::types::events::UtdCause,
     executor::{JoinHandle, spawn},
     sleep::sleep,
 };
 use matrix_sdk_base::{
     SendOutsideWasm, StateStoreDataKey, StateStoreDataValue, StoreError, SyncOutsideWasm,
+    crypto::types::events::UtdCause,
 };
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName, UserId,

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] Remove the `matrix-sdk-crypto` re-export.
+  ([#5769](https://github.com/matrix-org/matrix-rust-sdk/pull/5769))
 - Allow `Client::get_dm_room()` to be called without the `e2e-encryption` crate feature.
   ([#5787](https://github.com/matrix-org/matrix-rust-sdk/pull/5787))
 - [**breaking**] Add `encryption::secret_storage::SecretStorageError::ImportError` to indicate

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -26,6 +26,8 @@ use std::{collections::BTreeSet, fmt, sync::Arc};
 use homeserver_config::*;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::DecryptionSettings;
+#[cfg(feature = "e2e-encryption")]
+use matrix_sdk_base::crypto::{CollectStrategy, TrustRequirement};
 use matrix_sdk_base::{BaseClient, ThreadingSupport, store::StoreConfig};
 #[cfg(feature = "sqlite")]
 use matrix_sdk_sqlite::SqliteStoreConfig;
@@ -38,8 +40,6 @@ use tokio::sync::{Mutex, OnceCell, broadcast};
 use tracing::{Span, debug, field::debug, instrument};
 
 use super::{Client, ClientInner};
-#[cfg(feature = "e2e-encryption")]
-use crate::crypto::{CollectStrategy, TrustRequirement};
 #[cfg(feature = "e2e-encryption")]
 use crate::encryption::EncryptionSettings;
 #[cfg(not(target_family = "wasm"))]

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -55,12 +55,11 @@ use tracing::{Span, error, info, instrument, trace, warn};
 pub mod futures;
 pub(crate) mod types;
 
+use matrix_sdk_base::crypto::olm::ExportedRoomKey;
 pub use types::{BackupState, UploadState};
 
 use self::futures::WaitForSteadyState;
-use crate::{
-    Client, Error, Room, crypto::olm::ExportedRoomKey, encryption::BackupDownloadStrategy,
-};
+use crate::{Client, Error, Room, encryption::BackupDownloadStrategy};
 
 /// The backups manager for the [`Client`].
 #[derive(Debug, Clone)]

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -20,8 +20,6 @@
 
 pub use async_trait::async_trait;
 pub use bytes;
-#[cfg(feature = "e2e-encryption")]
-pub use matrix_sdk_base::crypto;
 pub use matrix_sdk_base::{
     ComposerDraft, ComposerDraftType, DraftAttachment, DraftAttachmentContent, DraftThumbnail,
     EncryptionState, PredecessorRoom, QueueWedgeError, Room as BaseRoom,

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -35,7 +35,9 @@ pub use identity_status_changes::IdentityStatusChanges;
 #[cfg(feature = "experimental-encrypted-state-events")]
 use matrix_sdk_base::crypto::types::events::room::encrypted::EncryptedEvent;
 #[cfg(feature = "e2e-encryption")]
-use matrix_sdk_base::crypto::{IdentityStatusChange, RoomIdentityProvider, UserIdentity};
+use matrix_sdk_base::crypto::{
+    IdentityStatusChange, RoomIdentityProvider, UserIdentity, types::events::CryptoContextInfo,
+};
 pub use matrix_sdk_base::store::StoredThreadSubscription;
 use matrix_sdk_base::{
     ComposerDraft, EncryptionState, RoomInfoNotableUpdateReasons, RoomMemberships, SendOutsideWasm,
@@ -154,6 +156,8 @@ pub use self::{
         Relations, RelationsOptions, ThreadRoots,
     },
 };
+#[cfg(feature = "e2e-encryption")]
+use crate::encryption::backups::BackupState;
 #[cfg(doc)]
 use crate::event_cache::EventCache;
 #[cfg(feature = "experimental-encrypted-state-events")]
@@ -177,8 +181,6 @@ use crate::{
     sync::RoomUpdate,
     utils::{IntoRawMessageLikeEventContent, IntoRawStateEventContent},
 };
-#[cfg(feature = "e2e-encryption")]
-use crate::{crypto::types::events::CryptoContextInfo, encryption::backups::BackupState};
 
 pub mod edit;
 pub mod futures;

--- a/crates/matrix-sdk/src/room/shared_room_history.rs
+++ b/crates/matrix-sdk/src/room/shared_room_history.rs
@@ -14,11 +14,14 @@
 
 use std::iter;
 
-use matrix_sdk_base::media::{MediaFormat, MediaRequestParameters};
+use matrix_sdk_base::{
+    crypto::types::events::room_key_bundle::RoomKeyBundleContent,
+    media::{MediaFormat, MediaRequestParameters},
+};
 use ruma::{OwnedUserId, UserId, events::room::MediaSource};
 use tracing::{info, instrument, warn};
 
-use crate::{Error, Result, Room, crypto::types::events::room_key_bundle::RoomKeyBundleContent};
+use crate::{Error, Result, Room};
 
 /// Share any shareable E2EE history in the given room with the given recipient,
 /// as per [MSC4268].

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -138,6 +138,8 @@ use std::{
 };
 
 use eyeball::SharedObservable;
+#[cfg(feature = "e2e-encryption")]
+use matrix_sdk_base::crypto::{OlmError, SessionRecipientCollectionError};
 #[cfg(feature = "unstable-msc4274")]
 use matrix_sdk_base::store::FinishGalleryItemInfo;
 use matrix_sdk_base::{
@@ -173,8 +175,6 @@ use ruma::{
 use tokio::sync::{Mutex, Notify, OwnedMutexGuard, broadcast, oneshot};
 use tracing::{debug, error, info, instrument, trace, warn};
 
-#[cfg(feature = "e2e-encryption")]
-use crate::crypto::{OlmError, SessionRecipientCollectionError};
 use crate::{
     Client, Media, Room, TransmissionProgress,
     client::WeakClient,

--- a/crates/matrix-sdk/src/test_utils/mocks/encryption.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/encryption.rs
@@ -22,6 +22,7 @@ use std::{
 };
 
 use assert_matches2::assert_let;
+use matrix_sdk_base::crypto::types::events::room::encrypted::EncryptedToDeviceEvent;
 use matrix_sdk_test::test_json;
 use ruma::{
     CrossSigningKeyId, DeviceId, MilliSecondsSinceUnixEpoch, OneTimeKeyAlgorithm, OwnedDeviceId,
@@ -43,7 +44,6 @@ use wiremock::{
 
 use crate::{
     Client,
-    crypto::types::events::room::encrypted::EncryptedToDeviceEvent,
     test_utils::{
         client::MockClientBuilder,
         mocks::{Keys, MatrixMockServer},

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -21,11 +21,6 @@ use matrix_sdk::{
     Client, SessionMeta,
     authentication::matrix::MatrixSession,
     config::RequestConfig,
-    crypto::{
-        olm::{InboundGroupSession, SenderData, SessionCreationError},
-        store::types::BackupDecryptionKey,
-        types::EventEncryptionAlgorithm,
-    },
     encryption::{
         BackupDownloadStrategy, EncryptionSettings,
         backups::{BackupState, UploadState, futures::SteadyStateError},
@@ -36,7 +31,11 @@ use matrix_sdk::{
         test_client_builder_with_server,
     },
 };
-use matrix_sdk_base::crypto::olm::OutboundGroupSession;
+use matrix_sdk_base::crypto::{
+    olm::{InboundGroupSession, OutboundGroupSession, SenderData, SessionCreationError},
+    store::types::BackupDecryptionKey,
+    types::EventEncryptionAlgorithm,
+};
 use matrix_sdk_common::timeout::timeout;
 use matrix_sdk_test::{JoinedRoomBuilder, SyncResponseBuilder, TestResult, async_test};
 use ruma::{
@@ -1422,7 +1421,7 @@ async fn test_enable_from_secret_storage_and_download_after_utd_from_old_message
         device_id!("KIUVQQSDTM").to_owned(),
         Arc::new(sender_identity_keys),
         room_id,
-        matrix_sdk::crypto::EncryptionSettings::default(),
+        matrix_sdk_base::crypto::EncryptionSettings::default(),
     )?;
 
     // Export the `OutboundGroupSession` to an `InboundGroupSession`, and export it

--- a/testing/matrix-sdk-integration-testing/src/helpers.rs
+++ b/testing/matrix-sdk-integration-testing/src/helpers.rs
@@ -12,7 +12,6 @@ use assign::assign;
 use matrix_sdk::{
     Client, ClientBuilder, Room,
     config::{RequestConfig, SyncSettings},
-    crypto::{CollectStrategy, DecryptionSettings},
     encryption::EncryptionSettings,
     ruma::{
         RoomId,
@@ -23,7 +22,7 @@ use matrix_sdk::{
     sync::SyncResponse,
     timeout::ElapsedError,
 };
-use matrix_sdk_base::crypto::TrustRequirement;
+use matrix_sdk_base::crypto::{CollectStrategy, DecryptionSettings, TrustRequirement};
 use once_cell::sync::Lazy;
 use rand::Rng as _;
 use tempfile::{TempDir, tempdir};

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/mod.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/mod.rs
@@ -9,7 +9,6 @@ use assert_matches2::assert_let;
 use assign::assign;
 use matrix_sdk::{
     Client, assert_next_eq_with_timeout,
-    crypto::{SasState, format_emojis},
     encryption::{
         BackupDownloadStrategy, EncryptionSettings, LocalTrust,
         backups::BackupState,
@@ -33,6 +32,7 @@ use matrix_sdk::{
     },
     timeout::timeout,
 };
+use matrix_sdk_base::crypto::{SasState, format_emojis};
 use matrix_sdk_ui::{
     notification_client::{NotificationClient, NotificationProcessSetup},
     sync_service::SyncService,


### PR DESCRIPTION

- [x] Public API changes documented in changelogs (optional)
