### PR TITLE
fix(xtask): The `pos` field can be absent when computing `log sync`

### DIFF
--- a/xtask/src/log/sync.rs
+++ b/xtask/src/log/sync.rs
@@ -33,8 +33,8 @@ pub(super) fn run(log_path: path::PathBuf, output_path: path::PathBuf) -> Result
                 # we have `pos` and `timeout`. We must consider they are
                 # optional.
                 (
-                    .*
-                    \spos="(?<pos>[^"]+)"
+                    .*?
+                    (\spos="(?<pos>[^"]+)")?
                     \stimeout=(?<timeout>\d+)
                 )?
             \}


### PR DESCRIPTION
This patch fixes a bug in `xtask log sync` which can miss a `sync_once` log when the `pos` field is absent. It happens when there is no `pos`!

Example where `pos` is absent before `timeout`. Note the double space before `timeout`:

```
… > sync_once{conn_id="room-list"  timeout=0} > send{request_id="REQ-15" …
```

While when the `pos` is present, it's:

```
… > sync_once{conn_id="room-list" pos="0/m67590980…" timeout=30000} > send{request_id="REQ-23" …
```
---

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.