### PR TITLE
fix(sdk): `new_local` returns an `Option`

### DIFF
--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -2772,6 +2772,12 @@ pub struct SendReactionHandle {
 }
 
 impl SendReactionHandle {
+    /// Creates a new [`SendReactionHandle`].
+    #[cfg(test)]
+    pub(crate) fn new(room: RoomSendQueue, transaction_id: ChildTransactionId) -> Self {
+        Self { room, transaction_id }
+    }
+
     /// Abort the sending of the reaction.
     ///
     /// Will return true if the reaction could be aborted, false if it's been


### PR DESCRIPTION
Based on top of https://github.com/matrix-org/matrix-rust-sdk/pull/5968. Must be merged before.

We can't use `LatestEventValue::None` as an optional value anymore, since it erases the previous `LatestEventValue`. This patch update `LatestEventValueBuilder::new_local` to return an `Option` to handle all the cases where a local value cannot be computed.

---

* Fix https://github.com/matrix-org/matrix-rust-sdk/issues/5958
* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4112