### PR TITLE
feat(timeline): enable focusing a thread root using `TimelineFocus::Event`

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] Extend `TimelineFocus::Event` to allow marking the target
+  event as the root of a thread.
+  [#6050](https://github.com/matrix-org/matrix-rust-sdk/pull/6050)
 - [**breaking**] Remove `TimelineFilter::EventTypeFilter` which has been replaced by
   the more generic `TimelineFilter::EventFilter`. Users of `TimelineEventTypeFilter::include`
   and `TimelineEventTypeFilter::exclude` can switch to `TimelineEventFilter::include_event_types`

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] Extend `TimelineFocus::Event` to allow marking the target
+  event as the root of a thread.
+  ([#6050](https://github.com/matrix-org/matrix-rust-sdk/pull/6050))
 - [**breaking**] Remove `TimelineEventTypeFilter` which has been replaced by
   the more generic `TimelineEventFilter`.
   ([#6070](https://github.com/matrix-org/matrix-rust-sdk/pull/6070/))

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -142,11 +142,8 @@ pub enum TimelineFocus {
     Event {
         target: OwnedEventId,
         num_context_events: u16,
-        /// Whether to hide in-thread replies from the live timeline.
-        ///
-        /// This should be set to true when the client can create
-        /// [`Self::Thread`]-focused timelines from the thread roots themselves.
-        hide_threaded_events: bool,
+        /// How to handle threaded events.
+        thread_mode: TimelineEventFocusThreadMode,
     },
 
     /// Focus on a specific thread
@@ -154,6 +151,31 @@ pub enum TimelineFocus {
 
     /// Only show pinned events.
     PinnedEvents { max_events_to_load: u16, max_concurrent_requests: u16 },
+}
+
+/// Options for controlling the behaviour of [`TimelineFocus::Event`]
+/// for threaded events.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[derive(Clone, Debug, PartialEq)]
+pub enum TimelineEventFocusThreadMode {
+    /// Force the timeline into threaded mode. When the focused event is part of
+    /// a thread, the timeline will be focused on that thread's root. Otherwise,
+    /// the timeline will treat the target event itself as the thread root.
+    /// Threaded events will never be hidden.
+    ForceThread,
+    /// Automatically determine if the target event is
+    /// part of a thread or not. If the event is part of a thread, the timeline
+    /// will be filtered to on-thread events.
+    Automatic {
+        /// When the target event is not part of a thread, whether to
+        /// hide in-thread replies from the live timeline. Has no effect
+        /// when the target event is part of a thread.
+        ///
+        /// This should be set to true when the client can create
+        /// [`TimelineFocus::Thread`]-focused timelines from the thread roots
+        /// themselves and doesn't use the [`Self::ForceThread`] mode.
+        hide_threaded_events: bool,
+    },
 }
 
 impl TimelineFocus {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -29,8 +29,8 @@ use matrix_sdk_test::{
     event_factory::EventFactory,
 };
 use matrix_sdk_ui::timeline::{
-    RoomExt as _, TimelineBuilder, TimelineDetails, TimelineEventItemId, TimelineFocus,
-    VirtualTimelineItem,
+    RoomExt as _, TimelineBuilder, TimelineDetails, TimelineEventFocusThreadMode,
+    TimelineEventItemId, TimelineFocus, VirtualTimelineItem,
 };
 use ruma::{
     MilliSecondsSinceUnixEpoch,
@@ -1875,7 +1875,7 @@ async fn test_permalink_doesnt_listen_to_thread_sync() {
         .with_focus(TimelineFocus::Event {
             target: owned_event_id!("$target"),
             num_context_events: 2,
-            hide_threaded_events: true,
+            thread_mode: TimelineEventFocusThreadMode::Automatic { hide_threaded_events: true },
         })
         .build()
         .await

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -54,8 +54,8 @@ use matrix_sdk_ui::{
     room_list_service::RoomListLoadingState,
     sync_service::SyncService,
     timeline::{
-        EventSendState, EventTimelineItem, ReactionStatus, RoomExt, TimelineBuilder, TimelineFocus,
-        TimelineItem,
+        EventSendState, EventTimelineItem, ReactionStatus, RoomExt, TimelineBuilder,
+        TimelineEventFocusThreadMode, TimelineFocus, TimelineItem,
     },
 };
 use similar_asserts::assert_eq;
@@ -973,7 +973,7 @@ async fn test_thread_focused_timeline() -> TestResult {
         .with_focus(TimelineFocus::Event {
             target: thread_reply_event_id.clone(),
             num_context_events: 42,
-            hide_threaded_events: false,
+            thread_mode: TimelineEventFocusThreadMode::Automatic { hide_threaded_events: true },
         })
         .build()
         .await?;
@@ -1337,7 +1337,7 @@ async fn test_permalink_timelines_redecrypt() -> TestResult {
         .with_focus(TimelineFocus::Event {
             target: event_id.to_owned(),
             num_context_events: 1,
-            hide_threaded_events: true,
+            thread_mode: TimelineEventFocusThreadMode::Automatic { hide_threaded_events: true },
         })
         .build()
         .await?;


### PR DESCRIPTION
Use case: Focus a timeline on a thread, initialize it with the thread root and let the timeline paginate _forward_ from there as the user scrolls. In other words, display a thread starting from the oldest messages.

This isn't currently possible with `TimelineFocus::Thread` because it only supports backwards pagination. It's also not possible with `TimelineFocus::Event` because the latter doesn't recognize that it's on a thread if the focused event is the thread root.

This PR extends `TimelineFocus::Event` to allow controlling the initialization behavior for threads, making it possible to mark the focused event as being the root of a thread.

- [x] Public API changes documented in changelogs (optional)

CC @bnjbvr 