### PR TITLE
doc(base): Move a changelog entry to its correct place

### DIFF
--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add `StateStore::upsert_thread_subscriptions()` method for bulk upserts.
+  ([#5848](https://github.com/matrix-org/matrix-rust-sdk/pull/5848))
 - The `LatestEventValue::LocalHasBeenSent` variant gains a new `event_id:
   OwnedEventId` field.
   ([#5977](https://github.com/matrix-org/matrix-rust-sdk/pull/5977))
@@ -56,8 +58,6 @@ All notable changes to this project will be documented in this file.
   ([#5817](https://github.com/matrix-org/matrix-rust-sdk/pull/5817))
 - `ComposerDraft` can now store attachments alongside text messages.
   ([#5794](https://github.com/matrix-org/matrix-rust-sdk/pull/5794))
-- Add `StateStore::upsert_thread_subscriptions()` method for bulk upserts.
-  ([#5848](https://github.com/matrix-org/matrix-rust-sdk/pull/5848))
 
 ## [0.14.1] - 2025-09-10
 


### PR DESCRIPTION
Thanks @richvdh for pointing it out in https://github.com/matrix-org/matrix-rust-sdk/pull/5848#discussion_r2664450570.