### PR TITLE
chore: Update the changelog to include the CVE and GSA references

### DIFF
--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 - Skip the serialization of custom join rules in the `RoomInfo` which prevented
   the processing of sync responses containing events with custom join rules.
-  ([#5924](https://github.com/matrix-org/matrix-rust-sdk/pull/5924))
+  ([#5924](https://github.com/matrix-org/matrix-rust-sdk/pull/5924)) (Low, [CVE-2025-66622](https://www.cve.org/CVERecord?id=CVE-2025-66622), [GHSA-jj6p-3m75-g2p3](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-jj6p-3m75-g2p3)).
 
 ### Refactor
 


### PR DESCRIPTION
This is a great CVE number, best we had so far.