### PR TITLE
FFI: Use multi-process lock config as the signal for enabling the OIDC cross process lock.

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -80,9 +80,11 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- [**breaking**] Removed `ClientBuilder::enable_oidc_refresh_lock` in favour of using `ClientBuilder::cross_process_lock_config`
+  to configure that lock when a `MultiProcess` configuration is supplied. ([#6204](https://github.com/matrix-org/matrix-rust-sdk/pull/6204))
 - `RoomPaginationStatus` is renamed to `PaginationStatus`.
   ([#6174](https://github.com/matrix-org/matrix-rust-sdk/pull/6174/))
-- Replaced `ClientBuilder::cross_process_store_locks_holder_name` with `ClientBuilder::cross_process_lock_config`, 
+- [**breaking**] Replaced `ClientBuilder::cross_process_store_locks_holder_name` with `ClientBuilder::cross_process_lock_config`, 
   which accepts a `CrossProcessLockConfig` value to specify whether the resulting `Client` will be used in a single 
   process or multiple processes. ([#6160](https://github.com/matrix-org/matrix-rust-sdk/pull/6160))
 - [**breaking**] Refactored `is_last_admin` to `is_last_owner` the check will now

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -131,7 +131,6 @@ pub struct ClientBuilder {
     sliding_sync_version_builder: SlidingSyncVersionBuilder,
     disable_automatic_token_refresh: bool,
     cross_process_lock_config: CrossProcessLockConfig,
-    enable_oidc_refresh_lock: bool,
     session_delegate: Option<Arc<dyn ClientSessionDelegate>>,
     encryption_settings: EncryptionSettings,
     room_key_recipient_strategy: CollectStrategy,
@@ -176,7 +175,6 @@ impl ClientBuilder {
             disable_ssl_verification: false,
             disable_automatic_token_refresh: false,
             cross_process_lock_config: CrossProcessLockConfig::SingleProcess,
-            enable_oidc_refresh_lock: false,
             session_delegate: None,
             #[cfg(not(target_family = "wasm"))]
             additional_root_certificates: Default::default(),
@@ -204,12 +202,6 @@ impl ClientBuilder {
     ) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.cross_process_lock_config = cross_process_lock_config;
-        Arc::new(builder)
-    }
-
-    pub fn enable_oidc_refresh_lock(self: Arc<Self>) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.enable_oidc_refresh_lock = true;
         Arc::new(builder)
     }
 
@@ -509,15 +501,7 @@ impl ClientBuilder {
 
         let sdk_client = inner_builder.build().await?;
 
-        Ok(Arc::new(
-            Client::new(
-                sdk_client,
-                builder.enable_oidc_refresh_lock,
-                builder.session_delegate,
-                store_path,
-            )
-            .await?,
-        ))
+        Ok(Arc::new(Client::new(sdk_client, builder.session_delegate, store_path).await?))
     }
 }
 


### PR DESCRIPTION
This is a small follow-up to #6160. After updating the SDK I wondered why we have both of these now that there's an explicit call-out for multi-process lock configuration.

It seems highly unlikely to me that anyone would want to configure these 2 locks independently of each other.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] I've read [the `CONTRIBUTING.md` file](https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md), notably the sections about Pull requests, Commit message format, and AI policy.
- [ ] This PR was made with the help of AI.

No AI was used in the making of this PR, I managed to delete these lines all by myself 😁
