### PR TITLE
Log more information about outgoing `m.secret.send` messages

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Improved logging when we are sending secrets in `GossipMachine`.
+  ([#6074](https://github.com/matrix-org/matrix-rust-sdk/pull/6074))
 - Added a new field `forwarder` to `InboundGroupSession` of type `ForwarderData`, which stores information about the forwarder of a session shared in a room key bundle under [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268).
   ([#5980])(https://github.com/matrix-org/matrix-rust-sdk/pull/5980)
 - The `OutboundGroupSession` and `OlmMachine` now return the `EncryptionInfo` 
@@ -19,7 +21,6 @@ All notable changes to this project will be documented in this file.
   key bundle.
   ([#6017](https://github.com/matrix-org/matrix-rust-sdk/pull/6017))
   ([#6044](https://github.com/matrix-org/matrix-rust-sdk/pull/6044))
-
 
 ### Refactor
 

--- a/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
+++ b/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
@@ -320,7 +320,7 @@ pub async fn get_machine_pair_with_setup_sessions_test_helper(
 
     let bob_device = alice.get_device(bob.user_id(), bob.device_id(), None).await.unwrap().unwrap();
 
-    let (session, content) =
+    let (session, content, _) =
         bob_device.encrypt("m.dummy", ToDeviceDummyEventContent::new()).await.unwrap();
     alice.store().save_sessions(&[session]).await.unwrap();
 

--- a/crates/matrix-sdk-crypto/src/machine/tests/olm_encryption.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/olm_encryption.rs
@@ -203,7 +203,7 @@ async fn olm_encryption_test_helper(use_fallback_key: bool) {
 
     let bob_device = alice.get_device(bob.user_id(), bob.device_id(), None).await.unwrap().unwrap();
 
-    let (_, content) = bob_device
+    let (_, content, _) = bob_device
         .encrypt("m.dummy", ToDeviceDummyEventContent::new())
         .await
         .expect("We should be able to encrypt a dummy event.");

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
@@ -952,7 +952,10 @@ async fn encrypt_content_for_devices(
         event_type: String,
         bundle_data: impl Serialize,
     ) -> OlmResult<(Session, Raw<ToDeviceEncryptedEventContent>)> {
-        device.encrypt(store.as_ref(), &event_type, bundle_data).await
+        device
+            .encrypt(store.as_ref(), &event_type, bundle_data)
+            .await
+            .map(|(session, message, _message_id)| (session, message))
     }
 
     let tasks = devices.iter().map(|device| {

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -151,7 +151,8 @@ impl SessionManager {
         if self.wedged_devices.write().get_mut(user_id).is_some_and(|d| d.remove(device_id))
             && let Some(device) = self.store.get_device(user_id, device_id).await?
         {
-            let (_, content) = device.encrypt("m.dummy", ToDeviceDummyEventContent::new()).await?;
+            let (_, content, _) =
+                device.encrypt("m.dummy", ToDeviceDummyEventContent::new()).await?;
 
             let event_type = content.event_type().to_owned();
 


### PR DESCRIPTION
Log more information about gossip requests, so we can track which `m.secret.send` messages were successfully sent or retried, and which secrets were contained in them.

Part of #6058

This makes the debug logging more verbose, but since these secret exchanges only happen in response to a UI action, and I'm only adding one or two more messages for each secret that is sent, and there are only ~4 secrets to send, I think that's OK.

After this change, after a verification exchange we see logs like this in the existing device (which sends secrets):

```
14:53:11.379 DEBUG matrix_sdk_crypto::gossiping::machine: Creating outgoing `m.secret.send` to-device request
    recipient="@andyblocal:localhost:8008" event_type="m.secret.send" request_id="0525e7bb0f1e406395b913de386a47c0" secret_name="m.cross_signing.self_signing" message_id="9ad21c513c9f4f6db3a5495f7ccfe1c4"
    at /home/andy/code/public/matrix-rust/matrix-rust-sdk/crates/matrix-sdk-crypto/src/gossiping/machine.rs:566
    in matrix_sdk_crypto::machine::receive_sync_changes rageshake.ts:69:27

14:53:45.442 DEBUG matrix_sdk_crypto::gossiping::machine: Marking outgoing request as sent
    request_id="0525e7bb0f1e406395b913de386a47c0"
    at /home/andy/code/public/matrix-rust/matrix-rust-sdk/crates/matrix-sdk-crypto/src/gossiping/machine.rs:848 rageshake.ts:69:27
```

Importantly, the `secret_name` can be matched up with a `request_id`, and then later we can see that the same `request_id` was successfully sent, and the `message_id` is included with the event, so can be matched up when the receiver gets it.

On the new device (which receives secrets):

```
12:59:45.135 DEBUG matrix_sdk_crypto::gossiping::machine: Marking outgoing secret request as sent
    recipient="@andyblocal:localhost:8008" request_type="m.cross_signing.user_signing" request_id="c5be84ead4e64e5d966959b56118bab5"
    at /home/andy/code/public/matrix-rust/matrix-rust-sdk/crates/matrix-sdk-crypto/src/gossiping/machine.rs:838 rageshake.ts:69:27
```

we can see that a request for the secret was sent, and then we see it being received:

```
12:59:45.370 DEBUG matrix_sdk_crypto::gossiping::machine: Received a m.secret.send event with a matching request
    at /home/andy/code/public/matrix-rust/matrix-rust-sdk/crates/matrix-sdk-crypto/src/gossiping/machine.rs:923
    in matrix_sdk_crypto::gossiping::machine::receive_secret_event with sender="@andyblocal:localhost:8008" request_id="c5be84ead4e64e5d966959b56118bab5" secret_name="m.cross_signing.user_signing"
    in matrix_sdk_crypto::machine::handle_decrypted_to_device_event with sender_key="curve25519:iH/T0d+dHVA4PmQbcI+GonWxEOE9UN/6IlUYH62urXY" event_type="m.secret.send"
    in matrix_sdk_crypto::machine::receive_to_device_event with sender="@andyblocal:localhost:8008" event_type="m.room.encrypted" message_id="f5401aa69464445d92789c7a6c039ece"
    in matrix_sdk_crypto::machine::receive_sync_changes rageshake.ts:69:27


12:59:45.373 DEBUG matrix_sdk_crypto::gossiping::machine: Successfully received a secret, removing the request
    recipient="@andyblocal:localhost:8008" request_type="m.cross_signing.user_signing" request_id="c5be84ead4e64e5d966959b56118bab5"
    at /home/andy/code/public/matrix-rust/matrix-rust-sdk/crates/matrix-sdk-crypto/src/gossiping/machine.rs:864
    in matrix_sdk_crypto::gossiping::machine::receive_secret_event with sender="@andyblocal:localhost:8008" request_id="c5be84ead4e64e5d966959b56118bab5" secret_name="m.cross_signing.user_signing"
    in matrix_sdk_crypto::machine::handle_decrypted_to_device_event with sender_key="curve25519:iH/T0d+dHVA4PmQbcI+GonWxEOE9UN/6IlUYH62urXY" event_type="m.secret.send"
    in matrix_sdk_crypto::machine::receive_to_device_event with sender="@andyblocal:localhost:8008" event_type="m.room.encrypted" message_id="f5401aa69464445d92789c7a6c039ece"
    in matrix_sdk_crypto::machine::receive_sync_changes rageshake.ts:69:27
```