### PR TITLE
Verify membership when test if name is ambiguous

### DIFF
--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -215,9 +215,10 @@ impl RoomMember {
             room_info;
 
         let display_name = event.display_name();
-        let display_name_ambiguous = users_display_names
-            .get(&display_name)
-            .is_some_and(|s| is_display_name_ambiguous(&display_name, s));
+        let membership = event.membership();
+        let display_name_ambiguous = users_display_names.get(&display_name).is_some_and(|s| {
+            is_display_name_ambiguous(&display_name, s) && *membership != MembershipState::Leave
+        });
         let is_ignored = ignored_users.as_ref().is_some_and(|s| s.contains(event.user_id()));
 
         Self {

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -495,13 +495,11 @@ pub fn normalize_power_level(power_level: Int, max_power_level: i64) -> Int {
 mod tests {
     use std::sync::Arc;
 
-    use proptest::prelude::*;
-
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
+    use proptest::prelude::*;
     use ruma::{room_id, user_id};
 
     use super::*;
-
     use crate::{RoomState, StateChanges, StateStore, store::MemoryStore};
 
     fn make_room_test_helper(room_type: RoomState) -> (Arc<MemoryStore>, Room) {

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -217,8 +217,10 @@ impl RoomMember {
         let display_name = event.display_name();
         let membership = event.membership();
         let display_name_ambiguous = users_display_names.get(&display_name).is_some_and(|s| {
-            is_display_name_ambiguous(&display_name, s)
-                && (*membership == MembershipState::Join || *membership == MembershipState::Invite)
+            if !is_display_name_ambiguous(&display_name, s) {
+                return false;
+            }
+            matches!(*membership, MembershipState::Join | MembershipState::Invite)
         });
         let is_ignored = ignored_users.as_ref().is_some_and(|s| s.contains(event.user_id()));
 

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -217,7 +217,8 @@ impl RoomMember {
         let display_name = event.display_name();
         let membership = event.membership();
         let display_name_ambiguous = users_display_names.get(&display_name).is_some_and(|s| {
-            is_display_name_ambiguous(&display_name, s) && *membership != MembershipState::Leave
+            is_display_name_ambiguous(&display_name, s)
+                && (*membership == MembershipState::Join || *membership == MembershipState::Invite)
         });
         let is_ignored = ignored_users.as_ref().is_some_and(|s| s.contains(event.user_id()));
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -238,6 +238,30 @@ pub trait StateStore: AsyncTraitDeps {
     /// # Arguments
     ///
     /// * `event_type` - The event type of the account data event.
+    async fn get_active_users_with_display_name(
+        &self,
+        room_id: &RoomId,
+        display_name: &DisplayName,
+    ) -> Result<BTreeSet<OwnedUserId>, Self::Error>;
+
+    /// Get all the active users that use the given display names in the given room.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The ID of the room to fetch the display names for.
+    ///
+    /// * `display_names` - The display names that the users use.
+    async fn get_active_users_with_display_names<'a>(
+        &self,
+        room_id: &RoomId,
+        display_names: &'a [DisplayName],
+    ) -> Result<HashMap<&'a DisplayName, BTreeSet<OwnedUserId>>, Self::Error>;
+
+    /// Get an event out of the account data store.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` - The event type of the account data event.
     async fn get_account_data_event(
         &self,
         event_type: GlobalAccountDataEventType,

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -996,6 +996,30 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
         })
         .await
     }
+    
+    async fn get_active_display_names(
+        &self,
+        room_id: Key,
+        names: Vec<Key>,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+        let names_length = names.len();
+
+        self.chunk_large_query_over(names, Some(names_length), move |txn, names| {
+            let sql_params = repeat_vars(names.len());
+            let sql = format!(
+                "SELECT name, data FROM display_name WHERE room_id = ? AND name IN ({sql_params}) AND membership = ?"
+            );
+
+            let params = rusqlite::params_from_iter(iter::once(room_id.clone()).chain(names).chain(iter::once(RoomMemberships::ACTIVE)));
+
+            Ok(txn
+                .prepare(&sql)?
+                .query(params)?
+                .mapped(|row| Ok((row.get(0)?, row.get(1)?)))
+                .collect::<Result<_, _>>()?)
+        })
+        .await
+    }
 
     async fn get_user_receipt(
         &self,
@@ -1652,7 +1676,7 @@ impl StateStore for SqliteStateStore {
             .transpose()?
             .unwrap_or_default())
     }
-
+    
     async fn get_users_with_display_names<'a>(
         &self,
         room_id: &RoomId,
@@ -1689,6 +1713,76 @@ impl StateStore for SqliteStateStore {
         let names = names_map.keys().cloned().collect();
 
         for (name, data) in self.read().await?.get_display_names(room_id, names).await?.into_iter()
+        {
+            let display_name =
+                names_map.remove(name.as_slice()).expect("returned display names were requested");
+            let user_ids: BTreeSet<_> = self.deserialize_json(&data)?;
+
+            result.entry(display_name).or_insert_with(BTreeSet::new).extend(user_ids);
+        }
+
+        Ok(result)
+    }
+
+    async fn get_active_users_with_display_name(
+        &self,
+        room_id: &RoomId,
+        display_name: &DisplayName,
+    ) -> Result<BTreeSet<OwnedUserId>> {
+        let room_id = self.encode_key(keys::DISPLAY_NAME, room_id);
+        let names = vec![self.encode_key(
+            keys::DISPLAY_NAME,
+            display_name.as_normalized_str().unwrap_or_else(|| display_name.as_raw_str()),
+        )];
+
+        Ok(self
+            .read()
+            .await?
+            .get_active_display_names(room_id, names)
+            .await?
+            .into_iter()
+            .next()
+            .map(|(_, data)| self.deserialize_json(&data))
+            .transpose()?
+            .unwrap_or_default())
+    }
+
+    async fn get_active_users_with_display_names<'a>(
+        &self,
+        room_id: &RoomId,
+        display_names: &'a [DisplayName],
+    ) -> Result<HashMap<&'a DisplayName, BTreeSet<OwnedUserId>>> {
+        let mut result = HashMap::new();
+
+        if display_names.is_empty() {
+            return Ok(result);
+        }
+
+        let room_id = self.encode_key(keys::DISPLAY_NAME, room_id);
+        let mut names_map = display_names
+            .iter()
+            .flat_map(|display_name| {
+                // We encode the display name as the `raw_str()` and the normalized string.
+                //
+                // This is for compatibility reasons since:
+                //  1. Previously "Alice" and "alice" were considered to be distinct display
+                //     names, while we now consider them to be the same so we need to merge the
+                //     previously distinct buckets of user IDs.
+                //  2. We can't do a migration to merge the previously distinct buckets of user
+                //     IDs since the display names itself are hashed before they are persisted
+                //     in the store.
+                let raw =
+                    (self.encode_key(keys::DISPLAY_NAME, display_name.as_raw_str()), display_name);
+                let normalized = display_name.as_normalized_str().map(|normalized| {
+                    (self.encode_key(keys::DISPLAY_NAME, normalized), display_name)
+                });
+
+                iter::once(raw).chain(normalized)
+            })
+            .collect::<BTreeMap<_, _>>();
+        let names = names_map.keys().cloned().collect();
+
+        for (name, data) in self.read().await?.get_active_display_names(room_id, names).await?.into_iter()
         {
             let display_name =
                 names_map.remove(name.as_slice()).expect("returned display names were requested");


### PR DESCRIPTION
Verify if the membership is not Leave when checking if a name in a room is ambiguous.

Signed-off-by: 
multi

Fix https://github.com/matrix-org/matrix-rust-sdk/issues/5774