### PR TITLE
feat(sdk): Add support for the stable `m.oauth` UIAA type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4798,8 +4798,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "070c1de99c5b1fe78827abfce71b858104a2d1dae8f19029ee52cd876e8d2654"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "assign",
  "js_int",
@@ -4816,8 +4815,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2353d8d42b3aa0b58ed4187ef40fba3ed66d12c47201fd201803a122262985c"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "as_variant",
  "assign",
@@ -4840,8 +4838,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9223155004bd089d840d87a6b77dc17378657d0f597087eb0eb541a28c37e0"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "as_variant",
  "base64",
@@ -4874,8 +4871,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ad82efa481b458c37ed3bdf47404bd41c8611d15336da387a0dd1e0f088689"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4901,8 +4897,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c464d081bcd3a677b1eef2e0f5db6b796acb7f5eed0a99ba501ca1423d2590ed"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "headers",
  "http",
@@ -4923,8 +4918,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6dcd6e9823e177d15460d3cd3a413f38a2beea381f26aca1001c05cd6954ff"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4935,8 +4929,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c6b5643060beec0fc9d7acfb41d2c5d91e1591db440ff62361d178e77c35fe"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "js_int",
  "thiserror 2.0.17",
@@ -4945,8 +4938,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffb3fa639bd851add9ca8a89200e6b8e00dd54cea9b21d39e8884e71e377633"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",
@@ -4961,8 +4953,7 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146ace2cd59b60ec80d3e801a84e7e6a91e3e01d18a9f5d896ea7ca16a6b8e08"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ rand = "0.8.5"
 regex = "1.12.2"
 reqwest = { version = "0.12.24", default-features = false }
 rmp-serde = "1.3.0"
-ruma = { version = "0.14.0", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "a67081e402dce14365089b34f50489dacc9c53b5", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-arbitrary-length-ids",

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -3629,8 +3629,8 @@ impl<'a> MockEndpoint<'a, UploadCrossSigningKeysEndpoint> {
         })))
     }
 
-    /// Returns an error response with an OAuth 2.0 UIAA stage.
-    pub fn uiaa_oauth(self) -> MatrixMock<'a> {
+    /// Returns an error response with an unstable OAuth 2.0 UIAA stage.
+    pub fn uiaa_unstable_oauth(self) -> MatrixMock<'a> {
         let server_uri = self.server.uri();
         self.respond_with(ResponseTemplate::new(401).set_body_json(json!({
             "session": "dummy",
@@ -3639,6 +3639,23 @@ impl<'a> MockEndpoint<'a, UploadCrossSigningKeysEndpoint> {
             }],
             "params": {
                 "org.matrix.cross_signing_reset": {
+                    "url": format!("{server_uri}/account/?action=org.matrix.cross_signing_reset"),
+                }
+            },
+            "msg": "To reset your end-to-end encryption cross-signing identity, you first need to approve it and then try again."
+        })))
+    }
+
+    /// Returns an error response with a stable OAuth 2.0 UIAA stage.
+    pub fn uiaa_stable_oauth(self) -> MatrixMock<'a> {
+        let server_uri = self.server.uri();
+        self.respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "session": "dummy",
+            "flows": [{
+                "stages": [ "m.oauth" ]
+            }],
+            "params": {
+                "m.oauth": {
                     "url": format!("{server_uri}/account/?action=org.matrix.cross_signing_reset"),
                 }
             },

--- a/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
@@ -16,6 +16,7 @@ use assert_matches2::assert_let;
 use matrix_sdk::{encryption::CrossSigningResetAuthType, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_test::async_test;
 use ruma::api::client::uiaa;
+use similar_asserts::assert_eq;
 
 #[async_test]
 async fn test_reset_legacy_auth() {
@@ -98,17 +99,13 @@ async fn test_reset_legacy_auth_invalid_password() {
 }
 
 #[async_test]
-async fn test_reset_oauth() {
-    use assert_matches2::assert_let;
-    use matrix_sdk::{encryption::CrossSigningResetAuthType, test_utils::mocks::MatrixMockServer};
-    use similar_asserts::assert_eq;
-
+async fn test_reset_unstable_oauth() {
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().logged_in_with_oauth().build().await;
 
     assert!(
         !client.encryption().cross_signing_status().await.unwrap().is_complete(),
-        "Initially we shouldn't have any cross-signin keys",
+        "Initially we shouldn't have any cross-signing keys",
     );
 
     server.mock_upload_keys().ok().expect(1).named("Initial device keys upload").mount().await;
@@ -116,7 +113,71 @@ async fn test_reset_oauth() {
     // Return the UIAA response 5 times.
     server
         .mock_upload_cross_signing_keys()
-        .uiaa_oauth()
+        .uiaa_unstable_oauth()
+        .up_to_n_times(5)
+        .expect(5)
+        .named("Trying to upload the cross-signing keys with UIAA response")
+        .mount()
+        .await;
+
+    // And finally succeed.
+    // This works because the first mocked endpoint that matches the path is used
+    // until it is invalidated by `up_to_n_times`.
+    server
+        .mock_upload_cross_signing_keys()
+        .ok()
+        .expect(1)
+        .named("Succeeding to upload the cross-signing keys")
+        .mount()
+        .await;
+
+    server
+        .mock_upload_cross_signing_signatures()
+        .ok()
+        .expect(1)
+        .named("Final signatures upload")
+        .mount()
+        .await;
+
+    // First requests gives us a reset handle.
+    let reset_handle = client
+        .encryption()
+        .reset_cross_signing()
+        .await
+        .unwrap()
+        .expect("We should have received a reset handle");
+
+    assert_let!(CrossSigningResetAuthType::OAuth(oauth_info) = reset_handle.auth_type());
+    assert_eq!(
+        oauth_info.approval_url.as_str(),
+        format!("{}/account/?action=org.matrix.cross_signing_reset", server.uri())
+    );
+
+    // Then it retries until it succeeds.
+    reset_handle.auth(None).await.expect("We should be able to reset the cross-signing keys after some attempts, waiting for the auth issue to allow us to upload");
+
+    assert!(
+        client.encryption().cross_signing_status().await.unwrap().is_complete(),
+        "After the reset we have the cross-signing available.",
+    );
+}
+
+#[async_test]
+async fn test_reset_stable_oauth() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().logged_in_with_oauth().build().await;
+
+    assert!(
+        !client.encryption().cross_signing_status().await.unwrap().is_complete(),
+        "Initially we shouldn't have any cross-signing keys",
+    );
+
+    server.mock_upload_keys().ok().expect(1).named("Initial device keys upload").mount().await;
+
+    // Return the UIAA response 5 times.
+    server
+        .mock_upload_cross_signing_keys()
+        .uiaa_stable_oauth()
         .up_to_n_times(5)
         .expect(5)
         .named("Trying to upload the cross-signing keys with UIAA response")


### PR DESCRIPTION
By replacing the custom implementation with the one in Ruma.

It landed recently in the spec: https://github.com/matrix-org/matrix-spec/pull/2234.