### PR TITLE
Spaces: Add a method to reset a SpaceRoomList.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/spaces.rs
+++ b/bindings/matrix-sdk-ffi/src/spaces.rs
@@ -156,7 +156,7 @@ impl SpaceService {
     }
 }
 
-/// The `SpaceRoomList`represents a paginated list of direct rooms
+/// The `SpaceRoomList` represents a paginated list of direct rooms
 /// that belong to a particular space.
 ///
 /// It can be used to paginate through the list (and have live updates on the
@@ -248,6 +248,18 @@ impl SpaceRoomList {
     /// yet. Otherwise it no-ops.
     pub async fn paginate(&self) -> Result<(), ClientError> {
         self.inner.paginate().await.map_err(ClientError::from)
+    }
+
+    /// Clears the room list back to its initial state so that any new changes
+    /// to the hierarchy will be included the next time [`Self::paginate`] is
+    /// called.
+    ///
+    /// This is useful when you've added or removed children from the space as
+    /// the list is based on a cached state that lives server-side, meaning
+    /// the /hierarchy request needs to be restarted from scratch to pick up
+    /// the changes.
+    pub async fn reset(&self) {
+        self.inner.reset().await;
     }
 }
 


### PR DESCRIPTION
We now have the ability to add/remove space children in #5871, however as the `SpaceRoomList` is based on `/hierarchy` it isn't aware of any changes made by the space service. This PR helps by making a way to reset the list so that the next `paginate()` call starts from the beginning again.

Whilst we could listen for `m.space.child`/`parent` events in the sync loop, this wouldn't help if you removed a room where you aren't a member.