### PR TITLE
refactor(tests): use the `MatrixMockServer` more in matrix-sdk-ui

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/filters/all.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/all.rs
@@ -24,7 +24,7 @@ pub fn new_filter(filters: Vec<BoxedFilterFn>) -> impl Filter {
 mod tests {
     use std::ops::Not;
 
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
 
@@ -32,7 +32,8 @@ mod tests {
 
     #[async_test]
     async fn test_one_filter() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         {
@@ -52,7 +53,8 @@ mod tests {
 
     #[async_test]
     async fn test_two_filters() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         {

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/any.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/any.rs
@@ -24,7 +24,7 @@ pub fn new_filter(filters: Vec<BoxedFilterFn>) -> impl Filter + use<> {
 mod tests {
     use std::ops::Not;
 
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
 
@@ -32,7 +32,8 @@ mod tests {
 
     #[async_test]
     async fn test_one_filter_is_true() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let filter = |_: &_| true;
@@ -43,7 +44,8 @@ mod tests {
 
     #[async_test]
     async fn test_one_filter_is_false() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let filter = |_: &_| false;
@@ -54,7 +56,8 @@ mod tests {
 
     #[async_test]
     async fn test_two_filters_with_true_true() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let filter1 = |_: &_| true;
@@ -66,7 +69,8 @@ mod tests {
 
     #[async_test]
     async fn test_two_filters_with_true_false() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let filter1 = |_: &_| true;
@@ -78,7 +82,8 @@ mod tests {
 
     #[async_test]
     async fn test_two_filters_with_false_true() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let filter1 = |_: &_| false;
@@ -90,7 +95,8 @@ mod tests {
 
     #[async_test]
     async fn test_two_filters_with_false_false() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let filter1 = |_: &_| false;

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/category.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/category.rs
@@ -68,7 +68,7 @@ pub fn new_filter(expected_category: RoomCategory) -> impl Filter {
 mod tests {
     use std::ops::Not;
 
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
 
@@ -76,7 +76,8 @@ mod tests {
 
     #[async_test]
     async fn test_kind_is_group() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let number_of_direct_targets = |_room: &RoomListItem| Some(42);
@@ -98,7 +99,8 @@ mod tests {
 
     #[async_test]
     async fn test_kind_is_people() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let number_of_direct_targets = |_room: &RoomListItem| Some(1);
@@ -120,7 +122,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_kind_cannot_be_found() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let number_of_direct_targets = |_room: &RoomListItem| None;

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/deduplicate_versions.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/deduplicate_versions.rs
@@ -82,7 +82,7 @@ pub fn new_filter() -> impl Filter {
 mod tests {
     use std::ops::Not;
 
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_base::RoomState;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
@@ -91,7 +91,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_joined_and_room_b_is_none() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_room: &RoomListItem| (RoomState::Joined, None), &room));
@@ -99,7 +100,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_joined_and_room_b_is_joined() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_| (RoomState::Joined, Some(SuccessorRoomState::Joined)), &room).not());
@@ -107,7 +109,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_joined_and_room_b_is_left() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_| (RoomState::Joined, Some(SuccessorRoomState::Left)), &room).not());
@@ -115,7 +118,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_joined_and_room_b_is_banned() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_| (RoomState::Joined, Some(SuccessorRoomState::Banned)), &room).not());
@@ -123,7 +127,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_joined_and_room_b_is_invited() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_| (RoomState::Joined, Some(SuccessorRoomState::Invited)), &room));
@@ -131,7 +136,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_joined_and_room_b_is_knocked() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_| (RoomState::Joined, Some(SuccessorRoomState::Knocked)), &room));
@@ -139,7 +145,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_left_and_room_b_is_joined() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_| (RoomState::Left, Some(RoomState::Joined)), &room).not());
@@ -147,7 +154,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_invited_and_room_b_is_joined() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_| (RoomState::Invited, Some(RoomState::Joined)), &room).not());
@@ -155,7 +163,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_banned_and_room_b_is_joined() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_| (RoomState::Banned, Some(RoomState::Joined)), &room).not());
@@ -163,7 +172,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_knocked_and_room_b_is_joined() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_| (RoomState::Knocked, Some(RoomState::Joined)), &room).not());
@@ -171,7 +181,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_left_and_room_b_is_none() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let state = |_: &RoomListItem| (RoomState::Left, None);
@@ -180,7 +191,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_invited_and_room_b_is_none() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let state = |_: &RoomListItem| (RoomState::Invited, None);
@@ -189,7 +201,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_banned_and_room_b_is_none() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let state = |_: &RoomListItem| (RoomState::Banned, None);
@@ -198,7 +211,8 @@ mod tests {
 
     #[async_test]
     async fn test_room_a_is_knocked_and_room_b_is_none() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let state = |_: &RoomListItem| (RoomState::Knocked, None);

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/favourite.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/favourite.rs
@@ -31,7 +31,7 @@ pub fn new_filter() -> impl Filter {
 mod tests {
     use std::ops::Not;
 
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
 
@@ -39,7 +39,8 @@ mod tests {
 
     #[async_test]
     async fn test_is_favourite() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_: &RoomListItem| true, &room));
@@ -47,7 +48,8 @@ mod tests {
 
     #[async_test]
     async fn test_is_not_favourite() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_: &RoomListItem| false, &room).not());

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/identifiers.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/identifiers.rs
@@ -24,7 +24,7 @@ pub fn new_filter(identifiers: Vec<OwnedRoomId>) -> impl Filter {
 
 #[cfg(test)]
 mod tests {
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::async_test;
     use ruma::{owned_room_id, room_id};
 
@@ -32,7 +32,8 @@ mod tests {
 
     #[async_test]
     async fn test_space() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let rooms = new_rooms(
             [room_id!("!alpha:b.c"), room_id!("!beta:b.c"), room_id!("!gamma:b.c")],
             &client,

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/invite.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/invite.rs
@@ -33,7 +33,7 @@ pub fn new_filter() -> impl Filter {
 
 #[cfg(test)]
 mod tests {
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_base::RoomState;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
@@ -42,7 +42,8 @@ mod tests {
 
     #[async_test]
     async fn test_all_invite_kind() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         // When a room has been left, it doesn't match.

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/joined.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/joined.rs
@@ -33,7 +33,7 @@ pub fn new_filter() -> impl Filter {
 
 #[cfg(test)]
 mod tests {
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_base::RoomState;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
@@ -42,7 +42,8 @@ mod tests {
 
     #[async_test]
     async fn test_all_joined_kind() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         // When a room has been left, it doesn't match.

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/low_priority.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/low_priority.rs
@@ -33,7 +33,7 @@ pub fn new_filter() -> impl Filter {
 mod tests {
     use std::ops::Not;
 
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
 
@@ -41,7 +41,8 @@ mod tests {
 
     #[async_test]
     async fn test_is_low_priority() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_| true, &room));
@@ -49,7 +50,8 @@ mod tests {
 
     #[async_test]
     async fn test_is_not_low_priority() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(matches(|_| false, &room).not());

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
@@ -79,9 +79,9 @@ pub use invite::new_filter as new_filter_invite;
 pub use joined::new_filter as new_filter_joined;
 pub use low_priority::new_filter as new_filter_low_priority;
 #[cfg(test)]
-use matrix_sdk::Client;
+use matrix_sdk::{Client, test_utils::mocks::MatrixMockServer};
 #[cfg(test)]
-use matrix_sdk_test::{JoinedRoomBuilder, SyncResponseBuilder};
+use matrix_sdk_test::JoinedRoomBuilder;
 pub use non_left::new_filter as new_filter_non_left;
 pub use none::new_filter as new_filter_none;
 pub use normalized_match_room_name::new_filter as new_filter_normalized_match_room_name;
@@ -91,11 +91,6 @@ use ruma::RoomId;
 pub use space::new_filter as new_filter_space;
 use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
 pub use unread::new_filter as new_filter_unread;
-#[cfg(test)]
-use wiremock::{
-    Mock, MockServer, ResponseTemplate,
-    matchers::{header, method, path},
-};
 
 use super::RoomListItem;
 
@@ -123,24 +118,16 @@ fn normalize_string(str: &str) -> String {
 pub(super) async fn new_rooms<const N: usize>(
     room_ids: [&RoomId; N],
     client: &Client,
-    server: &MockServer,
+    server: &MatrixMockServer,
 ) -> [RoomListItem; N] {
-    let mut response_builder = SyncResponseBuilder::default();
-
-    for room_id in room_ids {
-        response_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-    }
-
-    let json_response = response_builder.build_json_sync_response();
-
-    let _scope = Mock::given(method("GET"))
-        .and(path("/_matrix/client/r0/sync"))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json_response))
-        .mount_as_scoped(server)
+    server
+        .mock_sync()
+        .ok_and_run(client, |builder| {
+            for room_id in room_ids {
+                builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+            }
+        })
         .await;
-
-    let _response = client.sync_once(Default::default()).await.unwrap();
 
     room_ids.map(|room_id| client.get_room(room_id).unwrap().into())
 }

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/non_left.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/non_left.rs
@@ -35,7 +35,7 @@ pub fn new_filter() -> impl Filter {
 
 #[cfg(test)]
 mod tests {
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_base::RoomState;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
@@ -44,7 +44,8 @@ mod tests {
 
     #[async_test]
     async fn test_all_non_left_kind_of_room_list_entry() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         // When a room has been left, it doesn't match.

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/none.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/none.rs
@@ -23,7 +23,7 @@ pub fn new_filter() -> impl Filter {
 mod tests {
     use std::ops::Not;
 
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
 
@@ -31,7 +31,8 @@ mod tests {
 
     #[async_test]
     async fn test_all_kind_of_room_list_entry() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let none = new_filter();

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/not.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/not.rs
@@ -26,7 +26,7 @@ pub fn new_filter(filter: BoxedFilterFn) -> impl Filter {
 mod tests {
     use std::ops::Not;
 
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
 
@@ -34,7 +34,8 @@ mod tests {
 
     #[async_test]
     async fn test_true() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let filter = Box::new(|_: &_| true);
@@ -45,7 +46,8 @@ mod tests {
 
     #[async_test]
     async fn test_false() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let filter = Box::new(|_: &_| false);

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/space.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/space.rs
@@ -31,7 +31,7 @@ pub fn new_filter() -> impl Filter {
 
 #[cfg(test)]
 mod tests {
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
 
@@ -39,7 +39,8 @@ mod tests {
 
     #[async_test]
     async fn test_space() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         assert!(!matches(|_| false, &room));

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/unread.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/unread.rs
@@ -40,7 +40,7 @@ pub fn new_filter() -> impl Filter {
 mod tests {
     use std::ops::Not;
 
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_base::read_receipts::RoomReadReceipts;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
@@ -49,7 +49,8 @@ mod tests {
 
     #[async_test]
     async fn test_has_unread_notifications() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         for is_marked_as_unread in [true, false] {
@@ -69,7 +70,8 @@ mod tests {
 
     #[async_test]
     async fn test_has_unread_messages_but_no_unread_notifications_and_is_not_marked_as_unread() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let read_receipts_and_unread = |_: &RoomListItem| {
@@ -84,7 +86,8 @@ mod tests {
 
     #[async_test]
     async fn test_has_unread_messages_but_no_unread_notifications_and_is_marked_as_unread() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let read_receipts_and_unread = |_: &RoomListItem| {
@@ -99,7 +102,8 @@ mod tests {
 
     #[async_test]
     async fn test_has_no_unread_notifications_and_is_not_marked_as_unread() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let read_receipts_and_unread = |_: &RoomListItem| (RoomReadReceipts::default(), false);
@@ -109,7 +113,8 @@ mod tests {
 
     #[async_test]
     async fn test_has_no_unread_notifications_and_is_marked_as_unread() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
         let read_receipts_and_unread = |_: &RoomListItem| (RoomReadReceipts::default(), true);

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -558,50 +558,18 @@ mod tests {
     use std::future::ready;
 
     use futures_util::{StreamExt, pin_mut};
-    use matrix_sdk::{
-        Client, SlidingSyncMode, config::RequestConfig, test_utils::client::mock_matrix_session,
-    };
-    use matrix_sdk_test::async_test;
-    use ruma::api::MatrixVersion;
-    use serde_json::json;
-    use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate, http::Method};
+    use matrix_sdk::{SlidingSyncMode, test_utils::mocks::MatrixMockServer};
+    use matrix_sdk_test::{TestError, async_test};
+    use ruma::{api::client::sync::sync_events::v5, assign, uint};
 
     use super::{ALL_ROOMS_LIST_NAME, Error, RoomListService, State};
 
-    async fn new_client() -> (Client, MockServer) {
-        let session = mock_matrix_session();
-
-        let server = MockServer::start().await;
-        let client = Client::builder()
-            .homeserver_url(server.uri())
-            .server_versions([MatrixVersion::V1_0])
-            .request_config(RequestConfig::new().disable_retry())
-            .build()
-            .await
-            .unwrap();
-        client.restore_session(session).await.unwrap();
-
-        (client, server)
-    }
-
-    pub(super) async fn new_room_list() -> Result<RoomListService, Error> {
-        let (client, _) = new_client().await;
-
-        RoomListService::new(client).await
-    }
-
-    struct SlidingSyncMatcher;
-
-    impl Match for SlidingSyncMatcher {
-        fn matches(&self, request: &Request) -> bool {
-            request.url.path() == "/_matrix/client/unstable/org.matrix.simplified_msc3575/sync"
-                && request.method == Method::POST
-        }
-    }
-
     #[async_test]
-    async fn test_all_rooms_are_declared() -> Result<(), Error> {
-        let room_list = new_room_list().await?;
+    async fn test_all_rooms_are_declared() -> Result<(), TestError> {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let room_list = RoomListService::new(client).await?;
+
         let sliding_sync = room_list.sliding_sync();
 
         // List is present, in Selective mode.
@@ -620,7 +588,8 @@ mod tests {
 
     #[async_test]
     async fn test_expire_sliding_sync_session_manually() -> Result<(), Error> {
-        let (client, server) = new_client().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
 
         let room_list = RoomListService::new(client).await?;
 
@@ -629,20 +598,17 @@ mod tests {
 
         // Run a first sync.
         {
-            let _mock_guard = Mock::given(SlidingSyncMatcher)
-                .respond_with(move |_request: &Request| {
-                    ResponseTemplate::new(200).set_body_json(json!({
-                        "pos": "0",
-                        "lists": {
-                            ALL_ROOMS_LIST_NAME: {
-                                "count": 0,
-                                "ops": [],
-                            },
-                        },
-                        "rooms": {},
-                    }))
+            let _mock_guard = server
+                .mock_sliding_sync()
+                .ok({
+                    let mut response = v5::Response::new("0".to_owned());
+                    response.lists.insert(
+                        ALL_ROOMS_LIST_NAME.to_owned(),
+                        assign!(v5::response::List::default(), { count: uint!(0) }),
+                    );
+                    response
                 })
-                .mount_as_scoped(&server)
+                .mount_as_scoped()
                 .await;
 
             let _ = sync.next().await;

--- a/crates/matrix-sdk-ui/src/room_list_service/sorters/latest_event.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/sorters/latest_event.rs
@@ -68,7 +68,7 @@ mod tests {
     use matrix_sdk::{
         latest_events::{LatestEventValue, LocalLatestEventValue, RemoteLatestEventValue},
         store::SerializableEventContent,
-        test_utils::logged_in_client_with_server,
+        test_utils::mocks::MatrixMockServer,
     };
     use matrix_sdk_test::async_test;
     use ruma::{
@@ -142,7 +142,8 @@ mod tests {
 
     #[async_test]
     async fn test_none_or_remote_and_none_or_remote() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
 
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
@@ -170,7 +171,8 @@ mod tests {
 
     #[async_test]
     async fn test_none_or_remote_and_local() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
 
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
@@ -210,7 +212,8 @@ mod tests {
 
     #[async_test]
     async fn test_local_and_none_or_remote() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
 
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
@@ -250,7 +253,8 @@ mod tests {
 
     #[async_test]
     async fn test_local_and_local() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
 
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;

--- a/crates/matrix-sdk-ui/src/room_list_service/sorters/lexicographic.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/sorters/lexicographic.rs
@@ -37,7 +37,7 @@ pub fn new_sorter(sorters: Vec<BoxedSorterFn>) -> impl Sorter {
 
 #[cfg(test)]
 mod tests {
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
 
@@ -45,7 +45,8 @@ mod tests {
 
     #[async_test]
     async fn test_with_zero_sorter() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 
@@ -56,7 +57,8 @@ mod tests {
 
     #[async_test]
     async fn test_with_one_sorter() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 
@@ -68,7 +70,8 @@ mod tests {
 
     #[async_test]
     async fn test_with_two_sorters() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 
@@ -81,7 +84,8 @@ mod tests {
 
     #[async_test]
     async fn test_with_more_sorters() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 

--- a/crates/matrix-sdk-ui/src/room_list_service/sorters/name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/sorters/name.rs
@@ -41,7 +41,7 @@ pub fn new_sorter() -> impl Sorter {
 
 #[cfg(test)]
 mod tests {
-    use matrix_sdk::test_utils::logged_in_client_with_server;
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
 
@@ -49,7 +49,8 @@ mod tests {
 
     #[async_test]
     async fn test_with_two_names() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 
@@ -80,7 +81,8 @@ mod tests {
 
     #[async_test]
     async fn test_with_one_name() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 
@@ -100,7 +102,8 @@ mod tests {
 
     #[async_test]
     async fn test_with_zero_name() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 

--- a/crates/matrix-sdk-ui/src/room_list_service/sorters/recency.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/sorters/recency.rs
@@ -107,7 +107,7 @@ mod tests {
         RoomRecencyStamp,
         latest_events::{LatestEventValue, LocalLatestEventValue, RemoteLatestEventValue},
         store::SerializableEventContent,
-        test_utils::logged_in_client_with_server,
+        test_utils::mocks::MatrixMockServer,
     };
     use matrix_sdk_base::RoomInfoNotableUpdateReasons;
     use matrix_sdk_test::async_test;
@@ -179,7 +179,8 @@ mod tests {
 
     #[async_test]
     async fn test_extract_scores_with_none() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [mut room_a, mut room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 
@@ -219,7 +220,8 @@ mod tests {
 
     #[async_test]
     async fn test_extract_scores_with_remote_or_local() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [mut room_a, mut room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 
@@ -245,7 +247,8 @@ mod tests {
 
     #[async_test]
     async fn test_with_two_scores() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 
@@ -274,7 +277,8 @@ mod tests {
 
     #[async_test]
     async fn test_with_one_score() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 
@@ -293,7 +297,8 @@ mod tests {
 
     #[async_test]
     async fn test_with_zero_score() {
-        let (client, server) = logged_in_client_with_server().await;
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
         let [room_a, room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 

--- a/crates/matrix-sdk-ui/src/room_list_service/state.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/state.rs
@@ -199,10 +199,17 @@ pub const ALL_ROOMS_DEFAULT_GROWING_BATCH_SIZE: u32 = 100;
 
 #[cfg(test)]
 mod tests {
+    use matrix_sdk::test_utils::client::MockClientBuilder;
     use matrix_sdk_test::async_test;
     use tokio::time::sleep;
 
-    use super::{super::tests::new_room_list, *};
+    use super::*;
+    use crate::RoomListService;
+
+    async fn new_room_list() -> Result<RoomListService, Error> {
+        let client = MockClientBuilder::new(None).build().await;
+        RoomListService::new(client).await
+    }
 
     #[async_test]
     async fn test_states() -> Result<(), Error> {

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
@@ -7,12 +7,7 @@ use std::{
 };
 
 use futures_util::{StreamExt as _, pin_mut};
-use matrix_sdk::{
-    config::RequestConfig,
-    test_utils::{
-        client::mock_matrix_session, logged_in_client_with_server, test_client_builder_with_server,
-    },
-};
+use matrix_sdk::test_utils::mocks::MatrixMockServer;
 use matrix_sdk_base::crypto::store::types::Changes;
 use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
 use matrix_sdk_test::async_test;
@@ -27,14 +22,14 @@ use wiremock::{
 };
 
 use crate::{
-    mock_sync,
     sliding_sync::{PartialSlidingSyncRequest, SlidingSyncMatcher, check_requests},
     sliding_sync_then_assert_request_and_fake_response,
 };
 
 #[async_test]
 async fn test_smoke_encryption_sync_works() -> anyhow::Result<()> {
-    let (client, server) = logged_in_client_with_server().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new_for_testing()));
     let sync_permit_guard = sync_permit.clone().lock_owned().await;
@@ -177,7 +172,8 @@ async fn setup_mocking_sliding_sync_server(server: &MockServer) -> MockGuard {
 
 #[async_test]
 async fn test_encryption_sync_one_fixed_iteration() -> anyhow::Result<()> {
-    let (client, server) = logged_in_client_with_server().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let _guard = setup_mocking_sliding_sync_server(&server).await;
 
@@ -201,14 +197,15 @@ async fn test_encryption_sync_one_fixed_iteration() -> anyhow::Result<()> {
         }
     })];
 
-    check_requests(server, &expected_requests).await;
+    check_requests(&server, &expected_requests).await;
 
     Ok(())
 }
 
 #[async_test]
 async fn test_encryption_sync_two_fixed_iterations() -> anyhow::Result<()> {
-    let (client, server) = logged_in_client_with_server().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let _guard = setup_mocking_sliding_sync_server(&server).await;
 
@@ -243,14 +240,15 @@ async fn test_encryption_sync_two_fixed_iterations() -> anyhow::Result<()> {
         }),
     ];
 
-    check_requests(server, &expected_requests).await;
+    check_requests(&server, &expected_requests).await;
 
     Ok(())
 }
 
 #[async_test]
 async fn test_encryption_sync_always_reloads_todevice_token() -> anyhow::Result<()> {
-    let (client, server) = logged_in_client_with_server().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new_for_testing()));
     let sync_permit_guard = sync_permit.lock_owned().await;
@@ -351,17 +349,9 @@ async fn test_notification_client_does_not_upload_duplicate_one_time_keys() -> a
 
     let dir = tempdir().unwrap();
 
-    let (builder, server) = test_client_builder_with_server().await;
-    let client = builder
-        .request_config(RequestConfig::new().disable_retry())
-        .sqlite_store(dir.path(), None)
-        .build()
-        .await
-        .unwrap();
-
-    let session = mock_matrix_session();
-
-    client.restore_session(session.to_owned()).await.unwrap();
+    let server = MatrixMockServer::new().await;
+    let client =
+        server.client_builder().on_builder(|b| b.sqlite_store(dir.path(), None)).build().await;
 
     info!("Creating the notification client");
     let notification_client = client
@@ -377,9 +367,9 @@ async fn test_notification_client_does_not_upload_duplicate_one_time_keys() -> a
     pin_mut!(stream);
 
     Mock::given(method("POST"))
-        .and(path("/_matrix/client/r0/keys/query"))
+        .and(path("/_matrix/client/v3/keys/query"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     info!("First sync, uploading 50 one-time keys");
@@ -416,7 +406,7 @@ async fn test_notification_client_does_not_upload_duplicate_one_time_keys() -> a
     let uploaded_key_ids = Arc::new(Mutex::new(HashSet::new()));
 
     Mock::given(method("POST"))
-        .and(path("/_matrix/client/r0/keys/upload"))
+        .and(path("/_matrix/client/v3/keys/upload"))
         .respond_with({
             let found_duplicate = found_duplicate.clone();
             let uploaded_key_ids = uploaded_key_ids.clone();
@@ -456,7 +446,7 @@ async fn test_notification_client_does_not_upload_duplicate_one_time_keys() -> a
             }
         })
         .expect(4)
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     info!("Main sync now gets told that a one-time key has been used up.");
@@ -491,17 +481,16 @@ async fn test_notification_client_does_not_upload_duplicate_one_time_keys() -> a
         "The main sync should not have caused a duplicate one-time key"
     );
 
-    mock_sync(
-        &server,
-        json!({
+    server
+        .mock_sync()
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "next_batch": "foo",
             "device_one_time_keys_count": {
                 "signed_curve25519": 49
             }
-        }),
-        None,
-    )
-    .await;
+        })))
+        .mount()
+        .await;
 
     info!("The notification client now syncs and tries to upload some one-time keys");
 
@@ -562,7 +551,7 @@ async fn test_notification_client_does_not_upload_duplicate_one_time_keys() -> a
         "Duplicate one-time keys should not have been created"
     );
 
-    server.verify().await;
+    server.server().verify().await;
 
     Ok(())
 }

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use serde::Serialize;
-use wiremock::{
-    Mock, MockServer, ResponseTemplate,
-    matchers::{header, method, path, query_param, query_param_is_missing},
-};
-
 mod encryption_sync_service;
 mod notification_client;
 mod room_list_service;
@@ -26,23 +20,3 @@ mod sync_service;
 mod timeline;
 
 matrix_sdk_test_utils::init_tracing_for_tests!();
-
-/// Mount a Mock on the given server to handle the `GET /sync` endpoint with
-/// an optional `since` param that returns a 200 status code with the given
-/// response body.
-async fn mock_sync(server: &MockServer, response_body: impl Serialize, since: Option<String>) {
-    let mut mock_builder = Mock::given(method("GET"))
-        .and(path("/_matrix/client/r0/sync"))
-        .and(header("authorization", "Bearer 1234"));
-
-    if let Some(since) = since {
-        mock_builder = mock_builder.and(query_param("since", since));
-    } else {
-        mock_builder = mock_builder.and(query_param_is_missing("since"));
-    }
-
-    mock_builder
-        .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
-        .mount(server)
-        .await;
-}

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use itertools::Itertools as _;
-use matrix_sdk::deserialized_responses::TimelineEvent;
-use ruma::{EventId, RoomId, events::AnyStateEvent, serde::Raw};
 use serde::Serialize;
-use serde_json::json;
 use wiremock::{
     Mock, MockServer, ResponseTemplate,
-    matchers::{header, method, path, path_regex, query_param, query_param_is_missing},
+    matchers::{header, method, path, query_param, query_param_is_missing},
 };
 
 mod encryption_sync_service;
@@ -47,65 +43,6 @@ async fn mock_sync(server: &MockServer, response_body: impl Serialize, since: Op
 
     mock_builder
         .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
-        .mount(server)
-        .await;
-}
-
-/// Mocks the /context endpoint
-///
-/// Note: pass `events_before` in the normal order, I'll revert the order for
-/// you.
-// TODO: replace with MatrixMockServer
-#[allow(clippy::too_many_arguments)] // clippy you've got such a fixed mindset
-async fn mock_context(
-    server: &MockServer,
-    room_id: &RoomId,
-    event_id: &EventId,
-    prev_batch_token: Option<String>,
-    events_before: Vec<TimelineEvent>,
-    event: TimelineEvent,
-    events_after: Vec<TimelineEvent>,
-    next_batch_token: Option<String>,
-    state: Vec<Raw<AnyStateEvent>>,
-) {
-    Mock::given(method("GET"))
-        .and(path(format!("/_matrix/client/r0/rooms/{room_id}/context/{event_id}")))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "events_before": events_before.into_iter().rev().map(|ev| ev.into_raw()).collect_vec(),
-            "event": event.into_raw(),
-            "events_after": events_after.into_iter().map(|ev| ev.into_raw()).collect_vec(),
-            "state": state,
-            "start": prev_batch_token,
-            "end": next_batch_token
-        })))
-        .mount(server)
-        .await;
-}
-
-/// Mocks the /messages endpoint.
-///
-/// Note: pass `chunk` in the correct order: topological for forward pagination,
-/// reverse topological for backwards pagination.
-// TODO: replace with MatrixMockServer
-async fn mock_messages(
-    server: &MockServer,
-    start: String,
-    end: Option<String>,
-    chunk: Vec<TimelineEvent>,
-    state: Vec<Raw<AnyStateEvent>>,
-) {
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(header("authorization", "Bearer 1234"))
-        .and(query_param("from", start.clone()))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "start": start,
-            "end": end,
-            "chunk": chunk.into_iter().map(|ev| ev.into_raw()).collect_vec(),
-            "state": state,
-        })))
-        .expect(1)
         .mount(server)
         .await;
 }

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -7,16 +7,9 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use matrix_sdk::{
     ThreadingSupport,
-    config::SyncSettings,
-    test_utils::{
-        logged_in_client_with_server,
-        mocks::{MatrixMockServer, RoomContextResponseTemplate},
-    },
+    test_utils::mocks::{MatrixMockServer, RoomContextResponseTemplate},
 };
-use matrix_sdk_test::{
-    JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
-    mocks::mock_encryption_state,
-};
+use matrix_sdk_test::{JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::{
     notification_client::{
         NotificationClient, NotificationEvent, NotificationItemsRequest, NotificationProcessSetup,
@@ -37,10 +30,7 @@ use wiremock::{
     matchers::{header, method, path},
 };
 
-use crate::{
-    mock_sync,
-    sliding_sync::{PartialSlidingSyncRequest, SlidingSyncMatcher, check_requests},
-};
+use crate::sliding_sync::{PartialSlidingSyncRequest, SlidingSyncMatcher, check_requests};
 
 #[async_test]
 async fn test_notification_client_with_context() {
@@ -342,7 +332,8 @@ async fn test_unsubscribed_threads_get_notifications() {
 #[async_test]
 async fn test_notification_client_sliding_sync() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let event_id = event_id!("$example_event_id");
     let event_id2 = event_id!("$example_event_id2");
@@ -434,7 +425,7 @@ async fn test_notification_client_sliding_sync() {
                 }
             }))
         })
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     let dummy_sync_service = Arc::new(SyncService::builder(client.clone()).build().await.unwrap());
@@ -531,7 +522,8 @@ async fn test_notification_client_sliding_sync() {
 async fn test_notification_client_sliding_sync_invites() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let room_id2 = room_id!("!a98sd12bjh2:example.org");
-    let (client, server) = logged_in_client_with_server().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let event_id = event_id!("$example_event_id");
     let invite_event_id = event_id!("$invite_event_id");
@@ -628,7 +620,7 @@ async fn test_notification_client_sliding_sync_invites() {
                 }
             }))
         })
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     let dummy_sync_service = Arc::new(SyncService::builder(client.clone()).build().await.unwrap());
@@ -676,7 +668,8 @@ async fn test_notification_client_sliding_sync_invites() {
 async fn test_notification_client_sliding_sync_invites_with_event_id() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let room_id2 = room_id!("!a98sd12bjh2:example.org");
-    let (client, server) = logged_in_client_with_server().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let event_id = event_id!("$example_event_id");
     let invite_event_id = event_id!("$invite_event_id");
@@ -772,7 +765,7 @@ async fn test_notification_client_sliding_sync_invites_with_event_id() {
                 }
             }))
         })
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     let dummy_sync_service = Arc::new(SyncService::builder(client.clone()).build().await.unwrap());
@@ -819,7 +812,8 @@ async fn test_notification_client_sliding_sync_invites_with_event_id() {
 #[async_test]
 async fn test_notification_client_mixed() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let event_id = event_id!("$example_event_id");
     let event_id2 = event_id!("$example_event_id2");
@@ -849,26 +843,24 @@ async fn test_notification_client_mixed() {
     let event_json =
         event_factory.text_msg("Hello world!").event_id(event_id).sender(sender).into_raw_sync();
 
-    let event_json2 = event_factory
+    let event2 = event_factory
         .text_msg("Hello world again!")
         .sender(sender)
         .event_id(event_id2)
-        .into_raw_sync();
+        .into_event();
 
     let room_name = "The Maltese Falcon";
     let sender_display_name = "John Mastodon";
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_state_bulk([sender_member_event.clone(), own_member_event.clone()]),
-    );
-
     // First, mock a sync that contains a state event so we get a valid room for
     // room_id.
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(SyncSettings::default()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_state_bulk([sender_member_event.clone(), own_member_event.clone()]),
+        )
+        .await;
 
     let pos = Mutex::new(0);
     Mock::given(SlidingSyncMatcher)
@@ -913,27 +905,20 @@ async fn test_notification_client_mixed() {
                 }))
             }
         })
-        .mount(&server)
+        .mount(server.server())
         .await;
 
-    {
-        // The notification client retrieves the event via `/rooms/*/context/`.
-        Mock::given(method("GET"))
-            .and(path(format!("/_matrix/client/r0/rooms/{room_id}/context/{event_id2}")))
-            .and(header("authorization", "Bearer 1234"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "event": event_json2,
-                "state": [
-                    sender_member_event,
-                ],
-            })))
-            .mount(&server)
-            .await;
+    // The notification client retrieves the event via `/rooms/*/context/`.
+    server
+        .mock_room_event_context()
+        .ok(RoomContextResponseTemplate::new(event2)
+            .state_events(vec![sender_member_event.cast_unchecked()]))
+        .mount()
+        .await;
 
-        // The encryption state is also fetched to figure whether the room is encrypted
-        // or not.
-        mock_encryption_state(&server, false).await;
-    }
+    // The encryption state is also fetched to figure whether the room is encrypted
+    // or not.
+    server.mock_room_state_encryption().plain().mount().await;
 
     let dummy_sync_service = Arc::new(SyncService::builder(client.clone()).build().await.unwrap());
     let process_setup =
@@ -992,7 +977,7 @@ async fn test_notification_client_mixed() {
                 }
             }
         })))
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     let Some(Ok(item)) = result.remove(event_id) else {

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -450,7 +450,7 @@ async fn test_notification_client_sliding_sync() {
         .unwrap();
 
     check_requests(
-        server,
+        &server,
         &[json!({
             "conn_id": "notifications",
             "lists": {

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -23,14 +23,9 @@ use ruma::{
     owned_mxc_uri, room_id,
     time::{Duration, Instant},
 };
-use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
 use tempfile::TempDir;
 use tokio::{spawn, sync::Barrier, task::yield_now, time::sleep};
-use wiremock::{
-    Mock, ResponseTemplate,
-    matchers::{header, method, path},
-};
 
 use crate::timeline::sliding_sync::{assert_timeline_stream, timeline_event};
 
@@ -2673,14 +2668,7 @@ async fn test_room_empty_timeline() {
     let (client, server, room_list) = new_room_list_service().await.unwrap();
     server.mock_room_state_encryption().plain().mount().await;
 
-    Mock::given(method("POST"))
-        .and(path("_matrix/client/v3/createRoom"))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({ "room_id": "!example:localhost"})),
-        )
-        .mount(server.server())
-        .await;
+    server.mock_create_room().ok().mount().await;
 
     let room = client.create_room(CreateRoomRequest::default()).await.unwrap();
     let room_id = room.room_id().to_owned();

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -5,17 +5,10 @@ use eyeball_im::VectorDiff;
 use futures_util::{FutureExt, StreamExt, pin_mut};
 use matrix_sdk::{
     Client, RoomDisplayName,
-    config::RequestConfig,
-    test_utils::{
-        logged_in_client_with_server,
-        mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
-        set_client_session, test_client_builder,
-    },
+    test_utils::mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
 };
 use matrix_sdk_base::sync::UnreadNotificationsCount;
-use matrix_sdk_test::{
-    ALICE, async_test, event_factory::EventFactory, mocks::mock_encryption_state,
-};
+use matrix_sdk_test::{ALICE, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::{
     RoomListService,
     room_list_service::{
@@ -35,14 +28,15 @@ use stream_assert::{assert_next_matches, assert_pending};
 use tempfile::TempDir;
 use tokio::{spawn, sync::Barrier, task::yield_now, time::sleep};
 use wiremock::{
-    Mock, MockServer, ResponseTemplate,
+    Mock, ResponseTemplate,
     matchers::{header, method, path},
 };
 
 use crate::timeline::sliding_sync::{assert_timeline_stream, timeline_event};
 
-async fn new_room_list_service() -> Result<(Client, MockServer, RoomListService), Error> {
-    let (client, server) = logged_in_client_with_server().await;
+async fn new_room_list_service() -> Result<(Client, MatrixMockServer, RoomListService), Error> {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
     let room_list = RoomListService::new(client.clone()).await?;
 
     Ok((client, server, room_list))
@@ -50,15 +44,10 @@ async fn new_room_list_service() -> Result<(Client, MockServer, RoomListService)
 
 async fn new_persistent_room_list_service(
     store_path: &std::path::Path,
-) -> Result<(MockServer, RoomListService), Error> {
-    let server = MockServer::start().await;
-    let client = test_client_builder(Some(server.uri().to_string()))
-        .request_config(RequestConfig::new().disable_retry())
-        .sqlite_store(store_path, None)
-        .build()
-        .await
-        .unwrap();
-    set_client_session(&client).await;
+) -> Result<(MatrixMockServer, RoomListService), Error> {
+    let server = MatrixMockServer::new().await;
+    let client =
+        server.client_builder().on_builder(|b| b.sqlite_store(store_path, None)).build().await;
 
     let room_list = RoomListService::new(client.clone()).await?;
 
@@ -2631,7 +2620,7 @@ async fn test_room_timeline() -> Result<(), Error> {
         },
     };
 
-    mock_encryption_state(&server, false).await;
+    server.mock_room_state_encryption().plain().mount().await;
 
     let room = room_list.room(room_id)?;
     let timeline = room.timeline_builder().build().await.unwrap();
@@ -2682,15 +2671,15 @@ async fn test_room_timeline() -> Result<(), Error> {
 #[async_test]
 async fn test_room_empty_timeline() {
     let (client, server, room_list) = new_room_list_service().await.unwrap();
-    mock_encryption_state(&server, false).await;
+    server.mock_room_state_encryption().plain().mount().await;
 
     Mock::given(method("POST"))
-        .and(path("_matrix/client/r0/createRoom"))
+        .and(path("_matrix/client/v3/createRoom"))
         .and(header("authorization", "Bearer 1234"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(json!({ "room_id": "!example:localhost"})),
         )
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     let room = client.create_room(CreateRoomRequest::default()).await.unwrap();
@@ -2709,7 +2698,7 @@ async fn test_room_empty_timeline() {
 #[async_test]
 async fn test_room_latest_event() -> Result<(), Error> {
     let (client, server, room_list) = new_room_list_service().await?;
-    mock_encryption_state(&server, false).await;
+    server.mock_room_state_encryption().plain().mount().await;
 
     let sync = room_list.sync();
     pin_mut!(sync);

--- a/crates/matrix-sdk-ui/tests/integration/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sliding_sync.rs
@@ -2,7 +2,7 @@
 
 use wiremock::{Match, MockServer, Request, http::Method};
 
-pub(crate) async fn check_requests(server: MockServer, expected_requests: &[serde_json::Value]) {
+pub(crate) async fn check_requests(server: &MockServer, expected_requests: &[serde_json::Value]) {
     let mut num_requests = 0;
 
     for request in &server.received_requests().await.expect("Request recording has been disabled") {

--- a/crates/matrix-sdk-ui/tests/integration/sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sync_service.rs
@@ -18,10 +18,7 @@ use std::{
 };
 
 use assert_matches::assert_matches;
-use matrix_sdk::{
-    assert_next_matches_with_timeout,
-    test_utils::{logged_in_client_with_server, mocks::MatrixMockServer},
-};
+use matrix_sdk::{assert_next_matches_with_timeout, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_test::async_test;
 use matrix_sdk_ui::sync_service::{State, SyncService};
 use serde_json::json;
@@ -63,7 +60,8 @@ async fn setup_mocking_sliding_sync_server(
 
 #[async_test]
 async fn test_sync_service_state() -> anyhow::Result<()> {
-    let (client, server) = logged_in_client_with_server().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let encryption_pos = Arc::new(Mutex::new(0));
     let room_pos = Arc::new(Mutex::new(0));

--- a/crates/matrix-sdk-ui/tests/integration/sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sync_service.rs
@@ -213,11 +213,7 @@ async fn test_sync_service_offline_mode() {
     let sync_service = SyncService::builder(client).with_offline_mode().build().await.unwrap();
     let mut states = sync_service.state();
 
-    Mock::given(SlidingSyncMatcher)
-        .respond_with(ResponseTemplate::new(404))
-        .expect(1..)
-        .mount(mock_server.server())
-        .await;
+    mock_server.mock_sliding_sync().error_unrecognized().expect(1..).mount().await;
 
     {
         let _versions_guard = mock_server.mock_versions().error500().mount_as_scoped().await;
@@ -240,11 +236,7 @@ async fn test_sync_service_offline_mode_stopping() {
     let sync_service = SyncService::builder(client).with_offline_mode().build().await.unwrap();
     let mut states = sync_service.state();
 
-    Mock::given(SlidingSyncMatcher)
-        .respond_with(ResponseTemplate::new(404))
-        .expect(1..)
-        .mount(mock_server.server())
-        .await;
+    mock_server.mock_sliding_sync().error_unrecognized().expect(1..).mount().await;
     mock_server.mock_versions().error500().mount().await;
 
     sync_service.start().await;
@@ -263,10 +255,7 @@ async fn test_sync_service_offline_mode_restarting() {
     let sync_service = SyncService::builder(client).with_offline_mode().build().await.unwrap();
     let mut states = sync_service.state();
 
-    Mock::given(SlidingSyncMatcher)
-        .respond_with(ResponseTemplate::new(404))
-        .mount(mock_server.server())
-        .await;
+    mock_server.mock_sliding_sync().error_unrecognized().expect(1..).mount().await;
     mock_server.mock_versions().error500().mount().await;
 
     sync_service.start().await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -26,10 +26,8 @@ use ruma::{
     events::room::message::{MessageType, RoomMessageEventContent},
     room_id, user_id,
 };
-use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
 use tokio::task::yield_now;
-use wiremock::ResponseTemplate;
 
 #[async_test]
 async fn test_echo() {
@@ -227,14 +225,10 @@ async fn test_dedup_by_event_id_late() {
 
     server
         .mock_room_send()
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(json!({ "event_id": event_id }))
-                // Not great to use a timer for this, but it's what wiremock gives us right now.
-                // Ideally we'd wait on a channel to produce a value or sth. like that, but
-                // wiremock doesn't allow to handle multiple queries at the same time.
-                .set_delay(Duration::from_millis(500)),
-        )
+        // Not great to use a timer for this, but it's what wiremock gives us right now.
+        // Ideally we'd wait on a channel to produce a value or sth. like that, but
+        // wiremock doesn't allow to handle multiple queries at the same time.
+        .ok_with_delay(event_id, Duration::from_millis(500))
         .mount()
         .await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -21,62 +21,53 @@ use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{
     assert_let_timeout,
-    config::{SyncSettings, SyncToken},
-    test_utils::{
-        logged_in_client_with_server,
-        mocks::{MatrixMockServer, RoomContextResponseTemplate, RoomRelationsResponseTemplate},
+    test_utils::mocks::{
+        MatrixMockServer, RoomContextResponseTemplate, RoomMessagesResponseTemplate,
+        RoomRelationsResponseTemplate,
     },
 };
-use matrix_sdk_test::{
-    ALICE, BOB, JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
-    mocks::mock_encryption_state,
-};
+use matrix_sdk_test::{ALICE, BOB, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{TimelineBuilder, TimelineEventFocusThreadMode, TimelineFocus};
 use ruma::{event_id, events::room::message::RoomMessageEventContent, room_id};
 use stream_assert::assert_pending;
 use tokio::time::sleep;
 
-use crate::{mock_context, mock_messages, mock_sync};
-
 #[async_test]
 async fn test_new_focused() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
-
-    let mut sync_response_builder = SyncResponseBuilder::new();
-    sync_response_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    // Mark the room as joined.
-    mock_sync(&server, sync_response_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let f = EventFactory::new().room(room_id);
     let target_event = event_id!("$1");
 
-    mock_context(
-        &server,
-        room_id,
-        target_event,
-        Some("prev1".to_owned()),
-        vec![
-            f.text_msg("i tried so hard").sender(*ALICE).into_event(),
-            f.text_msg("and got so far").sender(*ALICE).into_event(),
-        ],
-        f.text_msg("in the end").event_id(target_event).sender(*BOB).into_event(),
-        vec![
-            f.text_msg("it doesn't even").sender(*ALICE).into_event(),
-            f.text_msg("matter").sender(*ALICE).into_event(),
-        ],
-        Some("next1".to_owned()),
-        vec![],
-    )
-    .await;
+    server
+        .mock_room_event_context()
+        .room(room_id)
+        .ok(
+            // events_before are passed in reverse chronological order (newest first),
+            // as required by the /context response format.
+            RoomContextResponseTemplate::new(
+                f.text_msg("in the end").event_id(target_event).sender(*BOB).into_event(),
+            )
+            .events_before(vec![
+                f.text_msg("and got so far").sender(*ALICE).into_event(),
+                f.text_msg("i tried so hard").sender(*ALICE).into_event(),
+            ])
+            .events_after(vec![
+                f.text_msg("it doesn't even").sender(*ALICE).into_event(),
+                f.text_msg("matter").sender(*ALICE).into_event(),
+            ])
+            .start("prev1")
+            .end("next1"),
+        )
+        .mock_once()
+        .mount()
+        .await;
 
-    mock_encryption_state(&server, false).await;
+    server.mock_room_state_encryption().plain().mount().await;
 
-    let room = client.get_room(room_id).unwrap();
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = TimelineBuilder::new(&room)
         .with_focus(TimelineFocus::Event {
             target: target_event.to_owned(),
@@ -91,8 +82,6 @@ async fn test_new_focused() {
         timeline.live_back_pagination_status().await.is_none(),
         "there should be no live back-pagination status for a focused timeline"
     );
-
-    server.reset().await;
 
     let (items, mut timeline_stream) = timeline.subscribe().await;
 
@@ -116,23 +105,22 @@ async fn test_new_focused() {
     assert_pending!(timeline_stream);
 
     // Now trigger a backward pagination.
-    mock_messages(
-        &server,
-        "prev1".to_owned(),
-        None,
-        vec![
+    server
+        .mock_room_messages()
+        .match_from("prev1")
+        .ok(RoomMessagesResponseTemplate::default().events(vec![
             // reversed manually here
-            f.text_msg("And even though I tried, it all fell apart").sender(*BOB).into_event(),
-            f.text_msg("I kept everything inside").sender(*BOB).into_event(),
-        ],
-        vec![],
-    )
-    .await;
+            f.text_msg("And even though I tried, it all fell apart")
+                .sender(*BOB)
+                .into_raw_timeline(),
+            f.text_msg("I kept everything inside").sender(*BOB).into_raw_timeline(),
+        ]))
+        .mock_once()
+        .mount()
+        .await;
 
     let hit_start = timeline.paginate_backwards(20).await.unwrap();
     assert!(hit_start);
-
-    server.reset().await;
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
@@ -150,22 +138,23 @@ async fn test_new_focused() {
     );
 
     // Now trigger a forward pagination.
-    mock_messages(
-        &server,
-        "next1".to_owned(),
-        Some("next2".to_owned()),
-        vec![
-            f.text_msg("I had to fall, to lose it all").sender(*BOB).into_event(),
-            f.text_msg("But in the end, it doesn't event matter").sender(*BOB).into_event(),
-        ],
-        vec![],
-    )
-    .await;
+    server
+        .mock_room_messages()
+        .match_from("next1")
+        .ok(RoomMessagesResponseTemplate::default()
+            .events(vec![
+                f.text_msg("I had to fall, to lose it all").sender(*BOB).into_raw_timeline(),
+                f.text_msg("But in the end, it doesn't event matter")
+                    .sender(*BOB)
+                    .into_raw_timeline(),
+            ])
+            .end_token("next2"))
+        .mock_once()
+        .mount()
+        .await;
 
     let hit_start = timeline.paginate_forwards(20).await.unwrap();
     assert!(!hit_start); // because we gave it another next2 token.
-
-    server.reset().await;
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
@@ -188,38 +177,26 @@ async fn test_new_focused() {
 #[async_test]
 async fn test_live_aggregations_are_reflected_on_focused_timelines() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings =
-        SyncSettings::new().timeout(Duration::from_millis(3000)).token(SyncToken::NoToken);
-
-    let mut sync_response_builder = SyncResponseBuilder::new();
-    sync_response_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    // Mark the room as joined.
-    mock_sync(&server, sync_response_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     // Start a focused timeline.
     let f = EventFactory::new().room(room_id);
     let target_event = event_id!("$1");
 
-    mock_context(
-        &server,
-        room_id,
-        target_event,
-        None,
-        vec![],
-        f.text_msg("yolo").event_id(target_event).sender(*BOB).into_event(),
-        vec![],
-        None,
-        vec![],
-    )
-    .await;
+    server
+        .mock_room_event_context()
+        .room(room_id)
+        .ok(RoomContextResponseTemplate::new(
+            f.text_msg("yolo").event_id(target_event).sender(*BOB).into_event(),
+        ))
+        .mock_once()
+        .mount()
+        .await;
 
-    mock_encryption_state(&server, false).await;
+    server.mock_room_state_encryption().plain().mount().await;
 
-    let room = client.get_room(room_id).unwrap();
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = TimelineBuilder::new(&room)
         .with_focus(TimelineFocus::Event {
             target: target_event.to_owned(),
@@ -229,8 +206,6 @@ async fn test_live_aggregations_are_reflected_on_focused_timelines() {
         .build()
         .await
         .unwrap();
-
-    server.reset().await;
 
     let (items, mut timeline_stream) = timeline.subscribe().await;
 
@@ -245,17 +220,17 @@ async fn test_live_aggregations_are_reflected_on_focused_timelines() {
 
     // Now simulate a sync that returns a new message-like event, and a reaction
     // to the $1 event.
-    sync_response_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_bulk([
-        // This event must be ignored.
-        f.text_msg("this is a sync event").sender(*ALICE).into(),
-        // This event must not be ignored.
-        f.reaction(target_event, "👍").sender(*BOB).into(),
-    ]));
-
-    // Sync the room.
-    mock_sync(&server, sync_response_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .mock_sync()
+        .ok_and_run(&client, |builder| {
+            builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_bulk([
+                // This event must be ignored.
+                f.text_msg("this is a sync event").sender(*ALICE).into(),
+                // This event must not be ignored.
+                f.reaction(target_event, "👍").sender(*BOB).into(),
+            ]));
+        })
+        .await;
 
     // We only receive one updated for the reaction, from the timeline stream.
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
@@ -272,37 +247,26 @@ async fn test_live_aggregations_are_reflected_on_focused_timelines() {
 #[async_test]
 async fn test_focused_timeline_local_echoes() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
-
-    let mut sync_response_builder = SyncResponseBuilder::new();
-    sync_response_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    // Mark the room as joined.
-    mock_sync(&server, sync_response_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     // Start a focused timeline.
     let f = EventFactory::new().room(room_id);
     let target_event = event_id!("$1");
 
-    mock_context(
-        &server,
-        room_id,
-        target_event,
-        None,
-        vec![],
-        f.text_msg("yolo").event_id(target_event).sender(*BOB).into_event(),
-        vec![],
-        None,
-        vec![],
-    )
-    .await;
+    server
+        .mock_room_event_context()
+        .room(room_id)
+        .ok(RoomContextResponseTemplate::new(
+            f.text_msg("yolo").event_id(target_event).sender(*BOB).into_event(),
+        ))
+        .mock_once()
+        .mount()
+        .await;
 
-    mock_encryption_state(&server, false).await;
+    server.mock_room_state_encryption().plain().mount().await;
 
-    let room = client.get_room(room_id).unwrap();
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = TimelineBuilder::new(&room)
         .with_focus(TimelineFocus::Event {
             target: target_event.to_owned(),
@@ -312,8 +276,6 @@ async fn test_focused_timeline_local_echoes() {
         .build()
         .await
         .unwrap();
-
-    server.reset().await;
 
     let (items, mut timeline_stream) = timeline.subscribe().await;
 
@@ -352,37 +314,26 @@ async fn test_focused_timeline_local_echoes() {
 #[async_test]
 async fn test_focused_timeline_doesnt_show_local_echoes() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
-
-    let mut sync_response_builder = SyncResponseBuilder::new();
-    sync_response_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    // Mark the room as joined.
-    mock_sync(&server, sync_response_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     // Start a focused timeline.
     let f = EventFactory::new().room(room_id);
     let target_event = event_id!("$1");
 
-    mock_context(
-        &server,
-        room_id,
-        target_event,
-        None,
-        vec![],
-        f.text_msg("yolo").event_id(target_event).sender(*BOB).into_event(),
-        vec![],
-        None,
-        vec![],
-    )
-    .await;
+    server
+        .mock_room_event_context()
+        .room(room_id)
+        .ok(RoomContextResponseTemplate::new(
+            f.text_msg("yolo").event_id(target_event).sender(*BOB).into_event(),
+        ))
+        .mock_once()
+        .mount()
+        .await;
 
-    mock_encryption_state(&server, false).await;
+    server.mock_room_state_encryption().plain().mount().await;
 
-    let room = client.get_room(room_id).unwrap();
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = TimelineBuilder::new(&room)
         .with_focus(TimelineFocus::Event {
             target: target_event.to_owned(),
@@ -392,8 +343,6 @@ async fn test_focused_timeline_doesnt_show_local_echoes() {
         .build()
         .await
         .unwrap();
-
-    server.reset().await;
 
     let (items, mut timeline_stream) = timeline.subscribe().await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
@@ -45,7 +45,7 @@ use ruma::{
         MediaSource,
         message::{MessageType, TextMessageEventContent},
     },
-    room_id, uint,
+    mxc_uri, room_id, uint,
 };
 use serde_json::json;
 use stream_assert::assert_pending;
@@ -385,22 +385,10 @@ async fn test_send_media_with_thumbnail() -> TestResult {
     let thumbnail_data = b"hello world".to_vec();
 
     // A mock to upload the thumbnail.
-    mock.mock_upload()
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-          "content_uri": "mxc://sdk.rs/thumbnail"
-        })))
-        .mock_once()
-        .mount()
-        .await;
+    mock.mock_upload().ok(mxc_uri!("mxc://sdk.rs/thumbnail")).mock_once().mount().await;
 
     // A mock to upload the media file.
-    mock.mock_upload()
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-          "content_uri": "mxc://sdk.rs/media"
-        })))
-        .mock_once()
-        .mount()
-        .await;
+    mock.mock_upload().ok(mxc_uri!("mxc://sdk.rs/media")).mock_once().mount().await;
 
     // A mock for sending the media event.
     mock.mock_room_send().ok(event_id!("$media")).mock_once().mount().await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -27,17 +27,10 @@ use futures_util::{
 };
 use matrix_sdk::{
     assert_let_timeout,
-    config::{SyncSettings, SyncToken},
     event_cache::PaginationStatus,
-    test_utils::{
-        logged_in_client_with_server,
-        mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
-    },
+    test_utils::mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
 };
-use matrix_sdk_test::{
-    ALICE, BOB, JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
-    mocks::mock_encryption_state,
-};
+use matrix_sdk_test::{ALICE, BOB, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{AnyOtherStateEventContentChange, RoomExt, TimelineItemContent};
 use ruma::{
     EventId, event_id,
@@ -50,50 +43,38 @@ use tokio::{
     spawn,
     time::{sleep, timeout},
 };
-use wiremock::{
-    Mock, ResponseTemplate,
-    matchers::{header, method, path_regex, query_param, query_param_is_missing},
-};
+use wiremock::ResponseTemplate;
 
-use crate::{mock_sync, timeline::sliding_sync::assert_timeline_stream};
+use crate::timeline::sliding_sync::assert_timeline_stream;
 
 #[async_test]
 async fn test_back_pagination() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
     let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&*ROOM_MESSAGES_BATCH_1))
-        .expect(1)
-        .named("messages_batch_1")
-        .mount(&server)
-        .await;
+    {
+        let _mock = server
+            .mock_room_messages()
+            .respond_with(ResponseTemplate::new(200).set_body_json(&*ROOM_MESSAGES_BATCH_1))
+            .mock_once()
+            .named("messages_batch_1")
+            .mount_as_scoped()
+            .await;
 
-    let paginate = async {
-        timeline.paginate_backwards(10).await.unwrap();
-        server.reset().await;
-    };
-    let observe_paginating = async {
-        assert_eq!(back_pagination_status.next().await, Some(PaginationStatus::Paginating));
-    };
-    join(paginate, observe_paginating).await;
+        let paginate = async {
+            timeline.paginate_backwards(10).await.unwrap();
+        };
+        let observe_paginating = async {
+            assert_eq!(back_pagination_status.next().await, Some(PaginationStatus::Paginating));
+        };
+        join(paginate, observe_paginating).await;
+    }
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
 
@@ -142,23 +123,27 @@ async fn test_back_pagination() {
 
     assert_pending!(timeline_stream);
 
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            // Usually there would be a few events here, but we just want to test
-            // that the timeline start item is added when there is no end token
-            "chunk": [],
-            "start": "t47409-4357353_219380_26003_2269"
-        })))
-        .expect(1)
-        .named("messages_batch_1")
-        .mount(&server)
-        .await;
+    {
+        let _mock = server
+            .mock_room_messages()
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                // Usually there would be a few events here, but we just want to test
+                // that the timeline start item is added when there is no end token
+                "chunk": [],
+                "start": "t47409-4357353_219380_26003_2269"
+            })))
+            .mock_once()
+            .named("messages_end")
+            .mount_as_scoped()
+            .await;
 
-    let hit_start = timeline.paginate_backwards(10).await.unwrap();
-    assert!(hit_start);
-    assert_next_eq!(back_pagination_status, PaginationStatus::Idle { hit_timeline_start: true });
+        let hit_start = timeline.paginate_backwards(10).await.unwrap();
+        assert!(hit_start);
+        assert_next_eq!(
+            back_pagination_status,
+            PaginationStatus::Idle { hit_timeline_start: true }
+        );
+    }
 
     // Timeline start is inserted.
     {
@@ -367,26 +352,21 @@ async fn test_skip_count_is_taken_into_account_in_pagination_status() {
 #[async_test]
 async fn test_back_pagination_highlighted() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let f = EventFactory::new().sender(user_id!("@example:localhost"));
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder
-        // We need the member event and power levels locally so the push rules processor works.
-        .add_joined_room(
+    // We need the member event and power levels locally so the push rules processor
+    // works.
+    let room = server
+        .sync_room(
+            &client,
             JoinedRoomBuilder::new(room_id)
                 .add_state_event(f.member(user_id!("@example:localhost")).display_name("example"))
                 .add_state_event(f.default_power_levels()),
-        );
+        )
+        .await;
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
@@ -419,17 +399,17 @@ async fn test_back_pagination_highlighted() {
         "end": "t47409-4357353_219380_26003_2269",
         "start": "t392-516_47314_0_7_1_1_1_11444_1"
     });
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(response_json))
-        .expect(1)
-        .named("messages_batch_1")
-        .mount(&server)
-        .await;
+    {
+        let _mock = server
+            .mock_room_messages()
+            .respond_with(ResponseTemplate::new(200).set_body_json(response_json))
+            .mock_once()
+            .named("messages_batch_1")
+            .mount_as_scoped()
+            .await;
 
-    timeline.paginate_backwards(10).await.unwrap();
-    server.reset().await;
+        timeline.paginate_backwards(10).await.unwrap();
+    }
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
 
@@ -461,44 +441,38 @@ async fn test_back_pagination_highlighted() {
 #[async_test]
 async fn test_wait_for_token() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-
-    let sync_settings =
-        SyncSettings::new().timeout(Duration::from_millis(3000)).token(SyncToken::NoToken);
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let f = EventFactory::new();
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
 
     let from = "t392-516_47314_0_7_1_1_1_11444_1";
     let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(header("authorization", "Bearer 1234"))
-        .and(query_param("from", from)) // make sure the right token is sent
+    server
+        .mock_room_messages()
+        .match_from(from)
         .respond_with(ResponseTemplate::new(200).set_body_json(&*ROOM_MESSAGES_BATCH_1))
         .expect(1)
         .named("messages_batch_1")
-        .mount(&server)
+        .mount()
         .await;
 
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(f.text_msg("live event!").sender(&ALICE))
-            .set_timeline_prev_batch(from.to_owned())
-            .set_timeline_limited(),
-    );
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
+    let sync_mock_guard = server
+        .mock_sync()
+        .ok(|b| {
+            b.add_joined_room(
+                JoinedRoomBuilder::new(room_id)
+                    .add_timeline_event(f.text_msg("live event!").sender(&ALICE))
+                    .set_timeline_prev_batch(from.to_owned())
+                    .set_timeline_limited(),
+            );
+        })
+        .mock_once()
+        .mount_as_scoped()
+        .await;
 
     let paginate = async {
         timeline.paginate_backwards(10).await.unwrap();
@@ -515,39 +489,27 @@ async fn test_wait_for_token() {
     let sync = async {
         // Make sure syncing starts a little bit later than pagination
         sleep(Duration::from_millis(100)).await;
-        client.sync_once(sync_settings.clone()).await.unwrap();
+        client.sync_once(Default::default()).await.unwrap();
     };
 
     timeout(Duration::from_secs(4), join3(paginate, observe_paginating, sync)).await.unwrap();
 
     // Make sure pagination was called (with the right parameters)
-    server.verify().await;
+    drop(sync_mock_guard);
+    server.server().verify().await;
 }
 
 #[async_test]
 async fn test_dedup_pagination() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
-    let f = EventFactory::new();
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
 
-    let from = "t392-516_47314_0_7_1_1_1_11444_1";
-
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(header("authorization", "Bearer 1234"))
+    server
+        .mock_room_messages()
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(&*ROOM_MESSAGES_BATCH_1)
@@ -557,15 +519,8 @@ async fn test_dedup_pagination() {
         )
         .expect(1) // endpoint should only be called once
         .named("messages_batch_1")
-        .mount(&server)
+        .mount()
         .await;
-
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(f.text_msg("live event!").sender(&ALICE))
-            .set_timeline_prev_batch(from.to_owned()),
-    );
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
 
     // If I try to paginate twice at the same time,
     let paginate_1 = async {
@@ -580,58 +535,58 @@ async fn test_dedup_pagination() {
     // `expect()`ed requested is indeed 1.
     //
     // Make sure pagination was called (with the right parameters).
-    server.verify().await;
+    server.server().verify().await;
 }
 
 #[async_test]
 async fn test_timeline_reset_while_paginating() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings =
-        SyncSettings::new().timeout(Duration::from_millis(3000)).token(SyncToken::NoToken);
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let f = EventFactory::new();
-    let mut sync_builder = SyncResponseBuilder::new();
-
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
 
     let alice_event = f.text_msg("live event!").sender(&ALICE).room(room_id).into_raw_timeline();
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(alice_event.clone().cast())
-            .set_timeline_prev_batch("pagination_1".to_owned())
-            .set_timeline_limited(),
-    );
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .mock_sync()
+        .ok(|b| {
+            b.add_joined_room(
+                JoinedRoomBuilder::new(room_id)
+                    .add_timeline_event(alice_event.clone().cast())
+                    .set_timeline_prev_batch("pagination_1".to_owned())
+                    .set_timeline_limited(),
+            );
+        })
+        .mock_once()
+        .mount()
+        .await;
+    client.sync_once(Default::default()).await.unwrap();
 
-    // Next sync response will response with pagination_2 token and limited
-    // response, resetting the timeline
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(f.text_msg("new live event.").sender(&BOB))
-            .set_timeline_prev_batch("pagination_2".to_owned())
-            .set_timeline_limited(),
-    );
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
+    // Next sync response will respond with pagination_2 token and limited
+    // response, resetting the timeline.
+    let sync_mock_guard = server
+        .mock_sync()
+        .ok(|b| {
+            b.add_joined_room(
+                JoinedRoomBuilder::new(room_id)
+                    .add_timeline_event(f.text_msg("new live event.").sender(&BOB))
+                    .set_timeline_prev_batch("pagination_2".to_owned())
+                    .set_timeline_limited(),
+            );
+        })
+        .mock_once()
+        .mount_as_scoped()
+        .await;
 
     // The pagination with the first token will be hit twice:
     // - first, before the sync response comes, then the gap is stored in the cache.
     // - second, after all other gaps have been resolved, we get back to resolving
     //   this one.
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(header("authorization", "Bearer 1234"))
-        .and(query_param("from", "pagination_1"))
+    server
+        .mock_room_messages()
+        .match_from("pagination_1")
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(json!({
@@ -644,37 +599,35 @@ async fn test_timeline_reset_while_paginating() {
         )
         .expect(2)
         .named("pagination_1")
-        .mount(&server)
+        .mount()
         .await;
 
     // The pagination with the second token must return Alice's event, to be
     // consistent with the room's timeline (Alice's event was observed before
     // Bob's event).
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(header("authorization", "Bearer 1234"))
-        .and(query_param("from", "pagination_2"))
+    server
+        .mock_room_messages()
+        .match_from("pagination_2")
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "chunk": [alice_event],
             "start": "pagination_2",
         })))
         .expect(1)
         .named("pagination_2")
-        .mount(&server)
+        .mount()
         .await;
 
     // pagination with third token
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(header("authorization", "Bearer 1234"))
-        .and(query_param("from", "pagination_3"))
+    server
+        .mock_room_messages()
+        .match_from("pagination_3")
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "chunk": [],
             "start": "pagination_3",
         })))
         .expect(1)
         .named("pagination_3")
-        .mount(&server)
+        .mount()
         .await;
 
     let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
@@ -723,7 +676,7 @@ async fn test_timeline_reset_while_paginating() {
     };
 
     let sync = async {
-        client.sync_once(sync_settings.clone()).await.unwrap();
+        client.sync_once(Default::default()).await.unwrap();
     };
 
     let (hit_start, _, _) =
@@ -738,7 +691,8 @@ async fn test_timeline_reset_while_paginating() {
     assert_eq!(timeline.items().await.len(), 4);
 
     // Make sure both pagination mocks were called.
-    server.verify().await;
+    drop(sync_mock_guard);
+    server.server().verify().await;
 }
 
 pub static ROOM_MESSAGES_BATCH_1: LazyLock<JsonValue> = LazyLock::new(|| {
@@ -815,56 +769,45 @@ pub static ROOM_MESSAGES_BATCH_2: LazyLock<JsonValue> = LazyLock::new(|| {
 #[async_test]
 async fn test_empty_chunk() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
     let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
     // It should try to do another request after the empty chunk.
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(query_param_is_missing("from"))
-        .and(header("authorization", "Bearer 1234"))
+    server
+        .mock_room_messages()
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "chunk": [],
             "start": "t112-4357353_219380_26003_2269",
             "end": "t392-516_47314_0_7_1_1_1_11444_1",
         })))
-        .expect(1)
+        .mock_once()
         .named("messages_empty_chunk")
-        .mount(&server)
+        .mount()
         .await;
 
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(query_param("from", "t392-516_47314_0_7_1_1_1_11444_1"))
-        .and(header("authorization", "Bearer 1234"))
+    server
+        .mock_room_messages()
+        .match_from("t392-516_47314_0_7_1_1_1_11444_1")
         .respond_with(ResponseTemplate::new(200).set_body_json(&*ROOM_MESSAGES_BATCH_1))
         .expect(1)
         .named("messages_batch_1")
-        .mount(&server)
+        .mount()
         .await;
 
-    let paginate = async {
-        timeline.paginate_backwards(10).await.unwrap();
-        server.reset().await;
-    };
-    let observe_paginating = async {
-        assert_eq!(back_pagination_status.next().await, Some(PaginationStatus::Paginating));
-    };
-    join(paginate, observe_paginating).await;
+    {
+        let paginate = async {
+            timeline.paginate_backwards(10).await.unwrap();
+        };
+        let observe_paginating = async {
+            assert_eq!(back_pagination_status.next().await, Some(PaginationStatus::Paginating));
+        };
+        join(paginate, observe_paginating).await;
+    }
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
 
@@ -917,55 +860,42 @@ async fn test_empty_chunk() {
 #[async_test]
 async fn test_until_num_items_with_empty_chunk() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
     let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(query_param_is_missing("from"))
-        .and(header("authorization", "Bearer 1234"))
+    server
+        .mock_room_messages()
         .respond_with(ResponseTemplate::new(200).set_body_json(&*ROOM_MESSAGES_BATCH_1))
-        .expect(1)
+        .mock_once()
         .named("messages_batch_1")
-        .mount(&server)
+        .mount()
         .await;
 
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(query_param("from", "t47409-4357353_219380_26003_2269"))
-        .and(header("authorization", "Bearer 1234"))
+    server
+        .mock_room_messages()
+        .match_from("t47409-4357353_219380_26003_2269")
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "chunk": [],
             "start": "t47409-4357353_219380_26003_2269",
             "end": "t54392-516_47314_0_7_1_1_1_11444_1",
         })))
-        .expect(1)
+        .mock_once()
         .named("messages_empty_chunk")
-        .mount(&server)
+        .mount()
         .await;
 
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(query_param("from", "t54392-516_47314_0_7_1_1_1_11444_1"))
-        .and(header("authorization", "Bearer 1234"))
+    server
+        .mock_room_messages()
+        .match_from("t54392-516_47314_0_7_1_1_1_11444_1")
         .respond_with(ResponseTemplate::new(200).set_body_json(&*ROOM_MESSAGES_BATCH_2))
         .expect(1)
         .named("messages_batch_2")
-        .mount(&server)
+        .mount()
         .await;
 
     let paginate = async {
@@ -1063,15 +993,14 @@ async fn test_back_pagination_aborted() {
     let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
     // Delay the server response, so we have time to abort the request.
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
-        .and(header("authorization", "Bearer 1234"))
+    server
+        .mock_room_messages()
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(&*ROOM_MESSAGES_BATCH_1)
                 .set_delay(Duration::from_secs(1)),
         )
-        .mount(server.server())
+        .mount()
         .await;
 
     let paginate = spawn({

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -5,18 +5,14 @@ use eyeball_im::VectorDiff;
 use futures_util::StreamExt as _;
 use matrix_sdk::{
     Client, Room, assert_let_timeout,
-    config::SyncSettings,
-    test_utils::{
-        logged_in_client_with_server,
-        mocks::{MatrixMockServer, RoomMessagesResponseTemplate, RoomRelationsResponseTemplate},
+    test_utils::mocks::{
+        MatrixMockServer, RoomMessagesResponseTemplate, RoomRelationsResponseTemplate,
     },
     timeout::timeout,
 };
 use matrix_sdk_base::deserialized_responses::TimelineEvent;
 use matrix_sdk_common::executor::spawn;
-use matrix_sdk_test::{
-    BOB, JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
-};
+use matrix_sdk_test::{BOB, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{RoomExt, TimelineBuilder, TimelineFocus};
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, RoomId, UserId, assign,
@@ -36,12 +32,7 @@ use ruma::{
 };
 use stream_assert::assert_pending;
 use tokio::time::sleep;
-use wiremock::{
-    Mock, ResponseTemplate,
-    matchers::{header, method, path_regex},
-};
-
-use crate::mock_sync;
+use wiremock::ResponseTemplate;
 
 #[async_test]
 async fn test_new_pinned_events_are_not_added_on_sync() {
@@ -860,7 +851,8 @@ async fn test_redacted_events_are_reflected_in_sync() {
 
 #[async_test]
 async fn test_ensure_max_concurrency_is_observed() {
-    let (client, server) = logged_in_client_with_server().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
     let room_id = owned_room_id!("!a_room:example.org");
 
     let pinned_event_ids: Vec<OwnedEventId> =
@@ -881,27 +873,19 @@ async fn test_ensure_max_concurrency_is_observed() {
 
     let pinned_event =
         EventFactory::new().room(&room_id).sender(*BOB).text_msg("A message").into_raw_timeline();
-    Mock::given(method("GET"))
-        .and(path_regex(r"/_matrix/client/r0/rooms/.*/event/.*"))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(
+    server
+        .mock_room_event()
+        .ok_with_template(
             ResponseTemplate::new(200)
                 .set_delay(Duration::from_secs(60))
                 .set_body_json(pinned_event.json()),
         )
         // Verify this endpoint is only called the max concurrent amount of times.
         .expect(max_concurrent_requests as u64)
-        .mount(&server)
+        .mount()
         .await;
 
-    let mut sync_response_builder = SyncResponseBuilder::new();
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
-    let json_response =
-        sync_response_builder.add_joined_room(joined_room_builder).build_json_sync_response();
-    mock_sync(&server, json_response, None).await;
-    let _ = client.sync_once(sync_settings.clone()).await;
-
-    let room = client.get_room(&room_id).unwrap();
+    let room = server.sync_room(&client, joined_room_builder).await;
 
     // Start loading the pinned event timeline asynchronously.
     let handle = spawn({
@@ -920,7 +904,7 @@ async fn test_ensure_max_concurrency_is_observed() {
 
     // The real check happens here, based on the `max_concurrent_requests` expected
     // value set above for the mock endpoint.
-    server.verify().await;
+    server.server().verify().await;
 }
 
 async fn mock_events_endpoint(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
@@ -12,84 +12,66 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use assert_matches::assert_matches;
-use matrix_sdk::{
-    config::{SyncSettings, SyncToken},
-    test_utils::logged_in_client_with_server,
-};
+use matrix_sdk::test_utils::mocks::MatrixMockServer;
 use matrix_sdk_common::executor::spawn;
 use matrix_sdk_test::{
-    ALICE, BOB, CAROL, DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, SyncResponseBuilder, async_test,
+    ALICE, BOB, CAROL, DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, async_test,
     event_factory::{EventFactory, PreviousMembership},
-    mocks::mock_encryption_state,
 };
 use matrix_sdk_ui::timeline::{RoomExt, TimelineDetails};
 use ruma::events::room::member::MembershipState;
-use serde_json::json;
-use wiremock::{
-    Mock, ResponseTemplate,
-    matchers::{method, path_regex},
-};
-
-use crate::mock_sync;
 
 #[async_test]
 async fn test_user_profile_after_being_banned() {
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings =
-        SyncSettings::new().timeout(Duration::from_millis(3000)).token(SyncToken::NoToken);
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let f = EventFactory::new();
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(&DEFAULT_TEST_ROOM_ID));
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server.mock_room_state_encryption().plain().mount().await;
 
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
+    let room = server.sync_joined_room(&client, &DEFAULT_TEST_ROOM_ID).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
 
     // Build a simple timeline with Bob joining the room, Alice accepting an invite,
     // sending some messages, and then getting banned by Bob. Alice's profile should
     // be unavailable after the ban, while Bob's profile should be unaffected.
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(&DEFAULT_TEST_ROOM_ID)
-            // Bob joins the room
-            .add_timeline_event(
-                f.member(&BOB)
-                    .display_name("Bob")
-                    .avatar_url("mxc://123".into())
-                    .membership(MembershipState::Join),
-            )
-            // Alice accepts an invite into the room
-            .add_timeline_event(
-                f.member(&ALICE)
-                    .display_name("*profanities*")
-                    .avatar_url("mxc://456".into())
-                    .membership(MembershipState::Join)
-                    .previous(MembershipState::Invite),
-            )
-            // Bob sends a text message
-            .add_timeline_event(f.text_msg("hey!").sender(&BOB))
-            // Alice send some insults and gets banned
-            .add_timeline_event(f.text_msg("*insults*").sender(&ALICE))
-            .add_timeline_event(f.text_msg("Nope. You are out.").sender(&BOB))
-            .add_timeline_event(
-                f.member(&ALICE).membership(MembershipState::Ban).sender(&BOB).previous(
-                    PreviousMembership::new(MembershipState::Join)
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(&DEFAULT_TEST_ROOM_ID)
+                // Bob joins the room
+                .add_timeline_event(
+                    f.member(&BOB)
+                        .display_name("Bob")
+                        .avatar_url("mxc://123".into())
+                        .membership(MembershipState::Join),
+                )
+                // Alice accepts an invite into the room
+                .add_timeline_event(
+                    f.member(&ALICE)
                         .display_name("*profanities*")
-                        .avatar_url("mxc://456".into()),
+                        .avatar_url("mxc://456".into())
+                        .membership(MembershipState::Join)
+                        .previous(MembershipState::Invite),
+                )
+                // Bob sends a text message
+                .add_timeline_event(f.text_msg("hey!").sender(&BOB))
+                // Alice send some insults and gets banned
+                .add_timeline_event(f.text_msg("*insults*").sender(&ALICE))
+                .add_timeline_event(f.text_msg("Nope. You are out.").sender(&BOB))
+                .add_timeline_event(
+                    f.member(&ALICE).membership(MembershipState::Ban).sender(&BOB).previous(
+                        PreviousMembership::new(MembershipState::Join)
+                            .display_name("*profanities*")
+                            .avatar_url("mxc://456".into()),
+                    ),
                 ),
-            ),
-    );
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+        )
+        .await;
 
     let timeline_items = timeline.items().await;
     // Date divider + 6 events
@@ -115,57 +97,50 @@ async fn test_user_profile_after_being_banned() {
 
 #[async_test]
 async fn test_user_profile_after_leaving() {
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings =
-        SyncSettings::new().timeout(Duration::from_millis(3000)).token(SyncToken::NoToken);
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let f = EventFactory::new();
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(&DEFAULT_TEST_ROOM_ID));
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server.mock_room_state_encryption().plain().mount().await;
 
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
+    let room = server.sync_joined_room(&client, &DEFAULT_TEST_ROOM_ID).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
 
     // Build a simple timeline with Bob joining the room, Alice accepting an invite
     // and sending a message, Bob sending a message, and Alice leaving
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(&DEFAULT_TEST_ROOM_ID)
-            // Bob joins the room
-            .add_timeline_event(
-                f.member(&BOB)
-                    .display_name("Bob")
-                    .avatar_url("mxc://...".into())
-                    .membership(MembershipState::Join),
-            )
-            // Alice accepts an invite into the room
-            .add_timeline_event(
-                f.member(&ALICE)
-                    .display_name("Alice")
-                    .avatar_url("mxc://...".into())
-                    .membership(MembershipState::Join)
-                    .previous(MembershipState::Invite),
-            )
-            // Bob sends a text message
-            .add_timeline_event(f.text_msg("hey!").sender(&BOB))
-            // Alice send a message and leaves the room
-            .add_timeline_event(f.text_msg("bye now").sender(&ALICE))
-            .add_timeline_event(
-                f.member(&ALICE).membership(MembershipState::Leave).previous(
-                    PreviousMembership::new(MembershipState::Join)
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(&DEFAULT_TEST_ROOM_ID)
+                // Bob joins the room
+                .add_timeline_event(
+                    f.member(&BOB)
+                        .display_name("Bob")
+                        .avatar_url("mxc://...".into())
+                        .membership(MembershipState::Join),
+                )
+                // Alice accepts an invite into the room
+                .add_timeline_event(
+                    f.member(&ALICE)
                         .display_name("Alice")
-                        .avatar_url("mxc://...".into()),
+                        .avatar_url("mxc://...".into())
+                        .membership(MembershipState::Join)
+                        .previous(MembershipState::Invite),
+                )
+                // Bob sends a text message
+                .add_timeline_event(f.text_msg("hey!").sender(&BOB))
+                // Alice send a message and leaves the room
+                .add_timeline_event(f.text_msg("bye now").sender(&ALICE))
+                .add_timeline_event(
+                    f.member(&ALICE).membership(MembershipState::Leave).previous(
+                        PreviousMembership::new(MembershipState::Join)
+                            .display_name("Alice")
+                            .avatar_url("mxc://...".into()),
+                    ),
                 ),
-            ),
-    );
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+        )
+        .await;
 
     let timeline_items = timeline.items().await;
     // Date divider + 5 events
@@ -201,39 +176,32 @@ async fn test_user_profile_after_leaving() {
 
 #[async_test]
 async fn test_update_sender_profiles() {
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings =
-        SyncSettings::new().timeout(Duration::from_millis(3000)).token(SyncToken::NoToken);
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let f = EventFactory::new();
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(&DEFAULT_TEST_ROOM_ID));
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server.mock_room_state_encryption().plain().mount().await;
 
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
+    let room = server.sync_joined_room(&client, &DEFAULT_TEST_ROOM_ID).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
 
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(&DEFAULT_TEST_ROOM_ID)
-            // Alice accepts an invite into the room
-            .add_timeline_event(
-                f.member(&ALICE)
-                    .membership(MembershipState::Join)
-                    .previous(MembershipState::Invite),
-            )
-            // Bob sends a text message
-            .add_timeline_event(f.text_msg("text message event").sender(&BOB))
-            // Carol kicks bob
-            .add_timeline_event(f.member(&CAROL).kicked(&BOB).previous(MembershipState::Join)),
-    );
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(&DEFAULT_TEST_ROOM_ID)
+                // Alice accepts an invite into the room
+                .add_timeline_event(
+                    f.member(&ALICE)
+                        .membership(MembershipState::Join)
+                        .previous(MembershipState::Invite),
+                )
+                // Bob sends a text message
+                .add_timeline_event(f.text_msg("text message event").sender(&BOB))
+                // Carol kicks bob
+                .add_timeline_event(f.member(&CAROL).kicked(&BOB).previous(MembershipState::Join)),
+        )
+        .await;
 
     let timeline_items = timeline.items().await;
     assert_eq!(timeline_items.len(), 4);
@@ -279,20 +247,19 @@ async fn test_update_sender_profiles() {
     let f = f.room(&DEFAULT_TEST_ROOM_ID);
 
     // Try again, this time we mock the endpoint to get a useful response.
-    Mock::given(method("GET"))
-        .and(path_regex(r"/_matrix/client/r0/rooms/.*/members"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "chunk": [
-                // This event wasn't previously observed by the client
-                f.member(&CAROL).membership(MembershipState::Join).into_raw_timeline(),
-
-                // Same as above
-                f.member(&ALICE).membership(MembershipState::Join).previous(MembershipState::Invite).into_raw_timeline(),
-
-                f.member(&CAROL).kicked(&BOB).previous(MembershipState::Join).into_raw_timeline(),
-            ]
-        })))
-        .mount(&server)
+    server
+        .mock_get_members()
+        .ok(vec![
+            // This event wasn't previously observed by the client
+            f.member(&CAROL).membership(MembershipState::Join).into_raw(),
+            // Same as above
+            f.member(&ALICE)
+                .membership(MembershipState::Join)
+                .previous(MembershipState::Invite)
+                .into_raw(),
+            f.member(&CAROL).kicked(&BOB).previous(MembershipState::Join).into_raw(),
+        ])
+        .mount()
         .await;
 
     // Spawn fetch_members as a background task, so we can observe the missing

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -28,10 +28,6 @@ use ruma::{
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
 use tokio::{task::yield_now, time::sleep};
-use wiremock::{
-    Mock, ResponseTemplate,
-    matchers::{body_string_contains, method, path_regex},
-};
 
 #[async_test]
 async fn test_message_order() {
@@ -46,28 +42,20 @@ async fn test_message_order() {
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
     // Response for first message takes 200ms to respond
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
-        .and(body_string_contains("First!"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(json!({ "event_id": "$ev0" }))
-                .set_delay(Duration::from_millis(200)),
-        )
-        .mount(server.server())
+    server
+        .mock_room_send()
+        .body_matches_partial_json(json!({ "body": "First!" }))
+        .ok_with_delay(event_id!("$ev0"), Duration::from_millis(200))
+        .mount()
         .await;
 
     // Response for second message only takes 100ms to respond, so should come
     // back first if we don't serialize requests
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
-        .and(body_string_contains("Second."))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(json!({ "event_id": "$ev1" }))
-                .set_delay(Duration::from_millis(100)),
-        )
-        .mount(server.server())
+    server
+        .mock_room_send()
+        .body_matches_partial_json(json!({ "body": "Second." }))
+        .ok_with_delay(event_id!("$ev1"), Duration::from_millis(100))
+        .mount()
         .await;
 
     timeline.send(RoomMessageEventContent::text_plain("First!").into()).await.unwrap();
@@ -132,12 +120,7 @@ async fn test_retry_order() {
 
     // When trying to send an event, return with a 500 error, which is interpreted
     // as a transient error.
-    let scoped_faulty_send = server
-        .mock_room_send()
-        .respond_with(ResponseTemplate::new(500))
-        .expect(3)
-        .mount_as_scoped()
-        .await;
+    let scoped_faulty_send = server.mock_room_send().error500().expect(3).mount_as_scoped().await;
 
     // Send two messages without mocking the server response.
     // It will respond with a 500, resulting in a failed-to-send state.
@@ -167,28 +150,20 @@ async fn test_retry_order() {
 
     // Response for first message takes 100ms to respond.
     drop(scoped_faulty_send);
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
-        .and(body_string_contains("First!"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(json!({ "event_id": "$ev0" }))
-                .set_delay(Duration::from_millis(100)),
-        )
-        .mount(server.server())
+    server
+        .mock_room_send()
+        .body_matches_partial_json(json!({ "body": "First!" }))
+        .ok_with_delay(event_id!("$ev0"), Duration::from_millis(100))
+        .mount()
         .await;
 
     // Response for second message takes 200ms to respond, so should come back
     // after first if we don't serialize retries.
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
-        .and(body_string_contains("Second."))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(json!({ "event_id": "$ev1" }))
-                .set_delay(Duration::from_millis(200)),
-        )
-        .mount(server.server())
+    server
+        .mock_room_send()
+        .body_matches_partial_json(json!({ "body": "Second." }))
+        .ok_with_delay(event_id!("$ev1"), Duration::from_millis(200))
+        .mount()
         .await;
 
     // Retry the second message first.
@@ -244,16 +219,7 @@ async fn test_reloaded_failed_local_echoes_are_marked_as_failed() {
 
     // When trying to send an event, return with a 413 error, which is interpreted
     // as a permanent error.
-    server
-        .mock_room_send()
-        .respond_with(ResponseTemplate::new(413).set_body_json(json!({
-            // From https://spec.matrix.org/v1.10/client-server-api/#standard-error-response
-            "errcode": "M_TOO_LARGE",
-            "error": "Sounds like you have a lot to say!"
-        })))
-        .expect(1)
-        .mount()
-        .await;
+    server.mock_room_send().error_too_large().expect(1).mount().await;
 
     // Sending an event will respond with a 500, resulting in a failed-to-send
     // state.
@@ -301,10 +267,7 @@ async fn test_reloaded_failed_local_echoes_are_marked_as_failed() {
             assert_matches!(&**error, QueueWedgeError::GenericApiError { msg } => { msg })
         }
     );
-    assert_eq!(
-        msg,
-        "the server returned an error: [413 / M_TOO_LARGE] Sounds like you have a lot to say!"
-    );
+    assert_eq!(msg, "the server returned an error: [413 / M_TOO_LARGE] Request body too large");
 }
 
 #[async_test]
@@ -338,14 +301,10 @@ async fn test_clear_with_echoes() {
     }
 
     // Next message will take "forever" to send.
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(json!({ "event_id": "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP" }))
-                .set_delay(Duration::from_secs(3600)),
-        )
-        .mount(server.server())
+    server
+        .mock_room_send()
+        .ok_with_delay(event_id!("$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP"), Duration::from_secs(3600))
+        .mount()
         .await;
 
     // (this one)
@@ -402,32 +361,20 @@ async fn test_no_duplicate_date_divider() {
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     // Response for first message takes 200ms to respond.
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
-        .and(body_string_contains("First!"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(json!({
-                    "event_id": "$ev0",
-                }))
-                .set_delay(Duration::from_millis(200)),
-        )
-        .mount(server.server())
+    server
+        .mock_room_send()
+        .body_matches_partial_json(json!({ "body": "First!" }))
+        .ok_with_delay(event_id!("$ev0"), Duration::from_millis(200))
+        .mount()
         .await;
 
     // Response for second message only takes 100ms to respond, so should come
     // back first if we don't serialize requests.
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
-        .and(body_string_contains("Second."))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(json!({
-                    "event_id": "$ev1",
-                }))
-                .set_delay(Duration::from_millis(100)),
-        )
-        .mount(server.server())
+    server
+        .mock_room_send()
+        .body_matches_partial_json(json!({ "body": "Second." }))
+        .ok_with_delay(event_id!("$ev1"), Duration::from_millis(100))
+        .mount()
         .await;
 
     timeline.send(RoomMessageEventContent::text_plain("First!").into()).await.unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -18,16 +18,9 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
-use matrix_sdk::{
-    Error, assert_let_timeout,
-    config::{SyncSettings, SyncToken},
-    test_utils::logged_in_client_with_server,
-};
+use matrix_sdk::{Error, assert_let_timeout, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_base::store::QueueWedgeError;
-use matrix_sdk_test::{
-    ALICE, JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
-    mocks::mock_encryption_state,
-};
+use matrix_sdk_test::{ALICE, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{EventItemOrigin, EventSendState, RoomExt};
 use ruma::{
     MilliSecondsSinceUnixEpoch, event_id, events::room::message::RoomMessageEventContent, room_id,
@@ -37,54 +30,44 @@ use stream_assert::{assert_next_matches, assert_pending};
 use tokio::{task::yield_now, time::sleep};
 use wiremock::{
     Mock, ResponseTemplate,
-    matchers::{body_string_contains, header, method, path_regex},
+    matchers::{body_string_contains, method, path_regex},
 };
-
-use crate::mock_sync;
 
 #[async_test]
 async fn test_message_order() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
-    let mut sync_response_builder = SyncResponseBuilder::new();
-    sync_response_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_response_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    server.mock_room_state_encryption().plain().mount().await;
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
     // Response for first message takes 200ms to respond
     Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
         .and(body_string_contains("First!"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(json!({ "event_id": "$ev0" }))
                 .set_delay(Duration::from_millis(200)),
         )
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     // Response for second message only takes 100ms to respond, so should come
     // back first if we don't serialize requests
     Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
         .and(body_string_contains("Second."))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(json!({ "event_id": "$ev1" }))
                 .set_delay(Duration::from_millis(100)),
         )
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     timeline.send(RoomMessageEventContent::text_plain("First!").into()).await.unwrap();
@@ -138,32 +121,22 @@ async fn test_message_order() {
 #[async_test]
 async fn test_retry_order() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
-    let mut sync_response_builder = SyncResponseBuilder::new();
-    sync_response_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_response_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    server.mock_room_state_encryption().plain().mount().await;
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
     // When trying to send an event, return with a 500 error, which is interpreted
     // as a transient error.
-    server.reset().await;
-    mock_encryption_state(&server, false).await;
-    let scoped_faulty_send = Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
-        .and(header("authorization", "Bearer 1234"))
+    let scoped_faulty_send = server
+        .mock_room_send()
         .respond_with(ResponseTemplate::new(500))
         .expect(3)
-        .mount_as_scoped(&server)
+        .mount_as_scoped()
         .await;
 
     // Send two messages without mocking the server response.
@@ -195,27 +168,27 @@ async fn test_retry_order() {
     // Response for first message takes 100ms to respond.
     drop(scoped_faulty_send);
     Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
         .and(body_string_contains("First!"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(json!({ "event_id": "$ev0" }))
                 .set_delay(Duration::from_millis(100)),
         )
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     // Response for second message takes 200ms to respond, so should come back
     // after first if we don't serialize retries.
     Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
         .and(body_string_contains("Second."))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(json!({ "event_id": "$ev1" }))
                 .set_delay(Duration::from_millis(200)),
         )
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     // Retry the second message first.
@@ -260,37 +233,26 @@ async fn test_retry_order() {
 async fn test_reloaded_failed_local_echoes_are_marked_as_failed() {
     let room_id = room_id!("!a98sd12bjh:example.org");
 
-    let (client, server) = logged_in_client_with_server().await;
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
-
-    let mut sync_response_builder = SyncResponseBuilder::new();
-    sync_response_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_response_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    server.mock_room_state_encryption().plain().mount().await;
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
-    // When trying to send an event, return with a 500 error, which is interpreted
-    // as a transient error.
-    server.reset().await;
-    mock_encryption_state(&server, false).await;
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
-        .and(header("authorization", "Bearer 1234"))
+    // When trying to send an event, return with a 413 error, which is interpreted
+    // as a permanent error.
+    server
+        .mock_room_send()
         .respond_with(ResponseTemplate::new(413).set_body_json(json!({
             // From https://spec.matrix.org/v1.10/client-server-api/#standard-error-response
             "errcode": "M_TOO_LARGE",
             "error": "Sounds like you have a lot to say!"
         })))
         .expect(1)
-        .mount(&server)
+        .mount()
         .await;
 
     // Sending an event will respond with a 500, resulting in a failed-to-send
@@ -348,21 +310,13 @@ async fn test_reloaded_failed_local_echoes_are_marked_as_failed() {
 #[async_test]
 async fn test_clear_with_echoes() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings =
-        SyncSettings::new().timeout(Duration::from_millis(3000)).token(SyncToken::NoToken);
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let f = EventFactory::new();
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    server.mock_room_state_encryption().plain().mount().await;
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = room.timeline().await.unwrap();
 
     // Send a message without mocking the server response.
@@ -385,25 +339,26 @@ async fn test_clear_with_echoes() {
 
     // Next message will take "forever" to send.
     Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(json!({ "event_id": "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP" }))
                 .set_delay(Duration::from_secs(3600)),
         )
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     // (this one)
     timeline.send(RoomMessageEventContent::text_plain("Pending").into()).await.unwrap();
 
     // Another message comes in.
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(f.text_msg("another message").sender(&ALICE)),
-    );
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    client.sync_once(sync_settings.clone()).await.unwrap();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.text_msg("another message").sender(&ALICE)),
+        )
+        .await;
 
     // At this point, there should be three timeline items:
     let timeline_items = timeline.items().await;
@@ -438,26 +393,17 @@ async fn test_clear_with_echoes() {
 #[async_test]
 async fn test_no_duplicate_date_divider() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings =
-        SyncSettings::new().timeout(Duration::from_millis(3000)).token(SyncToken::NoToken);
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
-    let mut sync_response_builder = SyncResponseBuilder::new();
-    sync_response_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_response_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    server.mock_room_state_encryption().plain().mount().await;
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     // Response for first message takes 200ms to respond.
     Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
         .and(body_string_contains("First!"))
         .respond_with(
             ResponseTemplate::new(200)
@@ -466,13 +412,13 @@ async fn test_no_duplicate_date_divider() {
                 }))
                 .set_delay(Duration::from_millis(200)),
         )
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     // Response for second message only takes 100ms to respond, so should come
     // back first if we don't serialize requests.
     Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(path_regex(r"^/_matrix/client/v3/rooms/.*/send/.*"))
         .and(body_string_contains("Second."))
         .respond_with(
             ResponseTemplate::new(200)
@@ -481,7 +427,7 @@ async fn test_no_duplicate_date_divider() {
                 }))
                 .set_delay(Duration::from_millis(100)),
         )
-        .mount(&server)
+        .mount(server.server())
         .await;
 
     timeline.send(RoomMessageEventContent::text_plain("First!").into()).await.unwrap();
@@ -545,19 +491,22 @@ async fn test_no_duplicate_date_divider() {
     let now = MilliSecondsSinceUnixEpoch::now();
     f.set_next_ts(now.0.into());
 
-    sync_response_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(
-                f.text_msg("First!").sender(client.user_id().unwrap()).event_id(event_id!("$ev2")),
-            )
-            .add_timeline_event(
-                f.text_msg("Second.").sender(client.user_id().unwrap()).event_id(event_id!("$ev3")),
-            ),
-    );
-
-    mock_sync(&server, sync_response_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    f.text_msg("First!")
+                        .sender(client.user_id().unwrap())
+                        .event_id(event_id!("$ev2")),
+                )
+                .add_timeline_event(
+                    f.text_msg("Second.")
+                        .sender(client.user_id().unwrap())
+                        .event_id(event_id!("$ev3")),
+                ),
+        )
+        .await;
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{sync::Mutex, time::Duration};
+use std::time::Duration;
 
 use assert_matches2::{assert_let, assert_matches};
 use eyeball_im::VectorDiff;
@@ -21,10 +21,8 @@ use matrix_sdk::{assert_let_timeout, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_test::{ALICE, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{EventSendState, ReactionStatus, RoomExt as _};
 use ruma::{event_id, events::room::message::RoomMessageEventContent, room_id};
-use serde_json::json;
 use stream_assert::assert_pending;
-use tokio::sync::oneshot;
-use wiremock::ResponseTemplate;
+use tokio::time::sleep;
 
 #[async_test]
 async fn test_abort_before_being_sent() {
@@ -76,31 +74,15 @@ async fn test_abort_before_being_sent() {
     // Mock the send endpoint with a delay, to give us time to abort the sending.
     server
         .mock_room_send()
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(json!({
-                    "event_id": "$2",
-                }))
-                .set_delay(Duration::from_millis(150)),
-        )
+        .ok_with_delay(event_id!("$2"), Duration::from_millis(150))
         .mock_once()
         .named("send for the first reaction")
         .mount()
         .await;
 
-    let (tx, rx) = oneshot::channel();
-    let tx = Mutex::new(Some(tx));
-
     server
         .mock_room_redact()
-        .respond_with(move |_req: &wiremock::Request| {
-            // Notify the main task that we're done with handling the request.
-            let mut tx_guard = tx.lock().unwrap();
-            let tx = tx_guard.take().expect("this endpoint called only once");
-            tx.send(()).unwrap();
-            // Return a response.
-            ResponseTemplate::new(200).set_body_json(json!({ "event_id": "$2" }))
-        })
+        .ok(event_id!("$3"))
         .named("redact for the first reaction")
         .mock_once()
         .mount()
@@ -188,8 +170,8 @@ async fn test_abort_before_being_sent() {
         assert_pending!(stream);
     }
 
-    // Wait for the redaction to be done in the background.
-    tokio::time::timeout(Duration::from_secs(2), rx).await.expect("timeout").expect("recv error");
+    // Let the send queue process the redaction in the background.
+    sleep(Duration::from_millis(300)).await;
 
     assert_let_timeout!(Some(timeline_updates) = stream.next());
     assert_eq!(timeline_updates.len(), 1);
@@ -276,7 +258,7 @@ async fn test_redact_failed() {
         1
     );
 
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    sleep(Duration::from_millis(150)).await;
     assert_pending!(stream);
 }
 
@@ -299,28 +281,18 @@ async fn test_local_reaction_to_local_echo() {
 
     assert!(initial_items.is_empty());
 
+    // Mock for the first message.
     // Add a duration to the response, so we can check other things in the
     // meanwhile.
-    let next_event_id = Mutex::new(0);
-
     server
         .mock_room_send()
-        .respond_with(move |_req: &wiremock::Request| {
-            let mut next_event_id = next_event_id.lock().unwrap();
-            let event_id = *next_event_id;
-            *next_event_id += 1;
-            let mut tmp = ResponseTemplate::new(200).set_body_json(json!({
-                "event_id": format!("${event_id}"),
-            }));
-
-            if event_id == 0 {
-                tmp = tmp.set_delay(Duration::from_secs(1));
-            }
-
-            tmp
-        })
+        .ok_with_delay(event_id!("$0"), Duration::from_millis(150))
+        .mock_once()
         .mount()
         .await;
+
+    // Mock for the first reaction.
+    server.mock_room_send().ok(event_id!("$1")).mock_once().mount().await;
 
     // Send a local event.
     let _ = timeline.send(RoomMessageEventContent::text_plain("lol").into()).await.unwrap();
@@ -458,6 +430,6 @@ async fn test_local_reaction_to_local_echo() {
     }
 
     // And we're done.
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    sleep(Duration::from_millis(150)).await;
     assert_pending!(stream);
 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -21,19 +21,19 @@ use eyeball_im::{Vector, VectorDiff};
 use futures_util::{Stream, StreamExt, pin_mut};
 use matrix_sdk::{
     Client, SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
-    assert_let_timeout, test_utils::logged_in_client_with_server,
+    assert_let_timeout, test_utils::mocks::MatrixMockServer,
 };
-use matrix_sdk_test::{async_test, mocks::mock_encryption_state};
+use matrix_sdk_test::async_test;
 use matrix_sdk_ui::timeline::{
     TimelineBuilder, TimelineItem, TimelineItemKind, TimelineReadReceiptTracking,
 };
 use ruma::{RoomId, room_id, user_id};
 use serde_json::json;
-use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate, http::Method};
+use wiremock::{Match, Mock, Request, ResponseTemplate, http::Method};
 
 macro_rules! receive_response {
     (
-        [$server:ident, $sliding_sync_stream:ident]
+        [$server:expr, $sliding_sync_stream:ident]
         $( $json:tt )+
     ) => {
         {
@@ -41,7 +41,7 @@ macro_rules! receive_response {
                 .respond_with(ResponseTemplate::new(200).set_body_json(
                     json!( $( $json )+ )
                 ))
-                .mount_as_scoped(&$server)
+                .mount_as_scoped($server)
                 .await;
 
             let next = $sliding_sync_stream.next().await.context("`sync` trip")??;
@@ -357,8 +357,9 @@ pub(crate) use assert_timeline_stream;
 
 async fn new_sliding_sync(
     lists: Vec<SlidingSyncListBuilder>,
-) -> Result<(Client, MockServer, SlidingSync)> {
-    let (client, server) = logged_in_client_with_server().await;
+) -> Result<(Client, MatrixMockServer, SlidingSync)> {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let mut sliding_sync_builder = client.sliding_sync("integration-test")?;
 
@@ -372,13 +373,13 @@ async fn new_sliding_sync(
 }
 
 async fn create_one_room(
-    server: &MockServer,
+    server: &MatrixMockServer,
     stream: &mut Pin<&mut impl Stream<Item = matrix_sdk::Result<UpdateSummary>>>,
     room_id: &RoomId,
     room_name: String,
 ) -> Result<()> {
     let update = receive_response!(
-        [server, stream]
+        [server.server(), stream]
         {
             "pos": "foo",
             "lists": {},
@@ -438,7 +439,7 @@ async fn test_timeline_basic() -> Result<()> {
 
     create_one_room(&server, &mut stream, room_id, "Room Name".to_owned()).await?;
 
-    mock_encryption_state(&server, false).await;
+    server.mock_room_state_encryption().plain().mount().await;
 
     let (timeline_items, mut timeline_stream) = timeline_test_helper(&client, room_id).await?;
     assert!(timeline_items.is_empty());
@@ -446,7 +447,7 @@ async fn test_timeline_basic() -> Result<()> {
     // Receiving a bunch of events.
     {
         receive_response! {
-            [server, stream]
+            [server.server(), stream]
             {
                 "pos": "1",
                 "lists": {},
@@ -488,14 +489,14 @@ async fn test_timeline_duplicated_events() -> Result<()> {
 
     create_one_room(&server, &mut stream, room_id, "Room Name".to_owned()).await?;
 
-    mock_encryption_state(&server, false).await;
+    server.mock_room_state_encryption().plain().mount().await;
 
     let (_, mut timeline_stream) = timeline_test_helper(&client, room_id).await?;
 
     // Receiving events.
     {
         receive_response! {
-            [server, stream]
+            [server.server(), stream]
             {
                 "pos": "1",
                 "lists": {},
@@ -525,7 +526,7 @@ async fn test_timeline_duplicated_events() -> Result<()> {
     // Receiving new events, where the first has already been received.
     {
         receive_response! {
-            [server, stream]
+            [server.server(), stream]
             {
                 "pos": "3",
                 "lists": {},
@@ -568,7 +569,7 @@ async fn test_timeline_read_receipts_are_updated_live() -> Result<()> {
 
     create_one_room(&server, &mut stream, room_id, "Room Name".to_owned()).await?;
 
-    mock_encryption_state(&server, false).await;
+    server.mock_room_state_encryption().plain().mount().await;
 
     let (timeline_items, mut timeline_stream) = timeline_test_helper(&client, room_id).await?;
     assert!(timeline_items.is_empty());
@@ -576,7 +577,7 @@ async fn test_timeline_read_receipts_are_updated_live() -> Result<()> {
     // Receiving initial events.
     {
         receive_response! {
-            [server, stream]
+            [server.server(), stream]
             {
                 "pos": "1",
                 "lists": {},
@@ -603,7 +604,7 @@ async fn test_timeline_read_receipts_are_updated_live() -> Result<()> {
     // Now receiving a read receipt from another user in the room.
     {
         receive_response! {
-            [server, stream]
+            [server.server(), stream]
             {
                 "pos": "2",
                 "lists": {},

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -18,16 +18,9 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
-use matrix_sdk::{
-    assert_let_timeout,
-    config::{SyncSettings, SyncToken},
-    test_utils::logged_in_client_with_server,
-};
+use matrix_sdk::{assert_let_timeout, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_common::executor::spawn;
-use matrix_sdk_test::{
-    ALICE, BOB, JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
-    mocks::mock_encryption_state,
-};
+use matrix_sdk_test::{ALICE, BOB, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use matrix_sdk_ui::timeline::{RoomExt, TimelineDetails};
 use ruma::{
     event_id,
@@ -39,26 +32,16 @@ use ruma::{
 };
 use stream_assert::assert_pending;
 
-use crate::mock_sync;
-
 #[async_test]
 async fn test_batched() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings =
-        SyncSettings::new().timeout(Duration::from_millis(3000)).token(SyncToken::NoToken);
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
     let f = EventFactory::new();
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    server.mock_room_state_encryption().plain().mount().await;
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = room.timeline_builder().event_filter(|_, _| true).build().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
@@ -69,17 +52,19 @@ async fn test_batched() {
         assert!(next_batch.len() >= 3);
     });
 
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(f.text_msg("text message event").sender(&ALICE))
-            .add_timeline_event(
-                f.member(&BOB).membership(MembershipState::Join).previous(MembershipState::Invite),
-            )
-            .add_timeline_event(f.notice("notice message event").sender(&BOB)),
-    );
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.text_msg("text message event").sender(&ALICE))
+                .add_timeline_event(
+                    f.member(&BOB)
+                        .membership(MembershipState::Join)
+                        .previous(MembershipState::Invite),
+                )
+                .add_timeline_event(f.notice("notice message event").sender(&BOB)),
+        )
+        .await;
 
     tokio::time::timeout(Duration::from_millis(500), hdl).await.unwrap().unwrap();
 }
@@ -87,32 +72,24 @@ async fn test_batched() {
 #[async_test]
 async fn test_event_filter() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings =
-        SyncSettings::new().timeout(Duration::from_millis(3000)).token(SyncToken::NoToken);
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
     let f = EventFactory::new();
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    server.mock_room_state_encryption().plain().mount().await;
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = room.timeline_builder().event_filter(|_, _| true).build().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let first_event_id = event_id!("$YTQwYl2ply");
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
-        f.text_msg("hello").sender(user_id!("@alice:example.org")).event_id(first_event_id),
-    ));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(
+                f.text_msg("hello").sender(user_id!("@alice:example.org")).event_id(first_event_id),
+            ),
+        )
+        .await;
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 2);
@@ -131,23 +108,22 @@ async fn test_event_filter() {
 
     let second_event_id = event_id!("$Ga6Y2l0gKY");
     let edit_event_id = event_id!("$7i9In0gEmB");
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id).add_timeline_bulk([
-            f.text_html("Test", "<em>Test</em>")
-                .sender(user_id!("@bob:example.org"))
-                .event_id(second_event_id)
-                .into(),
-            f.text_msg(" * hi")
-                .sender(user_id!("@alice:example.org"))
-                .event_id(edit_event_id)
-                .edit(first_event_id, RoomMessageEventContent::text_plain("hi").into())
-                .into(),
-        ]),
-    );
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_bulk([
+                f.text_html("Test", "<em>Test</em>")
+                    .sender(user_id!("@bob:example.org"))
+                    .event_id(second_event_id)
+                    .into(),
+                f.text_msg(" * hi")
+                    .sender(user_id!("@alice:example.org"))
+                    .event_id(edit_event_id)
+                    .edit(first_event_id, RoomMessageEventContent::text_plain("hi").into())
+                    .into(),
+            ]),
+        )
+        .await;
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 3);
@@ -178,20 +154,10 @@ async fn test_event_filter() {
 #[async_test]
 async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings =
-        SyncSettings::new().timeout(Duration::from_millis(3000)).token(SyncToken::NoToken);
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = room.timeline_builder().build().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
@@ -204,18 +170,21 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
 
     let mut ev_factory = EventFactory::new().room(room_id);
 
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(ev_factory.text_msg("hello").sender(alice).event_id(first_event_id))
-            .add_timeline_event(ev_factory.text_msg("hello").sender(bob).event_id(second_event_id))
-            .add_timeline_event(
-                ev_factory.text_msg("hello").sender(alice).event_id(third_event_id),
-            ),
-    );
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    ev_factory.text_msg("hello").sender(alice).event_id(first_event_id),
+                )
+                .add_timeline_event(
+                    ev_factory.text_msg("hello").sender(bob).event_id(second_event_id),
+                )
+                .add_timeline_event(
+                    ev_factory.text_msg("hello").sender(alice).event_id(third_event_id),
+                ),
+        )
+        .await;
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 5);
@@ -237,11 +206,12 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
 
     assert_pending!(timeline_stream);
 
-    sync_builder.add_global_account_data(ev_factory.ignored_user_list([bob.to_owned()]));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .mock_sync()
+        .ok_and_run(&client, |builder| {
+            builder.add_global_account_data(ev_factory.ignored_user_list([bob.to_owned()]));
+        })
+        .await;
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
@@ -255,15 +225,14 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     // All the next events are sent by Alice now.
     ev_factory = ev_factory.sender(alice);
 
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(ev_factory.text_msg("hello").event_id(fourth_event_id))
-            .add_timeline_event(ev_factory.text_msg("hello").event_id(fifth_event_id)),
-    );
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(ev_factory.text_msg("hello").event_id(fourth_event_id))
+                .add_timeline_event(ev_factory.text_msg("hello").event_id(fifth_event_id)),
+        )
+        .await;
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 4);
@@ -287,21 +256,12 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
 #[async_test]
 async fn test_profile_updates() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client_with_server().await;
-    let sync_settings =
-        SyncSettings::new().timeout(Duration::from_millis(3000)).token(SyncToken::NoToken);
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
     let f = EventFactory::new();
 
-    let mut sync_builder = SyncResponseBuilder::new();
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
-
-    let room = client.get_room(room_id).unwrap();
+    server.mock_room_state_encryption().plain().mount().await;
+    let room = server.sync_joined_room(&client, room_id).await;
     let timeline = room.timeline_builder().build().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
@@ -312,14 +272,15 @@ async fn test_profile_updates() {
     let event_1_id = event_id!("$YTQwYl2pl1");
     let event_2_id = event_id!("$YTQwYl2pl2");
 
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_bulk([
-        f.text_msg("hello").event_id(event_1_id).sender(alice).into(),
-        f.text_msg("hello").event_id(event_2_id).sender(bob).into(),
-    ]));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_bulk([
+                f.text_msg("hello").event_id(event_1_id).sender(alice).into(),
+                f.text_msg("hello").event_id(event_2_id).sender(bob).into(),
+            ]),
+        )
+        .await;
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 3);
@@ -344,15 +305,16 @@ async fn test_profile_updates() {
     let event_4_id = event_id!("$YTQwYl2pl4");
     let event_5_id = event_id!("$YTQwYl2pl5");
 
-    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_bulk([
-        f.member(bob).display_name("Member").event_id(event_3_id).into(),
-        f.member(alice).display_name("Alice").event_id(event_4_id).into(),
-        f.text_msg("hello").event_id(event_5_id).sender(alice).into(),
-    ]));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_bulk([
+                f.member(bob).display_name("Member").event_id(event_3_id).into(),
+                f.member(alice).display_name("Alice").event_id(event_4_id).into(),
+                f.text_msg("hello").event_id(event_5_id).sender(alice).into(),
+            ]),
+        )
+        .await;
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 8);
@@ -414,14 +376,13 @@ async fn test_profile_updates() {
     // Change name to be ambiguous.
     let event_6_id = event_id!("$YTQwYl2pl6");
 
-    sync_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(f.member(alice).display_name("Member").event_id(event_6_id)),
-    );
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.member(alice).display_name("Member").event_id(event_6_id)),
+        )
+        .await;
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 7);

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -2937,6 +2937,19 @@ impl<'a> MockEndpoint<'a, RoomEventEndpoint> {
             .respond_with(ResponseTemplate::new(200).set_body_json(event.into_raw().json()));
         MatrixMock { server: self.server, mock }
     }
+
+    /// Returns a room event endpoint mock with a custom [`ResponseTemplate`].
+    ///
+    /// The path restriction is applied automatically. This is useful when you
+    /// need to configure specific response properties like delays.
+    pub fn ok_with_template(self, template: ResponseTemplate) -> MatrixMock<'a> {
+        let room_path = self.endpoint.room.map_or_else(|| ".*".to_owned(), |room| room.to_string());
+        let mock = self
+            .mock
+            .and(path_regex(format!(r"^/_matrix/client/v3/rooms/{room_path}/event/")))
+            .respond_with(template);
+        MatrixMock { server: self.server, mock }
+    }
 }
 
 /// A builder pattern for the response to a [`RoomEventContextEndpoint`]

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -169,6 +169,14 @@ pub struct MatrixMockServer {
     token_counter: AtomicU32,
 }
 
+impl std::ops::Deref for MatrixMockServer {
+    type Target = MockServer;
+
+    fn deref(&self) -> &Self::Target {
+        &self.server
+    }
+}
+
 impl MatrixMockServer {
     /// Create a new [`wiremock`] server specialized for Matrix usage.
     pub async fn new() -> Self {

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -2068,6 +2068,7 @@ impl<'a, T> MockEndpoint<'a, T> {
         self.respond_with(ResponseTemplate::new(413).set_body_json(json!({
             // From https://spec.matrix.org/v1.10/client-server-api/#standard-error-response
             "errcode": "M_TOO_LARGE",
+            "error": "Request body too large",
         })))
     }
 }
@@ -2323,6 +2324,62 @@ impl<'a> MockEndpoint<'a, RoomSendEndpoint> {
     /// ```
     pub fn ok(self, returned_event_id: impl Into<OwnedEventId>) -> MatrixMock<'a> {
         self.ok_with_event_id(returned_event_id.into())
+    }
+
+    /// Returns a send endpoint that emulates success after a delay, i.e. the
+    /// event has been sent with the given event id, but the response is delayed
+    /// by the given duration.
+    ///
+    /// This is useful for testing ordering guarantees when multiple events are
+    /// in-flight simultaneously.
+    ///
+    /// # Examples
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// use std::time::Duration;
+    ///
+    /// use matrix_sdk::{
+    ///     ruma::{event_id, room_id},
+    ///     test_utils::mocks::MatrixMockServer,
+    /// };
+    /// use serde_json::json;
+    ///
+    /// let mock_server = MatrixMockServer::new().await;
+    /// let client = mock_server.client_builder().build().await;
+    ///
+    /// mock_server.mock_room_state_encryption().plain().mount().await;
+    ///
+    /// let room = mock_server
+    ///     .sync_joined_room(&client, room_id!("!room_id:localhost"))
+    ///     .await;
+    ///
+    /// mock_server
+    ///     .mock_room_send()
+    ///     .ok_with_delay(event_id!("$some_id"), Duration::from_millis(100))
+    ///     .mock_once()
+    ///     .mount()
+    ///     .await;
+    ///
+    /// let result = room.send_raw("m.room.message", json!({ "body": "Hello world" })).await?;
+    ///
+    /// assert_eq!(
+    ///     event_id!("$some_id"),
+    ///     result.response.event_id,
+    ///     "The event ID we mocked should match the one we received when we sent the event"
+    /// );
+    /// # anyhow::Ok(()) });
+    /// ```
+    pub fn ok_with_delay(
+        self,
+        returned_event_id: impl Into<OwnedEventId>,
+        delay: Duration,
+    ) -> MatrixMock<'a> {
+        let event_id = returned_event_id.into();
+        self.respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!({ "event_id": event_id }))
+                .set_delay(delay),
+        )
     }
 
     /// Returns a send endpoint that emulates success, i.e. the event has been


### PR DESCRIPTION
Some simple test refactorings, making more use of the `MatrixMockServer` and removing some duplicate helpers.

- [ ] No public changes
- [x] This PR was made with the help of AI.