### PR TITLE
feat(ffi): add bindings for listening to global send queue updates

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to this project will be documented in this file.
   ([#5786](https://github.com/matrix-org/matrix-rust-sdk/pull/5786))
 - `ComposerDraft` now includes attachments alongside the text message.
   ([#5794](https://github.com/matrix-org/matrix-rust-sdk/pull/5794))
+- Add `Client::subscribe_to_send_queue_updates` to observe global send queue updates.
+  ([#5784](https://github.com/matrix-org/matrix-rust-sdk/pull/5784))
 
 ### Features:
 

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -305,6 +305,31 @@ impl SendQueue {
         self.data().global_update_sender.subscribe()
     }
 
+    /// Get local echoes from all room send queues.
+    pub async fn local_echoes(
+        &self,
+    ) -> Result<BTreeMap<OwnedRoomId, Vec<LocalEcho>>, RoomSendQueueError> {
+        let room_ids =
+            self.client.state_store().load_rooms_with_unsent_requests().await.unwrap_or_else(
+                |err| {
+                    warn!("error when loading rooms with unsent requests: {err}");
+                    Vec::new()
+                },
+            );
+
+        let mut local_echoes: BTreeMap<OwnedRoomId, Vec<LocalEcho>> = BTreeMap::new();
+
+        for room_id in room_ids {
+            if let Some(room) = self.client.get_room(&room_id) {
+                let queue = self.for_room(room);
+                local_echoes
+                    .insert(room_id.to_owned(), queue.inner.queue.local_echoes(&queue).await?);
+            }
+        }
+
+        Ok(local_echoes)
+    }
+
     /// A subscriber to the enablement status (enabled or disabled) of the
     /// send queue, along with useful errors.
     pub fn subscribe_errors(&self) -> broadcast::Receiver<SendQueueRoomError> {


### PR DESCRIPTION
This is a small addendum to #5761 that does the same thing for the global update reporter.

CC @bnjbvr as the resident send queue expert.

- [x] Public API changes documented in changelogs (optional)
