### PR TITLE
refactor(timeline): replace a `bool::to_owned()` call with a dereference

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1583,7 +1583,7 @@ impl TimelineController {
         let state = self.state.read().await;
         let filter_out_thread_events = match self.focus() {
             TimelineFocusKind::Thread { .. } => false,
-            TimelineFocusKind::Live { hide_threaded_events } => hide_threaded_events.to_owned(),
+            TimelineFocusKind::Live { hide_threaded_events } => *hide_threaded_events,
             TimelineFocusKind::Event { .. } => {
                 // For event-focused timelines, filtering is handled in the event cache layer.
                 false


### PR DESCRIPTION
booleans can be copied \o/

- No public API Changes.
- This PR was not made with the help of AI. I am big brain.
