### PR TITLE
Revert "fix: Allow /versions requests to refresh the token"

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1956,8 +1956,7 @@ impl Client {
         request_config: Option<RequestConfig>,
     ) -> HttpResult<get_supported_versions::Response> {
         let server_versions = self
-            .send(get_supported_versions::Request::new())
-            .with_request_config(request_config)
+            .send_inner(get_supported_versions::Request::new(), request_config, Default::default())
             .await?;
 
         Ok(server_versions)


### PR DESCRIPTION
This reverts commit 05b40af2c1e07029244e110758413cdd412f9a66.

Turns out that this causes a deadlock, not fully understanding why but let's revert first.