### PR TITLE
fix(xtask): `log overview` sanitizes HTML

### DIFF
--- a/xtask/src/log/overview.rs
+++ b/xtask/src/log/overview.rs
@@ -319,20 +319,34 @@ pub(super) fn run(log_path: path::PathBuf, output_path: path::PathBuf) -> Result
         let fields_parser = &*FIELDS_PARSER;
 
         if let Some(captures) = message_parser.captures(&message) {
+            // Poor man HTML sanitizer.
+            let formatted_message = captures
+                .name("message")
+                .expect("Failed to parse the `message`")
+                .as_str()
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;");
+
             writeln!(
                 buffer,
-                "<li><time datetime=\"{date_time}\">{time}</time> {message} <span title=\"Log line\">[#{log_line}]</span>\
+                "<li><time datetime=\"{date_time}\">{time}</time> {formatted_message} <span title=\"Log line\">[#{log_line}]</span>\
                 <span class=\"aside\">\
                 <span class=\"highlight\"><input type=\"checkbox\" title=\"Highlight\" /></span>\
                 </span>\
                 ",
-                message = captures.name("message").expect("Failed to parse the `message`").as_str(),
                 date_time = date_time.format("%+"),
                 time = date_time.format("%H:%M:%S%.3f"),
             )
             .unwrap();
 
-            if let Some(fields) = captures.name("fields") {
+            // The message can contain HTML data. It happens notably when the
+            // homeserver is broken, and an HTML document is returned in some
+            // errors. We don't want to parse the fields in this case, because
+            // HTML breaks everything.
+            if !formatted_message.contains("!DOCTYPE html")
+                && let Some(fields) = captures.name("fields")
+            {
                 writeln!(buffer, "<ul class=\"fields\">").unwrap();
 
                 let mut fields = &message[fields.start()..fields.end()];


### PR DESCRIPTION
The log message can contain HTML data. It happens notably when the homeserver is broken, and an HTML document is returned in some errors. We don't want to parse the fields in this case, because HTML breaks everything.

I found the problem with this rageshake: https://github.com/element-hq/element-x-ios-rageshakes/issues/5738.

Before:

<img width="1065" height="411" alt="Screenshot 2026-03-03 at 18 40 17" src="https://github.com/user-attachments/assets/0917ff3d-a2e6-42d7-ac37-cf0424245e98" />

After the sanitizer:

<img width="1355" height="523" alt="Screenshot 2026-03-03 at 18 40 58" src="https://github.com/user-attachments/assets/d360ebc6-12a6-457c-9e25-09c081492717" />

After the “do not parse fields if HTML is detected”:

<img width="1355" height="185" alt="Screenshot 2026-03-03 at 18 41 20" src="https://github.com/user-attachments/assets/c28991ed-4e7d-4e9c-a0bf-ed31f36ed158" />

---

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.
