### PR TITLE
fix(ffi): Export Eq and Hash traits in enums used as HashMap keys

### DIFF
--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -89,6 +89,7 @@ impl From<AnyTimelineEvent> for TimelineEvent {
 
 /// The timeline event type.
 #[derive(Clone, uniffi::Enum, PartialEq, Eq, Hash)]
+#[uniffi::export(Eq, Hash)]
 pub enum TimelineEventType {
     /// The event is a message-like one and should be displayed as such.
     MessageLike { value: MessageLikeEventType },

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -1709,6 +1709,7 @@ pub enum RoomAccountDataEvent {
 
 /// The name of a tag.
 #[derive(Clone, PartialEq, Eq, Hash, uniffi::Enum)]
+#[uniffi::export(Eq, Hash)]
 pub enum TagName {
     /// `m.favourite`: The user's favorite rooms.
     Favorite,


### PR DESCRIPTION
`matrix_sdk_ffi::ruma::TagName` and `matrix_sdk_ffi::event::TimelineEventType` enums that are used as `HashMap` keys by `matrix_sdk_ffi::ruma::Tag` and `matrix_sdk_ffi::room::power_levels::RoomPowerLevels` respectively should probably export `Eq` and `Hash` traits in the FFI as well, so that we can generate correct bindings for languages that implement UniFFI's `record` (in UDL)/`HashMap` (in proc-macros) type using a hash table (e.g. `std::unordered_map` in C++).

After applying these changes, I was able to generate working bindings using my WIP generator for C++ (that I haven't open-sourced yet).

Additional context: mozilla/uniffi-rs#2839

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.