### PR TITLE
refactor(ffi): Remove unnecessary match branch in `ffi::Client::new`

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -110,6 +110,8 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- `Client::new` no longer unnecessarily instantiates an `OAuth` component if `CrossProcessLockConfig::SingleProcess` 
+  is used. ([#6293](https://github.com/matrix-org/matrix-rust-sdk/pull/6293))
 - [**breaking**] `Room::report_content()` no longer takes a `score` argument, because it was
   removed from the Matrix specification.
   ([#6256](https://github.com/matrix-org/matrix-rust-sdk/pull/6256))

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -392,9 +392,7 @@ impl Client {
                 }
                 client.inner.oauth().enable_cross_process_refresh_lock(holder_name.clone()).await?;
             }
-            CrossProcessLockConfig::SingleProcess => {
-                client.inner.oauth();
-            }
+            CrossProcessLockConfig::SingleProcess => {}
         }
 
         if let Some(session_delegate) = session_delegate {


### PR DESCRIPTION
When checking some related code, I noticed this was just instantiating a value that was never used. I kept the `match` instead of using an `if let` so if the enum ever changes this match would still be exhaustive.

<!-- description of the changes in this PR -->

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
