### PR TITLE
Fix crypto-ffi build instructions in README

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/README.md
+++ b/bindings/matrix-sdk-crypto-ffi/README.md
@@ -75,12 +75,13 @@ The bindings can built for the `aarch64` target with:
 $ cargo build --target aarch64-linux-android
 ```
 
-After that, a dynamic library can be found in the `target/aarch64-linux-android/debug` directory.
-The library will be called `libmatrix_crypto.so` and needs to be renamed and
+After that, a dynamic library can be found in the `target/aarch64-linux-android/debug` directory,
+under the repository root directory.
+The library will be called `libmatrix_sdk_crypto_ffi.so` and needs to be renamed and
 copied into the `jniLibs` directory of your Android project, for Element Android:
 
 ```
-$ cp ../../target/aarch64-linux-android/debug/libmatrix_crypto.so \
+$ cp ../../target/aarch64-linux-android/debug/libmatrix_sdk_crypto_ffi.so \
      /home/example/matrix-sdk-android/src/main/jniLibs/aarch64/libuniffi_olm.so
 ```
 


### PR DESCRIPTION
- Change the example config file to not make it appear as though it processes environment variables
- Remove the `ar` setting from the example config file, as that setting is deprecated and unused (see https://doc.rust-lang.org/cargo/reference/config.html#targettriplear)
- Replace references of `.cargo/config` to `.cargo/config.toml`, as the former is deprecated
- Add example of how to set the linker through an environment variable
- Add instruction to include the NDK binary tools directory to PATH, because builds may fail without it (see https://github.com/matrix-org/matrix-rust-sdk/issues/4042)

<!-- description of the changes in this PR -->

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>
