### PR TITLE
fix(ui): long-poll room list sync after initial request

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -234,8 +234,7 @@ impl RoomListService {
                                 PollTimeout::Default
                             }
 
-                            // The sync loop doesn't keep running in these states, but keeping an
-                            // explicit value here makes the policy exhaustive.
+                            // Terminal states — included for exhaustiveness.
                             State::Error { .. } | State::Terminated { .. } => PollTimeout::Some(0),
                         }
                     }),
@@ -680,7 +679,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_setting_up_uses_long_poll_timeout_after_first_sync() -> Result<(), Error> {
+    async fn test_long_poll_after_first_sync() -> Result<(), Error> {
         let (client, server) = new_client().await;
         let room_list = RoomListService::new(client).await?;
 

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -220,28 +220,23 @@ impl RoomListService {
                         // returned. If true, only invited rooms are returned.
                         is_invite: None,
                     })))
-                    .requires_timeout(move |request_generator| {
+                    .requires_timeout(move |_request_generator| {
                         // We want Sliding Sync to apply the poll + network timeout —i.e. to do the
                         // long-polling— in some particular cases. Let's define them.
                         match observable_state.get() {
-                            // These are the states where we want an immediate response from the
-                            // server, with no long-polling.
-                            State::Init
-                            | State::SettingUp
-                            | State::Recovering
-                            | State::Error { .. }
-                            | State::Terminated { .. } => PollTimeout::Some(0),
+                            // The very first request must return immediately so the session can
+                            // be established as fast as possible.
+                            State::Init => PollTimeout::Some(0),
 
-                            // Otherwise we want long-polling if the list is fully-loaded.
-                            State::Running => {
-                                if request_generator.is_fully_loaded() {
-                                    // Long-polling.
-                                    PollTimeout::Default
-                                } else {
-                                    // No long-polling yet.
-                                    PollTimeout::Some(0)
-                                }
+                            // Once we have a `pos`, let the server long-poll. If a list change
+                            // still needs to be delivered, the server can answer immediately.
+                            State::SettingUp | State::Recovering | State::Running => {
+                                PollTimeout::Default
                             }
+
+                            // The sync loop doesn't keep running in these states, but keeping an
+                            // explicit value here makes the policy exhaustive.
+                            State::Error { .. } | State::Terminated { .. } => PollTimeout::Some(0),
                         }
                     }),
             )
@@ -562,7 +557,13 @@ pub enum SyncIndicator {
 
 #[cfg(test)]
 mod tests {
-    use std::future::ready;
+    use std::{
+        future::ready,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
 
     use futures_util::{StreamExt, pin_mut};
     use matrix_sdk::{
@@ -674,6 +675,52 @@ mod tests {
 
         // State is `Error`, as a regular session expiration would generate!
         assert_eq!(room_list.state_machine.get(), State::Error { from: Box::new(State::Running) });
+
+        Ok(())
+    }
+
+    #[async_test]
+    async fn test_setting_up_uses_long_poll_timeout_after_first_sync() -> Result<(), Error> {
+        let (client, server) = new_client().await;
+        let room_list = RoomListService::new(client).await?;
+
+        let sync = room_list.sync();
+        pin_mut!(sync);
+
+        let pos = Arc::new(AtomicUsize::new(0));
+        let _mock_guard = Mock::given(SlidingSyncMatcher)
+            .respond_with(move |_request: &Request| {
+                let next_pos = pos.fetch_add(1, Ordering::SeqCst).to_string();
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "pos": next_pos,
+                    "lists": {
+                        ALL_ROOMS_LIST_NAME: {
+                            "count": 0,
+                            "ops": [],
+                        },
+                    },
+                    "rooms": {},
+                }))
+            })
+            .mount_as_scoped(&server)
+            .await;
+
+        let _ = sync.next().await;
+        assert_eq!(room_list.state().get(), State::SettingUp);
+        let _ = sync.next().await;
+
+        let requests = server.received_requests().await.unwrap();
+        let second_request =
+            requests.iter().filter(|request| SlidingSyncMatcher.matches(request)).nth(1).unwrap();
+
+        assert!(
+            second_request
+                .url
+                .query_pairs()
+                .any(|(key, value)| key == "timeout" && value == "30000"),
+            "expected second sync request to enable long-poll timeout, got {:?}",
+            second_request.url
+        );
 
         Ok(())
     }

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -224,18 +224,22 @@ impl RoomListService {
                         // We want Sliding Sync to apply the poll + network timeout —i.e. to do the
                         // long-polling— in some particular cases. Let's define them.
                         match observable_state.get() {
-                            // The very first request must return immediately so the session can
-                            // be established as fast as possible.
-                            State::Init => PollTimeout::Some(0),
+                            // Pre-`Running` states must respond immediately: the session is still
+                            // being established, recovering, or has terminated. `SyncIndicator`
+                            // also derives from the time spent outside `Running`, so long-polling
+                            // here would falsely trigger the loading hint.
+                            State::Init
+                            | State::SettingUp
+                            | State::Recovering
+                            | State::Error { .. }
+                            | State::Terminated { .. } => PollTimeout::Some(0),
 
-                            // Once we have a `pos`, let the server long-poll. If a list change
-                            // still needs to be delivered, the server can answer immediately.
-                            State::SettingUp | State::Recovering | State::Running => {
-                                PollTimeout::Default
-                            }
-
-                            // Terminal states — included for exhaustiveness.
-                            State::Error { .. } | State::Terminated { .. } => PollTimeout::Some(0),
+                            // Once we are `Running`, let the server long-poll regardless of
+                            // whether the list is fully loaded. If the next Growing batch is
+                            // ready (or any update is queued) the server can still answer
+                            // immediately; otherwise it holds the connection instead of forcing
+                            // the client to spin on empty responses.
+                            State::Running => PollTimeout::Default,
                         }
                     }),
             )
@@ -679,7 +683,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_long_poll_after_first_sync() -> Result<(), Error> {
+    async fn test_long_poll_once_running() -> Result<(), Error> {
         let (client, server) = new_client().await;
         let room_list = RoomListService::new(client).await?;
 
@@ -704,21 +708,44 @@ mod tests {
             .mount_as_scoped(&server)
             .await;
 
+        // Drive the state machine: Init -> SettingUp -> Running -> Running.
         let _ = sync.next().await;
         assert_eq!(room_list.state().get(), State::SettingUp);
         let _ = sync.next().await;
+        assert_eq!(room_list.state().get(), State::Running);
+        let _ = sync.next().await;
 
         let requests = server.received_requests().await.unwrap();
-        let second_request =
-            requests.iter().filter(|request| SlidingSyncMatcher.matches(request)).nth(1).unwrap();
+        let sliding_sync_requests: Vec<_> =
+            requests.iter().filter(|request| SlidingSyncMatcher.matches(request)).collect();
 
-        assert!(
-            second_request
+        let timeout_of = |index: usize| -> Option<String> {
+            sliding_sync_requests[index]
                 .url
                 .query_pairs()
-                .any(|(key, value)| key == "timeout" && value == "30000"),
-            "expected second sync request to enable long-poll timeout, got {:?}",
-            second_request.url
+                .find(|(key, _)| key == "timeout")
+                .map(|(_, value)| value.into_owned())
+        };
+
+        // The `SettingUp` request must keep `timeout=0`: `SyncIndicator` is derived
+        // from how long we stay outside `Running`, so long-polling here would falsely
+        // trigger the loading hint.
+        assert_eq!(
+            timeout_of(1).as_deref(),
+            Some("0"),
+            "request issued in `SettingUp` must not long-poll: {:?}",
+            sliding_sync_requests[1].url,
+        );
+
+        // The first request issued while already in `Running` must long-poll, even
+        // though the list is not yet fully loaded — otherwise an idle homeserver
+        // gets flooded with back-to-back `timeout=0` requests carrying the same
+        // `pos`.
+        assert_eq!(
+            timeout_of(2).as_deref(),
+            Some("30000"),
+            "request issued in `Running` must long-poll: {:?}",
+            sliding_sync_requests[2].url,
         );
 
         Ok(())

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -415,8 +415,8 @@ async fn test_sync_all_states() -> Result<(), Error> {
         states = SettingUp => Running,
         // The previous `pos`.
         assert pos Some("0"),
-        // Still no long-polling because the list isn't fully-loaded.
-        assert timeout Some(0),
+        // Long-polling is enabled for all post-init states.
+        assert timeout Some(30000),
         assert request >= {
             "conn_id": "room-list",
             "lists": {
@@ -443,8 +443,8 @@ async fn test_sync_all_states() -> Result<(), Error> {
         [server, room_list, sync]
         states = Running => Running,
         assert pos Some("1"),
-        // Still no long-polling because the list isn't fully-loaded.
-        assert timeout Some(0),
+        // Long-polling is enabled for all post-init states.
+        assert timeout Some(30000),
         assert request >= {
             "conn_id": "room-list",
             "lists": {
@@ -471,9 +471,8 @@ async fn test_sync_all_states() -> Result<(), Error> {
         [server, room_list, sync]
         states = Running => Running,
         assert pos Some("2"),
-        // Still no long-polling because the list isn't fully-loaded,
-        // but it's about to be!
-        assert timeout Some(0),
+        // Long-polling is enabled for all post-init states.
+        assert timeout Some(30000),
         assert request >= {
             "conn_id": "room-list",
             "lists": {
@@ -500,7 +499,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
         [server, room_list, sync]
         states = Running => Running,
         assert pos Some("3"),
-        // The list is fully-loaded, we can start long-polling.
+        // Long-polling is enabled for all post-init states.
         assert timeout Some(30000),
         assert request >= {
             "conn_id": "room-list",

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -415,8 +415,10 @@ async fn test_sync_all_states() -> Result<(), Error> {
         states = SettingUp => Running,
         // The previous `pos`.
         assert pos Some("0"),
-        // Long-polling is enabled for all post-init states.
-        assert timeout Some(30000),
+        // `SettingUp` keeps `timeout=0` to preserve `SyncIndicator` semantics:
+        // long-polling here would extend the time spent outside `Running` and
+        // falsely trigger the loading hint.
+        assert timeout Some(0),
         assert request >= {
             "conn_id": "room-list",
             "lists": {
@@ -443,7 +445,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
         [server, room_list, sync]
         states = Running => Running,
         assert pos Some("1"),
-        // Long-polling is enabled for all post-init states.
+        // Long-polling is enabled in `Running`, regardless of fully-loaded.
         assert timeout Some(30000),
         assert request >= {
             "conn_id": "room-list",
@@ -471,7 +473,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
         [server, room_list, sync]
         states = Running => Running,
         assert pos Some("2"),
-        // Long-polling is enabled for all post-init states.
+        // Long-polling is enabled in `Running`, regardless of fully-loaded.
         assert timeout Some(30000),
         assert request >= {
             "conn_id": "room-list",
@@ -499,7 +501,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
         [server, room_list, sync]
         states = Running => Running,
         assert pos Some("3"),
-        // Long-polling is enabled for all post-init states.
+        // Long-polling is enabled in `Running`, regardless of fully-loaded.
         assert timeout Some(30000),
         assert request >= {
             "conn_id": "room-list",


### PR DESCRIPTION
## Problem

After the initial room-list sync, `RoomListService` continues sending `timeout=0` requests because `SettingUp`, `Recovering`, and `Running` (before fully loaded) all forced immediate responses. This creates a tight polling loop when idle — the server returns empty responses instantly, and the client re-sends the same `pos` right away.

## Fix

Only force `timeout=0` for `State::Init`. All post-init states use `PollTimeout::Default`, letting the server long-poll when idle. If the server has pending changes, it can still respond immediately regardless of the timeout value.

## Test

Added a regression test verifying the second sync request carries `timeout=30000` instead of `timeout=0`.

- [ ] Public API changes documented in changelogs (optional)