### PR TITLE
doc(sdk): Remove a dead reference in the doc

### DIFF
--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -229,8 +229,6 @@ impl EventLinkedChunk {
     /// Be careful that each `VectorDiff` is returned only once!
     ///
     /// See [`AsVector`] to learn more.
-    ///
-    /// [`Update`]: matrix_sdk_base::linked_chunk::Update
     pub fn updates_as_vector_diffs(&mut self) -> Vec<VectorDiff<Event>> {
         let updates = self.chunks_updates_as_vectordiffs.take();
 


### PR DESCRIPTION
This patch removes the reference to `Update`, that is no longer required.