### PR TITLE
fix(ffi): remove undesired network request from the client builder

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -498,21 +498,6 @@ impl ClientBuilder {
 
         let sdk_client = inner_builder.build().await?;
 
-        // Disable retries for this request to prevent it from being retried
-        // indefinitely
-        let config = sdk_client.request_config().disable_retry();
-
-        // Log server version information at info level.
-        if let Ok(server_info) = sdk_client.server_vendor_info(Some(config)).await {
-            tracing::info!(
-                server_name = %server_info.server_name,
-                version = %server_info.version,
-                "Connected to Matrix server"
-            );
-        } else {
-            tracing::warn!("Could not retrieve server version information");
-        }
-
         Ok(Arc::new(
             Client::new(
                 sdk_client,


### PR DESCRIPTION
Making network requests before actually building a client interferes with offline support, especially so in lie-fi situations. The method is exposed through FFI though and can be used at the final user's discretion (e.g. when submitting a bug report).