### PR TITLE
ci: Explicitly state which tool we want to install, namely nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install nextest
-        uses: taiki-e/install-action@e28ca663369ecd0d4acc114be0b55092dcd84136 # nextest
+        uses: taiki-e/install-action@85b24a67ef0c632dfefad70b9d5ce8fddb040754 # v 2.75.10
+        with:
+          tool: nextest
 
       - name: Get xtask
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -101,7 +103,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install nextest
-        uses: taiki-e/install-action@e28ca663369ecd0d4acc114be0b55092dcd84136 # nextest
+        uses: taiki-e/install-action@85b24a67ef0c632dfefad70b9d5ce8fddb040754 # v 2.75.10
+        with:
+          tool: nextest
 
       - name: Get xtask
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -141,7 +145,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install nextest
-        uses: taiki-e/install-action@e28ca663369ecd0d4acc114be0b55092dcd84136 # nextest
+        uses: taiki-e/install-action@85b24a67ef0c632dfefad70b9d5ce8fddb040754 # v 2.75.10
+        with:
+          tool: nextest
 
       - name: Get xtask
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -202,7 +208,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install nextest
-        uses: taiki-e/install-action@e28ca663369ecd0d4acc114be0b55092dcd84136 # nextest
+        uses: taiki-e/install-action@85b24a67ef0c632dfefad70b9d5ce8fddb040754 # v 2.75.10
+        with:
+          tool: nextest
 
       - name: Test
         run: |
@@ -278,7 +286,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install nextest
-        uses: taiki-e/install-action@e28ca663369ecd0d4acc114be0b55092dcd84136 # nextest
+        uses: taiki-e/install-action@85b24a67ef0c632dfefad70b9d5ce8fddb040754 # v 2.75.10
+        with:
+          tool: nextest
 
       - name: Get xtask
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -395,7 +405,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install nextest
-        uses: taiki-e/install-action@e28ca663369ecd0d4acc114be0b55092dcd84136 # nextest
+        uses: taiki-e/install-action@85b24a67ef0c632dfefad70b9d5ce8fddb040754 # v 2.75.10
+        with:
+          tool: nextest
 
       - name: Test
         env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -129,7 +129,9 @@ jobs:
         uses: taiki-e/install-action@8a8ecf49de4feac160d13668bc406fe17413c1bf # cargo-llvm-cov
 
       - name: Install nextest
-        uses: taiki-e/install-action@e28ca663369ecd0d4acc114be0b55092dcd84136 # nextest
+        uses: taiki-e/install-action@85b24a67ef0c632dfefad70b9d5ce8fddb040754 # v 2.75.10
+        with:
+          tool: nextest
 
       - name: Get xtask
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5


### PR DESCRIPTION
This is the reason why one of our dependabot bumps fails: https://github.com/matrix-org/matrix-rust-sdk/pull/6439.