### PR TITLE
Fix up changelogs incorrectly updated since 0.14.0

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -67,6 +67,8 @@ All notable changes to this project will be documented in this file.
 - Add `Room::load_or_fetch_event` so we can get a `TimelineEvent` given its event id ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678)).
 - Add `TimelineEvent::thread_root_event_id` to expose the thread root event id for this type too ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678)).
 - Add `NotificationSettings::get_raw_push_rules` so clients can fetch the raw JSON content of the push rules of the current user and include it in bug reports ([#5706](https://github.com/matrix-org/matrix-rust-sdk/pull/5706)).
+- Add new API to decline calls ([MSC4310](https://github.com/matrix-org/matrix-spec-proposals/pull/4310)): `Room::decline_call` and `Room::subscribe_to_call_decline_events`
+  ([#5614](https://github.com/matrix-org/matrix-rust-sdk/pull/5614))
 
 ## [0.14.0] - 2025-09-04
 
@@ -97,8 +99,6 @@ All notable changes to this project will be documented in this file.
   This is primarily for Element X to give a dedicated error message in case
   it connects a homeserver with only this method available.
   ([#5222](https://github.com/matrix-org/matrix-rust-sdk/pull/5222))
-- Add new API to decline calls ([MSC4310](https://github.com/matrix-org/matrix-spec-proposals/pull/4310)): `Room::decline_call` and `Room::subscribe_to_call_decline_events`
-  ([#5614](https://github.com/matrix-org/matrix-rust-sdk/pull/5614))
 
 ### Breaking changes:
 

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -23,6 +23,10 @@ All notable changes to this project will be documented in this file.
   - `OlmMachine::receive_room_key_bundle` now appends withheld key information to the store.
   - [**breaking**] `Changes::withheld_session_info` now stores a `RoomKeyWithheldEntry` in each `room-id`-`session-id` entry.
   - [**breaking**] `CryptoStore::get_withheld_info` now returns `Result<Option<RoomKeyWithheldEntry>>`. This change also affects `MemoryStore`.
+- [**breaking**] Add `name` fields to some of the variants of
+  `store::SecretImportError` to indicate what secret was being imported when the
+  error occurred.
+  ([#5647](https://github.com/matrix-org/matrix-rust-sdk/pull/5647))
 
 ### Bug Fixes
 
@@ -37,10 +41,6 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- [**breaking**] Add `name` fields to some of the variants of
-  `store::SecretImportError` to indicate what secret was being imported when the
-  error occurred.
-  ([#5647](https://github.com/matrix-org/matrix-rust-sdk/pull/5647))
 - Log message index for Megolm sessions received over encrypted to-device messages. ([#5599](https://github.com/matrix-org/matrix-rust-sdk/pull/5599))
 - Add `RoomSettings::encrypt_state_events` flag. ([#5511](https://github.com/matrix-org/matrix-rust-sdk/pull/5511))
 - Make sure to accept historic room key bundles only if the sender is trusted


### PR DESCRIPTION
All of these entries have been incorrectly added to the changelogs *since* 0.14.0 was released :(