### PR TITLE
No reqwest::Certificate on wasm platforms

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -17,7 +17,7 @@
 
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_family = "wasm", target_os = "android")))]
 use matrix_sdk::reqwest::Certificate;
 use matrix_sdk::{
     cross_process_lock::CrossProcessLockConfig as SdkCrossProcessLockConfig,


### PR DESCRIPTION
Certificate is not available or used on wasm, but looks like the use statement was accidentally pulling it in, leading to a build break of the ffi bindings on wasm platforms.

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
