### PR TITLE
Gate aquamarine behind doc/docsrs target and feature

### DIFF
--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = { workspace = true }
 version = "0.16.0"
 
 [package.metadata.docs.rs]
+features = ["docsrs"]
 rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [features]
@@ -32,6 +33,8 @@ experimental-algorithms = []
 uniffi = ["dep:uniffi"]
 _disable-minimum-rotation-period-ms = []
 
+docsrs = ["dep:aquamarine"]
+
 # Private feature, see
 # https://github.com/matrix-org/matrix-rust-sdk/pull/3749#issuecomment-2312939823 for the gory
 # details.
@@ -42,7 +45,7 @@ testing = ["matrix-sdk-test"]
 
 [dependencies]
 aes = { version = "0.8.4", default-features = false }
-aquamarine.workspace = true
+aquamarine = { workspace = true, optional = true }
 as_variant.workspace = true
 async-trait.workspace = true
 bs58 = { version = "0.5.1", default-features = false, features = ["std"] }

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -154,7 +154,7 @@ pub enum RoomEventDecryptionResult {
     UnableToDecrypt(UnableToDecryptInfo),
 }
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
+#[cfg_attr(all(doc, feature = "docsrs"), aquamarine::aquamarine)]
 /// A step by step guide that explains how to include [end-to-end-encryption]
 /// support in a [Matrix] client library.
 ///

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -73,7 +73,7 @@ uniffi = ["dep:uniffi", "matrix-sdk-base/uniffi", "dep:matrix-sdk-ffi-macros"]
 
 experimental-widgets = ["dep:uuid", "experimental-send-custom-to-device"]
 
-docsrs = ["e2e-encryption", "sqlite", "indexeddb", "sso-login", "qrcode", "federation-api"]
+docsrs = ["e2e-encryption", "sqlite", "indexeddb", "sso-login", "qrcode", "federation-api", "dep:aquamarine"]
 
 # Add support for inline media galleries via msgtypes
 unstable-msc4274 = ["ruma/unstable-msc4274", "matrix-sdk-base/unstable-msc4274"]
@@ -85,7 +85,7 @@ experimental-element-recent-emojis = ["matrix-sdk-base/experimental-element-rece
 [dependencies]
 anyhow = { workspace = true, optional = true }
 anymap2 = { version = "0.13.0", default-features = false }
-aquamarine.workspace = true
+aquamarine = { workspace = true, optional = true }
 as_variant.workspace = true
 assert_matches2 = { workspace = true, optional = true }
 async-channel = "2.5.0"

--- a/crates/matrix-sdk/src/encryption/secret_storage/secret_store.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/secret_store.rs
@@ -33,7 +33,7 @@ use zeroize::Zeroize;
 use super::{DecryptionError, Result, SecretStorageError};
 use crate::Client;
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
+#[cfg_attr(all(doc, feature = "docsrs"), aquamarine::aquamarine)]
 /// Secure key/value storage for Matrix users.
 ///
 /// The `SecretStore` struct encapsulates the secret storage mechanism for


### PR DESCRIPTION
I didn't remove aquamarine since it seems working (now?)
Related: #4409 

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] I've read [the `CONTRIBUTING.md` file](https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md), notably the sections about Pull requests, Commit message format, and AI policy.
- [ ] This PR was made with the help of AI.
