### PR TITLE
feat(timeline): utilize the cache and include common relations when focusing on an event without context

### DIFF
--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Utilize the cache and include common relations when focusing a timeline on an event without
+  requestion context.
+  ([#5858](https://github.com/matrix-org/matrix-rust-sdk/pull/5858))
 - [**breaking**] `EventTimelineItem::get_shield` now returns a new type,
   `TimelineEventShieldState`, which extends the old `ShieldState` with a code
   for `SentInClear`, now that the latter has been removed from `ShieldState`.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -1859,7 +1859,7 @@ async fn test_permalink_doesnt_listen_to_thread_sync() {
     let timeline = TimelineBuilder::new(&room)
         .with_focus(TimelineFocus::Event {
             target: owned_event_id!("$target"),
-            num_context_events: 0,
+            num_context_events: 2,
             hide_threaded_events: true,
         })
         .build()


### PR DESCRIPTION
At the moment, `TimelineController::init_focus` doesn't use the event cache at all in the `TimelineFocus::Event` arm. I believe this is because the cache currently cannot load surrounding context for an event. However, when no context is requested, meaning `num_context_events = 0`, this result in a potentially superfluous `/context` request.

This pull request, differentiates this special case and attempts to load the event from the cache before falling back to the server.

Additionally, common relations (reactions & edits) are included, if possible. This is similar to the behavior in the `TimelineFocus::PinnedEvents` arm and allows using focused timelines to power event details views.

Open questions:

- Given the similarity to the `TimelineFocus::PinnedEvents` behavior, I'm not sure if it might be better to generalize `TimelineFocus::PinnedEvents` to support both cases.
- It would be great if `TimelineFocus::Event` would make use of the event cache regardless of whether context was requested or not. I'm not sure if that's feasibly possible though.

- [x] Public API changes documented in changelogs (optional)
