### PR TITLE
chore(event cache): remove the non-decreasing hack when computing unread counts

### DIFF
--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -1051,25 +1051,6 @@ impl<'a> RoomEventCacheStateLockWriteGuard<'a> {
         );
 
         if prev_read_receipts != read_receipts {
-            if prev_read_receipts.latest_active == read_receipts.latest_active {
-                // If the latest active read receipt hasn't changed, but the number of unread
-                // has *decreased*, then it means that we've recomputed receipts
-                // after a gap. Ditch the new values, as they're likely
-                // incorrect.
-                //
-                // TODO: use automatic back-pagination in this case, instead of ditching the new
-                // values.
-                if read_receipts.num_unread < prev_read_receipts.num_unread {
-                    read_receipts.num_unread = prev_read_receipts.num_unread;
-                }
-                if read_receipts.num_notifications < prev_read_receipts.num_notifications {
-                    read_receipts.num_notifications = prev_read_receipts.num_notifications;
-                }
-                if read_receipts.num_mentions < prev_read_receipts.num_mentions {
-                    read_receipts.num_mentions = prev_read_receipts.num_mentions;
-                }
-            }
-
             // The read receipt has changed! Do a little dance to update the `RoomInfo` in
             // the state store, and then in the room itself, so that observers
             // can be notified of the change.

--- a/crates/matrix-sdk/tests/integration/event_cache/read_receipts.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/read_receipts.rs
@@ -483,10 +483,13 @@ async fn test_gappy_sync_keeps_then_next_sync_resets_unread_count() {
     assert_let_timeout!(Ok(_) = room_cache_updates.recv());
 
     // The gappy sync cleared "$1" and "$2" from the linked chunk, so this sync
-    // only sees "$3" when recomputing the unread count, yielding 1. But this is
-    // incorrect, as the number should be *at least* 2, and the SDK should keep
-    // on showing this number in this case.
-    assert_eq!(room.num_unread_messages(), 2);
+    // only sees "$3" when recomputing the unread count, yielding 1.
+    //
+    // But this is incorrect, as the number should be *at least* 2, and the SDK
+    // should keep on showing this number in this case.
+    //
+    // TODO: fix it :-)
+    assert_eq!(room.num_unread_messages(), 1);
 }
 
 /// Test that messages with mentions increment the number of mentions.


### PR DESCRIPTION
There was a hack added that the unread count of a room shouldn't decrease, if the room's latest active receipt hasn't changed. Unfortunately, this heuristic doesn't hold: if an event was counted because it was encrypted, and it turns out that after decrypting it as a UTD, it should now be uncounted, then the read count would in fact legitimately decrease.

Let's remove this hack, and in the meantime keep on working on automatic backpagination, which should help fix this kind of issues.

- No public API changes.
- This PR wasn't made with the help of AI. I am big brain.