### PR TITLE
chore(sqlite): Update `deadpool` to 0.13 and `deadpool-sync` to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,8 +1207,19 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
 dependencies = [
- "deadpool-runtime",
+ "deadpool-runtime 0.1.4",
  "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883466cb8db62725aee5f4a6011e8a5d42912b42632df32aad57fc91127c6e04"
+dependencies = [
+ "deadpool-runtime 0.3.1",
  "num_cpus",
  "tokio",
 ]
@@ -1218,17 +1229,23 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2657f61fb1dd8bf37a8d51093cc7cee4e77125b22f7753f49b289f831bec2bae"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "deadpool-sync"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
+checksum = "e385cc95d3d582c328b36d1ff90feac061102b001894b555e6b465a2e0eaabbf"
 dependencies = [
- "deadpool-runtime",
+ "deadpool-runtime 0.3.1",
 ]
 
 [[package]]
@@ -3463,7 +3480,7 @@ dependencies = [
  "as_variant",
  "assert_matches",
  "async-trait",
- "deadpool",
+ "deadpool 0.13.0",
  "deadpool-sync",
  "glob",
  "itertools 0.14.0",
@@ -7288,7 +7305,7 @@ checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
  "base64",
- "deadpool",
+ "deadpool 0.12.3",
  "futures",
  "http",
  "http-body-util",

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -26,8 +26,8 @@ experimental-encrypted-state-events = [
 [dependencies]
 as_variant.workspace = true
 async-trait.workspace = true
-deadpool = { version = "0.12.3", default-features = false, features = ["managed", "rt_tokio_1"] }
-deadpool-sync = { version = "0.1.4", default-features = false }
+deadpool = { version = "0.13", default-features = false, features = ["managed", "rt_tokio_1"] }
+deadpool-sync = { version = "0.2", default-features = false }
 itertools.workspace = true
 matrix-sdk-base = { workspace = true, optional = true }
 matrix-sdk-crypto = { workspace = true, optional = true }

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -320,13 +320,13 @@ impl SqliteAsyncConnExt for SqliteAsyncConn {
 
 /// Map an [`InteractError`] into a [`rusqlite::Error`].
 ///
-/// An [`InteractError::Panic`] will panic. An [`InteractError::Aborted`] will
+/// An [`InteractError::Panic`] will panic. An [`InteractError::Cancelled`] will
 /// generate a [`rusqlite::Error::SqliteFailure`] with the
 /// [`rusqlite::ffi::SQLITE_ABORT`] code.
 fn map_interact_err(error: InteractError) -> rusqlite::Error {
     match error {
         InteractError::Panic(p) => panic!("{p:?}"),
-        InteractError::Aborted => rusqlite::Error::SqliteFailure(
+        InteractError::Cancelled => rusqlite::Error::SqliteFailure(
             rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ABORT),
             None,
         ),


### PR DESCRIPTION
These releases include our patch to fix a panic (see https://github.com/deadpool-rs/deadpool/pull/461). 

---

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] I've read [the `CONTRIBUTING.md` file](https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md), notably the sections about Pull requests, Commit message format, and AI policy.
- [ ] This PR was made with the help of AI.