### PR TITLE
feat(event timeline item): Handle beacon stop aggregation in latest event

### DIFF
--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- Keep stopped `beacon_info` live location sessions visible in
+  `Room::latest_event()`, so room summaries still show the last live location
+  sharing session after it ends.
+  ([#6437](https://github.com/matrix-org/matrix-rust-sdk/pull/6437))
 - Don't show a "sent in clear" shield on live location timeline items in
   encrypted rooms, since `beacon_info` is a state event that cannot be
   encrypted by design.

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -173,7 +173,18 @@ impl TimelineItemContent {
         {
             Some(TimelineAction::AddItem { content }) => Some(content),
 
-            // Aggregated event: only edits are supported at the moment.
+            // Aggregated event: only edits and beacon stop are supported at the moment.
+            Some(TimelineAction::HandleAggregation {
+                kind: HandleAggregationKind::BeaconStop { content },
+                ..
+            }) => Some(TimelineItemContent::MsgLike(MsgLikeContent {
+                kind: MsgLikeKind::LiveLocation(LiveLocationState::new(content)),
+                reactions: Default::default(),
+                thread_root: None,
+                in_reply_to: None,
+                thread_summary: None,
+            })),
+
             Some(TimelineAction::HandleAggregation {
                 kind: HandleAggregationKind::Edit { replacement: Replacement { new_content, .. } },
                 ..

--- a/crates/matrix-sdk-ui/src/timeline/latest_event.rs
+++ b/crates/matrix-sdk-ui/src/timeline/latest_event.rs
@@ -173,7 +173,7 @@ impl LatestEventValue {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Not;
+    use std::{ops::Not, time::Duration};
 
     use assert_matches::assert_matches;
     use matrix_sdk::{
@@ -377,6 +377,41 @@ mod tests {
                 content,
                 TimelineItemContent::MsgLike(MsgLikeContent { kind: MsgLikeKind::Message(message), .. }) => {
                     assert_eq!(message.body(), "fondue");
+                }
+            );
+        })
+    }
+
+    #[async_test]
+    async fn test_remote_beacon_stop() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let room = server.sync_room(&client, JoinedRoomBuilder::new(room_id!("!r0"))).await;
+        let sender = user_id!("@mnt_io:matrix.org");
+        let event_factory = EventFactory::new();
+
+        let base_value = BaseLatestEventValue::Remote(RemoteLatestEventValue::from_plaintext(
+            event_factory
+                .server_ts(42)
+                .sender(sender)
+                .beacon_info(Some("Alice's walk".to_owned()), Duration::from_secs(60), false, None)
+                .state_key(sender)
+                .event_id(event_id!("$beacon-stop"))
+                .into_raw_sync(),
+        ));
+        let value =
+            LatestEventValue::from_base_latest_event_value(base_value, &room, &client).await;
+
+        assert_matches!(value, LatestEventValue::Remote { timestamp, sender: received_sender, is_own, profile, content } => {
+            assert_eq!(u64::from(timestamp.get()), 42u64);
+            assert_eq!(received_sender, sender);
+            assert!(is_own.not());
+            assert_matches!(profile, TimelineDetails::Unavailable);
+            assert_matches!(
+                content,
+                TimelineItemContent::MsgLike(MsgLikeContent { kind: MsgLikeKind::LiveLocation(state), .. }) => {
+                    assert!(!state.is_live(), "stop beacon should not be live");
+                    assert_eq!(state.description(), Some("Alice's walk"));
                 }
             );
         })


### PR DESCRIPTION
Support BeaconStop aggregation to properly display stopped live location sharing in the latest event timeline content.

Follow up of https://github.com/matrix-org/matrix-rust-sdk/pull/6373 and https://github.com/matrix-org/matrix-rust-sdk/pull/6408

<!-- description of the changes in this PR -->

- [X] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
