### PR TITLE
Room: Add a method to set your own user's display name within a room

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -343,6 +343,14 @@ impl Room {
         Ok(avatar_url_string)
     }
 
+    pub async fn set_own_member_display_name(
+        &self,
+        display_name: Option<String>,
+    ) -> Result<(), ClientError> {
+        self.inner.set_own_member_display_name(display_name).await?;
+        Ok(())
+    }
+
     /// Get the membership details for the current user.
     ///
     /// Returns:

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add `Room::set_own_member_display_name` to set the current user's display name
+  within only the one single room (can be used for /myroomnick functionality).
+  [#5981](https://github.com/matrix-org/matrix-rust-sdk/pull/5981)
 - Sending `MessageLike` and `RawMessageLike` events through a `Room` now returns
   the used `EncryptionInfo`, if any.
   ([#5936](https://github.com/matrix-org/matrix-rust-sdk/pull/5936))


### PR DESCRIPTION
I've wanted to add this for ages now… This PR lets clients implement e.g. the `/myroomnick` slash command.

🎄🎁

