### PR TITLE
refactor(sdk): `waited_for_initial_prev_token` is no more an `Arc<AtomicBool>`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -186,7 +186,7 @@ impl RoomPagination {
 
             match state_guard.load_more_events_backwards().await? {
                 LoadMoreEventsBackwardsOutcome::Gap { prev_token } => {
-                    if prev_token.is_none() && !state_guard.waited_for_initial_prev_token() {
+                    if prev_token.is_none() && !*state_guard.waited_for_initial_prev_token() {
                         // We didn't reload a pagination token, and we haven't waited for one; wait
                         // and start over.
 
@@ -205,7 +205,7 @@ impl RoomPagination {
                         .await;
                         trace!("done waiting");
 
-                        self.inner.state.write().await?.assume_has_waited_for_initial_prev_token();
+                        *self.inner.state.write().await?.waited_for_initial_prev_token() = true;
 
                         // Retry!
                         //

--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1230,13 +1230,8 @@ mod private {
         }
 
         /// Get the `waited_for_initial_prev_token` value.
-        pub fn waited_for_initial_prev_token(&self) -> bool {
-            self.state.waited_for_initial_prev_token
-        }
-
-        /// Assume the system has already waited for the initial `prev_token`.
-        pub fn assume_has_waited_for_initial_prev_token(&mut self) {
-            self.state.waited_for_initial_prev_token = true;
+        pub fn waited_for_initial_prev_token(&mut self) -> &mut bool {
+            &mut self.state.waited_for_initial_prev_token
         }
 
         /// Find a single event in this room.
@@ -1725,7 +1720,7 @@ mod private {
             // If we've never waited for an initial previous-batch token, and we've now
             // inserted a gap, no need to wait for a previous-batch token later.
             if !self.state.waited_for_initial_prev_token && has_new_gap {
-                self.assume_has_waited_for_initial_prev_token();
+                self.state.waited_for_initial_prev_token = true;
             }
 
             // Remove the old duplicated events.


### PR DESCRIPTION
This patch changes `RoomEventCacheState::waited_for_initial_prev_token` from `Arc<AtomicBool>` to `bool`. First off, the `Arc` wasn't used in any useful way (never cloned for example). Second, the `AtomicBool` was always used as a regular bool, no atomicity was really used. Lastly, this patch adds the `assume_has_waited_for_initial_prev_token` method to replace the `= true` operation to make code a bit more readable.
