### PR TITLE
feat: Expose MSC4171 service members

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room/room_info.rs
@@ -48,6 +48,7 @@ pub struct RoomInfo {
     active_members_count: u64,
     invited_members_count: u64,
     joined_members_count: u64,
+    service_members: Vec<String>,
     highlight_count: u64,
     notification_count: u64,
     cached_user_defined_notification_mode: Option<RoomNotificationMode>,
@@ -138,6 +139,12 @@ impl RoomInfo {
             active_members_count: room.active_members_count(),
             invited_members_count: room.invited_members_count(),
             joined_members_count: room.joined_members_count(),
+            service_members: room
+                .service_members()
+                .iter()
+                .flatten()
+                .map(|m| m.to_string())
+                .collect(),
             highlight_count: unread_notification_counts.highlight_count,
             notification_count: unread_notification_counts.notification_count,
             cached_user_defined_notification_mode: room

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -27,7 +27,7 @@ mod tags;
 mod tombstone;
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     sync::Arc,
 };
 
@@ -340,6 +340,11 @@ impl Room {
     /// 0-100 where 100 would be the max power level.
     pub fn max_power_level(&self) -> i64 {
         self.info.read().base_info.max_power_level
+    }
+
+    /// Get the service members in this room, if available.
+    pub fn service_members(&self) -> Option<BTreeSet<OwnedUserId>> {
+        self.info.read().service_members().cloned()
     }
 
     /// Get the current power levels of this room.

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     sync::{Arc, atomic::AtomicBool},
 };
 
@@ -33,6 +33,7 @@ use ruma::{
             CallMemberStateKey, MembershipData, PossiblyRedactedCallMemberEventContent,
         },
         direct::OwnedDirectUserIdentifier,
+        member_hints::PossiblyRedactedMemberHintsEventContent,
         room::{
             avatar::{self, PossiblyRedactedRoomAvatarEventContent},
             canonical_alias::PossiblyRedactedRoomCanonicalAliasEventContent,
@@ -150,6 +151,9 @@ pub struct BaseRoomInfo {
     pub(crate) join_rules: Option<MinimalStateEvent<PossiblyRedactedRoomJoinRulesEventContent>>,
     /// The maximal power level that can be found in this room.
     pub(crate) max_power_level: i64,
+    /// The member hints for the room as per MSC4171, including service members,
+    /// if available.
+    pub(crate) member_hints: Option<MinimalStateEvent<PossiblyRedactedMemberHintsEventContent>>,
     /// The `m.room.name` of this room.
     pub(crate) name: Option<MinimalStateEvent<PossiblyRedactedRoomNameEventContent>>,
     /// The `m.room.tombstone` event content of this room.
@@ -263,6 +267,17 @@ impl BaseRoomInfo {
                 } else {
                     // Remove the previous content if the new content is unknown.
                     self.guest_access.take().is_some()
+                }
+            }
+            (StateEventType::MemberHints, "") => {
+                if let Some(event) = raw_event.deserialize_as(|any_event| {
+                    as_variant!(any_event, AnySyncStateEvent::MemberHints)
+                }) {
+                    self.member_hints = Some(event.into());
+                    true
+                } else {
+                    // Remove the previous content if the new content is unknown.
+                    self.member_hints.take().is_some()
                 }
             }
             (StateEventType::RoomJoinRules, "") => {
@@ -528,6 +543,7 @@ impl Default for BaseRoomInfo {
             canonical_alias: None,
             create: None,
             dm_targets: Default::default(),
+            member_hints: None,
             encryption: None,
             guest_access: None,
             history_visibility: None,
@@ -1054,6 +1070,12 @@ impl RoomInfo {
         Some(&self.base_info.join_rules.as_ref()?.content.join_rule)
     }
 
+    /// Return the service members for this room if the `m.member_hints` event
+    /// is available
+    pub fn service_members(&self) -> Option<&BTreeSet<OwnedUserId>> {
+        self.base_info.member_hints.as_ref()?.content.service_members.as_ref()
+    }
+
     /// Get the name of this room.
     pub fn name(&self) -> Option<&str> {
         self.base_info.name.as_ref()?.content.name.as_deref().filter(|name| !name.is_empty())
@@ -1442,6 +1464,7 @@ mod tests {
                 "is_marked_unread_source": "Unstable",
                 "join_rules": null,
                 "max_power_level": 100,
+                "member_hints": null,
                 "name": null,
                 "tombstone": null,
                 "topic": null,
@@ -1595,6 +1618,7 @@ mod tests {
                 "history_visibility": null,
                 "join_rules": null,
                 "max_power_level": 100,
+                "member_hints": null,
                 "name": null,
                 "tombstone": null,
                 "topic": null,
@@ -1634,6 +1658,7 @@ mod tests {
         assert!(info.base_info.history_visibility.is_none());
         assert!(info.base_info.join_rules.is_none());
         assert_eq!(info.base_info.max_power_level, 100);
+        assert!(info.base_info.member_hints.is_none());
         assert!(info.base_info.name.is_none());
         assert!(info.base_info.tombstone.is_none());
         assert!(info.base_info.topic.is_none());


### PR DESCRIPTION
Part of https://github.com/element-hq/element-x-android/issues/4034

As per title. Useful for client applications to appropriately filter out service members.

(I've never really written rust before, so if I did something stupid/suboptimal, please be kind. I also wildly guessed at the API shape here. Suggestions welcome)

- [ ] Public API changes documented in changelogs (optional)