### PR TITLE
feat(ffi): Expose `Client.request_openid_token()` in order to let sdk clients request an openId token.

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -44,7 +44,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Added the `Client.getOpenidToken()` method.
+- Added the `Client.request_openid_token()` method.
   ([#6458](https://github.com/matrix-org/matrix-rust-sdk/pull/6458))
 - Added the `Client::import_secrets_bundle` method.
   ([#6212](https://github.com/matrix-org/matrix-rust-sdk/pull/6212))

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -44,6 +44,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Added the `Client.getOpenidToken()` method.
+  ([#6458](https://github.com/matrix-org/matrix-rust-sdk/pull/6458))
 - Added the `Client::import_secrets_bundle` method.
   ([#6212](https://github.com/matrix-org/matrix-rust-sdk/pull/6212))
 - [**breaking**] Remove support for `native-tls` and remove all feature

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -3147,8 +3147,9 @@ mod tests {
     use std::time::Duration;
 
     use ruma::{
-        ServerName, authentication::TokenType,
+        ServerName,
         api::client::room::{Visibility, create_room},
+        authentication::TokenType,
         events::StateEventType,
         room::RoomType,
     };

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -35,6 +35,7 @@ use matrix_sdk::{
     ruma::{
         EventEncryptionAlgorithm, RoomId, TransactionId, UInt, UserId,
         api::client::{
+            account::request_openid_token,
             discovery::{
                 discover_homeserver::RtcFocusInfo,
                 get_authorization_server_metadata::v1::Prompt as RumaOidcPrompt,
@@ -312,6 +313,28 @@ impl From<matrix_sdk::TransmissionProgress> for TransmissionProgress {
         Self {
             current: value.current.try_into().unwrap_or(u64::MAX),
             total: value.total.try_into().unwrap_or(u64::MAX),
+        }
+    }
+}
+
+#[derive(Clone, uniffi::Record)]
+pub struct OpenIdToken {
+    pub access_token: String,
+    pub token_type: String,
+    pub matrix_server_name: String,
+    pub expires_in_seconds: u64,
+}
+
+impl From<request_openid_token::v3::Response> for OpenIdToken {
+    fn from(value: request_openid_token::v3::Response) -> Self {
+        Self {
+            access_token: value.access_token,
+            token_type: serde_json::to_value(&value.token_type)
+                .ok()
+                .and_then(|value| value.as_str().map(ToOwned::to_owned))
+                .unwrap_or_else(|| format!("{:?}", value.token_type)),
+            matrix_server_name: value.matrix_server_name.to_string(),
+            expires_in_seconds: value.expires_in.as_secs(),
         }
     }
 }
@@ -1213,6 +1236,10 @@ impl Client {
         let display_name =
             self.inner.account().get_display_name().await?.context("No User ID found")?;
         Ok(display_name)
+    }
+
+    pub async fn get_openid_token(&self) -> Result<OpenIdToken, ClientError> {
+        Ok(self.inner.account().request_openid_token().await?.into())
     }
 
     pub async fn upload_avatar(&self, mime_type: String, data: Vec<u8>) -> Result<(), ClientError> {
@@ -3117,14 +3144,17 @@ pub struct ExtendedProfileFields {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use ruma::{
+        ServerName, authentication::TokenType,
         api::client::room::{Visibility, create_room},
         events::StateEventType,
         room::RoomType,
     };
 
     use crate::{
-        client::{CreateRoomParameters, JoinRule, RoomPreset, RoomVisibility},
+        client::{CreateRoomParameters, JoinRule, OpenIdToken, RoomPreset, RoomVisibility},
         room::RoomHistoryVisibility,
     };
 
@@ -3175,5 +3205,22 @@ mod tests {
             .expect("Creation content can't be deserialized")
             .room_type;
         assert_eq!(room_type, Some(RoomType::Space));
+    }
+
+    #[test]
+    fn test_openid_token_mapping() {
+        let response = ruma::api::client::account::request_openid_token::v3::Response::new(
+            "open-id-token".to_owned(),
+            TokenType::Bearer,
+            ServerName::parse("example.com").expect("valid server name").to_owned(),
+            Duration::from_secs(3_600),
+        );
+
+        let token: OpenIdToken = response.into();
+
+        assert_eq!(token.access_token, "open-id-token");
+        assert_eq!(token.token_type, "Bearer");
+        assert_eq!(token.matrix_server_name, "example.com");
+        assert_eq!(token.expires_in_seconds, 3_600);
     }
 }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1238,7 +1238,7 @@ impl Client {
         Ok(display_name)
     }
 
-    pub async fn get_openid_token(&self) -> Result<OpenIdToken, ClientError> {
+    pub async fn request_openid_token(&self) -> Result<OpenIdToken, ClientError> {
         Ok(self.inner.account().request_openid_token().await?.into())
     }
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -3213,7 +3213,7 @@ mod tests {
         let response = ruma::api::client::account::request_openid_token::v3::Response::new(
             "open-id-token".to_owned(),
             TokenType::Bearer,
-            ServerName::parse("example.com").expect("valid server name").to_owned(),
+            ServerName::parse("example.com").expect("valid server name"),
             Duration::from_secs(3_600),
         );
 

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -37,8 +37,8 @@ use ruma::{
         client::{
             account::{
                 add_3pid, change_password, deactivate, delete_3pid, get_3pids,
-                request_openid_token,
                 request_3pid_management_token_via_email, request_3pid_management_token_via_msisdn,
+                request_openid_token,
             },
             config::{get_global_account_data, set_global_account_data},
             profile::{

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -37,6 +37,7 @@ use ruma::{
         client::{
             account::{
                 add_3pid, change_password, deactivate, delete_3pid, get_3pids,
+                request_openid_token,
                 request_3pid_management_token_via_email, request_3pid_management_token_via_msisdn,
             },
             config::{get_global_account_data, set_global_account_data},
@@ -152,6 +153,16 @@ impl Account {
         self.client.send(request).await?;
 
         Ok(())
+    }
+
+    /// Request an OpenID token for the current account.
+    pub async fn request_openid_token(&self) -> Result<request_openid_token::v3::Response> {
+        let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
+
+        self.client
+            .send(request_openid_token::v3::Request::new(user_id.to_owned()))
+            .await
+            .map_err(|error| Error::Http(Box::new(error)))
     }
 
     /// Get the MXC URI of the account's avatar, if set.


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
