### PR TITLE
fix(ui): Unexpected invites are now ignored for non-subscribed rooms in `NotificationClient::try_sliding_sync`

### DIFF
--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -569,10 +569,7 @@ impl NotificationClient {
             }
 
             remaining_attempts -= 1;
-            warn!(
-                "There are some missing notifications, remaining attempts: {}",
-                remaining_attempts
-            );
+            warn!("There are some missing notifications, remaining attempts: {remaining_attempts}");
             if remaining_attempts == 0 {
                 // We're out of luck.
                 break;


### PR DESCRIPTION
When using `NotificationClient::try_sliding_sync`, ignore invite state events that don't match any of the rooms we've subscribed to. 

This was causing the `if event_count + invite_count == expected_notification_count` check that stops the sync loop to fail, resulting in unnecessary syncs being done when we already had the wanted event long ago.

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] I've read [the `CONTRIBUTING.md` file](https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md), notably the sections about Pull requests, Commit message format, and AI policy.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
