### PR TITLE
chore: remove the bullet point about reading the CONTRIBUTING.md file in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 <!-- description of the changes in this PR -->
 
 - [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
-- [ ] I've read [the `CONTRIBUTING.md` file](https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md), notably the sections about Pull requests, Commit message format, and AI policy.
 - [ ] This PR was made with the help of AI.
 
 <!-- Sign-off, if not part of the commits -->


### PR DESCRIPTION
The PR template includes an item for a warning that is automatically shown once (and once and for all) by the Github UI. In the previous review of the changes to the pull request template, Ivan agreed that this was redundant, so it seems there's no point in keeping it in the pull request template itself.

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] I've read [the `CONTRIBUTING.md` file](https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md), notably the sections about Pull requests, Commit message format, and AI policy.
- [ ] This PR was made with the help of AI.