### PR TITLE
chore(sdk): Promote a `debug!` to `error!` when an HTTP request fails

### DIFF
--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -36,7 +36,7 @@ use ruma::api::{
     path_builder,
 };
 use tokio::sync::{Semaphore, SemaphorePermit};
-use tracing::{debug, field::debug, instrument, trace};
+use tracing::{debug, error, field::debug, instrument, trace};
 
 use crate::{HttpResult, client::caches::CachedValue, config::RequestConfig, error::HttpError};
 
@@ -215,7 +215,7 @@ impl HttpClient {
                 Ok(response)
             }
             Err(e) => {
-                debug!("Error while sending request: {e:?}");
+                error!("Error while sending request: {e:?}");
                 Err(e)
             }
         }


### PR DESCRIPTION
This patch increases a log from `debug` to `error` when an HTTP request fails. This is an error, and it must appear as such in the logs.

---

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] I've read [the `CONTRIBUTING.md` file](https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md), notably the sections about Pull requests, Commit message format, and AI policy.
- [ ] This PR was made with the help of AI.