### PR TITLE
feat(sync): Allow setting a custom Sliding Sync connection ID and timeline limit on `RoomListService`

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - Add `Client::set_avatar_url` to manually set the avatar URL of the user to a provided MXC one.
+- Allow setting a custom Sliding Sync connection ID and timeline limit on `RoomListService`.
+  ([#6289](https://github.com/matrix-org/matrix-rust-sdk/pull/6289))
 - Fix devices on Android 11 crashing because the SDK could not be initialized using `libloading` 
   to get a reference to the JVM. Replaced `libloading` with `jvm-getter`, which works like a 
   compatibility layer. ([#6370](https://github.com/matrix-org/matrix-rust-sdk/pull/6370))

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -128,6 +128,28 @@ impl SyncServiceBuilder {
         Arc::new(Self { builder, ..this })
     }
 
+    /// Set a custom Sliding Sync connection ID for the room list service.
+    ///
+    /// By default [`matrix_sdk_ui::room_list_service::DEFAULT_CONNECTION_ID`]
+    /// is used. Set a different value for secondary processes such as iOS
+    /// Share Extensions that are not meant to reuse the main app's
+    /// connection.
+    pub fn with_room_list_connection_id(self: Arc<Self>, connection_id: String) -> Arc<Self> {
+        let this = unwrap_or_clone_arc(self);
+        let builder = this.builder.with_room_list_conn_id(connection_id);
+        Arc::new(Self { builder, ..this })
+    }
+
+    /// Set a custom timeline limit for the room list service.
+    ///
+    /// When set, overrides the default timeline limit of
+    /// [`matrix_sdk_ui::room_list_service::DEFAULT_LIST_TIMELINE_LIMIT`].
+    pub fn with_room_list_timeline_limit(self: Arc<Self>, limit: u32) -> Arc<Self> {
+        let this = unwrap_or_clone_arc(self);
+        let builder = this.builder.with_room_list_timeline_limit(limit);
+        Arc::new(Self { builder, ..this })
+    }
+
     pub async fn finish(self: Arc<Self>) -> Result<Arc<SyncService>, ClientError> {
         let this = unwrap_or_clone_arc(self);
         Ok(Arc::new(SyncService {

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
   `Room::latest_event()`, so room summaries still show the last live location
   sharing session after it ends.
   ([#6437](https://github.com/matrix-org/matrix-rust-sdk/pull/6437))
+- Allow setting a custom Sliding Sync connection ID and timeline limit on `RoomListService`.
+  ([#6289](https://github.com/matrix-org/matrix-rust-sdk/pull/6289))
 - Don't show a "sent in clear" shield on live location timeline items in
   encrypted rooms, since `beacon_info` is a state event that cannot be
   encrypted by design.

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -107,6 +107,12 @@ const DEFAULT_REQUIRED_STATE: &[(StateEventType, &str)] = &[
 const DEFAULT_ROOM_SUBSCRIPTION_EXTRA_REQUIRED_STATE: &[(StateEventType, &str)] =
     &[(StateEventType::RoomPinnedEvents, "")];
 
+/// The default Sliding Sync connection ID for the room list service.
+pub(crate) const DEFAULT_CONNECTION_ID: &str = "room-list";
+
+/// The default timeline limit for the room list service.
+pub(crate) const DEFAULT_LIST_TIMELINE_LIMIT: u32 = 1;
+
 /// The default `timeline_limit` value when used with room subscriptions.
 const DEFAULT_ROOM_SUBSCRIPTION_TIMELINE_LIMIT: u32 = 20;
 
@@ -135,16 +141,25 @@ impl RoomListService {
     /// to create one in this case using
     /// [`EncryptionSyncService`][crate::encryption_sync_service::EncryptionSyncService].
     pub async fn new(client: Client) -> Result<Self, Error> {
-        Self::new_with_share_pos(client, true).await
+        Self::new_with(client, true, DEFAULT_CONNECTION_ID, DEFAULT_LIST_TIMELINE_LIMIT).await
     }
 
-    /// Like [`RoomListService::new`] but with a flag to turn the
-    /// [`SlidingSyncBuilder::share_pos`] on and off.
+    /// Like [`RoomListService::new`] but with additional configuration options.
+    ///
+    /// - `share_pos`: toggles [`SlidingSyncBuilder::share_pos`] for
+    ///   cross-process position sharing.
+    /// - `connection_id`: the Sliding Sync connection ID
+    /// - `timeline_limit`: the timeline limit
     ///
     /// [`SlidingSyncBuilder::share_pos`]: matrix_sdk::sliding_sync::SlidingSyncBuilder::share_pos
-    pub async fn new_with_share_pos(client: Client, share_pos: bool) -> Result<Self, Error> {
+    pub async fn new_with(
+        client: Client,
+        share_pos: bool,
+        connection_id: &str,
+        timeline_limit: u32,
+    ) -> Result<Self, Error> {
         let mut builder = client
-            .sliding_sync("room-list")
+            .sliding_sync(connection_id)
             .map_err(Error::SlidingSync)?
             .with_account_data_extension(
                 assign!(http::request::AccountData::default(), { enabled: Some(true) }),
@@ -202,7 +217,7 @@ impl RoomListService {
                         SlidingSyncMode::new_selective()
                             .add_range(ALL_ROOMS_DEFAULT_SELECTIVE_RANGE),
                     )
-                    .timeline_limit(1)
+                    .timeline_limit(timeline_limit)
                     .required_state(
                         DEFAULT_REQUIRED_STATE
                             .iter()

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -47,7 +47,9 @@ use tracing::{Instrument, Level, Span, error, info, instrument, trace, warn};
 
 use crate::{
     encryption_sync_service::{self, EncryptionSyncPermit, EncryptionSyncService},
-    room_list_service::{self, RoomListService},
+    room_list_service::{
+        self, DEFAULT_CONNECTION_ID, DEFAULT_LIST_TIMELINE_LIMIT, RoomListService,
+    },
 };
 
 /// Current state of the application.
@@ -773,6 +775,16 @@ pub struct SyncServiceBuilder {
     /// [`SlidingSyncBuilder::share_pos`]: matrix_sdk::sliding_sync::SlidingSyncBuilder::share_pos
     with_share_pos: bool,
 
+    /// Custom connection ID for the room list service.
+    /// Defaults to [`room_list_service::DEFAULT_CONNECTION_ID`]. Use a
+    /// different value for secondary processes such as iOS share extensions
+    /// that are not meant to reuse the main app's connection.
+    room_list_conn_id: String,
+
+    /// Custom timeline limit for the room list service. Defaults to
+    /// [`room_list_service::DEFAULT_LIST_TIMELINE_LIMIT`].
+    room_list_timeline_limit: u32,
+
     /// The parent tracing span to use for the tasks within this service.
     ///
     /// Normally this will be [`Span::none`], but it may be useful to assign a
@@ -783,7 +795,14 @@ pub struct SyncServiceBuilder {
 
 impl SyncServiceBuilder {
     fn new(client: Client) -> Self {
-        Self { client, with_offline_mode: false, with_share_pos: true, parent_span: Span::none() }
+        Self {
+            client,
+            with_offline_mode: false,
+            with_share_pos: true,
+            room_list_conn_id: DEFAULT_CONNECTION_ID.to_owned(),
+            room_list_timeline_limit: DEFAULT_LIST_TIMELINE_LIMIT,
+            parent_span: Span::none(),
+        }
     }
 
     /// Enable the "offline" mode for the [`SyncService`].
@@ -803,6 +822,18 @@ impl SyncServiceBuilder {
         self
     }
 
+    /// Set a custom conn_id for the room list sliding sync connection.
+    pub fn with_room_list_conn_id(mut self, conn_id: String) -> Self {
+        self.room_list_conn_id = conn_id;
+        self
+    }
+
+    /// Set a custom timeline limit for the room list service.
+    pub fn with_room_list_timeline_limit(mut self, limit: u32) -> Self {
+        self.room_list_timeline_limit = limit;
+        self
+    }
+
     /// Set the parent tracing span to be used for the tasks within this
     /// service.
     pub fn with_parent_span(mut self, parent_span: Span) -> Self {
@@ -816,11 +847,24 @@ impl SyncServiceBuilder {
     /// the background. The resulting [`SyncService`] must be kept alive as long
     /// as the sliding syncs are supposed to run.
     pub async fn build(self) -> Result<SyncService, Error> {
-        let Self { client, with_offline_mode, with_share_pos, parent_span } = self;
+        let Self {
+            client,
+            with_offline_mode,
+            with_share_pos,
+            room_list_conn_id,
+            room_list_timeline_limit,
+            parent_span,
+        } = self;
 
         let encryption_sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new()));
 
-        let room_list = RoomListService::new_with_share_pos(client.clone(), with_share_pos).await?;
+        let room_list = RoomListService::new_with(
+            client.clone(),
+            with_share_pos,
+            &room_list_conn_id,
+            room_list_timeline_limit,
+        )
+        .await?;
 
         let encryption_sync = Arc::new(EncryptionSyncService::new(client, None).await?);
 


### PR DESCRIPTION
This allows setting the roomlist service's connection ID and timeline limit over FFI. We've found this to be helpful when using the service from an iOS share extension simultaneously to the main app.

<!-- description of the changes in this PR -->

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

