### PR TITLE
feat(ffi): expose `Room.send_state_event_raw()`

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -38,6 +38,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Expose `Room.send_state_event_raw()` for sending arbitrary state events
+  through the FFI layer.
+  ([#6349](https://github.com/matrix-org/matrix-rust-sdk/issues/6349))
 - Introduce a `ThreadListService` which offers reactive interfaces for rendering
   and managing the list of threads from a particular room.
   ([6311](https://github.com/matrix-org/matrix-rust-sdk/pull/6311))

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -439,6 +439,37 @@ impl Room {
         Ok(())
     }
 
+    /// Send a raw state event to the room.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` - The type of the state event to send (e.g.
+    ///   `"m.room.name"` or a custom type).
+    ///
+    /// * `state_key` - A unique key which defines the overwriting semantics for
+    ///   this piece of room state. This is often an empty string.
+    ///
+    /// * `content` - The content of the state event encoded as a JSON string.
+    ///
+    /// Returns the event ID of the newly created state event.
+    pub async fn send_state_event_raw(
+        &self,
+        event_type: String,
+        state_key: String,
+        content: String,
+    ) -> Result<String, ClientError> {
+        let content_json: serde_json::Value =
+            serde_json::from_str(&content).map_err(|e| ClientError::Generic {
+                msg: format!("Failed to parse JSON: {e}"),
+                details: Some(format!("{e:?}")),
+            })?;
+
+        let response =
+            self.inner.send_state_event_raw(&event_type, &state_key, content_json).await?;
+
+        Ok(response.event_id.to_string())
+    }
+
     /// Redacts an event from the room.
     ///
     /// # Arguments


### PR DESCRIPTION
### Expose `Room.send_state_event_raw()` for sending arbitrary state events #6349 

Mobile clients can now send arbitrary state events through the FFI bindings. 

This PR introduces a new API (non-breaking change).

#### Implementation notes

I decided to expose the `event_id` in the `send_state_event_raw` result, as this id can be useful for clients. 

This creates a small inconsistency with the `send_raw` function, which does not return the `event_id`. I believe this inconsistency is acceptable. I would ideally like to see the `event_id` returned in the `send_raw` function as well, but I feel this PR should remain focused and not introduce any breaking change in the API.

#### Build

I verified building the `XCFramework`
```bash
cargo xtask swift build-framework --ios-deployment-target 15.0
```

I also verified integrating this build into our test iOS application and used the new API, with success. 

#### Use of AI

I used AI as a reference while making this change. I reviewed and validated the implementation myself, and take full accountability for it.

Closes #6349

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] This PR was made with the help of AI.
