### PR TITLE
feat(ffi, widgets) Expose widget state events to the ffi

### DIFF
--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -14,6 +14,7 @@
 
 use anyhow::{bail, Context};
 use matrix_sdk::IdParseError;
+use matrix_sdk_base::deserialized_responses::RawAnySyncOrStrippedState;
 use matrix_sdk_ui::timeline::TimelineEventItemId;
 use ruma::{
     events::{
@@ -743,6 +744,36 @@ impl TryFrom<EventOrTransactionId> for TimelineEventItemId {
             }
             EventOrTransactionId::TransactionId { transaction_id } => {
                 Ok(TimelineEventItemId::TransactionId(transaction_id.into()))
+            }
+        }
+    }
+}
+
+/// A raw state event, either synced or stripped (for invited rooms).
+///
+/// The event content is provided as a JSON string.
+#[derive(Clone, uniffi::Enum)]
+pub enum RawSyncOrStrippedStateEvent {
+    /// A state event from a room in joined or left state.
+    Sync {
+        /// The raw JSON content of the event.
+        json: String,
+    },
+    /// A stripped state event from a room in invited state.
+    Stripped {
+        /// The raw JSON content of the event.
+        json: String,
+    },
+}
+
+impl From<RawAnySyncOrStrippedState> for RawSyncOrStrippedStateEvent {
+    fn from(value: RawAnySyncOrStrippedState) -> Self {
+        match value {
+            RawAnySyncOrStrippedState::Sync(raw) => {
+                RawSyncOrStrippedStateEvent::Sync { json: raw.json().to_string() }
+            }
+            RawAnySyncOrStrippedState::Stripped(raw) => {
+                RawSyncOrStrippedStateEvent::Stripped { json: raw.json().to_string() }
             }
         }
     }

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -55,7 +55,7 @@ use crate::{
     chunk_iterator::ChunkIterator,
     client::{JoinRule, RoomVisibility},
     error::{ClientError, MediaInfoError, NotYetImplemented, QueueWedgeError, RoomError},
-    event::TimelineEvent,
+    event::{RawSyncOrStrippedStateEvent, StateEventType, TimelineEvent},
     identity_status_change::IdentityStatusChange,
     live_location_share::{LastLocation, LiveLocationShare},
     room_member::{RoomMember, RoomMemberWithSenderInfo},
@@ -363,6 +363,24 @@ impl Room {
     ) -> Result<(), ClientError> {
         self.inner.set_own_member_display_name(display_name).await?;
         Ok(())
+    }
+
+    /// Get all state events of a given type in this room.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` - The type of the state event to retrieve.
+    ///
+    /// # Returns
+    ///
+    /// A list of raw state events, either synced or stripped (for invited
+    /// rooms). Each event contains its raw JSON representation.
+    pub async fn get_state_events(
+        &self,
+        event_type: StateEventType,
+    ) -> Result<Vec<RawSyncOrStrippedStateEvent>, ClientError> {
+        let events = self.inner.get_state_events(event_type.into()).await?;
+        Ok(events.into_iter().map(Into::into).collect())
     }
 
     /// Get the membership details for the current user.

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -102,8 +102,11 @@ const DEFAULT_REQUIRED_STATE: &[(StateEventType, &str)] = &[
 
 /// The default `required_state` constant value for sliding sync room
 /// subscriptions that must be added to `DEFAULT_REQUIRED_STATE`.
-const DEFAULT_ROOM_SUBSCRIPTION_EXTRA_REQUIRED_STATE: &[(StateEventType, &str)] =
-    &[(StateEventType::RoomPinnedEvents, "")];
+const DEFAULT_ROOM_SUBSCRIPTION_EXTRA_REQUIRED_STATE: &[(StateEventType, &str)] = &[
+    (StateEventType::RoomPinnedEvents, ""),
+    // TODO add this to ruma properly
+    (StateEventType::Custom { value: "im.vector.modular.widgets" }, "*"),
+];
 
 /// The default `timeline_limit` value when used with room subscriptions.
 const DEFAULT_ROOM_SUBSCRIPTION_TIMELINE_LIMIT: u32 = 20;


### PR DESCRIPTION
 - add them to the required state once we sync a room timeline
 - expose get_state_events to the ffi
 - add required types to the ffi

<!-- description of the changes in this PR -->

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
