### PR TITLE
fix(ffi): Remove checksums in all crates using UniFFI

### DIFF
--- a/crates/matrix-sdk-base/uniffi.toml
+++ b/crates/matrix-sdk-base/uniffi.toml
@@ -1,0 +1,7 @@
+[bindings.kotlin]
+package_name = "uniffi.matrix_sdk_base"
+cdylib_name = "matrix_sdk_base"
+android_cleaner = true
+# Checksums are incorrectly failing for users with 32bit (and sometimes 64bit?) devices at the moment
+# Remove once https://github.com/mozilla/uniffi-rs/issues/2740 is fixed or JNI is used instead of JNA
+omit_checksums = true

--- a/crates/matrix-sdk-common/uniffi.toml
+++ b/crates/matrix-sdk-common/uniffi.toml
@@ -1,0 +1,7 @@
+[bindings.kotlin]
+package_name = "uniffi.matrix_sdk_common"
+cdylib_name = "matrix_sdk_common"
+android_cleaner = true
+# Checksums are incorrectly failing for users with 32bit (and sometimes 64bit?) devices at the moment
+# Remove once https://github.com/mozilla/uniffi-rs/issues/2740 is fixed or JNI is used instead of JNA
+omit_checksums = true

--- a/crates/matrix-sdk-crypto/uniffi.toml
+++ b/crates/matrix-sdk-crypto/uniffi.toml
@@ -1,0 +1,7 @@
+[bindings.kotlin]
+package_name = "uniffi.matrix_sdk_crypto"
+cdylib_name = "matrix_sdk_crypto"
+android_cleaner = true
+# Checksums are incorrectly failing for users with 32bit (and sometimes 64bit?) devices at the moment
+# Remove once https://github.com/mozilla/uniffi-rs/issues/2740 is fixed or JNI is used instead of JNA
+omit_checksums = true

--- a/crates/matrix-sdk-ui/uniffi.toml
+++ b/crates/matrix-sdk-ui/uniffi.toml
@@ -1,0 +1,7 @@
+[bindings.kotlin]
+package_name = "uniffi.matrix_sdk_ui"
+cdylib_name = "matrix_sdk_ui"
+android_cleaner = true
+# Checksums are incorrectly failing for users with 32bit (and sometimes 64bit?) devices at the moment
+# Remove once https://github.com/mozilla/uniffi-rs/issues/2740 is fixed or JNI is used instead of JNA
+omit_checksums = true


### PR DESCRIPTION
[Previously](https://github.com/matrix-org/matrix-rust-sdk/pull/6069), this was only applied to the FFI bindings crate, but it's not the only one affected by the issue with 32bit ARM checksum validations.

See https://github.com/element-hq/element-x-android/issues/6028#issuecomment-3843942410.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
