### PR TITLE
fix(sdk): `LatestEventValue::RemoteInvite` is computed once per room

### DIFF
--- a/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
@@ -106,6 +106,9 @@ impl Builder {
                     // If the event is a stripped state event, it has no event ID. This is
                     // acceptable.
                     event.event_id().map(ToOwned::to_owned),
+                    // If the event is a stripped state event, it has no timestamp (no
+                    // `origin_server_ts`). If, in any case, it has one (it could happen depending
+                    // of the server implementation), let's use it.
                     event.timestamp().map(MilliSecondsSinceUnixEpoch),
                     Some(inviter_id),
                 )
@@ -114,9 +117,9 @@ impl Builder {
 
         LatestEventValue::RemoteInvite {
             event_id,
-            // If the event is a stripped state event, it has no timestamp, let's
-            // use `now` as a fallback so that the `LatestEventValue` can be used to
-            // sort rooms in a room list for example.
+            // If the event is a stripped state event, it should not have a timestamp. Let's use
+            // `now()` as a fallback so that the `LatestEventValue` can be used to sort rooms in a
+            // room list for example.
             timestamp: timestamp.unwrap_or_else(MilliSecondsSinceUnixEpoch::now),
             inviter: inviter_id,
         }

--- a/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
@@ -156,6 +156,24 @@ impl LatestEvent {
                 // If the room' state is `Invited`, it means the current user has been recently
                 // invited to this room.
                 RoomState::Invited => {
+                    // Short: Let's not update a `RemoteInvite` to another `RemoteInvite`.
+                    //
+                    // Long: An invite room is only constituted of stripped-state events. These
+                    // events do not have an `origin_server_ts` field. It means we cannot compute
+                    // the timestamp of the `LatestEventValue`. To workaround this, we set the
+                    // timestamp to `now()`. See `Builder::new_remote_for_invite` to learn more.
+                    // If an invite room receives a new event, its `LatestEventValue`'s timestamp
+                    // will be updated to `now()`, which will make the room bumps to the top of the
+                    // room list for example. This is not an acceptable behaviour because it can be
+                    // an “attack vector”, i.e. a way to annoy people with spammy invites. That's
+                    // why, once a `RemoteInvite` has been computed, we do not refresh it.
+                    if matches!(
+                        self.current_value.read().await.deref(),
+                        LatestEventValue::RemoteInvite { .. }
+                    ) {
+                        return;
+                    }
+
                     let new_value = Builder::new_remote_for_invite(&room).await;
 
                     trace!(value = ?new_value, "Computed a remote `LatestEventValue` for invite");


### PR DESCRIPTION
An invite room is only constitued of stripped-state events. These events do not have an `origin_server_ts` field. It means we cannot compute the timestamp of the `LatestEventValue`. To workaround this, we set the timestamp to `now()`. See `Builder::new_remote_for_invite` to learn more. If an invite room receives a new event, its `LatestEventValue`'s timestamp can be updated to `now()` again, which will make the room bumps to the top of the room list for example. This is not an acceptable behaviour because it can be an “attack vector”, i.e. a way to annoy people with spammy invites. That's why, once a `RemoteInvite` has been computed, we do not refresh it.

The fix is 2 instructions. The rest are comments and tests.

Best to review [without whitespaces in the diff](./6171/changes?w=1) (add `w=1` to the diff URL), because I've increased the indentation in a test (I've added blocks).