### PR TITLE
doc(ffi): clarify when to call `Client::enable_automatic_backpagination`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2069,6 +2069,9 @@ impl Client {
     ///
     /// This is an experimental feature, and might cause performance issues on
     /// large accounts. Use with caution.
+    ///
+    /// This must be called after creating a client, but before subscribing to
+    /// the event cache (so, before spawning a sync service or a timeline).
     pub fn enable_automatic_backpagination(&self) {
         self.inner.event_cache().config_mut().experimental_auto_backpagination = true;
     }


### PR DESCRIPTION
Since the boolean is read only once when subscribing the event cache, let's make it clear when the FFI function should be called (based on most prominent types used at the FFI layer).

- No public API changes.
- Only my big brain was used during the making of this super complicated PR.