### PR TITLE
Use MSRV-aware resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["testing/data"]
 # xtask, testing and the bindings should only be built when invoked explicitly.
 default-members = ["benchmarks", "crates/*", "labs/*"]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 rust-version = "1.88"


### PR DESCRIPTION
After this, `cargo update` will take `rust-version` into account.

Signed-off-by: Jonas Platte
