### PR TITLE
Use the default `CryptoProvider` in `rustls`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,7 +3246,6 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "reqwest",
- "ring",
  "ruma",
  "rustls",
  "rustls-native-certs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ quote = { version = "1.0.37", default-features = false }
 rand = { version = "0.8.5", default-features = false, features = ["std", "std_rng"] }
 regex = { version = "1.12.2", default-features = false }
 reqwest = { version = "0.13.1", default-features = false }
-ring = { version = "0.17.14", default-features = false }
 rmp-serde = { version = "1.3.0", default-features = false }
 ruma = { git = "https://github.com/ruma/ruma", rev = "9666e207f2cd1a8b26e49bbdf656ad32e4639c7b", features = [
     "client-api-c",
@@ -96,8 +95,6 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "9666e207f2cd1a8b26e49bbdf6
     "unstable-msc4308",
     "unstable-msc4310",
 ] }
-rustls = { version = "0.23.37", default-features = false, features = ["ring"] }
-rustls-pki-types = { version = "1.14.0", default-features = false }
 sentry = { version = "0.47.0", default-features = false }
 sentry-tracing = { version = "0.47.0", default-features = false }
 serde = { version = "1.0.228", default-features = false, features = ["std", "rc", "derive"] }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -15,9 +15,6 @@ version = "0.16.0"
 features = ["docsrs"]
 rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
