### PR TITLE
Upgrade Ruma after EncryptedFile breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4884,7 +4884,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.14.1"
-source = "git+https://github.com/ruma/ruma?rev=dc36ccf119c065b75a9872ec5a6487d680289dc1#dc36ccf119c065b75a9872ec5a6487d680289dc1"
+source = "git+https://github.com/ruma/ruma?rev=9666e207f2cd1a8b26e49bbdf656ad32e4639c7b#9666e207f2cd1a8b26e49bbdf656ad32e4639c7b"
 dependencies = [
  "assign",
  "js_int",
@@ -4902,7 +4902,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.22.1"
-source = "git+https://github.com/ruma/ruma?rev=dc36ccf119c065b75a9872ec5a6487d680289dc1#dc36ccf119c065b75a9872ec5a6487d680289dc1"
+source = "git+https://github.com/ruma/ruma?rev=9666e207f2cd1a8b26e49bbdf656ad32e4639c7b#9666e207f2cd1a8b26e49bbdf656ad32e4639c7b"
 dependencies = [
  "as_variant",
  "assign",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.17.1"
-source = "git+https://github.com/ruma/ruma?rev=dc36ccf119c065b75a9872ec5a6487d680289dc1#dc36ccf119c065b75a9872ec5a6487d680289dc1"
+source = "git+https://github.com/ruma/ruma?rev=9666e207f2cd1a8b26e49bbdf656ad32e4639c7b#9666e207f2cd1a8b26e49bbdf656ad32e4639c7b"
 dependencies = [
  "as_variant",
  "base64",
@@ -4957,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.32.1"
-source = "git+https://github.com/ruma/ruma?rev=dc36ccf119c065b75a9872ec5a6487d680289dc1#dc36ccf119c065b75a9872ec5a6487d680289dc1"
+source = "git+https://github.com/ruma/ruma?rev=9666e207f2cd1a8b26e49bbdf656ad32e4639c7b#9666e207f2cd1a8b26e49bbdf656ad32e4639c7b"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4980,7 +4980,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.13.1"
-source = "git+https://github.com/ruma/ruma?rev=dc36ccf119c065b75a9872ec5a6487d680289dc1#dc36ccf119c065b75a9872ec5a6487d680289dc1"
+source = "git+https://github.com/ruma/ruma?rev=9666e207f2cd1a8b26e49bbdf656ad32e4639c7b#9666e207f2cd1a8b26e49bbdf656ad32e4639c7b"
 dependencies = [
  "headers",
  "http",
@@ -5001,7 +5001,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.6.0"
-source = "git+https://github.com/ruma/ruma?rev=dc36ccf119c065b75a9872ec5a6487d680289dc1#dc36ccf119c065b75a9872ec5a6487d680289dc1"
+source = "git+https://github.com/ruma/ruma?rev=9666e207f2cd1a8b26e49bbdf656ad32e4639c7b#9666e207f2cd1a8b26e49bbdf656ad32e4639c7b"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5012,7 +5012,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.12.0"
-source = "git+https://github.com/ruma/ruma?rev=dc36ccf119c065b75a9872ec5a6487d680289dc1#dc36ccf119c065b75a9872ec5a6487d680289dc1"
+source = "git+https://github.com/ruma/ruma?rev=9666e207f2cd1a8b26e49bbdf656ad32e4639c7b#9666e207f2cd1a8b26e49bbdf656ad32e4639c7b"
 dependencies = [
  "js_int",
  "thiserror 2.0.17",
@@ -5021,7 +5021,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.17.1"
-source = "git+https://github.com/ruma/ruma?rev=dc36ccf119c065b75a9872ec5a6487d680289dc1#dc36ccf119c065b75a9872ec5a6487d680289dc1"
+source = "git+https://github.com/ruma/ruma?rev=9666e207f2cd1a8b26e49bbdf656ad32e4639c7b#9666e207f2cd1a8b26e49bbdf656ad32e4639c7b"
 dependencies = [
  "as_variant",
  "cfg-if",
@@ -5037,7 +5037,7 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.19.0"
-source = "git+https://github.com/ruma/ruma?rev=dc36ccf119c065b75a9872ec5a6487d680289dc1#dc36ccf119c065b75a9872ec5a6487d680289dc1"
+source = "git+https://github.com/ruma/ruma?rev=9666e207f2cd1a8b26e49bbdf656ad32e4639c7b#9666e207f2cd1a8b26e49bbdf656ad32e4639c7b"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ regex = { version = "1.12.2", default-features = false }
 reqwest = { version = "0.13.1", default-features = false }
 ring = { version = "0.17.14", default-features = false }
 rmp-serde = { version = "1.3.0", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "dc36ccf119c065b75a9872ec5a6487d680289dc1", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "9666e207f2cd1a8b26e49bbdf656ad32e4639c7b", features = [
     "client-api-c",
     "compat-unset-avatar",
     "compat-upload-signatures",

--- a/crates/matrix-sdk-base/src/media/mod.rs
+++ b/crates/matrix-sdk-base/src/media/mod.rs
@@ -261,7 +261,7 @@ mod tests {
                     },
                     "iv": "AK1wyzigZtQAAAABAAAAKK",
                     "hashes": {
-                        "sha256": "foobar",
+                        "sha256": "/NogKqW5bz/m8xHgFiH5haFGjCNVmUIPLzfvOhHdrxY",
                     },
                     "v": "v2",
                 }))

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -36,6 +36,12 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- [**breaking**] The `MediaEncryptionInfo` fields changed to match the new fields of `EncryptedFile`
+  from Ruma. The serialized JSON format did not change and still matches the format of
+  `EncryptedFile` defined in the spec, without the `url` field. The `DecryptorError::KeyNonceLength`
+  variant was removed because the length of the key and nonce are now enforced in
+  `MediaEncryptionInfo`.
+  ([#6346](https://github.com/matrix-org/matrix-rust-sdk/pull/6346))
 - [**breaking**] Removed `WithLocking` from `EncryptionSyncService` and replaced it with `CrossProcessLockConfig`.
   ([#6160](https://github.com/matrix-org/matrix-rust-sdk/pull/6160))
 - [**breaking**] The QrcodeData struct has been reworked in preparation to

--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -12,28 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    collections::BTreeMap,
-    io::{Error as IoError, Read},
-};
+use std::io::{Error as IoError, Read};
 
 use aes::{
     Aes256,
-    cipher::{KeyIvInit, StreamCipher, generic_array::GenericArray},
+    cipher::{KeyIvInit, StreamCipher},
 };
 use rand::{RngCore, thread_rng};
 use ruma::{
-    events::room::{EncryptedFile, JsonWebKey, JsonWebKeyInit},
+    events::room::{
+        EncryptedFile, EncryptedFileHash, EncryptedFileHashAlgorithm, EncryptedFileHashes,
+        EncryptedFileInfo, V2EncryptedFileInfo,
+    },
     serde::Base64,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
-use zeroize::Zeroize;
 
 const IV_SIZE: usize = 16;
 const KEY_SIZE: usize = 32;
-const VERSION: &str = "v2";
+const HASH_SIZE: usize = 32;
 
 type Aes256Ctr = ctr::Ctr128BE<Aes256>;
 
@@ -41,7 +40,7 @@ type Aes256Ctr = ctr::Ctr128BE<Aes256>;
 /// Matrix attachment.
 pub struct AttachmentDecryptor<'a, R: Read> {
     inner: &'a mut R,
-    expected_hash: Vec<u8>,
+    expected_hash: [u8; HASH_SIZE],
     sha: Sha256,
     aes: Aes256Ctr,
 }
@@ -87,9 +86,6 @@ pub enum DecryptorError {
     /// A hash is missing from the encryption info.
     #[error("The encryption info is missing a hash")]
     MissingHash,
-    /// The supplied key or IV has an invalid length.
-    #[error("The supplied key or IV has an invalid length.")]
-    KeyNonceLength,
     /// The supplied data was encrypted with an unknown version of the
     /// attachment encryption spec.
     #[error("Unknown version for the encrypted attachment.")]
@@ -130,25 +126,22 @@ impl<'a, R: Read + 'a> AttachmentDecryptor<'a, R> {
         input: &'a mut R,
         info: MediaEncryptionInfo,
     ) -> Result<AttachmentDecryptor<'a, R>, DecryptorError> {
-        if info.version != VERSION {
+        let EncryptedFileInfo::V2(encryption_info) = info.encryption_info else {
             return Err(DecryptorError::UnknownVersion);
-        }
+        };
 
-        let hash =
-            info.hashes.get("sha256").ok_or(DecryptorError::MissingHash)?.as_bytes().to_owned();
-        let key = info.key.k.as_bytes();
-        let iv = info.iv.into_inner();
-
-        if key.len() != KEY_SIZE {
-            return Err(DecryptorError::KeyNonceLength);
-        }
-
-        let key_array = GenericArray::from_slice(key);
-        let iv = GenericArray::from_exact_iter(iv).ok_or(DecryptorError::KeyNonceLength)?;
+        let Some(EncryptedFileHash::Sha256(hash)) =
+            info.hashes.get(&EncryptedFileHashAlgorithm::Sha256)
+        else {
+            return Err(DecryptorError::MissingHash);
+        };
+        let hash = hash.clone().into_inner();
+        let key = encryption_info.k.as_inner();
+        let iv = encryption_info.iv.as_inner();
 
         let sha = Sha256::default();
 
-        let aes = Aes256Ctr::new(key_array, &iv);
+        let aes = Aes256Ctr::new(key.into(), iv.into());
 
         Ok(AttachmentDecryptor { inner: input, expected_hash: hash, sha, aes })
     }
@@ -158,9 +151,9 @@ impl<'a, R: Read + 'a> AttachmentDecryptor<'a, R> {
 pub struct AttachmentEncryptor<'a, R: Read + ?Sized> {
     finished: bool,
     inner: &'a mut R,
-    web_key: JsonWebKey,
-    iv: Base64,
-    hashes: BTreeMap<String, Base64>,
+    key: [u8; KEY_SIZE],
+    iv: [u8; IV_SIZE],
+    hashes: EncryptedFileHashes,
     aes: Aes256Ctr,
     sha: Sha256,
 }
@@ -180,10 +173,6 @@ impl<'a, R: Read + ?Sized + 'a> Read for AttachmentEncryptor<'a, R> {
         let read_bytes = self.inner.read(buf)?;
 
         if read_bytes == 0 {
-            let hash = self.sha.finalize_reset();
-            self.hashes
-                .entry("sha256".to_owned())
-                .or_insert_with(|| Base64::new(hash.as_slice().to_owned()));
             Ok(0)
         } else {
             self.aes.apply_keystream(&mut buf[0..read_bytes]);
@@ -234,28 +223,16 @@ impl<'a, R: Read + ?Sized + 'a> AttachmentEncryptor<'a, R> {
         // initialized for the counter.
         rng.fill_bytes(&mut iv[0..8]);
 
-        let web_key = JsonWebKey::from(JsonWebKeyInit {
-            kty: "oct".to_owned(),
-            key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
-            alg: "A256CTR".to_owned(),
-            #[allow(clippy::unnecessary_to_owned)]
-            k: Base64::new(key.to_vec()),
-            ext: true,
-        });
-        #[allow(clippy::unnecessary_to_owned)]
-        let encoded_iv = Base64::new(iv.to_vec());
-
         let key_array = &key.into();
 
         let aes = Aes256Ctr::new(key_array, &iv.into());
-        key.zeroize();
 
         AttachmentEncryptor {
             finished: false,
             inner: reader,
-            iv: encoded_iv,
-            web_key,
-            hashes: BTreeMap::new(),
+            iv,
+            key,
+            hashes: EncryptedFileHashes::new(),
             aes,
             sha: Sha256::default(),
         }
@@ -264,15 +241,11 @@ impl<'a, R: Read + ?Sized + 'a> AttachmentEncryptor<'a, R> {
     /// Consume the encryptor and get the encryption key.
     pub fn finish(mut self) -> MediaEncryptionInfo {
         let hash = self.sha.finalize();
-        self.hashes
-            .entry("sha256".to_owned())
-            .or_insert_with(|| Base64::new(hash.as_slice().to_owned()));
+        self.hashes.insert(EncryptedFileHash::Sha256(Base64::new(hash.into())));
 
         MediaEncryptionInfo {
-            version: VERSION.to_owned(),
+            encryption_info: V2EncryptedFileInfo::encode(self.key, self.iv).into(),
             hashes: self.hashes,
-            iv: self.iv,
-            key: self.web_key,
         }
     }
 }
@@ -281,20 +254,16 @@ impl<'a, R: Read + ?Sized + 'a> AttachmentEncryptor<'a, R> {
 /// file.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MediaEncryptionInfo {
-    /// The version of the encryption scheme.
-    #[serde(rename = "v")]
-    pub version: String,
-    /// The web key that was used to encrypt the file.
-    pub key: JsonWebKey,
-    /// The initialization vector that was used to encrypt the file.
-    pub iv: Base64,
+    /// The information about the file's encryption.
+    #[serde(flatten)]
+    pub encryption_info: EncryptedFileInfo,
     /// The hashes that can be used to check the validity of the file.
-    pub hashes: BTreeMap<String, Base64>,
+    pub hashes: EncryptedFileHashes,
 }
 
 impl From<EncryptedFile> for MediaEncryptionInfo {
     fn from(file: EncryptedFile) -> Self {
-        Self { version: file.v, key: file.key, iv: file.iv, hashes: file.hashes }
+        Self { encryption_info: file.info, hashes: file.hashes }
     }
 }
 
@@ -311,23 +280,35 @@ mod tests {
         172, 36, 26, 75, 47, 33, 160,
     ];
 
-    fn example_key() -> MediaEncryptionInfo {
-        let info = json!({
+    fn example_key_json() -> serde_json::Value {
+        json!({
             "v": "v2",
             "key": {
                 "kty": "oct",
                 "alg": "A256CTR",
                 "ext": true,
                 "k": "Voq2nkPme_x8no5-Tjq_laDAdxE6iDbxnlQXxwFPgE4",
-                "key_ops": ["encrypt", "decrypt"]
+                "key_ops": ["decrypt", "encrypt"]
             },
             "iv": "i0DovxYdJEcAAAAAAAAAAA",
             "hashes": {
                 "sha256": "ANdt819a8bZl4jKy3Z+jcqtiNICa2y0AW4BBJ/iQRAU"
             }
-        });
+        })
+    }
 
-        serde_json::from_value(info).unwrap()
+    fn example_key() -> MediaEncryptionInfo {
+        serde_json::from_value(example_key_json()).unwrap()
+    }
+
+    #[test]
+    fn media_encryption_info_serde_roundtrip() {
+        let json = example_key_json();
+
+        let info = serde_json::from_value::<MediaEncryptionInfo>(json.clone()).unwrap();
+
+        let serialized_info = serde_json::to_value(&info).unwrap();
+        assert_eq!(serialized_info, json);
     }
 
     #[test]

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
@@ -1098,11 +1098,8 @@ mod tests {
             to_device::send_event_to_device::v3::Response as ToDeviceResponse,
         },
         device_id,
-        events::room::{
-            EncryptedFileInit, JsonWebKey, JsonWebKeyInit, history_visibility::HistoryVisibility,
-        },
+        events::room::{EncryptedFile, V2EncryptedFileInfo, history_visibility::HistoryVisibility},
         owned_device_id, owned_room_id, room_id,
-        serde::Base64,
         to_device::DeviceIdOrAllDevices,
         user_id,
     };
@@ -1841,21 +1838,11 @@ mod tests {
 
         let content = RoomKeyBundleContent {
             room_id: owned_room_id!("!room:id"),
-            file: (EncryptedFileInit {
-                url: OwnedMxcUri::from("test"),
-                key: JsonWebKey::from(JsonWebKeyInit {
-                    kty: "oct".to_owned(),
-                    key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
-                    alg: "A256CTR".to_owned(),
-                    #[allow(clippy::unnecessary_to_owned)]
-                    k: Base64::new(vec![0u8; 0]),
-                    ext: true,
-                }),
-                iv: Base64::new(vec![0u8; 0]),
-                hashes: Default::default(),
-                v: "".to_owned(),
-            })
-            .into(),
+            file: EncryptedFile::new(
+                OwnedMxcUri::from("test"),
+                V2EncryptedFileInfo::encode([0; 32], [0; 16]).into(),
+                Default::default(),
+            ),
         };
 
         let requests = alice

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -1355,21 +1355,13 @@ macro_rules! cryptostore_integration_tests {
                 let test_room = room_id!("!room:example.org");
 
                 fn make_bundle_data(sender_user: &UserId, bundle_uri: &str) -> StoredRoomKeyBundleData {
-                    let jwk = ruma::events::room::JsonWebKeyInit {
-                        kty: "oct".to_owned(),
-                        key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
-                        alg: "A256CTR".to_owned(),
-                        k: ruma::serde::Base64::new(vec![0u8; 0]),
-                        ext: true,
-                    }.into();
+                    let info = ruma::events::room::V2EncryptedFileInfo::encode([0; 32], [0;16]).into();
 
-                    let file = ruma::events::room::EncryptedFileInit {
-                        url: ruma::OwnedMxcUri::from(bundle_uri),
-                        key: jwk,
-                        iv: ruma::serde::Base64::new(vec![0u8; 0]),
-                        hashes: Default::default(),
-                        v: "".to_owned(),
-                    }.into();
+                    let file = ruma::events::room::EncryptedFile::new(
+                        ruma::OwnedMxcUri::from(bundle_uri),
+                        info,
+                        Default::default()
+                    );
 
                     StoredRoomKeyBundleData {
                         sender_user: sender_user.to_owned(),

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -1906,10 +1906,8 @@ mod tests {
     use matrix_sdk_test::async_test;
     use ruma::{
         RoomId, device_id,
-        events::room::{EncryptedFileInit, JsonWebKeyInit},
-        owned_device_id, owned_mxc_uri, room_id,
-        serde::Base64,
-        user_id,
+        events::room::{EncryptedFile, EncryptedFileHashes, V2EncryptedFileInfo},
+        owned_device_id, owned_mxc_uri, room_id, user_id,
     };
     use serde_json::json;
     use vodozemac::{Ed25519Keypair, megolm::SessionKey};
@@ -2359,23 +2357,11 @@ mod tests {
                         room_id: room_id.to_owned(),
                         // This isn't used at all in the method call, so we can fill it with
                         // garbage.
-                        file: EncryptedFileInit {
-                            url: owned_mxc_uri!("mxc://example.com/0"),
-                            key: JsonWebKeyInit {
-                                kty: "oct".to_owned(),
-                                key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
-                                alg: "A256CTR.".to_owned(),
-                                k: Base64::new(vec![0u8; 128]),
-                                ext: true,
-                            }
-                            .into(),
-                            iv: Base64::new(vec![0u8; 128]),
-                            hashes: vec![("sha256".to_owned(), Base64::new(vec![0u8; 128]))]
-                                .into_iter()
-                                .collect(),
-                            v: "v2".to_owned(),
-                        }
-                        .into(),
+                        file: EncryptedFile::new(
+                            owned_mxc_uri!("mxc://example.com/0"),
+                            V2EncryptedFileInfo::encode([0; 32], [0; 16]).into(),
+                            EncryptedFileHashes::with_sha256([0; 32]),
+                        ),
                     },
                 },
                 bundle,

--- a/crates/matrix-sdk/src/encryption/futures.rs
+++ b/crates/matrix-sdk/src/encryption/futures.rs
@@ -21,7 +21,7 @@ use std::{future::IntoFuture, io::Read};
 
 use eyeball::{SharedObservable, Subscriber};
 use matrix_sdk_common::boxed_into_future;
-use ruma::events::room::{EncryptedFile, EncryptedFileInit};
+use ruma::events::room::EncryptedFile;
 
 use crate::{Client, Media, Result, TransmissionProgress, config::RequestConfig};
 
@@ -102,14 +102,7 @@ where
 
             let file: EncryptedFile = {
                 let keys = encryptor.finish();
-                EncryptedFileInit {
-                    url: response.content_uri,
-                    key: keys.key,
-                    iv: keys.iv,
-                    hashes: keys.hashes,
-                    v: keys.version,
-                }
-                .into()
+                EncryptedFile::new(response.content_uri, keys.encryption_info, keys.hashes)
             };
 
             Ok(file)

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -815,7 +815,7 @@ mod tests {
                 },
                 "iv": "AK1wyzigZtQAAAABAAAAKK",
                 "hashes": {
-                    "sha256": "foobar",
+                    "sha256": "/NogKqW5bz/m8xHgFiH5haFGjCNVmUIPLzfvOhHdrxY",
                 },
                 "v": "v2",
             }))


### PR DESCRIPTION
This upgrades Ruma after the changes due to https://github.com/ruma/ruma/pull/2424.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

