### PR TITLE
refactor(sdk): Remove one `Vec` allocation

### DIFF
--- a/crates/matrix-sdk/src/event_cache/room/events.rs
+++ b/crates/matrix-sdk/src/event_cache/room/events.rs
@@ -297,7 +297,7 @@ impl EventLinkedChunk {
             }
         }
 
-        self.chunks.push_items_back(events.to_vec());
+        self.chunks.push_items_back(events.iter().cloned());
     }
 
     /// Finish a network back-pagination for this linked chunk by updating the


### PR DESCRIPTION
`LinkedChunk::push_items_back` expects an `IntoIter<Item = Event>`. `EventLinkedChunk::push_live_events` has an `events` of kind `&[Event]`. Using `events.iter().cloned()` instead of `events.to_vec()` not only removes one `Vec` allocation, but it allows the compiler to apply more optimisation.

Checking on godbolt.org, I see twice fewer LLVM IR lines, and 2.8x times less ASM code.