### PR TITLE
feat(ffi): Enable `experimental-push-secrets` feature by default

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -44,6 +44,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Enable `experimental-push-secrets` feature by default. 
+  ([#6473](https://github.com/matrix-org/matrix-rust-sdk/pull/6394))
 - Add new high-level search helpers `RoomSearchIterator` and `GlobalSearchIterator` to perform
   searches for messages in a room or across all rooms.
   ([6394](https://github.com/matrix-org/matrix-rust-sdk/pull/6394))

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -24,7 +24,7 @@ crate-type = [
 ]
 
 [features]
-default = ["bundled-sqlite", "unstable-msc4274", "experimental-element-recent-emojis"]
+default = ["bundled-sqlite", "unstable-msc4274", "experimental-element-recent-emojis", "experimental-push-secrets"]
 # Use SQLite for the session storage.
 sqlite = ["matrix-sdk/sqlite"]
 # Use an embedded version of SQLite.

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1211,6 +1211,8 @@ impl GossipMachine {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "experimental-push-secrets")]
+    use std::ops::Deref;
     use std::sync::Arc;
 
     #[cfg(feature = "automatic-room-key-forwarding")]
@@ -2367,7 +2369,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let decryption_key = crate::store::types::BackupDecryptionKey::new().unwrap();
+        let decryption_key = crate::store::types::BackupDecryptionKey::new();
         alice_machine
             .backup_machine()
             .save_decryption_key(Some(decryption_key.clone()), None)

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -2024,7 +2024,8 @@ impl OlmMachine {
     /// Push a secret to all of our other verified devices.
     ///
     /// This function assumes that we already have Olm sessions with the other
-    /// devices.  This can be done by calling [`get_missing_sessions()`].
+    /// devices.  This can be done by calling
+    /// [`OlmMachine::get_missing_sessions()`].
     ///
     /// * `secret_name` - The name of the secret to push
     #[cfg(feature = "experimental-push-secrets")]

--- a/xtask/src/kotlin.rs
+++ b/xtask/src/kotlin.rs
@@ -21,13 +21,8 @@ enum Package {
 impl Package {
     fn values(self) -> PackageValues {
         match self {
-            Package::CryptoSDK => {
-                PackageValues { name: "matrix-sdk-crypto-ffi", features: "bundled-sqlite" }
-            }
-            Package::FullSDK => PackageValues {
-                name: "matrix-sdk-ffi",
-                features: "bundled-sqlite,unstable-msc4274,experimental-element-recent-emojis,sentry",
-            },
+            Package::CryptoSDK => PackageValues { name: "matrix-sdk-crypto-ffi", features: "" },
+            Package::FullSDK => PackageValues { name: "matrix-sdk-ffi", features: "sentry" },
         }
     }
 }
@@ -171,7 +166,7 @@ fn build_for_android_target(
     let sh = sh();
     cmd!(
         sh,
-        "cargo ndk --target {target} -o {dest_dir} build --profile {profile} --package {package_name} --no-default-features --features {features}"
+        "cargo ndk --target {target} -o {dest_dir} build --profile {profile} --package {package_name} --features {features}"
     )
     .run()?;
 


### PR DESCRIPTION
Also, have Kotlin bindings use the default features instead of overriding them and then adding the same features. We carried this override from the times when Kotlin used NativeTLS and iOS used RustTLS.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
