### PR TITLE
fix(ffi): Temporarily remove fn checksums for Android bindings

### DIFF
--- a/bindings/matrix-sdk-ffi/uniffi.toml
+++ b/bindings/matrix-sdk-ffi/uniffi.toml
@@ -2,3 +2,6 @@
 package_name = "org.matrix.rustcomponents.sdk"
 cdylib_name = "matrix_sdk_ffi"
 android_cleaner = true
+# Checksums are incorrectly failing for users with 32bit (and sometimes 64bit?) devices at the moment
+# Remove once https://github.com/mozilla/uniffi-rs/issues/2740 is fixed or JNI is used instead of JNA
+omit_checksums = true


### PR DESCRIPTION
There is [an error](https://github.com/mozilla/uniffi-rs/issues/2740) in how JNA performs the API checksums that results in incorrect checks that make the app fail as soon as any SDK method is called, since initializing the SDK performs these checks.

See https://github.com/element-hq/element-x-android/issues/6028 and https://github.com/element-hq/element-x-android/issues/6079.

Removing the checksums is not great, but I believe it's better to crash in that case than preventing users from using valid bindings because of incorrectly computed checks.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
