### PR TITLE
chore: Rewrite timeline redecryption tests to use HTTP mocking

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -107,13 +107,6 @@ impl TestTimelineBuilder {
         self
     }
 
-    fn unable_to_decrypt_hook(mut self, hook: Arc<UtdHookManager>) -> Self {
-        self.utd_hook = Some(hook);
-        // It only makes sense to have a UTD hook for an encrypted room.
-        self.is_room_encrypted = true;
-        self
-    }
-
     fn room_encrypted(mut self, encrypted: bool) -> Self {
         self.is_room_encrypted = encrypted;
         self
@@ -281,11 +274,6 @@ struct TestRoomDataProvider {
 }
 
 impl TestRoomDataProvider {
-    fn with_own_user_id(mut self, user_id: OwnedUserId) -> Self {
-        self.own_user_id = Some(user_id);
-        self
-    }
-
     fn with_initial_user_receipts(mut self, initial_user_receipts: ReadReceiptMap) -> Self {
         self.initial_user_receipts = initial_user_receipts;
         self


### PR DESCRIPTION
This is important since we want to move the redecryption logic out of the timeline into the main crate. This in turn means that we don't have such low level access to the redecryption logic.

Not all tests were rewritten:
- `test_retry_edit_and_more` Is proving to be difficult to rewrite, may come in a separate commit.
- `test_retry_fetching_encryption_info` Needs verification state changes. Will be rewritten on the event cache layer
