### PR TITLE
feat(timeline): allow threaded timelines to be initialised with events from the server in both directions

### DIFF
--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -1757,6 +1757,21 @@ impl From<RumaRoomAccountDataEvent<UnstableMarkedUnreadEventContent>> for RoomAc
     }
 }
 
+#[derive(Debug, Clone, Copy, uniffi::Enum)]
+pub enum Direction {
+    Backward,
+    Forward,
+}
+
+impl From<Direction> for ruma::api::Direction {
+    fn from(value: Direction) -> Self {
+        match value {
+            Direction::Backward => ruma::api::Direction::Backward,
+            Direction::Forward => ruma::api::Direction::Forward,
+        }
+    }
+}
+
 #[cfg(feature = "unstable-msc4274")]
 pub use galleries::*;
 

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -211,7 +211,7 @@ impl TimelineBuilder {
         });
 
         let thread_update_join_handle =
-            if let TimelineFocus::Thread { root_event_id: root } = &focus {
+            if let TimelineFocus::Thread { root_event_id: root, .. } = &focus {
                 Some({
                     let span = info_span!(
                         parent: Span::none(),

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -35,7 +35,8 @@ use stream_assert::{assert_next_matches, assert_pending};
 
 use super::{ReadReceiptMap, TestRoomDataProvider};
 use crate::timeline::{
-    MsgLikeContent, MsgLikeKind, RoomExt, TimelineFocus, TimelineReadReceiptTracking,
+    MsgLikeContent, MsgLikeKind, RoomExt, ThreadedTimelineInitializationMode, TimelineFocus,
+    TimelineReadReceiptTracking,
     controller::TimelineSettings,
     tests::{TestTimelineBuilder, encryption::get_client},
 };
@@ -791,7 +792,10 @@ async fn test_threaded_latest_user_read_receipt() {
     let receipt_thread = ReceiptThread::Thread(thread_root.clone());
 
     let timeline = TestTimelineBuilder::new()
-        .focus(TimelineFocus::Thread { root_event_id: thread_root })
+        .focus(TimelineFocus::Thread {
+            root_event_id: thread_root,
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .settings(TimelineSettings {
             track_read_receipts: TimelineReadReceiptTracking::AllEvents,
             ..Default::default()

--- a/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
@@ -27,7 +27,8 @@ use matrix_sdk_test::{
     ALICE, JoinedRoomBuilder, TestResult, async_test, event_factory::EventFactory,
 };
 use matrix_sdk_ui::timeline::{
-    AttachmentConfig, AttachmentSource, EventSendState, MediaUploadProgress, RoomExt, TimelineFocus,
+    AttachmentConfig, AttachmentSource, EventSendState, MediaUploadProgress, RoomExt,
+    ThreadedTimelineInitializationMode, TimelineFocus,
 };
 #[cfg(feature = "unstable-msc4274")]
 use matrix_sdk_ui::timeline::{GalleryConfig, GalleryItemInfo};
@@ -119,7 +120,10 @@ async fn test_send_attachment_from_file() -> TestResult {
     // Queue sending of an attachment in the thread.
     let thread_timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: event_id.to_owned() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: event_id.to_owned(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await?;
     let config = AttachmentConfig {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -32,8 +32,9 @@ use matrix_sdk_ui::{
     Timeline,
     timeline::{
         AnyOtherFullStateEventContent, Error, EventSendState, MsgLikeKind, OtherMessageLike,
-        RedactError, RoomExt, TimelineBuilder, TimelineEventItemId, TimelineEventShieldState,
-        TimelineFocus, TimelineItemContent, VirtualTimelineItem, default_event_filter,
+        RedactError, RoomExt, ThreadedTimelineInitializationMode, TimelineBuilder,
+        TimelineEventItemId, TimelineEventShieldState, TimelineFocus, TimelineItemContent,
+        VirtualTimelineItem, default_event_filter,
     },
 };
 use ruma::{
@@ -94,7 +95,10 @@ async fn test_timeline_is_threaded() {
     {
         // A thread timeline is threaded.
         let timeline = TimelineBuilder::new(&room)
-            .with_focus(TimelineFocus::Thread { root_event_id: owned_event_id!("$thread_root") })
+            .with_focus(TimelineFocus::Thread {
+                root_event_id: owned_event_id!("$thread_root"),
+                initialization_mode: ThreadedTimelineInitializationMode::Cache,
+            })
             .build()
             .await
             .unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -26,7 +26,9 @@ use matrix_sdk_test::{
     ALICE, BOB, CAROL, JoinedRoomBuilder, RoomAccountDataTestEvent, async_test,
     event_factory::EventFactory,
 };
-use matrix_sdk_ui::timeline::{RoomExt, TimelineFocus, TimelineReadReceiptTracking};
+use matrix_sdk_ui::timeline::{
+    RoomExt, ThreadedTimelineInitializationMode, TimelineFocus, TimelineReadReceiptTracking,
+};
 use ruma::{
     MilliSecondsSinceUnixEpoch,
     api::client::receipt::create_receipt::v3::ReceiptType as CreateReceiptType,
@@ -929,7 +931,10 @@ async fn test_send_single_receipt_threaded() {
 
     let timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id.to_owned() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root_event_id.to_owned(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -10,8 +10,9 @@ use matrix_sdk_test::{
     ALICE, BOB, CAROL, JoinedRoomBuilder, async_test, event_factory::EventFactory,
 };
 use matrix_sdk_ui::timeline::{
-    Error as TimelineError, EventSendState, MsgLikeContent, MsgLikeKind, RoomExt, TimelineDetails,
-    TimelineEventItemId, TimelineFocus, TimelineItemContent,
+    Error as TimelineError, EventSendState, MsgLikeContent, MsgLikeKind, RoomExt,
+    ThreadedTimelineInitializationMode, TimelineDetails, TimelineEventItemId, TimelineFocus,
+    TimelineItemContent,
 };
 use ruma::{
     MilliSecondsSinceUnixEpoch, UInt, event_id,
@@ -1054,7 +1055,10 @@ async fn test_send_reply_enforce_thread() {
     // Starting a thread.
     let thread_timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: event_id_from_bob.to_owned() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: event_id_from_bob.to_owned(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -1155,7 +1159,10 @@ async fn test_send_reply_enforce_thread_is_reply() {
     // Starting a thread, and making an explicit reply inside the thread.
     let thread_timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: event_id_from_bob.to_owned() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: event_id_from_bob.to_owned(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -29,8 +29,8 @@ use matrix_sdk_test::{
     event_factory::EventFactory,
 };
 use matrix_sdk_ui::timeline::{
-    RoomExt as _, TimelineBuilder, TimelineDetails, TimelineEventItemId, TimelineFocus,
-    VirtualTimelineItem,
+    RoomExt as _, ThreadedTimelineInitializationMode, TimelineBuilder, TimelineDetails,
+    TimelineEventItemId, TimelineFocus, VirtualTimelineItem,
 };
 use ruma::{
     MilliSecondsSinceUnixEpoch,
@@ -79,7 +79,10 @@ async fn test_new_empty_thread() {
     let room = server.sync_joined_room(&client, room_id).await;
 
     let timeline = TimelineBuilder::new(&room)
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root_event_id,
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -161,7 +164,10 @@ async fn test_thread_backpagination() {
     let room = server.sync_joined_room(&client, room_id).await;
 
     let timeline = TimelineBuilder::new(&room)
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id.clone() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root_event_id.clone(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -729,7 +735,10 @@ async fn test_thread_filtering_for_sync() {
 
     let thread_timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id.clone() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root_event_id.clone(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -869,7 +878,10 @@ async fn test_thread_timeline_gets_related_events_from_sync() {
 
     let timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id.clone() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root_event_id.clone(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -927,7 +939,10 @@ async fn test_thread_timeline_gets_related_events_from_sync() {
     // If I open another timeline on the same thread, I still see the related event.
     let other_timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root_event_id,
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -961,7 +976,10 @@ async fn test_thread_timeline_gets_local_echoes() {
 
     let timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id.clone() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root_event_id.clone(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -1099,7 +1117,10 @@ async fn test_thread_timeline_can_send_edit() {
 
     let timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id.clone() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root_event_id.clone(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -1183,7 +1204,10 @@ async fn test_send_sticker_thread() {
 
     let timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id.clone() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root_event_id.clone(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -1261,7 +1285,10 @@ async fn test_send_poll_thread() {
 
     let timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id.clone() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root_event_id.clone(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -1352,7 +1379,10 @@ async fn test_sending_read_receipt_with_no_events_doesnt_unset_read_flag() {
     // Create a threaded timeline, with no events in it.
     let timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id.clone() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root_event_id.clone(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -1387,7 +1417,10 @@ async fn test_read_receipts() {
     // Create a threaded timeline, with no events in it.
     let timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root.clone() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root.clone(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -1547,7 +1580,10 @@ async fn test_initial_read_receipts_are_correctly_populated() {
     // Create a threaded timeline.
     let timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root.clone() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root.clone(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -1701,7 +1737,10 @@ async fn test_send_read_receipts() {
     // Create a threaded timeline.
     let timeline = room
         .timeline_builder()
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root.clone() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root.clone(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();
@@ -1927,7 +1966,10 @@ async fn test_redacted_replied_to_is_updated() {
     let room = server.sync_joined_room(&client, room_id).await;
 
     let timeline = TimelineBuilder::new(&room)
-        .with_focus(TimelineFocus::Thread { root_event_id: thread_root.to_owned() })
+        .with_focus(TimelineFocus::Thread {
+            root_event_id: thread_root.to_owned(),
+            initialization_mode: ThreadedTimelineInitializationMode::Cache,
+        })
         .build()
         .await
         .unwrap();

--- a/labs/multiverse/src/widgets/room_view/mod.rs
+++ b/labs/multiverse/src/widgets/room_view/mod.rs
@@ -16,7 +16,10 @@ use matrix_sdk::{
 };
 use matrix_sdk_ui::{
     Timeline,
-    timeline::{TimelineBuilder, TimelineFocus, TimelineItem, TimelineReadReceiptTracking},
+    timeline::{
+        ThreadedTimelineInitializationMode, TimelineBuilder, TimelineFocus, TimelineItem,
+        TimelineReadReceiptTracking,
+    },
 };
 use ratatui::{prelude::*, widgets::*};
 use tokio::{spawn, sync::OnceCell, task::JoinHandle};
@@ -151,7 +154,10 @@ impl RoomView {
         let r = room.clone();
         let task = spawn(async move {
             let timeline = TimelineBuilder::new(&r)
-                .with_focus(TimelineFocus::Thread { root_event_id: cloned_root })
+                .with_focus(TimelineFocus::Thread {
+                    root_event_id: cloned_root,
+                    initialization_mode: ThreadedTimelineInitializationMode::Cache,
+                })
                 .track_read_marker_and_receipts(TimelineReadReceiptTracking::AllEvents)
                 .build()
                 .await


### PR DESCRIPTION
This adds a enum for controlling how a timeline using `TimelineFocus::Thread` is initialised with events. It supports the following modes:

- events from the cache only (the only mode existing today)
- events loaded from `/relations` starting from the thread root up to a specified limit (for later paginating forwards)
- events loaded from `/relations` starting from the end of the thread root up to a specified limit (for later paginating backwards)

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)
