### PR TITLE
refactor(sdk): Put ruma-federation-api dependency behind a feature

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -57,6 +57,7 @@ matrix-sdk = { workspace = true, features = [
     "markdown",
     "socks",
     "uniffi",
+    "federation-api",
 ] }
 matrix-sdk-base.workspace = true
 matrix-sdk-common.workspace = true

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- [**breaking**]: `Client::server_vendor_info()` requires to enable the
+  `federation-api` feature.
+  ([#5912](https://github.com/matrix-org/matrix-rust-sdk/pull/5912))
 - [**breaking**]: `Client::reset_server_info()` has been split into
   `reset_supported_versions()` and `reset_well_known()`.
   ([#5910](https://github.com/matrix-org/matrix-rust-sdk/pull/5910))

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -61,12 +61,14 @@ rustls-tls = ["reqwest/rustls-tls"]
 socks = ["reqwest/socks"]
 local-server = ["dep:axum", "dep:rand", "dep:tower"]
 sso-login = ["local-server"]
+# Enable methods that make calls to the federation API.
+federation-api = ["ruma/federation-api-c"]
 
 uniffi = ["dep:uniffi", "matrix-sdk-base/uniffi", "dep:matrix-sdk-ffi-macros"]
 
 experimental-widgets = ["dep:uuid", "experimental-send-custom-to-device"]
 
-docsrs = ["e2e-encryption", "sqlite", "indexeddb", "sso-login", "qrcode"]
+docsrs = ["e2e-encryption", "sqlite", "indexeddb", "sso-login", "qrcode", "federation-api"]
 
 # Add support for inline media galleries via msgtypes
 unstable-msc4274 = ["ruma/unstable-msc4274", "matrix-sdk-base/unstable-msc4274"]
@@ -116,7 +118,6 @@ pin-project-lite.workspace = true
 rand = { workspace = true, optional = true }
 ruma = { workspace = true, features = [
     "rand",
-    "federation-api-c",
     "unstable-msc2448",
     "unstable-msc4191",
     "unstable-msc3930",

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -73,7 +73,6 @@ use ruma::{
             user_directory::search_users,
         },
         error::FromHttpResponseError,
-        federation::discovery::get_server_version,
         path_builder::PathBuilder,
     },
     assign,
@@ -604,10 +603,13 @@ impl Client {
     /// );
     /// # anyhow::Ok(()) };
     /// ```
+    #[cfg(feature = "federation-api")]
     pub async fn server_vendor_info(
         &self,
         request_config: Option<RequestConfig>,
     ) -> HttpResult<ServerVendorInfo> {
+        use ruma::api::federation::discovery::get_server_version;
+
         let res = self
             .send_inner(get_server_version::v1::Request::new(), request_config, Default::default())
             .await?;

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -1513,6 +1513,7 @@ async fn test_room_sync_state_after() {
     assert_eq!(*member.membership(), MembershipState::Leave);
 }
 
+#[cfg(feature = "federation-api")]
 #[async_test]
 async fn test_server_vendor_info() {
     let server = MatrixMockServer::new().await;
@@ -1567,6 +1568,7 @@ async fn test_server_version_without_auth() {
         .expect("We should not fail here since we did not provide an auth token.");
 }
 
+#[cfg(feature = "federation-api")]
 #[async_test]
 async fn test_server_vendor_info_with_missing_fields() {
     let server = MatrixMockServer::new().await;


### PR DESCRIPTION
In theory clients shouldn't make requests to the server-server API. A way to work around it for this specific case would be to implement [MSC4383](https://github.com/matrix-org/matrix-spec-proposals/pull/4383).

In the meantime, clients that don't want to use `Client::server_vendor_info()` won't have to build the extra dependencies added by ruma-federation-api.

The feature is enabled for the bindings, so it isn't a breaking change for matrix-sdk-ffi.

An alternative way to avoid the extra dependencies would be to implement the endpoint in the SDK directly, since the extra dependencies of ruma-federation-api are not necessary for this endpoint. See also the discussion at https://matrix.to/#/!2Z7UlDlK4gFTCIiy2kotE0pyXM2qNp7228PZr9b87Y0/$oEV-B5fPMBgVg3JOR1Qy83DFWVyEcidfdGB0yeE0t8U?via=matrix.org&via=element.io&via=ahouansou.cz.