### PR TITLE
Ensure space children comparison is transitive

### DIFF
--- a/crates/matrix-sdk-ui/proptest-regressions/spaces/room.txt
+++ b/crates/matrix-sdk-ui/proptest-regressions/spaces/room.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 8d940b96b2b3cb4751344f6382a2fef3341ce7db4617c5e7108754f690749351 # shrinks to mut v = [("!R", None), ("!a", None), ("!a", None), ("!A", None), ("!A", None), ("!A", None), ("!A", None), ("!a", None), ("!a", None), ("!A", None), ("!a", None), ("!A", Some(SpaceRoomChildState { order: None, origin_server_ts: 1970-01-01T00:00:00.000 })), ("!a", Some(SpaceRoomChildState { order: Some("A"), origin_server_ts: 1970-01-01T00:00:00.000 })), ("!A", None), ("!A", None), ("!A", None), ("!A", None), ("!A", None), ("!A", None), ("!a", None), ("!A", None), ("!A", None)]
+cc e2d881839c61088f24a3addf623bd9a4b4393be229f567cf9e49026387bbd244 # shrinks to a = ("!A", Some(SpaceRoomChildState { order: None, origin_server_ts: 1970-01-01T00:00:00.000 })), b = ("!a", Some(SpaceRoomChildState { order: Some("a"), origin_server_ts: 1970-01-01T00:00:00.000 })), c = ("!A", None)

