### PR TITLE
chore(live_location): expose the inner `beacon_info`s location sharing session start timestamp.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -333,6 +333,14 @@ pub struct LiveLocationContent {
     /// Whether this sharing session is currently active.
     pub is_live: bool,
 
+    /// The timestamp when this live location sharing session started
+    /// (from the `org.matrix.msc3488.ts` field of the originating
+    /// `beacon_info` state event).
+    ///
+    /// This marks the *beginning* of the session. The session expires at
+    /// `ts + timeout_ms`.
+    pub ts: Timestamp,
+
     /// An optional human-readable label for this sharing session.
     pub description: Option<String>,
 

--- a/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
@@ -216,6 +216,7 @@ impl TryFrom<matrix_sdk_ui::timeline::MsgLikeContent> for MsgLikeContent {
                     kind: MsgLikeKind::LiveLocation {
                         content: LiveLocationContent {
                             is_live: state.is_live(),
+                            ts: state.ts().into(),
                             description: state.description().map(ToOwned::to_owned),
                             timeout_ms: state.timeout().as_millis() as u64,
                             asset_type: state.asset_type().into(),

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/live_location.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/live_location.rs
@@ -122,6 +122,17 @@ impl LiveLocationState {
         self.beacon_info.is_live()
     }
 
+    /// The timestamp when this live location sharing session started
+    /// (from the `org.matrix.msc3488.ts` field of the originating
+    /// `beacon_info` state event).
+    ///
+    /// This marks the *beginning* of the session. The session expires at
+    /// `ts + timeout` — see [`LiveLocationState::is_live`] and
+    /// [`LiveLocationState::timeout`].
+    pub fn ts(&self) -> MilliSecondsSinceUnixEpoch {
+        self.beacon_info.ts
+    }
+
     /// An optional human-readable description for this sharing session
     /// (from the originating `beacon_info` event).
     pub fn description(&self) -> Option<&str> {


### PR DESCRIPTION
Does what it says on the tin.