### PR TITLE
refactor(common): Provide a unified, solid API between `try_lock_once` and `spin_lock` on `CrossProcessLock`

### DIFF
--- a/crates/matrix-sdk-base/src/media/store/mod.rs
+++ b/crates/matrix-sdk-base/src/media/store/mod.rs
@@ -82,6 +82,12 @@ impl MediaStoreError {
     }
 }
 
+impl From<MediaStoreError> for CrossProcessLockError {
+    fn from(value: MediaStoreError) -> Self {
+        Self::TryLock(Box::new(value))
+    }
+}
+
 /// An `MediaStore` specific result type.
 pub type Result<T, E = MediaStoreError> = std::result::Result<T, E>;
 
@@ -127,7 +133,7 @@ impl MediaStoreLock {
 
     /// Acquire a spin lock (see [`CrossProcessLock::spin_lock`]).
     pub async fn lock(&self) -> Result<MediaStoreLockGuard<'_>, CrossProcessLockError> {
-        let cross_process_lock_guard = self.cross_process_lock.spin_lock(None).await?;
+        let cross_process_lock_guard = self.cross_process_lock.spin_lock(None).await??.into_guard();
 
         Ok(MediaStoreLockGuard { cross_process_lock_guard, store: self.store.deref() })
     }


### PR DESCRIPTION
This patch changes the signature of `CrossProcessLock::try_lock_once`. It was returning a:

```rust
Result<CrossProcessLockResult, CrossProcessLockError>
```

Now it returns a:

```rust
Result<Result<CrossProcessLockKind, CrossProcessLockUnobtained>, L::LockError>
```

We will explain these new types in a moment.

This patch also changes the signature of `CrossProcessLock::spin_lock`. It was returning a:

```rust
Result<CrossProcessLockGuard, CrossProcessLockError>
```

Now it returns a:

```rust
Result<Result<CrossProcessLockKind, CrossProcessLockUnobtained>, L::LockError>
```

First off, we notice that the returned types are now unified. The `CrossProcessLockResult` type has been renamed `CrossProcessLockKind` and lives in a `Result::Ok`. The `CrossProcessLockResult::Unobtained` variant has been removed, but `CrossProcessLockUnobtainedReason` has been renamed to `CrossProcessLockUnobtained` and lives in a `Result::Err`.

Second, the `CrossProcessLockError` now is a union type between `CrossProcessLockUnobtained` and `TryLock::LockError`. It's not used by `try_lock_once` or `spin_lock`, but only by the code using the cross-process lock to provide a unified error type.

The ideas behind these changes are:

- it's easy to forward an error from the `TryLock`,
- it's difficult to ignore the `Clean` vs. `Dirty` state of the lock guard,
- unified API with clearly separated responsibility (the first `Result` vs. the second `Result`).

Note: the `CrossProcessLockKind::into_guard` method aims at being removed. It's useful now to maintain compatibility but it's “dangerous” as it makes trivial to skip `Clean` vs. `Dirty` states. We ultimately don't want that.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4874