### PR TITLE
chore(spaces): make subscriptions explicit and rename certain fields.

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -27,8 +27,8 @@ All notable changes to this project will be documented in this file.
 ### Refactor
 
 - [**breaking**] The `SpaceService` will no longer auto-subscribe to required
-  client events when invoking the `subscribe_to_joined_spaces` method and the
-  `setup` method should be used instead.
+  client events when invoking the `subscribe_to_joined_spaces` but instead do it
+  through its, now async, constructor.
   ([#5972](https://github.com/matrix-org/matrix-rust-sdk/pull/5972))
 - [**breaking**] The `SpaceService`'s `joined_spaces` method has been renamed
   `top_level_joined_spaces` and `subscribe_to_joined_spaces` to `space_service.subscribe_to_top_level_joined_spaces`

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1505,8 +1505,8 @@ impl Client {
         SyncServiceBuilder::new((*self.inner).clone(), self.utd_hook_manager.get().cloned())
     }
 
-    pub fn space_service(&self) -> Arc<SpaceService> {
-        let inner = UISpaceService::new((*self.inner).clone());
+    pub async fn space_service(&self) -> Arc<SpaceService> {
+        let inner = UISpaceService::new((*self.inner).clone()).await;
         Arc::new(SpaceService::new(inner))
     }
 

--- a/bindings/matrix-sdk-ffi/src/spaces.rs
+++ b/bindings/matrix-sdk-ffi/src/spaces.rs
@@ -52,11 +52,6 @@ impl SpaceService {
 
 #[matrix_sdk_ffi_macros::export]
 impl SpaceService {
-    /// Sets up the `SpaceService` by subscribing to necessary client events.
-    pub async fn setup(&self) {
-        self.inner.setup().await;
-    }
-
     /// Returns a list of all the top-level joined spaces. It will eagerly
     /// compute the latest version and also notify subscribers if there were
     /// any changes.

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -33,8 +33,8 @@ All notable changes to this project will be documented in this file.
 ### Refactor
 
 - [**breaking**] The `SpaceService` will no longer auto-subscribe to required
-  client events when invoking the `subscribe_to_joined_spaces` method and the
-  `setup` method should be used instead.
+  client events when invoking the `subscribe_to_joined_spaces` but instead do it
+  through its, now async, constructor.
   ([#5972](https://github.com/matrix-org/matrix-rust-sdk/pull/5972))
 - [**breaking**] The `SpaceService`'s `joined_spaces` method has been renamed
   `top_level_joined_spaces` and `subscribe_to_joined_spaces` to `space_service.subscribe_to_top_level_joined_spaces`

--- a/crates/matrix-sdk-ui/src/spaces/leave.rs
+++ b/crates/matrix-sdk-ui/src/spaces/leave.rs
@@ -116,7 +116,7 @@ mod tests {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let user_id = client.user_id().unwrap();
-        let space_service = SpaceService::new(client.clone());
+        let space_service = SpaceService::new(client.clone()).await;
         let factory = EventFactory::new().sender(user_id);
 
         server.mock_room_state_encryption().plain().mount().await;

--- a/crates/matrix-sdk-ui/src/spaces/room_list.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room_list.rs
@@ -61,7 +61,7 @@ pub enum SpaceRoomListPaginationState {
 ///
 /// # async {
 /// # let client: Client = todo!();
-/// let space_service = SpaceService::new(client.clone());
+/// let space_service = SpaceService::new(client.clone()).await;
 ///
 /// // Get a list of all the rooms in a particular space
 /// let room_list = space_service
@@ -414,7 +414,7 @@ mod tests {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let user_id = client.user_id().unwrap();
-        let space_service = SpaceService::new(client.clone());
+        let space_service = SpaceService::new(client.clone()).await;
         let factory = EventFactory::new();
 
         server.mock_room_state_encryption().plain().mount().await;
@@ -523,7 +523,7 @@ mod tests {
     async fn test_room_state_updates() {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
-        let space_service = SpaceService::new(client.clone());
+        let space_service = SpaceService::new(client.clone()).await;
 
         let parent_space_id = room_id!("!parent_space:example.org");
         let child_room_id_1 = room_id!("!1:example.org");
@@ -578,7 +578,7 @@ mod tests {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let user_id = client.user_id().unwrap();
-        let space_service = SpaceService::new(client.clone());
+        let space_service = SpaceService::new(client.clone()).await;
         let factory = EventFactory::new();
 
         server.mock_room_state_encryption().plain().mount().await;
@@ -646,7 +646,7 @@ mod tests {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let user_id = client.user_id().unwrap();
-        let space_service = SpaceService::new(client.clone());
+        let space_service = SpaceService::new(client.clone()).await;
         let factory = EventFactory::new();
 
         server.mock_room_state_encryption().plain().mount().await;
@@ -686,7 +686,7 @@ mod tests {
     async fn test_via_retrieval() {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
-        let space_service = SpaceService::new(client.clone());
+        let space_service = SpaceService::new(client.clone()).await;
 
         server.mock_room_state_encryption().plain().mount().await;
 


### PR DESCRIPTION
This series of patches extracts the client events subscription from the `subscribe_to_joined_spaces` and moves it to the (now async) constructor, as well as rename certain fields and methods to clarify what each one of them does e.g. `joined_spaces` is actually a list of `top_level_spaces`, not all the joined ones.

Best reviewed commit by commit.