### PR TITLE
fix(base): Remove a panic in a log

### DIFF
--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -548,8 +548,8 @@ pub(crate) async fn cache_latest_events(
             }
         } else {
             warn!(
-                "Failed to deserialize event as AnySyncTimelineEvent. ID={}",
-                event.event_id().expect("Event has no ID!")
+                event_id = ?event.event_id(),
+                "Failed to deserialize event as `AnySyncTimelineEvent`",
             );
         }
     }


### PR DESCRIPTION
We must not panic if the event has no event ID.