### PR TITLE
fix(ui): Fix a possible panic in `Switch` by updating `async-rx`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,9 +281,9 @@ checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
 
 [[package]]
 name = "async-rx"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30de4e5329a0947e389f738a6ca0d0b938fea5cb7baaeae7d72e243614468a2"
+checksum = "9053bf9b3852b83be29d9a29dd7dcf68273f81b10d55ae8beceedb4d23f41448"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ assert_matches2 = { version = "0.1.2", default-features = false }
 async_cell = { version = "0.2.3", default-features = false }
 async-compat = { version = "0.2.5", default-features = false }
 async-once-cell = { version = "0.5.4", default-features = false }
-async-rx = { version = "0.1.3", default-features = false }
+async-rx = { version = "0.2.0", default-features = false }
 # Bumping this to 0.3.6 produces a test failure because the semantic between the
 # versions changed subtly: https://github.com/matrix-org/matrix-rust-sdk/issues/4599
 async-stream = { version = "0.3.6", default-features = false }

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- Fix a possible panic in `RoomList::entries_with_dynamic_adapters`.
+  ([#6459](https://github.com/matrix-org/matrix-rust-sdk/pull/6459))
 - Keep stopped `beacon_info` live location sessions visible in
   `Room::latest_event()`, so room summaries still show the last live location
   sharing session after it ends.

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -186,6 +186,7 @@ impl RoomList {
                     .chain(stream);
             }
         }
+        .fuse()
         .switch();
 
         (stream, dynamic_entries_controller)


### PR DESCRIPTION
This patch updates `async-rx` to fix a possible panic in `Switch`. It now requires the outer stream to implement `FusedStream` (for the moment).

See https://github.com/jplatte/async-rx/pull/5 to learn more.

---

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.