### PR TITLE
feat(composer): add support for attachments in drafts

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project will be documented in this file.
   current device scanning or generating the QR code. Additionally, new errors `HumanQrLoginError::CheckCodeAlreadySent`
   and `HumanQrLoginError::CheckCodeCannotBeSent` were added.
   ([#5786](https://github.com/matrix-org/matrix-rust-sdk/pull/5786))
+- `ComposerDraft` now includes attachments alongside the text message.
+  ([#5794](https://github.com/matrix-org/matrix-rust-sdk/pull/5794))
 
 ### Features:
 

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file.
 - `Client::sync_lock` has been renamed `Client::state_store_lock`.
   ([#5707](https://github.com/matrix-org/matrix-rust-sdk/pull/5707))
 
+### Features
+
+- `ComposerDraft` can now store attachments alongside text messages.
+  ([#5794](https://github.com/matrix-org/matrix-rust-sdk/pull/5794))
+
 ## [0.14.1] - 2025-09-10
 
 ### Security Fixes

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -64,8 +64,9 @@ pub use room::{
     RoomState, RoomStateFilter, SuccessorRoom, apply_redaction,
 };
 pub use store::{
-    ComposerDraft, ComposerDraftType, QueueWedgeError, StateChanges, StateStore, StateStoreDataKey,
-    StateStoreDataValue, StoreError, ThreadSubscriptionCatchupToken,
+    ComposerDraft, ComposerDraftType, DraftAttachment, DraftAttachmentContent, DraftThumbnail,
+    QueueWedgeError, StateChanges, StateStore, StateStoreDataKey, StateStoreDataValue, StoreError,
+    ThreadSubscriptionCatchupToken,
 };
 pub use utils::{
     MinimalRoomMemberEvent, MinimalStateEvent, OriginalMinimalStateEvent, RedactedMinimalStateEvent,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -94,9 +94,9 @@ pub use self::{
         SentMediaInfo, SentRequestKey, SerializableEventContent,
     },
     traits::{
-        ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, ServerInfo, StateStore,
-        StateStoreDataKey, StateStoreDataValue, StateStoreExt, ThreadSubscriptionCatchupToken,
-        WellKnownResponse,
+        ComposerDraft, ComposerDraftType, DraftAttachment, DraftAttachmentContent, DraftThumbnail,
+        DynStateStore, IntoStateStore, ServerInfo, StateStore, StateStoreDataKey,
+        StateStoreDataValue, StateStoreExt, ThreadSubscriptionCatchupToken, WellKnownResponse,
     },
 };
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -1195,6 +1195,97 @@ pub struct ComposerDraft {
     pub html_text: Option<String>,
     /// The type of draft.
     pub draft_type: ComposerDraftType,
+    /// Attachments associated with this draft.
+    #[serde(default)]
+    pub attachments: Vec<DraftAttachment>,
+}
+
+/// An attachment stored with a composer draft.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DraftAttachment {
+    /// The filename of the attachment.
+    pub filename: String,
+    /// The attachment content with type-specific data.
+    pub content: DraftAttachmentContent,
+}
+
+/// The content of a draft attachment with type-specific data.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum DraftAttachmentContent {
+    /// Image attachment.
+    Image {
+        /// The image file data.
+        data: Vec<u8>,
+        /// MIME type.
+        mimetype: Option<String>,
+        /// File size in bytes.
+        size: Option<u64>,
+        /// Width in pixels.
+        width: Option<u64>,
+        /// Height in pixels.
+        height: Option<u64>,
+        /// BlurHash string.
+        blurhash: Option<String>,
+        /// Optional thumbnail.
+        thumbnail: Option<DraftThumbnail>,
+    },
+    /// Video attachment.
+    Video {
+        /// The video file data.
+        data: Vec<u8>,
+        /// MIME type.
+        mimetype: Option<String>,
+        /// File size in bytes.
+        size: Option<u64>,
+        /// Width in pixels.
+        width: Option<u64>,
+        /// Height in pixels.
+        height: Option<u64>,
+        /// Duration.
+        duration: Option<std::time::Duration>,
+        /// BlurHash string.
+        blurhash: Option<String>,
+        /// Optional thumbnail.
+        thumbnail: Option<DraftThumbnail>,
+    },
+    /// Audio attachment.
+    Audio {
+        /// The audio file data.
+        data: Vec<u8>,
+        /// MIME type.
+        mimetype: Option<String>,
+        /// File size in bytes.
+        size: Option<u64>,
+        /// Duration.
+        duration: Option<std::time::Duration>,
+    },
+    /// Generic file attachment.
+    File {
+        /// The file data.
+        data: Vec<u8>,
+        /// MIME type.
+        mimetype: Option<String>,
+        /// File size in bytes.
+        size: Option<u64>,
+    },
+}
+
+/// Thumbnail data for a draft attachment.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DraftThumbnail {
+    /// The filename of the thumbnail.
+    pub filename: String,
+    /// The thumbnail image data.
+    pub data: Vec<u8>,
+    /// MIME type of the thumbnail.
+    pub mimetype: Option<String>,
+    /// Width in pixels.
+    pub width: Option<u64>,
+    /// Height in pixels.
+    pub height: Option<u64>,
+    /// File size in bytes.
+    pub size: Option<u64>,
 }
 
 /// The type of draft of the composer.

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -23,8 +23,9 @@ pub use bytes;
 #[cfg(feature = "e2e-encryption")]
 pub use matrix_sdk_base::crypto;
 pub use matrix_sdk_base::{
-    ComposerDraft, ComposerDraftType, EncryptionState, PredecessorRoom, QueueWedgeError,
-    Room as BaseRoom, RoomCreateWithCreatorEventContent, RoomDisplayName, RoomHero, RoomInfo,
+    ComposerDraft, ComposerDraftType, DraftAttachment, DraftAttachmentContent, DraftThumbnail,
+    EncryptionState, PredecessorRoom, QueueWedgeError, Room as BaseRoom,
+    RoomCreateWithCreatorEventContent, RoomDisplayName, RoomHero, RoomInfo,
     RoomMember as BaseRoomMember, RoomMemberships, RoomRecencyStamp, RoomState, SessionMeta,
     StateChanges, StateStore, StoreError, SuccessorRoom, ThreadingSupport, deserialized_responses,
     store::{self, DynStateStore, MemoryStore, StateStoreExt},

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -4656,7 +4656,7 @@ pub struct RoomMemberWithSenderInfo {
 mod tests {
     use std::collections::BTreeMap;
 
-    use matrix_sdk_base::{ComposerDraft, store::ComposerDraftType};
+    use matrix_sdk_base::{ComposerDraft, DraftAttachment, store::ComposerDraftType};
     use matrix_sdk_test::{
         JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder, async_test,
         event_factory::EventFactory, test_json,
@@ -4852,6 +4852,14 @@ mod tests {
             plain_text: "Hello, world!".to_owned(),
             html_text: Some("<strong>Hello</strong>, world!".to_owned()),
             draft_type: ComposerDraftType::NewMessage,
+            attachments: vec![DraftAttachment {
+                filename: "cat.txt".to_owned(),
+                content: matrix_sdk_base::DraftAttachmentContent::File {
+                    data: b"meow".to_vec(),
+                    mimetype: Some("text/plain".to_owned()),
+                    size: Some(5),
+                },
+            }],
         };
 
         room.save_composer_draft(draft.clone(), None).await.unwrap();
@@ -4861,6 +4869,14 @@ mod tests {
             plain_text: "Hello, thread!".to_owned(),
             html_text: Some("<strong>Hello</strong>, thread!".to_owned()),
             draft_type: ComposerDraftType::NewMessage,
+            attachments: vec![DraftAttachment {
+                filename: "dog.txt".to_owned(),
+                content: matrix_sdk_base::DraftAttachmentContent::File {
+                    data: b"wuv".to_vec(),
+                    mimetype: Some("text/plain".to_owned()),
+                    size: Some(4),
+                },
+            }],
         };
 
         room.save_composer_draft(thread_draft.clone(), Some(&thread_root)).await.unwrap();


### PR DESCRIPTION
This adds support for storing attachments with composer drafts. The API allows for multiple attachments in the draft. I believe this is ok, because the SDK doesn't provide more functionality than saving and loading the draft. It is up to the consuming client to decide how to use it. It may limit its usage to a single attachment, send multiple attachments as individual events or use [MSC4274](https://github.com/matrix-org/matrix-spec-proposals/pull/4274) galleries.

- [x] Public API changes documented in changelogs (optional)