### PR TITLE
Use stable identifiers for MSC4268

### DIFF
--- a/crates/matrix-sdk-common/CHANGELOG.md
+++ b/crates/matrix-sdk-common/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] Change to the stable identifiers for `m.history_not_shared`.
+  We still support reading the unstable identifier.
+  ([#6467](https://github.com/matrix-org/matrix-rust-sdk/pull/6467))
 - Add a method to check the validity of edits.
   ([#6454](https://github.com/matrix-org/matrix-rust-sdk/pull/6454))
 - A background task monitor has been added, that can spawn background tasks and monitor their

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -1249,7 +1249,7 @@ pub enum WithheldCode {
     /// that the session was not marked as "shared_history".
     ///
     /// [MSC4268]: https://github.com/matrix-org/matrix-spec-proposals/pull/4268
-    #[ruma_enum(rename = "io.element.msc4268.history_not_shared", alias = "m.history_not_shared")]
+    #[ruma_enum(rename = "m.history_not_shared", alias = "io.element.msc4268.history_not_shared")]
     HistoryNotShared,
 
     #[doc(hidden)]

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] Change to the stable identifiers for `m.room_key_bundle` and
+  `m.history_not_shared`. We still support reading the unstable identifiers.
+  ([#6467](https://github.com/matrix-org/matrix-rust-sdk/pull/6467))
 - Add support for MSC4385.
   ([#6164](https://github.com/matrix-org/matrix-rust-sdk/pull/6164))
   - Add new method `OlmMachine::push_secret_to_verified_devices`.

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -8,8 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- [**breaking**] Change to the stable identifiers for `m.room_key_bundle` and
-  `m.history_not_shared`. We still support reading the unstable identifiers.
+- [**breaking**] Change to the stable identifiers for `m.room_key_bundle`,
+  `m.history_not_shared` and `m.shared_history`. We still support reading the
+  unstable identifiers.
   ([#6467](https://github.com/matrix-org/matrix-rust-sdk/pull/6467))
 - Add support for MSC4385.
   ([#6164](https://github.com/matrix-org/matrix-rust-sdk/pull/6164))

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -960,8 +960,7 @@ impl OlmMachine {
         }
     }
 
-    /// Handle a received, decrypted, `io.element.msc4268.room_key_bundle`
-    /// to-device event.
+    /// Handle a received, decrypted, `m.room_key_bundle` to-device event.
     #[instrument()]
     async fn receive_room_key_bundle_data(
         &self,

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -1223,12 +1223,14 @@ mod tests {
         .unwrap()
     }
 
-    #[async_test]
-    async fn test_shared_history_from_m_room_key_content() {
-        let content = json!({
+    fn key_json(stable: bool) -> serde_json::Value {
+        let shared_history =
+            if stable { "m.shared_history" } else { "org.matrix.msc3061.shared_history" };
+
+        json!({
             "algorithm": "m.megolm.v1.aes-sha2",
             "room_id": "!Cuyf34gef24t:localhost",
-            "org.matrix.msc3061.shared_history": true,
+            shared_history: true,
             "session_id": "ZFD6+OmV7fVCsJ7Gap8UnORH8EnmiAkes8FAvQuCw/I",
             "session_key": "AgAAAADNp1EbxXYOGmJtyX4AkD1bvJvAUyPkbIaKxtnGKjv\
                             SQ3E/4mnuqdM4vsmNzpO1EeWzz1rDkUpYhYE9kP7sJhgLXi\
@@ -1237,7 +1239,12 @@ mod tests {
                             QrCexmqfFJzkR/BJ5ogJHrPBQL0LgsPyglIbMTLg7qygIaY\
                             U5Fe2QdKMH7nTZPNIRHh1RaMfHVETAUJBax88EWZBoifk80\
                             gdHUwHSgMk77vCc2a5KHKLDA",
-        });
+        })
+    }
+
+    #[async_test]
+    async fn test_shared_history_from_m_room_key_content_stable() {
+        let content = key_json(true);
 
         let sender_key = Curve25519PublicKey::from_bytes([0; 32]);
         let signing_key = Ed25519PublicKey::from_slice(&[0; 32]).expect("");
@@ -1267,20 +1274,57 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_shared_history_from_exported_room_key() {
-        let content = json!({
-                "algorithm": "m.megolm.v1.aes-sha2",
-                "room_id": "!room:id",
-                "sender_key": "FOvlmz18LLI3k/llCpqRoKT90+gFF8YhuL+v1YBXHlw",
-                "session_id": "/2K+V777vipCxPZ0gpY9qcpz1DYaXwuMRIu0UEP0Wa0",
-                "session_key": "AQAAAAAclzWVMeWBKH+B/WMowa3rb4ma3jEl6n5W4GCs9ue65CruzD3ihX+85pZ9hsV9Bf6fvhjp76WNRajoJYX0UIt7aosjmu0i+H+07hEQ0zqTKpVoSH0ykJ6stAMhdr6Q4uW5crBmdTTBIsqmoWsNJZKKoE2+ldYrZ1lrFeaJbjBIY/9ivle++74qQsT2dIKWPanKc9Q2Gl8LjESLtFBD9Fmt",
-                "sender_claimed_keys": {
-                    "ed25519": "F4P7f1Z0RjbiZMgHk1xBCG3KC4/Ng9PmxLJ4hQ13sHA"
-                },
-                "forwarding_curve25519_key_chain": [],
-                "org.matrix.msc3061.shared_history": true
+    async fn test_shared_history_from_m_room_key_content_unstable() {
+        let content = key_json(false);
 
-        });
+        let sender_key = Curve25519PublicKey::from_bytes([0; 32]);
+        let signing_key = Ed25519PublicKey::from_slice(&[0; 32]).expect("");
+        let mut content: room_key::MegolmV1AesSha2Content = serde_json::from_value(content)
+            .expect("We should be able to deserialize the m.room_key content");
+
+        let session = InboundGroupSession::from_room_key_content(sender_key, signing_key, &content)
+            .expect(
+                "We should be able to create an inbound group session from the room key content",
+            );
+
+        assert!(
+            session.shared_history,
+            "The shared history flag should be set as it was set in the m.room_key content"
+        );
+
+        content.shared_history = false;
+        let session = InboundGroupSession::from_room_key_content(sender_key, signing_key, &content)
+            .expect(
+                "We should be able to create an inbound group session from the room key content",
+            );
+
+        assert!(
+            !session.shared_history,
+            "The shared history flag should not be set as it was not set in the m.room_key content"
+        );
+    }
+
+    fn exported_key_json(stable: bool) -> serde_json::Value {
+        let shared_history =
+            if stable { "m.shared_history" } else { "org.matrix.msc3061.shared_history" };
+
+        json!({
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "room_id": "!room:id",
+            "sender_key": "FOvlmz18LLI3k/llCpqRoKT90+gFF8YhuL+v1YBXHlw",
+            "session_id": "/2K+V777vipCxPZ0gpY9qcpz1DYaXwuMRIu0UEP0Wa0",
+            "session_key": "AQAAAAAclzWVMeWBKH+B/WMowa3rb4ma3jEl6n5W4GCs9ue65CruzD3ihX+85pZ9hsV9Bf6fvhjp76WNRajoJYX0UIt7aosjmu0i+H+07hEQ0zqTKpVoSH0ykJ6stAMhdr6Q4uW5crBmdTTBIsqmoWsNJZKKoE2+ldYrZ1lrFeaJbjBIY/9ivle++74qQsT2dIKWPanKc9Q2Gl8LjESLtFBD9Fmt",
+            "sender_claimed_keys": {
+                "ed25519": "F4P7f1Z0RjbiZMgHk1xBCG3KC4/Ng9PmxLJ4hQ13sHA"
+            },
+            "forwarding_curve25519_key_chain": [],
+            shared_history: true
+        })
+    }
+
+    #[async_test]
+    async fn test_shared_history_from_exported_room_key_stable() {
+        let content = exported_key_json(true);
 
         let mut content: ExportedRoomKey = serde_json::from_value(content)
             .expect("We should be able to deserialize the m.room_key content");
@@ -1305,8 +1349,36 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_shared_history_from_backed_up_room_key() {
-        let content = json!({
+    async fn test_shared_history_from_exported_room_key_unstable() {
+        let content = exported_key_json(false);
+
+        let mut content: ExportedRoomKey = serde_json::from_value(content)
+            .expect("We should be able to deserialize the m.room_key content");
+
+        let session = InboundGroupSession::from_export(&content).expect(
+            "We should be able to create an inbound group session from the room key export",
+        );
+        assert!(
+            session.shared_history,
+            "The shared history flag should be set as it was set in the exported room key"
+        );
+
+        content.shared_history = false;
+
+        let session = InboundGroupSession::from_export(&content).expect(
+            "We should be able to create an inbound group session from the room key export",
+        );
+        assert!(
+            !session.shared_history,
+            "The shared history flag should not be set as it was not set in the exported room key"
+        );
+    }
+
+    fn backed_up_room_key(stable: bool) -> serde_json::Value {
+        let shared_history =
+            if stable { "m.shared_history" } else { "org.matrix.msc3061.shared_history" };
+
+        json!({
                 "algorithm": "m.megolm.v1.aes-sha2",
                 "sender_key": "FOvlmz18LLI3k/llCpqRoKT90+gFF8YhuL+v1YBXHlw",
                 "session_key": "AQAAAAAclzWVMeWBKH+B/WMowa3rb4ma3jEl6n5W4GCs9ue65CruzD3ihX+85pZ9hsV9Bf6fvhjp76WNRajoJYX0UIt7aosjmu0i+H+07hEQ0zqTKpVoSH0ykJ6stAMhdr6Q4uW5crBmdTTBIsqmoWsNJZKKoE2+ldYrZ1lrFeaJbjBIY/9ivle++74qQsT2dIKWPanKc9Q2Gl8LjESLtFBD9Fmt",
@@ -1314,9 +1386,34 @@ mod tests {
                     "ed25519": "F4P7f1Z0RjbiZMgHk1xBCG3KC4/Ng9PmxLJ4hQ13sHA"
                 },
                 "forwarding_curve25519_key_chain": [],
-                "org.matrix.msc3061.shared_history": true
+                shared_history: true
+        })
+    }
 
-        });
+    #[async_test]
+    async fn test_shared_history_from_backed_up_room_key_stable() {
+        let content = backed_up_room_key(true);
+
+        let session_id = "/2K+V777vipCxPZ0gpY9qcpz1DYaXwuMRIu0UEP0Wa0";
+        let room_id = owned_room_id!("!room:id");
+        let room_key: BackedUpRoomKey = serde_json::from_value(content)
+            .expect("We should be able to deserialize the backed up room key");
+
+        let room_key =
+            ExportedRoomKey::from_backed_up_room_key(room_id, session_id.to_owned(), room_key);
+
+        let session = InboundGroupSession::from_export(&room_key).expect(
+            "We should be able to create an inbound group session from the room key export",
+        );
+        assert!(
+            session.shared_history,
+            "The shared history flag should be set as it was set in the backed up room key"
+        );
+    }
+
+    #[async_test]
+    async fn test_shared_history_from_backed_up_room_key_unstable() {
+        let content = backed_up_room_key(false);
 
         let session_id = "/2K+V777vipCxPZ0gpY9qcpz1DYaXwuMRIu0UEP0Wa0";
         let room_id = owned_room_id!("!room:id");

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -109,7 +109,7 @@ pub struct ExportedRoomKey {
     /// defined in [MSC3061].
     ///
     /// [MSC3061]: https://github.com/matrix-org/matrix-spec-proposals/pull/3061
-    #[serde(default, rename = "org.matrix.msc3061.shared_history")]
+    #[serde(default, rename = "m.shared_history", alias = "org.matrix.msc3061.shared_history")]
     pub shared_history: bool,
 }
 
@@ -196,7 +196,7 @@ pub struct BackedUpRoomKey {
     /// defined in [MSC3061].
     ///
     /// [MSC3061]: https://github.com/matrix-org/matrix-spec-proposals/pull/3061
-    #[serde(default, rename = "org.matrix.msc3061.shared_history")]
+    #[serde(default, rename = "m.shared_history", alias = "org.matrix.msc3061.shared_history")]
     pub shared_history: bool,
 }
 

--- a/crates/matrix-sdk-crypto/src/store/snapshots/matrix_sdk_crypto__store__tests__build_room_key_bundle.snap
+++ b/crates/matrix-sdk-crypto/src/store/snapshots/matrix_sdk_crypto__store__tests__build_room_key_bundle.snap
@@ -28,7 +28,7 @@ expression: bundle
   "withheld": [
     {
       "algorithm": "[algorithm]",
-      "code": "io.element.msc4268.history_not_shared",
+      "code": "m.history_not_shared",
       "from_device": "BOB",
       "reason": "The sender disabled sharing encrypted history.",
       "room_id": "!room1:localhost",

--- a/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
@@ -721,7 +721,7 @@ mod tests {
             "content": {
                 "algorithm": "m.megolm.v1.aes-sha2",
                 "room_id": "!Cuyf34gef24t:localhost",
-                "org.matrix.msc3061.shared_history": true,
+                "m.shared_history": true,
                 "session_id": "ZFD6+OmV7fVCsJ7Gap8UnORH8EnmiAkes8FAvQuCw/I",
                 "session_key": "AgAAAADNp1EbxXYOGmJtyX4AkD1bvJvAUyPkbIaKxtnGKjv\
                             SQ3E/4mnuqdM4vsmNzpO1EeWzz1rDkUpYhYE9kP7sJhgLXi\

--- a/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
@@ -368,7 +368,11 @@ mod tests {
 
     use assert_matches::assert_matches;
     use insta::{assert_json_snapshot, with_settings};
-    use ruma::{KeyId, device_id, owned_user_id};
+    use ruma::{
+        KeyId, OwnedMxcUri, device_id,
+        events::room::{EncryptedFile, V2EncryptedFileInfo},
+        owned_room_id, owned_user_id, user_id,
+    };
     use serde_json::{Value, json};
     use similar_asserts::assert_eq;
     use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, Ed25519Signature};
@@ -376,7 +380,10 @@ mod tests {
     use super::AnyDecryptedOlmEvent;
     use crate::types::{
         DeviceKey, DeviceKeys, EventEncryptionAlgorithm, Signatures,
-        events::olm_v1::DecryptedRoomKeyEvent,
+        events::{
+            olm_v1::{DecryptedRoomKeyBundleEvent, DecryptedRoomKeyEvent},
+            room_key_bundle::RoomKeyBundleContent,
+        },
     };
 
     const ED25519_KEY: &str = "aOfOnlaeMb5GW1TxkZ8pXnblkGMgAvps+lAukrdYaZk";
@@ -469,6 +476,39 @@ mod tests {
                 "secret": "ThisIsASecretDon'tTellAnyone"
             },
             "type": "m.secret.send"
+        })
+    }
+
+    fn room_key_bundle_event_unstable() -> Value {
+        json!({
+            "sender": "@u:s.co",
+            "recipient": "@x:s.co",
+            "keys": {
+                "ed25519": "ee3Ek+J2LkkPmjGPGLhMxiKnhiX//xcqaVL4RP6EypE"
+            },
+            "recipient_keys": {
+                "ed25519": "ee3Ek+J2LkkPmjGPGLhMxiKnhiX//xcqaVL4RP6EypE"
+            },
+            "content": {
+                "room_id": "!r:s.co",
+                "file": {
+                    "url": "test",
+                    "v": "v2",
+                    "key": {
+                        "kty": "oct",
+                        "key_ops": [
+                            "decrypt",
+                            "encrypt"
+                        ],
+                        "alg": "A256CTR",
+                        "k": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "ext": true
+                    },
+                    "iv": "AAAAAAAAAAAAAAAAAAAAAA",
+                    "hashes": {}
+                }
+            },
+            "type": "io.element.msc4268.room_key_bundle"
         })
     }
 
@@ -582,6 +622,9 @@ mod tests {
 
             // `m.dummy`
             dummy_event => Dummy,
+
+            // `m.room_key_bundle`
+            room_key_bundle_event_unstable => RoomKeyBundle,
         );
 
         Ok(())
@@ -628,6 +671,29 @@ mod tests {
         with_settings!({ sort_maps => true, prepend_module_to_snapshot => false }, {
             assert_json_snapshot!(event);
         });
+    }
+
+    #[test]
+    fn serialize_room_key_bundle() {
+        let room_id = owned_room_id!("!r:s.co");
+        let sender = user_id!("@u:s.co");
+        let recipient = user_id!("@x:s.co");
+
+        let key =
+            Ed25519PublicKey::from_base64("ee3Ek+J2LkkPmjGPGLhMxiKnhiX//xcqaVL4RP6EypE").unwrap();
+
+        let content = RoomKeyBundleContent {
+            room_id,
+            file: EncryptedFile::new(
+                OwnedMxcUri::from("test"),
+                V2EncryptedFileInfo::encode([0; 32], [0; 16]).into(),
+                Default::default(),
+            ),
+        };
+
+        let event = DecryptedRoomKeyBundleEvent::new(sender, recipient, key, None, content);
+
+        assert_eq!(serde_json::to_value(&event).unwrap(), room_key_bundle_event_unstable());
     }
 
     #[test]

--- a/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
@@ -83,7 +83,7 @@ impl DecryptedForwardedRoomKeyEvent {
 /// `m.olm.v1.curve25519-aes-sha2` algorithm
 pub type DecryptedSecretSendEvent = DecryptedOlmV1Event<SecretSendContent>;
 
-/// An `io.element.msc4268.room_key_bundle` to-device event which has
+/// An `m.room_key_bundle` to-device event which has
 /// been decrypted using using the `m.olm.v1.curve25519-aes-sha2` algorithm
 pub type DecryptedRoomKeyBundleEvent = DecryptedOlmV1Event<RoomKeyBundleContent>;
 
@@ -104,7 +104,7 @@ pub enum AnyDecryptedOlmEvent {
     SecretSend(DecryptedSecretSendEvent),
     /// The `m.dummy` decrypted to-device event.
     Dummy(DecryptedDummyEvent),
-    /// The `io.element.msc4268.room_key_bundle` decrypted to-device event.
+    /// The `m.room_key_bundle` decrypted to-device event.
     RoomKeyBundle(DecryptedRoomKeyBundleEvent),
     /// The `io.element.msc4385.secret.push` decrypted to-device event.
     #[cfg(feature = "experimental-push-secrets")]
@@ -352,7 +352,7 @@ impl<'de> Deserialize<'de> for AnyDecryptedOlmEvent {
             }
             SecretSendContent::EVENT_TYPE => AnyDecryptedOlmEvent::SecretSend(from_str(json)?),
             DummyEventContent::EVENT_TYPE => AnyDecryptedOlmEvent::Dummy(from_str(json)?),
-            RoomKeyBundleContent::EVENT_TYPE => {
+            RoomKeyBundleContent::EVENT_TYPE | RoomKeyBundleContent::UNSTABLE_EVENT_TYPE => {
                 AnyDecryptedOlmEvent::RoomKeyBundle(from_str(json)?)
             }
             #[cfg(feature = "experimental-push-secrets")]
@@ -479,7 +479,7 @@ mod tests {
         })
     }
 
-    fn room_key_bundle_event_unstable() -> Value {
+    fn room_key_bundle_event(stable: bool) -> Value {
         json!({
             "sender": "@u:s.co",
             "recipient": "@x:s.co",
@@ -508,8 +508,16 @@ mod tests {
                     "hashes": {}
                 }
             },
-            "type": "io.element.msc4268.room_key_bundle"
+            "type": if stable { "m.room_key_bundle" } else { "io.element.msc4268.room_key_bundle" }
         })
+    }
+
+    fn room_key_bundle_event_stable() -> Value {
+        room_key_bundle_event(true)
+    }
+
+    fn room_key_bundle_event_unstable() -> Value {
+        room_key_bundle_event(false)
     }
 
     /// Return the JSON for creating sender device keys, and the matching
@@ -624,6 +632,9 @@ mod tests {
             dummy_event => Dummy,
 
             // `m.room_key_bundle`
+            room_key_bundle_event_stable => RoomKeyBundle,
+
+            // `m.io.element.msc4268.room_key_bundle`
             room_key_bundle_event_unstable => RoomKeyBundle,
         );
 
@@ -693,7 +704,7 @@ mod tests {
 
         let event = DecryptedRoomKeyBundleEvent::new(sender, recipient, key, None, content);
 
-        assert_eq!(serde_json::to_value(&event).unwrap(), room_key_bundle_event_unstable());
+        assert_eq!(serde_json::to_value(&event).unwrap(), room_key_bundle_event_stable());
     }
 
     #[test]

--- a/crates/matrix-sdk-crypto/src/types/events/room_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key.rs
@@ -124,7 +124,7 @@ pub struct MegolmV1AesSha2Content {
     /// [MSC3061].
     ///
     /// [MSC3061]: https://github.com/matrix-org/matrix-spec-proposals/pull/3061
-    #[serde(default, rename = "org.matrix.msc3061.shared_history")]
+    #[serde(default, rename = "m.shared_history", alias = "org.matrix.msc3061.shared_history")]
     pub shared_history: bool,
     /// Any other, custom and non-specced fields of the content.
     #[serde(flatten)]
@@ -229,14 +229,22 @@ pub(super) mod tests {
     use super::RoomKeyEvent;
     use crate::types::events::room_key::RoomKeyContent;
 
-    pub fn json() -> Value {
+    pub fn json_stable() -> Value {
+        json(true)
+    }
+
+    pub fn json_unstable() -> Value {
+        json(false)
+    }
+
+    pub fn json(stable: bool) -> Value {
         json!({
             "sender": "@alice:example.org",
             "content": {
                 "m.custom": "something custom",
                 "algorithm": "m.megolm.v1.aes-sha2",
                 "room_id": "!Cuyf34gef24t:localhost",
-                "org.matrix.msc3061.shared_history": false,
+                if stable { "m.shared_history" } else { "org.matrix.msc3061.shared_history" }: false,
                 "session_id": "ZFD6+OmV7fVCsJ7Gap8UnORH8EnmiAkes8FAvQuCw/I",
                 "session_key": "AgAAAADNp1EbxXYOGmJtyX4AkD1bvJvAUyPkbIaKxtnGKjv\
                                 SQ3E/4mnuqdM4vsmNzpO1EeWzz1rDkUpYhYE9kP7sJhgLXi\
@@ -252,13 +260,23 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn deserialization() -> Result<(), serde_json::Error> {
-        let json = json();
+    fn deserialization_stable() -> Result<(), serde_json::Error> {
+        let json = json_stable();
         let event: RoomKeyEvent = serde_json::from_value(json.clone())?;
 
         assert_matches!(event.content, RoomKeyContent::MegolmV1AesSha2(_));
         let serialized = serde_json::to_value(event)?;
         assert_eq!(json, serialized);
+
+        Ok(())
+    }
+
+    #[test]
+    fn deserialization_unstable() -> Result<(), serde_json::Error> {
+        let json = json_unstable();
+        let event: RoomKeyEvent = serde_json::from_value(json)?;
+
+        assert_matches!(event.content, RoomKeyContent::MegolmV1AesSha2(_));
 
         Ok(())
     }

--- a/crates/matrix-sdk-crypto/src/types/events/room_key_bundle.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key_bundle.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Types for `io.element.msc4268.room_key_bundle` to-device events, per
-//! [MSC4268].
+//! Types for `m.room_key_bundle` to-device events, per [MSC4268].
 //!
 //! [MSC4268]: https://github.com/matrix-org/matrix-spec-proposals/pull/4268
 
@@ -22,7 +21,7 @@ use serde::{Deserialize, Serialize};
 
 use super::EventType;
 
-/// The `io.element.msc4268.room_key_bundle` event content. See [MSC4268].
+/// The `m.room_key_bundle` event content. See [MSC4268].
 ///
 /// [MSC4268]: https://github.com/matrix-org/matrix-spec-proposals/pull/4268
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -34,6 +33,11 @@ pub struct RoomKeyBundleContent {
     pub file: EncryptedFile,
 }
 
+impl RoomKeyBundleContent {
+    /// The unstable event type for MSC4268 m.room_key_bundle
+    pub const UNSTABLE_EVENT_TYPE: &'static str = "io.element.msc4268.room_key_bundle";
+}
+
 impl EventType for RoomKeyBundleContent {
-    const EVENT_TYPE: &'static str = "io.element.msc4268.room_key_bundle";
+    const EVENT_TYPE: &'static str = "m.room_key_bundle";
 }

--- a/crates/matrix-sdk-crypto/src/types/events/snapshots/decrypted_to_device_event_snapshot.snap
+++ b/crates/matrix-sdk-crypto/src/types/events/snapshots/decrypted_to_device_event_snapshot.snap
@@ -13,7 +13,7 @@ expression: event
   },
   "content": {
     "algorithm": "m.megolm.v1.aes-sha2",
-    "org.matrix.msc3061.shared_history": false,
+    "m.shared_history": false,
     "room_id": "!Cuyf34gef24t:localhost",
     "session_id": "ZFD6+OmV7fVCsJ7Gap8UnORH8EnmiAkes8FAvQuCw/I",
     "session_key": "AgAAAADNp1EbxXYOGmJtyX4AkD1bvJvAUyPkbIaKxtnGKjvSQ3E/4mnuqdM4vsmNzpO1EeWzz1rDkUpYhYE9kP7sJhgLXijVv80fMPHfGc49hPdu8A+xnwD4SQiYdFmSWJOIqsxeo/fiHtino//CDQENtcKuEt0I9s0+Kk4YSH310Szse2RQ+vjple31QrCexmqfFJzkR/BJ5ogJHrPBQL0LgsPyglIbMTLg7qygIaYU5Fe2QdKMH7nTZPNIRHh1RaMfHVETAUJBax88EWZBoifk80gdHUwHSgMk77vCc2a5KHKLDA"

--- a/crates/matrix-sdk-crypto/src/types/events/snapshots/sender_device_keys_are_deserialized.snap
+++ b/crates/matrix-sdk-crypto/src/types/events/snapshots/sender_device_keys_are_deserialized.snap
@@ -30,7 +30,7 @@ expression: event
   },
   "content": {
     "algorithm": "m.megolm.v1.aes-sha2",
-    "org.matrix.msc3061.shared_history": false,
+    "m.shared_history": false,
     "room_id": "!Cuyf34gef24t:localhost",
     "session_id": "ZFD6+OmV7fVCsJ7Gap8UnORH8EnmiAkes8FAvQuCw/I",
     "session_key": "AgAAAADNp1EbxXYOGmJtyX4AkD1bvJvAUyPkbIaKxtnGKjvSQ3E/4mnuqdM4vsmNzpO1EeWzz1rDkUpYhYE9kP7sJhgLXijVv80fMPHfGc49hPdu8A+xnwD4SQiYdFmSWJOIqsxeo/fiHtino//CDQENtcKuEt0I9s0+Kk4YSH310Szse2RQ+vjple31QrCexmqfFJzkR/BJ5ogJHrPBQL0LgsPyglIbMTLg7qygIaYU5Fe2QdKMH7nTZPNIRHh1RaMfHVETAUJBax88EWZBoifk80gdHUwHSgMk77vCc2a5KHKLDA"

--- a/crates/matrix-sdk-crypto/src/types/events/to_device.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/to_device.rs
@@ -520,7 +520,7 @@ mod tests {
 
         assert_serialization_roundtrip!(
             // `m.room_key
-            crate::types::events::room_key::tests::json => RoomKey,
+            crate::types::events::room_key::tests::json_stable => RoomKey,
 
             // `m.forwarded_room_key`
             forwarded_room_key_event => ForwardedRoomKey,
@@ -570,7 +570,7 @@ mod tests {
 
         assert_serialization_roundtrip!(
             // `m.room_key
-            crate::types::events::room_key::tests::json => RoomKey,
+            crate::types::events::room_key::tests::json_stable => RoomKey,
 
             // `m.forwarded_room_key`
             forwarded_room_key_event => ForwardedRoomKey,

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/shared_history.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/shared_history.rs
@@ -1648,9 +1648,9 @@ fn assert_received_room_key_bundle(sync_response: matrix_sdk::sync::SyncResponse
         "Expected the to-device event to be decrypted"
     );
     assert_eq!(
-        "io.element.msc4268.room_key_bundle",
+        "m.room_key_bundle",
         raw.get_field::<String>("type").unwrap().unwrap(),
-        "Expected the event type to be 'io.element.msc4268.room_key_bundle'"
+        "Expected the event type to be 'm.room_key_bundle'"
     );
 }
 

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/state_events.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/state_events.rs
@@ -99,10 +99,7 @@ async fn test_e2ee_state_events() -> Result<()> {
     assert_eq!(bob_response.to_device.len(), 1);
     let to_device_event = &bob_response.to_device[0];
     assert_let!(ProcessedToDeviceEvent::Decrypted { raw, .. } = to_device_event);
-    assert_eq!(
-        raw.get_field::<String>("type").unwrap().unwrap(),
-        "io.element.msc4268.room_key_bundle"
-    );
+    assert_eq!(raw.get_field::<String>("type").unwrap().unwrap(), "m.room_key_bundle");
 
     bob.get_room(alice_room.room_id()).expect("Bob should have received the invite");
 


### PR DESCRIPTION
For [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268)

Part of https://github.com/element-hq/element-meta/issues/3168

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- No AI was used