### PR TITLE
Spaces: Add support for getting a flattened list of editable spaces.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/spaces.rs
+++ b/bindings/matrix-sdk-ffi/src/spaces.rs
@@ -78,6 +78,15 @@ impl SpaceService {
         })))
     }
 
+    /// Returns a flattened list containing all the spaces where the user has
+    /// permission to send `m.space.child` state events.
+    ///
+    /// Note: Unlike [`Self::joined_spaces()`], this method does not recompute
+    /// the space graph, nor does it notify subscribers about changes.
+    pub async fn editable_spaces(&self) -> Vec<SpaceRoom> {
+        self.inner.editable_spaces().await.into_iter().map(Into::into).collect()
+    }
+
     /// Returns a `SpaceRoomList` for the given space ID.
     pub async fn space_room_list(
         &self,


### PR DESCRIPTION
This PR makes 2 changes:
- Refactors the tests for Spaces to use a common `add_space_rooms` function instead of having 3 variants.
- Adds a new method to the `SpaceService` to get all of the user's joined spaces where they have the power to edit the spaces' children.