### PR TITLE
fix(client): Fix logic for profile fields capabilities

### DIFF
--- a/crates/matrix-sdk/src/client/homeserver_capabilities.rs
+++ b/crates/matrix-sdk/src/client/homeserver_capabilities.rs
@@ -235,6 +235,13 @@ struct ProfileCapabilities {
 #[cfg(all(not(target_family = "wasm"), test))]
 mod tests {
     use matrix_sdk_test::async_test;
+    #[allow(deprecated)]
+    use ruma::api::{
+        MatrixVersion,
+        client::discovery::get_capabilities::v3::{
+            SetAvatarUrlCapability, SetDisplayNameCapability,
+        },
+    };
 
     use super::*;
     use crate::test_utils::mocks::MatrixMockServer;
@@ -322,5 +329,267 @@ mod tests {
         // Check the values we get are not updated without a refresh, they're loaded
         // from the cache
         assert!(capabilities.can_change_displayname().await.expect("checking capabilities failed"));
+    }
+
+    #[async_test]
+    #[allow(deprecated)]
+    async fn test_deprecated_profile_fields_capabilities() {
+        let server = MatrixMockServer::new().await;
+
+        // The user can only set the display name but not the avatar url or extended
+        // profile fields.
+        let mut capabilities = Capabilities::new();
+        capabilities.profile_fields.take();
+        capabilities.set_displayname = SetDisplayNameCapability::new(true);
+        capabilities.set_avatar_url = SetAvatarUrlCapability::new(false);
+        server
+            .mock_get_homeserver_capabilities()
+            .ok_with_capabilities(capabilities)
+            // It should be called once by each client below.
+            .expect(2)
+            .mount()
+            .await;
+
+        // Client with Matrix 1.12 that did not support extended profile fields yet.
+        // Because there is no `m.profile_fields` capability, we rely on the legacy
+        // profile capabilities.
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_12]).build().await;
+        let capabilities_api = client.homeserver_capabilities();
+        assert!(
+            capabilities_api
+                .can_change_displayname()
+                .await
+                .expect("checking displayname capability failed")
+        );
+        assert!(
+            !capabilities_api.can_change_avatar().await.expect("checking avatar capability failed")
+        );
+        assert!(
+            !capabilities_api
+                .extended_profile_fields()
+                .await
+                .expect("checking profile fields capability failed")
+                .enabled
+        );
+
+        // Client with Matrix 1.16 that added support for extended profile fields, the
+        // deprecated profile capabilities are ignored.
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
+        let capabilities_api = client.homeserver_capabilities();
+        assert!(
+            capabilities_api
+                .can_change_displayname()
+                .await
+                .expect("checking displayname capability failed")
+        );
+        assert!(
+            capabilities_api.can_change_avatar().await.expect("checking avatar capability failed")
+        );
+        assert!(
+            capabilities_api
+                .extended_profile_fields()
+                .await
+                .expect("checking profile fields capability failed")
+                .enabled
+        );
+    }
+
+    #[async_test]
+    #[allow(deprecated)]
+    async fn test_extended_profile_fields_capabilities_enabled() {
+        let server = MatrixMockServer::new().await;
+
+        // The user can set any profile field.
+        // The legacy capabilities say differently, but they will be ignored.
+        let mut capabilities = Capabilities::new();
+        capabilities.profile_fields = Some(ProfileFieldsCapability::new(true));
+        capabilities.set_displayname = SetDisplayNameCapability::new(true);
+        capabilities.set_avatar_url = SetAvatarUrlCapability::new(false);
+        server
+            .mock_get_homeserver_capabilities()
+            .ok_with_capabilities(capabilities)
+            // It should be called once by each client below.
+            .expect(2)
+            .mount()
+            .await;
+
+        // Client with Matrix 1.12 that did not support extended profile fields yet.
+        // However, because there is an `m.profile_fields` capability, we still rely on
+        // it.
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_12]).build().await;
+        let capabilities_api = client.homeserver_capabilities();
+        assert!(
+            capabilities_api
+                .can_change_displayname()
+                .await
+                .expect("checking displayname capability failed")
+        );
+        assert!(
+            capabilities_api.can_change_avatar().await.expect("checking avatar capability failed")
+        );
+        assert!(
+            capabilities_api
+                .extended_profile_fields()
+                .await
+                .expect("checking profile fields capability failed")
+                .enabled
+        );
+
+        // Client with Matrix 1.16 that added support for extended profile fields, only
+        // the `m.profile_fields` capability is used too.
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
+        let capabilities_api = client.homeserver_capabilities();
+        assert!(
+            capabilities_api
+                .can_change_displayname()
+                .await
+                .expect("checking displayname capability failed")
+        );
+        assert!(
+            capabilities_api.can_change_avatar().await.expect("checking avatar capability failed")
+        );
+        assert!(
+            capabilities_api
+                .extended_profile_fields()
+                .await
+                .expect("checking profile fields capability failed")
+                .enabled
+        );
+    }
+
+    #[async_test]
+    #[allow(deprecated)]
+    async fn test_extended_profile_fields_capabilities_disabled() {
+        let server = MatrixMockServer::new().await;
+
+        // The user cannot set any profile field.
+        // The legacy capabilities say differently, but they will be ignored.
+        let mut capabilities = Capabilities::new();
+        capabilities.profile_fields = Some(ProfileFieldsCapability::new(false));
+        capabilities.set_displayname = SetDisplayNameCapability::new(true);
+        capabilities.set_avatar_url = SetAvatarUrlCapability::new(false);
+        server
+            .mock_get_homeserver_capabilities()
+            .ok_with_capabilities(capabilities)
+            // It should be called once by each client below.
+            .expect(2)
+            .mount()
+            .await;
+
+        // Client with Matrix 1.12 that did not support extended profile fields yet.
+        // However, because there is an `m.profile_fields` capability, we still rely on
+        // it.
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_12]).build().await;
+        let capabilities_api = client.homeserver_capabilities();
+        assert!(
+            !capabilities_api
+                .can_change_displayname()
+                .await
+                .expect("checking displayname capability failed")
+        );
+        assert!(
+            !capabilities_api.can_change_avatar().await.expect("checking avatar capability failed")
+        );
+        assert!(
+            !capabilities_api
+                .extended_profile_fields()
+                .await
+                .expect("checking profile fields capability failed")
+                .enabled
+        );
+
+        // Client with Matrix 1.16 that added support for extended profile fields, only
+        // the `m.profile_fields` capability is used too.
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
+        let capabilities_api = client.homeserver_capabilities();
+        assert!(
+            !capabilities_api
+                .can_change_displayname()
+                .await
+                .expect("checking displayname capability failed")
+        );
+        assert!(
+            !capabilities_api.can_change_avatar().await.expect("checking avatar capability failed")
+        );
+        assert!(
+            !capabilities_api
+                .extended_profile_fields()
+                .await
+                .expect("checking profile fields capability failed")
+                .enabled
+        );
+    }
+
+    #[async_test]
+    #[allow(deprecated)]
+    async fn test_fine_grained_extended_profile_fields_capabilities() {
+        let server = MatrixMockServer::new().await;
+
+        // The user can only set the avatar URL.
+        // The legacy capabilities say differently, but they will be ignored.
+        let mut profile_fields = ProfileFieldsCapability::new(true);
+        profile_fields.allowed = Some(vec![ProfileFieldName::AvatarUrl]);
+        let mut capabilities = Capabilities::new();
+        capabilities.profile_fields = Some(profile_fields);
+        capabilities.set_displayname = SetDisplayNameCapability::new(true);
+        capabilities.set_avatar_url = SetAvatarUrlCapability::new(false);
+        server
+            .mock_get_homeserver_capabilities()
+            .ok_with_capabilities(capabilities)
+            // It should be called once by each client below.
+            .expect(2)
+            .mount()
+            .await;
+
+        // Client with Matrix 1.12 that did not support extended profile fields yet.
+        // However, because there is an `m.profile_fields` capability, we still rely on
+        // it.
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_12]).build().await;
+        let capabilities_api = client.homeserver_capabilities();
+        assert!(
+            !capabilities_api
+                .can_change_displayname()
+                .await
+                .expect("checking displayname capability failed")
+        );
+        assert!(
+            capabilities_api.can_change_avatar().await.expect("checking avatar capability failed")
+        );
+        assert!(
+            capabilities_api
+                .extended_profile_fields()
+                .await
+                .expect("checking profile fields capability failed")
+                .enabled
+        );
+
+        // Client with Matrix 1.16 that added support for extended profile fields, only
+        // the `m.profile_fields` capability is used too.
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
+        let capabilities_api = client.homeserver_capabilities();
+        assert!(
+            !capabilities_api
+                .can_change_displayname()
+                .await
+                .expect("checking displayname capability failed")
+        );
+        assert!(
+            capabilities_api.can_change_avatar().await.expect("checking avatar capability failed")
+        );
+        assert!(
+            capabilities_api
+                .extended_profile_fields()
+                .await
+                .expect("checking profile fields capability failed")
+                .enabled
+        );
     }
 }

