### PR TITLE
feat(ffi): add bindings for granting login with a QR code

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking changes
 
+- Rename `Client::login_with_qr_code` to `Client::new_login_with_qr_code_handler`.
+  ([#5836](https://github.com/matrix-org/matrix-rust-sdk/pull/5836))
 - Add the `sqlite` feature, along with the `indexeddb` feature, to enable either
   the SQLite or IndexedDB store. The `session_paths`, `session_passphrase`,
   `session_pool_max_size`, `session_cache_size` and `session_journal_size_limit`
@@ -62,6 +64,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add `Client::new_grant_login_with_qr_code_handler` for granting login to a new device by way of
+  a QR code.
+  ([#5836](https://github.com/matrix-org/matrix-rust-sdk/pull/5836))
 - Add `Client::register_notification_handler` for observing notifications generated from sync responses.
   ([#5831](https://github.com/matrix-org/matrix-rust-sdk/pull/5831))
 - Add `Room::mark_as_fully_read_unchecked` so clients can mark a room as read without needing a `Timeline` instance. Note this method is not recommended as it can potentially cause incorrect read receipts, but it can needed in certain cases.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -104,7 +104,7 @@ use crate::{
     encryption::Encryption,
     notification::{NotificationClient, NotificationEvent},
     notification_settings::NotificationSettings,
-    qr_code::LoginWithQrCodeHandler,
+    qr_code::{GrantLoginWithQrCodeHandler, LoginWithQrCodeHandler},
     room::{RoomHistoryVisibility, RoomInfoListener, RoomSendQueueUpdate},
     room_directory_search::RoomDirectorySearch,
     room_preview::RoomPreview,
@@ -576,17 +576,24 @@ impl Client {
         Ok(())
     }
 
-    /// Log in using a QR code.
+    /// Create a handler for requesting an existing device to grant login to
+    /// this device by way of a QR code.
     ///
     /// # Arguments
     ///
     /// * `oidc_configuration` - The data to restore or register the client with
     ///   the server.
-    pub fn login_with_qr_code(
+    pub fn new_login_with_qr_code_handler(
         self: Arc<Self>,
         oidc_configuration: OidcConfiguration,
     ) -> LoginWithQrCodeHandler {
         LoginWithQrCodeHandler::new(self.inner.oauth(), oidc_configuration)
+    }
+
+    /// Create a handler for granting login from this device to a new device by
+    /// way of a QR code.
+    pub fn new_grant_login_with_qr_code_handler(self: Arc<Self>) -> GrantLoginWithQrCodeHandler {
+        GrantLoginWithQrCodeHandler::new(self.inner.oauth())
     }
 
     /// Restores the client from a `Session`.


### PR DESCRIPTION
This adds FFI bindings for the two flows of granting login to a new device by way of a QR code.

- [x] Public API changes documented in changelogs (optional)

