### PR TITLE
Log more information about gossip requests

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 - Improved logging when we are sending secrets in `GossipMachine`.
   ([#6074](https://github.com/matrix-org/matrix-rust-sdk/pull/6074))
+  ([#6083](https://github.com/matrix-org/matrix-rust-sdk/pull/6083))
 - Added a new field `forwarder` to `InboundGroupSession` of type `ForwarderData`, which stores information about the forwarder of a session shared in a room key bundle under [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268).
   ([#5980])(https://github.com/matrix-org/matrix-rust-sdk/pull/5980)
 - The `OutboundGroupSession` and `OlmMachine` now return the `EncryptionInfo` 

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -60,7 +60,7 @@ use serde::Serialize;
 use serde_json::{Value, value::to_raw_value};
 use tokio::sync::Mutex;
 use tracing::{
-    Span, debug, error,
+    Span, debug, enabled, error,
     field::{debug, display},
     info, instrument, trace, warn,
 };
@@ -1391,6 +1391,15 @@ impl OlmMachine {
                 {
                     e.content.secret_name = name;
                     decrypted.result.raw_event = Raw::from_json(to_raw_value(&e)?);
+                }
+
+                if enabled!(tracing::Level::DEBUG) {
+                    let cross_signing_status = self.cross_signing_status().await;
+                    let backup_enabled = self.backup_machine().enabled().await;
+                    debug!(
+                        ?cross_signing_status,
+                        backup_enabled, "Status after receiving secret event"
+                    );
                 }
             }
             AnyDecryptedOlmEvent::Dummy(_) => {


### PR DESCRIPTION
Write a log line showing the cross-signing and backup status when we receive a secret.

Example log line:

```
13:22:47.177 DEBUG matrix_sdk_crypto::machine: Status after receiving secret event
    cross_signing_status=CrossSigningStatus { has_master: true, has_self_signing: true, has_user_signing: false } backup_enabled=true
    at /home/andy/code/public/matrix-rust/matrix-rust-sdk/crates/matrix-sdk-crypto/src/machine/mod.rs:1399
    in matrix_sdk_crypto::machine::handle_decrypted_to_device_event with sender_key="curve25519:iH/T0d+dHVA4PmQbcI+GonWxEOE9UN/6IlUYH62urXY" event_type="m.secret.send"
    in matrix_sdk_crypto::machine::receive_to_device_event with sender="@andyblocal:localhost:8008" event_type="m.room.encrypted" message_id="d0a1757b48344e4a9a7050c8a5706b44"
    in matrix_sdk_crypto::machine::receive_sync_changes rageshake.ts:69:27
```

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/6058