### PR TITLE
refactor(base): Use `PossiblyRedactedStateEventContent` bound in `MinimalStateEvent`

### DIFF
--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -68,10 +68,7 @@ pub use store::{
     QueueWedgeError, StateChanges, StateStore, StateStoreDataKey, StateStoreDataValue, StoreError,
     ThreadSubscriptionCatchupToken,
 };
-pub use utils::{
-    MinimalRoomMemberEvent, MinimalStateEvent, OriginalMinimalStateEvent,
-    RawSyncStateEventWithKeys, RedactedMinimalStateEvent,
-};
+pub use utils::{MinimalRoomMemberEvent, MinimalStateEvent, RawSyncStateEventWithKeys};
 
 #[cfg(test)]
 matrix_sdk_test_utils::init_tracing_for_tests!();

--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -427,7 +427,7 @@ pub fn is_tombstone_event_valid(
             .state_changes
             .room_infos
             .get(&successor_room_id)
-            .and_then(|room_info| Some(room_info.tombstone()?.replacement_room.clone()))
+            .and_then(|room_info| room_info.tombstone()?.replacement_room.clone())
             .or_else(|| {
                 state_store
                     .room(&successor_room_id)

--- a/crates/matrix-sdk-base/src/room/create.rs
+++ b/crates/matrix-sdk-base/src/room/create.rs
@@ -16,7 +16,8 @@ use matrix_sdk_common::ROOM_VERSION_RULES_FALLBACK;
 use ruma::{
     OwnedUserId, RoomVersionId, assign,
     events::{
-        EmptyStateKey, RedactContent, RedactedStateEventContent, StateEventType,
+        EmptyStateKey, PossiblyRedactedStateEventContent, RedactContent, RedactedStateEventContent,
+        StateEventContent, StateEventType, StaticEventContent,
         macros::EventContent,
         room::create::{PreviousRoom, RoomCreateEventContent},
     },
@@ -135,10 +136,10 @@ impl RoomCreateWithCreatorEventContent {
 pub type RedactedRoomCreateWithCreatorEventContent = RoomCreateWithCreatorEventContent;
 
 impl RedactedStateEventContent for RedactedRoomCreateWithCreatorEventContent {
-    type StateKey = EmptyStateKey;
+    type StateKey = <RoomCreateWithCreatorEventContent as StateEventContent>::StateKey;
 
     fn event_type(&self) -> StateEventType {
-        StateEventType::RoomCreate
+        RoomCreateWithCreatorEventContent::TYPE.into()
     }
 }
 
@@ -155,4 +156,12 @@ impl RedactContent for RoomCreateWithCreatorEventContent {
 
 fn default_create_room_version_id() -> RoomVersionId {
     RoomVersionId::V1
+}
+
+impl PossiblyRedactedStateEventContent for RoomCreateWithCreatorEventContent {
+    type StateKey = <RoomCreateWithCreatorEventContent as StateEventContent>::StateKey;
+
+    fn event_type(&self) -> StateEventType {
+        RoomCreateWithCreatorEventContent::TYPE.into()
+    }
 }

--- a/crates/matrix-sdk-base/src/room/display_name.rs
+++ b/crates/matrix-sdk-base/src/room/display_name.rs
@@ -544,9 +544,11 @@ mod tests {
         events::{
             StateEventType,
             room::{
-                canonical_alias::RoomCanonicalAliasEventContent,
+                canonical_alias::{
+                    PossiblyRedactedRoomCanonicalAliasEventContent, RoomCanonicalAliasEventContent,
+                },
                 member::{MembershipState, RoomMemberEventContent, StrippedRoomMemberEvent},
-                name::RoomNameEventContent,
+                name::{PossiblyRedactedRoomNameEventContent, RoomNameEventContent},
             },
         },
         room_alias_id, room_id,
@@ -557,8 +559,7 @@ mod tests {
 
     use super::{Room, RoomDisplayName, compute_display_name_from_heroes};
     use crate::{
-        MinimalStateEvent, OriginalMinimalStateEvent, RoomHero, RoomState, StateChanges,
-        StateStore, store::MemoryStore,
+        MinimalStateEvent, RoomHero, RoomState, StateChanges, StateStore, store::MemoryStore,
     };
 
     fn make_room_test_helper(room_type: RoomState) -> (Arc<MemoryStore>, Room) {
@@ -584,22 +585,22 @@ mod tests {
     }
 
     fn make_canonical_alias_event() -> MinimalStateEvent<RoomCanonicalAliasEventContent> {
-        MinimalStateEvent::Original(OriginalMinimalStateEvent {
-            content: assign!(RoomCanonicalAliasEventContent::new(), {
+        MinimalStateEvent {
+            content: assign!(PossiblyRedactedRoomCanonicalAliasEventContent::new(), {
                 alias: Some(room_alias_id!("#test:example.com").to_owned()),
             }),
             event_id: None,
-        })
+        }
     }
 
-    fn make_name_event_with(name: &str) -> MinimalStateEvent<RoomNameEventContent> {
-        MinimalStateEvent::Original(OriginalMinimalStateEvent {
-            content: RoomNameEventContent::new(name.to_owned()),
+    fn make_name_event_with(name: &str) -> MinimalStateEvent<PossiblyRedactedRoomNameEventContent> {
+        MinimalStateEvent {
+            content: RoomNameEventContent::new(name.to_owned()).into(),
             event_id: None,
-        })
+        }
     }
 
-    fn make_name_event() -> MinimalStateEvent<RoomNameEventContent> {
+    fn make_name_event() -> MinimalStateEvent<PossiblyRedactedRoomNameEventContent> {
         make_name_event_with("Test Room")
     }
 
@@ -697,10 +698,7 @@ mod tests {
     async fn test_display_name_for_invited_room_is_empty_if_room_name_empty() {
         let (_, room) = make_room_test_helper(RoomState::Invited);
 
-        let room_name = MinimalStateEvent::Original(OriginalMinimalStateEvent {
-            content: RoomNameEventContent::new(String::new()),
-            event_id: None,
-        });
+        let room_name = make_name_event_with("");
         room.info.update(|info| info.base_info.name = Some(room_name));
 
         assert_eq!(room.compute_display_name().await.unwrap().into_inner(), RoomDisplayName::Empty);

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -259,7 +259,7 @@ impl RoomMember {
     /// Get the display name of the member if there is one.
     pub fn display_name(&self) -> Option<&str> {
         if let Some(p) = self.profile.as_ref() {
-            p.as_original().and_then(|e| e.content.displayname.as_deref())
+            p.content.displayname.as_deref()
         } else {
             self.event.displayname_value()
         }
@@ -276,7 +276,7 @@ impl RoomMember {
     /// Get the avatar url of the member, if there is one.
     pub fn avatar_url(&self) -> Option<&MxcUri> {
         if let Some(p) = self.profile.as_ref() {
-            p.as_original().and_then(|e| e.content.avatar_url.as_deref())
+            p.content.avatar_url.as_deref()
         } else {
             self.event.avatar_url()
         }

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -67,7 +67,7 @@ pub use tombstone::{PredecessorRoom, SuccessorRoom};
 use tracing::{info, instrument, warn};
 
 use crate::{
-    Error, MinimalStateEvent,
+    Error,
     deserialized_responses::MemberEvent,
     notification_settings::RoomNotificationMode,
     read_receipts::RoomReadReceipts,
@@ -244,10 +244,7 @@ impl Room {
     /// redacted, all fields except `creator` will be set to their default
     /// value.
     pub fn create_content(&self) -> Option<RoomCreateWithCreatorEventContent> {
-        match self.info.read().base_info.create.as_ref()? {
-            MinimalStateEvent::Original(ev) => Some(ev.content.clone()),
-            MinimalStateEvent::Redacted(ev) => Some(ev.content.clone()),
-        }
+        Some(self.info.read().base_info.create.as_ref()?.content.clone())
     }
 
     /// Is this room considered a direct message.

--- a/crates/matrix-sdk-base/src/store/ambiguity_map.rs
+++ b/crates/matrix-sdk-base/src/store/ambiguity_map.rs
@@ -193,14 +193,11 @@ impl AmbiguityCache {
             let display_name = if let Some(d) = changes
                 .profiles
                 .get(room_id)
-                .and_then(|p| p.get(user_id)?.as_original()?.content.displayname.as_deref())
+                .and_then(|p| p.get(user_id)?.content.displayname.as_deref())
             {
                 Some(d.to_owned())
-            } else if let Some(d) = self
-                .store
-                .get_profile(room_id, user_id)
-                .await?
-                .and_then(|p| p.into_original()?.content.displayname)
+            } else if let Some(d) =
+                self.store.get_profile(room_id, user_id).await?.and_then(|p| p.content.displayname)
             {
                 Some(d)
             } else {

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -1227,7 +1227,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         // The profile for the invited user has been updated.
         let invited_member_event = self.get_profile(room_id, invited_user_id).await?.unwrap();
         assert_eq!(
-            invited_member_event.as_original().unwrap().content.displayname.as_deref(),
+            invited_member_event.content.displayname.as_deref(),
             Some("example after update")
         );
         assert!(self.get_member_event(room_id, invited_user_id).await?.is_some());

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -20,27 +20,24 @@ use matrix_sdk_common::deserialized_responses::TimelineEvent;
 use ruma::{
     OwnedRoomId, OwnedUserId, RoomId,
     events::{
-        EmptyStateKey, RedactContent, StateEventContent, StateEventType,
         direct::OwnedDirectUserIdentifier,
         room::{
-            avatar::RoomAvatarEventContent,
-            canonical_alias::RoomCanonicalAliasEventContent,
-            create::RoomCreateEventContent,
-            encryption::RoomEncryptionEventContent,
-            guest_access::RoomGuestAccessEventContent,
-            history_visibility::RoomHistoryVisibilityEventContent,
-            join_rules::RoomJoinRulesEventContent,
-            name::{RedactedRoomNameEventContent, RoomNameEventContent},
-            tombstone::RoomTombstoneEventContent,
-            topic::RoomTopicEventContent,
+            avatar::PossiblyRedactedRoomAvatarEventContent,
+            canonical_alias::PossiblyRedactedRoomCanonicalAliasEventContent,
+            create::RoomCreateEventContent, encryption::RoomEncryptionEventContent,
+            guest_access::PossiblyRedactedRoomGuestAccessEventContent,
+            history_visibility::PossiblyRedactedRoomHistoryVisibilityEventContent,
+            join_rules::PossiblyRedactedRoomJoinRulesEventContent,
+            name::PossiblyRedactedRoomNameEventContent,
+            tombstone::PossiblyRedactedRoomTombstoneEventContent,
+            topic::PossiblyRedactedRoomTopicEventContent,
         },
     },
-    room_version_rules::RedactionRules,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    MinimalStateEvent, OriginalMinimalStateEvent, RoomInfo, RoomState,
+    MinimalStateEvent, RoomInfo, RoomState,
     deserialized_responses::SyncOrStrippedState,
     latest_event::LatestEventValue,
     room::{BaseRoomInfo, RoomSummary, SyncInfo},
@@ -143,17 +140,18 @@ fn encryption_state_default() -> bool {
 /// [`BaseRoomInfo`] version 1.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct BaseRoomInfoV1 {
-    avatar: Option<MinimalStateEvent<RoomAvatarEventContent>>,
-    canonical_alias: Option<MinimalStateEvent<RoomCanonicalAliasEventContent>>,
+    avatar: Option<MinimalStateEvent<PossiblyRedactedRoomAvatarEventContent>>,
+    canonical_alias: Option<MinimalStateEvent<PossiblyRedactedRoomCanonicalAliasEventContent>>,
     dm_targets: HashSet<OwnedUserId>,
     encryption: Option<RoomEncryptionEventContent>,
-    guest_access: Option<MinimalStateEvent<RoomGuestAccessEventContent>>,
-    history_visibility: Option<MinimalStateEvent<RoomHistoryVisibilityEventContent>>,
-    join_rules: Option<MinimalStateEvent<RoomJoinRulesEventContent>>,
+    guest_access: Option<MinimalStateEvent<PossiblyRedactedRoomGuestAccessEventContent>>,
+    history_visibility:
+        Option<MinimalStateEvent<PossiblyRedactedRoomHistoryVisibilityEventContent>>,
+    join_rules: Option<MinimalStateEvent<PossiblyRedactedRoomJoinRulesEventContent>>,
     max_power_level: i64,
-    name: Option<MinimalStateEvent<RoomNameEventContentV1>>,
-    tombstone: Option<MinimalStateEvent<RoomTombstoneEventContent>>,
-    topic: Option<MinimalStateEvent<RoomTopicEventContent>>,
+    name: Option<MinimalStateEvent<PossiblyRedactedRoomNameEventContent>>,
+    tombstone: Option<MinimalStateEvent<PossiblyRedactedRoomTombstoneEventContent>>,
+    topic: Option<MinimalStateEvent<PossiblyRedactedRoomTopicEventContent>>,
 }
 
 impl BaseRoomInfoV1 {
@@ -180,15 +178,6 @@ impl BaseRoomInfoV1 {
             SyncOrStrippedState::Sync(e) => e.into(),
             SyncOrStrippedState::Stripped(e) => e.into(),
         });
-        let name = name.map(|name| match name {
-            MinimalStateEvent::Original(ev) => {
-                MinimalStateEvent::Original(OriginalMinimalStateEvent {
-                    content: ev.content.into(),
-                    event_id: ev.event_id,
-                })
-            }
-            MinimalStateEvent::Redacted(ev) => MinimalStateEvent::Redacted(ev),
-        });
 
         let mut converted_dm_targets = HashSet::new();
         for dm_target in dm_targets {
@@ -210,33 +199,5 @@ impl BaseRoomInfoV1 {
             topic,
             ..Default::default()
         })
-    }
-}
-
-/// [`RoomNameEventContent`] version 1, with an optional `name`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-struct RoomNameEventContentV1 {
-    name: Option<String>,
-}
-
-impl StateEventContent for RoomNameEventContentV1 {
-    type StateKey = EmptyStateKey;
-
-    fn event_type(&self) -> StateEventType {
-        StateEventType::RoomName
-    }
-}
-
-impl RedactContent for RoomNameEventContentV1 {
-    type Redacted = RedactedRoomNameEventContent;
-
-    fn redact(self, _rules: &RedactionRules) -> Self::Redacted {
-        RedactedRoomNameEventContent::new()
-    }
-}
-
-impl From<RoomNameEventContentV1> for RoomNameEventContent {
-    fn from(value: RoomNameEventContentV1) -> Self {
-        RoomNameEventContent::new(value.name.unwrap_or_default())
     }
 }

--- a/crates/matrix-sdk-base/src/utils.rs
+++ b/crates/matrix-sdk-base/src/utils.rs
@@ -1,44 +1,21 @@
 use ruma::{
-    EventId, OwnedEventId, assign,
+    OwnedEventId,
     events::{
-        AnySyncStateEvent, AnySyncTimelineEvent, RedactContent, RedactedStateEventContent,
-        StateEventContent, StateEventType, StaticEventContent, StaticStateEventContent,
-        SyncStateEvent,
+        AnySyncStateEvent, AnySyncTimelineEvent, PossiblyRedactedStateEventContent, RedactContent,
+        RedactedStateEventContent, StateEventType, StaticEventContent, StaticStateEventContent,
+        StrippedStateEvent, SyncStateEvent,
         room::{
-            avatar::{RoomAvatarEventContent, StrippedRoomAvatarEvent},
-            canonical_alias::{RoomCanonicalAliasEventContent, StrippedRoomCanonicalAliasEvent},
             create::{StrippedRoomCreateEvent, SyncRoomCreateEvent},
-            guest_access::{
-                RedactedRoomGuestAccessEventContent, RoomGuestAccessEventContent,
-                StrippedRoomGuestAccessEvent,
-            },
-            history_visibility::{
-                RoomHistoryVisibilityEventContent, StrippedRoomHistoryVisibilityEvent,
-            },
-            join_rules::{RoomJoinRulesEventContent, StrippedRoomJoinRulesEvent},
-            member::{MembershipState, RoomMemberEventContent},
-            name::{RedactedRoomNameEventContent, RoomNameEventContent, StrippedRoomNameEvent},
-            tombstone::{
-                RedactedRoomTombstoneEventContent, RoomTombstoneEventContent,
-                StrippedRoomTombstoneEvent,
-            },
-            topic::{RedactedRoomTopicEventContent, RoomTopicEventContent, StrippedRoomTopicEvent},
+            member::PossiblyRedactedRoomMemberEventContent,
         },
     },
     room_version_rules::RedactionRules,
     serde::Raw,
 };
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{Deserialize, Serialize};
 use tracing::{error, warn};
 
 use crate::room::RoomCreateWithCreatorEventContent;
-
-// #[serde(bound)] instead of DeserializeOwned in type where clause does not
-// work, it can only be a single bound that replaces the default and if a helper
-// trait is used, the compiler still complains about Deserialize not being
-// implemented for C::Redacted.
-//
-// It is unclear why a Serialize bound on C::Redacted is not also required.
 
 /// A minimal state event.
 ///
@@ -46,42 +23,12 @@ use crate::room::RoomCreateWithCreatorEventContent;
 /// event ID. The event ID is optional so this type can also hold events from
 /// invited rooms, where event IDs are not available.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(bound(
-    serialize = "C: Serialize, C::Redacted: Serialize",
-    deserialize = "C: DeserializeOwned, C::Redacted: DeserializeOwned"
-))]
-pub enum MinimalStateEvent<C: StateEventContent + RedactContent>
-where
-    C::Redacted: RedactedStateEventContent,
-{
-    /// An unredacted event.
-    Original(OriginalMinimalStateEvent<C>),
-    /// A redacted event.
-    Redacted(RedactedMinimalStateEvent<C::Redacted>),
-}
-
-/// An unredacted minimal state event.
-///
-/// For more details see [`MinimalStateEvent`].
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct OriginalMinimalStateEvent<C>
-where
-    C: StateEventContent,
-{
-    /// The event's content.
-    pub content: C,
-    /// The event's ID, if known.
-    pub event_id: Option<OwnedEventId>,
-}
-
-/// A redacted minimal state event.
-///
-/// For more details see [`MinimalStateEvent`].
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct RedactedMinimalStateEvent<C>
-where
-    C: RedactedStateEventContent,
-{
+#[serde(
+    bound(serialize = "C: Serialize + Clone"),
+    from = "MinimalStateEventSerdeHelper<C>",
+    into = "MinimalStateEventSerdeHelper<C>"
+)]
+pub struct MinimalStateEvent<C: PossiblyRedactedStateEventContent + RedactContent> {
     /// The event's content.
     pub content: C,
     /// The event's ID, if known.
@@ -90,34 +37,9 @@ where
 
 impl<C> MinimalStateEvent<C>
 where
-    C: StateEventContent + RedactContent,
-    C::Redacted: RedactedStateEventContent,
+    C: PossiblyRedactedStateEventContent + RedactContent,
+    C::Redacted: Into<C>,
 {
-    /// Get the inner event's ID.
-    pub fn event_id(&self) -> Option<&EventId> {
-        match self {
-            MinimalStateEvent::Original(ev) => ev.event_id.as_deref(),
-            MinimalStateEvent::Redacted(ev) => ev.event_id.as_deref(),
-        }
-    }
-
-    /// Returns the inner event, if it isn't redacted.
-    pub fn as_original(&self) -> Option<&OriginalMinimalStateEvent<C>> {
-        match self {
-            MinimalStateEvent::Original(ev) => Some(ev),
-            MinimalStateEvent::Redacted(_) => None,
-        }
-    }
-
-    /// Converts `self` to the inner `OriginalMinimalStateEvent<C>`, if it isn't
-    /// redacted.
-    pub fn into_original(self) -> Option<OriginalMinimalStateEvent<C>> {
-        match self {
-            MinimalStateEvent::Original(ev) => Some(ev),
-            MinimalStateEvent::Redacted(_) => None,
-        }
-    }
-
     /// Redacts this event.
     ///
     /// Does nothing if it is already redacted.
@@ -125,63 +47,105 @@ where
     where
         C: Clone,
     {
-        if let MinimalStateEvent::Original(ev) = self {
-            *self = MinimalStateEvent::Redacted(RedactedMinimalStateEvent {
-                content: ev.content.clone().redact(rules),
-                event_id: ev.event_id.clone(),
-            });
+        self.content = self.content.clone().redact(rules).into()
+    }
+}
+
+/// Helper type to (de)serialize [`MinimalStateEvent`].
+#[derive(Serialize, Deserialize)]
+enum MinimalStateEventSerdeHelper<C> {
+    /// Previous variant for a non-redacted event.
+    Original(MinimalStateEventSerdeHelperInner<C>),
+    /// Previous variant for a redacted event.
+    Redacted(MinimalStateEventSerdeHelperInner<C>),
+    /// New variant.
+    PossiblyRedacted(MinimalStateEventSerdeHelperInner<C>),
+}
+
+impl<C> From<MinimalStateEventSerdeHelper<C>> for MinimalStateEvent<C>
+where
+    C: PossiblyRedactedStateEventContent + RedactContent,
+{
+    fn from(value: MinimalStateEventSerdeHelper<C>) -> Self {
+        match value {
+            MinimalStateEventSerdeHelper::Original(event) => event,
+            MinimalStateEventSerdeHelper::Redacted(event) => event,
+            MinimalStateEventSerdeHelper::PossiblyRedacted(event) => event,
         }
+        .into()
+    }
+}
+
+impl<C> From<MinimalStateEvent<C>> for MinimalStateEventSerdeHelper<C>
+where
+    C: PossiblyRedactedStateEventContent + RedactContent,
+{
+    fn from(value: MinimalStateEvent<C>) -> Self {
+        Self::PossiblyRedacted(value.into())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct MinimalStateEventSerdeHelperInner<C> {
+    content: C,
+    event_id: Option<OwnedEventId>,
+}
+
+impl<C> From<MinimalStateEventSerdeHelperInner<C>> for MinimalStateEvent<C>
+where
+    C: PossiblyRedactedStateEventContent + RedactContent,
+{
+    fn from(value: MinimalStateEventSerdeHelperInner<C>) -> Self {
+        let MinimalStateEventSerdeHelperInner { content, event_id } = value;
+        Self { content, event_id }
+    }
+}
+
+impl<C> From<MinimalStateEvent<C>> for MinimalStateEventSerdeHelperInner<C>
+where
+    C: PossiblyRedactedStateEventContent + RedactContent,
+{
+    fn from(value: MinimalStateEvent<C>) -> Self {
+        let MinimalStateEvent { content, event_id } = value;
+        Self { content, event_id }
     }
 }
 
 /// A minimal `m.room.member` event.
-pub type MinimalRoomMemberEvent = MinimalStateEvent<RoomMemberEventContent>;
+pub type MinimalRoomMemberEvent = MinimalStateEvent<PossiblyRedactedRoomMemberEventContent>;
 
-impl MinimalRoomMemberEvent {
-    /// Obtain the membership state, regardless of whether this event is
-    /// redacted.
-    pub fn membership(&self) -> &MembershipState {
-        match self {
-            MinimalStateEvent::Original(ev) => &ev.content.membership,
-            MinimalStateEvent::Redacted(ev) => &ev.content.membership,
+impl<C1, C2> From<SyncStateEvent<C1>> for MinimalStateEvent<C2>
+where
+    C1: StaticStateEventContent + RedactContent + Into<C2>,
+    C1::Redacted: RedactedStateEventContent + Into<C2>,
+    C2: PossiblyRedactedStateEventContent + RedactContent,
+{
+    fn from(ev: SyncStateEvent<C1>) -> Self {
+        match ev {
+            SyncStateEvent::Original(ev) => {
+                Self { content: ev.content.into(), event_id: Some(ev.event_id) }
+            }
+            SyncStateEvent::Redacted(ev) => {
+                Self { content: ev.content.into(), event_id: Some(ev.event_id) }
+            }
         }
     }
 }
 
-impl<C> From<SyncStateEvent<C>> for MinimalStateEvent<C>
+impl<C1, C2> From<&SyncStateEvent<C1>> for MinimalStateEvent<C2>
 where
-    C: StaticStateEventContent + RedactContent,
-    C::Redacted: RedactedStateEventContent,
+    C1: Clone + StaticStateEventContent + RedactContent + Into<C2>,
+    C1::Redacted: Clone + RedactedStateEventContent + Into<C2>,
+    C2: PossiblyRedactedStateEventContent + RedactContent,
 {
-    fn from(ev: SyncStateEvent<C>) -> Self {
+    fn from(ev: &SyncStateEvent<C1>) -> Self {
         match ev {
-            SyncStateEvent::Original(ev) => Self::Original(OriginalMinimalStateEvent {
-                content: ev.content,
-                event_id: Some(ev.event_id),
-            }),
-            SyncStateEvent::Redacted(ev) => Self::Redacted(RedactedMinimalStateEvent {
-                content: ev.content,
-                event_id: Some(ev.event_id),
-            }),
-        }
-    }
-}
-
-impl<C> From<&SyncStateEvent<C>> for MinimalStateEvent<C>
-where
-    C: Clone + StaticStateEventContent + RedactContent,
-    C::Redacted: Clone + RedactedStateEventContent,
-{
-    fn from(ev: &SyncStateEvent<C>) -> Self {
-        match ev {
-            SyncStateEvent::Original(ev) => Self::Original(OriginalMinimalStateEvent {
-                content: ev.content.clone(),
-                event_id: Some(ev.event_id.clone()),
-            }),
-            SyncStateEvent::Redacted(ev) => Self::Redacted(RedactedMinimalStateEvent {
-                content: ev.content.clone(),
-                event_id: Some(ev.event_id.clone()),
-            }),
+            SyncStateEvent::Original(ev) => {
+                Self { content: ev.content.clone().into(), event_id: Some(ev.event_id.clone()) }
+            }
+            SyncStateEvent::Redacted(ev) => {
+                Self { content: ev.content.clone().into(), event_id: Some(ev.event_id.clone()) }
+            }
         }
     }
 }
@@ -189,48 +153,39 @@ where
 impl From<&SyncRoomCreateEvent> for MinimalStateEvent<RoomCreateWithCreatorEventContent> {
     fn from(ev: &SyncRoomCreateEvent) -> Self {
         match ev {
-            SyncStateEvent::Original(ev) => Self::Original(OriginalMinimalStateEvent {
+            SyncStateEvent::Original(ev) => Self {
                 content: RoomCreateWithCreatorEventContent::from_event_content(
                     ev.content.clone(),
                     ev.sender.clone(),
                 ),
                 event_id: Some(ev.event_id.clone()),
-            }),
-            SyncStateEvent::Redacted(ev) => Self::Redacted(RedactedMinimalStateEvent {
+            },
+            SyncStateEvent::Redacted(ev) => Self {
                 content: RoomCreateWithCreatorEventContent::from_event_content(
                     ev.content.clone(),
                     ev.sender.clone(),
                 ),
                 event_id: Some(ev.event_id.clone()),
-            }),
+            },
         }
     }
 }
 
-impl From<&StrippedRoomAvatarEvent> for MinimalStateEvent<RoomAvatarEventContent> {
-    fn from(event: &StrippedRoomAvatarEvent) -> Self {
-        let content = assign!(RoomAvatarEventContent::new(), {
-            info: event.content.info.clone(),
-            url: event.content.url.clone(),
-        });
-        // event might actually be redacted, there is no way to tell for
-        // stripped state events.
-        Self::Original(OriginalMinimalStateEvent { content, event_id: None })
+impl<C> From<StrippedStateEvent<C>> for MinimalStateEvent<C>
+where
+    C: PossiblyRedactedStateEventContent + RedactContent,
+{
+    fn from(event: StrippedStateEvent<C>) -> Self {
+        Self { content: event.content, event_id: None }
     }
 }
 
-impl From<&StrippedRoomNameEvent> for MinimalStateEvent<RoomNameEventContent> {
-    fn from(event: &StrippedRoomNameEvent) -> Self {
-        match event.content.name.clone() {
-            Some(name) => {
-                let content = RoomNameEventContent::new(name);
-                Self::Original(OriginalMinimalStateEvent { content, event_id: None })
-            }
-            None => {
-                let content = RedactedRoomNameEventContent::new();
-                Self::Redacted(RedactedMinimalStateEvent { content, event_id: None })
-            }
-        }
+impl<C> From<&StrippedStateEvent<C>> for MinimalStateEvent<C>
+where
+    C: Clone + PossiblyRedactedStateEventContent + RedactContent,
+{
+    fn from(event: &StrippedStateEvent<C>) -> Self {
+        Self { content: event.content.clone(), event_id: None }
     }
 }
 
@@ -240,80 +195,7 @@ impl From<&StrippedRoomCreateEvent> for MinimalStateEvent<RoomCreateWithCreatorE
             event.content.clone(),
             event.sender.clone(),
         );
-        Self::Original(OriginalMinimalStateEvent { content, event_id: None })
-    }
-}
-
-impl From<&StrippedRoomHistoryVisibilityEvent>
-    for MinimalStateEvent<RoomHistoryVisibilityEventContent>
-{
-    fn from(event: &StrippedRoomHistoryVisibilityEvent) -> Self {
-        let content =
-            RoomHistoryVisibilityEventContent::new(event.content.history_visibility.clone());
-        Self::Original(OriginalMinimalStateEvent { content, event_id: None })
-    }
-}
-
-impl From<&StrippedRoomGuestAccessEvent> for MinimalStateEvent<RoomGuestAccessEventContent> {
-    fn from(event: &StrippedRoomGuestAccessEvent) -> Self {
-        match &event.content.guest_access {
-            Some(guest_access) => {
-                let content = RoomGuestAccessEventContent::new(guest_access.clone());
-                Self::Original(OriginalMinimalStateEvent { content, event_id: None })
-            }
-            None => {
-                let content = RedactedRoomGuestAccessEventContent::new();
-                Self::Redacted(RedactedMinimalStateEvent { content, event_id: None })
-            }
-        }
-    }
-}
-
-impl From<&StrippedRoomJoinRulesEvent> for MinimalStateEvent<RoomJoinRulesEventContent> {
-    fn from(event: &StrippedRoomJoinRulesEvent) -> Self {
-        let content = RoomJoinRulesEventContent::new(event.content.join_rule.clone());
-        Self::Original(OriginalMinimalStateEvent { content, event_id: None })
-    }
-}
-
-impl From<&StrippedRoomCanonicalAliasEvent> for MinimalStateEvent<RoomCanonicalAliasEventContent> {
-    fn from(event: &StrippedRoomCanonicalAliasEvent) -> Self {
-        let content = assign!(RoomCanonicalAliasEventContent::new(), {
-            alias: event.content.alias.clone(),
-            alt_aliases: event.content.alt_aliases.clone(),
-        });
-        Self::Original(OriginalMinimalStateEvent { content, event_id: None })
-    }
-}
-
-impl From<&StrippedRoomTopicEvent> for MinimalStateEvent<RoomTopicEventContent> {
-    fn from(event: &StrippedRoomTopicEvent) -> Self {
-        match &event.content.topic {
-            Some(topic) => {
-                let content = RoomTopicEventContent::new(topic.clone());
-                Self::Original(OriginalMinimalStateEvent { content, event_id: None })
-            }
-            None => {
-                let content = RedactedRoomTopicEventContent::new();
-                Self::Redacted(RedactedMinimalStateEvent { content, event_id: None })
-            }
-        }
-    }
-}
-
-impl From<&StrippedRoomTombstoneEvent> for MinimalStateEvent<RoomTombstoneEventContent> {
-    fn from(event: &StrippedRoomTombstoneEvent) -> Self {
-        match (&event.content.body, &event.content.replacement_room) {
-            (Some(body), Some(replacement_room)) => {
-                let content =
-                    RoomTombstoneEventContent::new(body.clone(), replacement_room.clone());
-                Self::Original(OriginalMinimalStateEvent { content, event_id: None })
-            }
-            _ => {
-                let content = RedactedRoomTombstoneEventContent::new();
-                Self::Redacted(RedactedMinimalStateEvent { content, event_id: None })
-            }
-        }
+        Self { content, event_id: None }
     }
 }
 
@@ -448,4 +330,50 @@ struct StateEventWithKeysDeHelper {
     /// The state key is optional to be able to differentiate state events from
     /// other messages in the timeline.
     state_key: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use ruma::{event_id, events::room::name::PossiblyRedactedRoomNameEventContent};
+
+    use super::MinimalStateEvent;
+
+    #[test]
+    fn test_backward_compatible_deserialize_minimal_state_event() {
+        let event_id = event_id!("$event");
+
+        // The old format with `Original` and `Redacted` variants works.
+        let event =
+            serde_json::from_str::<MinimalStateEvent<PossiblyRedactedRoomNameEventContent>>(
+                r#"{"Original":{"content":{"name":"My Room"},"event_id":"$event"}}"#,
+            )
+            .unwrap();
+        assert_eq!(event.content.name.as_deref(), Some("My Room"));
+        assert_eq!(event.event_id.as_deref(), Some(event_id));
+
+        let event =
+            serde_json::from_str::<MinimalStateEvent<PossiblyRedactedRoomNameEventContent>>(
+                r#"{"Redacted":{"content":{},"event_id":"$event"}}"#,
+            )
+            .unwrap();
+        assert_eq!(event.content.name, None);
+        assert_eq!(event.event_id.as_deref(), Some(event_id));
+
+        // The new format works.
+        let event =
+            serde_json::from_str::<MinimalStateEvent<PossiblyRedactedRoomNameEventContent>>(
+                r#"{"PossiblyRedacted":{"content":{"name":"My Room"},"event_id":"$event"}}"#,
+            )
+            .unwrap();
+        assert_eq!(event.content.name.as_deref(), Some("My Room"));
+        assert_eq!(event.event_id.as_deref(), Some(event_id));
+
+        let event =
+            serde_json::from_str::<MinimalStateEvent<PossiblyRedactedRoomNameEventContent>>(
+                r#"{"PossiblyRedacted":{"content":{},"event_id":"$event"}}"#,
+            )
+            .unwrap();
+        assert_eq!(event.content.name, None);
+        assert_eq!(event.event_id.as_deref(), Some(event_id));
+    }
 }

--- a/crates/matrix-sdk/tests/integration/sync.rs
+++ b/crates/matrix-sdk/tests/integration/sync.rs
@@ -1331,7 +1331,10 @@ async fn test_receive_room_tombstone_event_via_sync() {
         .await;
 
     // The room info is set and the valid state event is in the store.
-    assert_eq!(room.tombstone_content().unwrap().replacement_room, tombstone_replacement);
+    assert_eq!(
+        room.tombstone_content().unwrap().replacement_room.as_deref(),
+        Some(tombstone_replacement)
+    );
     assert_matches!(
         room.get_state_event_static::<RoomTombstoneEventContent>().await,
         Ok(Some(RawSyncOrStrippedState::Sync(raw_event)))


### PR DESCRIPTION
We usually don't care if the event was redacted or not, we usually want to know whether a field is set or not, so we don't need `Original` and `Redacted` variants.

This simplifies several parts of the code since we don't have to handle the intermediate enum to access the content now. Due to new APIs in Ruma we can also just convert original and redacted event contents to possibly redacted event contents.

This should allow further code removal in a follow-up PR, by allowing to use the same code to handle `Sync*` and `Stripped*` events in `RoomInfo`.

The backwards-compatible deserialization of `MinimalStateEvent` was verified in a client with Fractal.