### PR TITLE
refactor(state store): remove `StateStore::upsert_thread_subscription`

### DIFF
--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- [**breaking**] The `StateStore::upsert_thread_subscription` method has been removed in favor of a
+  bulk method `StateStore::upsert_thread_subscriptions`.
 - [**breaking**] The `message-ids` feature has been removed. It was already a no-op and has now
   been eliminated entirely.
   ([#5963](https://github.com/matrix-org/matrix-rust-sdk/pull/5963))

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -993,30 +993,6 @@ impl StateStore for MemoryStore {
             .unwrap_or_default())
     }
 
-    async fn upsert_thread_subscription(
-        &self,
-        room: &RoomId,
-        thread_id: &EventId,
-        mut new: StoredThreadSubscription,
-    ) -> Result<(), Self::Error> {
-        let mut inner = self.inner.write().unwrap();
-        let room_subs = inner.thread_subscriptions.entry(room.to_owned()).or_default();
-
-        if let Some(previous) = room_subs.get(thread_id) {
-            // Nothing to do.
-            if *previous == new {
-                return Ok(());
-            }
-            if !compare_thread_subscription_bump_stamps(previous.bump_stamp, &mut new.bump_stamp) {
-                return Ok(());
-            }
-        }
-
-        room_subs.insert(thread_id.to_owned(), new);
-
-        Ok(())
-    }
-
     async fn upsert_thread_subscriptions(
         &self,
         updates: Vec<(&RoomId, &EventId, StoredThreadSubscription)>,

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -480,22 +480,6 @@ pub trait StateStore: AsyncTraitDeps {
         room: &RoomId,
     ) -> Result<Vec<DependentQueuedRequest>, Self::Error>;
 
-    /// Insert or update a thread subscription for a given room and thread.
-    ///
-    /// If the new thread subscription hasn't set a bumpstamp, and there was a
-    /// previous subscription in the database with a bumpstamp, the existing
-    /// bumpstamp is kept.
-    ///
-    /// If the new thread subscription has a bumpstamp that's lower than or
-    /// equal to a previous one, the existing subscription is kept, i.e.
-    /// this method must have no effect.
-    async fn upsert_thread_subscription(
-        &self,
-        room: &RoomId,
-        thread_id: &EventId,
-        subscription: StoredThreadSubscription,
-    ) -> Result<(), Self::Error>;
-
     /// Inserts or updates multiple thread subscriptions.
     ///
     /// If the new thread subscription hasn't set a bumpstamp, and there was a
@@ -831,15 +815,6 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
             .update_dependent_queued_request(room_id, own_transaction_id, new_content)
             .await
             .map_err(Into::into)
-    }
-
-    async fn upsert_thread_subscription(
-        &self,
-        room: &RoomId,
-        thread_id: &EventId,
-        subscription: StoredThreadSubscription,
-    ) -> Result<(), Self::Error> {
-        self.0.upsert_thread_subscription(room, thread_id, subscription).await.map_err(Into::into)
     }
 
     async fn upsert_thread_subscriptions(

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -4199,7 +4199,7 @@ impl Room {
                 // Immediately save the result into the database.
                 self.client
                     .state_store()
-                    .upsert_thread_subscription(
+                    .upsert_thread_subscriptions(vec![(
                         self.room_id(),
                         &thread_root,
                         StoredThreadSubscription {
@@ -4208,7 +4208,7 @@ impl Room {
                             },
                             bump_stamp: None,
                         },
-                    )
+                    )])
                     .await?;
 
                 Ok(())
@@ -4277,14 +4277,14 @@ impl Room {
         // Immediately save the result into the database.
         self.client
             .state_store()
-            .upsert_thread_subscription(
+            .upsert_thread_subscriptions(vec![(
                 self.room_id(),
                 &thread_root,
                 StoredThreadSubscription {
                     status: ThreadSubscriptionStatus::Unsubscribed,
                     bump_stamp: None,
                 },
-            )
+            )])
             .await?;
 
         Ok(())
@@ -4331,14 +4331,14 @@ impl Room {
         if let Some(sub) = &subscription {
             self.client
                 .state_store()
-                .upsert_thread_subscription(
+                .upsert_thread_subscriptions(vec![(
                     self.room_id(),
                     &thread_root,
                     StoredThreadSubscription {
                         status: ThreadSubscriptionStatus::Subscribed { automatic: sub.automatic },
                         bump_stamp: None,
                     },
-                )
+                )])
                 .await?;
         } else {
             // If the subscription was not found, remove it from the database.


### PR DESCRIPTION
There is `StateStore::upsert_thread_subscriptions` as a proper replacement these days.

Fixes #5974.