### PR TITLE
fix(unread counts): a gappy sync shouldn't decrease the unread counts

### DIFF
--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -1074,6 +1074,25 @@ impl<'a> RoomEventCacheStateLockWriteGuard<'a> {
         );
 
         if prev_read_receipts != read_receipts {
+            if prev_read_receipts.latest_active == read_receipts.latest_active {
+                // If the latest active read receipt hasn't changed, but the number of unread
+                // has *decreased*, then it means that we've recomputed receipts
+                // after a gap. Ditch the new values, as they're likely
+                // incorrect.
+                //
+                // TODO: use automatic back-pagination in this case, instead of ditching the new
+                // values.
+                if read_receipts.num_unread < prev_read_receipts.num_unread {
+                    read_receipts.num_unread = prev_read_receipts.num_unread;
+                }
+                if read_receipts.num_notifications < prev_read_receipts.num_notifications {
+                    read_receipts.num_notifications = prev_read_receipts.num_notifications;
+                }
+                if read_receipts.num_mentions < prev_read_receipts.num_mentions {
+                    read_receipts.num_mentions = prev_read_receipts.num_mentions;
+                }
+            }
+
             // The read receipt has changed! Do a little dance to update the `RoomInfo` in
             // the state store, and then in the room itself, so that observers
             // can be notified of the change.

--- a/crates/matrix-sdk/tests/integration/event_cache/read_receipts.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/read_receipts.rs
@@ -482,8 +482,10 @@ async fn test_gappy_sync_keeps_then_next_sync_resets_unread_count() {
     assert_let_timeout!(Ok(_) = room_cache_updates.recv());
 
     // The gappy sync cleared "$1" and "$2" from the linked chunk, so this sync
-    // only sees "$3" when recomputing → unread count drops to 1.
-    assert_eq!(room.num_unread_messages(), 1);
+    // only sees "$3" when recomputing the unread count, yielding 1. But this is
+    // incorrect, as the number should be *at least* 2, and the SDK should keep
+    // on showing this number in this case.
+    assert_eq!(room.num_unread_messages(), 2);
 }
 
 /// Test that messages with mentions increment the number of mentions.


### PR DESCRIPTION
See code comments and commits descriptions :) This fixes a situation where a gappy sync could cause unread counts to decrease (because unread counts computation rely on the linked-chunk to be completely loaded up to the latest active read receipt).

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] This PR was made with the help of AI.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/4113