### PR TITLE
fix: Custom certs and disabling ssl with rustls on Android

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -17,7 +17,7 @@
 
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(not(target_os = "android"))]
 use matrix_sdk::reqwest::Certificate;
 use matrix_sdk::{
     cross_process_lock::CrossProcessLockConfig as SdkCrossProcessLockConfig,
@@ -409,27 +409,34 @@ impl ClientBuilder {
 
         #[cfg(not(target_family = "wasm"))]
         {
-            let mut certificates = Vec::new();
-
-            for certificate in builder.additional_root_certificates {
-                // We don't really know what type of certificate we may get here, so let's try
-                // first one type, then the other.
-                match Certificate::from_der(&certificate) {
-                    Ok(cert) => {
-                        certificates.push(cert);
-                    }
-                    Err(der_error) => {
-                        let cert = Certificate::from_pem(&certificate).map_err(|pem_error| {
-                            ClientBuildError::Generic {
-                                message: format!("Failed to add a root certificate as DER ({der_error:?}) or PEM ({pem_error:?})"),
-                            }
-                        })?;
-                        certificates.push(cert);
+            #[cfg(target_os = "android")]
+            {
+                inner_builder =
+                    inner_builder.add_raw_root_certificates(builder.additional_root_certificates)
+            }
+            #[cfg(not(target_os = "android"))]
+            {
+                let mut certificates = Vec::new();
+                for certificate in builder.additional_root_certificates {
+                    // We don't really know what type of certificate we may get here, so let's try
+                    // first one type, then the other.
+                    match Certificate::from_der(&certificate) {
+                        Ok(cert) => {
+                            certificates.push(cert);
+                        }
+                        Err(der_error) => {
+                            let cert = Certificate::from_pem(&certificate).map_err(|pem_error| {
+                                ClientBuildError::Generic {
+                                    message: format!("Failed to add a root certificate as DER ({der_error:?}) or PEM ({pem_error:?})"),
+                                }
+                            })?;
+                            certificates.push(cert);
+                        }
                     }
                 }
-            }
 
-            inner_builder = inner_builder.add_root_certificates(certificates);
+                inner_builder = inner_builder.add_root_certificates(certificates);
+            }
 
             if builder.disable_built_in_root_certificates {
                 inner_builder = inner_builder.disable_built_in_root_certificates();

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -92,6 +92,9 @@ All notable changes to this project will be documented in this file.
 
 ### Bugfix
 
+- Android: add back custom certificates and disabling SSL verification options in `ClientBuilder` using 
+  the previous `webkpi` verifier instead of platform verifier, otherwise these features will fail. 
+  ([#6328](https://github.com/matrix-org/matrix-rust-sdk/pull/6328))
 - Room keys are now rotated whenever the client receives an `m.room.member` event not belonging
   to the current user with `leave` membership in order to prevent
   [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) from leaking room keys

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -32,6 +32,8 @@ use matrix_sdk_base::{BaseClient, ThreadingSupport, store::StoreConfig};
 use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
 #[cfg(feature = "sqlite")]
 use matrix_sdk_sqlite::SqliteStoreConfig;
+#[cfg(not(target_family = "wasm"))]
+use reqwest::Certificate;
 use ruma::{
     OwnedServerName, ServerName,
     api::{MatrixVersion, SupportedVersions, error::FromHttpResponseError},
@@ -377,8 +379,18 @@ impl ClientBuilder {
     /// Internally this will call the
     /// [`reqwest::ClientBuilder::add_root_certificate()`] method.
     #[cfg(not(target_family = "wasm"))]
-    pub fn add_root_certificates(mut self, certificates: Vec<reqwest::Certificate>) -> Self {
+    pub fn add_root_certificates(mut self, certificates: Vec<Certificate>) -> Self {
         self.http_settings().additional_root_certificates = certificates;
+        self
+    }
+
+    /// Add the given list of certificates in a raw byte format to the
+    /// certificate store of the HTTP client.
+    ///
+    /// Not this will only be used in Android for the webkpi workaround.
+    #[cfg(target_os = "android")]
+    pub fn add_raw_root_certificates(mut self, raw_certificates: Vec<Vec<u8>>) -> Self {
+        self.http_settings().additional_raw_root_certificates = raw_certificates;
         self
     }
 

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -26,10 +26,16 @@ use bytes::Bytes;
 use bytesize::ByteSize;
 use eyeball::SharedObservable;
 use http::header::CONTENT_LENGTH;
-use reqwest::{Certificate, tls};
+#[cfg(not(target_family = "wasm"))]
+use reqwest::Certificate;
+#[cfg(target_os = "android")]
+use reqwest::ClientBuilder;
+use reqwest::tls;
 use ruma::api::{IncomingResponse, OutgoingRequest, error::FromHttpResponseError};
 #[cfg(target_os = "android")]
 use rustls::{RootCertStore, client::WebPkiServerVerifier};
+#[cfg(target_os = "android")]
+use rustls_pki_types::CertificateDer;
 use tracing::{debug, info, warn};
 
 use super::{DEFAULT_REQUEST_TIMEOUT, HttpClient, TransmissionProgress, response_to_http_response};
@@ -153,6 +159,8 @@ pub(crate) struct HttpSettings {
     pub(crate) timeout: Option<Duration>,
     pub(crate) read_timeout: Option<Duration>,
     pub(crate) additional_root_certificates: Vec<Certificate>,
+    #[cfg(target_os = "android")]
+    pub(crate) additional_raw_root_certificates: Vec<Vec<u8>>,
     pub(crate) disable_built_in_root_certificates: bool,
 }
 
@@ -166,6 +174,8 @@ impl Default for HttpSettings {
             timeout: Some(DEFAULT_REQUEST_TIMEOUT),
             read_timeout: None,
             additional_root_certificates: Default::default(),
+            #[cfg(target_os = "android")]
+            additional_raw_root_certificates: Default::default(),
             disable_built_in_root_certificates: false,
         }
     }
@@ -195,17 +205,62 @@ impl HttpSettings {
         // configuration.
         // Remove when https://github.com/rustls/rustls-platform-verifier/issues/221 is fixed.
         #[cfg(target_os = "android")]
+        {
+            http_client = self.android_setup_webkpi_verifier(http_client)?;
+        }
+
+        if self.disable_ssl_verification {
+            warn!("SSL verification disabled in the HTTP client!");
+            http_client = http_client.danger_accept_invalid_certs(true);
+        }
+
+        http_client = if self.disable_built_in_root_certificates {
+            info!("Built-in root certificates disabled in the HTTP client.");
+            http_client.tls_certs_only(self.additional_root_certificates.clone())
+        } else {
+            http_client.tls_certs_merge(self.additional_root_certificates.clone())
+        };
+
+        if let Some(p) = &self.proxy {
+            info!(proxy_url = p, "Setting the proxy for the HTTP client");
+            http_client = http_client.proxy(reqwest::Proxy::all(p.as_str())?);
+        }
+
+        Ok(http_client.build()?)
+    }
+
+    #[cfg(target_os = "android")]
+    fn android_setup_webkpi_verifier(
+        &self,
+        client_builder: ClientBuilder,
+    ) -> Result<ClientBuilder, HttpError> {
         if !self.disable_ssl_verification {
             let mut root_store = RootCertStore::empty();
-            // This seems to fix the 'revoked certificate' false positives issue
-            root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
             if self.disable_built_in_root_certificates {
                 info!("Built-in root certificates disabled in the HTTP client.");
             } else {
+                // This seems to fix the 'revoked certificate' false positives issue
+                root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
                 // Also load the native certs
                 let native_certs = rustls_native_certs::load_native_certs().certs;
                 root_store.add_parsable_certificates(native_certs);
+            }
+
+            if !self.additional_raw_root_certificates.is_empty() {
+                let mut additional_certs = Vec::new();
+
+                warn!(
+                    "Adding {} extra user certificates",
+                    self.additional_raw_root_certificates.len()
+                );
+
+                for certificate in self.additional_raw_root_certificates.iter() {
+                    additional_certs.push(CertificateDer::from_slice(certificate));
+                }
+
+                root_store.add_parsable_certificates(additional_certs);
             }
 
             let verifier = WebPkiServerVerifier::builder(Arc::new(root_store))
@@ -215,27 +270,10 @@ impl HttpSettings {
             let config = rustls::ClientConfig::builder()
                 .with_webpki_verifier(verifier)
                 .with_no_client_auth();
-            http_client = http_client.tls_backend_preconfigured(config);
-        }
-
-        if self.disable_ssl_verification {
-            warn!("SSL verification disabled in the HTTP client!");
-            http_client = http_client.danger_accept_invalid_certs(true)
-        }
-
-        if self.disable_built_in_root_certificates {
-            info!("Built-in root certificates disabled in the HTTP client.");
-            http_client = http_client.tls_certs_only(self.additional_root_certificates.clone());
+            Ok(client_builder.tls_backend_preconfigured(config))
         } else {
-            http_client = http_client.tls_certs_merge(self.additional_root_certificates.clone());
+            Ok(client_builder)
         }
-
-        if let Some(p) = &self.proxy {
-            info!(proxy_url = p, "Setting the proxy for the HTTP client");
-            http_client = http_client.proxy(reqwest::Proxy::all(p.as_str())?);
-        }
-
-        Ok(http_client.build()?)
     }
 }
 


### PR DESCRIPTION
## Changes

- Make additional provided certificates work again on Android. For this, I added a new `add_raw_root_certificates` method to pass the original byte arrays around, because we now had `Vec<Certificate>` instead and `Certificate`'s internals are private and it can't be casted to the needed `CertificateDer` type used in the Android workaround around `webpki`.
- Allow disabling SSL verification again on Android, by just using the default implementation: the problem with this implementation is the verifier, if we don't use it, it should work fine.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
