### PR TITLE
chore(ui): Always enable the latest event Room List sorter

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -183,15 +183,6 @@ impl RoomList {
         page_size: u32,
         listener: Box<dyn RoomListEntriesListener>,
     ) -> Arc<RoomListEntriesWithDynamicAdaptersResult> {
-        self.entries_with_dynamic_adapters_with(page_size, false, listener)
-    }
-
-    fn entries_with_dynamic_adapters_with(
-        self: Arc<Self>,
-        page_size: u32,
-        enable_latest_event_sorter: bool,
-        listener: Box<dyn RoomListEntriesListener>,
-    ) -> Arc<RoomListEntriesWithDynamicAdaptersResult> {
         let this = self;
 
         // The following code deserves a bit of explanation.
@@ -228,7 +219,7 @@ impl RoomList {
 
         // Get a reference to `this`. It is only borrowed, it's not moved.
         let this =
-            // SAFETY: `ptr` is correct aligned, the `this` field is correctly aligned,
+            // SAFETY: `ptr` is correctly aligned, the `this` field is correctly aligned,
             // is dereferenceable and points to a correctly initialized value as done
             // in the previous line.
             unsafe { addr_of_mut!((*ptr).this).as_ref() }
@@ -239,10 +230,7 @@ impl RoomList {
         // borrowing `this`, which is going to live long enough since it will live as
         // long as `entries_stream` and `dynamic_entries_controller`.
         let (entries_stream, dynamic_entries_controller) =
-            this.inner.entries_with_dynamic_adapters_with(
-                page_size.try_into().unwrap(),
-                enable_latest_event_sorter,
-            );
+            this.inner.entries_with_dynamic_adapters(page_size.try_into().unwrap());
 
         // FFI dance to make those values consumable by foreign language, nothing fancy
         // here, that's the real code for this method.

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -37,8 +37,7 @@ use super::{
     Error, State,
     filters::BoxedFilterFn,
     sorters::{
-        BoxedSorterFn, new_sorter_latest_event, new_sorter_lexicographic, new_sorter_name,
-        new_sorter_recency,
+        new_sorter_latest_event, new_sorter_lexicographic, new_sorter_name, new_sorter_recency,
     },
 };
 
@@ -142,25 +141,6 @@ impl RoomList {
         page_size: usize,
     ) -> (impl Stream<Item = Vec<VectorDiff<RoomListItem>>> + '_, RoomListDynamicEntriesController)
     {
-        self.entries_with_dynamic_adapters_impl(page_size, false)
-    }
-
-    #[doc(hidden)]
-    pub fn entries_with_dynamic_adapters_with(
-        &self,
-        page_size: usize,
-        enable_latest_event_sorter: bool,
-    ) -> (impl Stream<Item = Vec<VectorDiff<RoomListItem>>> + '_, RoomListDynamicEntriesController)
-    {
-        self.entries_with_dynamic_adapters_impl(page_size, enable_latest_event_sorter)
-    }
-
-    fn entries_with_dynamic_adapters_impl(
-        &self,
-        page_size: usize,
-        enable_latest_event_sorter: bool,
-    ) -> (impl Stream<Item = Vec<VectorDiff<RoomListItem>>> + '_, RoomListDynamicEntriesController)
-    {
         let room_info_notable_update_receiver = self.client.room_info_notable_update_receiver();
         let list = self.sliding_sync_list.clone();
 
@@ -186,24 +166,19 @@ impl RoomList {
                 // Combine normal stream events with other updates from rooms
                 let stream = merge_stream_and_receiver(values.clone(), raw_stream, room_info_notable_update_receiver.resubscribe());
 
-                let mut sorters: Vec<BoxedSorterFn> = Vec::with_capacity(3);
-
-                if enable_latest_event_sorter {
-                    // Sort by latest event's kind, i.e. put the rooms with a
-                    // **local** latest event first.
-                    sorters.push(Box::new(new_sorter_latest_event()));
-                }
-
-                // Sort rooms by their recency (either by looking
-                // at their latest event's timestamp, or their
-                // `recency_stamp`).
-                sorters.push(Box::new(new_sorter_recency()));
-                // Finally, sort by name.
-                sorters.push(Box::new(new_sorter_name()));
-
                 let (values, stream) = (values, stream)
                     .filter(filter_fn)
-                    .sort_by(new_sorter_lexicographic(sorters))
+                    .sort_by(new_sorter_lexicographic(vec![
+                        // Sort by latest event's kind, i.e. put the rooms with a
+                        // **local** latest event first.
+                        Box::new(new_sorter_latest_event()),
+                        // Sort rooms by their recency (either by looking
+                        // at their latest event's timestamp, or their
+                        // `recency_stamp`).
+                        Box::new(new_sorter_recency()),
+                        // Finally, sort by name.
+                        Box::new(new_sorter_name()),
+                    ]))
                     .dynamic_head_with_initial_value(page_size, limit_stream.clone());
 
                 // Clearing the stream before chaining with the real stream.


### PR DESCRIPTION
This patch removes the `enable_latest_event_sorter` flag in `RoomList::entry_with_dynamic_adapters_with`. This sorter is now stable enough, we can always enable it.

---

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.