### PR TITLE
doc: Add another checkbox about AI policy in `pull_request_template.md`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 <!-- description of the changes in this PR -->
 
-- [ ] Public API changes documented in changelogs (optional)
+- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
+- [ ] I've read [the `CONTRIBUTING.md` file](https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md), notably the sections about Pull requests, Commit message format, and AI policy.
+- [ ] This PR was made with the help of AI.
 
 <!-- Sign-off, if not part of the commits -->
 <!-- See CONTRIBUTING.md if you don't know what this is -->


### PR DESCRIPTION
This patch adds a new checkbox to ensure the user has read the `CONTRIBUTING.md` file, notably the Pull requests, Commit message format, and AI policy Sections.