--- a/crates/matrix-sdk-ui/src/spaces/mod.rs
+++ b/crates/matrix-sdk-ui/src/spaces/mod.rs
@@ -639,7 +639,10 @@ impl SpaceService {
                         let a_state = space_child_states.get(&a.room_id).cloned();
                         let b_state = space_child_states.get(&b.room_id).cloned();
 
-                        SpaceRoom::compare_rooms(a, b, a_state, b_state)
+                        SpaceRoom::compare_rooms(
+                            (&a.room_id, a_state.as_ref()),
+                            (&b.room_id, b_state.as_ref()),
+                        )
                     })
                     .map(|space_room| {
                         let descendants = graph.flattened_bottom_up_subtree(&space_room.room_id);

--- a/crates/matrix-sdk-ui/src/spaces/mod.rs
+++ b/crates/matrix-sdk-ui/src/spaces/mod.rs
@@ -38,7 +38,7 @@ use matrix_sdk::{
     task_monitor::BackgroundTaskHandle,
 };
 use ruma::{
-    OwnedRoomId, RoomId,
+    OwnedRoomId, RoomId, SpaceChildOrder,
     events::{
         self, StateEventType, SyncStateEvent,
         space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
@@ -576,18 +576,10 @@ impl SpaceService {
         let top_level_space_rooms = top_level_space_rooms
             .into_iter()
             .sorted_by(|a, b| {
-                // MSC3230: lexicographically by `order` and then by room ID
-                match (
-                    top_level_space_order.get(a.room_id()),
-                    top_level_space_order.get(b.room_id()),
-                ) {
-                    (Some(a_order), Some(b_order)) => {
-                        a_order.cmp(b_order).then(a.room_id().cmp(b.room_id()))
-                    }
-                    (Some(_), None) => Ordering::Less,
-                    (None, Some(_)) => Ordering::Greater,
-                    (None, None) => a.room_id().cmp(b.room_id()),
-                }
+                let a = (a.room_id(), top_level_space_order.get(a.room_id()).map(AsRef::as_ref));
+                let b = (b.room_id(), top_level_space_order.get(b.room_id()).map(AsRef::as_ref));
+
+                compare_top_level_space_rooms(a, b)
             })
             .collect::<Vec<_>>();
 
@@ -659,6 +651,22 @@ impl SpaceService {
         }
 
         filters
+    }
+}
+
+// MSC3230: lexicographically by `order` and then by room ID
+fn compare_top_level_space_rooms(
+    a: (&RoomId, Option<&SpaceChildOrder>),
+    b: (&RoomId, Option<&SpaceChildOrder>),
+) -> Ordering {
+    let (a_room_id, a_order) = a;
+    let (b_room_id, b_order) = b;
+
+    match (a_order, b_order) {
+        (Some(a_order), Some(b_order)) => a_order.cmp(b_order).then(a_room_id.cmp(b_room_id)),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => a_room_id.cmp(b_room_id),
     }
 }
 

--- a/crates/matrix-sdk-ui/src/spaces/mod.rs
+++ b/crates/matrix-sdk-ui/src/spaces/mod.rs
@@ -696,9 +696,10 @@ mod tests {
     use matrix_sdk_test::{
         JoinedRoomBuilder, LeftRoomBuilder, async_test, event_factory::EventFactory,
     };
+    use proptest::prelude::*;
     use ruma::{
-        MilliSecondsSinceUnixEpoch, RoomVersionId, UserId, event_id, owned_room_id, room_id,
-        serde::Raw,
+        MilliSecondsSinceUnixEpoch, OwnedSpaceChildOrder, RoomVersionId, UserId, event_id,
+        owned_room_id, room_id, serde::Raw,
     };
     use serde_json::json;
     use stream_assert::{assert_next_eq, assert_pending};
@@ -1752,5 +1753,86 @@ mod tests {
         parents: Vec<&'static RoomId>,
         children: Vec<&'static RoomId>,
         power_level: Option<i32>,
+    }
+
+    fn any_room_id_and_space_room_order()
+    -> impl Strategy<Value = (OwnedRoomId, Option<OwnedSpaceChildOrder>)> {
+        let room_id = "[a-zA-Z]{1,5}".prop_map(|r| {
+            RoomId::new_v2(&r).expect("Any string starting with ! should be a valid room ID")
+        });
+
+        let order = prop::option::of("[a-zA-Z]{1,5}").prop_map(|order| {
+            order.map(|o| SpaceChildOrder::parse(o).expect("Any string should be a valid order"))
+        });
+
+        (room_id, order)
+    }
+
+    proptest! {
+        #[test]
+        fn sort_top_level_space_room_never_panics(mut v in prop::collection::vec(any_room_id_and_space_room_order(), 0..100)) {
+            v.sort_by(|a, b| {
+                let (a_room_id, a_order) = a;
+                let (b_room_id, b_order) = b;
+
+                let a = (a_room_id.as_ref(), a_order.as_deref());
+                let b = (b_room_id.as_ref(), b_order.as_deref());
+
+                compare_top_level_space_rooms(a, b)
+            })
+        }
+
+        #[test]
+        fn test_compare_top_level_rooms_reflexive(a in any_room_id_and_space_room_order()) {
+            let (a_room_id, a_order) = a;
+            let a = (a_room_id.as_ref(), a_order.as_deref());
+
+            prop_assert_eq!(compare_top_level_space_rooms(a, a), Ordering::Equal);
+        }
+
+        #[test]
+        fn test_compare_top_level_rooms_antisymmetric(a in any_room_id_and_space_room_order(), b in any_room_id_and_space_room_order()) {
+            let (a_room_id, a_order) = a;
+            let (b_room_id, b_order) = b;
+
+            let a = (a_room_id.as_ref(), a_order.as_deref());
+            let b = (b_room_id.as_ref(), b_order.as_deref());
+
+            let ab = compare_top_level_space_rooms(a, b);
+            let ba = compare_top_level_space_rooms(b, a);
+
+            prop_assert_eq!(ab, ba.reverse());
+        }
+
+        #[test]
+        fn test_compare_top_level_rooms_transitive(
+            a in any_room_id_and_space_room_order(),
+            b in any_room_id_and_space_room_order(),
+            c in any_room_id_and_space_room_order()
+        ) {
+            let (a_room_id, a_order) = a;
+            let (b_room_id, b_order) = b;
+            let (c_room_id, c_order) = c;
+
+            let a = (a_room_id.as_ref(), a_order.as_deref());
+            let b = (b_room_id.as_ref(), b_order.as_deref());
+            let c = (c_room_id.as_ref(), c_order.as_deref());
+
+            let ab = compare_top_level_space_rooms(a, b);
+            let bc = compare_top_level_space_rooms(b, c);
+            let ac = compare_top_level_space_rooms(a, c);
+
+            if ab == Ordering::Less && bc == Ordering::Less {
+                prop_assert_eq!(ac, Ordering::Less);
+            }
+
+            if ab == Ordering::Equal && bc == Ordering::Equal {
+                prop_assert_eq!(ac, Ordering::Equal);
+            }
+
+            if ab == Ordering::Greater && bc == Ordering::Greater {
+                prop_assert_eq!(ac, Ordering::Greater);
+            }
+        }
     }
 }

--- a/crates/matrix-sdk-ui/src/spaces/room.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room.rs
@@ -193,7 +193,10 @@ mod tests {
     use std::cmp::Ordering;
 
     use matrix_sdk_test::async_test;
-    use ruma::{MilliSecondsSinceUnixEpoch, SpaceChildOrder, room_id, uint};
+    use proptest::prelude::*;
+    use ruma::{
+        MilliSecondsSinceUnixEpoch, OwnedRoomId, RoomId, SpaceChildOrder, UInt, room_id, uint,
+    };
 
     use crate::spaces::{SpaceRoom, room::SpaceRoomChildState};
 
@@ -337,5 +340,135 @@ mod tests {
             ),
             Ordering::Greater
         );
+    }
+
+    /// This test was written because the [`SpaceRoom::compare_rooms`] method
+    /// wasn't adhering to a total order.
+    ///
+    /// More precisely it wasn't transitive. This was because as soon as the
+    /// [SpaceRoomChildState] for one room was set to `None` we would fall
+    /// back to comparing only room IDs.
+    ///
+    /// The correct way to preserve transitivity was to only fall back to room
+    /// IDs if both rooms don't have a state.
+    #[test]
+    fn test_compare_rooms_minimal_transitive_failure() {
+        let (a_room_id, a_state) = (room_id!("!Q"), None);
+
+        let (b_room_id, b_state) = (
+            room_id!("!A"),
+            Some(SpaceRoomChildState {
+                order: None,
+                origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(10)),
+            }),
+        );
+
+        let (c_room_id, c_state) = (
+            room_id!("!a"),
+            Some(SpaceRoomChildState {
+                order: None,
+                origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(0)),
+            }),
+        );
+
+        let a = (a_room_id, a_state.as_ref());
+        let b = (b_room_id, b_state.as_ref());
+        let c = (c_room_id, c_state.as_ref());
+
+        let ab = SpaceRoom::compare_rooms(a, b);
+        let bc = SpaceRoom::compare_rooms(b, c);
+        let ac = SpaceRoom::compare_rooms(a, c);
+
+        assert_eq!(ab, Ordering::Greater, "a > b should hold");
+        assert_eq!(bc, Ordering::Greater, "b > c should hold");
+        assert_eq!(ac, Ordering::Greater, "therefore a > c should be true as well");
+    }
+
+    fn any_room_id_and_space_room_order()
+    -> impl Strategy<Value = (OwnedRoomId, Option<SpaceRoomChildState>)> {
+        let room_id = "[a-zA-Z]{1,5}".prop_map(|r| {
+            RoomId::new_v2(&r).expect("Any string starting with ! should be a valid room ID")
+        });
+
+        let timestamp = any::<u8>().prop_map(|t| MilliSecondsSinceUnixEpoch(UInt::from(t)));
+
+        let order = prop::option::of("[a-zA-Z]{1,5}").prop_map(|order| {
+            order.map(|o| SpaceChildOrder::parse(o).expect("Any string should be a valid order"))
+        });
+
+        let state = (order, timestamp)
+            .prop_map(|(o, t)| SpaceRoomChildState { order: o, origin_server_ts: t });
+
+        let state = prop::option::of(state);
+
+        (room_id, state)
+    }
+
+    proptest! {
+        #[test]
+        fn test_sort_space_room_children_never_panics(mut v in prop::collection::vec(any_room_id_and_space_room_order(), 0..100)) {
+            v.sort_by(|a, b| {
+                let (a_room_id, a_state) = a;
+                let (b_room_id, b_state) = b;
+
+                let a = (a_room_id.as_ref(), a_state.as_ref());
+                let b = (b_room_id.as_ref(), b_state.as_ref());
+
+                SpaceRoom::compare_rooms(a, b)
+            })
+        }
+
+        #[test]
+        fn test_compare_rooms_reflexive(a in any_room_id_and_space_room_order()) {
+            let (a_room_id, a_state) = a;
+            let a = (a_room_id.as_ref(), a_state.as_ref());
+
+            prop_assert_eq!(SpaceRoom::compare_rooms(a, a), Ordering::Equal);
+        }
+
+        #[test]
+        fn test_compare_rooms_antisymmetric(a in any_room_id_and_space_room_order(), b in any_room_id_and_space_room_order()) {
+            let (a_room_id, a_state) = a;
+            let (b_room_id, b_state) = b;
+
+            let a = (a_room_id.as_ref(), a_state.as_ref());
+            let b = (b_room_id.as_ref(), b_state.as_ref());
+
+            let ab = SpaceRoom::compare_rooms(a, b);
+            let ba = SpaceRoom::compare_rooms(b, a);
+
+            prop_assert_eq!(ab, ba.reverse());
+        }
+
+        #[test]
+        fn test_compare_rooms_transitive(
+            a in any_room_id_and_space_room_order(),
+            b in any_room_id_and_space_room_order(),
+            c in any_room_id_and_space_room_order()
+        ) {
+            let (a_room_id, a_state) = a;
+            let (b_room_id, b_state) = b;
+            let (c_room_id, c_state) = c;
+
+            let a = (a_room_id.as_ref(), a_state.as_ref());
+            let b = (b_room_id.as_ref(), b_state.as_ref());
+            let c = (c_room_id.as_ref(), c_state.as_ref());
+
+            let ab = SpaceRoom::compare_rooms(a, b);
+            let bc = SpaceRoom::compare_rooms(b, c);
+            let ac = SpaceRoom::compare_rooms(a, c);
+
+            if ab == Ordering::Less && bc == Ordering::Less {
+                prop_assert_eq!(ac, Ordering::Less);
+            }
+
+            if ab == Ordering::Equal && bc == Ordering::Equal {
+                prop_assert_eq!(ac, Ordering::Equal);
+            }
+
+            if ab == Ordering::Greater && bc == Ordering::Greater {
+                prop_assert_eq!(ac, Ordering::Greater);
+            }
+        }
     }
 }

