### PR TITLE
chore(ffi): use ruma's built-in uniffi support to eliminate some event type enums

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -47,7 +47,5 @@ allow-git = [
     "https://github.com/jplatte/const_panic",
     # A patch override for the bindings: https://github.com/smol-rs/async-compat/pull/22
     "https://github.com/element-hq/async-compat",
-    # We can release vodozemac whenever we need but let's not block development
-    # on releases.
-    "https://github.com/matrix-org/vodozemac",
+    "https://github.com/mozilla/uniffi-rs"
 ]

--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -194,7 +194,7 @@ jobs:
 
   complement-crypto:
     name: "Run Complement Crypto tests"
-    uses: matrix-org/complement-crypto/.github/workflows/single_sdk_tests.yml@399a1deeab0d7e4fa9604cbe83b1df6058c40193 # main
+    uses: matrix-org/complement-crypto/.github/workflows/single_sdk_tests.yml@1b1f86348079608fbc5276fe77c54dd66638a622 # main
     with:
         use_rust_sdk: "." # use local checkout
         use_complement_crypto: "MATCHING_BRANCH"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5118,8 +5118,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4fe5bfacdb0e95e733da3b6c37d98edf46447a4a8e8dea824e0da266d8ad59"
+source = "git+https://github.com/ruma/ruma?rev=8beb557b466a43b057c9c155277c77fe8766fadf#8beb557b466a43b057c9c155277c77fe8766fadf"
 dependencies = [
  "assign",
  "js_int",
@@ -5137,8 +5136,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7ca43a888ca569168d7e3901f4dd14a777b860bb19f4c08e35414162eb261c"
+source = "git+https://github.com/ruma/ruma?rev=8beb557b466a43b057c9c155277c77fe8766fadf#8beb557b466a43b057c9c155277c77fe8766fadf"
 dependencies = [
  "as_variant",
  "assign",
@@ -5160,8 +5158,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3b4f00112791b490acce57df1ce3eb3f88899b045bebcff8a29f75369640cc"
+source = "git+https://github.com/ruma/ruma?rev=8beb557b466a43b057c9c155277c77fe8766fadf#8beb557b466a43b057c9c155277c77fe8766fadf"
 dependencies = [
  "as_variant",
  "base64",
@@ -5194,8 +5191,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85d2f90830fc131691349b96a69ff53444eb6c3e8dc7869c77961b43cfaf3344"
+source = "git+https://github.com/ruma/ruma?rev=8beb557b466a43b057c9c155277c77fe8766fadf#8beb557b466a43b057c9c155277c77fe8766fadf"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -5210,6 +5206,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
+ "uniffi",
  "web-time",
  "wildmatch",
  "zeroize",
@@ -5218,8 +5215,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c9638f18d8da3183ebdf034a552ba6d7e86d217e6e680eebaa97c4e8d13d1a"
+source = "git+https://github.com/ruma/ruma?rev=8beb557b466a43b057c9c155277c77fe8766fadf#8beb557b466a43b057c9c155277c77fe8766fadf"
 dependencies = [
  "headers",
  "http",
@@ -5240,8 +5236,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d33a944650f4bbd2188dd204d39dd87a9a1498f14b3a13252910c90ed7cd43"
+source = "git+https://github.com/ruma/ruma?rev=8beb557b466a43b057c9c155277c77fe8766fadf#8beb557b466a43b057c9c155277c77fe8766fadf"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5252,8 +5247,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6cff00317675f487c4e7ccfb18875a14c5a14867b51d13f2a826053f03c432"
+source = "git+https://github.com/ruma/ruma?rev=8beb557b466a43b057c9c155277c77fe8766fadf#8beb557b466a43b057c9c155277c77fe8766fadf"
 dependencies = [
  "js_int",
  "thiserror 2.0.18",
@@ -5262,8 +5256,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cfb39eaa9b9fd389126ff941e060b496add5cbbfef559d80c46e571dda459c"
+source = "git+https://github.com/ruma/ruma?rev=8beb557b466a43b057c9c155277c77fe8766fadf#8beb557b466a43b057c9c155277c77fe8766fadf"
 dependencies = [
  "as_variant",
  "cfg-if",
@@ -5279,8 +5272,7 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d374cdc542bcb881da80fcb3e58403e5fd17cfe5e0ab03939fdf12f99ef9ba2"
+source = "git+https://github.com/ruma/ruma?rev=8beb557b466a43b057c9c155277c77fe8766fadf#8beb557b466a43b057c9c155277c77fe8766fadf"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6849,8 +6841,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "uniffi"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c6dec3fc6645f71a16a3fa9ff57991028153bd194ca97f4b55e610c73ce66a"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
 dependencies = [
  "anyhow",
  "camino",
@@ -6873,8 +6864,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed0150801958d4825da56a41c71f000a457ac3a4613fa9647df78ac4b6b6881"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
 dependencies = [
  "anyhow",
  "askama",
@@ -6899,8 +6889,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78fd9271a4c2e85bd2c266c5a9ede1fac676eb39fd77f636c27eaf67426fd5f"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
 dependencies = [
  "anyhow",
  "camino",
@@ -6910,8 +6899,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ef62e69762fbb9386dcb6c87cd3dd05d525fa8a3a579a290892e60ddbda47e"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -6923,8 +6911,7 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f51ebca0d9a4b2aa6c644d5ede45c56f73906b96403c08a1985e75ccb64a01"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -6936,8 +6923,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9d12529f1223d014fd501e5f29ca0884d15d6ed5ddddd9f506e55350327dc3"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
 dependencies = [
  "camino",
  "fs-err",
@@ -6953,8 +6939,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df6d413db2827c68588f8149d30d49b71d540d46539e435b23a7f7dbd4d4f86"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -6965,8 +6950,7 @@ dependencies = [
 [[package]]
 name = "uniffi_pipeline"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a806dddc8208f22efd7e95a5cdf88ed43d0f3271e8f63b47e757a8bbdb43b63a"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
 dependencies = [
  "anyhow",
  "heck",
@@ -6978,8 +6962,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1a7339539bf6f6fa3e9b534dece13f778bda2d54b1a6d4e40b4d6090ac26e7"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -7410,8 +7393,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ rand = { version = "0.10.1", default-features = false, features = ["std", "std_r
 regex = { version = "1.12.2", default-features = false }
 reqwest = { version = "0.13.1", default-features = false }
 rmp-serde = { version = "1.3.0", default-features = false }
-ruma = { version = "0.16.0", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "8beb557b466a43b057c9c155277c77fe8766fadf", features = [
     "client-api-c",
     "compat-unset-avatar",
     "compat-upload-signatures",
@@ -114,8 +114,8 @@ tracing-core = { version = "0.1.34", default-features = false }
 tracing-subscriber = { version = "0.3.20", default-features = false, features = ["std", "smallvec", "fmt"] }
 unicode-normalization = { version = "0.1.25", default-features = false }
 unicode-segmentation = { version = "1.12.0", default-features = false }
-uniffi = { version = "0.31.0", default-features = false, features = ["cargo-metadata"] }
-uniffi_bindgen = { version = "0.31.0", default-features = false, features = ["cargo-metadata"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs.git", rev = "e5f4821410bea19e71984ea5e06a7bc8b11ed9e5", version = "0.31.0", default-features = false, features = ["cargo-metadata"] }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs.git", rev = "e5f4821410bea19e71984ea5e06a7bc8b11ed9e5", version = "0.31.0", default-features = false, features = ["cargo-metadata"] }
 url = { version = "2.5.7", default-features = false }
 uuid = { version = "1.18.1", default-features = false }
 vergen-gitcl = { version = "1.0.8", default-features = false }

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -88,6 +88,7 @@ ruma = { workspace = true, features = [
     "unstable-msc2545",
     # Room language event type
     "unstable-msc4334",
+    "unstable-uniffi",
 ] }
 serde.workspace = true
 serde_json.workspace = true

--- a/bindings/matrix-sdk-ffi/changelog.d/6161.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6161.changed.md
@@ -1,0 +1,1 @@
+[**breaking**] Enable `unstable-uniffi` feature in ruma, rename `TimelineEventType` to `FfiTimelineEventType` and replace `StateEventType`, `MessageLikeEventType` and `RoomAccountDataEventType` with the ruma types. 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -89,7 +89,7 @@ use ruma::{
     events::{
         AnyMessageLikeEventContent, AnySyncTimelineEvent,
         GlobalAccountDataEvent as RumaGlobalAccountDataEvent,
-        RoomAccountDataEvent as RumaRoomAccountDataEvent,
+        RoomAccountDataEvent as RumaRoomAccountDataEvent, RoomAccountDataEventType,
         direct::DirectEventContent,
         fully_read::FullyReadEventContent,
         identity_server::IdentityServerEventContent,
@@ -141,7 +141,7 @@ use crate::{
     room_preview::RoomPreview,
     ruma::{
         AccountDataEvent, AccountDataEventType, AuthData, InviteAvatars, MediaPreviewConfig,
-        MediaPreviews, MediaSource, RoomAccountDataEvent, RoomAccountDataEventType,
+        MediaPreviews, MediaSource, RoomAccountDataEvent,
     },
     runtime::get_runtime_handle,
     spaces::SpaceService,
@@ -1023,6 +1023,13 @@ impl Client {
             }
             RoomAccountDataEventType::UnstableMarkedUnread => {
                 observe!(UnstableMarkedUnreadEventContent)
+            }
+            _ => {
+                // TODO: Support the remaining types
+                Err(ClientError::Generic {
+                    msg: "Unsupported room account data type".to_owned(),
+                    details: None,
+                })
             }
         }
     }

--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -19,9 +19,9 @@ use ruma::{
     EventId,
     events::{
         AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent,
-        MessageLikeEventContent as RumaMessageLikeEventContent, RedactContent,
-        RedactedStateEventContent, StaticStateEventContent, SyncMessageLikeEvent, SyncStateEvent,
-        TimelineEventType as RumaTimelineEventType,
+        MessageLikeEventContent as RumaMessageLikeEventContent, MessageLikeEventType,
+        RedactContent, RedactedStateEventContent, StateEventType, StaticStateEventContent,
+        SyncMessageLikeEvent, SyncStateEvent, TimelineEventType as RumaTimelineEventType,
         room::{
             encrypted,
             message::{MessageType as RumaMessageType, Relation},
@@ -90,7 +90,7 @@ impl From<AnyTimelineEvent> for TimelineEvent {
 /// The timeline event type.
 #[derive(Clone, uniffi::Enum, PartialEq, Eq, Hash)]
 #[uniffi::export(Eq, Hash)]
-pub enum TimelineEventType {
+pub enum FfiTimelineEventType {
     /// The event is a message-like one and should be displayed as such.
     MessageLike { value: MessageLikeEventType },
     /// The event is a state event, and may or may not be displayed in the
@@ -98,7 +98,7 @@ pub enum TimelineEventType {
     State { value: StateEventType },
 }
 
-impl From<RumaTimelineEventType> for TimelineEventType {
+impl From<RumaTimelineEventType> for FfiTimelineEventType {
     fn from(value: RumaTimelineEventType) -> Self {
         match value {
             RumaTimelineEventType::Audio => {
@@ -242,9 +242,7 @@ impl From<RumaTimelineEventType> for TimelineEventType {
             RumaTimelineEventType::RoomJoinRules => {
                 Self::State { value: StateEventType::RoomJoinRules }
             }
-            RumaTimelineEventType::RoomMember => {
-                Self::State { value: StateEventType::RoomMemberEvent }
-            }
+            RumaTimelineEventType::RoomMember => Self::State { value: StateEventType::RoomMember },
             RumaTimelineEventType::RoomLanguage => {
                 Self::State { value: StateEventType::RoomLanguage }
             }
@@ -278,9 +276,9 @@ impl From<RumaTimelineEventType> for TimelineEventType {
                 Self::State { value: StateEventType::MemberHints }
             }
             RumaTimelineEventType::_Custom(_) => {
-                Self::State { value: StateEventType::Custom { value: value.to_string() } }
+                Self::State { value: StateEventType::from(value.to_string()) }
             }
-            _ => Self::MessageLike { value: MessageLikeEventType::Other(value.to_string()) },
+            _ => Self::MessageLike { value: MessageLikeEventType::from(value.to_string()) },
         }
     }
 }
@@ -512,162 +510,6 @@ where
     let original_content =
         event.as_original().context("Failed to get original content")?.content.clone();
     Ok(original_content)
-}
-
-#[derive(Clone, uniffi::Enum, PartialEq, Eq, Hash)]
-pub enum StateEventType {
-    BeaconInfo,
-    CallMember,
-    MemberHints,
-    PolicyRuleRoom,
-    PolicyRuleServer,
-    PolicyRuleUser,
-    RoomAvatar,
-    RoomCanonicalAlias,
-    RoomCreate,
-    RoomEncryption,
-    RoomGuestAccess,
-    RoomHistoryVisibility,
-    RoomImagePack,
-    RoomJoinRules,
-    RoomMemberEvent,
-    RoomLanguage,
-    RoomName,
-    RoomPinnedEvents,
-    RoomPowerLevels,
-    RoomServerAcl,
-    RoomThirdPartyInvite,
-    RoomTombstone,
-    RoomTopic,
-    SpaceChild,
-    SpaceParent,
-    Custom { value: String },
-}
-
-impl From<StateEventType> for ruma::events::StateEventType {
-    fn from(val: StateEventType) -> Self {
-        match val {
-            StateEventType::BeaconInfo => Self::BeaconInfo,
-            StateEventType::CallMember => Self::CallMember,
-            StateEventType::MemberHints => Self::MemberHints,
-            StateEventType::PolicyRuleRoom => Self::PolicyRuleRoom,
-            StateEventType::PolicyRuleServer => Self::PolicyRuleServer,
-            StateEventType::PolicyRuleUser => Self::PolicyRuleUser,
-            StateEventType::RoomAvatar => Self::RoomAvatar,
-            StateEventType::RoomCanonicalAlias => Self::RoomCanonicalAlias,
-            StateEventType::RoomCreate => Self::RoomCreate,
-            StateEventType::RoomEncryption => Self::RoomEncryption,
-            StateEventType::RoomGuestAccess => Self::RoomGuestAccess,
-            StateEventType::RoomHistoryVisibility => Self::RoomHistoryVisibility,
-            StateEventType::RoomImagePack => Self::RoomImagePack,
-            StateEventType::RoomJoinRules => Self::RoomJoinRules,
-            StateEventType::RoomLanguage => Self::RoomLanguage,
-            StateEventType::RoomMemberEvent => Self::RoomMember,
-            StateEventType::RoomName => Self::RoomName,
-            StateEventType::RoomPinnedEvents => Self::RoomPinnedEvents,
-            StateEventType::RoomPowerLevels => Self::RoomPowerLevels,
-            StateEventType::RoomServerAcl => Self::RoomServerAcl,
-            StateEventType::RoomThirdPartyInvite => Self::RoomThirdPartyInvite,
-            StateEventType::RoomTombstone => Self::RoomTombstone,
-            StateEventType::RoomTopic => Self::RoomTopic,
-            StateEventType::SpaceChild => Self::SpaceChild,
-            StateEventType::SpaceParent => Self::SpaceParent,
-            StateEventType::Custom { value } => value.into(),
-        }
-    }
-}
-
-#[derive(Clone, uniffi::Enum, PartialEq, Eq, Hash)]
-pub enum MessageLikeEventType {
-    Audio,
-    Beacon,
-    CallAnswer,
-    CallCandidates,
-    CallHangup,
-    CallInvite,
-    CallNegotiate,
-    CallNotify,
-    CallReject,
-    CallSdpStreamMetadataChanged,
-    CallSelectAnswer,
-    Emote,
-    Encrypted,
-    File,
-    Image,
-    KeyVerificationAccept,
-    KeyVerificationCancel,
-    KeyVerificationDone,
-    KeyVerificationKey,
-    KeyVerificationMac,
-    KeyVerificationReady,
-    KeyVerificationStart,
-    Location,
-    Message,
-    PollEnd,
-    PollResponse,
-    PollStart,
-    Reaction,
-    RoomEncrypted,
-    RoomMessage,
-    RoomRedaction,
-    RtcDecline,
-    RtcNotification,
-    Sticker,
-    UnstablePollEnd,
-    UnstablePollResponse,
-    UnstablePollStart,
-    Video,
-    Voice,
-    Other(String),
-}
-
-impl From<MessageLikeEventType> for ruma::events::MessageLikeEventType {
-    fn from(val: MessageLikeEventType) -> Self {
-        match val {
-            MessageLikeEventType::Audio => Self::Audio,
-            MessageLikeEventType::File => Self::File,
-            MessageLikeEventType::Image => Self::Image,
-            MessageLikeEventType::Video => Self::Video,
-            MessageLikeEventType::Voice => Self::Voice,
-            MessageLikeEventType::Beacon => Self::Beacon,
-            MessageLikeEventType::CallAnswer => Self::CallAnswer,
-            MessageLikeEventType::CallCandidates => Self::CallCandidates,
-            MessageLikeEventType::CallInvite => Self::CallInvite,
-            MessageLikeEventType::CallHangup => Self::CallHangup,
-            MessageLikeEventType::CallNegotiate => Self::CallNegotiate,
-            MessageLikeEventType::CallNotify => Self::CallNotify,
-            MessageLikeEventType::CallReject => Self::CallReject,
-            MessageLikeEventType::CallSdpStreamMetadataChanged => {
-                Self::CallSdpStreamMetadataChanged
-            }
-            MessageLikeEventType::CallSelectAnswer => Self::CallSelectAnswer,
-            MessageLikeEventType::Emote => Self::Emote,
-            MessageLikeEventType::Encrypted => Self::Encrypted,
-            MessageLikeEventType::KeyVerificationReady => Self::KeyVerificationReady,
-            MessageLikeEventType::KeyVerificationStart => Self::KeyVerificationStart,
-            MessageLikeEventType::KeyVerificationCancel => Self::KeyVerificationCancel,
-            MessageLikeEventType::KeyVerificationAccept => Self::KeyVerificationAccept,
-            MessageLikeEventType::KeyVerificationKey => Self::KeyVerificationKey,
-            MessageLikeEventType::KeyVerificationMac => Self::KeyVerificationMac,
-            MessageLikeEventType::KeyVerificationDone => Self::KeyVerificationDone,
-            MessageLikeEventType::Location => Self::Location,
-            MessageLikeEventType::Message => Self::Message,
-            MessageLikeEventType::Reaction => Self::Reaction,
-            MessageLikeEventType::RoomEncrypted => Self::RoomEncrypted,
-            MessageLikeEventType::RoomMessage => Self::RoomMessage,
-            MessageLikeEventType::RoomRedaction => Self::RoomRedaction,
-            MessageLikeEventType::RtcDecline => Self::RtcDecline,
-            MessageLikeEventType::Sticker => Self::Sticker,
-            MessageLikeEventType::PollEnd => Self::PollEnd,
-            MessageLikeEventType::PollResponse => Self::PollResponse,
-            MessageLikeEventType::PollStart => Self::PollStart,
-            MessageLikeEventType::RtcNotification => Self::RtcNotification,
-            MessageLikeEventType::UnstablePollEnd => Self::UnstablePollEnd,
-            MessageLikeEventType::UnstablePollResponse => Self::UnstablePollResponse,
-            MessageLikeEventType::UnstablePollStart => Self::UnstablePollStart,
-            MessageLikeEventType::Other(msgtype) => Self::from(msgtype),
-        }
-    }
 }
 
 #[derive(Debug, PartialEq, Clone, uniffi::Enum)]

--- a/bindings/matrix-sdk-ffi/src/room/power_levels.rs
+++ b/bindings/matrix-sdk-ffi/src/room/power_levels.rs
@@ -18,15 +18,12 @@ use anyhow::Result;
 use ruma::{
     OwnedUserId, UserId,
     events::{
-        MessageLikeEventType as RumaMessageLikeEventType, StateEventType as RumaStateEventType,
-        TimelineEventType, room::power_levels::RoomPowerLevels as RumaPowerLevels,
+        MessageLikeEventType, StateEventType, TimelineEventType,
+        room::power_levels::RoomPowerLevels as RumaPowerLevels,
     },
 };
 
-use crate::{
-    error::ClientError,
-    event::{MessageLikeEventType, StateEventType},
-};
+use crate::error::ClientError;
 
 #[derive(uniffi::Object)]
 pub struct RoomPowerLevels {
@@ -46,7 +43,7 @@ impl RoomPowerLevels {
         self.inner.clone().into()
     }
 
-    fn events(&self) -> HashMap<crate::event::TimelineEventType, i64> {
+    fn events(&self) -> HashMap<crate::event::FfiTimelineEventType, i64> {
         self.inner.events.iter().map(|(key, value)| (key.clone().into(), (*value).into())).collect()
     }
 
@@ -137,7 +134,7 @@ impl RoomPowerLevels {
     /// Returns true if the current user is able to send a specific state event
     /// type in the room.
     pub fn can_own_user_send_state(&self, state_event: StateEventType) -> bool {
-        self.inner.user_can_send_state(&self.own_user_id, state_event.into())
+        self.inner.user_can_send_state(&self.own_user_id, state_event)
     }
 
     /// Returns true if the user with the given user_id is able to send a
@@ -150,13 +147,13 @@ impl RoomPowerLevels {
         state_event: StateEventType,
     ) -> Result<bool, ClientError> {
         let user_id = UserId::parse(&user_id)?;
-        Ok(self.inner.user_can_send_state(&user_id, state_event.into()))
+        Ok(self.inner.user_can_send_state(&user_id, state_event))
     }
 
     /// Returns true if the current user is able to send a specific message type
     /// in the room.
     pub fn can_own_user_send_message(&self, message: MessageLikeEventType) -> bool {
-        self.inner.user_can_send_message(&self.own_user_id, message.into())
+        self.inner.user_can_send_message(&self.own_user_id, message)
     }
 
     /// Returns true if the user with the given user_id is able to send a
@@ -169,13 +166,13 @@ impl RoomPowerLevels {
         message: MessageLikeEventType,
     ) -> Result<bool, ClientError> {
         let user_id = UserId::parse(&user_id)?;
-        Ok(self.inner.user_can_send_message(&user_id, message.into()))
+        Ok(self.inner.user_can_send_message(&user_id, message))
     }
 
     /// Returns true if the current user is able to pin or unpin events in the
     /// room.
     pub fn can_own_user_pin_unpin(&self) -> bool {
-        self.inner.user_can_send_state(&self.own_user_id, StateEventType::RoomPinnedEvents.into())
+        self.inner.user_can_send_state(&self.own_user_id, StateEventType::RoomPinnedEvents)
     }
 
     /// Returns true if the user with the given user_id is able to pin or unpin
@@ -184,7 +181,7 @@ impl RoomPowerLevels {
     /// The call may fail if there is an error in getting the power levels.
     pub fn can_user_pin_unpin(&self, user_id: String) -> Result<bool, ClientError> {
         let user_id = UserId::parse(&user_id)?;
-        Ok(self.inner.user_can_send_state(&user_id, StateEventType::RoomPinnedEvents.into()))
+        Ok(self.inner.user_can_send_state(&user_id, StateEventType::RoomPinnedEvents))
     }
 
     /// Returns true if the current user is able to trigger a notification in
@@ -263,8 +260,8 @@ impl From<RumaPowerLevels> for RoomPowerLevelsValues {
             room_avatar: state_event_level_for(&value, &TimelineEventType::RoomAvatar),
             room_topic: state_event_level_for(&value, &TimelineEventType::RoomTopic),
             space_child: state_event_level_for(&value, &TimelineEventType::SpaceChild),
-            beacon: message_event_level_for(&value, &RumaMessageLikeEventType::Beacon.into()),
-            beacon_info: state_event_level_for(&value, &RumaStateEventType::BeaconInfo.into()),
+            beacon: message_event_level_for(&value, &MessageLikeEventType::Beacon.into()),
+            beacon_info: state_event_level_for(&value, &StateEventType::BeaconInfo.into()),
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -27,7 +27,6 @@ use ruma::{
         GlobalAccountDataEvent as RumaGlobalAccountDataEvent,
         GlobalAccountDataEventType as RumaGlobalAccountDataEventType,
         RoomAccountDataEvent as RumaRoomAccountDataEvent,
-        RoomAccountDataEventType as RumaRoomAccountDataEventType,
         direct::DirectEventContent,
         fully_read::FullyReadEventContent,
         identity_server::IdentityServerEventContent,
@@ -1653,33 +1652,6 @@ impl TryFrom<RumaGlobalAccountDataEvent<SecretStorageKeyEventContent>> for Accou
             algorithm: value.content.algorithm.try_into()?,
             passphrase: value.content.passphrase.map(TryInto::try_into).transpose()?,
         })
-    }
-}
-
-/// Types of room account data events.
-#[derive(Clone, uniffi::Enum)]
-pub enum RoomAccountDataEventType {
-    /// m.fully_read
-    FullyRead,
-    /// m.marked_unread
-    MarkedUnread,
-    /// m.tag
-    Tag,
-    /// com.famedly.marked_unread
-    UnstableMarkedUnread,
-}
-
-impl TryFrom<RumaRoomAccountDataEventType> for RoomAccountDataEventType {
-    type Error = String;
-
-    fn try_from(value: RumaRoomAccountDataEventType) -> Result<Self, Self::Error> {
-        match value {
-            RumaRoomAccountDataEventType::FullyRead => Ok(Self::FullyRead),
-            RumaRoomAccountDataEventType::MarkedUnread => Ok(Self::MarkedUnread),
-            RumaRoomAccountDataEventType::Tag => Ok(Self::Tag),
-            RumaRoomAccountDataEventType::UnstableMarkedUnread => Ok(Self::UnstableMarkedUnread),
-            _ => Err("Unsupported account data event type".to_owned()),
-        }
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/timeline/configuration.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/configuration.rs
@@ -23,14 +23,11 @@ use matrix_sdk_ui::timeline::{
 };
 use ruma::{
     EventId,
-    events::{AnySyncTimelineEvent, TimelineEventType},
+    events::{AnySyncTimelineEvent, MessageLikeEventType, StateEventType, TimelineEventType},
 };
 
 use super::FocusEventError;
-use crate::{
-    error::ClientError,
-    event::{MessageLikeEventType, RoomMessageEventMessageType, StateEventType},
-};
+use crate::{error::ClientError, event::RoomMessageEventMessageType};
 
 /// A timeline filter that includes or excludes events based on their type or
 /// content.
@@ -90,12 +87,8 @@ pub enum FilterTimelineEventType {
 impl From<FilterTimelineEventType> for TimelineEventType {
     fn from(value: FilterTimelineEventType) -> TimelineEventType {
         match value {
-            FilterTimelineEventType::MessageLike { event_type } => {
-                ruma::events::MessageLikeEventType::from(event_type).into()
-            }
-            FilterTimelineEventType::State { event_type } => {
-                ruma::events::StateEventType::from(event_type).into()
-            }
+            FilterTimelineEventType::MessageLike { event_type } => event_type.into(),
+            FilterTimelineEventType::State { event_type } => event_type.into(),
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -21,7 +21,7 @@ use ruma::events::{
 };
 
 use crate::{
-    client::JoinRule, event::TimelineEventType, ruma::AssetType,
+    client::JoinRule, event::FfiTimelineEventType, ruma::AssetType,
     timeline::msg_like::MsgLikeContent, utils::Timestamp,
 };
 
@@ -294,8 +294,8 @@ pub enum OtherState {
         change: RoomPinnedEventsChange,
     },
     RoomPowerLevels {
-        events: HashMap<TimelineEventType, i64>,
-        previous_events: Option<HashMap<TimelineEventType, i64>>,
+        events: HashMap<FfiTimelineEventType, i64>,
+        previous_events: Option<HashMap<FfiTimelineEventType, i64>>,
         users: HashMap<String, i64>,
         previous_users: Option<HashMap<String, i64>>,
         thresholds: PowerLevelChanges,

--- a/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
@@ -15,7 +15,9 @@
 use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk_base::crypto::types::events::UtdCause;
-use ruma::events::{MessageLikeEventContent, room::MediaSource as RumaMediaSource};
+use ruma::events::{
+    MessageLikeEventContent, MessageLikeEventType, room::MediaSource as RumaMediaSource,
+};
 
 use super::{
     content::{BeaconInfo, LiveLocationContent, Reaction},
@@ -23,7 +25,6 @@ use super::{
 };
 use crate::{
     error::ClientError,
-    event::MessageLikeEventType,
     ruma::{ImageInfo, MediaSource, MediaSourceExt, Mentions, MessageType, PollKind},
     timeline::content::ReactionSenderData,
     utils::Timestamp,
@@ -194,7 +195,7 @@ impl TryFrom<matrix_sdk_ui::timeline::MsgLikeContent> for MsgLikeContent {
             },
             Kind::Other(other) => Self {
                 kind: MsgLikeKind::Other {
-                    event_type: MessageLikeEventType::Other(other.event_type().to_string()),
+                    event_type: MessageLikeEventType::from(other.event_type().to_string()),
                 },
                 reactions,
                 in_reply_to,


### PR DESCRIPTION
This is the smallest possible way that I could find to start using https://github.com/ruma/ruma/pull/2338 in the FFI bindings. It eliminates the types `StateEventType`, `MessageLikeEventType` and `RoomAccountDataEventType` from the FFI crate and instead uses the Ruma types directly .

The only difference of the two types in the foreign language should be the use of `Custom` vs. `Other`.

- [x] Public API changes documented in changelogs (optional)
