### PR TITLE
fix: Fix a small typo in ClientBuildError::MissingHomeserver error me…

### DIFF
--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -808,7 +808,7 @@ impl fmt::Debug for BuilderStoreConfig {
 #[derive(Debug, Error)]
 pub enum ClientBuildError {
     /// No homeserver or user ID was configured
-    #[error("no homeserver or user ID was configured")]
+    #[error("No homeserver or user ID was configured")]
     MissingHomeserver,
 
     /// The supplied server name was invalid.


### PR DESCRIPTION
…ssage

The error text for ClientBuildError::MissingHomeserver started with a lowercase letter instead of an uppercase one like in other cases, so I fixed that.

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] I've read [the `CONTRIBUTING.md` file](https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md), notably the sections about Pull requests, Commit message format, and AI policy.
- [ ] This PR was made with the help of AI.
