### PR TITLE
feat(ui): add custom event content to timeline items

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -194,7 +194,8 @@ impl<P: RoomDataProvider> TimelineState<P> {
             should_add_new_items,
         };
 
-        let timeline_action = TimelineAction::from_content(content, in_reply_to, thread_root, None);
+        let timeline_action =
+            TimelineAction::from_content(content, None, in_reply_to, thread_root, None);
         TimelineEventHandler::new(&mut txn, ctx)
             .handle_event(&mut date_divider_adjuster, timeline_action, None)
             .await;

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -285,6 +285,7 @@ impl TimelineAction {
                         // configured. We treat it the same as any other message-like event.
                         Self::from_content(
                             AnyMessageLikeEventContent::RoomEncrypted(content),
+                            Some(raw_event),
                             in_reply_to,
                             thread_root,
                             thread_summary,
@@ -292,9 +293,13 @@ impl TimelineAction {
                     }
                 }
 
-                Some(content) => {
-                    Self::from_content(content, in_reply_to, thread_root, thread_summary)
-                }
+                Some(content) => Self::from_content(
+                    content,
+                    Some(raw_event),
+                    in_reply_to,
+                    thread_root,
+                    thread_summary,
+                ),
 
                 None => Self::add_item(redacted_message_or_none(ev.event_type())?),
             },
@@ -369,6 +374,7 @@ impl TimelineAction {
     /// or an aggregation) is not supported for this event type.
     pub(super) fn from_content(
         content: AnyMessageLikeEventContent,
+        raw_event: Option<&Raw<AnySyncTimelineEvent>>,
         in_reply_to: Option<InReplyToDetails>,
         thread_root: Option<OwnedEventId>,
         thread_summary: Option<ThreadSummary>,
@@ -465,7 +471,10 @@ impl TimelineAction {
             },
 
             event => {
-                let other = OtherMessageLike { event_type: event.event_type() };
+                let other = OtherMessageLike {
+                    event_type: event.event_type(),
+                    raw_event: raw_event.cloned(),
+                };
 
                 Self::AddItem {
                     content: TimelineItemContent::MsgLike(MsgLikeContent {

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -183,6 +183,7 @@ impl TimelineItemContent {
                     None,
                     None,
                     None,
+                    None,
                 ) {
                     TimelineAction::AddItem { content } => Some(content),
                     _ => None,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/other.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/other.rs
@@ -15,21 +15,33 @@
 //! Timeline item content for other message-like events created by the
 //! EventContent macro from ruma.
 
-use ruma::events::MessageLikeEventType;
+use ruma::{
+    events::{AnyMessageLikeEventContent, AnySyncTimelineEvent, MessageLikeEventType},
+    serde::Raw,
+};
 
 /// A custom event created by the EventContent macro from ruma.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct OtherMessageLike {
     pub(in crate::timeline) event_type: MessageLikeEventType,
+    pub(in crate::timeline) raw_event: Option<Raw<AnySyncTimelineEvent>>,
 }
 
 impl OtherMessageLike {
-    pub fn from_event_type(event_type: MessageLikeEventType) -> Self {
-        Self { event_type }
+    pub fn from_event_type_and_event(
+        event_type: MessageLikeEventType,
+        raw_event: Option<Raw<AnySyncTimelineEvent>>,
+    ) -> Self {
+        Self { event_type, raw_event }
     }
 
     /// Get the event_type of this message.
     pub fn event_type(&self) -> &MessageLikeEventType {
         &self.event_type
+    }
+
+    /// Get the raw event of this message, if available.
+    pub fn raw_event(&self) -> &Option<Raw<AnySyncTimelineEvent>> {
+        &self.raw_event
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/latest_event.rs
+++ b/crates/matrix-sdk-ui/src/timeline/latest_event.rs
@@ -135,7 +135,13 @@ impl LatestEventValue {
                 let profile =
                     TimelineDetails::from_initial_value(Profile::load(room, &sender).await);
 
-                match TimelineAction::from_content(message_like_event_content, None, None, None) {
+                match TimelineAction::from_content(
+                    message_like_event_content,
+                    None,
+                    None,
+                    None,
+                    None,
+                ) {
                     TimelineAction::AddItem { content } => Self::Local {
                         timestamp: *timestamp,
                         sender,


### PR DESCRIPTION
This adds the actual raw event to `OtherMessageLike` timeline events, so that it is possible to decode the custom events and display them in clients that use the ui/timeline api.

I did not document this for now or add new tests, as I'm looking for feedback first. As this is my first contribution to this crate, I'd like to clarify if this approach is the right thing to do, or if there is a more idiomatic way to pass down raw ruma events.

With this change the usual case does not change. To actually retrieve the custom events in the timeline the timeline event filter needs to be changed from the default to include wanted custom events. Now if the timeline contains a custom (remote) event, the raw event is cloned and passed to the client as a field in `OtherMessageLike`. For local events this is not supported right now.

Example usage to decode custom events (kinda pseudo code):

```rust
#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
#[ruma_event(type = "com.example.message", kind = MessageLike)]
pub struct ExampleMessageContent {
    #[serde(rename = "fooBar")]
    foo_bar: u32,
}

/* … */

let timeline = room.timeline_builder()
    .event_filter(|_, _| true) // change filter to return all events
    .build()
    .await
    .expect("could not create timeline");

let (evs, mut diffs) = timeline.subscribe().await;

for event in evs.iter()
    match event.content() {
        TimelineItemContent::MsgLike(MsgLikeContent { kind: MsgLikeKind::Other(o), .. }) => {
            let ex = o.raw_event().as_ref().map(|x| x.deserialize_as_unchecked::<MessageLikeEvent<ExampleMessageContent>>());
            println!("{:?}", ex); // Some(Ok(Original(OriginalMessageLikeEvent …
        }
    }
}
```
cc #6177 

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

