### PR TITLE
refactor(crypto): Use to_canonical_value() directly

### DIFF
--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -304,12 +304,6 @@ pub enum SignatureError {
     StoreError(#[from] CryptoStoreError),
 }
 
-impl From<SerdeError> for SignatureError {
-    fn from(e: SerdeError) -> Self {
-        CanonicalJsonError::SerDe(e).into()
-    }
-}
-
 /// Error that occurs when a room key can't be converted into a valid Megolm
 /// session.
 #[derive(Error, Debug)]

--- a/crates/matrix-sdk-crypto/src/machine/tests/olm_encryption.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/olm_encryption.rs
@@ -23,7 +23,9 @@ use matrix_sdk_common::deserialized_responses::{
 };
 use matrix_sdk_test::async_test;
 use ruma::{
-    DeviceKeyAlgorithm, DeviceKeyId, SecondsSinceUnixEpoch, device_id,
+    DeviceKeyAlgorithm, DeviceKeyId, SecondsSinceUnixEpoch,
+    canonical_json::to_canonical_value,
+    device_id,
     events::{AnyToDeviceEvent, dummy::ToDeviceDummyEventContent},
     user_id,
 };
@@ -179,7 +181,7 @@ async fn test_get_most_recent_session_of_device_with_no_curve_key() {
             bob_user_id.to_owned(),
             DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, bob_device_id),
             bob_signing_key
-                .sign_json(serde_json::to_value(&bob_device_keys).unwrap())
+                .sign_json(to_canonical_value(&bob_device_keys).unwrap())
                 .expect("Could not sign device data"),
         );
 


### PR DESCRIPTION
Instead of going through `serde_json::to_value()` and then converting it to canonical JSON to serialize it.

Currently `to_canonical_value()` has the same behavior internally as here, but an upcoming change in Ruma makes it use its own `Serializer` so it is directly serialized as a `CanonicalJsonValue` which should be somewhat more efficient.

This upcoming change also removes the `CanonicalJsonError::SerDe` variant, so it is not as straightforward to propagate `serde_json::Error`s.

This commit also removes outdated `#[allow(clippy::…)]` attributes.

