### PR TITLE
feat(ffi): export is_low_priority for a room

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add `RoomInfo::is_low_priority` for getting the room's `m.lowpriority` tag state
+  ([#6183](https://github.com/matrix-org/matrix-rust-sdk/pull/6183))
 - Add `Client::subscribe_to_duplicate_key_upload_errors` for listening to duplicate key
   upload errors from `/keys/upload`.
   ([#6135](https://github.com/matrix-org/matrix-rust-sdk/pull/6135/))

--- a/bindings/matrix-sdk-ffi/src/room/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room/room_info.rs
@@ -49,6 +49,7 @@ pub struct RoomInfo {
     /// If present, it means the room has been archived/upgraded.
     successor_room: Option<SuccessorRoom>,
     is_favourite: bool,
+    is_low_priority: bool,
     canonical_alias: Option<String>,
     alternative_aliases: Vec<String>,
     membership: Membership,
@@ -134,6 +135,7 @@ impl RoomInfo {
             is_space: room.is_space(),
             successor_room: room.successor_room().map(Into::into),
             is_favourite: room.is_favourite(),
+            is_low_priority: room.is_low_priority(),
             canonical_alias: room.canonical_alias().map(Into::into),
             alternative_aliases: room.alt_aliases().into_iter().map(Into::into).collect(),
             membership: room.state().into(),


### PR DESCRIPTION
add access to room's low priority tag status.
interestingly, the api for setting that tag is already present as `room.set_is_low_priority`.

- [x] Public API changes documented in changelogs (optional)
