### PR TITLE
sdk: improve logging for received history bundles

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Improve logging around key history bundles when joining a room.
+  ([#5866](https://github.com/matrix-org/matrix-rust-sdk/pull/5866))
 - Expose the power level required to modify `m.space.child` on
   `room::power_levels::RoomPowerLevelChanges`.
   ([#5857](https://github.com/matrix-org/matrix-rust-sdk/pull/5857))

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -81,7 +81,7 @@ use ruma::{
 };
 use serde::de::DeserializeOwned;
 use tokio::sync::{Mutex, OnceCell, RwLock, RwLockReadGuard, broadcast};
-use tracing::{Instrument, Span, debug, error, instrument, trace, warn};
+use tracing::{Instrument, Span, debug, error, info, instrument, trace, warn};
 use url::Url;
 
 use self::futures::SendRequest;
@@ -1581,6 +1581,7 @@ impl Client {
         room_id: &RoomId,
         pre_join_room_info: Option<PreJoinRoomInfo>,
     ) -> Result<Room> {
+        info!(?room_id, ?pre_join_room_info, "Completing room join");
         let mark_as_dm = if let Some(room) = self.get_room(room_id) {
             room.state() == RoomState::Invited
                 && room.is_direct().await.unwrap_or_else(|e| {
@@ -1651,6 +1652,7 @@ impl Client {
     ///   alias looks like `#name:example.com`.
     /// * `server_names` - The server names to be used for resolving the alias,
     ///   if needs be.
+    #[instrument(skip(self))]
     pub async fn join_room_by_id_or_alias(
         &self,
         alias: &RoomOrAliasId,

--- a/crates/matrix-sdk/src/room/shared_room_history.rs
+++ b/crates/matrix-sdk/src/room/shared_room_history.rs
@@ -128,6 +128,7 @@ pub(crate) async fn maybe_accept_key_bundle(room: &Room, inviter: &UserId) -> Re
         olm_machine.store().get_received_room_key_bundle_data(room.room_id(), inviter).await?
     else {
         // No bundle received (yet).
+        info!("No room key bundle from inviter found");
         return Ok(());
     };
 


### PR DESCRIPTION
We had an instance where a user joined a room on Element X but did not download the key bundle, so let's add some logging to help figure out what was going on.