### PR TITLE
refactor(sqlite): Get rid of the `DATABASE_VERSION` constants

### DIFF
--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -195,22 +195,13 @@ impl SqliteCryptoStore {
     }
 }
 
-const DATABASE_VERSION: u8 = 14;
-
 /// key for the dehydrated device pickle key in the key/value table.
 const DEHYDRATED_DEVICE_PICKLE_KEY: &str = "dehydrated_device_pickle_key";
 
 /// Run migrations for the given version of the database.
 async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
-    if version == 0 {
-        debug!("Creating database");
-    } else if version < DATABASE_VERSION {
-        debug!(version, new_version = DATABASE_VERSION, "Upgrading database");
-    } else {
-        return Ok(());
-    }
-
     if version < 1 {
+        debug!("Creating database");
         // First turn on WAL mode, this can't be done in the transaction, it fails with
         // the error message: "cannot change into wal mode from within a transaction".
         conn.execute_batch("PRAGMA journal_mode = wal;").await?;
@@ -222,6 +213,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 2 {
+        debug!("Upgrading database to version 2");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/crypto_store/002_reset_olm_hash.sql"))?;
             txn.set_db_version(2)
@@ -230,6 +222,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 3 {
+        debug!("Upgrading database to version 3");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/crypto_store/003_room_settings.sql"))?;
             txn.set_db_version(3)
@@ -238,6 +231,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 4 {
+        debug!("Upgrading database to version 4");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/crypto_store/004_drop_outbound_group_sessions.sql"
@@ -248,6 +242,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 5 {
+        debug!("Upgrading database to version 5");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/crypto_store/005_withheld_code.sql"))?;
             txn.set_db_version(5)
@@ -256,6 +251,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 6 {
+        debug!("Upgrading database to version 6");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/crypto_store/006_drop_outbound_group_sessions.sql"
@@ -266,6 +262,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 7 {
+        debug!("Upgrading database to version 7");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/crypto_store/007_lock_leases.sql"))?;
             txn.set_db_version(7)
@@ -274,6 +271,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 8 {
+        debug!("Upgrading database to version 8");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/crypto_store/008_secret_inbox.sql"))?;
             txn.set_db_version(8)
@@ -282,6 +280,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 9 {
+        debug!("Upgrading database to version 9");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/crypto_store/009_inbound_group_session_sender_key_sender_data_type.sql"
@@ -292,6 +291,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 10 {
+        debug!("Upgrading database to version 10");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/crypto_store/010_received_room_key_bundles.sql"
@@ -302,6 +302,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 11 {
+        debug!("Upgrading database to version 11");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/crypto_store/011_received_room_key_bundles_with_curve_key.sql"
@@ -312,6 +313,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 12 {
+        debug!("Upgrading database to version 12");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/crypto_store/012_withheld_code_by_room.sql"
@@ -322,6 +324,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 13 {
+        debug!("Upgrading database to version 13");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/crypto_store/013_lease_locks_with_generation.sql"
@@ -332,6 +335,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 14 {
+        debug!("Upgrading database to version 14");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/crypto_store/014_room_key_backups_fully_downloaded.sql"
@@ -342,6 +346,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 15 {
+        debug!("Upgrading database to version 15");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/crypto_store/015_rooms_pending_key_bundle.sql"

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -62,13 +62,6 @@ mod keys {
 /// The database name.
 const DATABASE_NAME: &str = "matrix-sdk-event-cache.sqlite3";
 
-/// Identifier of the latest database version.
-///
-/// This is used to figure whether the SQLite database requires a migration.
-/// Every new SQL migration should imply a bump of this number, and changes in
-/// the [`run_migrations`] function.
-const DATABASE_VERSION: u8 = 14;
-
 /// The string used to identify a chunk of type events, in the `type` field in
 /// the database.
 const CHUNK_TYPE_EVENT_TYPE_STRING: &str = "E";
@@ -356,18 +349,11 @@ impl TransactionExtForLinkedChunks for Transaction<'_> {
 
 /// Run migrations for the given version of the database.
 async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
-    if version == 0 {
-        debug!("Creating database");
-    } else if version < DATABASE_VERSION {
-        debug!(version, new_version = DATABASE_VERSION, "Upgrading database");
-    } else {
-        return Ok(());
-    }
-
     // Always enable foreign keys for the current connection.
     conn.execute_batch("PRAGMA foreign_keys = ON;").await?;
 
     if version < 1 {
+        debug!("Creating database");
         // First turn on WAL mode, this can't be done in the transaction, it fails with
         // the error message: "cannot change into wal mode from within a transaction".
         conn.execute_batch("PRAGMA journal_mode = wal;").await?;
@@ -379,6 +365,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 2 {
+        debug!("Upgrading database to version 2");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/event_cache_store/002_lease_locks.sql"))?;
             txn.set_db_version(2)
@@ -387,6 +374,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 3 {
+        debug!("Upgrading database to version 3");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/event_cache_store/003_events.sql"))?;
             txn.set_db_version(3)
@@ -395,6 +383,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 4 {
+        debug!("Upgrading database to version 4");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/event_cache_store/004_ignore_policy.sql"
@@ -405,6 +394,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 5 {
+        debug!("Upgrading database to version 5");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/event_cache_store/005_events_index_on_event_id.sql"
@@ -415,6 +405,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 6 {
+        debug!("Upgrading database to version 6");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/event_cache_store/006_events.sql"))?;
             txn.set_db_version(6)
@@ -423,6 +414,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 7 {
+        debug!("Upgrading database to version 7");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/event_cache_store/007_event_chunks.sql"
@@ -433,6 +425,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 8 {
+        debug!("Upgrading database to version 8");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/event_cache_store/008_linked_chunk_id.sql"
@@ -443,6 +436,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 9 {
+        debug!("Upgrading database to version 9");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/event_cache_store/009_related_event_index.sql"
@@ -453,6 +447,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 10 {
+        debug!("Upgrading database to version 10");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/event_cache_store/010_drop_media.sql"))?;
             txn.set_db_version(10)
@@ -467,6 +462,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 11 {
+        debug!("Upgrading database to version 11");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/event_cache_store/011_empty_event_cache.sql"
@@ -477,6 +473,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 12 {
+        debug!("Upgrading database to version 12");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/event_cache_store/012_store_event_type.sql"
@@ -487,6 +484,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 13 {
+        debug!("Upgrading database to version 13");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/event_cache_store/013_lease_locks_with_generation.sql"
@@ -497,6 +495,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 14 {
+        debug!("Upgrading database to version 14");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/event_cache_store/014_event_chunks_event_id_index.sql"

--- a/crates/matrix-sdk-sqlite/src/media_store.rs
+++ b/crates/matrix-sdk-sqlite/src/media_store.rs
@@ -59,13 +59,6 @@ mod keys {
 /// The database name.
 const DATABASE_NAME: &str = "matrix-sdk-media.sqlite3";
 
-/// Identifier of the latest database version.
-///
-/// This is used to figure whether the SQLite database requires a migration.
-/// Every new SQL migration should imply a bump of this number, and changes in
-/// the [`run_migrations`] function.
-const DATABASE_VERSION: u8 = 2;
-
 /// An SQLite-based media store.
 #[derive(Clone)]
 pub struct SqliteMediaStore {
@@ -203,18 +196,11 @@ impl SqliteMediaStore {
 
 /// Run migrations for the given version of the database.
 async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
-    if version == 0 {
-        debug!("Creating database");
-    } else if version < DATABASE_VERSION {
-        debug!(version, new_version = DATABASE_VERSION, "Upgrading database");
-    } else {
-        return Ok(());
-    }
-
     // Always enable foreign keys for the current connection.
     conn.execute_batch("PRAGMA foreign_keys = ON;").await?;
 
     if version < 1 {
+        debug!("Creating database");
         // First turn on WAL mode, this can't be done in the transaction, it fails with
         // the error message: "cannot change into wal mode from within a transaction".
         conn.execute_batch("PRAGMA journal_mode = wal;").await?;
@@ -226,6 +212,7 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     }
 
     if version < 2 {
+        debug!("Upgrading database to version 2");
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!(
                 "../migrations/media_store/002_lease_locks_with_generation.sql"

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -72,13 +72,6 @@ mod keys {
 /// The filename used for the SQLITE database file used by the state store.
 pub const DATABASE_NAME: &str = "matrix-sdk-state.sqlite3";
 
-/// Identifier of the latest database version.
-///
-/// This is used to figure whether the SQLite database requires a migration.
-/// Every new SQL migration should imply a bump of this number, and changes in
-/// the [`SqliteStateStore::run_migrations`] function.
-const DATABASE_VERSION: u8 = 14;
-
 /// An SQLite-based state store.
 #[derive(Clone)]
 pub struct SqliteStateStore {
@@ -169,17 +162,14 @@ impl SqliteStateStore {
     ///
     /// If `to` is `None`, the current database version will be used.
     async fn run_migrations(&self, from: u8, to: Option<u8>) -> Result<()> {
-        let to = to.unwrap_or(DATABASE_VERSION);
-
-        if from < to {
-            debug!(version = from, new_version = to, "Upgrading database");
-        } else {
+        if to == Some(1) {
             return Ok(());
         }
 
         let conn = self.write().await;
 
-        if from < 2 && to >= 2 {
+        if from < 2 {
+            debug!("Upgrading database to version 2");
             let this = self.clone();
             conn.with_transaction(move |txn| {
                 // Create new table.
@@ -216,8 +206,13 @@ impl SqliteStateStore {
             .await?;
         }
 
+        if to == Some(2) {
+            return Ok(());
+        }
+
         // Migration to v3: RoomInfo format has changed.
-        if from < 3 && to >= 3 {
+        if from < 3 {
+            debug!("Upgrading database to version 3");
             let this = self.clone();
             conn.with_transaction(move |txn| {
                 // Migrate data .
@@ -267,7 +262,12 @@ impl SqliteStateStore {
             .await?;
         }
 
-        if from < 4 && to >= 4 {
+        if to == Some(3) {
+            return Ok(());
+        }
+
+        if from < 4 {
+            debug!("Upgrading database to version 4");
             conn.with_transaction(move |txn| {
                 // Create new table.
                 txn.execute_batch(include_str!("../migrations/state_store/003_send_queue.sql"))?;
@@ -276,7 +276,12 @@ impl SqliteStateStore {
             .await?;
         }
 
-        if from < 5 && to >= 5 {
+        if to == Some(4) {
+            return Ok(());
+        }
+
+        if from < 5 {
+            debug!("Upgrading database to version 5");
             conn.with_transaction(move |txn| {
                 // Create new table.
                 txn.execute_batch(include_str!(
@@ -287,7 +292,12 @@ impl SqliteStateStore {
             .await?;
         }
 
-        if from < 6 && to >= 6 {
+        if to == Some(5) {
+            return Ok(());
+        }
+
+        if from < 6 {
+            debug!("Upgrading database to version 6");
             conn.with_transaction(move |txn| {
                 // Create new table.
                 txn.execute_batch(include_str!(
@@ -298,7 +308,12 @@ impl SqliteStateStore {
             .await?;
         }
 
-        if from < 7 && to >= 7 {
+        if to == Some(6) {
+            return Ok(());
+        }
+
+        if from < 7 {
+            debug!("Upgrading database to version 7");
             conn.with_transaction(move |txn| {
                 // Drop media table.
                 txn.execute_batch(include_str!("../migrations/state_store/006_drop_media.sql"))?;
@@ -307,7 +322,12 @@ impl SqliteStateStore {
             .await?;
         }
 
-        if from < 8 && to >= 8 {
+        if to == Some(7) {
+            return Ok(());
+        }
+
+        if from < 8 {
+            debug!("Upgrading database to version 8");
             // Replace all existing wedged events with a generic error.
             let error = QueueWedgeError::GenericApiError {
                 msg: "local echo failed to send in a previous session".into(),
@@ -343,7 +363,12 @@ impl SqliteStateStore {
                 .await?;
         }
 
-        if from < 9 && to >= 9 {
+        if to == Some(8) {
+            return Ok(());
+        }
+
+        if from < 9 {
+            debug!("Upgrading database to version 9");
             conn.with_transaction(move |txn| {
                 // Run the migration.
                 txn.execute_batch(include_str!("../migrations/state_store/008_send_queue.sql"))?;
@@ -352,7 +377,12 @@ impl SqliteStateStore {
             .await?;
         }
 
-        if from < 10 && to >= 10 {
+        if to == Some(9) {
+            return Ok(());
+        }
+
+        if from < 10 {
+            debug!("Upgrading database to version 10");
             conn.with_transaction(move |txn| {
                 // Run the migration.
                 txn.execute_batch(include_str!(
@@ -363,7 +393,12 @@ impl SqliteStateStore {
             .await?;
         }
 
-        if from < 11 && to >= 11 {
+        if to == Some(10) {
+            return Ok(());
+        }
+
+        if from < 11 {
+            debug!("Upgrading database to version 11");
             conn.with_transaction(move |txn| {
                 // Run the migration.
                 txn.execute_batch(include_str!(
@@ -374,7 +409,12 @@ impl SqliteStateStore {
             .await?;
         }
 
-        if from < 12 && to >= 12 {
+        if to == Some(11) {
+            return Ok(());
+        }
+
+        if from < 12 {
+            debug!("Upgrading database to version 12");
             // Defragment the DB and optimize its size on the filesystem.
             // This should have been run in the migration for version 7, to reduce the size
             // of the DB as we removed the media cache.
@@ -382,7 +422,12 @@ impl SqliteStateStore {
             conn.set_kv("version", vec![12]).await?;
         }
 
-        if from < 13 && to >= 13 {
+        if to == Some(12) {
+            return Ok(());
+        }
+
+        if from < 13 {
+            debug!("Upgrading database to version 13");
             conn.with_transaction(move |txn| {
                 // Run the migration.
                 txn.execute_batch(include_str!(
@@ -393,7 +438,12 @@ impl SqliteStateStore {
             .await?;
         }
 
-        if from < 14 && to >= 14 {
+        if to == Some(13) {
+            return Ok(());
+        }
+
+        if from < 14 {
+            debug!("Upgrading database to version 14");
             conn.with_transaction(move |txn| {
                 // Run the migration.
                 txn.execute_batch(include_str!(
@@ -404,7 +454,12 @@ impl SqliteStateStore {
             .await?;
         }
 
-        if from < 15 && to >= 15 {
+        if to == Some(14) {
+            return Ok(());
+        }
+
+        if from < 15 {
+            debug!("Upgrading database to version 15");
             conn.with_transaction(move |txn| {
                 // Run the migration.
                 txn.execute_batch(include_str!(
@@ -413,6 +468,10 @@ impl SqliteStateStore {
                 txn.set_db_version(15)
             })
             .await?;
+        }
+
+        if to == Some(15) {
+            return Ok(());
         }
 
         Ok(())


### PR DESCRIPTION
They are error prone because they need to be bumped for every migration otherwise the new migration will not happen because we exit early. Case in point, this bump was forgotten in the latest migrations in #5920 and #6199.

So instead we get rid of the early returns and log each individual upgrade separately. It makes more noise when creating a new database, but since it is logged at the DEBUG level it is not much of a problem.

The IndexedDB store doesn't have this issue because it already doesn't use a constant.

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

