### PR TITLE
chore: Bump vodozemac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,9 +453,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-toml"
@@ -642,7 +642,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3239,7 +3239,7 @@ dependencies = [
  "similar-asserts",
  "stream_assert",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -3290,7 +3290,7 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "stream_assert",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "unicode-normalization",
@@ -3320,7 +3320,7 @@ dependencies = [
  "ruma",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3371,7 +3371,7 @@ dependencies = [
  "similar-asserts",
  "stream_assert",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -3404,7 +3404,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing-subscriber",
  "uniffi",
@@ -3446,7 +3446,7 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -3496,7 +3496,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3547,7 +3547,7 @@ dependencies = [
  "image",
  "qrcode",
  "ruma",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "vodozemac",
 ]
 
@@ -3567,7 +3567,7 @@ dependencies = [
  "sha2",
  "tantivy",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zeroize",
 ]
@@ -3598,7 +3598,7 @@ dependencies = [
  "serde_path_to_error",
  "similar-asserts",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "vodozemac",
@@ -3621,7 +3621,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -3701,7 +3701,7 @@ dependencies = [
  "serde_json",
  "stream_assert",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3730,7 +3730,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4124,7 +4124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "ucd-trie",
 ]
 
@@ -4358,9 +4358,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.4"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4368,12 +4368,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.4"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -4429,7 +4429,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -4451,7 +4451,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4668,7 +4668,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4834,7 +4834,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
  "web-time",
 ]
@@ -4862,7 +4862,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
@@ -4888,7 +4888,7 @@ dependencies = [
  "ruma-macros",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "web-time",
  "wildmatch",
@@ -4912,7 +4912,7 @@ dependencies = [
  "ruma-signatures",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -4933,7 +4933,7 @@ version = "0.12.0"
 source = "git+https://github.com/ruma/ruma?rev=7680eebd9586669e1a4e5b1fd1c2c691221369d4#7680eebd9586669e1a4e5b1fd1c2c691221369d4"
 dependencies = [
  "js_int",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4964,7 +4964,7 @@ dependencies = [
  "ruma-common",
  "serde_json",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5320,7 +5320,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "url",
  "uuid",
@@ -5349,11 +5349,12 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.15"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5800,7 +5801,7 @@ dependencies = [
  "tantivy-stacker",
  "tantivy-tokenizer-api",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "uuid",
  "winapi",
@@ -5945,11 +5946,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -5965,9 +5966,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6282,7 +6283,7 @@ version = "0.2.3"
 source = "git+https://github.com/tokio-rs/tracing.git?rev=20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05#20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -6361,7 +6362,7 @@ dependencies = [
  "itertools 0.14.0",
  "ratatui",
  "strum 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6761,9 +6762,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vodozemac"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c022a277687e4e8685d72b95a7ca3ccfec907daa946678e715f8badaa650883d"
+checksum = "b98bf83c0992966775b8012f194b07b44928996163e5a05b741b43891571ae5b"
 dependencies = [
  "aes",
  "arrayvec",
@@ -6784,7 +6785,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "x25519-dalek",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ uniffi_bindgen = { version = "0.31.0", default-features = false, features = ["ca
 url = { version = "2.5.7", default-features = false }
 uuid = { version = "1.18.1", default-features = false }
 vergen-gitcl = { version = "1.0.8", default-features = false }
-vodozemac = { version = "0.9.0", default-features = false, features = ["libolm-compat", "insecure-pk-encryption"] }
+vodozemac = { version = "0.10.0", default-features = false, features = ["libolm-compat", "insecure-pk-encryption", "experimental-session-config"] }
 wasm-bindgen = { version = "0.2.105", default-features = false }
 wasm-bindgen-test = { version = "0.3.55", default-features = false, features = ["std"] }
 web-sys = { version = "0.3.82", default-features = false }

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -1015,18 +1015,18 @@ impl PkEncryption {
     }
 
     /// Encrypt a message using this [`PkEncryption`] object.
-    pub fn encrypt(&self, plaintext: &str) -> PkMessage {
+    pub fn encrypt(&self, plaintext: &str) -> Option<PkMessage> {
         use vodozemac::base64_encode;
 
-        let message = self.inner.encrypt(plaintext.as_ref());
+        let message = self.inner.encrypt(plaintext.as_ref()).ok()?;
 
         let vodozemac::pk_encryption::Message { ciphertext, mac, ephemeral_key } = message;
 
-        PkMessage {
+        Some(PkMessage {
             ciphertext: base64_encode(ciphertext),
             mac: base64_encode(mac),
             ephemeral_key: ephemeral_key.to_base64(),
-        }
+        })
     }
 }
 

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -13,7 +13,6 @@ All notable changes to this project will be documented in this file.
   - Add new method `OlmMachine::push_secret_to_verified_devices`.
   - Pushed secrets that we receive from verified devices are added to the
     secrets inbox.
-
 - Add `Store::{store,clear}_room_pending_key_bundle`,
   `CryptoStore::get_pending_key_bundle_details_for_room` and
   `CryptoStore::get_all_rooms_pending_key_bundle`, which can be used by
@@ -40,28 +39,26 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- [**breaking**] The `MegolmV1BackupKey::encrypt` now returns a `Result`
+  ([#6477](https://github.com/matrix-org/matrix-rust-sdk/pull/6477))
 - [**breaking**] `CryptoStore::get_secrets_from_inbox` now returns a `Vec` of
   the secrets as strings, rather than a `Vec` of `GossippedSecret` structs.
   ([#6164](https://github.com/matrix-org/matrix-rust-sdk/pull/6164))
-
 - [**breaking**] `store::types::Changes::sessions` now stores a `Vec` of
   `SecretsInboxItem`.
   ([#6164](https://github.com/matrix-org/matrix-rust-sdk/pull/6164))
-
 - **breaking** The `BackupDecryptionKey::new` and `DehydratedDeviceKey::new`
   methods became infallible, they don't return a `Result` anymore.
   ([#5502](https://github.com/matrix-org/matrix-rust-sdk/pull/5502))
 - [**breaking**] Remove cross-process lock generation logic from `OlmMachine`, which is now
   implemented more generally in `matrix_sdk_common::cross_process_lock::CrossProcessLock`.
   ([#6326](https://github.com/matrix-org/matrix-rust-sdk/pull/6326))
-
 - [**breaking**] The `MediaEncryptionInfo` fields changed to match the new fields of `EncryptedFile`
   from Ruma. The serialized JSON format did not change and still matches the format of
   `EncryptedFile` defined in the spec, without the `url` field. The `DecryptorError::KeyNonceLength`
   variant was removed because the length of the key and nonce are now enforced in
   `MediaEncryptionInfo`.
   ([#6346](https://github.com/matrix-org/matrix-rust-sdk/pull/6346))
-
 - [**breaking**] Removed `WithLocking` from `EncryptionSyncService` and replaced it with `CrossProcessLockConfig`.
   ([#6160](https://github.com/matrix-org/matrix-rust-sdk/pull/6160))
 - [**breaking**] The QrcodeData struct has been reworked in preparation to
@@ -70,7 +67,6 @@ All notable changes to this project will be documented in this file.
   returns an MSC-specific struct now. The `rendezvous_url()` method has been
   removed.
   ([#6081](https://github.com/matrix-org/matrix-rust-sdk/pull/6081))
-
 - [**breaking**] The `message-ids` feature has been removed. It was already a no-op and has now
   been eliminated entirely.
   ([#5963](https://github.com/matrix-org/matrix-rust-sdk/pull/5963))

--- a/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
@@ -101,7 +101,10 @@ impl MegolmV1BackupKey {
 
     /// Export the given inbound group session, and encrypt the data, ready for
     /// writing to the backup.
-    pub async fn encrypt(&self, session: InboundGroupSession) -> KeyBackupData {
+    pub async fn encrypt(
+        &self,
+        session: InboundGroupSession,
+    ) -> Result<KeyBackupData, vodozemac::pk_encryption::Error> {
         let pk = PkEncryption::from_key(self.inner.key);
 
         // The forwarding chains don't mean much, we only care whether we received the
@@ -117,7 +120,7 @@ impl MegolmV1BackupKey {
         let key =
             Zeroizing::new(serde_json::to_vec(&key).expect("Can't serialize exported room key"));
 
-        let message = pk.encrypt(&key);
+        let message = pk.encrypt(&key)?;
 
         let session_data = EncryptedSessionDataInit {
             ephemeral: Base64::new(message.ephemeral_key.to_vec()),
@@ -126,7 +129,7 @@ impl MegolmV1BackupKey {
         }
         .into();
 
-        KeyBackupDataInit {
+        Ok(KeyBackupDataInit {
             first_message_index,
             forwarded_count,
             // TODO: is this actually used anywhere? seems to be completely
@@ -136,6 +139,6 @@ impl MegolmV1BackupKey {
             is_verified: false,
             session_data,
         }
-        .into()
+        .into())
     }
 }

--- a/crates/matrix-sdk-crypto/src/backups/keys/decryption.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/decryption.rs
@@ -397,7 +397,7 @@ mod tests {
         let decryption_key = BackupDecryptionKey::new();
         let encryption_key = decryption_key.megolm_v1_public_key();
 
-        let encrypted = encryption_key.encrypt(session).await;
+        let encrypted = encryption_key.encrypt(session).await.unwrap();
 
         let _ = decryption_key
             .decrypt_session_data(encrypted.session_data)

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -534,7 +534,7 @@ impl BackupMachine {
         }
 
         let key_count = sessions.len();
-        let (backup, session_record) = Self::backup_keys(sessions, backup_key).await;
+        let (backup, session_record) = Self::backup_keys(sessions, backup_key).await?;
 
         info!(
             key_count = key_count,
@@ -556,10 +556,13 @@ impl BackupMachine {
     async fn backup_keys(
         sessions: Vec<InboundGroupSession>,
         backup_key: &MegolmV1BackupKey,
-    ) -> (
-        BTreeMap<OwnedRoomId, RoomKeyBackup>,
-        BTreeMap<OwnedRoomId, BTreeMap<SenderKey, BTreeSet<SessionId>>>,
-    ) {
+    ) -> Result<
+        (
+            BTreeMap<OwnedRoomId, RoomKeyBackup>,
+            BTreeMap<OwnedRoomId, BTreeMap<SenderKey, BTreeSet<SessionId>>>,
+        ),
+        vodozemac::pk_encryption::Error,
+    > {
         let mut backup: BTreeMap<OwnedRoomId, RoomKeyBackup> = BTreeMap::new();
         let mut session_record: BTreeMap<OwnedRoomId, BTreeMap<SenderKey, BTreeSet<SessionId>>> =
             BTreeMap::new();
@@ -568,7 +571,7 @@ impl BackupMachine {
             let room_id = session.room_id().to_owned();
             let session_id = session.session_id().to_owned();
             let sender_key = session.sender_key().to_owned();
-            let session = backup_key.encrypt(session).await;
+            let session = backup_key.encrypt(session).await?;
 
             session_record
                 .entry(room_id.to_owned())
@@ -586,7 +589,7 @@ impl BackupMachine {
                 .insert(session_id, session);
         }
 
-        (backup, session_record)
+        Ok((backup, session_record))
     }
 
     /// Import the given room keys into our store.

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -73,6 +73,11 @@ pub enum OlmError {
     )]
     MissingSession,
 
+    /// Encrypting of an Olm message failed because of a low-level cryptographic
+    /// issue occurred.
+    #[error(transparent)]
+    Encryption(#[from] vodozemac::olm::EncryptionError),
+
     /// Encryption failed due to an error collecting the recipient devices.
     #[error("encryption failed due to an error collecting the recipient devices: {0}")]
     SessionRecipientCollectionError(SessionRecipientCollectionError),

--- a/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
+++ b/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
@@ -272,7 +272,7 @@ pub async fn build_encrypted_to_device_content_without_sender_data(
     }))
     .unwrap();
 
-    let ciphertext = olm_session.encrypt_helper(&plaintext).await;
+    let ciphertext = olm_session.encrypt_helper(&plaintext).await.unwrap();
     let content =
         olm_session.build_encrypted_event(ciphertext, None).await.expect("could not encrypt");
 

--- a/crates/matrix-sdk-crypto/src/machine/tests/megolm_sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/megolm_sender_data.rs
@@ -290,7 +290,7 @@ async fn create_and_share_session_without_sender_data(
     }))
     .unwrap();
 
-    let ciphertext = olm_session.encrypt_helper(&plaintext).await;
+    let ciphertext = olm_session.encrypt_helper(&plaintext).await.unwrap();
     ToDeviceEvent::new(
         alice.user_id().to_owned(),
         olm_session.build_encrypted_event(ciphertext, None).await.unwrap(),

--- a/crates/matrix-sdk-crypto/src/machine/tests/olm_encryption.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/olm_encryption.rs
@@ -296,7 +296,7 @@ async fn test_decrypt_to_device_message_with_unsigned_sender_keys() {
     }))
     .unwrap();
 
-    let ciphertext = alice_session.encrypt_helper(&plaintext).await;
+    let ciphertext = alice_session.encrypt_helper(&plaintext).await.unwrap();
     let event = ToDeviceEvent::new(
         alice.user_id().to_owned(),
         alice_session.build_encrypted_event(ciphertext, None).await.unwrap(),

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -966,13 +966,13 @@ impl Account {
         one_time_key: Curve25519PublicKey,
         fallback_used: bool,
         our_device_keys: DeviceKeys,
-    ) -> Session {
-        let session = self.inner.create_outbound_session(config, identity_key, one_time_key);
+    ) -> Result<Session, vodozemac::olm::SessionCreationError> {
+        let session = self.inner.create_outbound_session(config, identity_key, one_time_key)?;
 
         let now = SecondsSinceUnixEpoch::now();
         let session_id = session.session_id();
 
-        Session {
+        Ok(Session {
             inner: Arc::new(Mutex::new(session)),
             session_id: session_id.into(),
             sender_key: identity_key,
@@ -980,7 +980,7 @@ impl Account {
             created_using_fallback_key: fallback_used,
             creation_time: now,
             last_use_time: now,
-        }
+        })
     }
 
     #[instrument(
@@ -1066,7 +1066,7 @@ impl Account {
                     one_time_key,
                     is_fallback,
                     our_device_keys,
-                ))
+                )?)
             }
         }
     }
@@ -1094,7 +1094,13 @@ impl Account {
         Span::current().record("session_id", debug(message.session_id()));
         trace!("Creating a new Olm session from a pre-key message");
 
-        let result = self.inner.create_inbound_session(their_identity_key, message)?;
+        #[cfg(not(feature = "experimental-algorithms"))]
+        let config = SessionConfig::version_1();
+
+        #[cfg(feature = "experimental-algorithms")]
+        let config = SessionConfig::version_2();
+
+        let result = self.inner.create_inbound_session(config, their_identity_key, message)?;
         let now = SecondsSinceUnixEpoch::now();
         let session_id = result.session.session_id();
 

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -89,13 +89,15 @@ pub(crate) mod tests {
         bob.generate_one_time_keys(1);
         let one_time_key = *bob.one_time_keys().values().next().unwrap();
         let sender_key = bob.identity_keys().curve25519;
-        let session = alice.create_outbound_session_helper(
-            SessionConfig::default(),
-            sender_key,
-            one_time_key,
-            false,
-            alice.device_keys(),
-        );
+        let session = alice
+            .create_outbound_session_helper(
+                SessionConfig::default(),
+                sender_key,
+                one_time_key,
+                false,
+                alice.device_keys(),
+            )
+            .unwrap();
 
         (alice, session)
     }
@@ -141,17 +143,25 @@ pub(crate) mod tests {
 
         let one_time_key = *one_time_keys.values().next().unwrap();
 
-        let mut bob_session = bob.create_outbound_session_helper(
-            SessionConfig::default(),
-            alice_keys.curve25519,
-            one_time_key,
-            false,
-            bob.device_keys(),
-        );
+        #[cfg(not(feature = "experimental-algorithms"))]
+        let config = SessionConfig::version_1();
+
+        #[cfg(feature = "experimental-algorithms")]
+        let config = SessionConfig::version_2();
+
+        let mut bob_session = bob
+            .create_outbound_session_helper(
+                config,
+                alice_keys.curve25519,
+                one_time_key,
+                false,
+                bob.device_keys(),
+            )
+            .unwrap();
 
         let plaintext = "Hello world";
 
-        let message = bob_session.encrypt_helper(plaintext).await;
+        let message = bob_session.encrypt_helper(plaintext).await.unwrap();
 
         let prekey_message = match message {
             OlmMessage::PreKey(m) => m,

--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -123,12 +123,14 @@ impl Session {
     /// # Arguments
     ///
     /// * `plaintext` - The plaintext that should be encrypted.
-    pub(crate) async fn encrypt_helper(&mut self, plaintext: &str) -> OlmMessage {
+    pub(crate) async fn encrypt_helper(&mut self, plaintext: &str) -> OlmResult<OlmMessage> {
         let mut session = self.inner.lock().await;
-        let message = session.encrypt(plaintext);
+        let message = session.encrypt(plaintext)?;
+
         self.last_use_time = SecondsSinceUnixEpoch::now();
         debug!(?session, "Successfully encrypted an event");
-        message
+
+        Ok(message)
     }
 
     /// Encrypt the given event content as an m.room.encrypted event
@@ -206,7 +208,7 @@ impl Session {
             serde_json::to_string(&content)?
         };
 
-        let ciphertext = self.encrypt_helper(&plaintext).await;
+        let ciphertext = self.encrypt_helper(&plaintext).await?;
 
         let content = self.build_encrypted_event(ciphertext, message_id).await?;
         let content = Raw::new(&content)?;
@@ -364,17 +366,25 @@ mod tests {
             Account::with_device_id(user_id!("@alice:localhost"), device_id!("ALICEDEVICE"));
         let mut bob = Account::with_device_id(user_id!("@bob:localhost"), device_id!("BOBDEVICE"));
 
+        #[cfg(not(feature = "experimental-algorithms"))]
+        let config = SessionConfig::version_1();
+
+        #[cfg(feature = "experimental-algorithms")]
+        let config = SessionConfig::version_2();
+
         // When Alice creates an Olm session with Bob
         bob.generate_one_time_keys(1);
         let one_time_key = *bob.one_time_keys().values().next().unwrap();
         let sender_key = bob.identity_keys().curve25519;
-        let mut alice_session = alice.create_outbound_session_helper(
-            SessionConfig::default(),
-            sender_key,
-            one_time_key,
-            false,
-            alice.device_keys(),
-        );
+        let mut alice_session = alice
+            .create_outbound_session_helper(
+                config,
+                sender_key,
+                one_time_key,
+                false,
+                alice.device_keys(),
+            )
+            .unwrap();
 
         let alice_device = DeviceData::from_account(&alice);
 

--- a/crates/matrix-sdk-crypto/src/store/error.rs
+++ b/crates/matrix-sdk-crypto/src/store/error.rs
@@ -56,6 +56,10 @@ pub enum CryptoStoreError {
     #[error(transparent)]
     Pickle(#[from] vodozemac::PickleError),
 
+    /// Backing up a room key has failed.
+    #[error(transparent)]
+    Backup(#[from] vodozemac::pk_encryption::Error),
+
     /// The received room key couldn't be converted into a valid Megolm session.
     #[error(transparent)]
     SessionCreation(#[from] SessionCreationError),

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -127,7 +127,7 @@ macro_rules! cryptostore_integration_tests {
                     one_time_key,
                     false,
                     alice.device_keys(),
-                );
+                ).unwrap();
 
                 (alice, session)
             }

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -1661,7 +1661,8 @@ async fn mock_download_session_from_key_backup(
         .unwrap()
         .megolm_v1_public_key()
         .encrypt(inbound_group_session)
-        .await;
+        .await
+        .unwrap();
 
     Mock::given(method("GET"))
         .and(path(format!(


### PR DESCRIPTION
This PR bumps vodozemac to bring a couple of fixes vodozemac 0.10 brings.

A couple of methods became fallible because of that. This showcases where we'd need to introduce some more specific error types instead of our somewhat catch all `OlmError` and `StoreError` types.

For example, the backup submodule in the crypto crate could have a specific `BackupError` where one of the error variants is a IO/DB error.