### PR TITLE
chore: depersonalize some TODO code comments

### DIFF
--- a/crates/matrix-sdk-common/src/task_monitor.rs
+++ b/crates/matrix-sdk-common/src/task_monitor.rs
@@ -130,7 +130,7 @@ pub enum BackgroundTaskFailureReason {
     /// The task returned an error.
     Error {
         /// String representation of the error.
-        // TODO(bnjbvr): consider storing a boxed error instead?
+        // TODO: consider storing a boxed error instead?
         error: String,
     },
 

--- a/crates/matrix-sdk-crypto/src/store/caches.rs
+++ b/crates/matrix-sdk-crypto/src/store/caches.rs
@@ -377,7 +377,6 @@ impl StoreCache {
 /// should happen as part of a `StoreTransaction`.
 pub(crate) struct StoreCacheGuard {
     pub(super) cache: OwnedRwLockReadGuard<StoreCache>,
-    // TODO: (bnjbvr, #2624) add cross-process lock guard here.
 }
 
 impl StoreCacheGuard {

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -579,10 +579,6 @@ impl Store {
     }
 
     pub(crate) async fn cache(&self) -> Result<StoreCacheGuard> {
-        // TODO: (bnjbvr, #2624) If configured with a cross-process lock:
-        // - try to take the lock,
-        // - if acquired, look if another process touched the underlying storage,
-        // - if yes, reload everything; if no, return current cache
         Ok(StoreCacheGuard { cache: self.inner.cache.clone().read_owned().await })
     }
 

--- a/crates/matrix-sdk-ui/src/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync_service.rs
@@ -81,7 +81,7 @@ impl EncryptionSyncService {
         let mut builder = client
             .sliding_sync("encryption")
             .map_err(Error::SlidingSync)?
-            //.share_pos() // TODO(bnjbvr) This is racy, needs cross-process lock :')
+            //.share_pos() // TODO: This is racy, needs cross-process lock :')
             .with_to_device_extension(
                 assign!(http::request::ToDevice::default(), { enabled: Some(true)}),
             )

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -548,8 +548,8 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
                                 // the root, and update its thread summary, if the receipt is for
                                 // ourselves.
                                 //
-                                // TODO(bnjbvr): This is temporary code, and should be removed when
-                                // #4113 is done.
+                                // TODO: This is temporary code, and should be removed when #4113 is
+                                // done.
                                 if user_id == self.meta.own_user_id
                                     && let Some((item_pos, item)) =
                                         rfind_event_by_id(&self.items, &thread_root)

--- a/crates/matrix-sdk-ui/src/timeline/tasks.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tasks.rs
@@ -269,7 +269,7 @@ pub(in crate::timeline) async fn room_event_cache_updates_task(
             RoomEventCacheUpdate::AddEphemeralEvents { events } => {
                 trace!("Received new ephemeral events from sync.");
 
-                // TODO: (bnjbvr) ephemeral should be handled by the event cache.
+                // TODO: ephemeral (read receipts) should be handled by the event cache (#4113).
                 timeline_controller.handle_ephemeral_events(events).await;
             }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -200,7 +200,6 @@ impl TestTimeline {
         key: &str,
     ) -> Result<(), super::Error> {
         if self.controller.toggle_reaction_local(item_id, key).await? {
-            // TODO(bnjbvr): hacky?
             let items = self.controller.items().await;
             if let Some(event_id) = rfind_event_by_item_id(&items, item_id)
                 .and_then(|(_pos, item)| item.event_id().map(ToOwned::to_owned))

--- a/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
@@ -428,7 +428,7 @@ async fn test_local_reaction_to_local_echo() {
         let reactions = item.content().reactions().cloned().unwrap_or_default();
         assert_eq!(reactions.len(), 1);
         let reaction_info = reactions.get(key1).unwrap().get(user_id).unwrap();
-        // TODO(bnjbvr): why not LocalToRemote here?
+        // TODO: why not LocalToRemote here?
         assert_matches!(&reaction_info.status, ReactionStatus::LocalToLocal(..));
 
         // And since the local event has been sent, it is inserted in the Event

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -838,7 +838,7 @@ impl<'a> RoomEventCacheStateLockWriteGuard<'a> {
             // Sad time: there's a gap, somewhere, in the timeline, and there's at least one
             // non-duplicated event. We don't know which threads might have gappy, so we
             // must invalidate them all :(
-            // TODO(bnjbvr): figure out a better catchup mechanism for threads.
+            // TODO: figure out a better catchup mechanism for threads.
             let mut summaries_to_update = Vec::new();
 
             for (thread_root, thread) in self.state.threads.iter_mut() {

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -91,8 +91,8 @@ impl ThreadEventCache {
         }
     }
 
-    // TODO(bnjbvr): share more code with `RoomEventCacheState` to avoid the
-    // duplication here too.
+    // TODO: share more code with `RoomEventCacheState` to avoid the duplication
+    // here too.
     fn propagate_changes(&mut self) {
         // This is a lie, at the moment! We're not persisting threads yet, so we're just
         // forwarding all updates to the linked chunk update sender.
@@ -276,8 +276,7 @@ impl ThreadEventCache {
         new_token: Option<String>,
         events: Vec<Event>,
     ) -> Option<BackPaginationOutcome> {
-        // TODO(bnjbvr): consider deduplicating this code (~same for room) at some
-        // point.
+        // TODO: consider deduplicating this code (~same for room) at some point.
         let prev_gap_id = if let Some(token) = prev_token {
             // If the gap id is missing, it means that the gap disappeared during
             // pagination; in this case, early return to the caller.

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -1536,8 +1536,7 @@ async fn test_latest_thread_event_is_redecrypted_and_updated() -> TestResult {
     {
         // Her timeline sees a new item for the thread reply, because we don't know yet
         // that the thread reply is part of the thread, as it's encrypted.
-        // TODO(bnjbvr): we should know it, since an encrypted event includes the
-        // relationship?
+        // TODO: we should know it, since an encrypted event includes the relationship?
         let next_item = assert_next_with_timeout!(stream, 5000);
         assert_let!(VectorDiff::PushBack { value } = next_item);
         assert!(value.content().is_unable_to_decrypt());


### PR DESCRIPTION
Removed a few TODOs that were not applicable anymore, because they were either very low value (in timeline test code) or already done (in event cache, with respect to the cross-process locking).

Also removed my nick from some TODOs and comments, as code comments aren't the best way to store assignees for issues.