### PR TITLE
fix(ffi): Don't assume that all redacted state events have an empty content

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- [**breaking**] `OtherState` properly supports redacted events that still have fields in the
+  content. The following fields are no longer optional:
+  - `federate` in `OtherState::RoomCreate`.
+  - `history_visibility` in `OtherState::RoomHistoryVisibility`.
+  - `thresholds` in `OtherState::RoomPowerLevels`.
 - `omit_checksums` option is now enabled for the Kotlin bindings in all FFI-exporting crates.
   We enabled them because with JNA direct mapping enabled they result in invalid checks in
   ARM 32bit devices, preventing the SDK from working altogether (see

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -155,8 +155,8 @@ pub enum HistoryVisibility {
     },
 }
 
-impl From<RumaHistoryVisibility> for HistoryVisibility {
-    fn from(value: RumaHistoryVisibility) -> Self {
+impl From<&RumaHistoryVisibility> for HistoryVisibility {
+    fn from(value: &RumaHistoryVisibility) -> Self {
         match value {
             RumaHistoryVisibility::Invited => Self::Invited,
             RumaHistoryVisibility::Joined => Self::Joined,
@@ -300,12 +300,12 @@ pub enum OtherState {
     },
     RoomCanonicalAlias,
     RoomCreate {
-        federate: Option<bool>,
+        federate: bool,
     },
     RoomEncryption,
     RoomGuestAccess,
     RoomHistoryVisibility {
-        history_visibility: Option<HistoryVisibility>,
+        history_visibility: HistoryVisibility,
     },
     RoomJoinRules {
         join_rule: Option<JoinRule>,
@@ -321,7 +321,7 @@ pub enum OtherState {
         previous_events: Option<HashMap<TimelineEventType, i64>>,
         users: HashMap<String, i64>,
         previous_users: Option<HashMap<String, i64>>,
-        thresholds: Option<PowerLevelChanges>,
+        thresholds: PowerLevelChanges,
         previous_thresholds: Option<PowerLevelChanges>,
     },
     RoomServerAcl,
@@ -397,8 +397,8 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherStateEventContentChange> for OtherSt
             Content::RoomCanonicalAlias(_) => Self::RoomCanonicalAlias,
             Content::RoomCreate(c) => {
                 let federate = match c {
-                    FullContent::Original { content, .. } => Some(content.federate),
-                    FullContent::Redacted(_) => None,
+                    FullContent::Original { content, .. } => content.federate,
+                    FullContent::Redacted(content) => content.federate,
                 };
                 Self::RoomCreate { federate }
             }
@@ -406,25 +406,22 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherStateEventContentChange> for OtherSt
             Content::RoomGuestAccess(_) => Self::RoomGuestAccess,
             Content::RoomHistoryVisibility(c) => {
                 let history_visibility = match c {
-                    FullContent::Original { content, .. } => {
-                        Some(content.history_visibility.clone().into())
-                    }
-                    FullContent::Redacted(_) => None,
+                    FullContent::Original { content, .. } => &content.history_visibility,
+                    FullContent::Redacted(content) => &content.history_visibility,
                 };
-                Self::RoomHistoryVisibility { history_visibility }
+                Self::RoomHistoryVisibility { history_visibility: history_visibility.into() }
             }
             Content::RoomJoinRules(c) => {
-                let join_rule = match c {
-                    FullContent::Original { content, .. } => {
-                        match content.join_rule.clone().try_into() {
-                            Ok(jr) => Some(jr),
-                            Err(err) => {
-                                tracing::error!("Failed to convert join rule: {}", err);
-                                None
-                            }
-                        }
+                let ruma_join_rule = match c {
+                    FullContent::Original { content, .. } => &content.join_rule,
+                    FullContent::Redacted(content) => &content.join_rule,
+                };
+                let join_rule = match ruma_join_rule.clone().try_into() {
+                    Ok(jr) => Some(jr),
+                    Err(err) => {
+                        tracing::error!("Failed to convert join rule: {}", err);
+                        None
                     }
-                    FullContent::Redacted(_) => None,
                 };
                 Self::RoomJoinRules { join_rule }
             }
@@ -436,8 +433,13 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherStateEventContentChange> for OtherSt
                 Self::RoomName { name }
             }
             Content::RoomPinnedEvents(c) => Self::RoomPinnedEvents { change: c.into() },
-            Content::RoomPowerLevels(c) => match c {
-                FullContent::Original { content, prev_content } => Self::RoomPowerLevels {
+            Content::RoomPowerLevels(c) => {
+                let (content, prev_content) = match c.clone() {
+                    FullContent::Original { content, prev_content } => (content, prev_content),
+                    FullContent::Redacted(content) => (content.into(), None),
+                };
+
+                Self::RoomPowerLevels {
                     events: content
                         .events
                         .iter()
@@ -450,7 +452,7 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherStateEventContentChange> for OtherSt
                             .map(|(k, &v)| (k.clone().into(), v.into()))
                             .collect()
                     }),
-                    thresholds: Some(PowerLevelChanges {
+                    thresholds: PowerLevelChanges {
                         ban: content.ban.into(),
                         kick: content.kick.into(),
                         events_default: content.events_default.into(),
@@ -459,7 +461,7 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherStateEventContentChange> for OtherSt
                         state_default: content.state_default.into(),
                         users_default: content.users_default.into(),
                         notifications: content.notifications.room.into(),
-                    }),
+                    },
                     previous_thresholds: prev_content.as_ref().map(|prev_content| {
                         PowerLevelChanges {
                             ban: prev_content.ban.into(),
@@ -472,23 +474,15 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherStateEventContentChange> for OtherSt
                             notifications: prev_content.notifications.room.into(),
                         }
                     }),
-                    users: power_level_user_changes(content, prev_content)
+                    users: power_level_user_changes(&content, &prev_content)
                         .iter()
                         .map(|(k, v)| (k.to_string(), *v))
                         .collect(),
                     previous_users: prev_content.as_ref().map(|prev_content| {
                         prev_content.users.iter().map(|(k, &v)| (k.to_string(), v.into())).collect()
                     }),
-                },
-                FullContent::Redacted(_) => Self::RoomPowerLevels {
-                    events: Default::default(),
-                    previous_events: None,
-                    users: Default::default(),
-                    previous_users: None,
-                    thresholds: None,
-                    previous_thresholds: None,
-                },
-            },
+                }
+            }
             Content::RoomServerAcl(_) => Self::RoomServerAcl,
             Content::RoomThirdPartyInvite(c) => {
                 let display_name = match c {


### PR DESCRIPTION
- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

