### PR TITLE
feat(ffi): expose `Client.sync()`

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -41,10 +41,10 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Expose sync v2 API through FFI via `Client.sync()` and
-  `Client.sync_once()`, enabling mobile clients to sync without
-  requiring Sliding Sync support on the homeserver. `Client.sync()`
-  accepts a `SyncListener` callback that receives a `SyncResponse`
+- Expose sync v2 API through FFI via `Client.sync_v2()` and
+  `Client.sync_once_v2()`, enabling mobile clients to sync without
+  requiring Sliding Sync support on the homeserver. `Client.sync_v2()`
+  accepts a `SyncListenerV2` callback that receives a `SyncResponseV2`
   after each successful sync.
   ([#6359](https://github.com/matrix-org/matrix-rust-sdk/pull/6359))
 - Expose `Room.send_state_event_raw()` for sending arbitrary state events

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -138,6 +138,7 @@ use crate::{
     runtime::get_runtime_handle,
     spaces::SpaceService,
     sync_service::{SyncService, SyncServiceBuilder},
+    sync_v2::{SyncListenerV2, SyncResponseV2, SyncSettingsV2},
     task_handle::TaskHandle,
     utd::{UnableToDecryptDelegate, UtdHook},
     utils::AsyncRuntimeDropped,
@@ -252,77 +253,6 @@ pub trait SendQueueRoomErrorListener: SyncOutsideWasm + SendOutsideWasm {
 pub trait AccountDataListener: SyncOutsideWasm + SendOutsideWasm {
     /// Called when a global account data event has changed.
     fn on_change(&self, event: AccountDataEvent);
-}
-
-/// A listener for the sync loop.
-///
-/// Called after each successful sync response when using [`Client::sync`].
-#[matrix_sdk_ffi_macros::export(callback_interface)]
-pub trait SyncListener: SyncOutsideWasm + SendOutsideWasm {
-    /// Called after each successful sync response.
-    fn on_update(&self, response: SyncResponse);
-}
-
-/// Settings for a sync call.
-#[derive(uniffi::Record)]
-pub struct SyncSettings {
-    /// Timeout in milliseconds for the server long-poll.
-    /// If not set, defaults to 30 seconds.
-    #[uniffi(default = None)]
-    pub timeout_ms: Option<u64>,
-    /// Whether to request full state on the first sync.
-    #[uniffi(default = false)]
-    pub full_state: bool,
-}
-
-impl From<SyncSettings> for matrix_sdk::config::SyncSettings {
-    fn from(value: SyncSettings) -> Self {
-        let mut settings = matrix_sdk::config::SyncSettings::new();
-        if let Some(timeout_ms) = value.timeout_ms {
-            settings = settings.timeout(Duration::from_millis(timeout_ms));
-        }
-        if value.full_state {
-            settings = settings.full_state(true);
-        }
-        settings
-    }
-}
-
-/// The response from a sync call.
-#[derive(uniffi::Record)]
-pub struct SyncResponse {
-    /// The batch token to supply in the `since` param of the next `/sync`
-    /// request.
-    pub next_batch: String,
-    /// Updates to rooms.
-    pub rooms: SyncResponseRooms,
-}
-
-/// Room updates from a sync response.
-#[derive(uniffi::Record)]
-pub struct SyncResponseRooms {
-    /// Room IDs of rooms the user has been invited to.
-    pub invited: Vec<String>,
-    /// Room IDs of joined rooms that had updates.
-    pub joined: Vec<String>,
-    /// Room IDs of rooms the user has left.
-    pub left: Vec<String>,
-    /// Room IDs of rooms the user has knocked on.
-    pub knocked: Vec<String>,
-}
-
-impl From<matrix_sdk::sync::SyncResponse> for SyncResponse {
-    fn from(value: matrix_sdk::sync::SyncResponse) -> Self {
-        Self {
-            next_batch: value.next_batch,
-            rooms: SyncResponseRooms {
-                invited: value.rooms.invited.keys().map(ToString::to_string).collect(),
-                joined: value.rooms.joined.keys().map(ToString::to_string).collect(),
-                left: value.rooms.left.keys().map(ToString::to_string).collect(),
-                knocked: value.rooms.knocked.keys().map(ToString::to_string).collect(),
-            },
-        }
-    }
 }
 
 /// A listener for duplicate key upload errors triggered by requests to
@@ -1681,7 +1611,7 @@ impl Client {
         SyncServiceBuilder::new((*self.inner).clone(), self.utd_hook_manager.get().cloned())
     }
 
-    /// Start a sync loop.
+    /// Start a sync v2 loop.
     ///
     /// This is an alternative to [`Client::sync_service`] (which uses Sliding
     /// Sync / MSC4186). It works with any homeserver, including older
@@ -1689,10 +1619,14 @@ impl Client {
     ///
     /// Returns a `TaskHandle` that can be used to cancel the sync loop.
     /// The listener is called after each successful sync response.
-    pub fn sync(&self, settings: SyncSettings, listener: Box<dyn SyncListener>) -> Arc<TaskHandle> {
+    pub fn sync_v2(
+        &self,
+        settings: SyncSettingsV2,
+        listener: Box<dyn SyncListenerV2>,
+    ) -> Arc<TaskHandle> {
         let client = (*self.inner).clone();
         let sdk_settings: matrix_sdk::config::SyncSettings = settings.into();
-        let listener: Arc<dyn SyncListener> = Arc::from(listener);
+        let listener: Arc<dyn SyncListenerV2> = Arc::from(listener);
 
         Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
             let result = client
@@ -1700,7 +1634,7 @@ impl Client {
                     let listener = listener.clone();
                     async move {
                         let response = result?;
-                        let ffi_response: SyncResponse = response.into();
+                        let ffi_response: SyncResponseV2 = response.into();
                         listener.on_update(ffi_response);
                         Ok(matrix_sdk::LoopCtrl::Continue)
                     }
@@ -1713,11 +1647,14 @@ impl Client {
         })))
     }
 
-    /// Perform a single sync call.
+    /// Perform a single sync v2 call.
     ///
     /// This is useful for performing an initial sync or a one-shot sync
     /// without entering a continuous loop.
-    pub async fn sync_once(&self, settings: SyncSettings) -> Result<SyncResponse, ClientError> {
+    pub async fn sync_once_v2(
+        &self,
+        settings: SyncSettingsV2,
+    ) -> Result<SyncResponseV2, ClientError> {
         let sdk_settings: matrix_sdk::config::SyncSettings = settings.into();
         let response = self.inner.sync_once(sdk_settings).await?;
         Ok(response.into())

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -28,6 +28,7 @@ mod session_verification;
 mod spaces;
 mod store;
 mod sync_service;
+mod sync_v2;
 mod task_handle;
 mod timeline;
 mod utd;

--- a/bindings/matrix-sdk-ffi/src/sync_v2.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_v2.rs
@@ -1,0 +1,89 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
+
+/// A listener for the sync loop.
+///
+/// Called after each successful sync response when using
+/// [`Client::sync_v2`](crate::client::Client::sync_v2).
+#[matrix_sdk_ffi_macros::export(callback_interface)]
+pub trait SyncListenerV2: SyncOutsideWasm + SendOutsideWasm {
+    /// Called after each successful sync response.
+    fn on_update(&self, response: SyncResponseV2);
+}
+
+/// Settings for a sync v2 call.
+#[derive(uniffi::Record)]
+pub struct SyncSettingsV2 {
+    /// Timeout in milliseconds for the server long-poll.
+    /// If not set, defaults to 30 seconds.
+    #[uniffi(default = None)]
+    pub timeout_ms: Option<u64>,
+    /// Whether to request full state on the first sync.
+    #[uniffi(default = false)]
+    pub full_state: bool,
+}
+
+impl From<SyncSettingsV2> for matrix_sdk::config::SyncSettings {
+    fn from(value: SyncSettingsV2) -> Self {
+        let mut settings = matrix_sdk::config::SyncSettings::new();
+        if let Some(timeout_ms) = value.timeout_ms {
+            settings = settings.timeout(Duration::from_millis(timeout_ms));
+        }
+        if value.full_state {
+            settings = settings.full_state(true);
+        }
+        settings
+    }
+}
+
+/// The response from a sync v2 call.
+#[derive(uniffi::Record)]
+pub struct SyncResponseV2 {
+    /// The batch token to supply in the `since` param of the next `/sync`
+    /// request.
+    pub next_batch: String,
+    /// Updates to rooms.
+    pub rooms: SyncResponseRoomsV2,
+}
+
+/// Room updates from a sync v2 response.
+#[derive(uniffi::Record)]
+pub struct SyncResponseRoomsV2 {
+    /// Room IDs of rooms the user has been invited to.
+    pub invited: Vec<String>,
+    /// Room IDs of joined rooms that had updates.
+    pub joined: Vec<String>,
+    /// Room IDs of rooms the user has left.
+    pub left: Vec<String>,
+    /// Room IDs of rooms the user has knocked on.
+    pub knocked: Vec<String>,
+}
+
+impl From<matrix_sdk::sync::SyncResponse> for SyncResponseV2 {
+    fn from(value: matrix_sdk::sync::SyncResponse) -> Self {
+        Self {
+            next_batch: value.next_batch,
+            rooms: SyncResponseRoomsV2 {
+                invited: value.rooms.invited.keys().map(ToString::to_string).collect(),
+                joined: value.rooms.joined.keys().map(ToString::to_string).collect(),
+                left: value.rooms.left.keys().map(ToString::to_string).collect(),
+                knocked: value.rooms.knocked.keys().map(ToString::to_string).collect(),
+            },
+        }
+    }
+}


### PR DESCRIPTION
### Expose sync v2 API through FFI via `Client.sync()` and `Client.sync_once()` #6348

Mobile clients can now sync using the traditional `/sync` v2 endpoint through the FFI bindings, without requiring Sliding Sync (MSC4186) support on the homeserver.

This PR introduces a new API (non-breaking change).

#### Implementation notes

I chose to expose only the **list of room IDs** (invited, joined, left, knocked) in the `SyncResponse`, rather than forwarding the full per-room event payloads. This keeps the FFI surface simple. Clients that need room details can query them through the existing `Room` APIs after being notified of changes via the listener.

Two entry points are provided:

- **`Client.sync(settings, listener)`** starts a continuous sync loop, returning a `TaskHandle` for cancellation. The `SyncListener` callback fires after each successful sync response.
- **`Client.sync_once(settings)`** performs a single sync call, useful for initial sync or one-off use cases.

`SyncSettings` exposes `timeout_ms` and `full_state`

#### Build

I verified building the `XCFramework`
```bash
cargo xtask swift build-framework --ios-deployment-target 15.0
```

I also verified integrating this build into our test iOS application and used the new API, with success.

#### Use of AI

I used AI as a reference while making this change. I reviewed and validated the implementation myself, and take full accountability for it.

Closes #6348

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] This PR was made with the help of AI.
