### PR TITLE
fix(ffi): Using rustls in Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,6 +2919,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3392,7 +3402,9 @@ dependencies = [
  "eyeball-im",
  "futures-executor",
  "futures-util",
+ "jni",
  "language-tags",
+ "libloading",
  "log-panics",
  "matrix-sdk",
  "matrix-sdk-base",
@@ -3401,8 +3413,10 @@ dependencies = [
  "matrix-sdk-ui",
  "mime",
  "oauth2",
+ "once_cell",
  "paranoid-android",
  "ruma",
+ "rustls-platform-verifier",
  "sentry",
  "sentry-tracing",
  "serde",
@@ -3973,9 +3987,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oneshot"

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- Added `android_platform.rs` for fixing the `rustls` integration on Android, which was broken. 
+  ([#6306](https://github.com/matrix-org/matrix-rust-sdk/pull/6306)) 
 - [**breaking**] `OtherState` properly supports redacted events that still have fields in the
   content. The following fields are no longer optional:
   - `federate` in `OtherState::RoomCreate`.

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -124,6 +124,14 @@ uniffi = { workspace = true, features = ["tokio"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 paranoid-android = { version = "0.2.2", default-features = false }
+# Needed for `rustls-platform-verifier`. Newer versions aren't compatible with it.
+jni = "0.21.1"
+# Used to access the credential storage on Android
+rustls-platform-verifier = "0.6.2"
+# Used to avoid having to call an exposed JNI call from the Android client to initialize `rustls-platform-verifier`
+libloading = "0.9.0"
+# Needed for intializing and keeping the JavaVM reference around
+once_cell = "1.21.4"
 
 [dev-dependencies]
 similar-asserts.workspace = true

--- a/bindings/matrix-sdk-ffi/src/platform/android_platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform/android_platform.rs
@@ -1,0 +1,89 @@
+use std::error::Error;
+
+use jni::{
+    errors::JniError,
+    sys::{jint, jsize, JavaVM},
+};
+use tracing::debug;
+
+static ANDROID_JVM: once_cell::sync::OnceCell<jni::JavaVM> = once_cell::sync::OnceCell::new();
+
+/// Initialize the platform support for Android targets.
+///
+/// This includes setting up `rustls-platform-verifier`.
+pub(crate) fn init() {
+    debug!("Initializing Android platform support");
+
+    ANDROID_JVM.get_or_init(|| {
+        match get_java_vm() {
+            Ok(jvm) => {
+                // Initialize rustls platform verifier
+                let mut env =
+                    jvm.attach_current_thread_permanently().expect("Failed to attach thread");
+                init_rustls_platform_verifier(&mut env)
+                    .expect("Failed to initialize rustls platform verifier");
+
+                debug!("Android platform support initialized successfully");
+
+                jvm
+            }
+            Err(e) => {
+                panic!("Failed to initialize Android platform support: {}", e);
+            }
+        }
+    });
+}
+
+type JniGetCreatedJavaVms =
+    unsafe extern "system" fn(_: *mut *mut JavaVM, _: jsize, _: *mut jsize) -> jint;
+const JNI_GET_JAVA_VMS_NAME: &[u8] = b"JNI_GetCreatedJavaVMs";
+
+fn get_java_vm() -> Result<jni::JavaVM, Box<dyn Error>> {
+    // Use libloading to avoid having to create and expose a JNI function and call
+    // it from the Android side.
+    let library = libloading::os::unix::Library::this();
+    let get_created_java_vms: JniGetCreatedJavaVms =
+        unsafe { *library.get(JNI_GET_JAVA_VMS_NAME)? };
+
+    let mut java_vms: [*mut JavaVM; 1] = [std::ptr::null_mut() as *mut JavaVM];
+    let mut vm_count: i32 = 0;
+
+    let ok = unsafe { get_created_java_vms(java_vms.as_mut_ptr(), 1, &mut vm_count) };
+    if ok != jni::sys::JNI_OK {
+        return Err("Failed to get JavaVM".into());
+    }
+    if vm_count != 1 {
+        return Err(format!("Invalid JavaVM count: {vm_count}").into());
+    }
+
+    let jvm = unsafe { jni::JavaVM::from_raw(java_vms[0]) }?;
+    Ok(jvm)
+}
+
+fn init_rustls_platform_verifier(env: &mut jni::JNIEnv<'_>) -> jni::errors::Result<()> {
+    // Get the current activity thread
+    let activity_thread = env
+        .call_static_method(
+            "android/app/ActivityThread",
+            "currentActivityThread",
+            "()Landroid/app/ActivityThread;",
+            &[],
+        )?
+        .l()?;
+
+    // Then get the application context
+    let context = env
+        .call_method(activity_thread, "getApplication", "()Landroid/app/Application;", &[])?
+        .l()?;
+
+    Ok(rustls_platform_verifier::android::init_hosted(env, context)?)
+}
+
+/// Attach the current thread to a JVM one.
+pub(crate) fn android_attach_current_thread_permanently(
+) -> jni::errors::Result<jni::JNIEnv<'static>> {
+    ANDROID_JVM
+        .get()
+        .ok_or_else(|| jni::errors::Error::JniCall(JniError::Unknown))?
+        .attach_current_thread_permanently()
+}

--- a/bindings/matrix-sdk-ffi/src/platform/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/platform/mod.rs
@@ -49,6 +49,9 @@ const DEFAULT_MAX_AGE_SECONDS: u64 = 7 * 24 * 60 * 60;
 mod rolling_writer;
 pub mod tracing;
 
+#[cfg(target_os = "android")]
+mod android_platform;
+
 use rolling_writer::SizeAndDateRollingWriter;
 
 use self::tracing::LogLevel;
@@ -682,6 +685,9 @@ pub fn init_platform(
         }
     }
 
+    #[cfg(target_os = "android")]
+    android_platform::init();
+
     Ok(())
 }
 
@@ -739,6 +745,10 @@ fn setup_multithreaded_tokio_runtime() {
 
         let mut builder = tokio::runtime::Builder::new_multi_thread();
         builder.enable_all();
+        #[cfg(target_os = "android")]
+        builder.on_thread_start(|| {
+            _ = android_platform::android_attach_current_thread_permanently();
+        });
         builder
     }));
 }


### PR DESCRIPTION
It turns out on Android, rustls needs [a custom setup](https://github.com/rustls/rustls-platform-verifier#android) and adding the `rustls-platform-verifier-android` library that's [not available on Maven](https://github.com/rustls/rustls-platform-verifier/issues/115).

Then, from the Android clients we'd need to call some exposed JNI function so we can provide a JVM context from where Rust can take the `Application` component and access its contents to read its credentials storage. Thanks to some tricks we can use `libloading` to simulate this call from Rust itself and properly initialise the platform verifier.

Note self-signed certificates will no longer work with these changes on Android, and providing them in `ClientBuilder::add_root_certificates` will make most requests fail. This can be handled separately.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
