### PR TITLE
Revert "refactor: don't build the benchmarks by default either"

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -94,5 +94,6 @@ jobs:
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@4deb3275dd364fb96fb074c953133d29ec96f80f
         with:
-          mode: "simulation"
+          run: cargo codspeed run
+          mode: "instrumentation"
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,8 @@ members = [
     "xtask",
 ]
 exclude = ["testing/data"]
-# xtask, multiverse, benchmarks, testing and the bindings should only be built when invoked
-# explicitly.
-default-members = ["crates/*"]
+# xtask, multiverse, testing and the bindings should only be built when invoked explicitly.
+default-members = ["benchmarks", "crates/*"]
 resolver = "3"
 
 [workspace.package]


### PR DESCRIPTION
This reverts commit 66ea5d990d38115b47efaaebdfe7f4a518951bc5, as it's causing build failures and my little investigations have led me nowhere.