### PR TITLE
fix(oauth): use ruma::time::instant for wasm compatibility

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -110,6 +110,10 @@ All notable changes to this project will be documented in this file.
 
 ### Bugfix
 
+- Switch QR login implementation from `std::time::Instant` to `ruma::time::Instant` which
+  is compatible with Wasm.
+  ([#5889](https://github.com/matrix-org/matrix-rust-sdk/pull/5889))
+
 ## [0.14.0] - 2025-09-04
 
 ### Features

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use eyeball::SharedObservable;
 use futures_core::Stream;
@@ -24,6 +24,7 @@ use matrix_sdk_base::{
     },
 };
 use oauth2::VerificationUriComplete;
+use ruma::time::Instant;
 use url::Url;
 #[cfg(doc)]
 use vodozemac::ecies::CheckCode;


### PR DESCRIPTION
This switches from `std::time::Instant` to `ruma::time::Instant` because the former doesn't work under Wasm.

- [x] Public API changes documented in changelogs (optional)
