### PR TITLE
refactor(test): use `assert_let_timeout` more often

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -18,7 +18,7 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
-use matrix_sdk::{executor::spawn, test_utils::mocks::MatrixMockServer};
+use matrix_sdk::{assert_let_timeout, executor::spawn, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_test::{JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{EventSendState, RoomExt};
 use ruma::{
@@ -61,7 +61,7 @@ async fn test_echo() {
         timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into()).await
     });
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::PushBack { value: local_echo } = &timeline_updates[0]);
@@ -79,7 +79,7 @@ async fn test_echo() {
     // Wait for the sending to finish and assert everything was successful
     send_hdl.await.unwrap().unwrap();
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 5);
 
     // The `EventSendState` has been updated.
@@ -129,7 +129,7 @@ async fn test_echo() {
         .await;
 
     // The Event Cache deduplicates the first event, but we receive a second one.
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 5);
 
     assert_matches!(&timeline_updates[0], VectorDiff::Remove { index: 1 });
@@ -179,8 +179,13 @@ async fn test_retry_failed() {
     });
 
     // Sending fails, because the error is a transient one that's recoverable,
-    // indicating something's wrong on the client side.
-    assert_let!(Some(VectorDiff::Set { index: 0, value: item }) = timeline_stream.next().await);
+    // indicating something's wrong on the client side. The send queue uses
+    // `short_retry()` (3 retries) with 500ms minimum exponential backoff, so
+    // this can take up to ~1.5s before the failure is surfaced.
+    assert_let_timeout!(
+        Duration::from_secs(5),
+        Some(VectorDiff::Set { index: 0, value: item }) = timeline_stream.next()
+    );
     assert_matches!(
         item.send_state(),
         Some(EventSendState::SendingFailed { is_recoverable: true, .. })
@@ -201,7 +206,7 @@ async fn test_retry_failed() {
     tokio::time::sleep(Duration::from_millis(300)).await;
 
     // After mocking the endpoint and retrying, it succeeds.
-    assert_let!(Some(VectorDiff::Set { index: 0, value }) = timeline_stream.next().await);
+    assert_let_timeout!(Some(VectorDiff::Set { index: 0, value }) = timeline_stream.next());
     assert_matches!(value.send_state(), Some(EventSendState::Sent { .. }));
 }
 
@@ -235,7 +240,7 @@ async fn test_dedup_by_event_id_late() {
 
     timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into()).await.unwrap();
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     // Timeline: [local echo]
@@ -261,7 +266,7 @@ async fn test_dedup_by_event_id_late() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     // Timeline: [remote-echo, date-divider, local echo]
@@ -273,7 +278,8 @@ async fn test_dedup_by_event_id_late() {
     assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[1]);
     assert!(date_divider.is_date_divider());
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    // The mock server has a 500ms delay, so we need more than 100ms here.
+    assert_let_timeout!(Duration::from_secs(2), Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 6);
 
     // Local echo and its date divider are removed.
@@ -331,7 +337,7 @@ async fn test_cancel_failed() {
     });
 
     // Sending fails, the mock server has no matching route
-    assert_let!(Some(VectorDiff::Set { index: 0, value }) = timeline_stream.next().await);
+    assert_let_timeout!(Some(VectorDiff::Set { index: 0, value }) = timeline_stream.next());
     assert_matches!(value.send_state(), Some(EventSendState::SendingFailed { .. }));
 
     // Discard, assert the local echo is found

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -20,7 +20,7 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::{FutureExt, StreamExt};
 use matrix_sdk::{
-    Client,
+    Client, assert_let_timeout,
     room::edit::EditedContent,
     test_utils::mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
 };
@@ -76,7 +76,7 @@ async fn test_edit() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::PushBack { value: first } = &timeline_updates[0]);
@@ -110,7 +110,7 @@ async fn test_edit() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 4);
 
     assert_let!(VectorDiff::PushBack { value: second } = &timeline_updates[0]);
