### PR TITLE
chore: Reduce the number of logs

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -108,8 +108,6 @@ impl EventCacheStore for IndexeddbEventCacheStore {
         key: &str,
         holder: &str,
     ) -> Result<Option<CrossProcessLockGeneration>, IndexeddbEventCacheStoreError> {
-        let _timer = timer!("method");
-
         let transaction =
             self.transaction(&[Lease::OBJECT_STORE], IdbTransactionMode::Readwrite)?;
 

--- a/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
@@ -111,8 +111,6 @@ impl MediaStore for IndexeddbMediaStore {
         key: &str,
         holder: &str,
     ) -> Result<Option<CrossProcessLockGeneration>, IndexeddbMediaStoreError> {
-        let _timer = timer!("method");
-
         let transaction = self.transaction(&[Lease::OBJECT_STORE], TransactionMode::Readwrite)?;
 
         let now = Duration::from_millis(MilliSecondsSinceUnixEpoch::now().get().into());

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use matrix_sdk_base::{cross_process_lock::CrossProcessLockGeneration, timer};
+use matrix_sdk_base::cross_process_lock::CrossProcessLockGeneration;
 use matrix_sdk_crypto::{
     olm::{
         InboundGroupSession, OutboundGroupSession, PickledInboundGroupSession,
@@ -1501,8 +1501,6 @@ impl CryptoStore for SqliteCryptoStore {
         key: &str,
         holder: &str,
     ) -> Result<Option<CrossProcessLockGeneration>> {
-        let _timer = timer!("method");
-
         let key = key.to_owned();
         let holder = holder.to_owned();
 

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -167,9 +167,6 @@ impl SqliteEventCacheStore {
     /// Acquire a connection for executing read operations.
     #[instrument(skip_all)]
     async fn read(&self) -> Result<SqliteAsyncConn> {
-        trace!("Taking a `read` connection");
-        let _timer = timer!("connection");
-
         let connection = self.pool.get().await?;
 
         // Per https://www.sqlite.org/foreignkeys.html#fk_enable, foreign key
@@ -184,9 +181,6 @@ impl SqliteEventCacheStore {
     /// Acquire a connection for executing write operations.
     #[instrument(skip_all)]
     async fn write(&self) -> Result<OwnedMutexGuard<SqliteAsyncConn>> {
-        trace!("Taking a `write` connection");
-        let _timer = timer!("connection");
-
         let connection = self.write_connection.clone().lock_owned().await;
 
         // Per https://www.sqlite.org/foreignkeys.html#fk_enable, foreign key
@@ -505,8 +499,6 @@ impl EventCacheStore for SqliteEventCacheStore {
         key: &str,
         holder: &str,
     ) -> Result<Option<CrossProcessLockGeneration>> {
-        let _timer = timer!("method");
-
         let key = key.to_owned();
         let holder = holder.to_owned();
 

--- a/crates/matrix-sdk-sqlite/src/media_store.rs
+++ b/crates/matrix-sdk-sqlite/src/media_store.rs
@@ -35,7 +35,7 @@ use tokio::{
     fs,
     sync::{Mutex, OwnedMutexGuard},
 };
-use tracing::{debug, instrument, trace};
+use tracing::{debug, instrument};
 
 use crate::{
     connection::{Connection as SqliteAsyncConn, Pool as SqlitePool},
@@ -165,9 +165,6 @@ impl SqliteMediaStore {
     // Acquire a connection for executing read operations.
     #[instrument(skip_all)]
     async fn read(&self) -> Result<SqliteAsyncConn> {
-        trace!("Taking a `read` connection");
-        let _timer = timer!("connection");
-
         let connection = self.pool.get().await?;
 
         // Per https://www.sqlite.org/foreignkeys.html#fk_enable, foreign key
@@ -182,9 +179,6 @@ impl SqliteMediaStore {
     // Acquire a connection for executing write operations.
     #[instrument(skip_all)]
     async fn write(&self) -> Result<OwnedMutexGuard<SqliteAsyncConn>> {
-        trace!("Taking a `write` connection");
-        let _timer = timer!("connection");
-
         let connection = self.write_connection.clone().lock_owned().await;
 
         // Per https://www.sqlite.org/foreignkeys.html#fk_enable, foreign key
@@ -245,8 +239,6 @@ impl MediaStore for SqliteMediaStore {
         key: &str,
         holder: &str,
     ) -> Result<Option<CrossProcessLockGeneration>> {
-        let _timer = timer!("method");
-
         let key = key.to_owned();
         let holder = holder.to_owned();
 

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -16,7 +16,7 @@ use matrix_sdk_base::{
         QueuedRequestKind, RoomLoadSettings, SentRequestKey, StoredThreadSubscription,
         ThreadSubscriptionStatus,
     },
-    timer, MinimalRoomMemberEvent, RoomInfo, RoomMemberships, RoomState, StateChanges, StateStore,
+    MinimalRoomMemberEvent, RoomInfo, RoomMemberships, RoomState, StateChanges, StateStore,
     StateStoreDataKey, StateStoreDataValue, ROOM_VERSION_FALLBACK, ROOM_VERSION_RULES_FALLBACK,
 };
 use matrix_sdk_store_encryption::StoreCipher;
@@ -459,18 +459,12 @@ impl SqliteStateStore {
     /// Acquire a connection for executing read operations.
     #[instrument(skip_all)]
     async fn read(&self) -> Result<SqliteAsyncConn> {
-        trace!("Taking a `read` connection");
-        let _timer = timer!("connection");
-
         Ok(self.pool.get().await?)
     }
 
     /// Acquire a connection for executing write operations.
     #[instrument(skip_all)]
     async fn write(&self) -> OwnedMutexGuard<SqliteAsyncConn> {
-        trace!("Taking a `write` connection");
-        let _timer = timer!("connection");
-
         self.write_connection.clone().lock_owned().await
     }
 


### PR DESCRIPTION
This patch removes some logs around the cross-process lock methods. This is called pretty often by the cross-process lock task, which pollute the log files.
