### PR TITLE
fix(ffi): Don't override `package_name` and `cdylib_name` for Kotlin bindings

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to this project will be documented in this file.
 [this issue](https://github.com/mozilla/uniffi-rs/issues/2740)). 
 ([#6069](https://github.com/matrix-org/matrix-rust-sdk/pull/6069), 
 [#6112](https://github.com/matrix-org/matrix-rust-sdk/pull/6112), 
-[#6115](https://github.com/matrix-org/matrix-rust-sdk/pull/6115)).
+[#6115](https://github.com/matrix-org/matrix-rust-sdk/pull/6115),
+[#6116](https://github.com/matrix-org/matrix-rust-sdk/pull/6116)).
 - `Client::create_room` now uses `RoomPowerLevelsContentOverride` under the hood instead of 
   `RoomPowerLevelsEventContent` to be able to explicitly set values which would previously be 
   ignored if they matched the default power level values specified by the spec: these may not be 

--- a/crates/matrix-sdk-base/uniffi.toml
+++ b/crates/matrix-sdk-base/uniffi.toml
@@ -1,6 +1,4 @@
 [bindings.kotlin]
-package_name = "uniffi.matrix_sdk_base"
-cdylib_name = "matrix_sdk_base"
 android_cleaner = true
 # Checksums are incorrectly failing for users with 32bit (and sometimes 64bit?) devices at the moment
 # Remove once https://github.com/mozilla/uniffi-rs/issues/2740 is fixed or JNI is used instead of JNA

--- a/crates/matrix-sdk-common/uniffi.toml
+++ b/crates/matrix-sdk-common/uniffi.toml
@@ -1,6 +1,4 @@
 [bindings.kotlin]
-package_name = "uniffi.matrix_sdk_common"
-cdylib_name = "matrix_sdk_common"
 android_cleaner = true
 # Checksums are incorrectly failing for users with 32bit (and sometimes 64bit?) devices at the moment
 # Remove once https://github.com/mozilla/uniffi-rs/issues/2740 is fixed or JNI is used instead of JNA

--- a/crates/matrix-sdk-crypto/uniffi.toml
+++ b/crates/matrix-sdk-crypto/uniffi.toml
@@ -1,6 +1,4 @@
 [bindings.kotlin]
-package_name = "uniffi.matrix_sdk_crypto"
-cdylib_name = "matrix_sdk_crypto"
 android_cleaner = true
 # Checksums are incorrectly failing for users with 32bit (and sometimes 64bit?) devices at the moment
 # Remove once https://github.com/mozilla/uniffi-rs/issues/2740 is fixed or JNI is used instead of JNA

--- a/crates/matrix-sdk-ui/uniffi.toml
+++ b/crates/matrix-sdk-ui/uniffi.toml
@@ -1,6 +1,4 @@
 [bindings.kotlin]
-package_name = "uniffi.matrix_sdk_ui"
-cdylib_name = "matrix_sdk_ui"
 android_cleaner = true
 # Checksums are incorrectly failing for users with 32bit (and sometimes 64bit?) devices at the moment
 # Remove once https://github.com/mozilla/uniffi-rs/issues/2740 is fixed or JNI is used instead of JNA

--- a/crates/matrix-sdk/uniffi.toml
+++ b/crates/matrix-sdk/uniffi.toml
@@ -1,6 +1,4 @@
 [bindings.kotlin]
-package_name = "uniffi.matrix_sdk"
-cdylib_name = "matrix_sdk"
 android_cleaner = true
 # Checksums are incorrectly failing for users with 32bit (and sometimes 64bit?) devices at the moment
 # Remove once https://github.com/mozilla/uniffi-rs/issues/2740 is fixed or JNI is used instead of JNA


### PR DESCRIPTION
Otherwise, the bindings expect the generated JAR/AAR files to contain separate `.so` libraries for each crate

<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
