### PR TITLE
fix(crypto): invalidate account cache after duplicate key upload error

### DIFF
--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -585,6 +585,12 @@ impl Store {
         Ok(StoreCacheGuard { cache: self.inner.cache.clone().read_owned().await })
     }
 
+    /// Clear the cached account to force a reload from the store the next time
+    /// it is accessed.
+    pub async fn invalidate_account_cache(&self) {
+        *self.inner.cache.read().await.account.lock().await = None;
+    }
+
     pub(crate) async fn transaction(&self) -> StoreTransaction {
         StoreTransaction::new(self.clone()).await
     }


### PR DESCRIPTION
This is a blunt attempt at unsticking the duplicate key upload issue. When the error occurs, we rely on the other process having persisted the uploaded keys and force-reload them by invalidating the cached account. This (hopefully) ensures that the SDK has the private keys needed for decryption and prevents infinite upload loops on the client side.

Relates to: #3313

<!-- description of the changes in this PR -->

- [X] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [X] I've read [the `CONTRIBUTING.md` file](https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md), notably the sections about Pull requests, Commit message format, and AI policy.
- [ ] This PR was made with the help of AI.
