### PR TITLE
chore: Allow release branches for cargo release as well

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -13,4 +13,4 @@ tag-name = "{{prefix}}{{version}}"
 shared-version = true
 
 # Necessary to work with jujutsu
-allow-branch = ["HEAD"]
+allow-branch = ["HEAD", "release-*"]


### PR DESCRIPTION
Whoops, the previous modification removed the branches allowed by default.