### PR TITLE
xtask: Workaround UniFFI's noHandle generation for Swift.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7466,6 +7466,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "fs_extra",
+ "regex",
  "serde",
  "serde_json",
  "uniffi_bindgen",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,6 +17,7 @@ cargo_metadata = "0.19.0"
 camino = "1.0.8"
 clap = { version = "4.0.18", features = ["derive"] }
 fs_extra = "1"
+regex = "1"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 uniffi_bindgen.workspace = true


### PR DESCRIPTION
Replaces https://github.com/element-hq/matrix-rust-components-swift/commit/3f0075fb8acaf202755512dfbafc28024e5125b2, not really sure why I didn't just do it here in the first place…

It shouldn't need to stay for long, there's already a [PR](https://github.com/mozilla/uniffi-rs/pull/2720) open but this unblocks Swift SDK users for now.