### PR TITLE
fix(sdk): `EventCacheInner::by_room` can be a `HashMap`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -824,7 +824,7 @@ struct EventCacheInner {
     multiple_room_updates_lock: Mutex<()>,
 
     /// Lazily-filled cache of live [`RoomEventCache`], once per room.
-    by_room: RwLock<BTreeMap<OwnedRoomId, RoomEventCache>>,
+    by_room: RwLock<HashMap<OwnedRoomId, RoomEventCache>>,
 
     /// Handles to keep alive the task listening to updates.
     drop_handles: OnceLock<Arc<EventCacheDropHandles>>,


### PR DESCRIPTION
This patch replaces `BTreeMap` with `HashMap` in `EventCacheInner` as we don't need any ordering. It is then faster to get (or insert) a new `RoomEventCache`:

- an insert is O(1) for `HashMap` vs. O(log(n)) for `BTreeMap`,
- a get is O(1) for `HashMap` vs. O(log(n)) for `BTreeMap`.