### PR TITLE
refactor(pinned events): move `pin_event`/`unpin_event` from the Timeline to the Room

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -723,7 +723,7 @@ impl Timeline {
     /// pinned.
     async fn pin_event(&self, event_id: String) -> Result<bool, ClientError> {
         let event_id = EventId::parse(event_id).map_err(ClientError::from)?;
-        self.inner.pin_event(&event_id).await.map_err(ClientError::from)
+        self.inner.room().pin_event(&event_id).await.map_err(ClientError::from)
     }
 
     /// Adds a new pinned event by sending an updated `m.room.pinned_events`
@@ -733,7 +733,7 @@ impl Timeline {
     /// pinned
     async fn unpin_event(&self, event_id: String) -> Result<bool, ClientError> {
         let event_id = EventId::parse(event_id).map_err(ClientError::from)?;
-        self.inner.unpin_event(&event_id).await.map_err(ClientError::from)
+        self.inner.room().unpin_event(&event_id).await.map_err(ClientError::from)
     }
 
     pub fn create_message_content(

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -58,6 +58,10 @@ All notable changes to this project will be documented in this file.
   
 ### Refactor
 
+- [**breaking**] The [`Timeline::pin_event`] and [`Timeline::unpin_event`] methods have been
+  moved to the SDK crate, in the `Room` object. Users can replace previous uses with
+  `timeline.room().pin_event()` etc.
+  ([#6106](https://github.com/matrix-org/matrix-rust-sdk/pull/6106))
 - [**breaking**] Refactored `is_last_admin` to `is_last_owner` the check will now
   account also for v12 rooms, where creators and users with PL 150 matter.
   ([#6036](https://github.com/matrix-org/matrix-rust-sdk/pull/6036))

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -39,7 +39,6 @@ use matrix_sdk::{
     send_queue::{RoomSendQueueError, SendHandle},
 };
 use mime::Mime;
-use pinned_events_loader::PinnedEventsRoom;
 use ruma::{
     EventId, OwnedEventId, OwnedTransactionId, UserId,
     api::client::receipt::create_receipt::v3::ReceiptType,
@@ -48,12 +47,9 @@ use ruma::{
         poll::unstable_start::{NewUnstablePollStartEventContent, UnstablePollStartEventContent},
         receipt::{Receipt, ReceiptThread},
         relation::Thread,
-        room::{
-            message::{
-                Relation, RelationWithoutReplacement, ReplyWithinThread,
-                RoomMessageEventContentWithoutRelation, TextMessageEventContent,
-            },
-            pinned_events::RoomPinnedEventsEventContent,
+        room::message::{
+            Relation, RelationWithoutReplacement, ReplyWithinThread,
+            RoomMessageEventContentWithoutRelation, TextMessageEventContent,
         },
     },
     room_version_rules::RoomVersionRules,
@@ -828,58 +824,6 @@ impl Timeline {
                 self.room().set_unread_flag(false).await?;
             }
 
-            Ok(false)
-        }
-    }
-
-    /// Adds a new pinned event by sending an updated `m.room.pinned_events`
-    /// event containing the new event id.
-    ///
-    /// This method will first try to get the pinned events from the current
-    /// room's state and if it fails to do so it'll try to load them from the
-    /// homeserver.
-    ///
-    /// Returns `true` if we pinned the event, `false` if the event was already
-    /// pinned.
-    pub async fn pin_event(&self, event_id: &EventId) -> Result<bool> {
-        let mut pinned_event_ids = if let Some(event_ids) = self.room().pinned_event_ids() {
-            event_ids
-        } else {
-            self.room().load_pinned_events().await?.unwrap_or_default()
-        };
-        let event_id = event_id.to_owned();
-        if pinned_event_ids.contains(&event_id) {
-            Ok(false)
-        } else {
-            pinned_event_ids.push(event_id);
-            let content = RoomPinnedEventsEventContent::new(pinned_event_ids);
-            self.room().send_state_event(content).await?;
-            Ok(true)
-        }
-    }
-
-    /// Removes a pinned event by sending an updated `m.room.pinned_events`
-    /// event without the event id we want to remove.
-    ///
-    /// This method will first try to get the pinned events from the current
-    /// room's state and if it fails to do so it'll try to load them from the
-    /// homeserver.
-    ///
-    /// Returns `true` if we unpinned the event, `false` if the event wasn't
-    /// pinned before.
-    pub async fn unpin_event(&self, event_id: &EventId) -> Result<bool> {
-        let mut pinned_event_ids = if let Some(event_ids) = self.room().pinned_event_ids() {
-            event_ids
-        } else {
-            self.room().load_pinned_events().await?.unwrap_or_default()
-        };
-        let event_id = event_id.to_owned();
-        if let Some(idx) = pinned_event_ids.iter().position(|e| *e == *event_id) {
-            pinned_event_ids.remove(idx);
-            let content = RoomPinnedEventsEventContent::new(pinned_event_ids);
-            self.room().send_state_event(content).await?;
-            Ok(true)
-        } else {
             Ok(false)
         }
     }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -28,14 +28,11 @@ use matrix_sdk_test::{
     ALICE, BOB, JoinedRoomBuilder, RoomAccountDataTestEvent, StateTestEvent, async_test,
     event_factory::EventFactory,
 };
-use matrix_sdk_ui::{
-    Timeline,
-    timeline::{
-        AnyOtherFullStateEventContent, Error, EventSendState, MsgLikeKind, OtherMessageLike,
-        RedactError, RoomExt, TimelineBuilder, TimelineEventFocusThreadMode, TimelineEventItemId,
-        TimelineEventShieldState, TimelineFocus, TimelineItemContent, VirtualTimelineItem,
-        default_event_filter,
-    },
+use matrix_sdk_ui::timeline::{
+    AnyOtherFullStateEventContent, Error, EventSendState, MsgLikeKind, OtherMessageLike,
+    RedactError, RoomExt, TimelineBuilder, TimelineEventFocusThreadMode, TimelineEventItemId,
+    TimelineEventShieldState, TimelineFocus, TimelineItemContent, VirtualTimelineItem,
+    default_event_filter,
 };
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, event_id,
@@ -50,13 +47,8 @@ use ruma::{
     serde::Raw,
     user_id,
 };
-use serde_json::json;
 use sliding_sync::assert_timeline_stream;
 use stream_assert::assert_pending;
-use wiremock::{
-    Mock, ResponseTemplate,
-    matchers::{header, method, path_regex},
-};
 
 mod decryption;
 mod echo;
@@ -781,90 +773,6 @@ async fn test_duplicate_maintains_correct_order() {
 }
 
 #[async_test]
-async fn test_pin_event_is_sent_successfully() {
-    let mut setup = PinningTestSetup::new().await;
-    let timeline = setup.timeline().await;
-
-    setup.mock_sync(false).await;
-    assert!(!timeline.items().await.is_empty());
-
-    // Pinning a remote event succeeds.
-    setup.server.mock_set_room_pinned_events().ok(owned_event_id!("$42")).mock_once().mount().await;
-
-    let event_id = setup.event_id();
-    assert!(timeline.pin_event(event_id).await.unwrap());
-}
-
-#[async_test]
-async fn test_pin_event_is_returning_false_because_is_already_pinned() {
-    let mut setup = PinningTestSetup::new().await;
-    let timeline = setup.timeline().await;
-
-    setup.mock_sync(true).await;
-    assert!(!timeline.items().await.is_empty());
-
-    let event_id = setup.event_id();
-    assert!(!timeline.pin_event(event_id).await.unwrap());
-}
-
-#[async_test]
-async fn test_pin_event_is_returning_an_error() {
-    let mut setup = PinningTestSetup::new().await;
-    let timeline = setup.timeline().await;
-
-    setup.mock_sync(false).await;
-    assert!(!timeline.items().await.is_empty());
-
-    // Pinning a remote event fails.
-    setup.server.mock_set_room_pinned_events().unauthorized().mock_once().mount().await;
-
-    let event_id = setup.event_id();
-    assert!(timeline.pin_event(event_id).await.is_err());
-}
-
-#[async_test]
-async fn test_unpin_event_is_sent_successfully() {
-    let mut setup = PinningTestSetup::new().await;
-    let timeline = setup.timeline().await;
-
-    setup.mock_sync(true).await;
-    assert!(!timeline.items().await.is_empty());
-
-    // Unpinning a remote event succeeds.
-    setup.server.mock_set_room_pinned_events().ok(owned_event_id!("$42")).mock_once().mount().await;
-
-    let event_id = setup.event_id();
-    assert!(timeline.unpin_event(event_id).await.unwrap());
-}
-
-#[async_test]
-async fn test_unpin_event_is_returning_false_because_is_not_pinned() {
-    let mut setup = PinningTestSetup::new().await;
-    let timeline = setup.timeline().await;
-
-    setup.mock_sync(false).await;
-    assert!(!timeline.items().await.is_empty());
-
-    let event_id = setup.event_id();
-    assert!(!timeline.unpin_event(event_id).await.unwrap());
-}
-
-#[async_test]
-async fn test_unpin_event_is_returning_an_error() {
-    let mut setup = PinningTestSetup::new().await;
-    let timeline = setup.timeline().await;
-
-    setup.mock_sync(true).await;
-    assert!(!timeline.items().await.is_empty());
-
-    // Unpinning a remote event fails.
-    setup.server.mock_set_room_pinned_events().unauthorized().mock_once().mount().await;
-
-    let event_id = setup.event_id();
-    assert!(timeline.unpin_event(event_id).await.is_err());
-}
-
-#[async_test]
 async fn test_timeline_without_encryption_info() {
     // The room encryption state is NOT mocked on purpose.
     let server = MatrixMockServer::new().await;
@@ -1073,58 +981,4 @@ async fn test_custom_msglike_event_in_timeline() {
            assert_eq!(observed_other, other_msglike);
        }
     );
-}
-
-struct PinningTestSetup<'a> {
-    event_id: &'a EventId,
-    room_id: &'a ruma::RoomId,
-    client: matrix_sdk::Client,
-    server: MatrixMockServer,
-}
-
-impl PinningTestSetup<'_> {
-    async fn new() -> Self {
-        let server = MatrixMockServer::new().await;
-        let client = server.client_builder().build().await;
-
-        let room_id = room_id!("!a98sd12bjh:example.org");
-        server.sync_joined_room(&client, room_id).await;
-
-        server.mock_room_state_encryption().plain().mount().await;
-
-        // This is necessary to get an empty list of pinned events when there are no
-        // pinned events state event in the required state
-        Mock::given(method("GET"))
-            .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/m.room.pinned_events/.*"))
-            .and(header("authorization", "Bearer 1234"))
-            .respond_with(ResponseTemplate::new(404).set_body_json(json!({})))
-            .mount(server.server())
-            .await;
-
-        let event_id = event_id!("$a");
-        Self { event_id, room_id, client, server }
-    }
-
-    async fn timeline(&self) -> Timeline {
-        let room = self.client.get_room(self.room_id).unwrap();
-        room.timeline().await.unwrap()
-    }
-
-    async fn mock_sync(&mut self, is_using_pinned_state_event: bool) {
-        let f = EventFactory::new().sender(user_id!("@a:b.c"));
-
-        let mut joined_room_builder = JoinedRoomBuilder::new(self.room_id)
-            .add_timeline_event(f.text_msg("A").event_id(self.event_id).into_raw_sync());
-
-        if is_using_pinned_state_event {
-            joined_room_builder =
-                joined_room_builder.add_state_event(StateTestEvent::RoomPinnedEvents);
-        }
-
-        self.server.sync_room(&self.client, joined_room_builder).await;
-    }
-
-    fn event_id(&self) -> &EventId {
-        self.event_id
-    }
 }

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add `Room::pin_event` and `Room::unpin_event`, which allow pinning and unpinning events from a
+  room. These were extracted from the `matrix_sdk_ui` crate, with no changes in functionality.
+  ([#6106](https://github.com/matrix-org/matrix-rust-sdk/pull/6106))
 - `LatestEventValue::RemoteInvite` is added to handle a Latest Event for invite room.
   ([#6056](https://github.com/matrix-org/matrix-rust-sdk/pull/6056))
 - Add `Room::set_own_member_display_name` to set the current user's display name

--- a/crates/matrix-sdk/tests/integration/room/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/mod.rs
@@ -6,6 +6,7 @@ mod common;
 mod joined;
 mod left;
 mod notification_mode;
+mod pinned_events;
 mod spaces;
 mod tags;
 mod thread;

--- a/crates/matrix-sdk/tests/integration/room/pinned_events.rs
+++ b/crates/matrix-sdk/tests/integration/room/pinned_events.rs
@@ -1,0 +1,122 @@
+use std::ops::Not as _;
+
+use matrix_sdk::{Room, test_utils::mocks::MatrixMockServer};
+use matrix_sdk_test::{JoinedRoomBuilder, StateTestEvent, async_test, event_factory::EventFactory};
+use ruma::{EventId, event_id, owned_event_id, room_id, user_id};
+use serde_json::json;
+use wiremock::{
+    Mock, ResponseTemplate,
+    matchers::{header, method, path_regex},
+};
+
+struct PinningTestSetup<'a> {
+    event_id: &'a EventId,
+    room_id: &'a ruma::RoomId,
+    room: Room,
+    client: matrix_sdk::Client,
+    server: MatrixMockServer,
+}
+
+impl PinningTestSetup<'_> {
+    async fn new() -> Self {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        let room_id = room_id!("!a98sd12bjh:example.org");
+        let room = server.sync_joined_room(&client, room_id).await;
+
+        server.mock_room_state_encryption().plain().mount().await;
+
+        // This is necessary to get an empty list of pinned events when there are no
+        // pinned events state event in the required state.
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/m.room.pinned_events/.*"))
+            .and(header("authorization", "Bearer 1234"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(json!({})))
+            .mount(server.server())
+            .await;
+
+        let event_id = event_id!("$a");
+        Self { event_id, room_id, client, server, room }
+    }
+
+    async fn mock_sync(&mut self, include_pinned_state_event: bool) {
+        let f = EventFactory::new().sender(user_id!("@a:b.c"));
+
+        let mut joined_room_builder = JoinedRoomBuilder::new(self.room_id)
+            .add_timeline_event(f.text_msg("A").event_id(self.event_id).into_raw_sync());
+
+        if include_pinned_state_event {
+            joined_room_builder =
+                joined_room_builder.add_state_event(StateTestEvent::RoomPinnedEvents);
+        }
+
+        self.server.sync_room(&self.client, joined_room_builder).await;
+    }
+}
+
+#[async_test]
+async fn test_pin_event_is_sent_successfully() {
+    let mut setup = PinningTestSetup::new().await;
+
+    setup.mock_sync(false).await;
+
+    // Pinning a remote event succeeds.
+    setup.server.mock_set_room_pinned_events().ok(owned_event_id!("$42")).mock_once().mount().await;
+
+    assert!(setup.room.pin_event(setup.event_id).await.unwrap());
+}
+
+#[async_test]
+async fn test_pin_event_is_returning_false_because_is_already_pinned() {
+    let mut setup = PinningTestSetup::new().await;
+
+    setup.mock_sync(true).await;
+
+    assert!(setup.room.pin_event(setup.event_id).await.unwrap().not());
+}
+
+#[async_test]
+async fn test_pin_event_is_returning_an_error() {
+    let mut setup = PinningTestSetup::new().await;
+
+    setup.mock_sync(false).await;
+
+    // Pinning a remote event fails.
+    setup.server.mock_set_room_pinned_events().unauthorized().mock_once().mount().await;
+
+    assert!(setup.room.pin_event(setup.event_id).await.is_err());
+}
+
+#[async_test]
+async fn test_unpin_event_is_sent_successfully() {
+    let mut setup = PinningTestSetup::new().await;
+
+    setup.mock_sync(true).await;
+
+    // Unpinning a remote event succeeds.
+    setup.server.mock_set_room_pinned_events().ok(owned_event_id!("$42")).mock_once().mount().await;
+
+    assert!(setup.room.unpin_event(setup.event_id).await.unwrap());
+}
+
+#[async_test]
+async fn test_unpin_event_is_returning_false_because_is_not_pinned() {
+    let mut setup = PinningTestSetup::new().await;
+
+    setup.mock_sync(false).await;
+
+    assert!(setup.room.unpin_event(setup.event_id).await.unwrap().not());
+}
+
+#[async_test]
+async fn test_unpin_event_is_returning_an_error() {
+    let mut setup = PinningTestSetup::new().await;
+
+    setup.mock_sync(true).await;
+
+    // Unpinning a remote event fails.
+    setup.server.mock_set_room_pinned_events().unauthorized().mock_once().mount().await;
+
+    assert!(setup.room.unpin_event(setup.event_id).await.is_err());
+}

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -1112,7 +1112,7 @@ async fn prepare_room_with_pinned_events(
     let event_id = result.response.event_id;
 
     let timeline = room.timeline().await?;
-    timeline.pin_event(&event_id).await?;
+    timeline.room().pin_event(&event_id).await?;
 
     // Now send a bunch of normal events, this ensures that our pinned event isn't
     // in the main timeline when we restore things.


### PR DESCRIPTION
These make sense to have in the `Room` in general, and they will help getting rid of one of the `PinnedEventsRoom` trait methods in a subsequent PR.

Part of #5954. Prerequisite for #6085.