### PR TITLE
Improve the wording of error messages when redecryption fails

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -481,10 +481,7 @@ async fn decrypt_by_index<P: RoomDataProvider, D: Decryptor>(
             match decryptor.decrypt_event_impl(original_json, push_ctx).await {
                 Ok(event) => {
                     if let SdkTimelineEventKind::UnableToDecrypt { utd_info, .. } = event.kind {
-                        info!(
-                            "Failed to decrypt event after receiving room key: {:?}",
-                            utd_info.reason
-                        );
+                        info!("Failed to redecrypt event. Reason: {:?}", utd_info.reason);
                         None
                     } else {
                         // Notify observers that we managed to eventually decrypt an event.
@@ -496,7 +493,7 @@ async fn decrypt_by_index<P: RoomDataProvider, D: Decryptor>(
                     }
                 }
                 Err(e) => {
-                    info!("Failed to decrypt event after receiving room key: {e}");
+                    info!("Encountered an error while redecrypting event: {e}");
                     None
                 }
             }


### PR DESCRIPTION
The previous message implied that we had received a session for this message, but that is only one of the several reasons we might encounter this situation. If redecryption failed, it is more likely we got here because we'd been asked to attempt redecryption for all UTDs e.g. when we build a new timeline.

Additionally, having similar wording for the error case and the unable to decrypt case could also cause confusion, so I adjusted the wording to make clear which situation is happening.