### PR TITLE
Add support for MSC4385 secret pushing

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -38,6 +38,7 @@ js = ["matrix-sdk-ui/js"]
 sentry = ["dep:sentry", "dep:sentry-tracing"]
 
 experimental-element-recent-emojis = ["matrix-sdk/experimental-element-recent-emojis"]
+experimental-push-secrets = ["matrix-sdk/experimental-push-secrets"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -40,6 +40,12 @@ experimental-encrypted-state-events = [
     "matrix-sdk-crypto?/experimental-encrypted-state-events"
 ]
 
+# Enable experimental support for pushing secrets
+experimental-push-secrets = [
+    "e2e-encryption",
+    "matrix-sdk-crypto?/experimental-push-secrets"
+]
+
 uniffi = ["dep:uniffi", "matrix-sdk-crypto?/uniffi", "matrix-sdk-common/uniffi"]
 
 # Private feature, see

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add support for pushing the backup key to other clients, and receiving a
+  pushed backup key from other clients
+  ([MSC4385](https://github.com/matrix-org/matrix-spec-proposals/pull/4385)),
+  gated behind the `experimental-push-secrets` feature.
+  ([#6432](https://github.com/matrix-org/matrix-rust-sdk/pull/6432))
 - Add `room_versions()` & `account_moderation()` to `HomeserverCapabilities`.
   ([#6413](https://github.com/matrix-org/matrix-rust-sdk/pull/6413))
 - Enable sending redaction events through the send queue via `RoomSendQueue::redact`.

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -63,6 +63,14 @@ experimental-encrypted-state-events = [
     "matrix-sdk-test?/experimental-encrypted-state-events",
 ]
 
+experimental-push-secrets = [
+    "e2e-encryption",
+    "matrix-sdk-base/experimental-push-secrets",
+    "matrix-sdk-sqlite?/experimental-push-secrets",
+    "matrix-sdk-indexeddb?/experimental-push-secrets",
+    "ruma/unstable-msc4385",
+]
+
 markdown = ["ruma/markdown"]
 socks = ["reqwest/socks"]
 local-server = ["dep:axum", "dep:rand", "dep:tower"]

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -158,6 +158,11 @@ impl Backups {
 
             #[cfg(feature = "experimental-push-secrets")]
             {
+                // Push the backup key to our own verified devices.
+                // `push_secret_to_verified_devices` depends on having existing
+                // Olm sessions with the devices that the secret is being pushed
+                // to, so make sure we have Olm sessions with all our other
+                // devices.
                 if let Some((txn_id, keys_claim_request)) = olm_machine
                     .get_missing_sessions(vec![olm_machine.user_id()].into_iter())
                     .await?

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -767,6 +767,8 @@ impl Backups {
         info!("Setting up secret listeners and trying to resume backups");
 
         self.client.add_event_handler(Self::secret_send_event_handler);
+        #[cfg(feature = "experimental-push-secrets")]
+        self.client.add_event_handler(Self::secret_push_event_handler);
 
         if self.client.inner.e2ee.encryption_settings.backup_download_strategy
             == BackupDownloadStrategy::AfterDecryptionFailure
@@ -941,8 +943,9 @@ impl Backups {
         }
     }
 
-    /// Try to resume backups by iterating through the `m.secret.send` to-device
-    /// messages the [`OlmMachine`] has received and stored in the secret inbox.
+    /// Try to resume backups by iterating through the `m.secret.send` and
+    /// `io.element.msc4385.secret.push` to-device messages the [`OlmMachine`]
+    /// has received and stored in the secret inbox.
     async fn maybe_resume_from_secret_inbox(&self, olm_machine: &OlmMachine) -> Result<(), Error> {
         let secrets = olm_machine.store().get_secrets_from_inbox(&SecretName::RecoveryKey).await?;
 
@@ -1000,6 +1003,31 @@ impl Backups {
             }
         } else {
             error!("Tried to handle a `m.secret.send` event but no OlmMachine was initialized");
+        }
+    }
+
+    /// Listen for `io.element.msc4385.secret.push` to-device messages and check
+    /// the pushed secret inbox if we do receive one.
+    #[cfg(feature = "experimental-push-secrets")]
+    #[instrument(skip_all)]
+    pub(crate) async fn secret_push_event_handler(_: ToDeviceSecretPushEvent, client: Client) {
+        let olm_machine = client.olm_machine().await;
+
+        // TODO: As with `secret_send_event_handler`, because of our crude
+        // multi-process support, which reloads the whole [`OlmMachine`] the
+        // `secrets_stream` might stop giving you updates. Once that's fixed,
+        // stop listening to individual secret push events and listen to the
+        // secrets stream.
+        if let Some(olm_machine) = olm_machine.as_ref() {
+            if let Err(e) =
+                client.encryption().backups().maybe_resume_from_secret_inbox(olm_machine).await
+            {
+                error!("Could not handle `io.element.msc4385.secret.push` event: {e:?}");
+            }
+        } else {
+            error!(
+                "Tried to handle a `io.element.msc4385.secret.push` event but no OlmMachine was initialized"
+            );
         }
     }
 

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -1128,6 +1128,7 @@ mod test {
         },
     };
     use matrix_sdk_test::async_test;
+    #[cfg(feature = "experimental-push-secrets")]
     use ruma::{device_id, user_id};
     use serde_json::json;
     use vodozemac::Curve25519PublicKey;

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -32,6 +32,8 @@ use matrix_sdk_base::crypto::{
     store::types::BackupDecryptionKey,
     types::{RoomKeyBackupInfo, requests::KeysBackupRequest},
 };
+#[cfg(feature = "experimental-push-secrets")]
+use ruma::events::secret::push::ToDeviceSecretPushEvent;
 #[cfg(feature = "experimental-encrypted-state-events")]
 use ruma::serde::JsonCastable;
 use ruma::{
@@ -153,6 +155,22 @@ impl Backups {
 
             // Enable the backup and start the upload of room keys.
             self.enable(olm_machine, backup_key, version).await?;
+
+            #[cfg(feature = "experimental-push-secrets")]
+            {
+                if let Some((txn_id, keys_claim_request)) = olm_machine
+                    .get_missing_sessions(vec![olm_machine.user_id()].into_iter())
+                    .await?
+                {
+                    let keys_claim_response = self.client.send(keys_claim_request).await?;
+                    olm_machine.mark_request_as_sent(&txn_id, &keys_claim_response).await?;
+                }
+
+                // We can ignore errors here because the only way this function
+                // fails is if the secret is not found.  But we saved the decryption
+                // key above, so this will never happen.
+                let _ = olm_machine.push_secret_to_verified_devices(SecretName::RecoveryKey).await;
+            }
 
             Ok(())
         };
@@ -1082,6 +1100,7 @@ mod test {
         },
     };
     use matrix_sdk_test::async_test;
+    use ruma::{device_id, user_id};
     use serde_json::json;
     use vodozemac::Curve25519PublicKey;
     use wiremock::{
@@ -1612,5 +1631,51 @@ mod test {
             .save_changes(changes)
             .await
             .expect("We should be able to import a room key");
+    }
+
+    #[async_test]
+    #[cfg(feature = "experimental-push-secrets")]
+    async fn test_push_secret_on_create() {
+        let server = MatrixMockServer::new().await;
+        server.mock_add_room_keys_version().ok().mount().await;
+        server.mock_crypto_endpoints_preset().await;
+
+        // Set up two devices for the test user
+        let client = server
+            .client_builder_for_crypto_end_to_end(
+                user_id!("@example:localhost"),
+                device_id!("DEVICEID"),
+            )
+            .build()
+            .await;
+        let _other_client = server
+            .set_up_new_device_for_encryption(&client, device_id!("OTHERDEVICEID"), vec![])
+            .await;
+
+        // both devices are cross-signed
+        client.encryption().bootstrap_cross_signing(None).await.unwrap();
+        let other_device = client
+            .encryption()
+            .get_device(user_id!("@example:localhost"), device_id!("OTHERDEVICEID"))
+            .await
+            .unwrap()
+            .unwrap();
+        other_device.verify().await.unwrap();
+        client.encryption().request_user_identity(user_id!("@example:localhost")).await.unwrap();
+
+        // We create a new backup on one device
+        client
+            .encryption()
+            .backups()
+            .create()
+            .await
+            .expect("We should be able to create a new backup");
+
+        // which should result in pushing the key to our other device (i.e. a
+        // to-device event should be sent)
+        let (_guard, to_device) =
+            server.mock_capture_put_to_device(client.user_id().unwrap()).await;
+        client.send_outgoing_requests().await.unwrap();
+        to_device.await;
     }
 }

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -875,7 +875,7 @@ impl MatrixMockServer {
     pub fn mock_add_room_keys_version(&self) -> MockEndpoint<'_, AddRoomKeysVersionEndpoint> {
         let mock =
             Mock::given(method("POST")).and(path_regex(r"_matrix/client/v3/room_keys/version"));
-        self.mock_endpoint(mock, AddRoomKeysVersionEndpoint).expect_default_access_token()
+        self.mock_endpoint(mock, AddRoomKeysVersionEndpoint).expect_any_access_token()
     }
 
     /// Create a prebuilt mock for adding key storage backups via POST


### PR DESCRIPTION
Add support for secret pushing (MSC4385) to the `matrix-sdk` crate, and the FFI.  This applies the functionality added in https://github.com/matrix-org/matrix-rust-sdk/pull/6164 in the `matrix-sdk` crate.

fixes https://github.com/matrix-org/matrix-rust-sdk/issues/6175
