### PR TITLE
test(qr-login): assert expect error codes in grant test cases

### DIFF
--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
@@ -1175,7 +1175,11 @@ mod test {
         });
 
         // Wait for all tasks to finish / fail.
-        grant.await.expect_err("Alice should abort the login");
+        assert_matches!(
+            grant.await,
+            Err(QRCodeGrantLoginError::Unknown(_)),
+            "Alice should abort the login with expected error"
+        );
         updates_task.await.expect("Alice should run through all progress states");
         bob_task.await.expect("Bob's task should finish");
     }
@@ -1276,9 +1280,12 @@ mod test {
             .await;
         });
 
-        grant.await.expect_err("Alice should abort the login");
-
         // Wait for all tasks to finish / fail.
+        assert_matches!(
+            grant.await,
+            Err(QRCodeGrantLoginError::Unknown(_)),
+            "Alice should abort the login with expected error"
+        );
         updates_task.await.expect("Alice should run through all progress states");
         bob_task.await.expect("Bob's task should finish");
     }
@@ -1404,7 +1411,11 @@ mod test {
         });
 
         // Wait for all tasks to finish.
-        grant.await.expect_err("Alice should abort the login");
+        assert_matches!(
+            grant.await,
+            Err(QRCodeGrantLoginError::DeviceIDAlreadyInUse),
+            "Alice should abort the login with expected error"
+        );
         updates_task.await.expect("Alice should run through all progress states");
         bob_task.await.expect("Bob's task should finish");
     }
@@ -1515,7 +1526,11 @@ mod test {
         });
 
         // Wait for all tasks to finish.
-        grant.await.expect_err("Alice should abort the login");
+        assert_matches!(
+            grant.await,
+            Err(QRCodeGrantLoginError::DeviceIDAlreadyInUse),
+            "Alice should abort the login with expected error"
+        );
         updates_task.await.expect("Alice should run through all progress states");
         bob_task.await.expect("Bob's task should finish");
     }
@@ -1651,7 +1666,13 @@ mod test {
             .await;
         });
 
-        grant.await.expect_err("Alice should abort the login");
+        // TODO: the DeviceIDAlreadyInUse error here doesn't make much sense, instead
+        // something like UnableToCreateDevice?
+        assert_matches!(
+            grant.await,
+            Err(QRCodeGrantLoginError::DeviceIDAlreadyInUse),
+            "Alice should abort the login with expected error"
+        );
         updates_task.await.expect("Alice should run through all progress states");
         bob_task.await.expect("Bob's task should finish");
     }
@@ -1770,7 +1791,13 @@ mod test {
             .await;
         });
 
-        grant.await.expect_err("Alice should abort the login");
+        // TODO: the DeviceIDAlreadyInUse error here doesn't make much sense, instead
+        // something like UnableToCreateDevice?
+        assert_matches!(
+            grant.await,
+            Err(QRCodeGrantLoginError::DeviceIDAlreadyInUse),
+            "Alice should abort the login with expected error"
+        );
         updates_task.await.expect("Alice should run through all progress states");
         bob_task.await.expect("Bob's task should finish");
     }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

This PR asserts the type of error that is returned when a grant login test case is expected to fail.

In adding these I've identified that for two of the test cases the error given doesn't make sense and should be fixed. I've added a TODO for these and will fix in a subsequent PR.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:  Hugh Nimmo-Smith <hughns@element.io>
