### PR TITLE
fix(event cache): don't select an implicit threaded receipt for counting unreads

### DIFF
--- a/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
@@ -234,6 +234,7 @@ fn select_best_receipt(
     pending_receipts: &mut RingBuffer<OwnedEventId>,
     new_receipt_event: Option<&ReceiptEventContent>,
     latest_active: Option<&EventId>,
+    with_threading_support: bool,
 ) -> Option<OwnedEventId> {
     // If we had a new receipt event, add the main/unthreaded receipts it contains
     // to the pending receipts list. We'll try to chase them later.
@@ -276,8 +277,11 @@ fn select_best_receipt(
             }
             // Try to find an implicit read receipt (i.e. an event sent by the current
             // user).
+            //
+            // If the client is enabled with threading support, skip events that are in threads.
             else if event.raw().get_field::<OwnedUserId>("sender").ok().flatten().as_deref()
                 == Some(user_id)
+                && (!with_threading_support || extract_thread_root(event.raw()).is_none())
             {
                 trace!(implicit = %event_id, "found an implicit receipt; stopping search");
                 found = Some(event_id.clone());
@@ -345,6 +349,7 @@ pub(crate) fn compute_unread_counts(
         &mut read_receipts.pending,
         receipt_event,
         read_receipts.latest_active.as_ref().map(|latest_active| latest_active.event_id.as_ref()),
+        with_threading_support,
     )
     .map(|event_id| LatestReadReceipt { event_id });
 
@@ -828,6 +833,7 @@ mod tests {
         let new_receipt_event = None;
         // And no active receipt,
         let active_receipt = None;
+        let with_threading_support = false;
 
         // Then there's no best receipt.
         let result = select_best_receipt(
@@ -836,6 +842,7 @@ mod tests {
             &mut pending_receipts,
             new_receipt_event,
             active_receipt,
+            with_threading_support,
         );
         assert!(result.is_none());
         // And there are no pending receipts.
@@ -863,6 +870,7 @@ mod tests {
         let new_receipt_event = None;
         // And no active receipt,
         let active_receipt = None;
+        let with_threading_support = false;
 
         // Then there's a new best receipt, which is the implicit one.
         let result = select_best_receipt(
@@ -871,6 +879,7 @@ mod tests {
             &mut pending_receipts,
             new_receipt_event,
             active_receipt,
+            with_threading_support,
         );
         assert_eq!(result.unwrap(), event_id!("$2"));
         // And there are no pending receipts.
@@ -898,6 +907,7 @@ mod tests {
         let new_receipt_event = None;
         // And an active receipt pointing at $2,
         let active_receipt = Some(event_id!("$2"));
+        let with_threading_support = false;
 
         // Then the best receipt is still $2.
         let result = select_best_receipt(
@@ -906,6 +916,7 @@ mod tests {
             &mut pending_receipts,
             new_receipt_event,
             active_receipt,
+            with_threading_support,
         );
         assert_eq!(result.unwrap(), event_id!("$2"));
         // And there are no pending receipts.
@@ -938,6 +949,7 @@ mod tests {
 
         // And no active receipt,
         let active_receipt = None;
+        let with_threading_support = false;
 
         // Then there's a new best receipt, which is the explicit one from the event
         let result = select_best_receipt(
@@ -946,6 +958,7 @@ mod tests {
             &mut pending_receipts,
             new_receipt_event.as_ref(),
             active_receipt,
+            with_threading_support,
         );
         assert_eq!(result.unwrap(), event_id!("$2"));
         // And there are no pending receipts.
@@ -978,6 +991,7 @@ mod tests {
 
         // And no active receipt,
         let active_receipt = None;
+        let with_threading_support = false;
 
         // Then there's no new best receipts.
         let result = select_best_receipt(
@@ -986,6 +1000,7 @@ mod tests {
             &mut pending_receipts,
             new_receipt_event.as_ref(),
             active_receipt,
+            with_threading_support,
         );
 
         assert!(result.is_none());
@@ -1017,6 +1032,7 @@ mod tests {
 
         // And no active receipt,
         let active_receipt = None;
+        let with_threading_support = false;
 
         // Then there's a new best receipt, which is the matched pending receipt.
         let result = select_best_receipt(
@@ -1025,6 +1041,7 @@ mod tests {
             &mut pending_receipts,
             new_receipt_event.as_ref(),
             active_receipt,
+            with_threading_support,
         );
         assert_eq!(result.unwrap(), event_id!("$2"));
         // And there are no more pending receipts.
@@ -1064,6 +1081,8 @@ mod tests {
         // And an active receipt point at $1,
         let active_receipt = Some(event_id!("$1"));
 
+        let with_threading_support = false;
+
         // Then there's a new best receipt, which is the most advanced in the linked
         // chunk: $4.
         let result = select_best_receipt(
@@ -1072,6 +1091,7 @@ mod tests {
             &mut pending_receipts,
             new_receipt_event.as_ref(),
             active_receipt,
+            with_threading_support,
         );
         assert_eq!(result.unwrap(), event_id!("$4"));
 

--- a/crates/matrix-sdk/tests/integration/event_cache/read_receipts.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/read_receipts.rs
@@ -25,7 +25,8 @@
 //! processing by the event cache isn't, at the time we check the unread counts.
 
 use matrix_sdk::{
-    assert_let_timeout, event_cache::RoomEventCacheUpdate, test_utils::mocks::MatrixMockServer,
+    ThreadingSupport, assert_let_timeout, event_cache::RoomEventCacheUpdate,
+    test_utils::mocks::MatrixMockServer,
 };
 use matrix_sdk_test::{BOB, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use ruma::{
@@ -593,5 +594,58 @@ async fn test_compute_unread_counts_considers_active_receipt() {
     assert_let_timeout!(Ok(_) = room_cache_updates.recv());
 
     // The message counts are properly updated (two messages after $2).
+    assert_eq!(room.num_unread_messages(), 2);
+}
+
+/// Test that the unread count computation doesn't select an implicit receipt
+/// from a thread message, when it's configured for the main/unthreaded
+/// timeline.
+#[async_test]
+async fn test_select_best_receipt_considers_thread_config() {
+    let server = MatrixMockServer::new().await;
+
+    // For a client that supports threading,
+    let client = server
+        .client_builder()
+        .on_builder(|builder| {
+            builder.with_threading_support(ThreadingSupport::Enabled { with_subscriptions: false })
+        })
+        .build()
+        .await;
+    let own_user_id = client.user_id().unwrap();
+
+    client.event_cache().subscribe().unwrap();
+
+    let room_id = room_id!("!omelette:fromage.fr");
+    let f = EventFactory::new().room(room_id).sender(*BOB);
+
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
+    let (_, mut room_cache_updates) = room_event_cache.subscribe().await.unwrap();
+    assert!(room_cache_updates.is_empty());
+
+    // Starting with a room that has two messages from Bob, and one threaded answer
+    // to one of Bob's messages.
+    let thread_root = event_id!("$1");
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.text_msg("hello 1").event_id(thread_root))
+                .add_timeline_event(f.text_msg("hello 2").event_id(event_id!("$2")))
+                .add_timeline_event(
+                    f.text_msg("hello 3")
+                        .in_thread(thread_root, thread_root)
+                        .sender(own_user_id)
+                        .event_id(event_id!("$3")),
+                ),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = room_cache_updates.recv());
+
+    // The message counts include all messages from the main timeline, because the
+    // implicit receipt sent in a thread isn't taken into account.
     assert_eq!(room.num_unread_messages(), 2);
 }


### PR DESCRIPTION
The test shows a situation where an in-thread message would be counted as an implicit receipt, while, when we're in the `main` timeline mode, we're counting unreads only for the main timeline. In this case, the test would fail because the unread counts would be set to 0, since select_best_receipt would have selected $3.

The patch is to *not* select an implicit receipt, in that mode, when it's in a thread.

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] This PR was made with the help of AI autocomplete.

Part of #4113.