### PR TITLE
fix(event cache): make sure the room info is as up to date as it can be before updating read receipts

### DIFF
--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -1037,8 +1037,7 @@ impl<'a> RoomEventCacheStateLockWriteGuard<'a> {
         let user_id = &state.own_user_id;
         let room_id = &state.room_id;
 
-        let room_info = room.clone_info();
-        let prev_read_receipts = room_info.read_receipts().clone();
+        let prev_read_receipts = room.read_receipts().clone();
         let mut read_receipts = prev_read_receipts.clone();
 
         compute_unread_counts(


### PR DESCRIPTION
We think this might be a cause for intermittent failures of the `room_unread_count` test on CI, as the `room_info` might be outdated after we decided to process it.

More generally, the room info is a critical resources that should be protected in better ways, as it's inner mutable state that can be modified by all code claling `set_room_info` in any place, but that'll be a problem for later.

I'll say this fixes https://github.com/matrix-org/matrix-rust-sdk/issues/6307, and we can reopen it if that's not the case.

- No public API changes.
- This PR was made without the help of AI.