### PR TITLE
fix(ui): Undo an optimisation to start at `SettingUp`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -219,17 +219,7 @@ impl RoomListService {
         // Eagerly subscribe the event cache to sync responses.
         client.event_cache().subscribe()?;
 
-        let state_machine = StateMachine::new();
-
-        // If the sliding sync has successfully restored a sync position, skip the
-        // waiting for the initial sync, and set the state to `SettingUp`; this
-        // way, the first sync will move us to the steady state, and update the
-        // sliding sync list to use the growing sync mode.
-        if sliding_sync.has_pos().await {
-            state_machine.set(State::SettingUp);
-        }
-
-        Ok(Self { client, sliding_sync, state_machine })
+        Ok(Self { client, sliding_sync, state_machine: StateMachine::new() })
     }
 
     /// Start to sync the room list.

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -1293,15 +1293,14 @@ async fn test_loading_states() -> Result<(), Error> {
             RoomListLoadingState::Loaded { maximum_number_of_rooms: Some(12) }
         );
 
-        // The sync skips the `Init` state, and immediately starts in the `SettingUp`
-        // state, as the sync `pos`ition marker was set.
+        // The sync starts at the `Init` state but the `pos` marker is set to 3.
         sync_then_assert_request_and_fake_response! {
             [server, room_list, sync]
-            states = SettingUp => Running,
+            states = Init => SettingUp,
             assert request >= {
                 "lists": {
                     ALL_ROOMS: {
-                        "ranges": [[0, 11]],
+                        "ranges": [[0, 19]],
                         "timeline_limit": 1,
                     },
                 },

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -123,12 +123,6 @@ impl SlidingSync {
         Self { inner: Arc::new(inner) }
     }
 
-    /// Whether the current sliding sync instance has set a sync position
-    /// marker.
-    pub async fn has_pos(&self) -> bool {
-        self.inner.position.lock().await.pos.is_some()
-    }
-
     async fn cache_to_storage(&self, position: &SlidingSyncPositionMarkers) -> Result<()> {
         cache::store_sliding_sync_state(self, position).await
     }


### PR DESCRIPTION
This patch undo an optimisation that was initialising the `RoomListService` at the `SettingUp` state if a `pos` value was recovered successfully (see bbf9bf2c0be026c2bcf237f48953918057a1e15c from https://github.com/matrix-org/matrix-rust-sdk/pull/4741). The problem is that it starts with a range of 0..99 instead of 0..19, which can slow things done in particular cases. Whilst a good idea on paper, it's not in practise. So let's continue to recover the `pos`, but let's keep starting at the `Init` state.
