### PR TITLE
refactor(oauth): remove superfluous join in QR login tests

### DIFF
--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
@@ -485,7 +485,7 @@ impl<'a> LoginWithGeneratedQrCode<'a> {
 #[cfg(all(test, not(target_family = "wasm")))]
 mod test {
     use assert_matches2::{assert_let, assert_matches};
-    use futures_util::{StreamExt, join};
+    use futures_util::StreamExt;
     use matrix_sdk_base::crypto::types::{SecretsBundle, qr_login::QrCodeModeData};
     use matrix_sdk_common::executor::spawn;
     use matrix_sdk_test::async_test;
@@ -644,15 +644,10 @@ mod test {
         let alice_task =
             spawn(async { grant_login(alice, receiver, AliceBehaviour::HappyPath).await });
 
-        join!(
-            async {
-                login_bob.await.expect("Bob should be able to login");
-            },
-            async {
-                alice_task.await.expect("Alice should have completed it's task successfully");
-            },
-            async { updates_task.await.unwrap() }
-        );
+        // Wait for all tasks to finish.
+        login_bob.await.expect("Bob should be able to login");
+        alice_task.await.expect("Alice should have completed it's task successfully");
+        updates_task.await.unwrap();
 
         assert!(bob.encryption().cross_signing_status().await.unwrap().is_complete());
         let own_identity =
@@ -832,11 +827,10 @@ mod test {
             .await
         });
 
-        join!(
-            async { bob_login.await.expect("Bob should be able to login") },
-            async { alice_task.await.expect("Alice should have completed it's task successfully") },
-            async { updates_task.await.unwrap() }
-        );
+        // Wait for all tasks to finish.
+        bob_login.await.expect("Bob should be able to login");
+        alice_task.await.expect("Alice should have completed it's task successfully");
+        updates_task.await.unwrap();
 
         assert!(bob.encryption().cross_signing_status().await.unwrap().is_complete());
         let own_identity =
@@ -937,11 +931,10 @@ mod test {
             .await
         });
 
-        join!(
-            async { bob_login.await.expect("Bob should be able to login") },
-            async { alice_task.await.expect("Alice should have completed it's task successfully") },
-            async { updates_task.await.unwrap() }
-        );
+        // Wait for all tasks to finish.
+        bob_login.await.expect("Bob should be able to login");
+        alice_task.await.expect("Alice should have completed it's task successfully");
+        updates_task.await.unwrap();
 
         assert!(bob.encryption().cross_signing_status().await.unwrap().is_complete());
         let own_identity =


### PR DESCRIPTION
As discussed in https://github.com/matrix-org/matrix-rust-sdk/pull/5840#discussion_r2505232877, the `join`s are not needed because two of the `await`ed tasks were already `spawn`ed.

- [X] Public API changes documented in changelogs (optional)
