### PR TITLE
Better edit validation and don't apply invalid edits in the latest event

### DIFF
--- a/crates/matrix-sdk-common/CHANGELOG.md
+++ b/crates/matrix-sdk-common/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add a method to check the validity of edits.
+  ([#6454](https://github.com/matrix-org/matrix-rust-sdk/pull/6454))
 - A background task monitor has been added, that can spawn background tasks and monitor their
   execution on a separate channel. Such tasks can run forever, or they can run for one-shot jobs.
   ([#6075](https://github.com/matrix-org/matrix-rust-sdk/pull/6075) &&

--- a/crates/matrix-sdk-common/src/edit_validation.rs
+++ b/crates/matrix-sdk-common/src/edit_validation.rs
@@ -1,0 +1,194 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ruma::{events::AnySyncTimelineEvent, serde::Raw};
+use serde::Deserialize;
+
+use crate::deserialized_responses::EncryptionInfo;
+
+/// Represents all possible validation errors that can occur when processing
+/// an event edit.
+///
+/// These errors ensure that a replacement event complies with the rules
+/// required to safely and correctly modify an existing event.
+///
+/// [spec]: https://spec.matrix.org/v1.17/client-server-api/#validity-of-replacement-events
+#[derive(Debug, thiserror::Error)]
+pub enum EditValidityError {
+    /// Occurs when the sender of the replacement event does not match
+    /// the sender of the original event.
+    ///
+    /// Only the original sender is allowed to edit their own event.
+    #[error(
+        "the sender of the original event isn't the same as the sender of the replacement event"
+    )]
+    InvalidSender,
+
+    /// Occurs when either the original event or the replacement event contains
+    /// a state key.
+    ///
+    /// State events are not allowed to be edited.
+    #[error("the original event or the replacement event contains a state key")]
+    StateKeyPresent,
+
+    /// Occurs when the content type of the original event differs from
+    /// that of the replacement event.
+    ///
+    /// Edits must not change the event’s content type, as this would
+    /// introduce semantic inconsistencies.
+    #[error(
+        "the content type of the original event is `{content_type}` while the replacement is a `{replacement_type}`"
+    )]
+    MismatchContentType {
+        /// The content type of the original event.
+        content_type: String,
+
+        /// The content type of the replacement event.
+        replacement_type: String,
+    },
+
+    /// Occurs when the original event is itself already a replacement (edit).
+    #[error("the original event is an edit as well")]
+    OriginalEventIsReplacement,
+
+    /// Occurs when the replacement event is not a replacement for the original
+    /// event.
+    #[error("the replacement event is not a replacement for the original event")]
+    NotReplacement,
+
+    /// Occurs when a required field is missing from either the original
+    /// or the replacement event.
+    ///
+    /// The event is considered malformed and cannot be validated.
+    #[error("the event was encrypted, as such it should have an `m.new_content` field")]
+    MissingNewContent,
+
+    #[error(transparent)]
+    InvalidJson(#[from] serde_json::Error),
+
+    /// Occurs when the original event is encrypted but the replacement
+    /// event is not.
+    #[error("the original event was encrypted while the replacement is not")]
+    ReplacementNotEncrypted,
+}
+
+/// This implements the Matrix spec rule set for validity of replacement events
+/// (edits). Invalid replacements must be ignored.
+///
+/// This function implements the steps documented in the [spec] with one
+/// exception, the step to check if the room IDs match isn't done. The JSON of
+/// the event might not contain the room ID if it wasn received over a `/sync`
+/// request.
+///
+/// *Warning*: Callers must ensure that the original event and replacement event
+/// belong to the same room, that is, they have the same room ID.
+///
+/// [spec]: https://spec.matrix.org/v1.17/client-server-api/#validity-of-replacement-events
+pub fn check_validity_of_replacement_events(
+    original_json: &Raw<AnySyncTimelineEvent>,
+    original_encryption_info: Option<&EncryptionInfo>,
+    replacement_json: &Raw<AnySyncTimelineEvent>,
+    replacement_encryption_info: Option<&EncryptionInfo>,
+) -> Result<(), EditValidityError> {
+    const REPLACEMENT_REL_TYPE: &str = "m.replace";
+
+    #[derive(Debug, Deserialize)]
+    struct MinimalEvent<'a> {
+        sender: &'a str,
+        event_id: &'a str,
+        #[serde(rename = "type")]
+        event_type: &'a str,
+        state_key: Option<&'a str>,
+        content: MinimalContent<'a>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct MinimalContent<'a> {
+        #[serde(borrow, rename = "m.relates_to")]
+        relates_to: Option<MinimalRelatesTo<'a>>,
+        #[serde(rename = "m.new_content")]
+        new_content: Option<MinimalNewContent>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct MinimalNewContent {}
+
+    #[derive(Debug, Deserialize)]
+    struct MinimalRelatesTo<'a> {
+        rel_type: Option<&'a str>,
+        event_id: Option<&'a str>,
+    }
+
+    let original_event = original_json.deserialize_as_unchecked::<MinimalEvent<'_>>()?;
+    let replacement_event = replacement_json.deserialize_as_unchecked::<MinimalEvent<'_>>()?;
+
+    // We don't check the room ID here since this event might have been received
+    // over /sync, in this case the JSON likely won't contain the room ID field.
+
+    // The original event and replacement event must have the same sender (i.e. you
+    // cannot edit someone else’s messages).
+    if original_event.sender != replacement_event.sender {
+        return Err(EditValidityError::InvalidSender);
+    }
+
+    // This check isn't part of the list in the spec, but it makes sense to check if
+    // the replacement event is has the correct rel_type and if it's an edit for the
+    // original event.
+    if let Some(relates_to) = replacement_event.content.relates_to {
+        if relates_to.rel_type != Some(REPLACEMENT_REL_TYPE)
+            || relates_to.event_id != Some(original_event.event_id)
+        {
+            return Err(EditValidityError::NotReplacement);
+        }
+    } else {
+        return Err(EditValidityError::NotReplacement);
+    }
+
+    // The replacement and original events must have the same type (i.e. you cannot
+    // change the original event’s type).
+    if original_event.event_type != replacement_event.event_type {
+        return Err(EditValidityError::MismatchContentType {
+            content_type: original_event.event_type.to_owned(),
+            replacement_type: replacement_event.event_type.to_owned(),
+        });
+    }
+
+    // The replacement and original events must not have a state_key property (i.e.
+    // you cannot edit state events at all).
+    if original_event.state_key.is_some() || replacement_event.state_key.is_some() {
+        return Err(EditValidityError::StateKeyPresent);
+    }
+
+    // The original event must not, itself, have a rel_type of m.replace (i.e. you
+    // cannot edit an edit — though you can send multiple edits for a single
+    // original event).
+    if let Some(relates_to) = original_event.content.relates_to
+        && relates_to.rel_type == Some(REPLACEMENT_REL_TYPE)
+    {
+        return Err(EditValidityError::OriginalEventIsReplacement);
+    }
+
+    // The replacement event (once decrypted, if appropriate) must have an
+    // m.new_content property.
+    if replacement_encryption_info.is_some() && replacement_event.content.new_content.is_none() {
+        return Err(EditValidityError::MissingNewContent);
+    }
+
+    // If the original event was encrypted, the replacement should be too.
+    if original_encryption_info.is_some() && replacement_encryption_info.is_none() {
+        return Err(EditValidityError::ReplacementNotEncrypted);
+    }
+
+    Ok(())
+}

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -17,6 +17,8 @@
 
 use std::pin::Pin;
 
+use ruma::{RoomVersionId, room_version_rules::RoomVersionRules};
+
 #[cfg(test)]
 matrix_sdk_test_utils::init_tracing_for_tests!();
 
@@ -27,6 +29,7 @@ pub use ruma;
 pub mod cross_process_lock;
 pub mod debug;
 pub mod deserialized_responses;
+mod edit_validation;
 pub mod executor;
 pub mod failures_cache;
 pub mod linked_chunk;
@@ -47,7 +50,7 @@ pub mod ttl_cache;
 pub mod js_tracing;
 
 pub use cross_process_lock::LEASE_DURATION_MS;
-use ruma::{RoomVersionId, room_version_rules::RoomVersionRules};
+pub use edit_validation::*;
 
 /// Alias for `Send` on non-wasm, empty trait (implemented by everything) on
 /// wasm.

--- a/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
@@ -40,7 +40,7 @@
 use std::{borrow::Cow, collections::HashMap, sync::Arc};
 
 use as_variant::as_variant;
-use matrix_sdk::deserialized_responses::EncryptionInfo;
+use matrix_sdk::{check_validity_of_replacement_events, deserialized_responses::EncryptionInfo};
 use ruma::{
     MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
     events::{
@@ -51,7 +51,7 @@ use ruma::{
     room_version_rules::RoomVersionRules,
     serde::Raw,
 };
-use tracing::{info, trace, warn};
+use tracing::{error, info, trace, warn};
 
 use super::{ObservableItemsTransaction, rfind_event_by_item_id};
 use crate::timeline::{
@@ -782,7 +782,11 @@ fn resolve_edits(
     items: &ObservableItemsTransaction<'_>,
     event: &mut Cow<'_, EventTimelineItem>,
 ) -> bool {
-    let mut best_edit: Option<PendingEdit> = None;
+    // A tuple of the best edit, if we have found one and a boolean indicating if
+    // the edit is coming from a local echo. If it's from a local echo, we can't
+    // validate it as we don't have a raw JSON, but this isn't that important as
+    // we're sure we won't send ourselves invalid edits.
+    let mut best_edit: Option<(PendingEdit, bool)> = None;
     let mut best_edit_pos = None;
 
     for a in aggregations {
@@ -790,7 +794,7 @@ fn resolve_edits(
             match &a.own_id {
                 TimelineEventItemId::TransactionId(_) => {
                     // A local echo is always the most recent edit: use this one.
-                    best_edit = Some(pending_edit.clone());
+                    best_edit = Some((pending_edit.clone(), true));
                     break;
                 }
 
@@ -806,7 +810,7 @@ fn resolve_edits(
                             // If the edit is more recent (higher index) than the previous best
                             // edit we knew about, use this one.
                             if pos > *best_edit_pos {
-                                best_edit = Some(pending_edit.clone());
+                                best_edit = Some((pending_edit.clone(), false));
                                 *best_edit_pos = pos;
                                 trace!(?best_edit_pos, edit_id = ?a.own_id, "found better edit");
                             }
@@ -817,14 +821,14 @@ fn resolve_edits(
                             // edit. In this case, record it as the best edit if and only if
                             // there wasn't any other.
                             if best_edit.is_none() {
-                                best_edit = Some(pending_edit.clone());
+                                best_edit = Some((pending_edit.clone(), false));
                                 trace!(?best_edit_pos, edit_id = ?a.own_id, "found bundled edit");
                             }
                         }
                     } else {
                         // There wasn't any best edit yet, so record this one as being it, with
                         // its position.
-                        best_edit = Some(pending_edit.clone());
+                        best_edit = Some((pending_edit.clone(), false));
                         best_edit_pos = items.position_by_event_id(event_id);
                         trace!(?best_edit_pos, edit_id = ?a.own_id, "first best edit");
                     }
@@ -833,29 +837,54 @@ fn resolve_edits(
         }
     }
 
-    if let Some(edit) = best_edit { edit_item(event, edit) } else { false }
+    if let Some((edit, is_local_echo)) = best_edit {
+        edit_item(event, edit, is_local_echo)
+    } else {
+        false
+    }
 }
 
 /// Apply the selected edit to the given EventTimelineItem.
 ///
 /// Returns true if the edit was applied, false otherwise (because the edit and
 /// original timeline item types didn't match, for instance).
-fn edit_item(item: &mut Cow<'_, EventTimelineItem>, edit: PendingEdit) -> bool {
-    let PendingEdit { kind: edit_kind, edit_json, encryption_info, bundled_item_owner: _ } = edit;
-
-    if let Some(event_json) = &edit_json {
-        let Some(edit_sender) = event_json.get_field::<OwnedUserId>("sender").ok().flatten() else {
-            info!("edit event didn't have a sender; likely a malformed event");
+fn edit_item(
+    item: &mut Cow<'_, EventTimelineItem>,
+    edit: PendingEdit,
+    is_local_echo: bool,
+) -> bool {
+    // We can receive edits from a local echo, i.e. the edit wasn't yet received
+    // from the homeserver.
+    //
+    // Before we send an edit we check that the event is allowed to be edited and
+    // that the replacement content is allowed.
+    //
+    // We don't have yet a full JSON of the event, so we can't do the validation
+    // here.
+    if !is_local_echo {
+        let Some(original_json) = item.original_json() else {
+            error!("The original event does not have the JSON field set.");
             return false;
         };
 
-        if edit_sender != item.sender() {
-            info!(
-                original_sender = %item.sender(),
-                %edit_sender,
-                "Edit event applies to another user's timeline item, discarding"
+        let Some(edit_json) = &edit.edit_json else {
+            error!(
+                "The replacement event of a remotely received edit does not have the JSON field set."
             );
             return false;
+        };
+
+        match check_validity_of_replacement_events(
+            original_json,
+            item.encryption_info(),
+            edit_json,
+            edit.encryption_info.as_deref(),
+        ) {
+            Ok(content) => content,
+            Err(e) => {
+                warn!("Event wasn't replaced due to the replacement event being invalid: {e}");
+                return false;
+            }
         }
     }
 
@@ -863,6 +892,8 @@ fn edit_item(item: &mut Cow<'_, EventTimelineItem>, edit: PendingEdit) -> bool {
         info!("Edit of message event applies to {:?}, discarding", item.content().debug_string());
         return false;
     };
+
+    let PendingEdit { kind: edit_kind, edit_json, encryption_info, bundled_item_owner: _ } = edit;
 
     match (edit_kind, content) {
         (

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -123,6 +123,8 @@ All notable changes to this project will be documented in this file.
 
 ### Bugfix
 
+- Reject invalid edits as candidates for the latest event.
+  ([#6454](https://github.com/matrix-org/matrix-rust-sdk/pull/6454))
 - Fix an infinite loop when loading pinned events from the storage.
   ([#6453](https://github.com/matrix-org/matrix-rust-sdk/pull/6453))
 - `beacon_info` stop events (`live: false`, [MSC3672](https://github.com/matrix-org/matrix-spec-proposals/pull/3672))

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -24,6 +24,7 @@ use eyeball::SharedObservable;
 use eyeball_im::VectorDiff;
 use matrix_sdk_base::{
     RoomInfoNotableUpdateReasons, StateChanges, apply_redaction,
+    check_validity_of_replacement_events,
     deserialized_responses::{ThreadSummary, ThreadSummaryStatus},
     event_cache::{
         Event, Gap,
@@ -1122,12 +1123,28 @@ impl<'a> RoomEventCacheStateLockWriteGuard<'a> {
             // If there's an edit to the latest event in the thread, use the latest edit
             // event id as the latest event id for the thread summary.
             if let Some(event_id) = latest_event_id.as_ref()
-                && let Some((_, edits)) = self
+                && let Some((original_event, edits)) = self
                     .find_event_with_relations(event_id, Some(vec![RelationType::Replacement]))
                     .await?
-                && let Some(latest_edit) = edits.last()
             {
-                latest_event_id = latest_edit.event_id();
+                let latest_valid_edit = edits.into_iter().rfind(|edit| {
+                    let original_json = original_event.raw();
+                    let original_encryption_info = original_event.encryption_info();
+                    let replacement_json = edit.raw();
+                    let replacement_encryption_info = edit.encryption_info();
+
+                    check_validity_of_replacement_events(
+                        original_json,
+                        original_encryption_info.map(|v| &**v),
+                        replacement_json,
+                        replacement_encryption_info.map(|v| &**v),
+                    )
+                    .is_ok()
+                });
+
+                if let Some(latest_valid_edit) = latest_valid_edit {
+                    latest_event_id = latest_valid_edit.event_id();
+                }
             }
 
             self.maybe_update_thread_summary(thread_root, latest_event_id, post_processing_origin)

--- a/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
@@ -44,7 +44,7 @@ impl Builder {
     /// Create a new [`LatestEventValue::Remote`].
     pub async fn new_remote(
         room_event_cache: &RoomEventCache,
-        current_value_event_id: Option<OwnedEventId>,
+        current_event: LatestEventValue,
         own_user_id: &UserId,
         power_levels: Option<&RoomPowerLevels>,
     ) -> Option<LatestEventValue> {
@@ -68,7 +68,7 @@ impl Builder {
 
                 match filter_timeline_event(
                     event,
-                    current_value_event_id.as_ref(),
+                    current_event.event_id().as_ref(),
                     own_user_id,
                     power_levels,
                 ) {
@@ -92,6 +92,10 @@ impl Builder {
                     ControlFlow::Break(()) => {
                         // Return the latest known edit of the event or the event itself if it
                         // hasn't been replaced.
+                        // TODO: Here we pick the event, and if there's an edit for the event we
+                        // pick the edit instead.
+                        //
+                        // We should check if the edit is valid.
                         event
                             .event_id()
                             .and_then(|event_id| latest_edit_for_event.get(&event_id))
@@ -149,7 +153,7 @@ impl Builder {
         send_queue_update: &RoomSendQueueUpdate,
         buffer_of_values_for_local_events: &mut BufferOfValuesForLocalEvents,
         room_event_cache: &RoomEventCache,
-        current_value_event_id: Option<OwnedEventId>,
+        current_event: LatestEventValue,
         own_user_id: &UserId,
         power_levels: Option<&RoomPowerLevels>,
     ) -> Option<LatestEventValue> {
@@ -168,7 +172,7 @@ impl Builder {
                         Ok(content) => {
                             if filter_any_message_like_event_content(
                                 content,
-                                current_value_event_id.as_ref(),
+                                current_event.event_id().as_ref(),
                             )
                             .is_break()
                             {
@@ -238,7 +242,7 @@ impl Builder {
                 Self::new_local_or_remote(
                     buffer_of_values_for_local_events,
                     room_event_cache,
-                    current_value_event_id,
+                    current_event,
                     own_user_id,
                     power_levels,
                 )
@@ -269,7 +273,7 @@ impl Builder {
                         if let Ok(Some(_)) = room_event_cache.find_event(event_id).await
                             && let Some(latest_event_value) = Self::new_remote(
                                 room_event_cache,
-                                current_value_event_id,
+                                current_event,
                                 own_user_id,
                                 power_levels,
                             )
@@ -293,7 +297,7 @@ impl Builder {
                 Self::new_local_or_remote(
                     buffer_of_values_for_local_events,
                     room_event_cache,
-                    current_value_event_id,
+                    current_event,
                     own_user_id,
                     power_levels,
                 )
@@ -313,7 +317,7 @@ impl Builder {
                         Ok(content) => {
                             if filter_any_message_like_event_content(
                                 content,
-                                current_value_event_id.as_ref(),
+                                current_event.event_id().as_ref(),
                             )
                             .is_break()
                             {
@@ -340,7 +344,7 @@ impl Builder {
                 Self::new_local_or_remote(
                     buffer_of_values_for_local_events,
                     room_event_cache,
-                    current_value_event_id,
+                    current_event,
                     own_user_id,
                     power_levels,
                 )
@@ -366,7 +370,7 @@ impl Builder {
                 Self::new_local_or_remote(
                     buffer_of_values_for_local_events,
                     room_event_cache,
-                    current_value_event_id,
+                    current_event,
                     own_user_id,
                     power_levels,
                 )
@@ -383,7 +387,7 @@ impl Builder {
                 Self::new_local_or_remote(
                     buffer_of_values_for_local_events,
                     room_event_cache,
-                    current_value_event_id,
+                    current_event,
                     own_user_id,
                     power_levels,
                 )
@@ -406,15 +410,14 @@ impl Builder {
     async fn new_local_or_remote(
         buffer_of_values_for_local_events: &mut BufferOfValuesForLocalEvents,
         room_event_cache: &RoomEventCache,
-        current_value_event_id: Option<OwnedEventId>,
+        current_event: LatestEventValue,
         own_user_id: &UserId,
         power_levels: Option<&RoomPowerLevels>,
     ) -> Option<LatestEventValue> {
         if let Some((_, value)) = buffer_of_values_for_local_events.last() {
             Some(value.clone())
         } else {
-            Self::new_remote(room_event_cache, current_value_event_id, own_user_id, power_levels)
-                .await
+            Self::new_remote(room_event_cache, current_event, own_user_id, power_levels).await
         }
     }
 }
@@ -1837,7 +1840,7 @@ mod builder_tests {
             // We get `event_id_1` because `event_id_2` isn't a candidate,
             // and `event_id_0` hasn't been read yet (because events are read
             // backwards).
-            Builder::new_remote(&room_event_cache, None, user_id, None).await => with body = "world"
+            Builder::new_remote(&room_event_cache, LatestEventValue::None, user_id, None).await => with body = "world"
         );
     }
 
@@ -1895,7 +1898,7 @@ mod builder_tests {
         //
         // No candidate is found, so it's just `None` here.
         assert_matches!(
-            Builder::new_remote(&room_event_cache, current_value.event_id(), user_id, None,).await,
+            Builder::new_remote(&room_event_cache, current_value, user_id, None,).await,
             None
         );
     }
@@ -1958,7 +1961,7 @@ mod builder_tests {
         // A candidate is found, so it's a `Some(LatestEventValue::Remote)`
         // that is returned! Let's check the event.
         assert_remote_value_matches_room_message_with_body!(
-            Builder::new_remote(&room_event_cache, current_value.event_id(), user_id, None).await => with body = "hello"
+            Builder::new_remote(&room_event_cache, current_value, user_id, None).await => with body = "hello"
         );
     }
 
@@ -2011,7 +2014,7 @@ mod builder_tests {
         //
         // No candidate is found, so it's just a `None` here.
         assert_matches!(
-            Builder::new_remote(&room_event_cache, current_value.event_id(), user_id, None).await,
+            Builder::new_remote(&room_event_cache, current_value, user_id, None).await,
             None
         );
     }
@@ -2068,7 +2071,7 @@ mod builder_tests {
         // `m.room.redaction` targeting our `current_value`, it MUST BE a
         // `Some(LatestEventValue::None)` to erase it.
         assert_matches!(
-            Builder::new_remote(&room_event_cache, current_value.event_id(), user_id, None).await,
+            Builder::new_remote(&room_event_cache, current_value, user_id, None).await,
             Some(LatestEventValue::None)
         );
     }
@@ -2128,7 +2131,7 @@ mod builder_tests {
         // `Some(LatestEventValue::Remote(_))`, whatever the `current_value`
         // is.
         assert_remote_value_matches_room_message_with_body!(
-            Builder::new_remote(&room_event_cache, current_value.event_id(), user_id, None).await => with body = "world"
+            Builder::new_remote(&room_event_cache, current_value, user_id, None).await => with body = "world"
         );
     }
 
@@ -2187,7 +2190,7 @@ mod builder_tests {
         // Compute a new remote value: will be able to find a relevant
         // candidate.
         let current_value = assert_remote_value_matches_room_message_with_body!(
-            Builder::new_remote(&room_event_cache, current_value.event_id(), user_id, None).await => with body = "hello"
+            Builder::new_remote(&room_event_cache, current_value, user_id, None).await => with body = "hello"
         );
 
         // Now, let's clear all rooms.
@@ -2195,7 +2198,7 @@ mod builder_tests {
 
         // The latest event has been erased!
         assert_matches!(
-            Builder::new_remote(&room_event_cache, current_value.event_id(), user_id, None).await,
+            Builder::new_remote(&room_event_cache, current_value, user_id, None).await,
             Some(LatestEventValue::None)
         );
     }
@@ -2261,7 +2264,7 @@ mod builder_tests {
 
         assert_remote_value_matches_room_message_with_body!(
             // We get `event_id_1` because it edits `event_id_0` which is a candidate.
-            Builder::new_remote(&room_event_cache, None, user_id, None).await => with body = "* goodbye"
+            Builder::new_remote(&room_event_cache, LatestEventValue::None, user_id, None).await => with body = "* goodbye"
         );
     }
 
@@ -2338,7 +2341,7 @@ mod builder_tests {
             // We get `event_id_1` because `event_id_2` isn't a candidate,
             // and `event_id_0` hasn't been read yet (because events are read
             // backwards).
-            Builder::new_remote(&room_event_cache, None, user_id, None).await => with body = "* err, hello"
+            Builder::new_remote(&room_event_cache, LatestEventValue::None, user_id, None).await => with body = "* err, hello"
         );
     }
 
@@ -2419,7 +2422,7 @@ mod builder_tests {
 
         assert_remote_value_matches_room_message_with_body!(
             // We get `event_id_3` because `event_id_4` edits an older event.
-            Builder::new_remote(&room_event_cache, None, user_id, None).await => with body = "* D"
+            Builder::new_remote(&room_event_cache, LatestEventValue::None, user_id, None).await => with body = "* D"
         );
     }
 
@@ -2485,7 +2488,7 @@ mod builder_tests {
 
         assert_remote_value_matches_room_message_with_body!(
             // We get `event_id_0` because `event_id_1` edits an event that is unknown.
-            Builder::new_remote(&room_event_cache, None, user_id, None).await => with body = "A"
+            Builder::new_remote(&room_event_cache, LatestEventValue::None, user_id, None).await => with body = "A"
         );
     }
 
@@ -2547,7 +2550,11 @@ mod builder_tests {
         let (room_event_cache, _) = event_cache.for_room(room_id).await.unwrap();
 
         // We get no latest event value because no candidate event is known.
-        assert!(Builder::new_remote(&room_event_cache, None, user_id, None).await.is_none());
+        assert!(
+            Builder::new_remote(&room_event_cache, LatestEventValue::None, user_id, None)
+                .await
+                .is_none()
+        );
     }
 
     async fn local_prelude() -> (Client, OwnedRoomId, RoomSendQueue, RoomEventCache) {
@@ -2631,7 +2638,7 @@ mod builder_tests {
 
             // The `LatestEventValue` matches the new local event.
             assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, None, user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, LatestEventValue::None, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "A"
             )
         };
@@ -2645,7 +2652,7 @@ mod builder_tests {
 
             // The `LatestEventValue` matches the new local event.
             assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
             );
         }
@@ -2673,7 +2680,7 @@ mod builder_tests {
 
             // The `LatestEventValue` matches the new local event.
             let value = assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, None, user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, LatestEventValue::None, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "A"
             );
 
@@ -2693,7 +2700,7 @@ mod builder_tests {
             // The `LatestEventValue` has changed, it still matches the latest local
             // event but it's marked as “cannot be sent”.
             let value = assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalCannotBeSent => with body = "A"
             );
 
@@ -2714,7 +2721,7 @@ mod builder_tests {
 
             // The `LatestEventValue` matches the new local event.
             assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalCannotBeSent => with body = "B"
             );
         }
@@ -2743,7 +2750,7 @@ mod builder_tests {
 
             // The `LatestEventValue` matches the new local event.
             let value = assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, None, user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, LatestEventValue::None, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "A"
             );
 
@@ -2771,7 +2778,7 @@ mod builder_tests {
                     &update,
                     &mut buffer,
                     &room_event_cache,
-                    previous_value.event_id(),
+                    previous_value,
                     user_id,
                     None
                 )
@@ -2809,7 +2816,7 @@ mod builder_tests {
 
                 // The `LatestEventValue` matches the new local event.
                 value = Some(assert_local_value_matches_room_message_with_body!(
-                    Builder::new_local(&update, &mut buffer, &room_event_cache, value.and_then(|value: LatestEventValue| value.event_id()), user_id, None).await,
+                    Builder::new_local(&update, &mut buffer, &room_event_cache, value.unwrap_or_default(), user_id, None).await,
                     LatestEventValue::LocalIsSending => with body = body
                 ));
             }
@@ -2829,7 +2836,7 @@ mod builder_tests {
             // The `LatestEventValue` hasn't changed, it still matches the latest local
             // event.
             let value = assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "C"
             );
 
@@ -2848,7 +2855,7 @@ mod builder_tests {
             // The `LatestEventValue` has changed, it matches the previous (so the first)
             // local event.
             let value = assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "A"
             );
 
@@ -2871,7 +2878,7 @@ mod builder_tests {
                     &update,
                     &mut buffer,
                     &room_event_cache,
-                    previous_value.event_id(),
+                    previous_value,
                     user_id,
                     None
                 )
@@ -2906,7 +2913,7 @@ mod builder_tests {
 
                 // The `LatestEventValue` matches the new local event.
                 value = Some(assert_local_value_matches_room_message_with_body!(
-                    Builder::new_local(&update, &mut buffer, &room_event_cache, value.and_then(|value: LatestEventValue| value.event_id()), user_id, None).await,
+                    Builder::new_local(&update, &mut buffer, &room_event_cache, value.unwrap_or_default(), user_id, None).await,
                     LatestEventValue::LocalIsSending => with body = body
                 ));
             }
@@ -2927,7 +2934,7 @@ mod builder_tests {
             // The `LatestEventValue` hasn't changed, it still matches the latest local
             // event.
             let value = assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
             );
 
@@ -2948,7 +2955,7 @@ mod builder_tests {
 
             // The `LatestEventValue` hasn't changed.
             assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalHasBeenSent {
                     value with body = "B",
                     event_id => {
@@ -2984,7 +2991,7 @@ mod builder_tests {
 
                 // The `LatestEventValue` matches the new local event.
                 value = Some(assert_local_value_matches_room_message_with_body!(
-                    Builder::new_local(&update, &mut buffer, &room_event_cache, value.and_then(|value: LatestEventValue| value.event_id()), user_id, None).await,
+                    Builder::new_local(&update, &mut buffer, &room_event_cache, value.unwrap_or_default(), user_id, None).await,
                     LatestEventValue::LocalIsSending => with body = body
                 ));
             }
@@ -3012,7 +3019,7 @@ mod builder_tests {
             // The `LatestEventValue` hasn't changed, it still matches the latest local
             // event.
             let value = assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
             );
 
@@ -3039,7 +3046,7 @@ mod builder_tests {
             // The `LatestEventValue` has changed, it still matches the latest local
             // event but with its new content.
             assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B."
             );
 
@@ -3066,7 +3073,7 @@ mod builder_tests {
 
             // The `LatestEventValue` matches the new local event.
             let value = assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, None, user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, LatestEventValue::None, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "A"
             );
 
@@ -3099,7 +3106,7 @@ mod builder_tests {
                     &update,
                     &mut buffer,
                     &room_event_cache,
-                    previous_value.event_id(),
+                    previous_value,
                     user_id,
                     None
                 )
@@ -3130,7 +3137,7 @@ mod builder_tests {
 
             // The `LatestEventValue` matches the new local event.
             let value = assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, None, user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, LatestEventValue::None, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "A"
             );
 
@@ -3156,7 +3163,7 @@ mod builder_tests {
             // The `LatestEventValue` has changed, it still matches the latest local
             // event but with its new content.
             assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.clone(), user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
             );
 
@@ -3180,7 +3187,7 @@ mod builder_tests {
             // The `LatestEventValue` has changed, it still matches the latest local
             // event but with its new content.
             assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "C"
             );
 
@@ -3211,7 +3218,7 @@ mod builder_tests {
 
                 // The `LatestEventValue` matches the new local event.
                 value = Some(assert_local_value_matches_room_message_with_body!(
-                    Builder::new_local(&update, &mut buffer, &room_event_cache, value.and_then(|value: LatestEventValue| value.event_id()), user_id, None).await,
+                    Builder::new_local(&update, &mut buffer, &room_event_cache, value.unwrap_or_default(), user_id, None).await,
                     LatestEventValue::LocalIsSending => with body = body
                 ));
             }
@@ -3234,7 +3241,7 @@ mod builder_tests {
             // The `LatestEventValue` has changed, it still matches the latest local
             // event but it's marked as “cannot be sent”.
             let value = assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalCannotBeSent => with body = "B"
             );
 
@@ -3257,7 +3264,7 @@ mod builder_tests {
             // The `LatestEventValue` has changed, it still matches the latest local
             // event but it's “is sending”.
             assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
             );
 
@@ -3289,7 +3296,7 @@ mod builder_tests {
 
                 // The `LatestEventValue` matches the new local event.
                 value = Some(assert_local_value_matches_room_message_with_body!(
-                    Builder::new_local(&update, &mut buffer, &room_event_cache, value.and_then(|value: LatestEventValue| value.event_id()), user_id, None).await,
+                    Builder::new_local(&update, &mut buffer, &room_event_cache, value.unwrap_or_default(), user_id, None).await,
                     LatestEventValue::LocalIsSending => with body = body
                 ));
             }
@@ -3312,7 +3319,7 @@ mod builder_tests {
             // The `LatestEventValue` still matches the latest local event and should still
             // be marked as a local being sent.
             let value = assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
             );
 
@@ -3335,7 +3342,7 @@ mod builder_tests {
             // The `LatestEventValue` has changed, it still matches the latest local
             // event but it's “is sending”.
             assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
             );
 
@@ -3367,7 +3374,7 @@ mod builder_tests {
 
                 // The `LatestEventValue` matches the new local event.
                 value = Some(assert_local_value_matches_room_message_with_body!(
-                    Builder::new_local(&update, &mut buffer, &room_event_cache, value.and_then(|value: LatestEventValue| value.event_id()), user_id, None).await,
+                    Builder::new_local(&update, &mut buffer, &room_event_cache, value.unwrap_or_default(), user_id, None).await,
                     LatestEventValue::LocalIsSending => with body = body
                 ));
             }
@@ -3390,7 +3397,7 @@ mod builder_tests {
             // The `LatestEventValue` has changed, it still matches the latest local
             // event but it's marked as “cannot be sent”.
             let value = assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalCannotBeSent => with body = "B"
             );
 
@@ -3410,7 +3417,7 @@ mod builder_tests {
             // The `LatestEventValue` has changed, it still matches the latest local
             // event but it's “is sending”.
             assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.event_id(), user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
             );
 
@@ -3439,7 +3446,7 @@ mod builder_tests {
 
             // The `LatestEventValue` matches the new local event.
             let value = assert_local_value_matches_room_message_with_body!(
-                Builder::new_local(&update, &mut buffer, &room_event_cache, None, user_id, None).await,
+                Builder::new_local(&update, &mut buffer, &room_event_cache, LatestEventValue::None, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "A"
             );
 
@@ -3465,7 +3472,7 @@ mod builder_tests {
                     &update,
                     &mut buffer,
                     &room_event_cache,
-                    previous_value.event_id(),
+                    previous_value,
                     user_id,
                     None
                 )
@@ -3539,7 +3546,7 @@ mod builder_tests {
                 },
                 &mut buffer,
                 &room_event_cache,
-                None,
+                LatestEventValue::None,
                 user_id,
                 None,
             )
@@ -3616,7 +3623,7 @@ mod builder_tests {
                     &update,
                     &mut buffer,
                     &room_event_cache,
-                    None,
+                    LatestEventValue::None,
                     user_id,
                     None,
                 )
@@ -3637,7 +3644,7 @@ mod builder_tests {
                 },
                 &mut buffer,
                 &room_event_cache,
-                previous_value.event_id(),
+                previous_value,
                 user_id,
                 None,
             )
@@ -3709,7 +3716,7 @@ mod builder_tests {
                 },
                 &mut buffer,
                 &room_event_cache,
-                None,
+                LatestEventValue::None,
                 user_id,
                 None,
             )
@@ -3719,6 +3726,9 @@ mod builder_tests {
 
         // A local redaction of the latest event value is being sent
         {
+            let previous_value =
+                LatestEventValue::Remote(remote_room_message(event_id!("$foo"), "Hello world"));
+
             let transaction_id = OwnedTransactionId::from("txnid0");
             let content = LocalEchoContent::Redaction {
                 redacts: event_id.to_owned(),
@@ -3740,7 +3750,7 @@ mod builder_tests {
                     &update,
                     &mut buffer,
                     &room_event_cache,
-                    Some(event_id.to_owned()),
+                    previous_value,
                     user_id,
                     None
                 )

--- a/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
@@ -2291,6 +2291,76 @@ mod builder_tests {
     }
 
     #[async_test]
+    async fn test_remote_edit_invalid_edit() {
+        let room_id = room_id!("!r0");
+        let user_id = user_id!("@mnt_io:matrix.org");
+        let event_factory = EventFactory::new().sender(user_id).room(room_id);
+        let event_id_0 = event_id!("$ev0");
+        let event_id_1 = event_id!("$ev1");
+
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        // Prelude.
+        {
+            // Create the room.
+            client.base_client().get_or_create_room(room_id, RoomState::Joined);
+
+            // Initialise the event cache store.
+            client
+                .event_cache_store()
+                .lock()
+                .await
+                .expect("Could not acquire the event cache lock")
+                .as_clean()
+                .expect("Could not acquire a clean event cache lock")
+                .handle_linked_chunk_updates(
+                    LinkedChunkId::Room(room_id),
+                    vec![
+                        Update::NewItemsChunk {
+                            previous: None,
+                            new: ChunkIdentifier::new(0),
+                            next: None,
+                        },
+                        Update::PushItems {
+                            at: Position::new(ChunkIdentifier::new(0), 0),
+                            items: vec![
+                                // a text message
+                                event_factory
+                                    .text_msg("hello")
+                                    .sender(user_id!("@alice:example.org"))
+                                    .event_id(event_id_0)
+                                    .into(),
+                                // a replacement of the previous message
+                                event_factory
+                                    .text_msg("* goodbye")
+                                    .event_id(event_id_1)
+                                    .sender(user_id!("@malory:example.org"))
+                                    .edit(
+                                        event_id_0,
+                                        RoomMessageEventContent::text_plain("goodbye").into(),
+                                    )
+                                    .into(),
+                            ],
+                        },
+                    ],
+                )
+                .await
+                .unwrap();
+        }
+
+        let event_cache = client.event_cache();
+        event_cache.subscribe().unwrap();
+
+        let (room_event_cache, _) = event_cache.for_room(room_id).await.unwrap();
+
+        assert_remote_value_matches_room_message_with_body!(
+            // We get `event_id_0` because the edit `event_id_1` is invalid.
+            Builder::new_remote(&room_event_cache, LatestEventValue::None, user_id, None).await => with body = "hello"
+        );
+    }
+
+    #[async_test]
     async fn test_remote_double_edit() {
         let room_id = room_id!("!r0");
         let user_id = user_id!("@mnt_io:matrix.org");

--- a/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
@@ -19,7 +19,10 @@ use std::{
 };
 
 pub use matrix_sdk_base::latest_event::{LatestEventValue, LocalLatestEventValue};
-use matrix_sdk_base::{deserialized_responses::TimelineEvent, store::SerializableEventContent};
+use matrix_sdk_base::{
+    check_validity_of_replacement_events, deserialized_responses::TimelineEvent,
+    store::SerializableEventContent,
+};
 use ruma::{
     MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, TransactionId, UserId,
     events::{
@@ -33,7 +36,7 @@ use ruma::{
         },
     },
 };
-use tracing::error;
+use tracing::{debug, error};
 
 use crate::{Room, event_cache::RoomEventCache, room::Invite, send_queue::RoomSendQueueUpdate};
 
@@ -91,16 +94,35 @@ impl Builder {
                     // Stop! We found a suitable event!
                     ControlFlow::Break(()) => {
                         // Return the latest known edit of the event or the event itself if it
-                        // hasn't been replaced.
-                        // TODO: Here we pick the event, and if there's an edit for the event we
-                        // pick the edit instead.
-                        //
-                        // We should check if the edit is valid.
-                        event
-                            .event_id()
-                            .and_then(|event_id| latest_edit_for_event.get(&event_id))
-                            .cloned()
-                            .or_else(|| Some(event.clone()))
+                        // hasn't been replaced or the replacement is invalid.
+                        if let Some(event_id) = event.event_id()
+                            && let Some(edit) = latest_edit_for_event.get(&event_id)
+                        {
+                            let original = event.kind.raw();
+                            let original_encryption_info = event.kind.encryption_info();
+
+                            let replacement = edit.kind.raw();
+                            let replacement_encryption_info = event.kind.encryption_info();
+
+                            Some(
+                                match check_validity_of_replacement_events(
+                                    original,
+                                    original_encryption_info.map(|e| &(**e)),
+                                    replacement,
+                                    replacement_encryption_info.map(|e| &(**e)),
+                                ) {
+                                    Ok(_) => edit.clone(),
+                                    Err(e) => {
+                                        debug!(
+                                        "Skipping an edit of a latest event due to the replacement event being invalid: {e}"
+                                    );
+                                        event.clone()
+                                    }
+                                },
+                            )
+                        } else {
+                            Some(event.clone())
+                        }
                     }
                 }
             })

--- a/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
@@ -101,14 +101,9 @@ impl LatestEvent {
             return;
         }
 
-        let current_value_event_id = self.current_value.read().await.event_id();
-        let new_value = Builder::new_remote(
-            room_event_cache,
-            current_value_event_id,
-            own_user_id,
-            power_levels,
-        )
-        .await;
+        let current_event = self.current_value.get().await;
+        let new_value =
+            Builder::new_remote(room_event_cache, current_event, own_user_id, power_levels).await;
 
         trace!(value = ?new_value, "Computed a remote `LatestEventValue`");
 
@@ -126,12 +121,12 @@ impl LatestEvent {
         own_user_id: &UserId,
         power_levels: Option<&RoomPowerLevels>,
     ) {
-        let current_value_event_id = self.current_value.read().await.event_id();
+        let current_event = self.current_value.get().await;
         let new_value = Builder::new_local(
             send_queue_update,
             &mut self.buffer_of_values_for_local_events,
             room_event_cache,
-            current_value_event_id,
+            current_event,
             own_user_id,
             power_levels,
         )

--- a/crates/matrix-sdk/tests/integration/edit_validation.rs
+++ b/crates/matrix-sdk/tests/integration/edit_validation.rs
@@ -1,0 +1,210 @@
+use assert_matches2::assert_matches;
+use matrix_sdk::{
+    EditValidityError, check_validity_of_replacement_events,
+    deserialized_responses::{AlgorithmInfo, EncryptionInfo, VerificationState},
+};
+use matrix_sdk_test::event_factory::EventFactory;
+use ruma::{
+    event_id,
+    events::{AnySyncTimelineEvent, room::message::RoomMessageEventContentWithoutRelation},
+    serde::Raw,
+    user_id,
+};
+use serde_json::json;
+
+fn original_event() -> Raw<AnySyncTimelineEvent> {
+    let event_factory = EventFactory::new();
+    event_factory
+        .sender(user_id!("@example:localhost"))
+        .text_msg("Hello world")
+        .event_id(event_id!("$asbc"))
+        .into()
+}
+
+#[test]
+fn test_edit_validity_invalid_sender() {
+    let event_factory = EventFactory::new();
+    let event = original_event();
+
+    let replacement = event_factory
+        .sender(user_id!("@not_example:localhost"))
+        .text_msg("* edit")
+        .edit(event_id!("$asbc"), RoomMessageEventContentWithoutRelation::text_plain("edit"))
+        .into();
+
+    let result = check_validity_of_replacement_events(&event, None, &replacement, None);
+
+    assert_matches!(result, Err(EditValidityError::InvalidSender));
+}
+
+#[test]
+fn test_edit_validity_replacement_is_state_event() {
+    let event = original_event();
+
+    let replacement = Raw::new(&json!({
+        "content": {
+            "body":"* edit",
+            "msgtype": "m.text",
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": "$asbc"
+            }
+        },
+        "event_id":"$xG2xPOiRLXoEjG4Cgq:dummy.org",
+        "origin_server_ts":0,
+        "sender":"@example:localhost",
+        "state_key":"@example:localhost",
+        "type":"m.room.message"
+    }))
+    .unwrap()
+    .cast_unchecked();
+
+    let result = check_validity_of_replacement_events(&event, None, &replacement, None);
+
+    assert_matches!(result, Err(EditValidityError::StateKeyPresent));
+}
+
+#[test]
+fn test_edit_validity_original_is_edit_as_well() {
+    let event_factory = EventFactory::new().sender(user_id!("@example:localhost"));
+
+    let event = event_factory
+        .text_msg("Hello world")
+        .edit(
+            event_id!("$some_event_id"),
+            RoomMessageEventContentWithoutRelation::text_plain("* another edit"),
+        )
+        .event_id(event_id!("$asbc"))
+        .into();
+
+    let replacement = event_factory
+        .text_msg("* edit")
+        .edit(event_id!("$asbc"), RoomMessageEventContentWithoutRelation::text_plain("edit"))
+        .into();
+
+    let result = check_validity_of_replacement_events(&event, None, &replacement, None);
+
+    assert_matches!(result, Err(EditValidityError::OriginalEventIsReplacement));
+}
+
+#[test]
+fn test_edit_validity_mismatched_content() {
+    let event_factory = EventFactory::new();
+    let event = original_event();
+
+    let replacement = event_factory
+        .sender(user_id!("@example:localhost"))
+        .poll_edit(event_id!("$asbc"), "Foo", vec!["bar"])
+        .into();
+
+    let result = check_validity_of_replacement_events(&event, None, &replacement, None);
+
+    assert_matches!(result, Err(EditValidityError::MismatchContentType { .. }));
+}
+
+#[test]
+fn test_edit_validity_replacement_not_replacement() {
+    let event_factory = EventFactory::new();
+    let event = original_event();
+
+    let replacement =
+        event_factory.sender(user_id!("@example:localhost")).text_msg("* edit").into();
+
+    let result = check_validity_of_replacement_events(&event, None, &replacement, None);
+
+    assert_matches!(result, Err(EditValidityError::NotReplacement));
+}
+
+#[test]
+fn test_edit_validity_replacement_is_not_encrypted() {
+    let user_id = user_id!("@example:localhost");
+    let event_factory = EventFactory::new();
+    let event = original_event();
+
+    let original_encryption_info = Some(EncryptionInfo {
+        sender: user_id.into(),
+        sender_device: Some("DEVICEID".into()),
+        forwarder: None,
+        algorithm_info: AlgorithmInfo::MegolmV1AesSha2 {
+            curve25519_key: "1337".to_owned(),
+            sender_claimed_keys: Default::default(),
+            session_id: Some("mysessionid9".to_owned()),
+        },
+        verification_state: VerificationState::Verified,
+    });
+
+    let replacement = event_factory
+        .sender(user_id)
+        .text_msg("* edit")
+        .edit(event_id!("$asbc"), RoomMessageEventContentWithoutRelation::text_plain("edit"))
+        .into();
+
+    let result = check_validity_of_replacement_events(
+        &event,
+        original_encryption_info.as_ref(),
+        &replacement,
+        None,
+    );
+
+    assert_matches!(result, Err(EditValidityError::ReplacementNotEncrypted));
+}
+
+#[test]
+fn test_edit_validity_replacement_is_missing_new_content() {
+    let user_id = user_id!("@example:localhost");
+    let event = original_event();
+
+    let original_encryption_info = Some(EncryptionInfo {
+        sender: user_id.into(),
+        sender_device: Some("DEVICEID".into()),
+        forwarder: None,
+        algorithm_info: AlgorithmInfo::MegolmV1AesSha2 {
+            curve25519_key: "1337".to_owned(),
+            sender_claimed_keys: Default::default(),
+            session_id: Some("mysessionid9".to_owned()),
+        },
+        verification_state: VerificationState::Verified,
+    });
+
+    let replacement = Raw::new(&json!({
+        "content": {
+            "body":"* edit",
+            "msgtype": "m.text",
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": "$asbc"
+            }
+        },
+        "event_id":"$xG2xPOiRLXoEjG4Cgq:dummy.org",
+        "origin_server_ts":0,
+        "sender":"@example:localhost",
+        "type":"m.room.message"
+    }))
+    .unwrap()
+    .cast_unchecked();
+
+    let result = check_validity_of_replacement_events(
+        &event,
+        original_encryption_info.as_ref(),
+        &replacement,
+        original_encryption_info.as_ref(),
+    );
+
+    assert_matches!(result, Err(EditValidityError::MissingNewContent));
+}
+
+#[test]
+fn test_edit_validity_valid_edit() {
+    let event_factory = EventFactory::new();
+    let event = original_event();
+
+    let replacement = event_factory
+        .sender(user_id!("@example:localhost"))
+        .text_msg("* edit")
+        .edit(event_id!("$asbc"), RoomMessageEventContentWithoutRelation::text_plain("edit"))
+        .into();
+
+    let result = check_validity_of_replacement_events(&event, None, &replacement, None);
+
+    assert_matches!(result, Ok(_));
+}

--- a/crates/matrix-sdk/tests/integration/event_cache/threads.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads.rs
@@ -12,11 +12,14 @@ use matrix_sdk::{
         assert_event_matches_msg,
         mocks::{MatrixMockServer, RoomRelationsResponseTemplate},
     },
+    timeout::timeout,
 };
 use matrix_sdk_test::{ALICE, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use ruma::{
     OwnedEventId, OwnedRoomId, event_id,
-    events::{AnySyncTimelineEvent, Mentions},
+    events::{
+        AnySyncTimelineEvent, Mentions, room::message::RoomMessageEventContentWithoutRelation,
+    },
     push::{ConditionalPushRule, Ruleset},
     room_id,
     serde::Raw,
@@ -969,4 +972,110 @@ async fn test_redact_touches_threads() {
             assert!(new_root.thread_summary.summary().is_none());
         }
     }
+}
+
+#[async_test]
+async fn test_edits_touches_threads() {
+    // We start with a thread with some replies, then receive an edit and an invalid
+    // edit for the replies over sync. We observe that valid edits update the
+    // thread linked chunks as well as the thread summary on the thread root
+    // event. Invalid ones don't update the state.
+
+    let s = thread_subscription_test_setup().await;
+    let f = s.factory;
+
+    let event_cache = s.client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    let thread_root_id = s.thread_root;
+
+    let room = s.server.sync_joined_room(&s.client, &s.room_id).await;
+
+    let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
+
+    let (thread_events, mut thread_stream) =
+        room_event_cache.subscribe_to_thread(thread_root_id.to_owned()).await.unwrap();
+
+    // Receive a thread root, and a threaded reply.
+    s.server
+        .sync_room(
+            &s.client,
+            JoinedRoomBuilder::new(&s.room_id)
+                .add_timeline_event(f.text_msg("Talking to myself.").event_id(&thread_root_id))
+                .add_timeline_event(s.events[0].clone())
+                .add_timeline_event(s.events[1].clone()),
+        )
+        .await;
+
+    wait_for_initial_events(thread_events, &mut thread_stream).await;
+    let (room_events, mut room_stream) = room_event_cache.subscribe().await.unwrap();
+
+    // A valid edit for the first reply comes through sync.
+    let valid_edit_event_id = event_id!("$valid_edit");
+    s.server
+        .sync_room(
+            &s.client,
+            JoinedRoomBuilder::new(&s.room_id).add_timeline_event(
+                f.text_msg("Nobody speaks English anymore.").event_id(valid_edit_event_id).edit(
+                    &room_events[2].event_id().unwrap(),
+                    RoomMessageEventContentWithoutRelation::text_plain("edited text"),
+                ),
+            ),
+        )
+        .await;
+
+    // Edits are not emitted over the thread subscriber, the timeline uses the
+    // normal room stream to handle those.
+    //
+    // So we're going to look only at the room stream and see if the thread summary
+    // gets correctly updated.
+    {
+        // The room stream receives an update.
+        assert_let_timeout!(
+            Ok(RoomEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) =
+                room_stream.recv()
+        );
+        assert_eq!(diffs.len(), 2);
+
+        // The edit gets appended to the stream.
+        assert_let!(VectorDiff::Append { values: new_events } = &diffs[0]);
+        assert_eq!(new_events.len(), 1);
+        assert_eq!(new_events[0].event_id().as_deref(), Some(valid_edit_event_id));
+
+        // The thread summary is updated.
+        {
+            assert_let!(VectorDiff::Set { index: 0, value: new_root } = &diffs[1]);
+            assert_eq!(new_root.event_id().as_ref(), Some(&thread_root_id));
+            let summary = new_root.thread_summary.summary().unwrap();
+            assert_eq!(summary.latest_reply.as_deref(), Some(valid_edit_event_id));
+            assert_eq!(summary.num_replies, 2);
+        }
+    }
+
+    // An invalid edit for the second reply comes through sync.
+    let invalid_edit_id = event_id!("$invalid_edit");
+    s.server
+        .sync_room(
+            &s.client,
+            JoinedRoomBuilder::new(&s.room_id).add_timeline_event(
+                f.text_msg("Nobody speaks english anymore.").event_id(invalid_edit_id).edit(
+                    &room_events[2].event_id().unwrap(),
+                    RoomMessageEventContentWithoutRelation::text_plain("edited text"),
+                ),
+            ),
+        )
+        .await;
+
+    // It's a bit hard to know when the update should have been ready. This makes it
+    // hard to prove that no update happened.
+    let result = timeout(room_stream.recv(), Duration::from_secs(1)).await;
+
+    assert!(result.is_err(), "The room stream should have timed out as the edit was invnalid");
+
+    let room_events = room_event_cache.events().await.unwrap();
+    let first = room_events.first().unwrap();
+    let thread_summary = first.thread_summary.summary().unwrap();
+
+    // The latest reply should still be our valid event, not our invalid one.
+    assert_eq!(thread_summary.latest_reply.as_deref(), Some(valid_edit_event_id));
 }

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -9,6 +9,7 @@ use wiremock::{
 
 mod account;
 mod client;
+mod edit_validation;
 #[cfg(feature = "e2e-encryption")]
 mod encryption;
 mod event_cache;


### PR DESCRIPTION
This PR fixes an issue where we would not adhere to the [spec](https://spec.matrix.org/v1.17/client-server-api/#validity-of-replacement-events) when it comes to edit validation in the latest event logic.

Since the event cache isn't the one applying edits this validation logic needs to happen in two places. The first place is the timeline aggregation and the second one the latest event module.

I created a common method which operates on the raw JSON which is now used in the two relevant places.

A review commit by commit would be the easiest.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