--- a/crates/matrix-sdk-ui/src/spaces/room.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room.rs
@@ -17,7 +17,7 @@ use std::cmp::Ordering;
 use matrix_sdk::{Room, RoomHero, RoomState};
 use ruma::{
     MilliSecondsSinceUnixEpoch, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedServerName,
-    OwnedSpaceChildOrder,
+    OwnedSpaceChildOrder, RoomId,
     events::{
         room::{guest_access::GuestAccess, history_visibility::HistoryVisibility},
         space::child::HierarchySpaceChildEvent,
@@ -149,25 +149,26 @@ impl SpaceRoom {
     /// Sorts space rooms by various criteria as defined in
     /// https://spec.matrix.org/latest/client-server-api/#ordering-of-children-within-a-space
     pub(crate) fn compare_rooms(
-        a: &SpaceRoom,
-        b: &SpaceRoom,
-        a_state: Option<SpaceRoomChildState>,
-        b_state: Option<SpaceRoomChildState>,
+        a: (&RoomId, Option<&SpaceRoomChildState>),
+        b: (&RoomId, Option<&SpaceRoomChildState>),
     ) -> Ordering {
+        let (a_room_id, a_state) = a;
+        let (b_room_id, b_state) = b;
+
         match (a_state, b_state) {
             (Some(a_state), Some(b_state)) => match (&a_state.order, &b_state.order) {
                 (Some(a_order), Some(b_order)) => a_order
                     .cmp(b_order)
                     .then(a_state.origin_server_ts.cmp(&b_state.origin_server_ts))
-                    .then(a.room_id.cmp(&b.room_id)),
+                    .then(a_room_id.cmp(b_room_id)),
                 (Some(_), None) => Ordering::Less,
                 (None, Some(_)) => Ordering::Greater,
                 (None, None) => a_state
                     .origin_server_ts
                     .cmp(&b_state.origin_server_ts)
-                    .then(a.room_id.to_string().cmp(&b.room_id.to_string())),
+                    .then(a_room_id.cmp(b_room_id)),
             },
-            _ => a.room_id.to_string().cmp(&b.room_id.to_string()),
+            _ => a_room_id.cmp(b_room_id),
         }
     }
 }
@@ -192,7 +193,7 @@ mod tests {
     use std::cmp::Ordering;
 
     use matrix_sdk_test::async_test;
-    use ruma::{MilliSecondsSinceUnixEpoch, OwnedRoomId, SpaceChildOrder, owned_room_id, uint};
+    use ruma::{MilliSecondsSinceUnixEpoch, SpaceChildOrder, room_id, uint};
 
     use crate::spaces::{SpaceRoom, room::SpaceRoomChildState};
 
@@ -201,21 +202,14 @@ mod tests {
         // Rooms without a `m.space.child` state event should be sorted by their
         // `room_id`
         assert_eq!(
-            SpaceRoom::compare_rooms(
-                &make_space_room(owned_room_id!("!A:a.b")),
-                &make_space_room(owned_room_id!("!B:a.b")),
-                None,
-                None
-            ),
+            SpaceRoom::compare_rooms((room_id!("!A:a.b"), None), (room_id!("!B:a.b"), None),),
             Ordering::Less
         );
 
         assert_eq!(
             SpaceRoom::compare_rooms(
-                &make_space_room(owned_room_id!("!Marțolea:a.b")),
-                &make_space_room(owned_room_id!("!Luana:a.b")),
-                None,
-                None,
+                (room_id!("!Marțolea:a.b"), None),
+                (room_id!("!Luana:a.b"), None),
             ),
             Ordering::Greater
         );
@@ -224,16 +218,20 @@ mod tests {
         // sorted by their `m.space.child` `origin_server_ts`
         assert_eq!(
             SpaceRoom::compare_rooms(
-                &make_space_room(owned_room_id!("!Luana:a.b")),
-                &make_space_room(owned_room_id!("!Marțolea:a.b")),
-                Some(SpaceRoomChildState {
-                    origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
-                    order: None
-                }),
-                Some(SpaceRoomChildState {
-                    origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(0)),
-                    order: None
-                })
+                (
+                    room_id!("!Luana:a.b"),
+                    Some(&SpaceRoomChildState {
+                        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
+                        order: None
+                    })
+                ),
+                (
+                    room_id!("!Marțolea:a.b"),
+                    Some(&SpaceRoomChildState {
+                        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(0)),
+                        order: None
+                    })
+                )
             ),
             Ordering::Greater
         );
@@ -241,16 +239,20 @@ mod tests {
         // The `m.space.child` `content.order` field should be used if provided
         assert_eq!(
             SpaceRoom::compare_rooms(
-                &make_space_room(owned_room_id!("!Joiana:a.b"),),
-                &make_space_room(owned_room_id!("!Mioara:a.b"),),
-                Some(SpaceRoomChildState {
-                    origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(123)),
-                    order: Some(SpaceChildOrder::parse("second").unwrap())
-                }),
-                Some(SpaceRoomChildState {
-                    origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(234)),
-                    order: Some(SpaceChildOrder::parse("first").unwrap())
-                }),
+                (
+                    room_id!("!Joiana:a.b"),
+                    Some(&SpaceRoomChildState {
+                        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(123)),
+                        order: Some(SpaceChildOrder::parse("second").unwrap())
+                    })
+                ),
+                (
+                    room_id!("!Mioara:a.b"),
+                    Some(&SpaceRoomChildState {
+                        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(234)),
+                        order: Some(SpaceChildOrder::parse("first").unwrap())
+                    })
+                ),
             ),
             Ordering::Greater
         );
