### PR TITLE
feat(encryption): Add high-level API for Device Dehydration (MSC3814)

### DIFF
--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -64,6 +64,8 @@ unstable-msc4274 = []
 
 experimental-element-recent-emojis = []
 
+unstable-msc3814 = ["matrix-sdk-crypto?/unstable-msc3814"]
+
 [dependencies]
 as_variant.workspace = true
 assert_matches = { workspace = true, optional = true }

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -40,6 +40,8 @@ test-send-sync = []
 # Testing helpers for implementations based upon this
 testing = ["matrix-sdk-test"]
 
+unstable-msc3814 = []
+
 [dependencies]
 aes = { version = "0.8.4", default-features = false }
 aquamarine.workspace = true

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -76,6 +76,7 @@ All notable changes to this project will be documented in this file.
   to true will now trigger a download of all historical keys for the room in
   question from the client's key backup.
   ([#6017](https://github.com/matrix-org/matrix-rust-sdk/pull/6017))
+- Add a high-level API for Device Dehydration (MSC3814) behind the `unstable-msc3814` feature flag. This allows clients to create a virtual device to receive E2EE keys while offline using `client.encryption().dehydrated_devices().upload(...)` and later retrieve them using `rehydrate_and_absorb(...)`. ([#6273](https://github.com/matrix-org/matrix-rust-sdk/pull/6273))
 
 ### Bugfix
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -90,6 +90,8 @@ experimental-search = ["matrix-sdk-search"]
 
 experimental-element-recent-emojis = ["matrix-sdk-base/experimental-element-recent-emojis"]
 
+unstable-msc3814 = ["matrix-sdk-base/unstable-msc3814"]
+
 [dependencies]
 anyhow = { workspace = true, optional = true }
 anymap2 = { version = "0.13.0", default-features = false }

--- a/crates/matrix-sdk/src/encryption/dehydrated_devices.rs
+++ b/crates/matrix-sdk/src/encryption/dehydrated_devices.rs
@@ -1,0 +1,168 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! High-level wrapper for Device Dehydration (MSC3814).
+
+use matrix_sdk_base::crypto::{
+    DecryptionSettings, TrustRequirement, store::types::DehydratedDeviceKey,
+};
+use ruma::api::client::dehydrated_device::{
+    delete_dehydrated_device, get_dehydrated_device, get_events,
+};
+use tracing::{debug, info};
+
+use crate::{Client, Result};
+
+/// A high-level interface to manage dehydrated devices.
+#[derive(Debug, Clone)]
+pub struct DehydratedDevices {
+    pub(crate) client: Client,
+}
+
+impl DehydratedDevices {
+    /// Creates a new dehydrated device and uploads it to the server.
+    ///
+    /// This allows the server to store a virtual device that can receive E2EE
+    /// keys while the user is offline.
+    ///
+    /// # Arguments
+    ///
+    /// * `display_name` - An optional display name for the dehydrated device.
+    ///   If `None`, defaults to "Dehydrated device".
+    /// * `pickle_key` - The encryption key used to securely encrypt the
+    ///   dehydrated device data before uploading it to the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the user is not authenticated, if there is a
+    /// cryptographic failure during device creation, or if the server
+    /// request fails.
+    pub async fn upload(
+        &self,
+        display_name: Option<&str>,
+        pickle_key: &DehydratedDeviceKey,
+    ) -> Result<()> {
+        debug!("Creating a new dehydrated device in the crypto store");
+        let machine_guard = self.client.olm_machine().await;
+        let machine = machine_guard.as_ref().ok_or(crate::Error::AuthenticationRequired)?;
+
+        let dehydrated_device = machine.dehydrated_devices().create().await?;
+
+        let display_name_str = display_name.unwrap_or("Dehydrated device");
+
+        let upload_req =
+            dehydrated_device.keys_for_upload(display_name_str.to_owned(), pickle_key).await?;
+
+        debug!(device_id = ?upload_req.device_id, "Uploading keys to the server");
+        self.client.send(upload_req).await?;
+        info!("Successfully uploaded dehydrated device");
+
+        Ok(())
+    }
+
+    /// Rehydrates a device from the server and absorbs its room keys.
+    ///
+    /// This fetches the dehydrated device, decrypts its data, fetches the
+    /// stored events, and processes them to import the accumulated room
+    /// keys into the current session. Finally, the device is deleted from
+    /// the server.
+    ///
+    /// # Arguments
+    ///
+    /// * `pickle_key` - The decryption key previously used to encrypt the
+    ///   dehydrated device data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the user is not authenticated, if decryption fails,
+    /// or if a server request fails. Returns `Ok(())` (without doing anything)
+    /// if the server returns a `404 Not Found`, indicating no dehydrated device
+    /// exists.
+    pub async fn rehydrate_and_absorb(&self, pickle_key: &DehydratedDeviceKey) -> Result<()> {
+        let machine_guard = self.client.olm_machine().await;
+        let machine = machine_guard.as_ref().ok_or(crate::Error::AuthenticationRequired)?;
+
+        let request = get_dehydrated_device::unstable::Request::new();
+        let response = match self.client.send(request).await {
+            Ok(res) => res,
+            Err(e) => {
+                if let Some(api_err) = e.as_client_api_error() {
+                    if api_err.status_code == http::StatusCode::NOT_FOUND {
+                        // 404 implies there is no dehydrated device to rehydrate.
+                        return Ok(());
+                    }
+                }
+                return Err(e.into());
+            }
+        };
+
+        let rehydrated = machine
+            .dehydrated_devices()
+            .rehydrate(pickle_key, &response.device_id, response.device_data)
+            .await?;
+
+        let mut next_batch: Option<String> = None;
+
+        let settings =
+            DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
+
+        loop {
+            let mut ev_req = get_events::unstable::Request::new(response.device_id.clone());
+            ev_req.next_batch = next_batch.clone();
+
+            let ev_res = self.client.send(ev_req).await?;
+
+            if ev_res.events.is_empty() {
+                break;
+            }
+
+            rehydrated.receive_events(ev_res.events, &settings).await?;
+
+            let received_token = ev_res.next_batch;
+
+            if received_token.is_none() || received_token == next_batch {
+                break;
+            }
+
+            next_batch = received_token;
+        }
+
+        let del_req = delete_dehydrated_device::unstable::Request::new();
+        self.client.send(del_req).await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl DehydratedDevices {
+    /// Generates a mock `device_id` and `device_data` payload for integration
+    /// tests.
+    pub async fn generate_mock_data(
+        &self,
+        display_name: &str,
+        pickle_key: &DehydratedDeviceKey,
+    ) -> Result<(String, serde_json::Value)> {
+        let machine_guard = self.client.olm_machine().await;
+        let machine = machine_guard.as_ref().ok_or(crate::Error::AuthenticationRequired)?;
+
+        let dehydrated_device = machine.dehydrated_devices().create().await?;
+        let req = dehydrated_device.keys_for_upload(display_name.to_owned(), pickle_key).await?;
+
+        let device_data =
+            serde_json::to_value(&req.device_data).expect("Failed to serialize mock device data");
+
+        Ok((req.device_id.to_string(), device_data))
+    }
+}

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -95,6 +95,8 @@ use crate::{
 };
 
 pub mod backups;
+#[cfg(feature = "unstable-msc3814")]
+pub mod dehydrated_devices;
 pub mod futures;
 pub mod identities;
 pub mod recovery;
@@ -2024,6 +2026,15 @@ impl Encryption {
         }
 
         Ok(failures)
+    }
+
+    /// Get a high-level manager to interact with dehydrated devices.
+    ///
+    /// This allows creating, uploading, and fetching a virtual device which
+    /// stores End-to-End Encryption keys while the user is offline.
+    #[cfg(feature = "unstable-msc3814")]
+    pub fn dehydrated_devices(&self) -> dehydrated_devices::DehydratedDevices {
+        dehydrated_devices::DehydratedDevices { client: self.client.clone() }
     }
 }
 

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -410,6 +410,11 @@ pub enum Error {
     /// An error happened while attempting to change power levels.
     #[error("power levels error: {0}")]
     PowerLevels(#[from] PowerLevelsError),
+
+    /// An error happened while performing a dehydration operation.
+    #[cfg(feature = "unstable-msc3814")]
+    #[error(transparent)]
+    Dehydration(#[from] matrix_sdk_base::crypto::dehydrated_devices::DehydrationError),
 }
 
 #[rustfmt::skip] // stop rustfmt breaking the `<code>` in docs across multiple lines

--- a/crates/matrix-sdk/tests/integration/encryption.rs
+++ b/crates/matrix-sdk/tests/integration/encryption.rs
@@ -1,5 +1,7 @@
 mod backups;
 mod cross_signing;
+#[cfg(feature = "unstable-msc3814")]
+mod dehydrated_devices;
 mod recovery;
 mod secret_storage;
 mod shared_history;

--- a/crates/matrix-sdk/tests/integration/encryption/dehydrated_devices.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/dehydrated_devices.rs
@@ -1,0 +1,354 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk_base::crypto::store::types::DehydratedDeviceKey;
+use matrix_sdk_test::async_test;
+use serde_json::json;
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path, path_regex},
+};
+
+use crate::logged_in_client_with_server;
+
+async fn mock_encryption_setup(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/r0/keys/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "one_time_key_counts": { "signed_curve25519": 50 }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/unstable/keys/device_signing/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/unstable/keys/signatures/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"failures": {}})))
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path_regex(r"/_matrix/client/r0/user/.* /account_data/m.secret_storage.default_key"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(server)
+        .await;
+}
+
+#[async_test]
+async fn test_upload_dehydrated_device() {
+    let (client, server) = logged_in_client_with_server().await;
+    mock_encryption_setup(&server).await;
+
+    client
+        .encryption()
+        .bootstrap_cross_signing(None)
+        .await
+        .expect("Failed to bootstrap cross-signing");
+
+    Mock::given(method("PUT"))
+        .and(path("/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "device_id": "VIRTUAL_DEVICE"
+        })))
+        .mount(&server)
+        .await;
+
+    let pickle_key = DehydratedDeviceKey::from_slice(&[1u8; 32]).unwrap();
+
+    client
+        .encryption()
+        .dehydrated_devices()
+        .upload(Some("My Dehydrated Device"), &pickle_key)
+        .await
+        .expect("Failed to upload dehydrated device");
+}
+
+#[async_test]
+async fn test_rehydrate_returns_ok_on_404() {
+    let (client, server) = logged_in_client_with_server().await;
+
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "errcode": "M_NOT_FOUND",
+            "error": "No dehydrated device found"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let pickle_key = DehydratedDeviceKey::from_slice(&[1u8; 32]).unwrap();
+
+    client
+        .encryption()
+        .dehydrated_devices()
+        .rehydrate_and_absorb(&pickle_key)
+        .await
+        .expect("Expected Ok(()) when server returns 404 Not Found");
+}
+
+#[async_test]
+async fn test_rehydrate_and_absorb() {
+    let (client, server) = logged_in_client_with_server().await;
+    mock_encryption_setup(&server).await;
+
+    client
+        .encryption()
+        .bootstrap_cross_signing(None)
+        .await
+        .expect("Failed to bootstrap cross-signing");
+
+    let pickle_key = DehydratedDeviceKey::from_slice(&[1u8; 32]).unwrap();
+
+    let (device_id, device_data) = client
+        .encryption()
+        .dehydrated_devices()
+        .generate_mock_data("Mock Device", &pickle_key)
+        .await
+        .expect("Failed to generate mock device data");
+
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "device_id": device_id,
+            "device_data": device_data,
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(
+            r"/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/.*/events",
+        ))
+        .and(wiremock::matchers::body_json(json!({})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "events": []
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "device_id": device_id
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    client
+        .encryption()
+        .dehydrated_devices()
+        .rehydrate_and_absorb(&pickle_key)
+        .await
+        .expect("Happy path rehydrate_and_absorb failed");
+}
+
+#[async_test]
+async fn test_rehydrate_and_absorb_with_pagination() {
+    let (client, server) = logged_in_client_with_server().await;
+    mock_encryption_setup(&server).await;
+
+    client
+        .encryption()
+        .bootstrap_cross_signing(None)
+        .await
+        .expect("Failed to bootstrap cross-signing");
+
+    let pickle_key = DehydratedDeviceKey::from_slice(&[1u8; 32]).unwrap();
+
+    let (device_id, device_data) = client
+        .encryption()
+        .dehydrated_devices()
+        .generate_mock_data("Mock Device", &pickle_key)
+        .await
+        .expect("Failed to generate mock device data");
+
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "device_id": device_id,
+            "device_data": device_data,
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(
+            r"/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/.*/events",
+        ))
+        .and(wiremock::matchers::body_json(json!({})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "events": [{
+                "type": "m.room.encryption",
+                "sender": "@alice:example.org",
+                "content": {},
+                "event_id": "$event1",
+                "origin_server_ts": 123456
+            }],
+            "next_batch": "batch_token_2"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(
+            r"/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/.*/events",
+        ))
+        .and(wiremock::matchers::body_json(json!({ "next_batch": "batch_token_2" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "events": [],
+            "next_batch": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "device_id": device_id })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    client
+        .encryption()
+        .dehydrated_devices()
+        .rehydrate_and_absorb(&pickle_key)
+        .await
+        .expect("Rehydrate with pagination failed");
+}
+
+#[async_test]
+async fn test_rehydrate_infinite_pagination_guard() {
+    let (client, server) = logged_in_client_with_server().await;
+    mock_encryption_setup(&server).await;
+
+    client.encryption().bootstrap_cross_signing(None).await.unwrap();
+    let pickle_key = DehydratedDeviceKey::from_slice(&[1u8; 32]).unwrap();
+
+    let (device_id, device_data) = client
+        .encryption()
+        .dehydrated_devices()
+        .generate_mock_data("Mock Device", &pickle_key)
+        .await
+        .expect("Failed to generate mock device data");
+
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "device_id": device_id,
+            "device_data": device_data,
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(
+            r"/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/.*/events",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "events": [{
+                "type": "m.room.encryption",
+                "sender": "@alice:example.org",
+                "content": {},
+                "event_id": "$event1",
+                "origin_server_ts": 123456
+            }],
+            "next_batch": "stuck_token"
+        })))
+        .expect(1..=2)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "device_id": device_id })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    client
+        .encryption()
+        .dehydrated_devices()
+        .rehydrate_and_absorb(&pickle_key)
+        .await
+        .expect("Rehydrate infinite pagination guard failed");
+}
+
+#[async_test]
+async fn test_rehydrate_fails_with_wrong_key() {
+    let (client, server) = logged_in_client_with_server().await;
+    mock_encryption_setup(&server).await;
+
+    client.encryption().bootstrap_cross_signing(None).await.unwrap();
+    let correct_key = DehydratedDeviceKey::from_slice(&[1u8; 32]).unwrap();
+    let wrong_key = DehydratedDeviceKey::from_slice(&[2u8; 32]).unwrap();
+
+    let (device_id, device_data) = client
+        .encryption()
+        .dehydrated_devices()
+        .generate_mock_data("Mock Device", &correct_key)
+        .await
+        .expect("Failed to generate mock device data");
+
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "device_id": device_id,
+            "device_data": device_data,
+        })))
+        .mount(&server)
+        .await;
+
+    let result = client.encryption().dehydrated_devices().rehydrate_and_absorb(&wrong_key).await;
+
+    assert!(result.is_err(), "Expected rehydration to fail with incorrect pickle key");
+}
+
+#[async_test]
+async fn test_upload_dehydrated_device_default_name() {
+    let (client, server) = logged_in_client_with_server().await;
+    mock_encryption_setup(&server).await;
+
+    client.encryption().bootstrap_cross_signing(None).await.unwrap();
+
+    Mock::given(method("PUT"))
+        .and(path("/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device"))
+        .and(wiremock::matchers::body_partial_json(json!({
+            "initial_device_display_name": "Dehydrated device"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "device_id": "VIRTUAL_DEVICE"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let pickle_key = DehydratedDeviceKey::from_slice(&[1u8; 32]).unwrap();
+
+    client
+        .encryption()
+        .dehydrated_devices()
+        .upload(None, &pickle_key)
+        .await
+        .expect("Failed to upload dehydrated device with default name");
+}


### PR DESCRIPTION
This introduces a high-level interface for Device Dehydration, which allows clients to proactively create a virtual device on the server to receive E2EE keys while the primary client is offline. Currently the only way to use this is with the raw bindings of the ruma crate.

The new functionality is exposed via `client.encryption().dehydrated_devices()` and provides `upload` and `rehydrate_and_absorb` methods. All new additions are gated behind the `unstable-msc3814` cargo feature.

As I'm unfamiliar with wiremock, I had some AI assistance when making the integration tests. I'm currently running them like the following:
```bash
cargo test -p matrix-sdk --test integration --features unstable-msc3814,testing dehydrated_devices
```

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] This PR was made with the help of AI.

Signed-off-by: Thomas Q <thomasqsa@gmail.com>