### PR TITLE
feat(event cache): cache the return value of `mark_as_unread()` to improve perf

### DIFF
--- a/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
@@ -147,6 +147,7 @@ trait RoomReadReceiptsExt {
         event: &TimelineEvent,
         user_id: &UserId,
         with_threading_support: bool,
+        interesting_event_map: &mut InterestingUnreadEventCache,
     );
 
     fn reset(&mut self);
@@ -159,6 +160,7 @@ trait RoomReadReceiptsExt {
         user_id: &UserId,
         events: impl IntoIterator<Item = &'a TimelineEvent>,
         with_threading_support: bool,
+        interesting_event_map: &mut InterestingUnreadEventCache,
     ) -> bool;
 }
 
@@ -173,12 +175,18 @@ impl RoomReadReceiptsExt for RoomReadReceipts {
         event: &TimelineEvent,
         user_id: &UserId,
         with_threading_support: bool,
+        interesting_event_map: &mut InterestingUnreadEventCache,
     ) {
         if with_threading_support && extract_thread_root(event.raw()).is_some() {
             return;
         }
 
-        if marks_as_unread(event.raw(), user_id) {
+        if let Some(event_id) = event.event_id() {
+            let entry = interesting_event_map.entry(event_id);
+            if *entry.or_insert_with(|| marks_as_unread(event.raw(), user_id)) {
+                self.num_unread += 1;
+            }
+        } else if marks_as_unread(event.raw(), user_id) {
             self.num_unread += 1;
         }
 
@@ -217,6 +225,7 @@ impl RoomReadReceiptsExt for RoomReadReceipts {
         user_id: &UserId,
         events: impl IntoIterator<Item = &'a TimelineEvent>,
         with_threading_support: bool,
+        interesting_event_map: &mut InterestingUnreadEventCache,
     ) -> bool {
         let mut counting_receipts = false;
 
@@ -236,7 +245,7 @@ impl RoomReadReceiptsExt for RoomReadReceipts {
             }
 
             if counting_receipts {
-                self.process_event(event, user_id, with_threading_support);
+                self.process_event(event, user_id, with_threading_support, interesting_event_map);
             }
         }
 
@@ -448,6 +457,7 @@ fn compute_unread_counts_legacy(
         matrix_sdk_base::ThreadingSupport::Disabled => false,
     };
 
+    let mut interesting_event_map = BTreeMap::new();
     compute_unread_counts(
         user_id,
         room_id,
@@ -455,8 +465,16 @@ fn compute_unread_counts_legacy(
         all_events,
         read_receipts,
         threading_support,
+        &mut interesting_event_map,
     );
 }
+
+/// A cache to avoid recomputing multiple times whether an event counts as
+/// "interesting" or not, in the context of the unread count computation.
+///
+/// The key is the event id, the value is the cached returned value of
+/// `marks_as_unread` for that event.
+pub(crate) type InterestingUnreadEventCache = BTreeMap<OwnedEventId, bool>;
 
 /// Given a set of events coming from sync, for a room, update the
 /// [`RoomReadReceipts`]'s counts of unread messages, notifications and
@@ -474,6 +492,7 @@ pub(crate) fn compute_unread_counts(
     all_events: Vec<TimelineEvent>,
     read_receipts: &mut RoomReadReceipts,
     with_threading_support: bool,
+    interesting_event_map: &mut InterestingUnreadEventCache,
 ) {
     debug!(?read_receipts, "Starting");
 
@@ -513,6 +532,7 @@ pub(crate) fn compute_unread_counts(
             user_id,
             &all_events,
             with_threading_support,
+            interesting_event_map,
         );
 
         debug!(?read_receipts, "after finding a better receipt");
@@ -528,7 +548,7 @@ pub(crate) fn compute_unread_counts(
     read_receipts.reset();
 
     for event in &all_events {
-        read_receipts.process_event(event, user_id, with_threading_support);
+        read_receipts.process_event(event, user_id, with_threading_support, interesting_event_map);
     }
 
     debug!(?read_receipts, "no better receipt");
@@ -749,7 +769,7 @@ mod tests {
         // An interesting event from oneself doesn't count as a new unread message.
         let event = make_event(user_id, Vec::new());
         let mut receipts = RoomReadReceipts::default();
-        receipts.process_event(&event, user_id, threading_support);
+        receipts.process_event(&event, user_id, threading_support, &mut Default::default());
         assert_eq!(receipts.num_unread, 0);
         assert_eq!(receipts.num_mentions, 0);
         assert_eq!(receipts.num_notifications, 0);
@@ -757,7 +777,7 @@ mod tests {
         // An interesting event from someone else does count as a new unread message.
         let event = make_event(user_id!("@bob:example.org"), Vec::new());
         let mut receipts = RoomReadReceipts::default();
-        receipts.process_event(&event, user_id, threading_support);
+        receipts.process_event(&event, user_id, threading_support, &mut Default::default());
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 0);
         assert_eq!(receipts.num_notifications, 0);
@@ -765,7 +785,7 @@ mod tests {
         // Push actions computed beforehand are respected.
         let event = make_event(user_id!("@bob:example.org"), vec![Action::Notify]);
         let mut receipts = RoomReadReceipts::default();
-        receipts.process_event(&event, user_id, threading_support);
+        receipts.process_event(&event, user_id, threading_support, &mut Default::default());
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 0);
         assert_eq!(receipts.num_notifications, 1);
@@ -775,7 +795,7 @@ mod tests {
             vec![Action::SetTweak(ruma::push::Tweak::Highlight(true))],
         );
         let mut receipts = RoomReadReceipts::default();
-        receipts.process_event(&event, user_id, threading_support);
+        receipts.process_event(&event, user_id, threading_support, &mut Default::default());
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 1);
         assert_eq!(receipts.num_notifications, 0);
@@ -785,7 +805,7 @@ mod tests {
             vec![Action::SetTweak(ruma::push::Tweak::Highlight(true)), Action::Notify],
         );
         let mut receipts = RoomReadReceipts::default();
-        receipts.process_event(&event, user_id, threading_support);
+        receipts.process_event(&event, user_id, threading_support, &mut Default::default());
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 1);
         assert_eq!(receipts.num_notifications, 1);
@@ -794,7 +814,7 @@ mod tests {
         // make sure to resist against it.
         let event = make_event(user_id!("@bob:example.org"), vec![Action::Notify, Action::Notify]);
         let mut receipts = RoomReadReceipts::default();
-        receipts.process_event(&event, user_id, threading_support);
+        receipts.process_event(&event, user_id, threading_support, &mut Default::default());
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 0);
         assert_eq!(receipts.num_notifications, 1);
@@ -809,7 +829,11 @@ mod tests {
         // When provided with no events, we report not finding the event to which the
         // receipt relates.
         let mut receipts = RoomReadReceipts::default();
-        assert!(receipts.find_and_process_events(ev0, user_id, &[], thread_support).not());
+        assert!(
+            receipts
+                .find_and_process_events(ev0, user_id, &[], thread_support, &mut Default::default())
+                .not()
+        );
         assert_eq!(receipts.num_unread, 0);
         assert_eq!(receipts.num_notifications, 0);
         assert_eq!(receipts.num_mentions, 0);
@@ -836,7 +860,8 @@ mod tests {
                     ev0,
                     user_id,
                     &[make_event(event_id!("$1"))],
-                    thread_support
+                    thread_support,
+                    &mut Default::default()
                 )
                 .not()
         );
@@ -853,7 +878,13 @@ mod tests {
             num_mentions: 37,
             ..Default::default()
         };
-        assert!(receipts.find_and_process_events(ev0, user_id, &[make_event(ev0)], thread_support),);
+        assert!(receipts.find_and_process_events(
+            ev0,
+            user_id,
+            &[make_event(ev0)],
+            thread_support,
+            &mut Default::default(),
+        ));
         assert_eq!(receipts.num_unread, 0);
         assert_eq!(receipts.num_notifications, 0);
         assert_eq!(receipts.num_mentions, 0);
@@ -876,7 +907,8 @@ mod tests {
                         make_event(event_id!("$2")),
                         make_event(event_id!("$3"))
                     ],
-                    thread_support
+                    thread_support,
+                    &mut Default::default()
                 )
                 .not()
         );
@@ -901,7 +933,8 @@ mod tests {
                 make_event(event_id!("$2")),
                 make_event(event_id!("$3"))
             ],
-            thread_support
+            thread_support,
+            &mut Default::default()
         ));
         assert_eq!(receipts.num_unread, 2);
         assert_eq!(receipts.num_notifications, 0);