@@ -258,16 +260,20 @@ mod tests {
         // The timestamp should be used when the `order` is the same
         assert_eq!(
             SpaceRoom::compare_rooms(
-                &make_space_room(owned_room_id!("!Joiana:a.b")),
-                &make_space_room(owned_room_id!("!Mioara:a.b")),
-                Some(SpaceRoomChildState {
-                    origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
-                    order: Some(SpaceChildOrder::parse("Same pasture").unwrap())
-                }),
-                Some(SpaceRoomChildState {
-                    origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(0)),
-                    order: Some(SpaceChildOrder::parse("Same pasture").unwrap())
-                }),
+                (
+                    room_id!("!Joiana:a.b"),
+                    Some(&SpaceRoomChildState {
+                        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
+                        order: Some(SpaceChildOrder::parse("Same pasture").unwrap())
+                    })
+                ),
+                (
+                    room_id!("!Mioara:a.b"),
+                    Some(&SpaceRoomChildState {
+                        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(0)),
+                        order: Some(SpaceChildOrder::parse("Same pasture").unwrap())
+                    })
+                ),
             ),
             Ordering::Greater
         );
@@ -276,16 +282,20 @@ mod tests {
         // `timestamp` are equal
         assert_eq!(
             SpaceRoom::compare_rooms(
-                &make_space_room(owned_room_id!("!Joiana:a.b")),
-                &make_space_room(owned_room_id!("!Mioara:a.b")),
-                Some(SpaceRoomChildState {
-                    origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(0)),
-                    order: Some(SpaceChildOrder::parse("Same pasture").unwrap())
-                }),
-                Some(SpaceRoomChildState {
-                    origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(0)),
-                    order: Some(SpaceChildOrder::parse("Same pasture").unwrap())
-                }),
+                (
+                    room_id!("!Joiana:a.b"),
+                    Some(&SpaceRoomChildState {
+                        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(0)),
+                        order: Some(SpaceChildOrder::parse("Same pasture").unwrap())
+                    })
+                ),
+                (
+                    room_id!("!Mioara:a.b"),
+                    Some(&SpaceRoomChildState {
+                        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(0)),
+                        order: Some(SpaceChildOrder::parse("Same pasture").unwrap())
+                    })
+                ),
             ),
             Ordering::Less
         );
