### PR TITLE
feat(xtask): Display `pos` and `timeout` for sync report

### DIFF
--- a/xtask/src/log/sync.template.html
+++ b/xtask/src/log/sync.template.html
@@ -35,10 +35,11 @@
     --color-canvas-lighter-2: oklch(0.343 0.009 285.935);
     --color-canvas-lighter-3: oklch(0.6 0 0);
 
-    --color-green: oklch(0.524 0.164 145.0);
-    --color-red : oklch(0.503 0.172 25.0);
-    --color-orange: oklch(0.793 0.171 70.670);
-    --color-yellow: oklch(0.968 0.211 109.769);
+    --color-green: oklch(.524 .164 145);
+    --color-red: oklch(.503 .172 25);
+    --color-orange: oklch(.793 .171 70.67);
+    --color-yellow: oklch(.968 .211 109.769);
+    --color-violet: oklch(.39 .193 328.363);
   }
 
   .content-grid {
@@ -224,8 +225,8 @@
 
         .span {
           --_start-at: var(--start-at, 0);
-          --_duration: var(--duration);
-          --_background: var(--color-accent);
+          --_timeout: var(--timeout, 0);
+          --_duration: var(--duration, 0);
           --_end-gutter: 10ch; /* spaces for the labels */
 
           display: block;
@@ -235,11 +236,24 @@
           width: max(1px, calc((var(--_duration) * (100% - var(--_end-gutter))) / var(--_end-at)));
           height: 1.2rem;
           background: var(--_background);
+
+          --_duration-color: var(--color-accent);
+          --_timeout-color: var(--color-violet);
+          --_timeout-stop: calc(
+            (var(--_timeout) * 100%) / var(--_duration)
+            + 1px /* in case 100% is rounded to the nearest sub-pixel */
+          );
+
+          background: linear-gradient(
+            90deg,
+            var(--_timeout-color) var(--_timeout-stop),
+            var(--_duration-color) var(--_timeout-stop)
+          );
           border-radius: var(--border-radius);
 
           tr:has(> td[data-status-family="cancelled"]) & {
-            width: 3px;
-            --_background: var(--color-orange);
+            width: 3px; /* to be sure it is seen */
+            --_duration-color: var(--color-orange);
           }
 
           > span {


### PR DESCRIPTION
Follow up of https://github.com/matrix-org/matrix-rust-sdk/pull/6118.

This patch updates the `cargo xtask log sync` command to extract the `pos` and `timeout` fields so that we can display them. The `timeout` is displayed in its own column, while the `pos` is displayed in the line details.

Screenshot: see the new “Req. timeout” column, and the “Sliding Sync `pos`” list item in the log line details.

<img width="2840" height="628" alt="Screenshot 2026-02-04 at 17-09-41 Network viewer" src="https://github.com/user-attachments/assets/088f47ad-6568-4bd6-86e4-e6a5fe4af6a8" />

🆕  After the feature requested by @poljar to display the timeout in the duration graph, it looks like this:

<img width="1705" height="328" alt="Screenshot 2026-02-05 at 10-44-35 Network viewer" src="https://github.com/user-attachments/assets/7e2e6c5c-da3a-4814-9a83-c49a5c21198c" />

- When the duration is smaller than the timeout, the timeout is not displayed in the graph (e.g. with REQ-7 and REQ-9).
- When the duration is longer than the duration (it can happen if the server doesn't return because it is calculating a response), the total duration is larger than the timeout, and then the timeout is displayed (e.g. with REQ-6).
- When the timeout is reached with no response, the bar is filled by the timeout only (e.g. with REQ-8).