### PR TITLE
feat(ui): Disable smart case for the Room List fuzzy filter

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
@@ -23,7 +23,7 @@ struct FuzzyMatcher {
 
 impl FuzzyMatcher {
     fn new() -> Self {
-        Self { matcher: SkimMatcherV2::default().smart_case().use_cache(true), pattern: None }
+        Self { matcher: SkimMatcherV2::default().ignore_case().use_cache(true), pattern: None }
     }
 
     fn with_pattern(mut self, pattern: &str) -> Self {
@@ -90,23 +90,12 @@ mod tests {
         let matcher = FuzzyMatcher::new();
 
         let matcher = matcher.with_pattern("mtx");
+        assert!(matcher.matches("matrix"));
         assert!(matcher.matches("MaTrIX"));
 
-        let matcher = matcher.with_pattern("mxt");
-        assert!(matcher.matches("MaTrIX").not());
-    }
-
-    #[test]
-    fn test_smart_case() {
-        let matcher = FuzzyMatcher::new();
-
-        let matcher = matcher.with_pattern("mtx");
-        assert!(matcher.matches("matrix"));
-        assert!(matcher.matches("Matrix"));
-
         let matcher = matcher.with_pattern("Mtx");
-        assert!(matcher.matches("matrix").not());
-        assert!(matcher.matches("Matrix"));
+        assert!(matcher.matches("matrix"));
+        assert!(matcher.matches("MaTrIX"));
     }
 
     #[test]


### PR DESCRIPTION
This patch updates the fuzzy filter from using _smart case_ to _ignore case_. Most of the time, the keyboard might activate an upper case for the first character pressed in the search bar. Some users aren't used to smart case and will believe there is a bug. Let's disable smart case here.

---

* Fix https://github.com/element-hq/element-x-ios/issues/3926

---

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.