@@ -294,13 +304,14 @@ mod tests {
         // should take precedence
         assert_eq!(
             SpaceRoom::compare_rooms(
-                &make_space_room(owned_room_id!("!Viola:a.b")),
-                &make_space_room(owned_room_id!("!Sâmbotina:a.b")),
-                None,
-                Some(SpaceRoomChildState {
-                    origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(0)),
-                    order: None
-                }),
+                (room_id!("!Viola:a.b"), None),
+                (
+                    room_id!("!Sâmbotina:a.b"),
+                    Some(&SpaceRoomChildState {
+                        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(0)),
+                        order: None
+                    })
+                ),
             ),
             Ordering::Greater
         );
@@ -309,40 +320,22 @@ mod tests {
         // is present then the other one should come first
         assert_eq!(
             SpaceRoom::compare_rooms(
-                &make_space_room(owned_room_id!("!Sâmbotina:a.b")),
-                &make_space_room(owned_room_id!("!Dumana:a.b")),
-                Some(SpaceRoomChildState {
-                    origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
-                    order: None
-                }),
-                Some(SpaceRoomChildState {
-                    origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
-                    order: Some(SpaceChildOrder::parse("Some pasture").unwrap())
-                }),
+                (
+                    room_id!("!Sâmbotina:a.b"),
+                    Some(&SpaceRoomChildState {
+                        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
+                        order: None
+                    })
+                ),
+                (
+                    room_id!("!Dumana:a.b"),
+                    Some(&SpaceRoomChildState {
+                        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
+                        order: Some(SpaceChildOrder::parse("Some pasture").unwrap())
+                    })
+                ),
             ),
             Ordering::Greater
         );
-    }
-
-    fn make_space_room(room_id: OwnedRoomId) -> SpaceRoom {
-        SpaceRoom {
-            room_id,
-            canonical_alias: None,
-            name: Some("New room name".to_owned()),
-            display_name: "Empty room".to_owned(),
-            topic: None,
-            avatar_url: None,
-            room_type: None,
-            num_joined_members: 0,
-            join_rule: None,
-            world_readable: None,
-            guest_can_join: false,
-            is_direct: None,
-            children_count: 0,
-            state: None,
-            heroes: None,
-            via: vec![],
-            suggested: false,
-        }
     }
 }

