### PR TITLE
default push notifications to be noisy

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -957,7 +957,10 @@ impl Client {
 
                 async move {
                     // Extract information about the actions
-                    let is_noisy = notification.actions.iter().any(|a| a.sound().is_some());
+                    let is_noisy = notification.actions.iter().any(|a| a.sound().is_some() || a.should_notify())
+                        && !notification.actions.iter().any(|a| {
+                            a.sound().is_some_and(|s| s.is_empty() || s.eq_ignore_ascii_case("none"))
+                        });
                     let has_mention = notification.actions.iter().any(|a| a.is_highlight());
 
                     // Convert SDK actions to FFI type

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -1019,7 +1019,12 @@ impl NotificationItem {
             }
         }
 
-        let is_noisy = push_actions.map(|actions| actions.iter().any(|a| a.sound().is_some()));
+        let is_noisy = push_actions.map(|actions| {
+            actions.iter().any(|a| a.sound().is_some() || a.should_notify())
+                && !actions.iter().any(|a| {
+                    a.sound().is_some_and(|s| s.is_empty() || s.eq_ignore_ascii_case("none"))
+                })
+        });
         let has_mention = push_actions.map(|actions| actions.iter().any(|a| a.is_highlight()));
         let thread_id = event.thread_id().clone();
 


### PR DESCRIPTION
some servers (continuwuity) don't send any actions/tweaks in the push notifications after push registration using the flag event_id_only that discard them (just as synapse btw),

in that case they send push notifications without filling the "tweaks" field https://spec.matrix.org/v1.17/push-gateway-api/#post_matrixpushv1notify_request_device

other clients like fluffychat, element classic, etc default this situation to noisy notifications but element x default to silent (because of the behaviour of this lib) in that case there's no way to get noisy notifications on element x and continuwuity,

more informations about this issue can be found there:
https://github.com/element-hq/element-x-ios/issues/5132
https://forgejo.ellis.link/continuwuation/continuwuity/issues/1533
https://forgejo.ellis.link/continuwuation/continuwuity/issues/1424