--- a/crates/matrix-sdk/src/client/homeserver_capabilities.rs
+++ b/crates/matrix-sdk/src/client/homeserver_capabilities.rs
@@ -1,10 +1,16 @@
 use matrix_sdk_base::{StateStoreDataKey, StateStoreDataValue};
 use ruma::{
-    api::client::discovery::{
-        get_capabilities,
-        get_capabilities::v3::{
-            AccountModerationCapability, Capabilities, ProfileFieldsCapability,
-            RoomVersionsCapability,
+    api::{
+        Metadata,
+        client::{
+            discovery::get_capabilities::{
+                self,
+                v3::{
+                    AccountModerationCapability, Capabilities, ProfileFieldsCapability,
+                    RoomVersionsCapability,
+                },
+            },
+            profile::delete_profile_field,
         },
     },
     profile::ProfileFieldName,
@@ -46,17 +52,13 @@ impl HomeserverCapabilities {
     ///
     /// Spec: <https://spec.matrix.org/latest/client-server-api/#mset_displayname-capability>
     pub async fn can_change_displayname(&self) -> crate::Result<bool> {
-        let capabilities = self.load_or_fetch_homeserver_capabilities().await?;
-        if let Some(profile_fields) = capabilities.profile_fields
-            && profile_fields.enabled
-        {
-            let allowed = profile_fields.allowed.unwrap_or_default();
-            let disallowed = profile_fields.disallowed.unwrap_or_default();
-            return Ok(allowed.contains(&ProfileFieldName::DisplayName)
-                || !disallowed.contains(&ProfileFieldName::DisplayName));
+        let capabilities = self.profile_capabilities().await?;
+
+        if let Some(profile_fields) = capabilities.profile_fields {
+            Ok(profile_fields.can_set_field(&ProfileFieldName::DisplayName))
+        } else {
+            Ok(capabilities.set_displayname)
         }
-        #[allow(deprecated)]
-        Ok(capabilities.set_displayname.enabled)
     }
 
     /// Returns whether the user can change their avatar or not.
@@ -66,17 +68,13 @@ impl HomeserverCapabilities {
     ///
     /// Spec: <https://spec.matrix.org/latest/client-server-api/#mset_avatar_url-capability>
     pub async fn can_change_avatar(&self) -> crate::Result<bool> {
-        let capabilities = self.load_or_fetch_homeserver_capabilities().await?;
-        if let Some(profile_fields) = capabilities.profile_fields
-            && profile_fields.enabled
-        {
-            let allowed = profile_fields.allowed.unwrap_or_default();
-            let disallowed = profile_fields.disallowed.unwrap_or_default();
-            return Ok(allowed.contains(&ProfileFieldName::AvatarUrl)
-                || !disallowed.contains(&ProfileFieldName::AvatarUrl));
+        let capabilities = self.profile_capabilities().await?;
+
+        if let Some(profile_fields) = capabilities.profile_fields {
+            Ok(profile_fields.can_set_field(&ProfileFieldName::AvatarUrl))
+        } else {
+            Ok(capabilities.set_avatar_url)
         }
-        #[allow(deprecated)]
-        Ok(capabilities.set_avatar_url.enabled)
     }
 
     /// Returns whether the user can add, remove, or change 3PID associations on
@@ -105,11 +103,11 @@ impl HomeserverCapabilities {
     ///
     /// Spec: <https://spec.matrix.org/latest/client-server-api/#mprofile_fields-capability>
     pub async fn extended_profile_fields(&self) -> crate::Result<ProfileFieldsCapability> {
-        let capabilities = self.load_or_fetch_homeserver_capabilities().await?;
-        if let Some(profile_fields) = capabilities.profile_fields {
-            return Ok(profile_fields);
-        }
-        Ok(ProfileFieldsCapability::new(false))
+        Ok(self
+            .profile_capabilities()
+            .await?
+            .profile_fields
+            .unwrap_or_else(|| ProfileFieldsCapability::new(false)))
     }
 
     /// Returns the room versions supported by the server.
@@ -181,6 +179,57 @@ impl HomeserverCapabilities {
 
         Ok(res.capabilities)
     }
+
+    /// Gets or computes the supported [`ProfileCapabilities`].
+    async fn profile_capabilities(&self) -> crate::Result<ProfileCapabilities> {
+        let capabilities = self.load_or_fetch_homeserver_capabilities().await?;
+
+        let profile_fields = match capabilities.profile_fields {
+            Some(profile_fields) => Some(profile_fields),
+            None => {
+                // According to the Matrix spec about the `m.profile_fields` capability:
+                //
+                // > When this capability is not listed, clients SHOULD assume the user is
+                // > able to change profile fields without any restrictions, provided the
+                // > homeserver advertises a specification version that includes the
+                // > `m.profile_fields` capability in the `/versions` response.
+                if self.homeserver_supports_extended_profile_fields().await? {
+                    Some(ProfileFieldsCapability::new(true))
+                } else {
+                    None
+                }
+            }
+        };
+
+        #[allow(deprecated)]
+        Ok(ProfileCapabilities {
+            profile_fields,
+            set_displayname: capabilities.set_displayname.enabled,
+            set_avatar_url: capabilities.set_avatar_url.enabled,
+        })
+    }
+
+    /// Whether the homeserver supports extended profile fields.
+    ///
+    ///
+    /// [Matrix spec]: https://spec.matrix.org/latest/client-server-api/#mprofile_fields-capability
+    async fn homeserver_supports_extended_profile_fields(&self) -> crate::Result<bool> {
+        let supported_versions = self.client.supported_versions().await?;
+        // If the homeserver supports the endpoint to delete profile fields, it supports
+        // extended profile fields.
+        Ok(delete_profile_field::v3::Request::PATH_BUILDER.is_supported(&supported_versions))
+    }
+}
+
+/// All the capabilities to change a profile field.
+struct ProfileCapabilities {
+    /// The capability to change profile fields, advertised by the homeserver or
+    /// computed.
+    profile_fields: Option<ProfileFieldsCapability>,
+    /// The capability to set the display name advertised by the homeserver.
+    set_displayname: bool,
+    /// The capability to set the avatar URL advertised by the homeserver.
+    set_avatar_url: bool,
 }
 
 #[cfg(all(not(target_family = "wasm"), test))]


### PR DESCRIPTION
The current implementation assumes that if the `m.profile_fields` capability is missing, it means that the capability is not enabled. However the spec says that it depends on the Matrix versions advertised by the homeserver. So this adds a method that properly computes the capability depending on the supported versions too.

Similarly, for the display name and avatar URL fields the implementation assumes that if the `m.profile_fields` capability is present but disabled, we should fallback to the legacy capabilities. This behavior is not present in the spec, so the code is changed to always use the new capability when it is present, whether it is enabled or not. The legacy capabilities are only used if the new capability is missing and the homeserver doesn't advertise support for extended profile fields.

<!-- description of the changes in this PR -->

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