@@ -924,7 +957,8 @@ mod tests {
                 make_event(event_id!("$2")),
                 make_event(event_id!("$3"))
             ],
-            thread_support
+            thread_support,
+            &mut Default::default()
         ));
         assert_eq!(receipts.num_unread, 2);
         assert_eq!(receipts.num_notifications, 0);
@@ -1625,22 +1659,26 @@ mod tests {
             &make_event(own_alice, event_id!("$some_thread_root")),
             own_alice,
             threading_support,
+            &mut Default::default(),
         );
         receipts.process_event(
             &make_event(own_alice, event_id!("$some_other_thread_root")),
             own_alice,
             threading_support,
+            &mut Default::default(),
         );
 
         receipts.process_event(
             &make_event(bob, event_id!("$some_thread_root")),
             own_alice,
             threading_support,
+            &mut Default::default(),
         );
         receipts.process_event(
             &make_event(bob, event_id!("$some_other_thread_root")),
             own_alice,
             threading_support,
+            &mut Default::default(),
         );
 
         assert_eq!(receipts.num_unread, 0);
@@ -1652,6 +1690,7 @@ mod tests {
             &EventFactory::new().text_msg("A").sender(bob).event_id(event_id!("$ida")).into_event(),
             own_alice,
             threading_support,
+            &mut Default::default(),
         );
 
         assert_eq!(receipts.num_unread, 1);

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -74,7 +74,10 @@ use crate::{
     Room,
     event_cache::{
         EventFocusThreadMode,
-        caches::{event_focused::EventFocusedCache, read_receipts::compute_unread_counts},
+        caches::{
+            event_focused::EventFocusedCache,
+            read_receipts::{InterestingUnreadEventCache, compute_unread_counts},
+        },
     },
     room::WeakRoom,
 };
