### PR TITLE
crypto: correct UtdCause for unshared historical messages

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
   ([#5819](https://github.com/matrix-org/matrix-rust-sdk/pull/5819))
 - Use new withheld code in key bundles for sessions not marked as
   `shared_history`.
-  ([#5807](https://github.com/matrix-org/matrix-rust-sdk/pull/5807)
+  ([#5807](https://github.com/matrix-org/matrix-rust-sdk/pull/5807), ([#5834](https://github.com/matrix-org/matrix-rust-sdk/pull/5834))
 - Improve feedback support for shared history when downloading room key
   bundles.
   ([#5737](https://github.com/matrix-org/matrix-rust-sdk/pull/5737))

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/shared_history.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/shared_history.rs
@@ -23,6 +23,7 @@ use matrix_sdk::{
     },
     timeout::timeout,
 };
+use matrix_sdk_base::crypto::types::events::UtdCause;
 use matrix_sdk_common::deserialized_responses::{
     ProcessedToDeviceEvent, UnableToDecryptReason::MissingMegolmSession, WithheldCode,
 };
@@ -659,8 +660,7 @@ async fn assert_utd_history_not_shared(timeline: &Timeline, event_id: &EventId) 
     assert_let!(EncryptedMessage::MegolmV1AesSha2 { cause, .. } = encrypted);
     // It should be reported in the UI as a regular "You don't have access to this
     // event".
-    // FIXME: this doesn't work yet.
-    // assert_eq!(*cause, UtdCause::SentBeforeWeJoined);
+    assert_eq!(*cause, UtdCause::SentBeforeWeJoined);
 
     // The timeline interface doesn't expose the raw withheld code, so call
     // `Room::event` to find it.


### PR DESCRIPTION
Per https://github.com/element-hq/element-meta/issues/2876, we want messages where the history was not shared to appear the same as regular  "historical" messages.