### PR TITLE
chore(sqlite): Don't log the room ID twice when saving events

### DIFF
--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -1332,7 +1332,7 @@ impl EventCacheStore for SqliteEventCacheStore {
         let _timer = timer!("method");
 
         let Some(event_id) = event.event_id() else {
-            error!(%room_id, "Trying to save an event with no ID");
+            error!("Trying to save an event with no ID");
             return Ok(());
         };
 


### PR DESCRIPTION
The room ID is already logged as part of the span due to the instrument attribute.