### PR TITLE
feat(sdk): Refresh supported versions cache in the background

### DIFF
--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- [**breaking**] `TtlStoreValue` was moved and renamed to `matrix_sdk_common::ttl_cache::TtlValue`.
 - [**breaking**] `Gap::prev_token` has been renamed to `Gap::token` since it's now used for both
   the previous batch token and the next batch token.
   ([#6236](https://github.com/matrix-org/matrix-rust-sdk/pull/6236))

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -8,6 +8,7 @@ use std::{
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use growable_bloom_filter::GrowableBloomBuilder;
+use matrix_sdk_common::ttl_cache::TtlValue;
 use matrix_sdk_test::{TestResult, event_factory::EventFactory};
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedUserId, RoomId, TransactionId, UserId,
@@ -46,7 +47,7 @@ use serde_json::json;
 
 use super::{
     DependentQueuedRequestKind, DisplayName, DynStateStore, RoomLoadSettings,
-    SupportedVersionsResponse, TtlStoreValue, WellKnownResponse, send_queue::SentRequestKey,
+    SupportedVersionsResponse, WellKnownResponse, send_queue::SentRequestKey,
 };
 use crate::{
     RoomInfo, RoomMemberships, RoomState, StateChanges, StateStoreDataKey, StateStoreDataValue,
@@ -531,7 +532,7 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         self.set_kv_data(
             StateStoreDataKey::SupportedVersions,
-            StateStoreDataValue::SupportedVersions(TtlStoreValue::new(supported_versions.clone())),
+            StateStoreDataValue::SupportedVersions(TtlValue::new(supported_versions.clone())),
         )
         .await?;
 
@@ -563,7 +564,7 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         self.set_kv_data(
             StateStoreDataKey::WellKnown,
-            StateStoreDataValue::WellKnown(TtlStoreValue::new(Some(well_known.clone()))),
+            StateStoreDataValue::WellKnown(TtlValue::new(Some(well_known.clone()))),
         )
         .await?;
 
@@ -579,7 +580,7 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         self.set_kv_data(
             StateStoreDataKey::WellKnown,
-            StateStoreDataValue::WellKnown(TtlStoreValue::new(None)),
+            StateStoreDataValue::WellKnown(TtlValue::new(None)),
         )
         .await?;
 

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -20,7 +20,7 @@ use std::{
 
 use async_trait::async_trait;
 use growable_bloom_filter::GrowableBloom;
-use matrix_sdk_common::{ROOM_VERSION_FALLBACK, ROOM_VERSION_RULES_FALLBACK};
+use matrix_sdk_common::{ROOM_VERSION_FALLBACK, ROOM_VERSION_RULES_FALLBACK, ttl_cache::TtlValue};
 use ruma::{
     CanonicalJsonObject, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri,
     OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
@@ -41,7 +41,7 @@ use tracing::{debug, instrument, warn};
 use super::{
     DependentQueuedRequest, DependentQueuedRequestKind, QueuedRequestKind, Result, RoomInfo,
     RoomLoadSettings, StateChanges, StateStore, StoreError, SupportedVersionsResponse,
-    TtlStoreValue, WellKnownResponse,
+    WellKnownResponse,
     send_queue::{ChildTransactionId, QueuedRequest, SentRequestKey},
     traits::ComposerDraft,
 };
@@ -61,8 +61,8 @@ struct MemoryStoreInner {
     composer_drafts: HashMap<(OwnedRoomId, Option<OwnedEventId>), ComposerDraft>,
     user_avatar_url: HashMap<OwnedUserId, OwnedMxcUri>,
     sync_token: Option<String>,
-    supported_versions: Option<TtlStoreValue<SupportedVersionsResponse>>,
-    well_known: Option<TtlStoreValue<Option<WellKnownResponse>>>,
+    supported_versions: Option<TtlValue<SupportedVersionsResponse>>,
+    well_known: Option<TtlValue<Option<WellKnownResponse>>>,
     filters: HashMap<String, String>,
     utd_hook_manager_data: Option<GrowableBloom>,
     one_time_key_uploaded_error: bool,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -95,7 +95,7 @@ pub use self::{
     traits::{
         ComposerDraft, ComposerDraftType, DraftAttachment, DraftAttachmentContent, DraftThumbnail,
         DynStateStore, IntoStateStore, StateStore, StateStoreDataKey, StateStoreDataValue,
-        StateStoreExt, SupportedVersionsResponse, ThreadSubscriptionCatchupToken, TtlStoreValue,
+        StateStoreExt, SupportedVersionsResponse, ThreadSubscriptionCatchupToken,
         WellKnownResponse,
     },
 };

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -22,7 +22,7 @@ use std::{
 use as_variant::as_variant;
 use async_trait::async_trait;
 use growable_bloom_filter::GrowableBloom;
-use matrix_sdk_common::AsyncTraitDeps;
+use matrix_sdk_common::{AsyncTraitDeps, ttl_cache::TtlValue};
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomId,
     OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
@@ -44,7 +44,6 @@ use ruma::{
         receipt::{Receipt, ReceiptThread, ReceiptType},
     },
     serde::Raw,
-    time::SystemTime,
 };
 use serde::{Deserialize, Serialize};
 
@@ -1044,37 +1043,6 @@ where
     }
 }
 
-/// A TTL value in the store whose data can only be accessed before it expires.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TtlStoreValue<T> {
-    /// The data of the item.
-    #[serde(flatten)]
-    data: T,
-
-    /// Last time we fetched this data from the server, in milliseconds since
-    /// epoch.
-    last_fetch_ts: f64,
-}
-
-impl<T> TtlStoreValue<T> {
-    /// The number of milliseconds after which the data is considered stale.
-    pub const STALE_THRESHOLD: f64 = (1000 * 60 * 60 * 24 * 7) as _; // seven days
-
-    /// Construct a new `TtlStoreValue` with the given data.
-    pub fn new(data: T) -> Self {
-        Self { data, last_fetch_ts: now_timestamp_ms() }
-    }
-
-    /// Get the data of this value, if it hasn't expired.
-    pub fn into_data(self) -> Option<T> {
-        if now_timestamp_ms() - self.last_fetch_ts >= Self::STALE_THRESHOLD {
-            None
-        } else {
-            Some(self.data)
-        }
-    }
-}
-
 /// Serialisable representation of get_supported_versions::Response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SupportedVersionsResponse {
@@ -1123,15 +1091,6 @@ impl From<discover_homeserver::Response> for WellKnownResponse {
     }
 }
 
-/// Get the current timestamp as the number of milliseconds since Unix Epoch.
-fn now_timestamp_ms() -> f64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("System clock was before 1970.")
-        .as_secs_f64()
-        * 1000.0
-}
-
 /// A value for key-value data that should be persisted into the store.
 #[derive(Debug, Clone)]
 pub enum StateStoreDataValue {
@@ -1139,10 +1098,10 @@ pub enum StateStoreDataValue {
     SyncToken(String),
 
     /// The supported versions of the server.
-    SupportedVersions(TtlStoreValue<SupportedVersionsResponse>),
+    SupportedVersions(TtlValue<SupportedVersionsResponse>),
 
     /// The well-known information of the server.
-    WellKnown(TtlStoreValue<Option<WellKnownResponse>>),
+    WellKnown(TtlValue<Option<WellKnownResponse>>),
 
     /// A filter with the given ID.
     Filter(String),
@@ -1358,12 +1317,12 @@ impl StateStoreDataValue {
     }
 
     /// Get this value if it is the supported versions metadata.
-    pub fn into_supported_versions(self) -> Option<TtlStoreValue<SupportedVersionsResponse>> {
+    pub fn into_supported_versions(self) -> Option<TtlValue<SupportedVersionsResponse>> {
         as_variant!(self, Self::SupportedVersions)
     }
 
     /// Get this value if it is the well-known metadata.
-    pub fn into_well_known(self) -> Option<TtlStoreValue<Option<WellKnownResponse>>> {
+    pub fn into_well_known(self) -> Option<TtlValue<Option<WellKnownResponse>>> {
         as_variant!(self, Self::WellKnown)
     }
 
@@ -1509,48 +1468,4 @@ pub fn compare_thread_subscription_bump_stamps(
     }
 
     true
-}
-
-#[cfg(test)]
-mod tests {
-    use serde_json::json;
-
-    use super::{SupportedVersionsResponse, TtlStoreValue, now_timestamp_ms};
-
-    #[test]
-    fn test_stale_ttl_store_value() {
-        // Definitely stale.
-        let ttl_value = TtlStoreValue {
-            data: (),
-            last_fetch_ts: now_timestamp_ms() - TtlStoreValue::<()>::STALE_THRESHOLD - 1.0,
-        };
-        assert!(ttl_value.into_data().is_none());
-
-        // Definitely not stale.
-        let ttl_value = TtlStoreValue::new(());
-        assert!(ttl_value.into_data().is_some());
-    }
-
-    #[test]
-    fn test_stale_ttl_store_value_serialize_roundtrip() {
-        let server_info = SupportedVersionsResponse {
-            versions: vec!["1.2".to_owned(), "1.3".to_owned(), "1.4".to_owned()],
-            unstable_features: [("org.matrix.msc3916.stable".to_owned(), true)].into(),
-        };
-        let ttl_value = TtlStoreValue { data: server_info.clone(), last_fetch_ts: 1000.0 };
-        let json = json!({
-            "versions": ["1.2", "1.3", "1.4"],
-            "unstable_features": {
-                "org.matrix.msc3916.stable": true,
-            },
-            "last_fetch_ts": 1000.0,
-        });
-
-        assert_eq!(serde_json::to_value(&ttl_value).unwrap(), json);
-
-        let deserialized =
-            serde_json::from_value::<TtlStoreValue<SupportedVersionsResponse>>(json).unwrap();
-        assert_eq!(deserialized.data, server_info);
-        assert!(deserialized.last_fetch_ts - ttl_value.last_fetch_ts < 0.0001);
-    }
 }

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -27,7 +27,7 @@ use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomId,
     OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
     api::{
-        SupportedVersions,
+        MatrixVersion, SupportedVersions,
         client::discovery::{
             discover_homeserver::{
                 self, HomeserverInfo, IdentityServerInfo, RtcFocusInfo, TileServerInfo,
@@ -1060,7 +1060,16 @@ impl SupportedVersionsResponse {
     /// Note: Matrix versions and features that Ruma cannot parse, or does not
     /// know about, are discarded.
     pub fn supported_versions(&self) -> SupportedVersions {
-        SupportedVersions::from_parts(&self.versions, &self.unstable_features)
+        let mut supported_versions =
+            SupportedVersions::from_parts(&self.versions, &self.unstable_features);
+
+        // We need at least one supported version to be able to make requests, so we
+        // default to Matrix 1.0.
+        if supported_versions.versions.is_empty() {
+            supported_versions.versions.insert(MatrixVersion::V1_0);
+        }
+
+        supported_versions
     }
 }
 

--- a/crates/matrix-sdk-common/src/ttl_cache.rs
+++ b/crates/matrix-sdk-common/src/ttl_cache.rs
@@ -212,7 +212,7 @@ fn now_timestamp_ms() -> f64 {
 
 /// The default timestamp if it is missing during deserialization.
 ///
-/// We expect that value that was serialized always has an expiry time, so the
+/// We expect that a value that was serialized always has an expiry time, so the
 /// default is `Some(0.0)`.
 fn default_timestamp() -> Option<f64> {
     Some(0.0)

--- a/crates/matrix-sdk-common/src/ttl_cache.rs
+++ b/crates/matrix-sdk-common/src/ttl_cache.rs
@@ -140,8 +140,8 @@ pub struct TtlValue<T> {
     /// which means that the data is always expired. This allows to be
     /// compatible with data that was persisted before deciding to add an
     /// expiration time.
-    #[serde(default)]
-    last_fetch_ts: f64,
+    #[serde(default = "default_timestamp")]
+    last_fetch_ts: Option<f64>,
 }
 
 impl<T> TtlValue<T> {
@@ -152,12 +152,47 @@ impl<T> TtlValue<T> {
 
     /// Construct a new `TtlValue` with the given data.
     pub fn new(data: T) -> Self {
-        Self { data, last_fetch_ts: now_timestamp_ms() }
+        Self { data, last_fetch_ts: Some(now_timestamp_ms()) }
+    }
+
+    /// Construct a new `TtlValue` with the given data that never expires.
+    pub fn without_expiry(data: T) -> Self {
+        Self { data, last_fetch_ts: None }
+    }
+
+    /// Converts from `&TtlValue<T>` to `TtlValue<&T>`.
+    pub fn as_ref(&self) -> TtlValue<&T> {
+        TtlValue { data: &self.data, last_fetch_ts: self.last_fetch_ts }
+    }
+
+    /// Transform the data of this `TtlValue` with the given function.
+    pub fn map<U, F>(self, f: F) -> TtlValue<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        TtlValue { data: f(self.data), last_fetch_ts: self.last_fetch_ts }
     }
 
     /// Whether this value has expired.
     pub fn has_expired(&self) -> bool {
-        now_timestamp_ms() - self.last_fetch_ts >= Self::STALE_THRESHOLD
+        self.last_fetch_ts.is_some_and(|ts| now_timestamp_ms() - ts >= Self::STALE_THRESHOLD)
+    }
+
+    /// Mark this value has expired.
+    pub fn expire(&mut self) {
+        // We assume that the system time is always correct and we are far from the UNIX
+        // epoch so a timestamp of 0 should always be expired.
+        self.last_fetch_ts = Some(0.0)
+    }
+
+    /// Get a reference to the data of this value.
+    pub fn data(&self) -> &T {
+        &self.data
+    }
+
+    /// Get the data of this value.
+    pub fn into_data_unchecked(self) -> T {
+        self.data
     }
 
     /// Get the data of this value if it hasn't expired.
@@ -173,6 +208,14 @@ fn now_timestamp_ms() -> f64 {
         .expect("System clock was before 1970.")
         .as_secs_f64()
         * 1000.0
+}
+
+/// The default timestamp if it is missing during deserialization.
+///
+/// We expect that value that was serialized always has an expiry time, so the
+/// default is `Some(0.0)`.
+fn default_timestamp() -> Option<f64> {
+    Some(0.0)
 }
 
 #[cfg(test)]
@@ -204,12 +247,16 @@ mod tests {
         // Definitely stale.
         let ttl_value = TtlValue {
             data: (),
-            last_fetch_ts: now_timestamp_ms() - TtlValue::<()>::STALE_THRESHOLD - 1.0,
+            last_fetch_ts: Some(now_timestamp_ms() - TtlValue::<()>::STALE_THRESHOLD - 1.0),
         };
         assert!(ttl_value.has_expired());
 
         // Definitely not stale.
         let ttl_value = TtlValue::new(());
+        assert!(!ttl_value.has_expired());
+
+        // Cannot be stale.
+        let ttl_value = TtlValue::without_expiry(());
         assert!(!ttl_value.has_expired());
     }
 
@@ -223,7 +270,7 @@ mod tests {
         let data = Data { foo: "bar".to_owned() };
 
         // With timestamp.
-        let ttl_value = TtlValue { data: data.clone(), last_fetch_ts: 1000.0 };
+        let ttl_value = TtlValue { data: data.clone(), last_fetch_ts: Some(1000.0) };
         let json = json!({
             "foo": "bar",
             "last_fetch_ts": 1000.0,
@@ -232,7 +279,7 @@ mod tests {
 
         let deserialized = serde_json::from_value::<TtlValue<Data>>(json).unwrap();
         assert_eq!(deserialized.data, data);
-        assert!(deserialized.last_fetch_ts - ttl_value.last_fetch_ts < 0.0001);
+        assert!(deserialized.last_fetch_ts.unwrap() - ttl_value.last_fetch_ts.unwrap() < 0.0001);
 
         // Without timestamp the value is always expired in theory.
         let json = json!({
@@ -240,6 +287,6 @@ mod tests {
         });
         let deserialized = serde_json::from_value::<TtlValue<Data>>(json).unwrap();
         assert_eq!(deserialized.data, data);
-        assert!(deserialized.last_fetch_ts - 0.0 < 0.0001);
+        assert!(deserialized.last_fetch_ts.unwrap() - 0.0 < 0.0001);
     }
 }

--- a/crates/matrix-sdk-common/src/ttl_cache.rs
+++ b/crates/matrix-sdk-common/src/ttl_cache.rs
@@ -17,7 +17,8 @@
 
 use std::{borrow::Borrow, collections::HashMap, hash::Hash, time::Duration};
 
-use ruma::time::Instant;
+use ruma::time::{Instant, SystemTime};
+use serde::{Deserialize, Serialize};
 
 // One day is the default lifetime.
 const DEFAULT_LIFETIME: Duration = Duration::from_secs(24 * 60 * 60);
@@ -123,10 +124,63 @@ impl<K: Eq + Hash, V: Clone> Default for TtlCache<K, V> {
     }
 }
 
+/// A value that expires after some time.
+///
+/// This value is (de)serializable so it can be persisted in a store.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TtlValue<T> {
+    /// The data of the item.
+    #[serde(flatten)]
+    data: T,
+
+    /// Last time we fetched this data from the server, in milliseconds since
+    /// UNIX epoch.
+    ///
+    /// When this field is missing during deserialization, it defaults to `0.0`,
+    /// which means that the data is always expired. This allows to be
+    /// compatible with data that was persisted before deciding to add an
+    /// expiration time.
+    #[serde(default)]
+    last_fetch_ts: f64,
+}
+
+impl<T> TtlValue<T> {
+    /// The number of milliseconds after which the data is considered stale.
+    ///
+    /// This matches 7 days.
+    pub const STALE_THRESHOLD: f64 = (1000 * 60 * 60 * 24) as _;
+
+    /// Construct a new `TtlValue` with the given data.
+    pub fn new(data: T) -> Self {
+        Self { data, last_fetch_ts: now_timestamp_ms() }
+    }
+
+    /// Whether this value has expired.
+    pub fn has_expired(&self) -> bool {
+        now_timestamp_ms() - self.last_fetch_ts >= Self::STALE_THRESHOLD
+    }
+
+    /// Get the data of this value if it hasn't expired.
+    pub fn into_data(self) -> Option<T> {
+        (!self.has_expired()).then_some(self.data)
+    }
+}
+
+/// Get the current timestamp as the number of milliseconds since Unix Epoch.
+fn now_timestamp_ms() -> f64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("System clock was before 1970.")
+        .as_secs_f64()
+        * 1000.0
+}
+
 #[cfg(test)]
 mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
 
-    use super::TtlCache;
+    use super::{TtlCache, TtlValue, now_timestamp_ms};
 
     #[test]
     fn test_ttl_cache_insertion() {
@@ -143,5 +197,49 @@ mod tests {
 
         assert!(!cache.contains("A"));
         assert!(cache.get("A").is_none(), "The item should have been removed from the cache");
+    }
+
+    #[test]
+    fn test_ttl_value_expiry() {
+        // Definitely stale.
+        let ttl_value = TtlValue {
+            data: (),
+            last_fetch_ts: now_timestamp_ms() - TtlValue::<()>::STALE_THRESHOLD - 1.0,
+        };
+        assert!(ttl_value.has_expired());
+
+        // Definitely not stale.
+        let ttl_value = TtlValue::new(());
+        assert!(!ttl_value.has_expired());
+    }
+
+    #[test]
+    fn test_ttl_value_serialize_roundtrip() {
+        #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Data {
+            foo: String,
+        }
+
+        let data = Data { foo: "bar".to_owned() };
+
+        // With timestamp.
+        let ttl_value = TtlValue { data: data.clone(), last_fetch_ts: 1000.0 };
+        let json = json!({
+            "foo": "bar",
+            "last_fetch_ts": 1000.0,
+        });
+        assert_eq!(serde_json::to_value(&ttl_value).unwrap(), json);
+
+        let deserialized = serde_json::from_value::<TtlValue<Data>>(json).unwrap();
+        assert_eq!(deserialized.data, data);
+        assert!(deserialized.last_fetch_ts - ttl_value.last_fetch_ts < 0.0001);
+
+        // Without timestamp the value is always expired in theory.
+        let json = json!({
+            "foo": "bar",
+        });
+        let deserialized = serde_json::from_value::<TtlValue<Data>>(json).unwrap();
+        assert_eq!(deserialized.data, data);
+        assert!(deserialized.last_fetch_ts - 0.0 < 0.0001);
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -34,9 +34,10 @@ use matrix_sdk_base::{
         ChildTransactionId, ComposerDraft, DependentQueuedRequest, DependentQueuedRequestKind,
         QueuedRequest, QueuedRequestKind, RoomLoadSettings, SentRequestKey,
         SerializableEventContent, StateChanges, StateStore, StoreError, StoredThreadSubscription,
-        SupportedVersionsResponse, ThreadSubscriptionStatus, TtlStoreValue, WellKnownResponse,
+        SupportedVersionsResponse, ThreadSubscriptionStatus, WellKnownResponse,
         compare_thread_subscription_bump_stamps,
     },
+    ttl_cache::TtlValue,
 };
 use matrix_sdk_store_encryption::{Error as EncryptionError, StoreCipher};
 use ruma::{
@@ -633,11 +634,11 @@ impl_state_store!({
                 .transpose()?
                 .map(StateStoreDataValue::SyncToken),
             StateStoreDataKey::SupportedVersions => value
-                .map(|f| self.deserialize_value::<TtlStoreValue<SupportedVersionsResponse>>(&f))
+                .map(|f| self.deserialize_value::<TtlValue<SupportedVersionsResponse>>(&f))
                 .transpose()?
                 .map(StateStoreDataValue::SupportedVersions),
             StateStoreDataKey::WellKnown => value
-                .map(|f| self.deserialize_value::<TtlStoreValue<Option<WellKnownResponse>>>(&f))
+                .map(|f| self.deserialize_value::<TtlValue<Option<WellKnownResponse>>>(&f))
                 .transpose()?
                 .map(StateStoreDataValue::WellKnown),
             StateStoreDataKey::Filter(_) => value

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -28,7 +28,7 @@ use homeserver_config::*;
 use matrix_sdk_base::crypto::DecryptionSettings;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::{CollectStrategy, TrustRequirement};
-use matrix_sdk_base::{BaseClient, ThreadingSupport, store::StoreConfig};
+use matrix_sdk_base::{BaseClient, ThreadingSupport, store::StoreConfig, ttl_cache::TtlValue};
 use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
 #[cfg(feature = "sqlite")]
 use matrix_sdk_sqlite::SqliteStoreConfig;
@@ -606,7 +606,10 @@ impl ClientBuilder {
         let send_queue = Arc::new(SendQueueData::new(true));
 
         let supported_versions = match self.server_versions {
-            Some(versions) => Cached(SupportedVersions { versions, features: Default::default() }),
+            Some(versions) => Cached(TtlValue::without_expiry(SupportedVersions {
+                versions,
+                features: Default::default(),
+            })),
             None => NotSet,
         };
         let well_known = match well_known {

--- a/crates/matrix-sdk/src/client/caches.rs
+++ b/crates/matrix-sdk/src/client/caches.rs
@@ -12,12 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use matrix_sdk_base::{store::WellKnownResponse, ttl_cache::TtlCache};
+use matrix_sdk_common::{locks::Mutex, ttl_cache::TtlValue};
 use ruma::api::{
     SupportedVersions,
     client::discovery::get_authorization_server_metadata::v1::AuthorizationServerMetadata,
 };
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex as AsyncMutex, RwLock};
+
+use crate::HttpError;
 
 /// A collection of in-memory data that the `Client` might want to cache to
 /// avoid hitting the homeserver every time users request the data.
@@ -28,16 +33,16 @@ pub(crate) struct ClientCaches {
     ///
     /// - The versions prefilled with `ClientBuilder::server_versions()`
     /// - The versions fetched from an *authenticated* request to the server.
-    pub(crate) supported_versions: RwLock<CachedValue<SupportedVersions>>,
+    pub(crate) supported_versions: Cache<SupportedVersions>,
     /// Well-known information.
     pub(super) well_known: RwLock<CachedValue<Option<WellKnownResponse>>>,
-    pub(crate) server_metadata: tokio::sync::Mutex<TtlCache<String, AuthorizationServerMetadata>>,
+    pub(crate) server_metadata: AsyncMutex<TtlCache<String, AuthorizationServerMetadata>>,
 }
 
 /// A cached value that can either be set or not set, used to avoid confusion
 /// between a value that is set to `None` (because it doesn't exist) and a value
 /// that has not been cached yet.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum CachedValue<Value> {
     /// A value has been cached.
     Cached(Value),
@@ -55,5 +60,42 @@ impl<Value> CachedValue<Value> {
             Self::Cached(value) => Some(value),
             Self::NotSet => None,
         }
+    }
+}
+
+/// A cache in the [`ClientCaches`].
+pub(crate) struct Cache<Value> {
+    /// The value that is cached.
+    value: Mutex<CachedValue<TtlValue<Value>>>,
+    /// Lock making sure that we are only refreshing the value once at a time.
+    ///
+    /// Stores the error that happened during the last refresh, if any.
+    pub(crate) refresh_lock: AsyncMutex<Result<(), Arc<HttpError>>>,
+}
+
+impl<Value> Cache<Value> {
+    /// Construct a new `Cache` with the given value.
+    pub(crate) fn with_value(value: CachedValue<TtlValue<Value>>) -> Self {
+        Self { value: Mutex::new(value), refresh_lock: AsyncMutex::new(Ok(())) }
+    }
+
+    /// Set the value.
+    pub(crate) fn set_value(&self, value: TtlValue<Value>) {
+        *self.value.lock() = CachedValue::Cached(value);
+    }
+
+    /// Reset the cache by dropping the value.
+    pub(crate) fn reset(&self) {
+        self.value.lock().take();
+    }
+}
+
+impl<Value> Cache<Value>
+where
+    Value: Clone,
+{
+    /// Get the cached value.
+    pub(crate) fn value(&self) -> CachedValue<TtlValue<Value>> {
+        self.value.lock().clone()
     }
 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -36,14 +36,14 @@ use matrix_sdk_base::{
     StateStoreDataKey, StateStoreDataValue, StoreError, SyncOutsideWasm, ThreadingSupport,
     event_cache::store::EventCacheStoreLock,
     media::store::MediaStoreLock,
-    store::{
-        DynStateStore, RoomLoadSettings, SupportedVersionsResponse, TtlStoreValue,
-        WellKnownResponse,
-    },
+    store::{DynStateStore, RoomLoadSettings, SupportedVersionsResponse, WellKnownResponse},
     sync::{Notification, RoomUpdates},
     task_monitor::TaskMonitor,
 };
-use matrix_sdk_common::{cross_process_lock::CrossProcessLockConfig, ttl_cache::TtlCache};
+use matrix_sdk_common::{
+    cross_process_lock::CrossProcessLockConfig,
+    ttl_cache::{TtlCache, TtlValue},
+};
 #[cfg(feature = "e2e-encryption")]
 use ruma::events::{InitialStateEvent, room::encryption::RoomEncryptionEventContent};
 use ruma::{
@@ -2133,7 +2133,7 @@ impl Client {
                 .state_store()
                 .set_kv_data(
                     StateStoreDataKey::SupportedVersions,
-                    StateStoreDataValue::SupportedVersions(TtlStoreValue::new(
+                    StateStoreDataValue::SupportedVersions(TtlValue::new(
                         supported_versions.clone(),
                     )),
                 )
@@ -2356,7 +2356,7 @@ impl Client {
             .state_store()
             .set_kv_data(
                 StateStoreDataKey::WellKnown,
-                StateStoreDataValue::WellKnown(TtlStoreValue::new(well_known.clone())),
+                StateStoreDataValue::WellKnown(TtlValue::new(well_known.clone())),
             )
             .await
         {

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -42,7 +42,6 @@ use matrix_sdk_base::{
 };
 use matrix_sdk_common::{
     cross_process_lock::CrossProcessLockConfig,
-    executor::spawn,
     ttl_cache::{TtlCache, TtlValue},
 };
 #[cfg(feature = "e2e-encryption")]
@@ -2307,7 +2306,7 @@ impl Client {
             debug!("spawning task to refresh supported versions cache");
 
             let client = self.clone();
-            spawn(async move {
+            self.task_monitor().spawn_finite_task("refresh supported versions cache", async move {
                 if let Err(error) = client.refresh_supported_versions_cache(failsafe).await {
                     warn!("failed to refresh supported versions cache: {error}");
                 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -42,6 +42,7 @@ use matrix_sdk_base::{
 };
 use matrix_sdk_common::{
     cross_process_lock::CrossProcessLockConfig,
+    executor::spawn,
     ttl_cache::{TtlCache, TtlValue},
 };
 #[cfg(feature = "e2e-encryption")]
@@ -86,7 +87,7 @@ use tracing::{Instrument, Span, debug, error, info, instrument, trace, warn};
 use url::Url;
 
 use self::{
-    caches::{CachedValue, ClientCaches},
+    caches::{Cache, CachedValue, ClientCaches},
     futures::SendRequest,
 };
 use crate::{
@@ -390,7 +391,7 @@ impl ClientInner {
         sliding_sync_version: SlidingSyncVersion,
         http_client: HttpClient,
         base_client: BaseClient,
-        supported_versions: CachedValue<SupportedVersions>,
+        supported_versions: CachedValue<TtlValue<SupportedVersions>>,
         well_known: CachedValue<Option<WellKnownResponse>>,
         respect_login_well_known: bool,
         event_cache: OnceCell<EventCache>,
@@ -403,7 +404,7 @@ impl ClientInner {
         thread_subscription_catchup: OnceCell<Arc<ThreadSubscriptionCatchup>>,
     ) -> Arc<Self> {
         let caches = ClientCaches {
-            supported_versions: supported_versions.into(),
+            supported_versions: Cache::with_value(supported_versions),
             well_known: well_known.into(),
             server_metadata: Mutex::new(TtlCache::new()),
         };
@@ -2100,59 +2101,17 @@ impl Client {
     ///
     /// If `failsafe` is true, this will try to minimize side effects to avoid
     /// possible deadlocks.
-    async fn load_or_fetch_supported_versions(
+    async fn fetch_supported_versions(
         &self,
         failsafe: bool,
     ) -> HttpResult<SupportedVersionsResponse> {
-        match self.state_store().get_kv_data(StateStoreDataKey::SupportedVersions).await {
-            Ok(Some(stored)) => {
-                if let Some(supported_versions) =
-                    stored.into_supported_versions().and_then(|value| value.into_data())
-                {
-                    return Ok(supported_versions);
-                }
-            }
-            Ok(None) => {
-                // fallthrough: cache is empty
-            }
-            Err(err) => {
-                warn!("error when loading cached supported versions: {err}");
-                // fallthrough to network.
-            }
-        }
-
         let server_versions = self.fetch_server_versions_inner(failsafe, None).await?;
         let supported_versions = SupportedVersionsResponse {
             versions: server_versions.versions,
             unstable_features: server_versions.unstable_features,
         };
 
-        // Only attempt to cache the result in storage if the request was authenticated.
-        if self.auth_ctx().has_valid_access_token()
-            && let Err(err) = self
-                .state_store()
-                .set_kv_data(
-                    StateStoreDataKey::SupportedVersions,
-                    StateStoreDataValue::SupportedVersions(TtlValue::new(
-                        supported_versions.clone(),
-                    )),
-                )
-                .await
-        {
-            warn!("error when caching supported versions: {err}");
-        }
-
         Ok(supported_versions)
-    }
-
-    pub(crate) async fn get_cached_supported_versions(&self) -> Option<SupportedVersions> {
-        let supported_versions = &self.inner.caches.supported_versions;
-
-        if let CachedValue::Cached(val) = &*supported_versions.read().await {
-            Some(val.clone())
-        } else {
-            None
-        }
     }
 
     /// Get the Matrix versions and features supported by the homeserver by
@@ -2195,30 +2154,87 @@ impl Client {
         &self,
         failsafe: bool,
     ) -> HttpResult<SupportedVersions> {
+        match self.supported_versions_cached_inner(failsafe).await {
+            Ok(Some(value)) => {
+                return Ok(value);
+            }
+            Ok(None) => {
+                // The cache is empty, make a request.
+            }
+            Err(error) => {
+                warn!("error when loading cached supported versions: {error}");
+                // Fallthrough to make a request.
+            }
+        }
+
+        self.refresh_supported_versions_cache(failsafe).await
+    }
+
+    /// Refresh the Matrix versions and features supported by the homeserver in
+    /// the cache.
+    ///
+    /// If `failsafe` is true, this will try to minimize side effects to avoid
+    /// possible deadlocks.
+    async fn refresh_supported_versions_cache(
+        &self,
+        failsafe: bool,
+    ) -> HttpResult<SupportedVersions> {
         let cached_supported_versions = &self.inner.caches.supported_versions;
-        if let CachedValue::Cached(val) = &*cached_supported_versions.read().await {
-            return Ok(val.clone());
-        }
 
-        let mut guarded_supported_versions = cached_supported_versions.write().await;
-        if let CachedValue::Cached(val) = &*guarded_supported_versions {
-            return Ok(val.clone());
-        }
+        let mut supported_versions_guard = match cached_supported_versions.refresh_lock.try_lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                // There is already a refresh in progress, wait for it to finish.
+                let guard = cached_supported_versions.refresh_lock.lock().await;
 
-        let supported = self.load_or_fetch_supported_versions(failsafe).await?;
+                if let Err(error) = guard.as_ref() {
+                    // There was an error in the previous refresh, return it.
+                    return Err(HttpError::SupportedVersions(error.clone()));
+                }
 
-        // Fill both unstable features and server versions at once.
-        let mut supported_versions = supported.supported_versions();
-        if supported_versions.versions.is_empty() {
-            supported_versions.versions = [MatrixVersion::V1_0].into();
-        }
+                // Reuse the data if it was cached and it hasn't expired.
+                if let CachedValue::Cached(value) = cached_supported_versions.value()
+                    && !value.has_expired()
+                {
+                    return Ok(value.into_data_unchecked());
+                }
+
+                // The data wasn't cached or has expired, we need to make another request.
+                guard
+            }
+        };
+
+        let response = match self.fetch_supported_versions(failsafe).await {
+            Ok(response) => {
+                *supported_versions_guard = Ok(());
+                TtlValue::new(response)
+            }
+            Err(error) => {
+                let error = Arc::new(error);
+                *supported_versions_guard = Err(error.clone());
+                return Err(HttpError::SupportedVersions(error));
+            }
+        };
+
+        let supported_versions = response.as_ref().map(|response| response.supported_versions());
 
         // Only cache the result if the request was authenticated.
         if self.auth_ctx().has_valid_access_token() {
-            *guarded_supported_versions = CachedValue::Cached(supported_versions.clone());
+            if let Err(err) = self
+                .state_store()
+                .set_kv_data(
+                    StateStoreDataKey::SupportedVersions,
+                    StateStoreDataValue::SupportedVersions(response),
+                )
+                .await
+            {
+                warn!("error when caching supported versions: {err}");
+            }
+
+            cached_supported_versions.set_value(supported_versions.clone());
         }
 
-        Ok(supported_versions)
+        Ok(supported_versions.into_data_unchecked())
     }
 
     /// Get the Matrix versions and features supported by the homeserver by
@@ -2226,8 +2242,11 @@ impl Client {
     ///
     /// For a version of this function that fetches the supported versions and
     /// features from the homeserver if the [`SupportedVersions`] aren't
-    /// found in the cache, take a look at the [`Client::server_versions()`]
+    /// found in the cache, take a look at the [`Client::supported_versions()`]
     /// method.
+    ///
+    /// If the data in the cache has expired, this will trigger a background
+    /// task to refresh it.
     ///
     /// # Examples
     ///
@@ -2255,21 +2274,47 @@ impl Client {
     /// # anyhow::Ok(()) };
     /// ```
     pub async fn supported_versions_cached(&self) -> Result<Option<SupportedVersions>, StoreError> {
-        if let Some(cached) = self.get_cached_supported_versions().await {
-            Ok(Some(cached))
-        } else if let Some(stored) =
-            self.state_store().get_kv_data(StateStoreDataKey::SupportedVersions).await?
+        self.supported_versions_cached_inner(false).await
+    }
+
+    async fn supported_versions_cached_inner(
+        &self,
+        failsafe: bool,
+    ) -> Result<Option<SupportedVersions>, StoreError> {
+        let supported_versions_cache = &self.inner.caches.supported_versions;
+
+        let value = if let CachedValue::Cached(cached) = supported_versions_cache.value() {
+            cached
+        } else if let Some(stored) = self
+            .state_store()
+            .get_kv_data(StateStoreDataKey::SupportedVersions)
+            .await?
+            .and_then(|value| value.into_supported_versions())
         {
-            if let Some(supported) =
-                stored.into_supported_versions().and_then(|value| value.into_data())
-            {
-                Ok(Some(supported.supported_versions()))
-            } else {
-                Ok(None)
-            }
+            let stored = stored.map(|response| response.supported_versions());
+
+            // Copy the data from the store in the in-memory cache.
+            supported_versions_cache.set_value(stored.clone());
+
+            stored
         } else {
-            Ok(None)
+            return Ok(None);
+        };
+
+        // Spawn a task to refresh the cache if it has expired and we have a valid
+        // access token.
+        if value.has_expired() && self.auth_ctx().has_valid_access_token() {
+            debug!("spawning task to refresh supported versions cache");
+
+            let client = self.clone();
+            spawn(async move {
+                if let Err(error) = client.refresh_supported_versions_cache(failsafe).await {
+                    warn!("failed to refresh supported versions cache: {error}");
+                }
+            });
         }
+
+        Ok(Some(value.into_data_unchecked()))
     }
 
     /// Get the Matrix versions supported by the homeserver by fetching them
@@ -2323,8 +2368,8 @@ impl Client {
     /// stale entry in the cache. This functions makes it possible to force
     /// reset it.
     pub async fn reset_supported_versions(&self) -> Result<()> {
-        // Empty the in-memory caches.
-        self.inner.caches.supported_versions.write().await.take();
+        // Empty the in-memory cache.
+        self.inner.caches.supported_versions.reset();
 
         // Empty the store cache.
         Ok(self.state_store().remove_kv_data(StateStoreDataKey::SupportedVersions).await?)
@@ -3072,7 +3117,7 @@ impl Client {
                     .base_client
                     .clone_with_in_memory_state_store(cross_process_lock_config.clone(), false)
                     .await?,
-                self.inner.caches.supported_versions.read().await.clone(),
+                self.inner.caches.supported_versions.value(),
                 self.inner.caches.well_known.read().await.clone(),
                 self.inner.respect_login_well_known,
                 self.inner.event_cache.clone(),
@@ -3413,6 +3458,7 @@ pub(crate) mod tests {
     use matrix_sdk_base::{
         RoomState,
         store::{MemoryStore, StoreConfig},
+        ttl_cache::TtlValue,
     };
     use matrix_sdk_test::{
         DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, SyncResponseBuilder, async_test,
@@ -3449,7 +3495,7 @@ pub(crate) mod tests {
     use super::Client;
     use crate::{
         Error, TransmissionProgress,
-        client::{WeakClient, futures::SendMediaUploadRequest},
+        client::{WeakClient, caches::CachedValue, futures::SendMediaUploadRequest},
         config::{RequestConfig, SyncSettings},
         futures::SendRequest,
         media::MediaError,
@@ -3837,6 +3883,7 @@ pub(crate) mod tests {
                 .unwrap()
                 .contains(&FeatureFlag::from("org.matrix.e2e_cross_signing"))
         );
+
         let supported = client.supported_versions().await.unwrap();
         assert!(supported.versions.contains(&MatrixVersion::V1_0));
         assert!(supported.features.contains(&FeatureFlag::from("org.matrix.e2e_cross_signing")));
@@ -3848,15 +3895,29 @@ pub(crate) mod tests {
 
         drop(versions_mock);
 
-        // Now, reset the cache, and observe the endpoints being called again once.
+        // Now, reset the cache, and observe the endpoint being called again once.
         client.reset_supported_versions().await.unwrap();
 
-        server.mock_versions().ok().expect(1).named("second versions mock").mount().await;
+        server.mock_versions().ok().expect(2).named("second versions mock").mount().await;
 
         // Hits network again.
         assert!(client.server_versions().await.unwrap().contains(&MatrixVersion::V1_0));
         // Hits in-memory cache again.
         assert!(client.server_versions().await.unwrap().contains(&MatrixVersion::V1_0));
+        assert_matches!(client.inner.caches.supported_versions.value(), CachedValue::Cached(value) if !value.has_expired());
+
+        // Force an expiry of the data.
+        let supported_versions = client.supported_versions_cached().await.unwrap().unwrap();
+        let mut ttl_value = TtlValue::new(supported_versions);
+        ttl_value.expire();
+        client.inner.caches.supported_versions.set_value(ttl_value);
+
+        // Call the method to trigger a cache refresh background task.
+        client.supported_versions_cached().await.unwrap().unwrap();
+
+        // We wait for the task to finish, the endpoint should have been called again.
+        sleep(Duration::from_secs(1)).await;
+        assert_matches!(client.inner.caches.supported_versions.value(), CachedValue::Cached(value) if !value.has_expired());
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -106,6 +106,10 @@ pub enum HttpError {
     #[error(transparent)]
     RefreshToken(RefreshTokenError),
 
+    /// Error while fetching the versions supported by the homeserver.
+    #[error(transparent)]
+    SupportedVersions(Arc<HttpError>),
+
     /// Error creating the TLS verifier.
     #[cfg(target_os = "android")]
     #[error(transparent)]

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -38,7 +38,7 @@ use ruma::api::{
 use tokio::sync::{Semaphore, SemaphorePermit};
 use tracing::{debug, error, field::debug, instrument, trace};
 
-use crate::{HttpResult, client::caches::CachedValue, config::RequestConfig, error::HttpError};
+use crate::{HttpResult, config::RequestConfig, error::HttpError};
 
 #[cfg(not(target_family = "wasm"))]
 mod native;
@@ -320,13 +320,9 @@ impl SupportedPathBuilder for path_builder::VersionHistory {
         // to avoid possible deadlocks.
 
         if !client.auth_ctx().has_valid_access_token() {
-            // Get the value in the cache without waiting. If the lock is not available, we
-            // are in the middle of refreshing the cache so waiting for it would result in a
-            // deadlock.
-            if let Ok(CachedValue::Cached(versions)) =
-                client.inner.caches.supported_versions.try_read().as_deref()
-            {
-                return Ok(Cow::Owned(versions.clone()));
+            // Try to get the value in the cache.
+            if let Ok(Some(versions)) = client.supported_versions_cached().await {
+                return Ok(Cow::Owned(versions));
             }
 
             // The request will skip auth so we might not get all the supported features, so
@@ -335,9 +331,9 @@ impl SupportedPathBuilder for path_builder::VersionHistory {
 
             Ok(Cow::Owned(response.as_supported_versions()))
         } else if skip_auth {
-            let cached_versions = client.get_cached_supported_versions().await;
+            let cached_versions = client.supported_versions_cached().await;
 
-            let versions = if let Some(versions) = cached_versions {
+            let versions = if let Ok(Some(versions)) = cached_versions {
                 versions
             } else {
                 // If we're skipping auth we might not get all the supported features, so just


### PR DESCRIPTION
The previous behavior was making the data unavailable as soon as it is
expired, forcing the user to make a request to access fresh data. This
change keeps the data after it is expired, allowing the function to
return quickly, and triggers a background task to refresh it so that
later calls will be able to use the updated data.

This is a step towards https://github.com/matrix-org/matrix-rust-sdk/issues/6090. While it's not clear in the issue what
should be the trigger for the background refreshes, this implements at
least the background refresh while keeping the expiry time as a trigger.

The next steps are to apply this to other cached values and shorten the
expiry time to something like 1 day, which should be more helpful.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.