@@ -190,7 +190,7 @@ async fn test_edit_local_echo() {
     // Redacting a local event works.
     timeline.send(RoomMessageEventContent::text_plain("hello, just you").into()).await.unwrap();
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::PushBack { value: item } = &timeline_updates[0]);
@@ -205,7 +205,7 @@ async fn test_edit_local_echo() {
 
     // We haven't set a route for sending events, so this will fail.
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
 
     assert_let!(VectorDiff::Set { index: 1, value: item } = &timeline_updates[0]);
@@ -236,7 +236,7 @@ async fn test_edit_local_echo() {
         .await
         .unwrap();
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
 
     // Observe local echo being replaced.
@@ -256,7 +256,7 @@ async fn test_edit_local_echo() {
     // Re-enable the room's queue.
     timeline.room().send_queue().set_enabled(true);
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 5);
 
     // Observe the event being sent, and replacing the local echo.
@@ -660,7 +660,7 @@ async fn test_edit_local_echo_with_unsupported_content() {
 
     timeline.send(RoomMessageEventContent::text_plain("hello, just you").into()).await.unwrap();
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::PushBack { value: item } = &timeline_updates[0]);
@@ -672,7 +672,7 @@ async fn test_edit_local_echo_with_unsupported_content() {
     assert!(date_divider.is_date_divider());
 
     // We haven't set a route for sending events, so this will fail.
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
 
     assert_let!(VectorDiff::Set { index: 1, value: item } = &timeline_updates[0]);
@@ -714,7 +714,7 @@ async fn test_edit_local_echo_with_unsupported_content() {
         .await
         .unwrap();
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
 
     assert_let!(VectorDiff::PushBack { value: item } = &timeline_updates[0]);
@@ -819,7 +819,7 @@ async fn test_pending_edit() {
     )
     .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     // Then I get the edited content immediately.
@@ -879,7 +879,7 @@ async fn test_pending_edit_overrides() {
     )
     .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     // Then I get the latest edited content immediately.
@@ -930,7 +930,7 @@ async fn test_pending_edit_from_backpagination() {
     )
     .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     // Then I get the latest edited content immediately.
@@ -995,7 +995,7 @@ async fn test_pending_edit_from_backpagination_doesnt_override_pending_edit_from
     )
     .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     // Then I get the edit from the sync, even if the back-pagination happened
@@ -1064,7 +1064,7 @@ async fn test_pending_poll_edit() {
     )
     .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     // Then I get the edited content immediately.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -258,7 +258,7 @@ async fn test_live_aggregations_are_reflected_on_focused_timelines() {
     server.reset().await;
 
     // We only receive one updated for the reaction, from the timeline stream.
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
     assert_let!(VectorDiff::Set { index: 1, value: item } = &timeline_updates[0]);
 
@@ -330,7 +330,7 @@ async fn test_focused_timeline_local_echoes() {
     // Add a reaction to the focused event, which will cause a local echo to happen.
     timeline.toggle_reaction(&event_item.identifier(), "✨").await.unwrap();
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
 
     // We immediately get the local echo for the reaction.
@@ -498,7 +498,7 @@ async fn test_focused_timeline_handles_threaded_event() {
         timeline.paginate_backwards(10).await.expect("Could not paginate backwards");
     assert!(!start_of_timeline);
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
     // The new item loaded is inserted at the start, just after the date divider.
     assert_let!(VectorDiff::Insert { index: 1, value: item } = &timeline_updates[0]);
@@ -532,7 +532,7 @@ async fn test_focused_timeline_handles_threaded_event() {
         timeline.paginate_backwards(10).await.expect("Could not paginate backwards a 2nd time");
     assert!(start_of_timeline);
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
     // Same as before, the previous event is inserted at the front, after the date
     // divider.
@@ -562,7 +562,7 @@ async fn test_focused_timeline_handles_threaded_event() {
         timeline.paginate_forwards(10).await.expect("Could not paginate forwards");
     assert!(!end_of_timeline);
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
     assert_let!(VectorDiff::PushBack { value: item } = &timeline_updates[0]);
     assert_eq!(item.as_event().unwrap().content().as_message().unwrap().body(), "Next1");
@@ -591,7 +591,7 @@ async fn test_focused_timeline_handles_threaded_event() {
         timeline.paginate_forwards(10).await.expect("Could not paginate forwards a 2nd time");
     assert!(end_of_timeline);
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
     assert_let!(VectorDiff::PushBack { value: item } = &timeline_updates[0]);
     assert_eq!(item.as_event().unwrap().content().as_message().unwrap().body(), "Next2");
@@ -670,7 +670,7 @@ async fn test_focused_timeline_handles_thread_root_event_when_forcing_threaded_m
         timeline.paginate_forwards(10).await.expect("Could not paginate forwards");
     assert!(!end_of_timeline);
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
     assert_let!(VectorDiff::PushBack { value: item } = &timeline_updates[0]);
     assert_eq!(item.as_event().unwrap().content().as_message().unwrap().body(), "Next1");
@@ -698,7 +698,7 @@ async fn test_focused_timeline_handles_thread_root_event_when_forcing_threaded_m
         timeline.paginate_forwards(10).await.expect("Could not paginate forwards a 2nd time");
     assert!(end_of_timeline);
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
     assert_let!(VectorDiff::PushBack { value: item } = &timeline_updates[0]);
     assert_eq!(item.as_event().unwrap().content().as_message().unwrap().body(), "Next2");

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -19,6 +19,7 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{
+    assert_let_timeout,
     linked_chunk::{ChunkIdentifier, LinkedChunkId, Position, Update},
     test_utils::mocks::{MatrixMockServer, RoomContextResponseTemplate},
 };
@@ -307,7 +308,7 @@ async fn test_reaction() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 4);
 
     // The new message starts with their author's read receipt.
@@ -352,7 +353,7 @@ async fn test_reaction() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
 
     assert_let!(VectorDiff::Set { index: 1, value: updated_message } = &timeline_updates[0]);
@@ -390,7 +391,7 @@ async fn test_redacted_message() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::PushBack { value: first } = &timeline_updates[0]);
@@ -427,7 +428,7 @@ async fn test_redact_message() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::PushBack { value: first } = &timeline_updates[0]);
@@ -450,7 +451,7 @@ async fn test_redact_message() {
         .await
         .unwrap();
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
 
     assert_let!(VectorDiff::PushBack { value: second } = &timeline_updates[0]);
@@ -458,7 +459,7 @@ async fn test_redact_message() {
     let second = second.as_event().unwrap();
     assert_matches!(second.send_state(), Some(EventSendState::NotSentYet { progress: None }));
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
 
     // We haven't set a route for sending events, so this will fail.
@@ -472,7 +473,7 @@ async fn test_redact_message() {
     // Let's redact the local echo.
     timeline.redact(&second.identifier(), None).await.unwrap();
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
 
     // Observe local echo being removed.
@@ -504,7 +505,7 @@ async fn test_redact_local_sent_message() {
         .await
         .unwrap();
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     // Assert the local event is in the timeline now and is not sent yet.
@@ -517,7 +518,7 @@ async fn test_redact_local_sent_message() {
     assert_let!(VectorDiff::PushFront { value: date_divider } = &timeline_updates[1]);
     assert!(date_divider.is_date_divider());
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 5);
 
     // We receive an update in the timeline from the send queue.
@@ -593,7 +594,7 @@ async fn test_read_marker() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::PushBack { value: message } = &timeline_updates[0]);
@@ -625,7 +626,7 @@ async fn test_read_marker() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::PushBack { value: message } = &timeline_updates[0]);
@@ -669,7 +670,7 @@ async fn test_sync_highlighted() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::PushBack { value: first } = &timeline_updates[0]);
@@ -690,7 +691,7 @@ async fn test_sync_highlighted() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
 
     assert_let!(VectorDiff::PushBack { value: second } = &timeline_updates[0]);
@@ -827,7 +828,7 @@ async fn test_timeline_without_encryption_can_update() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = stream.next());
     assert_eq!(timeline_updates.len(), 3);
 
     // Previous timeline event now has a shield.
@@ -958,7 +959,7 @@ async fn test_custom_msglike_event_in_timeline() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_let!(VectorDiff::PushBack { value: first } = &timeline_updates[0]);
     let event_type = MessageLikeEventType::from("rs.matrix-sdk.custom.test");
     let other_msglike = OtherMessageLike::from_event_type(event_type);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -95,7 +95,7 @@ async fn test_back_pagination() {
     };
     join(paginate, observe_paginating).await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
 
     // `m.room.name`
     {
@@ -162,7 +162,7 @@ async fn test_back_pagination() {
 
     // Timeline start is inserted.
     {
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 1);
         assert_let!(VectorDiff::PushFront { value } = &timeline_updates[0]);
         assert!(value.is_timeline_start());
@@ -216,14 +216,14 @@ async fn test_skip_count_is_taken_into_account_in_pagination_status() {
     {
         // Before the event cache returns the items, it will report that we've hit the
         // timeline start.
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 1);
         assert_let!(VectorDiff::PushFront { value: start } = &timeline_updates[0]);
         assert!(start.is_timeline_start());
     }
 
     // Then we get the events from the event cache.
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 60);
 
     for i in 0..30 {
@@ -372,7 +372,7 @@ async fn test_back_pagination_highlighted() {
     timeline.paginate_backwards(10).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
 
     // `m.room.tombstone`
     {
@@ -807,7 +807,7 @@ async fn test_empty_chunk() {
     };
     join(paginate, observe_paginating).await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
 
     // `m.room.name`
     {
@@ -917,7 +917,7 @@ async fn test_until_num_items_with_empty_chunk() {
     };
     join(paginate, observe_paginating).await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
 
     // `m.room.name`
     {
@@ -965,14 +965,14 @@ async fn test_until_num_items_with_empty_chunk() {
     let reached_start = timeline.paginate_backwards(10).await.unwrap();
     assert!(reached_start);
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
     assert_let!(VectorDiff::PushFront { value } = &timeline_updates[0]);
     assert!(value.is_timeline_start());
 
     // `m.room.name`: “hello room then”
     {
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 1);
 
         assert_let!(VectorDiff::Insert { index: 2, value: message } = &timeline_updates[0]);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -19,7 +19,7 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{
-    Error,
+    Error, assert_let_timeout,
     config::{SyncSettings, SyncToken},
     test_utils::logged_in_client_with_server,
 };
@@ -183,8 +183,13 @@ async fn test_retry_order() {
     });
 
     // Local echoes are updated with the failed send state as soon as
-    // the 404 response is received.
-    assert_let!(Some(VectorDiff::Set { index: 0, value: first }) = timeline_stream.next().await);
+    // the 404 response is received. The send queue uses `short_retry()`
+    // (3 retries) with 500ms minimum exponential backoff, so this can take
+    // up to ~1.5s before the failure is surfaced.
+    assert_let_timeout!(
+        Duration::from_secs(5),
+        Some(VectorDiff::Set { index: 0, value: first }) = timeline_stream.next()
+    );
     assert_matches!(first.send_state().unwrap(), EventSendState::SendingFailed { .. });
 
     // Response for first message takes 100ms to respond.
@@ -302,7 +307,7 @@ async fn test_reloaded_failed_local_echoes_are_marked_as_failed() {
 
     // Local echoes are updated with the failed send state as soon as the error
     // response has been received.
-    assert_let!(Some(VectorDiff::Set { index: 0, value: first }) = timeline_stream.next().await);
+    assert_let_timeout!(Some(VectorDiff::Set { index: 0, value: first }) = timeline_stream.next());
     let (error, is_recoverable) = assert_matches!(first.send_state().unwrap(), EventSendState::SendingFailed { error, is_recoverable } => (error, is_recoverable));
 
     // The error is not recoverable.
@@ -369,11 +374,11 @@ async fn test_clear_with_echoes() {
         // Wait for the first message to fail. Don't use time, but listen for the first
         // timeline item diff to get back signalling the error.
 
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         // 2 updates: date divider and local echo.
         assert_eq!(timeline_updates.len(), 2);
 
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         // 1 updates: local echo replaced with failure.
         assert_eq!(timeline_updates.len(), 1);
     }
@@ -485,7 +490,7 @@ async fn test_no_duplicate_date_divider() {
     // Let the send queue handle the event.
     yield_now().await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 3);
 
     // Local echoes are available as soon as `timeline.send` returns.
@@ -501,7 +506,7 @@ async fn test_no_duplicate_date_divider() {
     // Wait 200ms for the first msg, 100ms for the second, 200ms for overhead.
     sleep(Duration::from_millis(500)).await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 8);
 
     // The first item should be updated first.
@@ -554,7 +559,7 @@ async fn test_no_duplicate_date_divider() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
@@ -234,7 +234,7 @@ async fn test_redact_failed() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = stream.next());
     assert_eq!(timeline_updates.len(), 3);
 
     let item_id = {
@@ -262,7 +262,7 @@ async fn test_redact_failed() {
     // We toggle the reaction, which fails with an error.
     timeline.toggle_reaction(&item_id, "😆").await.unwrap_err();
 
-    assert_let!(Some(timeline_updates) = stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     // The local echo is removed (assuming the redaction works)…

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -19,6 +19,7 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{
+    assert_let_timeout,
     room::Receipts,
     test_utils::mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
 };
@@ -98,7 +99,7 @@ async fn test_read_receipts_updates() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 5);
 
     // We don't list the read receipt of our own user on events.
@@ -195,7 +196,7 @@ async fn test_read_receipts_updates() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
 
     assert_let!(VectorDiff::Set { index: 3, value: third_item } = &timeline_updates[0]);
@@ -288,7 +289,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 4);
 
     // We don't list the read receipt of our own user on events.
@@ -361,7 +362,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::Set { index: 1, value: item_a } = &timeline_updates[0]);
@@ -466,7 +467,7 @@ async fn test_read_receipts_updates_on_message_like_events() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 5);
 
     // We don't list the read receipt of our own user on events.
@@ -543,7 +544,7 @@ async fn test_read_receipts_updates_on_message_like_events() {
         )
         .await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::Set { index: 1, value: item_a } = &timeline_updates[0]);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -4,7 +4,7 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
-use matrix_sdk::test_utils::mocks::MatrixMockServer;
+use matrix_sdk::{assert_let_timeout, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_base::timeout::timeout;
 use matrix_sdk_test::{
     ALICE, BOB, CAROL, JoinedRoomBuilder, async_test, event_factory::EventFactory,
@@ -82,7 +82,7 @@ async fn test_in_reply_to_details() {
         .await;
 
     {
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 3);
 
         // We get the original message.
@@ -123,7 +123,7 @@ async fn test_in_reply_to_details() {
         .await;
 
     let third_unique_id = {
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 2);
 
         assert_let!(VectorDiff::Set { value: _read_receipt_update, .. } = &timeline_updates[0]);
@@ -160,7 +160,7 @@ async fn test_in_reply_to_details() {
     timeline.fetch_details_for_event(eid3).await.unwrap();
 
     {
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 2);
 
         // First it's set to pending, because we're starting the request…
@@ -206,7 +206,7 @@ async fn test_in_reply_to_details() {
     timeline.fetch_details_for_event(eid3).await.unwrap();
 
     {
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 2);
 
         // First it's set to pending, because we're starting the request…
@@ -297,7 +297,7 @@ async fn test_fetch_details_utd() {
         .await;
 
     {
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 2);
 
         // We get the reply, but with no details.
@@ -323,7 +323,7 @@ async fn test_fetch_details_utd() {
     timeline.fetch_details_for_event(response_event_id).await.unwrap();
 
     {
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 2);
 
         // First it's set to pending, because we're starting the request…
@@ -409,7 +409,7 @@ async fn test_fetch_details_poll() {
         .await;
 
     {
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 2);
 
         // We get the reply, but with no details.
@@ -435,7 +435,7 @@ async fn test_fetch_details_poll() {
     timeline.fetch_details_for_event(response_event_id).await.unwrap();
 
     {
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 2);
 
         // First it's set to pending, because we're starting the request…
@@ -520,7 +520,7 @@ async fn test_fetch_details_sticker() {
         .await;
 
     {
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 2);
 
         // We get the reply.
@@ -546,7 +546,7 @@ async fn test_fetch_details_sticker() {
     timeline.fetch_details_for_event(response_event_id).await.unwrap();
 
     {
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 2);
 
         // First it's set to pending, because we're starting the request…

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -21,7 +21,7 @@ use eyeball_im::{Vector, VectorDiff};
 use futures_util::{Stream, StreamExt, pin_mut};
 use matrix_sdk::{
     Client, SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
-    test_utils::logged_in_client_with_server,
+    assert_let_timeout, test_utils::logged_in_client_with_server,
 };
 use matrix_sdk_test::{async_test, mocks::mock_encryption_state};
 use matrix_sdk_ui::timeline::{
@@ -630,7 +630,7 @@ async fn test_timeline_read_receipts_are_updated_live() -> Result<()> {
             }
         };
 
-        assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         assert_eq!(timeline_updates.len(), 1);
 
         assert_let!(VectorDiff::Set { index: 2, value } = &timeline_updates[0]);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -19,6 +19,7 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{
+    assert_let_timeout,
     config::{SyncSettings, SyncToken},
     test_utils::logged_in_client_with_server,
 };
@@ -113,7 +114,7 @@ async fn test_event_filter() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
 
     assert_let!(VectorDiff::PushBack { value: first } = &timeline_updates[0]);
@@ -148,7 +149,7 @@ async fn test_event_filter() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 3);
 
     assert_let!(VectorDiff::PushBack { value: second } = &timeline_updates[0]);
@@ -216,7 +217,7 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 5);
 
     assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);
@@ -242,7 +243,7 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
 
     // The timeline has been emptied.
@@ -264,7 +265,7 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 4);
 
     // Timeline receives events as before.
@@ -320,7 +321,7 @@ async fn test_profile_updates() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 3);
 
     assert_let!(VectorDiff::PushBack { value: item_1 } = &timeline_updates[0]);
@@ -353,7 +354,7 @@ async fn test_profile_updates() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 8);
 
     // Read receipt change.
@@ -422,7 +423,7 @@ async fn test_profile_updates() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    assert_let!(Some(timeline_updates) = timeline_stream.next().await);
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 7);
 
     // Read receipt change.

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -5,6 +5,7 @@ use eyeball_im::VectorDiff;
 use futures_util::FutureExt;
 use matrix_sdk::{
     Client, Error, MemoryStore, SlidingSyncList, StateChanges, StateStore, ThreadingSupport,
+    assert_let_timeout,
     authentication::oauth::{OAuthError, error::OAuthTokenRevocationError},
     config::{RequestConfig, StoreConfig, SyncSettings, SyncToken},
     sleep::sleep,
@@ -1304,7 +1305,7 @@ async fn test_rooms_stream() {
     assert!(client.get_room(room_id_3).is_some());
 
     // We receive 3 diffs…
-    assert_let!(Some(diffs) = rooms_stream.next().await);
+    assert_let_timeout!(Some(diffs) = rooms_stream.next());
     assert_eq!(diffs.len(), 3);
 
     // … which map to the new rooms!

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -9,11 +9,11 @@ use std::{
 
 use anyhow::Result;
 use assert_matches::assert_matches;
-use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::{StreamExt as _, pin_mut};
 use matrix_sdk::{
     Client, Room, RoomInfo, RoomMemberships, RoomState, SlidingSyncList, SlidingSyncMode,
+    assert_let_timeout,
     bytes::Bytes,
     config::SyncSettings,
     room_preview::RoomPreview,
@@ -862,7 +862,7 @@ async fn test_room_info_notable_update_deduplication() -> Result<()> {
     pin_mut!(alice_rooms);
 
     // First, we observe the initial reset.
-    assert_let!(Ok(Some(diffs)) = timeout(Duration::from_secs(3), alice_rooms.next()).await);
+    assert_let_timeout!(Duration::from_secs(3), Some(diffs) = alice_rooms.next());
     assert_eq!(diffs.len(), 1);
     assert_matches!(
         &diffs[0],
@@ -898,7 +898,7 @@ async fn test_room_info_notable_update_deduplication() -> Result<()> {
     sleep(Duration::from_secs(2)).await;
 
     // Room has been updated because of the latest event.
-    assert_let!(Ok(Some(diffs)) = timeout(Duration::from_secs(3), alice_rooms.next()).await);
+    assert_let_timeout!(Duration::from_secs(3), Some(diffs) = alice_rooms.next());
     assert_eq!(diffs.len(), 1);
     assert_matches!(
         &diffs[0],

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -22,7 +22,7 @@ use eyeball_im::{Vector, VectorDiff};
 use futures::pin_mut;
 use futures_util::{FutureExt, StreamExt};
 use matrix_sdk::{
-    Client, Room, RoomState, ThreadingSupport, assert_next_with_timeout,
+    Client, Room, RoomState, ThreadingSupport, assert_let_timeout, assert_next_with_timeout,
     config::SyncSettings,
     deserialized_responses::{VerificationLevel, VerificationState},
     encryption::{
@@ -196,7 +196,7 @@ async fn test_toggling_reaction() -> Result<()> {
 
         sleep(Duration::from_secs(1)).await;
 
-        assert_let!(Some(timeline_updates) = stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = stream.next());
         assert_eq!(timeline_updates.len(), 3);
 
         // Local echo is added.
@@ -237,7 +237,7 @@ async fn test_toggling_reaction() -> Result<()> {
 
         sleep(Duration::from_secs(1)).await;
 
-        assert_let!(Some(timeline_updates) = stream.next().await);
+        assert_let_timeout!(Some(timeline_updates) = stream.next());
         assert_eq!(timeline_updates.len(), 1);
 
         // The reaction is removed.


### PR DESCRIPTION
Many of our tests make use of `assert_let` for checking that some value comes out of a stream, while they could use `assert_let_timeout`, which provides better ergonomics when the expected value doesn't arrive immediately, by failing quickly.

This converts a few instances, making those tests easier to debug in the future, would they fail again.

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] This PR was made with the help of AI.
