### PR TITLE
Spaces: Remove the redundant LeaveSpaceRoom.joined_members_count property

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -13,8 +13,8 @@ All notable changes to this project will be documented in this file.
   ignored if they matched the default power level values specified by the spec: these may not be 
   the same in the homeserver and result in rooms with incorrect power levels being created.
   ([#6034](https://github.com/matrix-org/matrix-rust-sdk/pull/6034))
-- Fix the `is_last_admin` check in `LeaveSpaceRoom` since it was not 
-  accounting for the membership state. Also added the joined_members_count.
+- Fix the `is_last_admin` check in `LeaveSpaceRoom` since it was not
+  accounting for the membership state.
   [#6032](https://github.com/matrix-org/matrix-rust-sdk/pull/6032)
 - [**breaking**] `LatestEventValue::Local { is_sending: bool }` is replaced
   by [`state: LatestEventValueLocalState`] to represent 3 states: `IsSending`,

--- a/bindings/matrix-sdk-ffi/src/spaces.rs
+++ b/bindings/matrix-sdk-ffi/src/spaces.rs
@@ -512,17 +512,11 @@ pub struct LeaveSpaceRoom {
     /// Whether the user is the last admin in the room. This helps clients
     /// better inform the user about the consequences of leaving the room.
     is_last_admin: bool,
-    /// The amount of joined members in the room.
-    joined_members_count: u64,
 }
 
 impl From<UILeaveSpaceRoom> for LeaveSpaceRoom {
     fn from(room: UILeaveSpaceRoom) -> Self {
-        LeaveSpaceRoom {
-            space_room: room.space_room.into(),
-            is_last_admin: room.is_last_admin,
-            joined_members_count: room.joined_members_count,
-        }
+        LeaveSpaceRoom { space_room: room.space_room.into(), is_last_admin: room.is_last_admin }
     }
 }
 

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-- Fix the `is_last_admin` check in `LeaveSpaceRoom` since it was not 
-  accounting for the membership state. Also added the `joined_members_count`.
+- Fix the `is_last_admin` check in `LeaveSpaceRoom` since it was not
+  accounting for the membership state.
   [#6032](https://github.com/matrix-org/matrix-rust-sdk/pull/6032)
 - [**breaking**] `LatestEventValue::Local { is_sending: bool }` is replaced
   by [`state: LatestEventValueLocalState`] to represent 3 states: `IsSending`,

--- a/crates/matrix-sdk-ui/src/spaces/leave.rs
+++ b/crates/matrix-sdk-ui/src/spaces/leave.rs
@@ -27,8 +27,6 @@ pub struct LeaveSpaceRoom {
     /// Whether the user is the last admin in the room. This helps clients
     /// better inform the user about the consequences of leaving the room.
     pub is_last_admin: bool,
-    /// The amount of joined members in the room.
-    pub joined_members_count: u64,
 }
 
 /// The `LeaveSpaceHandle` processes rooms to be left in the order they were
@@ -88,7 +86,6 @@ impl LeaveSpaceHandle {
             rooms.push(LeaveSpaceRoom {
                 space_room: SpaceRoom::new_from_known(&room, 0),
                 is_last_admin,
-                joined_members_count: room.joined_members_count(),
             });
         }
 
@@ -235,11 +232,11 @@ mod tests {
 
         let child_room_1 = &rooms[0];
         assert!(child_room_1.is_last_admin);
-        assert_eq!(child_room_1.joined_members_count, 2);
+        assert_eq!(child_room_1.space_room.num_joined_members, 2);
 
         let child_room_2 = &rooms[1];
         assert!(!child_room_2.is_last_admin);
-        assert_eq!(child_room_2.joined_members_count, 3);
+        assert_eq!(child_room_2.space_room.num_joined_members, 3);
 
         let room_ids = rooms.iter().map(|r| r.space_room.room_id.clone()).collect::<Vec<_>>();
         assert_eq!(room_ids, vec![child_space_id_1, child_space_id_2, parent_space_id]);


### PR DESCRIPTION
#6032 added this property, but turns out its already available via `space_room.num_joined_members`.

I haven't included a changelog as that PR was only merged a few hours ago so it doesn't seem at all worthwhile to say that something is being removed that has only just appeared.