### PR TITLE
Enable ruma's `compat-unset-avatar` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ reqwest = { version = "0.12.24", default-features = false }
 rmp-serde = "1.3.0"
 ruma = { git = "https://github.com/ruma/ruma", rev = "d4f29e2a70dbfb0bd4fdb839ca4629794644ba97", features = [
     "client-api-c",
+    "compat-unset-avatar",
     "compat-upload-signatures",
     "compat-arbitrary-length-ids",
     "compat-tag-info",


### PR DESCRIPTION
Based on [the discussion starting here](https://matrix.to/#/!2GTp0cl8dqhPideYm7pKNABc2m2VqBZz7pVX_UUlijE/$pqz67F2x1dD4pQIWliNH9sf1It8fKEp6HcyXAzck5QI?via=matrix.org&via=element.io&via=sosnowkadub.de) and specifically [this comment](https://matrix.to/#/!2GTp0cl8dqhPideYm7pKNABc2m2VqBZz7pVX_UUlijE/$EX-TMEHTC6UC2gyxeC92ooT-iGMOONXcuSgGaoZk1CQ?via=matrix.org&via=element.io&via=sosnowkadub.de), the SDK should enable the `compat-unset-avatar` feature in `ruma`.

Without this, the `Account::set_avatar_url()` function does not work on homeservers that don't advertise support for the new endpoints for setting profile fields.

I tested that this fix does work properly in [Robrix](https://github.com/project-robius/robrix/).

- [x] Public API changes documented in changelogs (optional)
None

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Kevin Boos <kevinaboos@gmail.com>
