### PR TITLE
ci: Explicitly state that we want cargo-hack installed

### DIFF
--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -17,4 +17,6 @@ jobs:
       with:
         persist-credentials: false
     - uses: taiki-e/install-action@4146cc238a18f9b3f3427572fd4585d2d2d78c88 # cargo-hack
+      with:
+        tool: cargo-hack
     - run: cargo hack check --rust-version --workspace --all-targets


### PR DESCRIPTION
Another one that needs to be explicitly state for https://github.com/matrix-org/matrix-rust-sdk/pull/6439 to work.