--- a/crates/matrix-sdk-ui/src/spaces/room.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room.rs
@@ -168,7 +168,9 @@ impl SpaceRoom {
                     .cmp(&b_state.origin_server_ts)
                     .then(a_room_id.cmp(b_room_id)),
             },
-            _ => a_room_id.cmp(b_room_id),
+            (None, Some(_)) => Ordering::Greater,
+            (Some(_), None) => Ordering::Less,
+            (None, None) => a_room_id.cmp(b_room_id),
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/spaces/room_list.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room_list.rs
@@ -390,7 +390,10 @@ impl SpaceRoomList {
         let a_state = children_state.get(&a.room_id);
         let b_state = children_state.get(&b.room_id);
 
-        SpaceRoom::compare_rooms(a, b, a_state.map(Into::into), b_state.map(Into::into))
+        SpaceRoom::compare_rooms(
+            (&a.room_id, a_state.map(Into::into).as_ref()),
+            (&b.room_id, b_state.map(Into::into).as_ref()),
+        )
     }
 }
 


### PR DESCRIPTION
A review commit by commit is most helpful. The majority of this PR introduces small refactors to make it easier to property test the two comparison functions we have in the spaces module.

A bunch of property tests were added to ensure that the comparison functions produce a total order.

In the case of the space children comparison function this wasn't true. The actual fix is contained in 7379e40a, which also has a longer description to explain what's going on.

This closes #5783.