### PR TITLE
feat(qr-login): add additional QRCodeGrantLoginError enum values

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -90,6 +90,8 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- [**breaking**] `HumanQrGrantLoginError::UnableToCreateDevice` has been removed
+  ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
 - [**breaking**] Removed `ClientBuilder::enable_oidc_refresh_lock` in favour of using `ClientBuilder::cross_process_lock_config`
   to configure that lock when a `MultiProcess` configuration is supplied. ([#6204](https://github.com/matrix-org/matrix-rust-sdk/pull/6204))
 - `RoomPaginationStatus` is renamed to `PaginationStatus`.

--- a/bindings/matrix-sdk-ffi/src/qr_code.rs
+++ b/bindings/matrix-sdk-ffi/src/qr_code.rs
@@ -398,10 +398,6 @@ pub enum HumanQrGrantLoginError {
     #[error("The rendezvous session was not found and might have expired")]
     NotFound,
 
-    /// The device could not be created.
-    #[error("The device could not be created.")]
-    UnableToCreateDevice,
-
     /// An unknown error has happened.
     #[error("An unknown error has happened.")]
     Unknown(String),
@@ -436,7 +432,6 @@ impl From<qrcode::QRCodeGrantLoginError> for HumanQrGrantLoginError {
             QRCodeGrantLoginError::DeviceIDAlreadyInUse => Self::DeviceIDAlreadyInUse,
             QRCodeGrantLoginError::DeviceNotFound => Self::DeviceNotFound,
             QRCodeGrantLoginError::InvalidCheckCode => Self::InvalidCheckCode,
-            QRCodeGrantLoginError::UnableToCreateDevice => Self::UnableToCreateDevice,
             QRCodeGrantLoginError::UnsupportedProtocol(protocol) => {
                 Self::UnsupportedProtocol(protocol.to_string())
             }

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -79,6 +79,8 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- [**breaking**] `QRCodeGrantLoginError::UnableToCreateDevice` has been removed
+  ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
 - The `RoomEventCache::paginate_thread_backwards` method is replaced by `RoomEventCache::thread_pagination` which returns a new `ThreadPagination` type, similar to `RoomPagination`.
   ([#6174](https://github.com/matrix-org/matrix-rust-sdk/pull/6174))
 

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
@@ -115,7 +115,7 @@ async fn finish_login_grant<Q>(
             .unwrap_or(device_authorization_grant.verification_uri.to_string())
             .as_str(),
     )
-    .map_err(|_| QRCodeGrantLoginError::UnableToCreateDevice)?;
+    .map_err(|e| QRCodeGrantLoginError::Unknown(e.to_string()))?;
     state.set(GrantLoginProgress::WaitingForAuth { verification_uri });
 
     // We send the new device the m.login.protocol_accepted message to let it know

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
@@ -151,10 +151,6 @@ pub enum QRCodeGrantLoginError {
     #[error("The check code was incorrect")]
     InvalidCheckCode,
 
-    /// The device could not be created.
-    #[error("The device could not be created")]
-    UnableToCreateDevice,
-
     /// The rendezvous session was not found and might have expired.
     #[error("The rendezvous session was not found and might have expired")]
     NotFound,


### PR DESCRIPTION
<!-- description of the changes in this PR -->

On top of https://github.com/matrix-org/matrix-rust-sdk/pull/6178

This adds additional `QRCodeGrantLoginError` enum values in the SDK crate and additional `HumanQrGrantLoginError` enum values in the FFI crate.

Most of the new values are assigned from what previous went to `Unknown` enum values.

The is one bugfix for where `::DeviceIDAlreadyInUse` was erroneously being returned when the actually the device was not returned by the homeserver. This is now mapped to `::DeviceNotFound` values.

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
