### PR TITLE
default push notification to be noisy

### DIFF
--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -941,8 +941,10 @@ pub struct NotificationItem {
     /// Is the room a space?
     pub is_space: bool,
 
-    /// Is it a noisy notification? (i.e. does any push action contain a sound
-    /// action)
+    /// Is it a noisy notification?
+    ///
+    /// Notifications are considered noisy when their push actions notify. If a
+    /// sound tweak is present, it is treated as noisy as well.
     ///
     /// It is set if and only if the push actions could be determined.
     pub is_noisy: Option<bool>,
@@ -1019,7 +1021,12 @@ impl NotificationItem {
             }
         }
 
-        let is_noisy = push_actions.map(|actions| actions.iter().any(|a| a.sound().is_some()));
+        // Treat notify actions as noisy by default, even when servers don't
+        // include an explicit sound tweak in the matching rule.
+        let is_noisy = push_actions.map(|actions| {
+            actions.iter().any(Action::should_notify)
+                || actions.iter().any(|action| action.sound().is_some())
+        });
         let has_mention = push_actions.map(|actions| actions.iter().any(|a| a.is_highlight()));
         let thread_id = event.thread_id().clone();
 

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -524,7 +524,7 @@ async fn test_notification_client_sliding_sync() {
     assert_eq!(item.sender_display_name.as_deref(), Some(sender_display_name));
     assert_eq!(item.sender_avatar_url, Some(sender_avatar_url.to_string()));
     assert_eq!(item.room_computed_display_name, sender_display_name);
-    assert_eq!(item.is_noisy, Some(false));
+    assert_eq!(item.is_noisy, Some(true));
 }
 
 #[async_test]
@@ -669,7 +669,7 @@ async fn test_notification_client_sliding_sync_invites() {
     assert_eq!(item.sender_display_name.as_deref(), Some(sender_display_name));
     assert_eq!(item.sender_avatar_url, Some(sender_avatar_url.to_string()));
     assert_eq!(item.room_computed_display_name, sender_display_name);
-    assert_eq!(item.is_noisy, Some(false));
+    assert_eq!(item.is_noisy, Some(true));
 }
 
 #[async_test]
@@ -813,7 +813,7 @@ async fn test_notification_client_sliding_sync_invites_with_event_id() {
     assert_eq!(item.sender_display_name.as_deref(), Some(sender_display_name));
     assert_eq!(item.sender_avatar_url, Some(sender_avatar_url.to_string()));
     assert_eq!(item.room_computed_display_name, sender_display_name);
-    assert_eq!(item.is_noisy, Some(false));
+    assert_eq!(item.is_noisy, Some(true));
 }
 
 #[async_test]
@@ -1008,7 +1008,7 @@ async fn test_notification_client_mixed() {
     assert_eq!(item.sender_display_name.as_deref(), Some(sender_display_name));
     assert_eq!(item.sender_avatar_url, Some(sender_avatar_url.to_string()));
     assert_eq!(item.room_computed_display_name, sender_display_name);
-    assert_eq!(item.is_noisy, Some(false));
+    assert_eq!(item.is_noisy, Some(true));
 }
 
 #[async_test]


### PR DESCRIPTION
some servers (continuwuity) don't send any actions/tweaks in the push notifications after push registration using the flag event_id_only that discard them (just as synapse btw),

in that case they send push notifications without filling the "tweaks" field https://spec.matrix.org/v1.17/push-gateway-api/#post_matrixpushv1notify_request_device

other clients like fluffychat, element classic, etc default this situation to noisy notifications but element x default to silent (because of the behaviour of this lib) in that case there's no way to get noisy notifications on element x and continuwuity,

more informations about this issue can be found there:
https://github.com/element-hq/element-x-ios/issues/5132
https://forgejo.ellis.link/continuwuation/continuwuity/issues/1533
https://forgejo.ellis.link/continuwuation/continuwuity/issues/1424