-[package.metadata.cargo-machete]
-ignored = ["ring", "rustls-pki-types"]
-
 [features]
 default = ["e2e-encryption", "automatic-room-key-forwarding", "sqlite", "rustls-tls"]
 testing = [
@@ -39,8 +36,6 @@ e2e-encryption = [
 js = [
     "matrix-sdk-common/js",
     "matrix-sdk-base/js",
-    "rustls-pki-types?/web",
-    "ring?/wasm32_unknown_unknown_js"
 ]
 
 sqlite = [
@@ -70,7 +65,7 @@ experimental-encrypted-state-events = [
 
 markdown = ["ruma/markdown"]
 native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-no-provider", "dep:rustls", "dep:rustls-pki-types", "dep:ring"]
+rustls-tls = ["reqwest/rustls"]
 socks = ["reqwest/socks"]
 local-server = ["dep:axum", "dep:rand", "dep:tower"]
 sso-login = ["local-server"]
@@ -130,7 +125,6 @@ oauth2-reqwest.workspace = true
 percent-encoding = "2.3.2"
 pin-project-lite.workspace = true
 rand = { workspace = true, optional = true }
-ring = { workspace = true, optional = true }
 ruma = { workspace = true, features = [
     "rand",
     "unstable-msc2448",
@@ -139,8 +133,6 @@ ruma = { workspace = true, features = [
     "unstable-msc4108",
     "unstable-msc4278",
 ] }
-rustls = { workspace = true, optional = true, features = ["std", "logging"] }
-rustls-pki-types = { workspace = true, optional = true }
 serde.workspace = true
 serde_html_form.workspace = true
 serde_json.workspace = true
@@ -198,6 +190,8 @@ wiremock.workspace = true
 wasm-bindgen-test.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies]
+rustls = "0.23.37"
+rustls-pki-types = "1.14.0"
 rustls-native-certs = "0.8.3"
 webpki-roots = "1.0.6"
 

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -92,10 +92,6 @@ use crate::{
 ///
 /// use matrix_sdk::Client;
 ///
-/// // setting up rustls crypto provider if using rustls
-/// #[cfg(feature = "rustls-tls")]
-/// matrix_sdk::rustls::install_default_crypto_provider_if_none_installed();
-///
 /// // setting up a custom http client
 /// let reqwest_builder = reqwest::ClientBuilder::new()
 ///     .https_only(true)
@@ -550,9 +546,6 @@ impl ClientBuilder {
 
         let homeserver_cfg = self.homeserver_cfg.ok_or(ClientBuildError::MissingHomeserver)?;
         Span::current().record("homeserver", debug(&homeserver_cfg));
-
-        #[cfg(feature = "rustls-tls")]
-        crate::http_client::rustls::install_default_crypto_provider_if_none_installed();
 
         #[cfg_attr(target_family = "wasm", allow(clippy::infallible_destructuring_match))]
         let inner_http_client = match self.http_cfg.unwrap_or_default() {

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -362,56 +362,6 @@ impl SupportedPathBuilder for path_builder::SinglePath {
     }
 }
 
-#[cfg(feature = "rustls-tls")]
-pub mod rustls {
-    //! Functions for configuring the default [`CryptoProvider`] when using
-    //! `reqwest` with `rustls`'s implementation of TLS.
-
-    use rustls::crypto::CryptoProvider;
-
-    /// The default [`CryptoProvider`] preferred by this crate.
-    ///
-    /// Typically, the default [`CryptoProvider`] for `rustls`
-    /// is `aws-lc-rs`, but due to licensing issues this crate
-    /// prefers `ring`.
-    pub fn default_crypto_provider() -> CryptoProvider {
-        rustls::crypto::ring::default_provider()
-    }
-
-    /// The `rustls-tls` flag enables the `rustls` implementation of TLS for
-    /// `reqwest`, but without a [`CryptoProvider`]. This means that no
-    /// default provider is installed, which will cause `reqwest::Client::new()`
-    /// to panic.
-    ///
-    /// This functions installs the preferred default provider given by
-    /// [`default_crypto_provider`], if no default has previously been
-    /// installed.
-    pub fn install_default_crypto_provider_if_none_installed() {
-        if default_crypto_provider().install_default().is_ok() {
-            // This log message seems to cause `nextest` to get confused,
-            // so it won't be printed when running tests.
-            #[cfg(not(test))]
-            tracing::info!("No rustls crypto provider set, setting default provider to ring.");
-        }
-    }
-
-    /// Install a default [`CryptoProvider`] for `rustls`, if one isn't already
-    /// installed. This uses [`ctor`] to run before any tests.
-    #[cfg(test)]
-    macro_rules! install_default_crypto_provider_for_tests {
-        () => {
-            #[cfg(not(target_family = "wasm"))]
-            #[ctor::ctor]
-            fn install_default_crypto_provider_for_tests() {
-                $crate::http_client::rustls::install_default_crypto_provider_if_none_installed();
-            }
-        };
-    }
-
-    #[cfg(test)]
-    pub(crate) use install_default_crypto_provider_for_tests;
-}
-
 #[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::{

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -76,8 +76,6 @@ pub use error::{
     RumaApiError,
 };
 pub use http_client::TransmissionProgress;
-#[cfg(feature = "rustls-tls")]
-pub use http_client::rustls;
 #[cfg(all(feature = "e2e-encryption", feature = "sqlite"))]
 pub use matrix_sdk_sqlite::SqliteCryptoStore;
 #[cfg(feature = "sqlite")]
@@ -103,5 +101,3 @@ pub mod test_utils;
 
 #[cfg(test)]
 matrix_sdk_test_utils::init_tracing_for_tests!();
-#[cfg(all(test, feature = "rustls-tls"))]
-crate::http_client::rustls::install_default_crypto_provider_for_tests!();


### PR DESCRIPTION
Previously, `reqwest` was configured to use a non-default `CryptoProvider` for `rustls` - i.e., `ring` - due to licensing issues with the default provider - i.e., `aws-lc-rs`.

Now that those licensing issues have been [resolved](https://github.com/aws/aws-lc-rs/pull/1062) and [released](https://github.com/aws/aws-lc-rs/releases/tag/v1.16.2), we can go back to using the default provider. This is preferable in part because [`aws-lc-rs` supports post-quantum algorithms, and `ring` does not](https://github.com/rustls/rustls?tab=readme-ov-file#first-party-providers).

---
Closes #6333.

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
