### PR TITLE
refactor(sdk): Inline `RoomEventCacheStateLockWriteGuard::load_more_events_backwards` in `RoomPagination`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -875,12 +875,13 @@ mod timed_tests {
     use tokio::task::yield_now;
 
     use super::{
-        super::{lock::Reload as _, pagination::LoadMoreEventsBackwardsOutcome},
+        super::{
+            super::TimelineVectorDiffs, lock::Reload as _,
+            pagination::LoadMoreEventsBackwardsOutcome,
+        },
         RoomEventCache, RoomEventCacheGenericUpdate, RoomEventCacheUpdate,
     };
-    use crate::{
-        assert_let_timeout, event_cache::TimelineVectorDiffs, test_utils::client::MockClientBuilder,
-    };
+    use crate::{assert_let_timeout, test_utils::client::MockClientBuilder};
 
     #[async_test]
     async fn test_write_to_storage() {
@@ -1465,7 +1466,7 @@ mod timed_tests {
         assert!(generic_stream.is_empty());
 
         {
-            let mut state = room_event_cache.inner.state.write().await.unwrap();
+            let state = room_event_cache.inner.state.read().await.unwrap();
 
             let mut num_gaps = 0;
             let mut num_events = 0;
@@ -1481,15 +1482,20 @@ mod timed_tests {
             // the events.
             assert_eq!(num_gaps, 0);
             assert_eq!(num_events, 1);
+        }
 
-            // But if I manually reload more of the chunk, the gap will be present.
-            assert_matches!(
-                state.load_more_events_backwards().await.unwrap(),
-                LoadMoreEventsBackwardsOutcome::Gap { .. }
-            );
+        // But if I manually reload more of the chunk, the gap will be present.
+        assert_matches!(
+            room_event_cache.pagination().load_more_events_backwards().await.unwrap(),
+            LoadMoreEventsBackwardsOutcome::Gap { .. }
+        );
 
-            num_gaps = 0;
-            num_events = 0;
+        {
+            let state = room_event_cache.inner.state.read().await.unwrap();
+
+            let mut num_gaps = 0;
+            let mut num_events = 0;
+
             for c in state.room_linked_chunk().chunks() {
                 match c.content() {
                     ChunkContent::Items(items) => num_events += items.len(),

--- a/crates/matrix-sdk/src/event_cache/caches/room/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/pagination.rs
@@ -23,9 +23,10 @@ use eyeball::{SharedObservable, Subscriber};
 use eyeball_im::VectorDiff;
 use matrix_sdk_base::{
     event_cache::{Event, Gap},
-    linked_chunk::{ChunkContent, LinkedChunkId},
+    linked_chunk::{ChunkContent, LinkedChunkId, Update},
 };
 use ruma::api::Direction;
+use tracing::{error, trace};
 
 pub use super::super::pagination::PaginationStatus;
 use super::{
@@ -88,6 +89,13 @@ impl RoomPagination {
     pub fn status(&self) -> Subscriber<PaginationStatus> {
         self.0.cache.status().subscribe()
     }
+
+    #[cfg(test)]
+    pub(super) async fn load_more_events_backwards(
+        &self,
+    ) -> Result<LoadMoreEventsBackwardsOutcome> {
+        self.0.cache.load_more_events_backwards().await
+    }
 }
 
 impl PaginatedCache for Arc<RoomEventCacheInner> {
@@ -96,11 +104,121 @@ impl PaginatedCache for Arc<RoomEventCacheInner> {
     }
 
     async fn load_more_events_backwards(&self) -> Result<LoadMoreEventsBackwardsOutcome> {
-        self.state.write().await?.load_more_events_backwards().await
+        let mut state = self.state.write().await?;
+
+        // If any in-memory chunk is a gap, don't load more events, and let the caller
+        // resolve the gap.
+        if let Some(prev_token) = state.room_linked_chunk().rgap().map(|gap| gap.token) {
+            return Ok(LoadMoreEventsBackwardsOutcome::Gap {
+                prev_token: Some(prev_token),
+                waited_for_initial_prev_token: state.waited_for_initial_prev_token(),
+            });
+        }
+
+        let prev_first_chunk =
+            state.room_linked_chunk().chunks().next().expect("a linked chunk is never empty");
+
+        // The first chunk is not a gap, we can load its previous chunk.
+        let linked_chunk_id = LinkedChunkId::Room(&state.state.room_id);
+        let new_first_chunk = match state
+            .store
+            .load_previous_chunk(linked_chunk_id, prev_first_chunk.identifier())
+            .await
+        {
+            Ok(Some(new_first_chunk)) => {
+                // All good, let's continue with this chunk.
+                new_first_chunk
+            }
+
+            Ok(None) => {
+                // If we never received events for this room, this means we've never received a
+                // sync for that room, because every room must have *at least* a room creation
+                // event. Otherwise, we have reached the start of the timeline.
+
+                if state.room_linked_chunk().events().next().is_some() {
+                    // If there's at least one event, this means we've reached the start of the
+                    // timeline, since the chunk is fully loaded.
+                    trace!("chunk is fully loaded and non-empty: reached_start=true");
+                    return Ok(LoadMoreEventsBackwardsOutcome::StartOfTimeline);
+                }
+
+                // Otherwise, start back-pagination from the end of the room.
+                return Ok(LoadMoreEventsBackwardsOutcome::Gap {
+                    prev_token: None,
+                    waited_for_initial_prev_token: state.waited_for_initial_prev_token(),
+                });
+            }
+
+            Err(err) => {
+                error!("error when loading the previous chunk of a linked chunk: {err}");
+
+                // Clear storage for this room.
+                state
+                    .store
+                    .handle_linked_chunk_updates(linked_chunk_id, vec![Update::Clear])
+                    .await?;
+
+                // Return the error.
+                return Err(err.into());
+            }
+        };
+
+        let chunk_content = new_first_chunk.content.clone();
+
+        // We've reached the start on disk, if and only if, there was no chunk prior to
+        // the one we just loaded.
+        //
+        // This value is correct, if and only if, it is used for a chunk content of kind
+        // `Items`.
+        let reached_start = new_first_chunk.previous.is_none();
+
+        if let Err(err) = state.room_linked_chunk_mut().insert_new_chunk_as_first(new_first_chunk) {
+            error!("error when inserting the previous chunk into its linked chunk: {err}");
+
+            // Clear storage for this room.
+            state
+                .store
+                .handle_linked_chunk_updates(
+                    LinkedChunkId::Room(&state.state.room_id),
+                    vec![Update::Clear],
+                )
+                .await?;
+
+            // Return the error.
+            return Err(err.into());
+        }
+
+        // ⚠️ Let's not propagate the updates to the store! We already have these data
+        // in the store! Let's drain them.
+        let _ = state.room_linked_chunk_mut().store_updates().take();
+
+        // However, we want to get updates as `VectorDiff`s.
+        let timeline_event_diffs = state.room_linked_chunk_mut().updates_as_vector_diffs();
+
+        Ok(match chunk_content {
+            ChunkContent::Gap(gap) => {
+                trace!("reloaded chunk from disk (gap)");
+
+                LoadMoreEventsBackwardsOutcome::Gap {
+                    prev_token: Some(gap.token),
+                    waited_for_initial_prev_token: state.waited_for_initial_prev_token(),
+                }
+            }
+
+            ChunkContent::Items(events) => {
+                trace!(?reached_start, "reloaded chunk from disk ({} items)", events.len());
+
+                LoadMoreEventsBackwardsOutcome::Events {
+                    events,
+                    timeline_event_diffs,
+                    reached_start,
+                }
+            }
+        })
     }
 
     async fn mark_has_waited_for_initial_prev_token(&self) -> Result<()> {
-        *self.state.write().await?.waited_for_initial_prev_token() = true;
+        *self.state.write().await?.waited_for_initial_prev_token_mut() = true;
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -30,8 +30,8 @@ use matrix_sdk_base::{
         store::{EventCacheStoreLock, EventCacheStoreLockGuard, EventCacheStoreLockState},
     },
     linked_chunk::{
-        ChunkContent, ChunkIdentifierGenerator, ChunkMetadata, LinkedChunkId, OwnedLinkedChunkId,
-        Position, Update, lazy_loader,
+        ChunkIdentifierGenerator, ChunkMetadata, LinkedChunkId, OwnedLinkedChunkId, Position,
+        Update, lazy_loader,
     },
     serde_helpers::{extract_edit_target, extract_thread_root},
     sync::Timeline,
@@ -62,7 +62,6 @@ use super::{
         EventLocation, TimelineVectorDiffs,
         event_linked_chunk::EventLinkedChunk,
         lock,
-        pagination::LoadMoreEventsBackwardsOutcome,
         pinned_events::PinnedEventCache,
         thread::ThreadEventCache,
     },
@@ -458,7 +457,12 @@ impl<'a> RoomEventCacheStateLockWriteGuard<'a> {
     }
 
     /// Get the `waited_for_initial_prev_token` value.
-    pub fn waited_for_initial_prev_token(&mut self) -> &mut bool {
+    pub fn waited_for_initial_prev_token(&self) -> bool {
+        self.state.waited_for_initial_prev_token
+    }
+
+    /// Get a mutable reference to the `waited_for_initial_prev_token` value.
+    pub fn waited_for_initial_prev_token_mut(&mut self) -> &mut bool {
         &mut self.state.waited_for_initial_prev_token
     }
 
@@ -498,117 +502,6 @@ impl<'a> RoomEventCacheStateLockWriteGuard<'a> {
             &self.store,
         )
         .await
-    }
-
-    /// Load more events backwards if the last chunk is **not** a gap.
-    pub async fn load_more_events_backwards(
-        &mut self,
-    ) -> Result<LoadMoreEventsBackwardsOutcome, EventCacheError> {
-        // If any in-memory chunk is a gap, don't load more events, and let the caller
-        // resolve the gap.
-        if let Some(prev_token) = self.state.room_linked_chunk.rgap().map(|gap| gap.token) {
-            return Ok(LoadMoreEventsBackwardsOutcome::Gap {
-                prev_token: Some(prev_token),
-                waited_for_initial_prev_token: self.state.waited_for_initial_prev_token,
-            });
-        }
-
-        let prev_first_chunk =
-            self.state.room_linked_chunk.chunks().next().expect("a linked chunk is never empty");
-
-        // The first chunk is not a gap, we can load its previous chunk.
-        let linked_chunk_id = LinkedChunkId::Room(&self.state.room_id);
-        let new_first_chunk = match self
-            .store
-            .load_previous_chunk(linked_chunk_id, prev_first_chunk.identifier())
-            .await
-        {
-            Ok(Some(new_first_chunk)) => {
-                // All good, let's continue with this chunk.
-                new_first_chunk
-            }
-
-            Ok(None) => {
-                // If we never received events for this room, this means we've never received a
-                // sync for that room, because every room must have *at least* a room creation
-                // event. Otherwise, we have reached the start of the timeline.
-
-                if self.state.room_linked_chunk.events().next().is_some() {
-                    // If there's at least one event, this means we've reached the start of the
-                    // timeline, since the chunk is fully loaded.
-                    trace!("chunk is fully loaded and non-empty: reached_start=true");
-                    return Ok(LoadMoreEventsBackwardsOutcome::StartOfTimeline);
-                }
-
-                // Otherwise, start back-pagination from the end of the room.
-                return Ok(LoadMoreEventsBackwardsOutcome::Gap {
-                    prev_token: None,
-                    waited_for_initial_prev_token: self.state.waited_for_initial_prev_token,
-                });
-            }
-
-            Err(err) => {
-                error!("error when loading the previous chunk of a linked chunk: {err}");
-
-                // Clear storage for this room.
-                self.store
-                    .handle_linked_chunk_updates(linked_chunk_id, vec![Update::Clear])
-                    .await?;
-
-                // Return the error.
-                return Err(err.into());
-            }
-        };
-
-        let chunk_content = new_first_chunk.content.clone();
-
-        // We've reached the start on disk, if and only if, there was no chunk prior to
-        // the one we just loaded.
-        //
-        // This value is correct, if and only if, it is used for a chunk content of kind
-        // `Items`.
-        let reached_start = new_first_chunk.previous.is_none();
-
-        if let Err(err) = self.state.room_linked_chunk.insert_new_chunk_as_first(new_first_chunk) {
-            error!("error when inserting the previous chunk into its linked chunk: {err}");
-
-            // Clear storage for this room.
-            self.store
-                .handle_linked_chunk_updates(
-                    LinkedChunkId::Room(&self.state.room_id),
-                    vec![Update::Clear],
-                )
-                .await?;
-
-            // Return the error.
-            return Err(err.into());
-        }
-
-        // ⚠️ Let's not propagate the updates to the store! We already have these data
-        // in the store! Let's drain them.
-        let _ = self.state.room_linked_chunk.store_updates().take();
-
-        // However, we want to get updates as `VectorDiff`s.
-        let timeline_event_diffs = self.state.room_linked_chunk.updates_as_vector_diffs();
-
-        Ok(match chunk_content {
-            ChunkContent::Gap(gap) => {
-                trace!("reloaded chunk from disk (gap)");
-                LoadMoreEventsBackwardsOutcome::Gap {
-                    prev_token: Some(gap.token),
-                    waited_for_initial_prev_token: self.state.waited_for_initial_prev_token,
-                }
-            }
-
-            ChunkContent::Items(events) => {
-                trace!(?reached_start, "reloaded chunk from disk ({} items)", events.len());
-                LoadMoreEventsBackwardsOutcome::Events {
-                    events,
-                    timeline_event_diffs,
-                    reached_start,
-                }
-            }
-        })
     }
 
     /// If storage is enabled, unload all the chunks, then reloads only the

--- a/crates/matrix-sdk/src/event_cache/caches/thread/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/pagination.rs
@@ -99,7 +99,7 @@ impl PaginatedCache for ThreadEventCacheWrapper {
     }
 
     async fn mark_has_waited_for_initial_prev_token(&self) -> Result<()> {
-        *self.cache.state.write().await?.waited_for_initial_prev_token() = true;
+        *self.cache.state.write().await?.waited_for_initial_prev_token_mut() = true;
 
         Ok(())
     }


### PR DESCRIPTION
The method `RoomEventCacheStateLockWriteGuard::load_more_events_backwards` is used only in one-place: in `RoomPagination::load_more_events_backwards`. This patch inlines this method as it aims at living in `RoomPagination`, not somewhere else.

It's purely code move. Nothing else has changed.

This patch also updates a test that was accessing `load_more_events_backwards` directly. Now it runs it via `RoomPagination`.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/4869

---

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.