### PR TITLE
Remove unneeded TODO in RoomKeyBundleContent

### DIFF
--- a/crates/matrix-sdk-crypto/src/types/events/room_key_bundle.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key_bundle.rs
@@ -22,8 +22,6 @@ use serde::{Deserialize, Serialize};
 
 use super::EventType;
 
-// TODO: We need implement zeroize for this type.
-
 /// The `io.element.msc4268.room_key_bundle` event content. See [MSC4268].
 ///
 /// [MSC4268]: https://github.com/matrix-org/matrix-spec-proposals/pull/4268


### PR DESCRIPTION
Quoting @poljar:

> If you follow the stack till you get where the secret key is, you end up here:
> https://github.com/ruma/ruma/blob/6282fd8838fd2c84f252f85973d8a43577ced91a/crates/ruma-events/src/room.rs#L269-L273
> And that is now zeroized.
> So yeah, the TODO was resolved in Ruma.

- No API changes
- I did not use AI
