### PR TITLE
refactor(base): Remove unused `beacons` from `BaseRoomInfo`

### DIFF
--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -28,7 +28,6 @@ use ruma::{
     events::{
         AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, StateEventType,
         SyncStateEvent,
-        beacon_info::BeaconInfoEventContent,
         call::member::{CallMemberEventContent, CallMemberStateKey, MembershipData},
         direct::OwnedDirectUserIdentifier,
         room::{
@@ -123,9 +122,6 @@ impl Room {
 pub struct BaseRoomInfo {
     /// The avatar URL of this room.
     pub(crate) avatar: Option<MinimalStateEvent<RoomAvatarEventContent>>,
-    /// All shared live location beacons of this room.
-    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
-    pub(crate) beacons: BTreeMap<OwnedUserId, MinimalStateEvent<BeaconInfoEventContent>>,
     /// The canonical alias of this room.
     pub(crate) canonical_alias: Option<MinimalStateEvent<RoomCanonicalAliasEventContent>>,
     /// The `m.room.create` event content of this room.
@@ -192,9 +188,6 @@ impl BaseRoomInfo {
     /// Returns true if the event modified the info, false otherwise.
     pub fn handle_state_event(&mut self, ev: &AnySyncStateEvent) -> bool {
         match ev {
-            AnySyncStateEvent::BeaconInfo(b) => {
-                self.beacons.insert(b.state_key().clone(), b.into());
-            }
             // No redacted branch - enabling encryption cannot be undone.
             AnySyncStateEvent::RoomEncryption(SyncStateEvent::Original(encryption)) => {
                 self.encryption = Some(encryption.content.clone());
@@ -404,7 +397,6 @@ impl Default for BaseRoomInfo {
     fn default() -> Self {
         Self {
             avatar: None,
-            beacons: BTreeMap::new(),
             canonical_alias: None,
             create: None,
             dm_targets: Default::default(),

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -14,10 +14,7 @@
 
 //! Data migration helpers for StateStore implementations.
 
-use std::{
-    collections::{BTreeMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashSet, sync::Arc};
 
 use matrix_sdk_common::deserialized_responses::TimelineEvent;
 use ruma::{
@@ -200,7 +197,6 @@ impl BaseRoomInfoV1 {
 
         Box::new(BaseRoomInfo {
             avatar,
-            beacons: BTreeMap::new(),
             canonical_alias,
             create,
             dm_targets: converted_dm_targets,


### PR DESCRIPTION
This field was added already unused in the initial PR https://github.com/matrix-org/matrix-rust-sdk/pull/3741 for live location sharing. By "unused" I mean that it is written to but never read.

The follow up live location PRs didn't make use of it either:

- https://github.com/matrix-org/matrix-rust-sdk/pull/3771
- https://github.com/matrix-org/matrix-rust-sdk/pull/3794
- https://github.com/matrix-org/matrix-rust-sdk/pull/4025

Note that it is not exposed in the public API so no one can use it outside of the crate.

Maybe ping @torrybr which added this field, to clarify what it was intended to be used for in the first place, or if it is still intended to be used but the feature hasn't been implemented yet?
