### PR TITLE
refactor(examples): update get-profiles example to use `Account::fetch_user_profile`

### DIFF
--- a/examples/get_profiles/src/main.rs
+++ b/examples/get_profiles/src/main.rs
@@ -31,7 +31,7 @@ async fn get_profile(client: Client, mxid: &UserId) -> MatrixResult<UserProfile>
 
     // Start the request using matrix_sdk::Client::send
     // To avoid having to deal with auth errors, you can also use
-    // account().fetch_user_profile() which handles auth correctly
+    // account().fetch_user_profile() which handles auth correctly.
     let resp = client.send(request).await?;
 
     // Use the response and construct a UserProfile struct.
@@ -94,7 +94,6 @@ async fn main() -> anyhow::Result<()> {
             if e.as_client_api_error()
                 .is_some_and(|err| err.status_code == StatusCode::UNAUTHORIZED)
             {
-                // if is_auth_error(&e) {
                 eprintln!(
                     "Authentication error: {e}. Check if the server requires authentication for profile requests. Trying to fetch profile using the authenticated client instead..."
                 );
@@ -106,7 +105,6 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    // get_profile(client, &user_id).await?;
     println!("{profile:#?}");
     Ok(())
 }

--- a/examples/get_profiles/src/main.rs
+++ b/examples/get_profiles/src/main.rs
@@ -1,10 +1,14 @@
 use std::{env, process::exit};
 
 use matrix_sdk::{
-    Client, Result as MatrixResult,
+    Client, HttpError, Result as MatrixResult, RumaApiError,
+    reqwest::StatusCode,
     ruma::{
         OwnedMxcUri, UserId,
-        api::client::profile::{self, AvatarUrl, DisplayName},
+        api::{
+            client::profile::{self, AvatarUrl, DisplayName},
+            error::FromHttpResponseError,
+        },
     },
 };
 use url::Url;
@@ -19,17 +23,44 @@ struct UserProfile {
 /// This function calls the GET profile endpoint
 /// Spec: <https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3profileuserid>
 /// Ruma: <https://docs.rs/ruma-client-api/latest/ruma_client_api/profile/get_profile/v3/index.html>
+/// The Matrix spec does not require authentication for this endpooint. However, some server configurations (e.g. Synapse's
+/// `require_auth_for_profile_requests`) enfonce auth to prevent user enumeration, which will cause `client.send()` to
+/// return a 401 error.
 async fn get_profile(client: Client, mxid: &UserId) -> MatrixResult<UserProfile> {
     // First construct the request you want to make
     // See https://docs.rs/ruma-client-api/latest/ruma_client_api/index.html for all available Endpoints
     let request = profile::get_profile::v3::Request::new(mxid.to_owned());
 
     // Start the request using matrix_sdk::Client::send
+    // To avoid having to deal with auth errors, you can also use account().fetch_user_profile() which handles auth correctly
     let resp = client.send(request).await?;
 
     // Use the response and construct a UserProfile struct.
     // See https://docs.rs/ruma-client-api/latest/ruma_client_api/profile/get_profile/v3/struct.Response.html
     // for details on the Response for this Request
+    let user_profile = UserProfile {
+        avatar_url: resp.get_static::<AvatarUrl>()?,
+        displayname: resp.get_static::<DisplayName>()?,
+    };
+    Ok(user_profile)
+}
+
+// Helper function to avoid having a lot of nested errors in main() when trying to get profile.
+fn is_auth_error(e: &matrix_sdk::Error) -> bool {
+    if let matrix_sdk::Error::Http(http_err) = e
+        && let HttpError::Api(resp_err) = http_err.as_ref()
+        && let FromHttpResponseError::Server(ruma_err) = resp_err.as_ref()
+        && let RumaApiError::ClientApi(inner_err) = ruma_err
+    {
+        return inner_err.status_code == StatusCode::UNAUTHORIZED;
+    }
+    false
+}
+
+/// This function calls the GET profile endpoint using the authenticated client. It should succeed even if the server requires auth for profile requests.
+async fn get_profile_authenticated(client: Client) -> MatrixResult<UserProfile> {
+    let resp = client.account().fetch_user_profile().await?;
+
     let user_profile = UserProfile {
         avatar_url: resp.get_static::<AvatarUrl>()?,
         displayname: resp.get_static::<DisplayName>()?,
@@ -69,7 +100,22 @@ async fn main() -> anyhow::Result<()> {
     let client = login(homeserver_url, &username, &password).await?;
 
     let user_id = UserId::parse(username).expect("Couldn't parse the MXID");
-    let profile = get_profile(client, &user_id).await?;
+    let profile = match get_profile(client.clone(), &user_id).await {
+        Ok(profile) => profile,
+        Err(e) => {
+            if is_auth_error(&e) {
+                eprintln!(
+                    "Authentication error: {e}. Check if the server requires authentication for profile requests. Trying to fetch profile using the authenticated client instead..."
+                );
+                get_profile_authenticated(client).await?
+            } else {
+                eprintln!("Error fetching profile: {e}");
+                UserProfile { avatar_url: None, displayname: None }
+            }
+        }
+    };
+    
+    // get_profile(client, &user_id).await?;
     println!("{profile:#?}");
     Ok(())
 }

--- a/examples/get_profiles/src/main.rs
+++ b/examples/get_profiles/src/main.rs
@@ -1,14 +1,11 @@
 use std::{env, process::exit};
 
 use matrix_sdk::{
-    Client, HttpError, Result as MatrixResult, RumaApiError,
+    Client, Result as MatrixResult,
     reqwest::StatusCode,
     ruma::{
         OwnedMxcUri, UserId,
-        api::{
-            client::profile::{self, AvatarUrl, DisplayName},
-            error::FromHttpResponseError,
-        },
+        api::client::profile::{self, AvatarUrl, DisplayName},
     },
 };
 use url::Url;
@@ -45,19 +42,6 @@ async fn get_profile(client: Client, mxid: &UserId) -> MatrixResult<UserProfile>
         displayname: resp.get_static::<DisplayName>()?,
     };
     Ok(user_profile)
-}
-
-// Helper function to avoid having a lot of nested errors in main() when trying
-// to get profile.
-fn is_auth_error(e: &matrix_sdk::Error) -> bool {
-    if let matrix_sdk::Error::Http(http_err) = e
-        && let HttpError::Api(resp_err) = http_err.as_ref()
-        && let FromHttpResponseError::Server(ruma_err) = resp_err.as_ref()
-        && let RumaApiError::ClientApi(inner_err) = ruma_err
-    {
-        return inner_err.status_code == StatusCode::UNAUTHORIZED;
-    }
-    false
 }
 
 /// This function calls the GET profile endpoint using the authenticated client.
@@ -107,7 +91,10 @@ async fn main() -> anyhow::Result<()> {
     let profile = match get_profile(client.clone(), &user_id).await {
         Ok(profile) => profile,
         Err(e) => {
-            if is_auth_error(&e) {
+            if e.as_client_api_error()
+                .is_some_and(|err| err.status_code == StatusCode::UNAUTHORIZED)
+            {
+                // if is_auth_error(&e) {
                 eprintln!(
                     "Authentication error: {e}. Check if the server requires authentication for profile requests. Trying to fetch profile using the authenticated client instead..."
                 );

--- a/examples/get_profiles/src/main.rs
+++ b/examples/get_profiles/src/main.rs
@@ -23,16 +23,18 @@ struct UserProfile {
 /// This function calls the GET profile endpoint
 /// Spec: <https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3profileuserid>
 /// Ruma: <https://docs.rs/ruma-client-api/latest/ruma_client_api/profile/get_profile/v3/index.html>
-/// The Matrix spec does not require authentication for this endpooint. However, some server configurations (e.g. Synapse's
-/// `require_auth_for_profile_requests`) enfonce auth to prevent user enumeration, which will cause `client.send()` to
-/// return a 401 error.
+/// The Matrix spec does not require authentication for this endpoint. However,
+/// some server configurations (e.g. Synapse's
+/// `require_auth_for_profile_requests`) enforce auth to prevent user
+/// enumeration, which will cause `client.send()` to return a 401 error.
 async fn get_profile(client: Client, mxid: &UserId) -> MatrixResult<UserProfile> {
     // First construct the request you want to make
     // See https://docs.rs/ruma-client-api/latest/ruma_client_api/index.html for all available Endpoints
     let request = profile::get_profile::v3::Request::new(mxid.to_owned());
 
     // Start the request using matrix_sdk::Client::send
-    // To avoid having to deal with auth errors, you can also use account().fetch_user_profile() which handles auth correctly
+    // To avoid having to deal with auth errors, you can also use
+    // account().fetch_user_profile() which handles auth correctly
     let resp = client.send(request).await?;
 
     // Use the response and construct a UserProfile struct.
@@ -45,7 +47,8 @@ async fn get_profile(client: Client, mxid: &UserId) -> MatrixResult<UserProfile>
     Ok(user_profile)
 }
 
-// Helper function to avoid having a lot of nested errors in main() when trying to get profile.
+// Helper function to avoid having a lot of nested errors in main() when trying
+// to get profile.
 fn is_auth_error(e: &matrix_sdk::Error) -> bool {
     if let matrix_sdk::Error::Http(http_err) = e
         && let HttpError::Api(resp_err) = http_err.as_ref()
@@ -57,7 +60,8 @@ fn is_auth_error(e: &matrix_sdk::Error) -> bool {
     false
 }
 
-/// This function calls the GET profile endpoint using the authenticated client. It should succeed even if the server requires auth for profile requests.
+/// This function calls the GET profile endpoint using the authenticated client.
+/// It should succeed even if the server requires auth for profile requests.
 async fn get_profile_authenticated(client: Client) -> MatrixResult<UserProfile> {
     let resp = client.account().fetch_user_profile().await?;
 
@@ -114,7 +118,7 @@ async fn main() -> anyhow::Result<()> {
             }
         }
     };
-    
+
     // get_profile(client, &user_id).await?;
     println!("{profile:#?}");
     Ok(())


### PR DESCRIPTION
Fixes #5902

## What this PR does

Keeps the existing `Client::send()` demo but extends it with:

- A doc comment on `get_profile` explaining the spec behaviour and the 401 
condition on  (Synapse's `require_auth_for_profile_requests`)
- A `get_profile_authenticated()` fallback using `account().fetch_user_profile()` 
which internally uses `force_auth()`

## Testing

Tested against:
- matrix.org — both methods return the same profile
- Local Synapse with `require_auth_for_profile_requests: true` — 401 fallback triggers correctly and recovers
