### PR TITLE
Sync Indicator: Don't show the indicator until the sync service is started.

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -392,11 +392,11 @@ impl RoomListService {
 
             loop {
                 let (sync_indicator, yield_delay) = match current_state {
-                    State::Init | State::SettingUp | State::Error { .. } => {
+                    State::SettingUp | State::Error { .. } => {
                         (SyncIndicator::Show, delay_before_showing)
                     }
 
-                    State::Recovering | State::Running | State::Terminated { .. } => {
+                    State::Init | State::Recovering | State::Running | State::Terminated { .. } => {
                         (SyncIndicator::Hide, delay_before_hiding)
                     }
                 };

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2714,10 +2714,11 @@ async fn test_sync_indicator() -> Result<(), Error> {
 
         // Request 1.
         {
-            // The state transitions into `Init`. The `SyncIndicator` must be `Show`.
+            // The state transitions into `Init`. The `SyncIndicator` stays in `Hide` as
+            // nothing is happening yet.
             assert_next_sync_indicator!(
                 sync_indicator,
-                SyncIndicator::Show,
+                SyncIndicator::Hide,
                 under DELAY_BEFORE_SHOWING + request_margin,
             );
         }
@@ -2726,7 +2727,8 @@ async fn test_sync_indicator() -> Result<(), Error> {
 
         // Request 2.
         {
-            // The state transitions into `SettingUp`. The `SyncIndicator` stays in `Show`.
+            // The state transitions into `SettingUp`. The `SyncIndicator` must be `Show` as
+            // the service has now been started.
             assert_next_sync_indicator!(
                 sync_indicator,
                 SyncIndicator::Show,


### PR DESCRIPTION
As part of https://github.com/element-hq/element-x-ios/issues/4786 I noticed the following sequence of events:
- The app is started without an internet connection.
- The app is aware it is offline so ignores any calls to start the sync service.
- The SDK would ask the app to show a syncing indicator even though the app isn't expecting it to sync.

In theory the app could ignore the SDK by combining the indicator state with the network reachability but it seems neater to do the right thing in the SDK and I *think*[^1] this PR does that.

[^1]: I say think because my understanding is that the state machine starts as `Init` and then immediately transitions to `SettingUp` when `SyncService::start` is called. If this isn't the case then this PR may not make any sense.