### PR TITLE
feat(timeline): Use read receipt as fallback for read marker

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1012,11 +1012,18 @@ impl<P: RoomDataProvider> TimelineController<P> {
                 .await;
         }
 
-        if track_read_markers
-            && let Some(fully_read_event_id) =
+        if track_read_markers {
+            if let Some(fully_read_event_id) =
                 self.room_data_provider.load_fully_read_marker().await
-        {
-            state.handle_fully_read_marker(fully_read_event_id);
+            {
+                state.handle_fully_read_marker(fully_read_event_id);
+            } else if let Some(latest_receipt_event_id) = state
+                .latest_user_read_receipt_timeline_event_id(self.room_data_provider.own_user_id())
+            {
+                // Fall back to read receipt if no fully read marker exists.
+                debug!("no `m.fully_read` marker found, falling back to read receipt");
+                state.handle_fully_read_marker(latest_receipt_event_id);
+            }
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -65,7 +65,7 @@ impl ReadReceipts {
 
     /// Read the latest read receipt of the given type for the given user, from
     /// the in-memory cache.
-    fn get_latest(
+    pub(crate) fn get_latest(
         &self,
         user_id: &UserId,
         receipt_type: &ReceiptType,

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -30,6 +30,7 @@ use matrix_sdk_test::{
 };
 use matrix_sdk_ui::timeline::{
     RoomExt as _, TimelineBuilder, TimelineDetails, TimelineEventItemId, TimelineFocus,
+    VirtualTimelineItem,
 };
 use ruma::{
     MilliSecondsSinceUnixEpoch,
@@ -1719,11 +1720,16 @@ async fn test_send_read_receipts() {
     assert_eq!(ev.event_id(), Some(event_id!("$2")));
     assert!(ev.read_receipts().is_empty());
 
-    let ev = initial_items[3].as_event().unwrap();
+    // Since the room has no `m.fully_read` event, the read marker falls back to
+    // the normal read receipt.
+    let ev = initial_items[3].as_virtual().unwrap();
+    assert!(matches!(ev, VirtualTimelineItem::ReadMarker));
+
+    let ev = initial_items[4].as_event().unwrap();
     assert_eq!(ev.event_id(), Some(event_id!("$3")));
     assert!(ev.read_receipts().is_empty());
 
-    let ev = initial_items[4].as_event().unwrap();
+    let ev = initial_items[5].as_event().unwrap();
     assert_eq!(ev.event_id(), Some(event_id!("$4")));
     let rr = ev.read_receipts();
     assert_eq!(rr.len(), 1);


### PR DESCRIPTION
According to the [spec](https://spec.matrix.org/v1.16/client-server-api/#events-7) if a `m.fully_read` event does not exist, the normal `m.read` marker should be used as a fallback.