### PR TITLE
feat(ffi): add sender and room information to sync notifications

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -64,6 +64,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add push actions to `NotificationItem` and replace `SyncNotification` with `NotificationItem`.
+  ([#5835](https://github.com/matrix-org/matrix-rust-sdk/pull/5835))
 - Add `Client::new_grant_login_with_qr_code_handler` for granting login to a new device by way of
   a QR code.
   ([#5836](https://github.com/matrix-org/matrix-rust-sdk/pull/5836))

--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -51,6 +51,9 @@ pub struct NotificationItem {
     pub is_noisy: Option<bool>,
     pub has_mention: Option<bool>,
     pub thread_id: Option<String>,
+
+    /// The push actions for this notification (notify, sound, highlight, etc.).
+    pub actions: Option<Vec<crate::notification_settings::Action>>,
 }
 
 impl NotificationItem {
@@ -83,6 +86,9 @@ impl NotificationItem {
             is_noisy: item.is_noisy,
             has_mention: item.has_mention,
             thread_id: item.thread_id.map(|t| t.to_string()),
+            actions: item
+                .actions
+                .map(|a| a.into_iter().filter_map(|action| action.try_into().ok()).collect()),
         }
     }
 }

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased] - ReleaseDate
 
 ### Features
+
+- Add push actions to `NotificationItem`.
+  ([#5835](https://github.com/matrix-org/matrix-rust-sdk/pull/5835))
 - Add support for top level space ordering through [MSC3230](https://github.com/matrix-org/matrix-spec-proposals/pull/3230)
   and `m.space_order` room account data fields ([#5799](https://github.com/matrix-org/matrix-rust-sdk/pull/5799))
 

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -889,6 +889,9 @@ pub struct NotificationItem {
     pub is_noisy: Option<bool>,
     pub has_mention: Option<bool>,
     pub thread_id: Option<OwnedEventId>,
+
+    /// The push actions for this notification (notify, sound, highlight, etc.).
+    pub actions: Option<Vec<Action>>,
 }
 
 impl NotificationItem {
@@ -982,6 +985,7 @@ impl NotificationItem {
             is_noisy,
             has_mention,
             thread_id,
+            actions: push_actions.map(|actions| actions.to_vec()),
         };
 
         Ok(item)


### PR DESCRIPTION
This builds upon #5831 and enriches sync notifications with the same sender and room information already present on `NotificationItem`.

- [x] Public API changes documented in changelogs (optional)
