### PR TITLE
fix(ffi): Stop logging errors in `ClientError::from_str`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -29,7 +29,6 @@ use ruma::{
     MilliSecondsSinceUnixEpoch,
     api::error::{ErrorBody, ErrorKind as RumaApiErrorKind, RetryAfter, StandardErrorBody},
 };
-use tracing::error;
 use uniffi::UnexpectedUniFFICallbackError;
 
 use crate::{room_list::RoomListError, timeline::FocusEventError};
@@ -44,7 +43,6 @@ pub enum ClientError {
 
 impl ClientError {
     pub(crate) fn from_str<E: Display>(error: E, details: Option<String>) -> Self {
-        error!("{error}");
         Self::Generic { msg: error.to_string(), details }
     }
 

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -29,7 +29,7 @@ use ruma::{
     MilliSecondsSinceUnixEpoch,
     api::error::{ErrorBody, ErrorKind as RumaApiErrorKind, RetryAfter, StandardErrorBody},
 };
-use tracing::warn;
+use tracing::error;
 use uniffi::UnexpectedUniFFICallbackError;
 
 use crate::{room_list::RoomListError, timeline::FocusEventError};
@@ -44,7 +44,7 @@ pub enum ClientError {
 
 impl ClientError {
     pub(crate) fn from_str<E: Display>(error: E, details: Option<String>) -> Self {
-        warn!("Error: {error}");
+        error!("{error}");
         Self::Generic { msg: error.to_string(), details }
     }
 


### PR DESCRIPTION
This patch stops logging errors in `ClientError::from_str` as it was an artifact of some old debugging sessions.

---

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.
