### PR TITLE
chore(ffi): The `federation-api` feature is useless

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -57,7 +57,6 @@ matrix-sdk = { workspace = true, features = [
     "markdown",
     "socks",
     "uniffi",
-    "federation-api",
 ] }
 matrix-sdk-base.workspace = true
 matrix-sdk-common.workspace = true


### PR DESCRIPTION
This patch disables the `matrix-sdk/federation-api` in `matrix-sdk-ffi` because it's no longer useful since the merge of https://github.com/matrix-org/matrix-rust-sdk/pull/5919.
