### PR TITLE
feat(ffi): expose required_state configuration on SyncServiceBuilder

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -41,6 +41,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add `SyncServiceBuilder::with_required_state()` to request additional state
+  events during sliding sync. The provided entries are merged with the built-in
+  defaults, ensuring that essential state events are always requested.
 - Added the `Client::import_secrets_bundle` method.
   ([#6212](https://github.com/matrix-org/matrix-rust-sdk/pull/6212))
 - [**breaking**] Remove support for `native-tls` and remove all feature

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -41,9 +41,13 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Add `SyncServiceBuilder::with_required_state()` to request additional state
-  events during sliding sync. The provided entries are merged with the built-in
-  defaults, ensuring that essential state events are always requested.
+- Add `SyncServiceBuilder::with_all_rooms_required_state()` to request
+  additional state events for `ALL_ROOMS` during sliding sync. The provided
+  entries are merged with the built-in defaults for that list, and user
+  entries override defaults with the same event type.
+- Expose `Room.account_data()`, `Room.set_account_data()`, and `Room.get_state_event()`
+  through FFI bindings, allowing non-Rust clients to read/write room-scoped account data
+  and read room state events.
 - Added the `Client::import_secrets_bundle` method.
   ([#6212](https://github.com/matrix-org/matrix-rust-sdk/pull/6212))
 - [**breaking**] Remove support for `native-tls` and remove all feature

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -26,8 +26,8 @@ use matrix_sdk_ui::{
 };
 
 use crate::{
-    TaskHandle, error::ClientError, helpers::unwrap_or_clone_arc, room_list::RoomListService,
-    runtime::get_runtime_handle,
+    TaskHandle, error::ClientError, event::StateEventType, helpers::unwrap_or_clone_arc,
+    room_list::RoomListService, runtime::get_runtime_handle,
 };
 
 #[derive(uniffi::Enum)]
@@ -101,6 +101,13 @@ impl SyncService {
     }
 }
 
+/// A state event type and state key pair to request during sliding sync.
+#[derive(Clone, uniffi::Record)]
+pub struct RequiredState {
+    pub event_type: StateEventType,
+    pub state_key: String,
+}
+
 #[derive(Clone, uniffi::Object)]
 pub struct SyncServiceBuilder {
     builder: MatrixSyncServiceBuilder,
@@ -125,6 +132,24 @@ impl SyncServiceBuilder {
     pub fn with_share_pos(self: Arc<Self>, enable: bool) -> Arc<Self> {
         let this = unwrap_or_clone_arc(self);
         let builder = this.builder.with_share_pos(enable);
+        Arc::new(Self { builder, ..this })
+    }
+
+    /// Request additional state events during sliding sync.
+    ///
+    /// These entries are merged with the built-in defaults; they do not
+    /// replace them. Use the special state key `"*"` to request all state
+    /// keys for a given event type.
+    pub fn with_required_state(
+        self: Arc<Self>,
+        required_state: Vec<RequiredState>,
+    ) -> Arc<Self> {
+        let this = unwrap_or_clone_arc(self);
+        let entries: Vec<(ruma::events::StateEventType, String)> = required_state
+            .into_iter()
+            .map(|rs| (rs.event_type.into(), rs.state_key))
+            .collect();
+        let builder = this.builder.with_required_state(entries);
         Arc::new(Self { builder, ..this })
     }
 

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -101,7 +101,7 @@ impl SyncService {
     }
 }
 
-/// A state event type and state key pair to request during sliding sync.
+/// A state event type and state key pair to request for `lists.ALL_ROOMS`.
 #[derive(Clone, uniffi::Record)]
 pub struct RequiredState {
     pub event_type: StateEventType,
@@ -135,16 +135,21 @@ impl SyncServiceBuilder {
         Arc::new(Self { builder, ..this })
     }
 
-    /// Request additional state events during sliding sync.
+    /// Request additional state entries for `lists.ALL_ROOMS.required_state`.
     ///
-    /// These entries are merged with the built-in defaults; they do not
-    /// replace them. Use the special state key `"*"` to request all state
-    /// keys for a given event type.
-    pub fn with_required_state(self: Arc<Self>, required_state: Vec<RequiredState>) -> Arc<Self> {
+    /// User-provided entries override built-in defaults for matching event
+    /// types. This does not affect `room_subscriptions.required_state`.
+    ///
+    /// Use the special state key `"*"` to request all state keys for a given
+    /// state event type.
+    pub fn with_all_rooms_required_state(
+        self: Arc<Self>,
+        required_state: Vec<RequiredState>,
+    ) -> Arc<Self> {
         let this = unwrap_or_clone_arc(self);
-        let entries: Vec<(ruma::events::StateEventType, String)> =
+        let entries =
             required_state.into_iter().map(|rs| (rs.event_type.into(), rs.state_key)).collect();
-        let builder = this.builder.with_required_state(entries);
+        let builder = this.builder.with_all_rooms_required_state(entries);
         Arc::new(Self { builder, ..this })
     }
 

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -140,10 +140,7 @@ impl SyncServiceBuilder {
     /// These entries are merged with the built-in defaults; they do not
     /// replace them. Use the special state key `"*"` to request all state
     /// keys for a given event type.
-    pub fn with_required_state(
-        self: Arc<Self>,
-        required_state: Vec<RequiredState>,
-    ) -> Arc<Self> {
+    pub fn with_required_state(self: Arc<Self>, required_state: Vec<RequiredState>) -> Arc<Self> {
         let this = unwrap_or_clone_arc(self);
         let entries: Vec<(ruma::events::StateEventType, String)> = required_state
             .into_iter()

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -142,10 +142,8 @@ impl SyncServiceBuilder {
     /// keys for a given event type.
     pub fn with_required_state(self: Arc<Self>, required_state: Vec<RequiredState>) -> Arc<Self> {
         let this = unwrap_or_clone_arc(self);
-        let entries: Vec<(ruma::events::StateEventType, String)> = required_state
-            .into_iter()
-            .map(|rs| (rs.event_type.into(), rs.state_key))
-            .collect();
+        let entries: Vec<(ruma::events::StateEventType, String)> =
+            required_state.into_iter().map(|rs| (rs.event_type.into(), rs.state_key)).collect();
         let builder = this.builder.with_required_state(entries);
         Arc::new(Self { builder, ..this })
     }

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -121,6 +121,10 @@ pub struct RoomListService {
     ///
     /// `RoomListService` is a simple state-machine.
     state_machine: StateMachine,
+
+    /// Additional required state events requested by the caller, merged with
+    /// the defaults for both the all-rooms list and room subscriptions.
+    extra_required_state: Vec<(StateEventType, String)>,
 }
 
 impl RoomListService {
@@ -141,6 +145,17 @@ impl RoomListService {
     ///
     /// [`SlidingSyncBuilder::share_pos`]: matrix_sdk::sliding_sync::SlidingSyncBuilder::share_pos
     pub async fn new_with_share_pos(client: Client, share_pos: bool) -> Result<Self, Error> {
+        Self::new_with_extra_required_state(client, share_pos, vec![]).await
+    }
+
+    /// Like [`RoomListService::new_with_share_pos`] but with additional
+    /// required state events that will be merged with the defaults for both
+    /// the all-rooms list and room subscriptions.
+    pub async fn new_with_extra_required_state(
+        client: Client,
+        share_pos: bool,
+        extra_required_state: Vec<(StateEventType, String)>,
+    ) -> Result<Self, Error> {
         let mut builder = client
             .sliding_sync("room-list")
             .map_err(Error::SlidingSync)?
@@ -205,6 +220,7 @@ impl RoomListService {
                         DEFAULT_REQUIRED_STATE
                             .iter()
                             .map(|(state_event, value)| (state_event.clone(), (*value).to_owned()))
+                            .chain(extra_required_state.iter().cloned())
                             .collect(),
                     )
                     .filters(Some(assign!(http::request::ListFilters::default(), {
@@ -248,7 +264,7 @@ impl RoomListService {
         // Eagerly subscribe the event cache to sync responses.
         client.event_cache().subscribe()?;
 
-        Ok(Self { client, sliding_sync, state_machine })
+        Ok(Self { client, sliding_sync, state_machine, extra_required_state })
     }
 
     /// Start to sync the room list.
@@ -472,6 +488,7 @@ impl RoomListService {
                     (state_event.clone(), (*value).to_owned())
                 })
             )
+            .chain(self.extra_required_state.iter().cloned())
             .collect(),
             timeline_limit: UInt::from(DEFAULT_ROOM_SUBSCRIPTION_TIMELINE_LIMIT),
         });
@@ -565,6 +582,8 @@ mod tests {
     use ruma::api::MatrixVersion;
     use serde_json::json;
     use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate, http::Method};
+
+    use ruma::events::StateEventType;
 
     use super::{ALL_ROOMS_LIST_NAME, Error, RoomListService, State};
 
@@ -667,6 +686,34 @@ mod tests {
 
         // State is `Error`, as a regular session expiration would generate!
         assert_eq!(room_list.state_machine.get(), State::Error { from: Box::new(State::Running) });
+
+        Ok(())
+    }
+
+    #[async_test]
+    async fn test_extra_required_state_is_accepted() -> Result<(), Error> {
+        let (client, _) = new_client().await;
+
+        let extra = vec![
+            (StateEventType::RoomPinnedEvents, "".to_owned()),
+            (StateEventType::RoomTopic, "".to_owned()),
+        ];
+
+        let room_list =
+            RoomListService::new_with_extra_required_state(client, true, extra).await?;
+
+        // The service was built successfully with extra required state. Verify
+        // the all_rooms list is present and operational.
+        let sliding_sync = room_list.sliding_sync();
+        assert_eq!(
+            sliding_sync
+                .on_list(ALL_ROOMS_LIST_NAME, |list| ready(matches!(
+                    list.sync_mode(),
+                    SlidingSyncMode::Selective { ranges } if ranges == vec![0..=19]
+                )))
+                .await,
+            Some(true)
+        );
 
         Ok(())
     }

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -581,9 +581,8 @@ mod tests {
     use matrix_sdk_test::async_test;
     use ruma::api::MatrixVersion;
     use serde_json::json;
-    use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate, http::Method};
-
     use ruma::events::StateEventType;
+    use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate, http::Method};
 
     use super::{ALL_ROOMS_LIST_NAME, Error, RoomListService, State};
 

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -56,7 +56,7 @@ mod room_list;
 pub mod sorters;
 mod state;
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use async_stream::stream;
 use eyeball::Subscriber;
@@ -108,6 +108,23 @@ const DEFAULT_ROOM_SUBSCRIPTION_EXTRA_REQUIRED_STATE: &[(StateEventType, &str)] 
 /// The default `timeline_limit` value when used with room subscriptions.
 const DEFAULT_ROOM_SUBSCRIPTION_TIMELINE_LIMIT: u32 = 20;
 
+fn merge_required_state<'a>(
+    defaults: impl IntoIterator<Item = &'a (StateEventType, &'a str)>,
+    extra: &[(StateEventType, String)],
+) -> Vec<(StateEventType, String)> {
+    let overridden_types: HashSet<StateEventType> =
+        extra.iter().map(|(event_type, _)| event_type.clone()).collect();
+
+    let mut result = defaults
+        .into_iter()
+        .filter(|(event_type, _)| !overridden_types.contains(event_type))
+        .map(|(event_type, state_key)| (event_type.clone(), (*state_key).to_owned()))
+        .collect::<Vec<_>>();
+
+    result.extend(extra.iter().cloned());
+    result
+}
+
 /// The [`RoomListService`] type. See the module's documentation to learn more.
 #[derive(Debug)]
 pub struct RoomListService {
@@ -121,10 +138,6 @@ pub struct RoomListService {
     ///
     /// `RoomListService` is a simple state-machine.
     state_machine: StateMachine,
-
-    /// Additional required state events requested by the caller, merged with
-    /// the defaults for both the all-rooms list and room subscriptions.
-    extra_required_state: Vec<(StateEventType, String)>,
 }
 
 impl RoomListService {
@@ -145,16 +158,18 @@ impl RoomListService {
     ///
     /// [`SlidingSyncBuilder::share_pos`]: matrix_sdk::sliding_sync::SlidingSyncBuilder::share_pos
     pub async fn new_with_share_pos(client: Client, share_pos: bool) -> Result<Self, Error> {
-        Self::new_with_extra_required_state(client, share_pos, vec![]).await
+        Self::new_with_all_rooms_required_state(client, share_pos, vec![]).await
     }
 
     /// Like [`RoomListService::new_with_share_pos`] but with additional
-    /// required state events that will be merged with the defaults for both
-    /// the all-rooms list and room subscriptions.
-    pub async fn new_with_extra_required_state(
+    /// required state entries that apply only to the `ALL_ROOMS` list.
+    ///
+    /// User-provided entries override built-in defaults with the same event
+    /// type. This does not affect `room_subscriptions`.
+    pub async fn new_with_all_rooms_required_state(
         client: Client,
         share_pos: bool,
-        extra_required_state: Vec<(StateEventType, String)>,
+        all_rooms_required_state: Vec<(StateEventType, String)>,
     ) -> Result<Self, Error> {
         let mut builder = client
             .sliding_sync("room-list")
@@ -216,13 +231,10 @@ impl RoomListService {
                             .add_range(ALL_ROOMS_DEFAULT_SELECTIVE_RANGE),
                     )
                     .timeline_limit(1)
-                    .required_state(
-                        DEFAULT_REQUIRED_STATE
-                            .iter()
-                            .map(|(state_event, value)| (state_event.clone(), (*value).to_owned()))
-                            .chain(extra_required_state.iter().cloned())
-                            .collect(),
-                    )
+                    .required_state(merge_required_state(
+                        DEFAULT_REQUIRED_STATE.iter(),
+                        &all_rooms_required_state,
+                    ))
                     .filters(Some(assign!(http::request::ListFilters::default(), {
                         // As defined in the [SlidingSync MSC](https://github.com/matrix-org/matrix-spec-proposals/blob/9450ced7fb9cf5ea9077d029b3adf36aebfa8709/proposals/3575-sync.md?plain=1#L444)
                         // If unset, both invited and joined rooms are returned. If false, no invited rooms are
@@ -264,7 +276,7 @@ impl RoomListService {
         // Eagerly subscribe the event cache to sync responses.
         client.event_cache().subscribe()?;
 
-        Ok(Self { client, sliding_sync, state_machine, extra_required_state })
+        Ok(Self { client, sliding_sync, state_machine })
     }
 
     /// Start to sync the room list.
@@ -488,7 +500,6 @@ impl RoomListService {
                     (state_event.clone(), (*value).to_owned())
                 })
             )
-            .chain(self.extra_required_state.iter().cloned())
             .collect(),
             timeline_limit: UInt::from(DEFAULT_ROOM_SUBSCRIPTION_TIMELINE_LIMIT),
         });
@@ -684,33 +695,6 @@ mod tests {
 
         // State is `Error`, as a regular session expiration would generate!
         assert_eq!(room_list.state_machine.get(), State::Error { from: Box::new(State::Running) });
-
-        Ok(())
-    }
-
-    #[async_test]
-    async fn test_extra_required_state_is_accepted() -> Result<(), Error> {
-        let (client, _) = new_client().await;
-
-        let extra = vec![
-            (StateEventType::RoomPinnedEvents, "".to_owned()),
-            (StateEventType::RoomTopic, "".to_owned()),
-        ];
-
-        let room_list = RoomListService::new_with_extra_required_state(client, true, extra).await?;
-
-        // The service was built successfully with extra required state. Verify
-        // the all_rooms list is present and operational.
-        let sliding_sync = room_list.sliding_sync();
-        assert_eq!(
-            sliding_sync
-                .on_list(ALL_ROOMS_LIST_NAME, |list| ready(matches!(
-                    list.sync_mode(),
-                    SlidingSyncMode::Selective { ranges } if ranges == vec![0..=19]
-                )))
-                .await,
-            Some(true)
-        );
 
         Ok(())
     }

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -579,9 +579,8 @@ mod tests {
         Client, SlidingSyncMode, config::RequestConfig, test_utils::client::mock_matrix_session,
     };
     use matrix_sdk_test::async_test;
-    use ruma::api::MatrixVersion;
+    use ruma::{api::MatrixVersion, events::StateEventType};
     use serde_json::json;
-    use ruma::events::StateEventType;
     use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate, http::Method};
 
     use super::{ALL_ROOMS_LIST_NAME, Error, RoomListService, State};
@@ -698,8 +697,7 @@ mod tests {
             (StateEventType::RoomTopic, "".to_owned()),
         ];
 
-        let room_list =
-            RoomListService::new_with_extra_required_state(client, true, extra).await?;
+        let room_list = RoomListService::new_with_extra_required_state(client, true, extra).await?;
 
         // The service was built successfully with extra required state. Verify
         // the all_rooms list is present and operational.

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -38,6 +38,7 @@ use matrix_sdk::{
     executor::{JoinHandle, spawn},
     sleep::sleep,
 };
+use ruma::events::StateEventType;
 use thiserror::Error;
 use tokio::sync::{
     Mutex as AsyncMutex, OwnedMutexGuard,
@@ -779,11 +780,21 @@ pub struct SyncServiceBuilder {
     /// defined span, for example if there is more than one active sync
     /// service.
     parent_span: Span,
+
+    /// Additional state events to request during sliding sync, merged with
+    /// the built-in defaults in the [`RoomListService`].
+    extra_required_state: Vec<(StateEventType, String)>,
 }
 
 impl SyncServiceBuilder {
     fn new(client: Client) -> Self {
-        Self { client, with_offline_mode: false, with_share_pos: true, parent_span: Span::none() }
+        Self {
+            client,
+            with_offline_mode: false,
+            with_share_pos: true,
+            parent_span: Span::none(),
+            extra_required_state: vec![],
+        }
     }
 
     /// Enable the "offline" mode for the [`SyncService`].
@@ -810,17 +821,42 @@ impl SyncServiceBuilder {
         self
     }
 
+    /// Request additional state events during sliding sync.
+    ///
+    /// The provided entries are merged with the built-in defaults; they do
+    /// not replace them. Each entry is a `(event_type, state_key)` pair
+    /// following the same conventions as the sliding-sync `required_state`
+    /// field (e.g. `""` for singleton state, `"*"` for all state keys).
+    pub fn with_required_state(
+        mut self,
+        required_state: Vec<(StateEventType, String)>,
+    ) -> Self {
+        self.extra_required_state = required_state;
+        self
+    }
+
     /// Finish setting up the [`SyncService`].
     ///
     /// This creates the underlying sliding syncs, and will *not* start them in
     /// the background. The resulting [`SyncService`] must be kept alive as long
     /// as the sliding syncs are supposed to run.
     pub async fn build(self) -> Result<SyncService, Error> {
-        let Self { client, with_offline_mode, with_share_pos, parent_span } = self;
+        let Self {
+            client,
+            with_offline_mode,
+            with_share_pos,
+            parent_span,
+            extra_required_state,
+        } = self;
 
         let encryption_sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new()));
 
-        let room_list = RoomListService::new_with_share_pos(client.clone(), with_share_pos).await?;
+        let room_list = RoomListService::new_with_extra_required_state(
+            client.clone(),
+            with_share_pos,
+            extra_required_state,
+        )
+        .await?;
 
         let encryption_sync = Arc::new(EncryptionSyncService::new(client, None).await?);
 

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -827,10 +827,7 @@ impl SyncServiceBuilder {
     /// not replace them. Each entry is a `(event_type, state_key)` pair
     /// following the same conventions as the sliding-sync `required_state`
     /// field (e.g. `""` for singleton state, `"*"` for all state keys).
-    pub fn with_required_state(
-        mut self,
-        required_state: Vec<(StateEventType, String)>,
-    ) -> Self {
+    pub fn with_required_state(mut self, required_state: Vec<(StateEventType, String)>) -> Self {
         self.extra_required_state = required_state;
         self
     }
@@ -841,13 +838,8 @@ impl SyncServiceBuilder {
     /// the background. The resulting [`SyncService`] must be kept alive as long
     /// as the sliding syncs are supposed to run.
     pub async fn build(self) -> Result<SyncService, Error> {
-        let Self {
-            client,
-            with_offline_mode,
-            with_share_pos,
-            parent_span,
-            extra_required_state,
-        } = self;
+        let Self { client, with_offline_mode, with_share_pos, parent_span, extra_required_state } =
+            self;
 
         let encryption_sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new()));
 

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -781,9 +781,8 @@ pub struct SyncServiceBuilder {
     /// service.
     parent_span: Span,
 
-    /// Additional state events to request during sliding sync, merged with
-    /// the built-in defaults in the [`RoomListService`].
-    extra_required_state: Vec<(StateEventType, String)>,
+    /// Additional required state entries for `lists.ALL_ROOMS`.
+    all_rooms_required_state: Vec<(StateEventType, String)>,
 }
 
 impl SyncServiceBuilder {
@@ -793,7 +792,7 @@ impl SyncServiceBuilder {
             with_offline_mode: false,
             with_share_pos: true,
             parent_span: Span::none(),
-            extra_required_state: vec![],
+            all_rooms_required_state: vec![],
         }
     }
 
@@ -821,14 +820,19 @@ impl SyncServiceBuilder {
         self
     }
 
-    /// Request additional state events during sliding sync.
+    /// Request additional state entries for `lists.ALL_ROOMS.required_state`.
     ///
-    /// The provided entries are merged with the built-in defaults; they do
-    /// not replace them. Each entry is a `(event_type, state_key)` pair
-    /// following the same conventions as the sliding-sync `required_state`
-    /// field (e.g. `""` for singleton state, `"*"` for all state keys).
-    pub fn with_required_state(mut self, required_state: Vec<(StateEventType, String)>) -> Self {
-        self.extra_required_state = required_state;
+    /// User-provided entries override built-in defaults for matching event
+    /// types. This does not affect `room_subscriptions.required_state`.
+    ///
+    /// Each entry is a `(event_type, state_key)` pair following the sliding
+    /// sync `required_state` conventions, such as `""` for singleton state or
+    /// `"*"` for all state keys of a state event type.
+    pub fn with_all_rooms_required_state(
+        mut self,
+        all_rooms_required_state: Vec<(StateEventType, String)>,
+    ) -> Self {
+        self.all_rooms_required_state = all_rooms_required_state;
         self
     }
 
@@ -838,15 +842,20 @@ impl SyncServiceBuilder {
     /// the background. The resulting [`SyncService`] must be kept alive as long
     /// as the sliding syncs are supposed to run.
     pub async fn build(self) -> Result<SyncService, Error> {
-        let Self { client, with_offline_mode, with_share_pos, parent_span, extra_required_state } =
-            self;
+        let Self {
+            client,
+            with_offline_mode,
+            with_share_pos,
+            parent_span,
+            all_rooms_required_state,
+        } = self;
 
         let encryption_sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new()));
 
-        let room_list = RoomListService::new_with_extra_required_state(
+        let room_list = RoomListService::new_with_all_rooms_required_state(
             client.clone(),
             with_share_pos,
-            extra_required_state,
+            all_rooms_required_state,
         )
         .await?;
 

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -26,6 +26,7 @@ use matrix_sdk_ui::{
 };
 use ruma::{
     api::client::room::create_room::v3::Request as CreateRoomRequest,
+    events::StateEventType,
     events::room::message::RoomMessageEventContent,
     owned_mxc_uri, room_id,
     time::{Duration, Instant},
@@ -61,6 +62,17 @@ async fn new_persistent_room_list_service(
     set_client_session(&client).await;
 
     let room_list = RoomListService::new(client.clone()).await?;
+
+    Ok((server, room_list))
+}
+
+async fn new_room_list_service_with_all_rooms_required_state(
+    all_rooms_required_state: Vec<(StateEventType, String)>,
+) -> Result<(MockServer, RoomListService), Error> {
+    let (client, server) = logged_in_client_with_server().await;
+    let room_list =
+        RoomListService::new_with_all_rooms_required_state(client, true, all_rooms_required_state)
+            .await?;
 
     Ok((server, room_list))
 }
@@ -521,6 +533,258 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "rooms": {
                 // let's ignore them for now
             },
+        },
+    };
+
+    Ok(())
+}
+
+#[async_test]
+async fn test_all_rooms_required_state_is_added_to_all_rooms_only() -> Result<(), Error> {
+    let (server, room_list) = new_room_list_service_with_all_rooms_required_state(vec![(
+        StateEventType::RoomGuestAccess,
+        "".to_owned(),
+    )])
+    .await?;
+
+    let sync = room_list.sync();
+    pin_mut!(sync);
+
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        states = Init => SettingUp,
+        assert pos None,
+        assert timeout Some(0),
+        assert request = {
+            "conn_id": "room-list",
+            "lists": {
+                ALL_ROOMS: {
+                    "ranges": [[0, 19]],
+                    "required_state": [
+                        ["m.room.name", ""],
+                        ["m.room.encryption", ""],
+                        ["m.room.member", "$LAZY"],
+                        ["m.room.member", "$ME"],
+                        ["m.room.topic", ""],
+                        ["m.room.avatar", ""],
+                        ["m.room.canonical_alias", ""],
+                        ["m.room.power_levels", ""],
+                        ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.join_rules", ""],
+                        ["m.room.tombstone", ""],
+                        ["m.room.create", ""],
+                        ["m.room.history_visibility", ""],
+                        ["io.element.functional_members", ""],
+                        ["m.space.parent", "*"],
+                        ["m.space.child", "*"],
+                        ["m.room.guest_access", ""],
+                    ],
+                    "filters": {},
+                    "timeline_limit": 1,
+                },
+            },
+            "extensions": {
+                "account_data": {
+                    "enabled": true
+                },
+                "receipts": {
+                    "enabled": true,
+                    "rooms": ["*"]
+                },
+                "typing": {
+                    "enabled": true,
+                },
+            },
+        },
+        respond with = {
+            "pos": "0",
+            "lists": {
+                ALL_ROOMS: {
+                    "count": 1,
+                },
+            },
+            "rooms": {},
+            "extensions": {},
+        },
+    };
+
+    Ok(())
+}
+
+#[async_test]
+async fn test_all_rooms_required_state_does_not_affect_room_subscriptions() -> Result<(), Error> {
+    let (server, room_list) = new_room_list_service_with_all_rooms_required_state(vec![(
+        StateEventType::RoomGuestAccess,
+        "".to_owned(),
+    )])
+    .await?;
+
+    let sync = room_list.sync();
+    pin_mut!(sync);
+
+    let room_id = room_id!("!r1:bar.org");
+
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        assert request >= {
+            "lists": {
+                ALL_ROOMS: {
+                    "ranges": [[0, 19]],
+                    "timeline_limit": 1,
+                },
+            },
+        },
+        respond with = {
+            "pos": "0",
+            "lists": {
+                ALL_ROOMS: {
+                    "count": 1,
+                },
+            },
+            "rooms": {
+                room_id: {
+                    "initial": true,
+                }
+            },
+        },
+    };
+
+    room_list.subscribe_to_rooms(&[room_id]).await;
+
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        assert request = {
+            "conn_id": "room-list",
+            "lists": {
+                ALL_ROOMS: {
+                    "ranges": [[0, 0]],
+                    "required_state": [
+                        ["m.room.name", ""],
+                        ["m.room.encryption", ""],
+                        ["m.room.member", "$LAZY"],
+                        ["m.room.member", "$ME"],
+                        ["m.room.topic", ""],
+                        ["m.room.avatar", ""],
+                        ["m.room.canonical_alias", ""],
+                        ["m.room.power_levels", ""],
+                        ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.join_rules", ""],
+                        ["m.room.tombstone", ""],
+                        ["m.room.create", ""],
+                        ["m.room.history_visibility", ""],
+                        ["io.element.functional_members", ""],
+                        ["m.space.parent", "*"],
+                        ["m.space.child", "*"],
+                        ["m.room.guest_access", ""],
+                    ],
+                    "filters": {},
+                    "timeline_limit": 1,
+                },
+            },
+            "room_subscriptions": {
+                room_id: {
+                    "required_state": [
+                        ["m.room.name", ""],
+                        ["m.room.encryption", ""],
+                        ["m.room.member", "$LAZY"],
+                        ["m.room.member", "$ME"],
+                        ["m.room.topic", ""],
+                        ["m.room.avatar", ""],
+                        ["m.room.canonical_alias", ""],
+                        ["m.room.power_levels", ""],
+                        ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.join_rules", ""],
+                        ["m.room.tombstone", ""],
+                        ["m.room.create", ""],
+                        ["m.room.history_visibility", ""],
+                        ["io.element.functional_members", ""],
+                        ["m.space.parent", "*"],
+                        ["m.space.child", "*"],
+                        ["m.room.pinned_events", ""],
+                    ],
+                    "timeline_limit": 20,
+                },
+            },
+            "extensions": {
+                "account_data": { "enabled": true },
+                "receipts": { "enabled": true, "rooms": [ "*" ] },
+                "typing": { "enabled": true },
+            },
+        },
+        respond with = {
+            "pos": "1",
+            "lists": {},
+            "rooms": {},
+        },
+    };
+
+    Ok(())
+}
+
+#[async_test]
+async fn test_all_rooms_required_state_overrides_default_event_type_entries() -> Result<(), Error> {
+    let (server, room_list) = new_room_list_service_with_all_rooms_required_state(vec![(
+        StateEventType::RoomMember,
+        "*".to_owned(),
+    )])
+    .await?;
+
+    let sync = room_list.sync();
+    pin_mut!(sync);
+
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        states = Init => SettingUp,
+        assert pos None,
+        assert timeout Some(0),
+        assert request = {
+            "conn_id": "room-list",
+            "lists": {
+                ALL_ROOMS: {
+                    "ranges": [[0, 19]],
+                    "required_state": [
+                        ["m.room.name", ""],
+                        ["m.room.encryption", ""],
+                        ["m.room.topic", ""],
+                        ["m.room.avatar", ""],
+                        ["m.room.canonical_alias", ""],
+                        ["m.room.power_levels", ""],
+                        ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.join_rules", ""],
+                        ["m.room.tombstone", ""],
+                        ["m.room.create", ""],
+                        ["m.room.history_visibility", ""],
+                        ["io.element.functional_members", ""],
+                        ["m.space.parent", "*"],
+                        ["m.space.child", "*"],
+                        ["m.room.member", "*"],
+                    ],
+                    "filters": {},
+                    "timeline_limit": 1,
+                },
+            },
+            "extensions": {
+                "account_data": {
+                    "enabled": true
+                },
+                "receipts": {
+                    "enabled": true,
+                    "rooms": ["*"]
+                },
+                "typing": {
+                    "enabled": true,
+                },
+            },
+        },
+        respond with = {
+            "pos": "0",
+            "lists": {
+                ALL_ROOMS: {
+                    "count": 0,
+                },
+            },
+            "rooms": {},
+            "extensions": {},
         },
     };
 


### PR DESCRIPTION
Add SyncServiceBuilder::with_required_state() so FFI consumers can request additional state events during sliding sync beyond the hardcoded defaults.

## Motivation

The RoomListService hardcodes DEFAULT_REQUIRED_STATE and DEFAULT_ROOM_SUBSCRIPTION_EXTRA_REQUIRED_STATE, which cover common Matrix state events. However, applications that use custom state events have no way to include them in the sliding sync request through the FFI layer.

Tested by integrating a build into our iOS application with custom state event types.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
