### PR TITLE
fix(search): Create key dirs if they don't exist.

### DIFF
--- a/crates/matrix-sdk-search/src/encrypted/encrypted_dir.rs
+++ b/crates/matrix-sdk-search/src/encrypted/encrypted_dir.rs
@@ -415,7 +415,7 @@ impl EncryptedMmapDirectory {
     ) -> Result<KeyBuffer, OpenDirectoryError> {
         let dir_path = key_path.parent().unwrap_or(key_path);
 
-        let _ = create_dir_all(dir_path);
+        create_dir_all(dir_path).map_err(|err| err.into_tv_err(dir_path))?;
         // Derive a AES key from our passphrase using a randomly generated salt
         // to prevent bruteforce attempts using rainbow tables.
         let (key, hmac_key, salt) = EncryptedMmapDirectory::derive_key(passphrase, pbkdf_count)


### PR DESCRIPTION
The issue is related to the encrypt_store_dir fn where, when creating the key file, it doesn't ensure that the parent directory exists first. It might be not optimal for the user of the crate to ensure in an non hacky manner, as the sdk iterates through most of its directories internally. Have a test to verify it, which can be removed later (if being merged) 

Needs a review, might not be the optimal solution as this is my first pr with the crate and am not that familiar with it (although do use it in one of my apps).