### PR TITLE
chore: Remove the dead message-ids feature

### DIFF
--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Refactor
+
+- [**breaking**] The `message-ids` feature has been removed. It was already a no-op and has now
+  been eliminated entirely.
+  ([#5963](https://github.com/matrix-org/matrix-rust-sdk/pull/5963))
+
 ## [0.16.0] - 2025-12-04
 
 ### Security Fixes

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -50,9 +50,6 @@ test-send-sync = [
     "matrix-sdk-crypto?/test-send-sync",
 ]
 
-# "message-ids" feature doesn't do anything and is deprecated.
-message-ids = []
-
 # helpers for testing features build upon this
 testing = [
     "dep:assert_matches",

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file.
   used when encrypting raw events.
   ([#5936](https://github.com/matrix-org/matrix-rust-sdk/pull/5936))
 
+### Refactor
+
+- [**breaking**] The `message-ids` feature has been removed. It was already a no-op and has now
+  been eliminated entirely.
+  ([#5963](https://github.com/matrix-org/matrix-rust-sdk/pull/5963))
+
 ## [0.16.0] - 2025-12-04
 
 ### Features

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -37,9 +37,6 @@ _disable-minimum-rotation-period-ms = []
 # details.
 test-send-sync = []
 
-# "message-ids" feature doesn't do anything and is deprecated.
-message-ids = []
-
 # Testing helpers for implementations based upon this
 testing = ["matrix-sdk-test"]
 


### PR DESCRIPTION

- [x] Public API changes documented in changelogs (optional)