### PR TITLE
feat(ffi): expose Room.get_state_event(), Room.account_data(), and Room.set_account_data()

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -41,6 +41,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Expose `Room.account_data()`, `Room.set_account_data()`, and `Room.get_state_event()`
+  through FFI bindings, allowing non-Rust clients to read/write room-scoped account data
+  and read room state events.
 - Added the `Client::import_secrets_bundle` method.
   ([#6212](https://github.com/matrix-org/matrix-rust-sdk/pull/6212))
 - [**breaking**] Remove support for `native-tls` and remove all feature

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -38,6 +38,7 @@ use ruma::{
     ServerName, UserId, assign,
     events::{
         AnyMessageLikeEventContent, AnySyncTimelineEvent,
+        RoomAccountDataEventType as RumaRoomAccountDataEventType,
         receipt::ReceiptThread,
         room::{
             MediaSource as RumaMediaSource, avatar::ImageInfo as RumaAvatarImageInfo,
@@ -45,6 +46,7 @@ use ruma::{
             join_rules::JoinRule as RumaJoinRule, message::RoomMessageEventContentWithoutRelation,
         },
     },
+    serde::Raw,
 };
 use tracing::{error, warn};
 
@@ -697,6 +699,34 @@ impl Room {
     /// explicitly marked it as unread.
     pub async fn set_unread_flag(&self, new_value: bool) -> Result<(), ClientError> {
         Ok(self.inner.set_unread_flag(new_value).await?)
+    }
+
+    /// Get the content of the event of the given type out of the room's
+    /// account data store.
+    ///
+    /// It will be returned as a JSON string.
+    pub async fn account_data(
+        &self,
+        event_type: String,
+    ) -> Result<Option<String>, ClientError> {
+        let event_type = RumaRoomAccountDataEventType::from(event_type);
+        let event = self.inner.account_data(event_type).await?;
+        Ok(event.map(|e| e.json().get().to_owned()))
+    }
+
+    /// Set the given account data content for the given event type in
+    /// this room.
+    ///
+    /// It should be supplied as a JSON string.
+    pub async fn set_account_data(
+        &self,
+        event_type: String,
+        content: String,
+    ) -> Result<(), ClientError> {
+        let event_type = RumaRoomAccountDataEventType::from(event_type);
+        let raw_content = Raw::from_json_string(content)?;
+        self.inner.set_account_data_raw(event_type, raw_content).await?;
+        Ok(())
     }
 
     /// Mark a room as read, by attaching a read receipt on the latest event.

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -33,12 +33,14 @@ use matrix_sdk_ui::{
     unable_to_decrypt_hook::UtdHookManager,
 };
 use mime::Mime;
+use matrix_sdk_base::deserialized_responses::RawAnySyncOrStrippedState;
 use ruma::{
     EventId, Int, OwnedDeviceId, OwnedRoomOrAliasId, OwnedServerName, OwnedUserId, RoomAliasId,
     ServerName, UserId, assign,
     events::{
         AnyMessageLikeEventContent, AnySyncTimelineEvent,
         RoomAccountDataEventType as RumaRoomAccountDataEventType,
+        StateEventType as RumaStateEventType,
         receipt::ReceiptThread,
         room::{
             MediaSource as RumaMediaSource, avatar::ImageInfo as RumaAvatarImageInfo,
@@ -727,6 +729,23 @@ impl Room {
         let raw_content = Raw::from_json_string(content)?;
         self.inner.set_account_data_raw(event_type, raw_content).await?;
         Ok(())
+    }
+
+    /// Get a specific state event in this room, from the local store.
+    ///
+    /// It will be returned as a raw JSON string, or `None` if no such
+    /// state event exists.
+    pub async fn get_state_event(
+        &self,
+        event_type: String,
+        state_key: String,
+    ) -> Result<Option<String>, ClientError> {
+        let event_type = RumaStateEventType::from(event_type);
+        let raw = self.inner.get_state_event(event_type, &state_key).await?;
+        Ok(raw.map(|e| match e {
+            RawAnySyncOrStrippedState::Sync(ev) => ev.json().get().to_owned(),
+            RawAnySyncOrStrippedState::Stripped(ev) => ev.json().get().to_owned(),
+        }))
     }
 
     /// Mark a room as read, by attaching a read receipt on the latest event.

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -27,13 +27,13 @@ use matrix_sdk::{
     },
     send_queue::RoomSendQueueUpdate as SdkRoomSendQueueUpdate,
 };
+use matrix_sdk_base::deserialized_responses::RawAnySyncOrStrippedState;
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
 use matrix_sdk_ui::{
     timeline::{RoomExt, TimelineBuilder, default_event_filter},
     unable_to_decrypt_hook::UtdHookManager,
 };
 use mime::Mime;
-use matrix_sdk_base::deserialized_responses::RawAnySyncOrStrippedState;
 use ruma::{
     EventId, Int, OwnedDeviceId, OwnedRoomOrAliasId, OwnedServerName, OwnedUserId, RoomAliasId,
     ServerName, UserId, assign,
@@ -707,10 +707,7 @@ impl Room {
     /// account data store.
     ///
     /// It will be returned as a JSON string.
-    pub async fn account_data(
-        &self,
-        event_type: String,
-    ) -> Result<Option<String>, ClientError> {
+    pub async fn account_data(&self, event_type: String) -> Result<Option<String>, ClientError> {
         let event_type = RumaRoomAccountDataEventType::from(event_type);
         let event = self.inner.account_data(event_type).await?;
         Ok(event.map(|e| e.json().get().to_owned()))

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -704,20 +704,25 @@ impl Room {
     }
 
     /// Get the content of the event of the given type out of the room's
-    /// account data store.
+    /// account data store as a JSON string.
     ///
-    /// It will be returned as a JSON string.
-    pub async fn account_data(&self, event_type: String) -> Result<Option<String>, ClientError> {
+    /// This is mostly useful for custom event types that are not modeled by
+    /// typed SDK APIs.
+    pub async fn account_data_json(
+        &self,
+        event_type: String,
+    ) -> Result<Option<String>, ClientError> {
         let event_type = RumaRoomAccountDataEventType::from(event_type);
         let event = self.inner.account_data(event_type).await?;
         Ok(event.map(|e| e.json().get().to_owned()))
     }
 
     /// Set the given account data content for the given event type in
-    /// this room.
+    /// this room, from a JSON string.
     ///
-    /// It should be supplied as a JSON string.
-    pub async fn set_account_data(
+    /// This is mostly useful for custom event types that are not modeled by
+    /// typed SDK APIs.
+    pub async fn set_account_data_json(
         &self,
         event_type: String,
         content: String,
@@ -728,11 +733,12 @@ impl Room {
         Ok(())
     }
 
-    /// Get a specific state event in this room, from the local store.
+    /// Get a specific state event in this room, from the local store, as a
+    /// JSON string.
     ///
-    /// It will be returned as a raw JSON string, or `None` if no such
-    /// state event exists.
-    pub async fn get_state_event(
+    /// This is mostly useful for custom event types that are not modeled by
+    /// typed SDK APIs. Returns `None` if no such state event exists.
+    pub async fn get_state_event_json(
         &self,
         event_type: String,
         state_key: String,


### PR DESCRIPTION
Expose room-scoped state event reading and account data read/write through the FFI bindings.

## Motivation

Non-Rust clients (Swift/iOS, Kotlin/Android) currently have no way to read arbitrary room state events or room-scoped account data through FFI. The underlying SDK already has Room::get_state_event(), Room::account_data(), and Room::set_account_data_raw() — this PR surfaces them.

- Room.account_data(event_type) / Room.set_account_data(event_type, content) follow the same pattern as the existing Client.account_data() / Client.set_account_data()
- Room.get_state_event(event_type, state_key) complements the already-merged Room.send_state_event_raw() (#6350) with the read side

Tested by integrating a build into our iOS application.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 