### PR TITLE
refactor(base): pass references to e2ee context instead of cloning

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -627,6 +627,13 @@ impl BaseClient {
         let mut updated_members_in_room: BTreeMap<OwnedRoomId, BTreeSet<OwnedUserId>> =
             BTreeMap::new();
 
+        #[cfg(feature = "e2e-encryption")]
+        let e2ee_context = processors::e2ee::E2EE::new(
+            olm_machine.as_ref(),
+            &self.decryption_settings,
+            self.handle_verification_events,
+        );
+
         for (room_id, joined_room) in response.rooms.join {
             let joined_room_update = processors::room::sync_v2::update_joined_room(
                 &mut context,
@@ -643,11 +650,7 @@ impl BaseClient {
                     &self.state_store,
                 ),
                 #[cfg(feature = "e2e-encryption")]
-                processors::e2ee::E2EE::new(
-                    olm_machine.as_ref(),
-                    &self.decryption_settings,
-                    self.handle_verification_events,
-                ),
+                &e2ee_context,
             )
             .await?;
 
@@ -669,11 +672,7 @@ impl BaseClient {
                     &self.state_store,
                 ),
                 #[cfg(feature = "e2e-encryption")]
-                processors::e2ee::E2EE::new(
-                    olm_machine.as_ref(),
-                    &self.decryption_settings,
-                    self.handle_verification_events,
-                ),
+                &e2ee_context,
             )
             .await?;
 

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
@@ -30,7 +30,7 @@ use crate::Result;
 /// The returned [`TimelineEvent`] has no push actions set up. It's the
 /// responsibility of the caller to set them.
 pub async fn sync_timeline_event(
-    e2ee: E2EE<'_>,
+    e2ee: &E2EE<'_>,
     event: &TimelineEvent,
     room_id: &RoomId,
 ) -> Result<Option<TimelineEvent>> {

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -111,7 +111,7 @@ pub async fn update_any_room(
         &mut new_user_ids,
         state_store,
         #[cfg(feature = "experimental-encrypted-state-events")]
-        e2ee.clone(),
+        &e2ee,
     )
     .await?;
 
@@ -141,7 +141,7 @@ pub async fn update_any_room(
         timeline::builder::Timeline::from(room_response),
         notification,
         #[cfg(feature = "e2e-encryption")]
-        e2ee.clone(),
+        &e2ee,
     )
     .await?;
 

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -41,7 +41,7 @@ pub async fn update_joined_room(
     joined_room: JoinedRoom,
     updated_members_in_room: &mut BTreeMap<OwnedRoomId, BTreeSet<OwnedUserId>>,
     notification: notification::Notification<'_>,
-    #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'_>,
+    #[cfg(feature = "e2e-encryption")] e2ee: &e2ee::E2EE<'_>,
 ) -> Result<JoinedRoomUpdate> {
     let RoomCreationData { room_id, requested_required_states, ambiguity_cache } =
         room_creation_data;
@@ -71,7 +71,7 @@ pub async fn update_joined_room(
         &mut new_user_ids,
         state_store,
         #[cfg(feature = "experimental-encrypted-state-events")]
-        e2ee.clone(),
+        e2ee,
     )
     .await?;
 
@@ -147,7 +147,7 @@ pub async fn update_left_room(
     room_creation_data: RoomCreationData<'_>,
     left_room: LeftRoom,
     notification: notification::Notification<'_>,
-    #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'_>,
+    #[cfg(feature = "e2e-encryption")] e2ee: &e2ee::E2EE<'_>,
 ) -> Result<LeftRoomUpdate> {
     let RoomCreationData { room_id, requested_required_states, ambiguity_cache } =
         room_creation_data;
@@ -172,7 +172,7 @@ pub async fn update_left_room(
         &mut (),
         state_store,
         #[cfg(feature = "experimental-encrypted-state-events")]
-        e2ee.clone(),
+        e2ee,
     )
     .await?;
 

--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -97,7 +97,7 @@ pub mod sync {
         ambiguity_cache: &mut AmbiguityCache,
         new_users: &mut U,
         state_store: &BaseStateStore,
-        #[cfg(feature = "experimental-encrypted-state-events")] e2ee: e2ee::E2EE<'_>,
+        #[cfg(feature = "experimental-encrypted-state-events")] e2ee: &e2ee::E2EE<'_>,
     ) -> StoreResult<()>
     where
         U: NewUsers,
@@ -146,7 +146,7 @@ pub mod sync {
                 #[cfg(feature = "experimental-encrypted-state-events")]
                 (StateEventType::RoomEncrypted, _) => {
                     let Some(mut raw_event) =
-                        super::decrypt_state_event(&mut raw_event, &room_info.room_id, &e2ee).await
+                        super::decrypt_state_event(&mut raw_event, &room_info.room_id, e2ee).await
                     else {
                         continue;
                     };

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -43,7 +43,7 @@ pub async fn build<'notification, 'e2ee>(
     room_info: &mut RoomInfo,
     timeline_inputs: builder::Timeline,
     mut notification: notification::Notification<'notification>,
-    #[cfg(feature = "e2e-encryption")] e2ee: e2ee::E2EE<'e2ee>,
+    #[cfg(feature = "e2e-encryption")] e2ee: &e2ee::E2EE<'e2ee>,
 ) -> Result<Timeline> {
     let _timer = timer!(tracing::Level::TRACE, "build a timeline from sync");
 
@@ -95,7 +95,7 @@ pub async fn build<'notification, 'e2ee>(
                             ) => {
                                 if let Some(decrypted_timeline_event) =
                                     Box::pin(e2ee::decrypt::sync_timeline_event(
-                                        e2ee.clone(),
+                                        e2ee,
                                         &timeline_event,
                                         room_id,
                                     ))
@@ -108,7 +108,7 @@ pub async fn build<'notification, 'e2ee>(
                             _ => {
                                 Box::pin(verification::process_if_relevant(
                                     &sync_timeline_event,
-                                    e2ee.clone(),
+                                    e2ee,
                                     room_id,
                                 ))
                                 .await?;

--- a/crates/matrix-sdk-base/src/response_processors/verification.rs
+++ b/crates/matrix-sdk-base/src/response_processors/verification.rs
@@ -36,7 +36,7 @@ use crate::Result;
 /// processing the response with [`OlmMachine::mark_request_as_sent`].
 pub async fn process_if_relevant(
     event: &AnySyncTimelineEvent,
-    e2ee: E2EE<'_>,
+    e2ee: &E2EE<'_>,
     room_id: &RoomId,
 ) -> Result<()> {
     if !e2ee.verification_is_allowed {


### PR DESCRIPTION
`matrix_sdk_base::response_processors::e2ee::E2EE` exists to pass E2EE context to the logic within `response_processors`. Currently we pass it around by value in many places, and hence have repetitive code for building the context, as well as lots of calls to `.clone`.

Cloning of this type is cheap, but we can do better, by passing it around by reference instead.