### PR TITLE
refactor(crypto): use an async closure in `Store::with_transaction`

### DIFF
--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1292,19 +1292,19 @@ mod tests {
             let (alice_session, bob_session) = alice_machine
                 .inner
                 .store
-                .with_transaction(|mut atr| async {
+                .with_transaction(async |atr| {
                     let sessions = bob_machine
                         .inner
                         .store
-                        .with_transaction(|mut btr| async {
+                        .with_transaction(async |btr| {
                             let alice_account = atr.account().await?;
                             let bob_account = btr.account().await?;
                             let sessions =
                                 alice_account.create_session_for_test_helper(bob_account).await;
-                            Ok((btr, sessions))
+                            Ok(sessions)
                         })
                         .await?;
-                    Ok((atr, sessions))
+                    Ok(sessions)
                 })
                 .await
                 .unwrap();
@@ -1774,7 +1774,7 @@ mod tests {
         let decrypted = alice_machine
             .inner
             .store
-            .with_transaction(|mut tr| async {
+            .with_transaction(async |tr| {
                 let res = tr
                     .account()
                     .await?
@@ -1786,7 +1786,7 @@ mod tests {
                         },
                     )
                     .await?;
-                Ok((tr, res))
+                Ok(res)
             })
             .await
             .unwrap();
@@ -1863,7 +1863,7 @@ mod tests {
         let decrypted = alice_machine
             .inner
             .store
-            .with_transaction(|mut tr| async {
+            .with_transaction(async |tr| {
                 let res = tr
                     .account()
                     .await?
@@ -1875,10 +1875,11 @@ mod tests {
                         },
                     )
                     .await?;
-                Ok((tr, res))
+                Ok(res)
             })
             .await
             .unwrap();
+
         let AnyDecryptedOlmEvent::ForwardedRoomKey(ev) = &*decrypted.result.event else {
             panic!("Invalid decrypted event type");
         };
@@ -1920,11 +1921,11 @@ mod tests {
         let alice_session = alice_machine
             .inner
             .store
-            .with_transaction(|mut tr| async {
+            .with_transaction(async |tr| {
                 let alice_account = tr.account().await?;
                 let (alice_session, _) =
                     alice_account.create_session_for_test_helper(&mut second_account).await;
-                Ok((tr, alice_session))
+                Ok(alice_session)
             })
             .await
             .unwrap();
@@ -2147,19 +2148,19 @@ mod tests {
         let (alice_session, bob_session) = alice_machine
             .inner
             .store
-            .with_transaction(|mut atr| async {
+            .with_transaction(async |atr| {
                 let res = bob_machine
                     .inner
                     .store
-                    .with_transaction(|mut btr| async {
+                    .with_transaction(async |btr| {
                         let alice_account = atr.account().await?;
                         let bob_account = btr.account().await?;
                         let sessions =
                             alice_account.create_session_for_test_helper(bob_account).await;
-                        Ok((btr, sessions))
+                        Ok(sessions)
                     })
                     .await?;
-                Ok((atr, res))
+                Ok(res)
             })
             .await
             .unwrap();
@@ -2199,7 +2200,7 @@ mod tests {
         let decrypted = alice_machine
             .inner
             .store
-            .with_transaction(|mut tr| async {
+            .with_transaction(async |tr| {
                 let res = tr
                     .account()
                     .await?
@@ -2211,7 +2212,7 @@ mod tests {
                         },
                     )
                     .await?;
-                Ok((tr, res))
+                Ok(res)
             })
             .await
             .unwrap();

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -753,10 +753,10 @@ impl OlmMachine {
     async fn receive_keys_upload_response(&self, response: &UploadKeysResponse) -> OlmResult<()> {
         self.inner
             .store
-            .with_transaction(|mut tr| async {
+            .with_transaction(async |tr| {
                 let account = tr.account().await?;
                 account.receive_keys_upload_response(response)?;
-                Ok((tr, ()))
+                Ok(())
             })
             .await
     }

--- a/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
+++ b/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
@@ -84,14 +84,14 @@ pub async fn get_prepared_machine_test_helper(
 
     let request = machine
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let account = tr.account().await.unwrap();
             account.generate_fallback_key_if_needed();
             account.update_uploaded_key_count(0);
             account.generate_one_time_keys_if_needed();
             let request =
                 machine.keys_for_upload(account).await.expect("Can't prepare initial key upload");
-            Ok((tr, request))
+            Ok(request)
         })
         .await
         .unwrap();
@@ -332,16 +332,11 @@ pub async fn get_machine_pair_with_setup_sessions_test_helper(
 
     let decrypted = bob
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let res = bob
-                .decrypt_to_device_event(
-                    &mut tr,
-                    &event,
-                    &mut Changes::default(),
-                    &decryption_settings,
-                )
+                .decrypt_to_device_event(tr, &event, &mut Changes::default(), &decryption_settings)
                 .await?;
-            Ok((tr, res))
+            Ok(res)
         })
         .await
         .unwrap();

--- a/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
@@ -85,16 +85,11 @@ async fn test_decryption_verification_state() {
 
     let group_session = bob
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let res = bob
-                .decrypt_to_device_event(
-                    &mut tr,
-                    &event,
-                    &mut Changes::default(),
-                    &decryption_settings,
-                )
+                .decrypt_to_device_event(tr, &event, &mut Changes::default(), &decryption_settings)
                 .await?;
-            Ok((tr, res))
+            Ok(res)
         })
         .await
         .unwrap()
@@ -654,16 +649,11 @@ async fn encrypt_message(
 
     let group_session = recipient
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let res = recipient
-                .decrypt_to_device_event(
-                    &mut tr,
-                    &event,
-                    &mut Changes::default(),
-                    &decryption_settings,
-                )
+                .decrypt_to_device_event(tr, &event, &mut Changes::default(), &decryption_settings)
                 .await?;
-            Ok((tr, res))
+            Ok(res)
         })
         .await
         .unwrap()

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -167,10 +167,10 @@ async fn test_generate_one_time_keys() {
 
     machine
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let account = tr.account().await.unwrap();
             assert!(account.generate_one_time_keys_if_needed().is_some());
-            Ok((tr, ()))
+            Ok(())
         })
         .await
         .unwrap();
@@ -181,10 +181,10 @@ async fn test_generate_one_time_keys() {
 
     machine
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let account = tr.account().await.unwrap();
             assert!(account.generate_one_time_keys_if_needed().is_some());
-            Ok((tr, ()))
+            Ok(())
         })
         .await
         .unwrap();
@@ -195,11 +195,11 @@ async fn test_generate_one_time_keys() {
 
     machine
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let account = tr.account().await.unwrap();
             assert!(account.generate_one_time_keys_if_needed().is_none());
 
-            Ok((tr, ()))
+            Ok(())
         })
         .await
         .unwrap();
@@ -657,16 +657,11 @@ async fn test_megolm_encryption() {
 
     let group_session = bob
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let res = bob
-                .decrypt_to_device_event(
-                    &mut tr,
-                    &event,
-                    &mut Changes::default(),
-                    &decryption_settings,
-                )
+                .decrypt_to_device_event(tr, &event, &mut Changes::default(), &decryption_settings)
                 .await?;
-            Ok((tr, res))
+            Ok(res)
         })
         .await
         .unwrap()
@@ -768,16 +763,11 @@ async fn megolm_encryption_setup_helper(room_id: &RoomId) -> (OlmMachine, OlmMac
 
     let group_session = bob
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let res = bob
-                .decrypt_to_device_event(
-                    &mut tr,
-                    &event,
-                    &mut Changes::default(),
-                    &decryption_settings,
-                )
+                .decrypt_to_device_event(tr, &event, &mut Changes::default(), &decryption_settings)
                 .await?;
-            Ok((tr, res))
+            Ok(res)
         })
         .await
         .unwrap()
@@ -1314,16 +1304,11 @@ async fn test_query_ratcheted_key() {
 
     let group_session = bob
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let res = bob
-                .decrypt_to_device_event(
-                    &mut tr,
-                    &event,
-                    &mut Changes::default(),
-                    &decryption_settings,
-                )
+                .decrypt_to_device_event(tr, &event, &mut Changes::default(), &decryption_settings)
                 .await?;
-            Ok((tr, res))
+            Ok(res)
         })
         .await
         .unwrap()
@@ -1413,16 +1398,11 @@ async fn test_room_key_over_megolm() {
 
     let decrypt_result = bob
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let res = bob
-                .decrypt_to_device_event(
-                    &mut tr,
-                    &event,
-                    &mut Changes::default(),
-                    &decryption_settings,
-                )
+                .decrypt_to_device_event(tr, &event, &mut Changes::default(), &decryption_settings)
                 .await?;
-            Ok((tr, res))
+            Ok(res)
         })
         .await;
 
@@ -1729,16 +1709,16 @@ async fn test_unsigned_decryption() {
     // Save the first room key.
     let group_session = bob
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let res = bob
                 .decrypt_to_device_event(
-                    &mut tr,
+                    tr,
                     &first_room_key_event,
                     &mut Changes::default(),
                     &decryption_settings,
                 )
                 .await?;
-            Ok((tr, res))
+            Ok(res)
         })
         .await
         .unwrap()
@@ -1848,16 +1828,16 @@ async fn test_unsigned_decryption() {
     // Give Bob the second room key.
     let group_session = bob
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let res = bob
                 .decrypt_to_device_event(
-                    &mut tr,
+                    tr,
                     &second_room_key_event,
                     &mut Changes::default(),
                     &decryption_settings,
                 )
                 .await?;
-            Ok((tr, res))
+            Ok(res)
         })
         .await
         .unwrap()
@@ -1971,16 +1951,16 @@ async fn test_unsigned_decryption() {
     // Give Bob the third room key.
     let group_session = bob
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let res = bob
                 .decrypt_to_device_event(
-                    &mut tr,
+                    tr,
                     &third_room_key_event,
                     &mut Changes::default(),
                     &decryption_settings,
                 )
                 .await?;
-            Ok((tr, res))
+            Ok(res)
         })
         .await
         .unwrap()

--- a/crates/matrix-sdk-crypto/src/machine/tests/olm_encryption.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/olm_encryption.rs
@@ -221,16 +221,11 @@ async fn olm_encryption_test_helper(use_fallback_key: bool) {
     // Decrypting the first time should succeed.
     let decrypted = bob
         .store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let res = bob
-                .decrypt_to_device_event(
-                    &mut tr,
-                    &event,
-                    &mut Changes::default(),
-                    &decryption_settings,
-                )
+                .decrypt_to_device_event(tr, &event, &mut Changes::default(), &decryption_settings)
                 .await?;
-            Ok((tr, res))
+            Ok(res)
         })
         .await
         .expect("We should be able to decrypt the event.")
@@ -244,16 +239,11 @@ async fn olm_encryption_test_helper(use_fallback_key: bool) {
 
     // Replaying the event should now result in a decryption failure.
     bob.store()
-        .with_transaction(|mut tr| async {
+        .with_transaction(async |tr| {
             let res = bob
-                .decrypt_to_device_event(
-                    &mut tr,
-                    &event,
-                    &mut Changes::default(),
-                    &decryption_settings,
-                )
+                .decrypt_to_device_event(tr, &event, &mut Changes::default(), &decryption_settings)
                 .await?;
-            Ok((tr, res))
+            Ok(res)
         })
         .await
         .expect_err(

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -830,10 +830,10 @@ mod tests {
 
         let (_, mut session) = manager
             .store
-            .with_transaction(|mut tr| async {
+            .with_transaction(async |tr| {
                 let manager_account = tr.account().await.unwrap();
                 let res = bob.create_session_for_test_helper(manager_account).await;
-                Ok((tr, res))
+                Ok(res)
             })
             .await
             .unwrap();

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -590,18 +590,12 @@ impl Store {
         StoreTransaction::new(self.clone()).await
     }
 
-    // Note: bnjbvr lost against borrowck here. Ideally, the `F` parameter would
-    // take a `&StoreTransaction`, but callers didn't quite like that.
-    pub(crate) async fn with_transaction<
-        T,
-        Fut: Future<Output = Result<(StoreTransaction, T), crate::OlmError>>,
-        F: FnOnce(StoreTransaction) -> Fut,
-    >(
+    pub(crate) async fn with_transaction<T>(
         &self,
-        func: F,
+        func: impl AsyncFnOnce(&mut StoreTransaction) -> Result<T, crate::OlmError>,
     ) -> Result<T, crate::OlmError> {
-        let tr = self.transaction().await;
-        let (tr, res) = func(tr).await?;
+        let mut tr = self.transaction().await;
+        let res = func(&mut tr).await?;
         tr.commit().await?;
         Ok(res)
     }


### PR DESCRIPTION
This allows passing the `Transaction` by mutable reference, instead of passing it by ownership and requiring the callback to pass it back, which is slightly better in terms of ergonomics. This was hard to achieve without async closures, but now that we have them, this is trivial.

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] This PR was made with the help of AI.