### PR TITLE
docs(sdk): Fix grammar

### DIFF
--- a/crates/matrix-sdk/src/latest_events/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/mod.rs
@@ -16,7 +16,7 @@
 //! the latest event for a room or a thread.
 //!
 //! The latest event represents the last displayable and relevant event a room
-//! or a thread has been received. It is usually displayed in a _summary_, e.g.
+//! or a thread has received. It is usually displayed in a _summary_, e.g.
 //! below the room title in a room list.
 //!
 //! The entry point is [`LatestEvents`]. It is preferable to get a reference to


### PR DESCRIPTION
Fix the grammar in a doc string.

- <del>[ ] Public API changes documented in changelogs (optional)</del>

Signed-off-by: Tobias Fella <tobias.fella@kde.org>
