### PR TITLE
doc(sdk): Fix a typo in `subscribe_to_pinned_events`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/room/mod.rs
@@ -1826,7 +1826,7 @@ mod private {
         /// be kept up-to-date as new events are pinned, and new related
         /// events show up from sync or backpagination.
         ///
-        /// This requires that the room's event cache be initialized.
+        /// This requires the room's event cache to be initialized.
         pub async fn subscribe_to_pinned_events(
             &mut self,
             room: Room,


### PR DESCRIPTION
Yup.