### PR TITLE
chore(sdk): `reload_from_storage` emits an `EventsOrigin::Cache`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
@@ -140,7 +140,7 @@ impl<'a> PinnedEventCacheStateLockWriteGuard<'a> {
         self.state.chunk.store_updates().take();
 
         // Let observers know about it.
-        self.notify_subscribers(EventsOrigin::Sync);
+        self.notify_subscribers(EventsOrigin::Cache);
 
         Ok(())
     }


### PR DESCRIPTION
This patch updates
`PinnedEventCacheStateLockWriteGuard::reload_from_storage`. It calls `notify_subscribers` with `EventsOrigin::Sync`. This patch changes for `EventsOrigin::Cache`. All events are indeed loaded from the store, so the cache.

---

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.