### PR TITLE
crypto: Avoid dereferencing to clone identifier

### DIFF
--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -304,8 +304,8 @@ impl StaticAccountData {
         ]);
 
         let mut ret = DeviceKeys::new(
-            (*self.user_id).to_owned(),
-            (*self.device_id).to_owned(),
+            self.user_id.clone(),
+            self.device_id.clone(),
             Self::ALGORITHMS.iter().map(|a| (**a).clone()).collect(),
             keys,
             Default::default(),
@@ -769,8 +769,8 @@ impl Account {
 
         Ok(Self {
             static_data: StaticAccountData {
-                user_id: (*pickle.user_id).into(),
-                device_id: (*pickle.device_id).into(),
+                user_id: pickle.user_id.clone(),
+                device_id: pickle.device_id.clone(),
                 identity_keys: Arc::new(identity_keys),
                 dehydrated: pickle.dehydrated,
                 creation_local_time: pickle.creation_local_time,

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -394,7 +394,7 @@ impl OutboundGroupSession {
             self.room_id().to_owned(),
             self.session_id().to_owned(),
             self.sender_key().to_owned(),
-            (*self.device_id).to_owned(),
+            self.device_id.clone(),
         )
     }
 

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -631,7 +631,7 @@ impl PrivateCrossSigningIdentity {
         let user_signing = keys.user_signing_key.map(UserSigning::from_pickle).transpose()?;
 
         Ok(Self {
-            user_id: (*pickle.user_id).into(),
+            user_id: pickle.user_id.clone(),
             shared: Arc::new(AtomicBool::from(pickle.shared)),
             master_key: Arc::new(Mutex::new(master)),
             self_signing_key: Arc::new(Mutex::new(self_signing)),


### PR DESCRIPTION
The code was dereferencing to the borrowed type, only to convert it back to the owned type. We can just use `.clone()` for this. Looking through the commits history, it looks like that this comes from a time where the identifiers were wrapped in `Arc`, rather than using the `Owned*` type.

<!-- description of the changes in this PR -->

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] I've read [the `CONTRIBUTING.md` file](https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md), notably the sections about Pull requests, Commit message format, and AI policy.
- [ ] This PR was made with the help of AI.