@@ -147,6 +150,13 @@ pub struct RoomEventCacheState {
     /// An atomic count of the current number of subscriber of the
     /// [`super::RoomEventCache`].
     subscriber_count: Arc<AtomicUsize>,
+
+    /// A stateful cache of the "interesting unread" events, that is, events
+    /// that count in the number of unread messages in a room.
+    ///
+    /// Basically a cache of event id to the return value of
+    /// `marks_as_unread()`.
+    interesting_unread_cache: InterestingUnreadEventCache,
 }
 
 impl lock::Store for RoomEventCacheState {
@@ -265,6 +275,7 @@ impl RoomEventCacheStateLock {
             waited_for_initial_prev_token: false,
             subscriber_count: Default::default(),
             pinned_event_cache: OnceLock::new(),
+            interesting_unread_cache: Default::default(),
         }))
     }
 }
@@ -798,6 +809,10 @@ impl<'a> RoomEventCacheStateLockWriteGuard<'a> {
         // TODO: likely must cancel any ongoing back-paginations too
         self.state.pagination_status.set(PaginationStatus::Idle { hit_timeline_start: false });
 
+        // Reset the interesting unread cache, since we don't know about any event
+        // anymore (and they could have been redacted while we've lost sight of them).
+        self.state.interesting_unread_cache.clear();
+
         Ok(())
     }
 
@@ -1055,8 +1070,9 @@ impl<'a> RoomEventCacheStateLockWriteGuard<'a> {
             .map(|(_, event)| event.clone())
             .collect::<Vec<_>>();
 
-        let user_id = &self.state.own_user_id;
-        let room_id = &self.state.room_id;
+        let state = &mut *self.state;
+        let user_id = &state.own_user_id;
+        let room_id = &state.room_id;
 
         let mut room_info = room.clone_info();
         let prev_read_receipts = room_info.read_receipts().clone();
@@ -1068,7 +1084,8 @@ impl<'a> RoomEventCacheStateLockWriteGuard<'a> {
             receipt_event,
             all_events,
             &mut read_receipts,
-            self.state.enabled_thread_support,
+            state.enabled_thread_support,
+            &mut state.interesting_unread_cache,
         );
 
         if prev_read_receipts != read_receipts {
@@ -1297,6 +1314,10 @@ impl<'a> RoomEventCacheStateLockWriteGuard<'a> {
             target_event.replace_raw(redacted_event.cast_unchecked());
 
             self.replace_event_at(location, target_event).await?;
+
+            // Also drop the interesting unread cache entry for this event, if any, since
+            // the redaction will change the result.
+            self.state.interesting_unread_cache.remove(event_id);
 
             // If the redacted event was part of a thread, remove it in the thread linked
             // chunk too, and make sure to update the thread root's summary

--- a/crates/matrix-sdk/tests/integration/event_cache/read_receipts.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/read_receipts.rs
@@ -353,6 +353,43 @@ async fn test_redaction_does_not_increment_unread() {
     assert_eq!(room.num_unread_messages(), 0);
 }
 
+/// Test that a redaction coming *after* the message has been seen does subtract
+/// to the number of unreads.
+#[async_test]
+async fn test_posteriori_redaction_lowers_unread_count() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    client.event_cache().subscribe().unwrap();
+
+    let room_id = room_id!("!omelette:fromage.fr");
+    let f = EventFactory::new().room(room_id).sender(*BOB);
+
+    // First we receive a message in the clear.
+    let room = server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.text_msg("hi there").event_id(event_id!("$1"))),
+        )
+        .await;
+
+    // It's counted as unread.
+    assert_eq!(room.num_unread_messages(), 1);
+
+    // Later, we do receive a redaction for that message.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.redaction(event_id!("$1")).event_id(event_id!("$2"))),
+        )
+        .await;
+
+    // It's not counted as unread anymore.
+    assert_eq!(room.num_unread_messages(), 0);
+}
+
 /// Test that messages with mentions increment the number of mentions.
 #[async_test]
 async fn test_mentions_increments_unread_mentions() {


### PR DESCRIPTION
Looking at a profile shows that most of the time spent in the new function is caused by the JSON deserialization of events, in `mark_as_unread()`. As a result, memoizing the return value of `mark_as_unread()` should make it more performant, since the events are immutable!… except when they aren't, after being redacted, in which case we manually evict entries from the cache. (A new test covers this.)

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.