### PR TITLE
test(integration): revert the workaround to make the latest event integration test pass

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -615,18 +615,14 @@ async fn test_latest_event_few_rooms() -> Result<()> {
     debug!("Running check for second client, room1");
     assert_latest_event_is_remote_event(&room1, &mut room1_sub, &room1_msg_event_id).await;
 
-    // Test passes if we uncomment this line, since more events will be fetched from
-    // the server and there will be a latest event update.
-    room2.event_cache().await?.0.pagination().run_backwards_until(100).await?;
+    warn!("Subscribing to rooms on second client…");
+    bob2_sync_service
+        .room_list_service()
+        .subscribe_to_rooms(&[room1.room_id(), room2.room_id()])
+        .await;
 
-    //warn!("Subscribing to rooms on second client…");
-    //bob2_sync_service
-    //.room_list_service()
-    //.subscribe_to_rooms(&[room1.room_id(), room2.room_id()])
-    //.await;
-
-    //// Wait for a bit, for a sync response to be returned.
-    //sleep(Duration::from_secs(3)).await;
+    // Wait for a bit, for a sync response to be returned.
+    sleep(Duration::from_secs(3)).await;
 
     warn!("Rendering timeline.");
     let timeline = TimelineBuilder::new(&room2).build().await?;


### PR DESCRIPTION
Opening this as a draft PR, on top of #6475. When the underlying Synapse bug https://github.com/element-hq/synapse/issues/19713 has been fixed, it will only need a bump of the version of Synapse used in the integration testing (so, in the Dockerfile), and it should start to pass magically.