### PR TITLE
Ensure `StateStore` lock is acquired before updating `RoomInfo`

### DIFF
--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -33,6 +33,11 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] Enforce atomic and synchronized updates to `RoomInfo`. Requires 
+  `StateStore::save_changes` to acquire state store lock and replaces `Room::set_room_info` 
+  with an atomic version, `Room::update_room_info`, which is also synchronized by
+  the state store lock.
+  ([#6478](https://github.com/matrix-org/matrix-rust-sdk/pull/6478))
 - Add `RoomMember::is_service_member` that automatically checks the room info and retrieves this info. 
   ([#6536](https://github.com/matrix-org/matrix-rust-sdk/pull/6536))
 - [**breaking**] Add `DmRoomDefinition` enum, allowing clients to specify what a DM 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -760,17 +760,14 @@ impl BaseClient {
 
         context.state_changes.ambiguity_maps = ambiguity_cache.cache;
 
-        {
-            let _state_store_lock = self.state_store_lock().lock().await;
-
-            processors::changes::save_and_apply(
-                context,
-                &self.state_store,
-                &self.ignore_user_list_changes,
-                Some(response.next_batch.clone()),
-            )
-            .await?;
-        }
+        processors::changes::save_and_apply(
+            context,
+            &self.state_store,
+            &self.state_store_lock().lock().await,
+            &self.ignore_user_list_changes,
+            Some(response.next_batch.clone()),
+        )
+        .await?;
 
         let mut context = Context::default();
 
@@ -784,11 +781,12 @@ impl BaseClient {
         .await;
 
         // Save the new display name updates if any.
-        {
-            let _state_store_lock = self.state_store_lock().lock().await;
-
-            processors::changes::save_only(context, &self.state_store).await?;
-        }
+        processors::changes::save_only(
+            context,
+            &self.state_store,
+            &self.state_store_lock().lock().await,
+        )
+        .await?;
 
         for (room_id, member_ids) in updated_members_in_room {
             if let Some(room) = self.get_room(&room_id) {
@@ -910,7 +908,7 @@ impl BaseClient {
         context.state_changes.ambiguity_maps.insert(room_id.to_owned(), ambiguity_map);
 
         {
-            let _state_store_lock = self.state_store_lock().lock().await;
+            let state_store_guard = self.state_store_lock().lock().await;
 
             let mut room_info = room.clone_info();
             room_info.mark_members_synced();
@@ -919,6 +917,7 @@ impl BaseClient {
             processors::changes::save_and_apply(
                 context,
                 &self.state_store,
+                &state_store_guard,
                 &self.ignore_user_list_changes,
                 None,
             )

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -405,24 +405,22 @@ impl BaseClient {
         let room = self.state_store.get_or_create_room(room_id, RoomState::Knocked);
 
         if room.state() != RoomState::Knocked {
-            let _state_store_lock = self.state_store_lock().lock().await;
-
-            let mut room_info = room.clone_info();
-            room_info.mark_as_knocked();
-            room_info.mark_state_partially_synced();
-            room_info.mark_members_missing(); // the own member event changed
+            let store_guard = self.state_store.lock().lock().await;
 
             // We are no longer joined to the room, so the invite acceptance details are no
             // longer relevant.
             #[cfg(feature = "e2e-encryption")]
             if let Some(olm_machine) = self.olm_machine().await.as_ref() {
-                olm_machine.store().clear_room_pending_key_bundle(room_info.room_id()).await?
+                olm_machine.store().clear_room_pending_key_bundle(room_id).await?
             }
 
-            let mut changes = StateChanges::default();
-            changes.add_room(room_info.clone());
-            self.state_store.save_changes(&changes).await?; // Update the store
-            room.set_room_info(room_info, RoomInfoNotableUpdateReasons::MEMBERSHIP);
+            room.update_and_save_room_info_with_store_guard(&store_guard, |mut info| {
+                info.mark_as_knocked();
+                info.mark_state_partially_synced();
+                info.mark_members_missing(); // the own member event changed
+                (info, RoomInfoNotableUpdateReasons::MEMBERSHIP)
+            })
+            .await?;
         }
 
         Ok(room)
@@ -481,13 +479,7 @@ impl BaseClient {
         // If the state isn't `RoomState::Joined` then this means that we knew about
         // this room before. Let's modify the existing state now.
         if room.state() != RoomState::Joined {
-            let _state_store_lock = self.state_store_lock().lock().await;
-
-            let mut room_info = room.clone_info();
-
-            room_info.mark_as_joined();
-            room_info.mark_state_partially_synced();
-            room_info.mark_members_missing(); // the own member event changed
+            let store_guard = self.state_store_lock().lock().await;
 
             #[cfg(feature = "e2e-encryption")]
             {
@@ -515,12 +507,13 @@ impl BaseClient {
                 let _ = inviter;
             }
 
-            let mut changes = StateChanges::default();
-            changes.add_room(room_info.clone());
-
-            self.state_store.save_changes(&changes).await?; // Update the store
-
-            room.set_room_info(room_info, RoomInfoNotableUpdateReasons::MEMBERSHIP);
+            room.update_and_save_room_info_with_store_guard(&store_guard, |mut info| {
+                info.mark_as_joined();
+                info.mark_state_partially_synced();
+                info.mark_members_missing(); // the own member event changed
+                (info, RoomInfoNotableUpdateReasons::MEMBERSHIP)
+            })
+            .await?;
         }
 
         Ok(room)
@@ -533,24 +526,22 @@ impl BaseClient {
         let room = self.state_store.get_or_create_room(room_id, RoomState::Left);
 
         if room.state() != RoomState::Left {
-            let _state_store_lock = self.state_store_lock().lock().await;
-
-            let mut room_info = room.clone_info();
-            room_info.mark_as_left();
-            room_info.mark_state_partially_synced();
-            room_info.mark_members_missing(); // the own member event changed
+            let store_guard = self.state_store.lock().lock().await;
 
             // We are no longer joined to the room, so the invite acceptance details are no
             // longer relevant.
             #[cfg(feature = "e2e-encryption")]
             if let Some(olm_machine) = self.olm_machine().await.as_ref() {
-                olm_machine.store().clear_room_pending_key_bundle(room_info.room_id()).await?
+                olm_machine.store().clear_room_pending_key_bundle(room_id).await?
             }
 
-            let mut changes = StateChanges::default();
-            changes.add_room(room_info.clone());
-            self.state_store.save_changes(&changes).await?; // Update the store
-            room.set_room_info(room_info, RoomInfoNotableUpdateReasons::MEMBERSHIP);
+            room.update_and_save_room_info_with_store_guard(&store_guard, |mut info| {
+                info.mark_as_left();
+                info.mark_state_partially_synced();
+                info.mark_members_missing(); // the own member event changed
+                (info, RoomInfoNotableUpdateReasons::MEMBERSHIP)
+            })
+            .await?;
         }
 
         Ok(())

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -652,7 +652,7 @@ impl BaseClient {
             })
             .collect();
 
-        let mut ambiguity_cache = AmbiguityCache::new(self.state_store.inner.store().clone());
+        let mut ambiguity_cache = AmbiguityCache::new(self.state_store.inner.clone());
 
         let global_account_data_processor =
             processors::account_data::global(&response.account_data.events);

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -55,7 +55,7 @@ use tracing::{Level, debug, enabled, info, instrument, warn};
 #[cfg(feature = "e2e-encryption")]
 use crate::RoomMemberships;
 use crate::{
-    RoomStateFilter, SessionMeta,
+    RoomStateFilter, SessionMeta, StateStore,
     deserialized_responses::DisplayName,
     error::{Error, Result},
     event_cache::store::{EventCacheStoreLock, EventCacheStoreLockState},
@@ -652,7 +652,7 @@ impl BaseClient {
             })
             .collect();
 
-        let mut ambiguity_cache = AmbiguityCache::new(self.state_store.inner.clone());
+        let mut ambiguity_cache = AmbiguityCache::new(self.state_store.inner.store().clone());
 
         let global_account_data_processor =
             processors::account_data::global(&response.account_data.events);

--- a/crates/matrix-sdk-base/src/response_processors/account_data/global.rs
+++ b/crates/matrix-sdk-base/src/response_processors/account_data/global.rs
@@ -28,7 +28,7 @@ use ruma::{
 use tracing::{debug, instrument, trace, warn};
 
 use super::super::Context;
-use crate::{RoomInfo, StateChanges, store::BaseStateStore};
+use crate::{RoomInfo, StateChanges, StateStore, store::BaseStateStore};
 
 /// Create the [`Global`] account data processor.
 pub fn global(events: &[Raw<AnyGlobalAccountDataEvent>]) -> Global {

--- a/crates/matrix-sdk-base/src/response_processors/changes.rs
+++ b/crates/matrix-sdk-base/src/response_processors/changes.rs
@@ -22,7 +22,7 @@ use tracing::{error, instrument, trace};
 
 use super::Context;
 use crate::{
-    Result,
+    Result, StateStore,
     store::{BaseStateStore, StateStoreExt as _},
 };
 

--- a/crates/matrix-sdk-base/src/response_processors/changes.rs
+++ b/crates/matrix-sdk-base/src/response_processors/changes.rs
@@ -33,7 +33,7 @@ pub async fn save_only(context: Context, state_store: &BaseStateStore) -> Result
     let _timer = timer!(tracing::Level::TRACE, "_method");
 
     save_changes(&context, state_store, None).await?;
-    broadcast_room_info_notable_updates(&context, state_store);
+    broadcast_room_info_notable_updates(&context, state_store).await;
 
     Ok(())
 }
@@ -56,7 +56,7 @@ pub async fn save_and_apply(
 
     save_changes(&context, state_store, sync_token).await?;
     apply_changes(&context, ignore_user_list_changes, previous_ignored_user_list);
-    broadcast_room_info_notable_updates(&context, state_store);
+    broadcast_room_info_notable_updates(&context, state_store).await;
 
     trace!("applied changes");
 
@@ -118,13 +118,12 @@ fn apply_changes(
     }
 }
 
-fn broadcast_room_info_notable_updates(context: &Context, state_store: &BaseStateStore) {
+async fn broadcast_room_info_notable_updates(context: &Context, state_store: &BaseStateStore) {
     for (room_id, room_info) in &context.state_changes.room_infos {
         if let Some(room) = state_store.room(room_id) {
             let room_info_notable_update_reasons =
                 context.room_info_notable_updates.get(room_id).copied().unwrap_or_default();
-
-            room.set_room_info(room_info.clone(), room_info_notable_update_reasons)
+            room.update_room_info(|_| (room_info.clone(), room_info_notable_update_reasons)).await;
         }
     }
 }

--- a/crates/matrix-sdk-base/src/response_processors/changes.rs
+++ b/crates/matrix-sdk-base/src/response_processors/changes.rs
@@ -18,22 +18,27 @@ use ruma::{
     events::{GlobalAccountDataEventType, ignored_user_list::IgnoredUserListEvent},
     serde::Raw,
 };
+use tokio::sync::MutexGuard;
 use tracing::{error, instrument, trace};
 
 use super::Context;
 use crate::{
-    Result, StateStore,
+    Result, StoreError,
     store::{BaseStateStore, StateStoreExt as _},
 };
 
 /// Save the [`StateChanges`] from the [`Context`] inside the [`BaseStateStore`]
 /// only! The changes aren't applied on the in-memory rooms.
 #[instrument(skip_all)]
-pub async fn save_only(context: Context, state_store: &BaseStateStore) -> Result<()> {
+pub async fn save_only(
+    context: Context,
+    state_store: &BaseStateStore,
+    state_store_guard: &MutexGuard<'_, ()>,
+) -> Result<()> {
     let _timer = timer!(tracing::Level::TRACE, "_method");
 
-    save_changes(&context, state_store, None).await?;
-    broadcast_room_info_notable_updates(&context, state_store).await;
+    save_changes(&context, state_store, state_store_guard, None).await?;
+    broadcast_room_info_notable_updates(&context, state_store, state_store_guard)?;
 
     Ok(())
 }
@@ -44,6 +49,7 @@ pub async fn save_only(context: Context, state_store: &BaseStateStore) -> Result
 pub async fn save_and_apply(
     context: Context,
     state_store: &BaseStateStore,
+    state_store_guard: &MutexGuard<'_, ()>,
     ignore_user_list_changes: &SharedObservable<Vec<String>>,
     sync_token: Option<String>,
 ) -> Result<()> {
@@ -54,9 +60,9 @@ pub async fn save_and_apply(
     let previous_ignored_user_list =
         state_store.get_account_data_event_static().await.ok().flatten();
 
-    save_changes(&context, state_store, sync_token).await?;
+    save_changes(&context, state_store, state_store_guard, sync_token).await?;
     apply_changes(&context, ignore_user_list_changes, previous_ignored_user_list);
-    broadcast_room_info_notable_updates(&context, state_store).await;
+    broadcast_room_info_notable_updates(&context, state_store, state_store_guard)?;
 
     trace!("applied changes");
 
@@ -66,9 +72,10 @@ pub async fn save_and_apply(
 async fn save_changes(
     context: &Context,
     state_store: &BaseStateStore,
+    state_store_guard: &MutexGuard<'_, ()>,
     sync_token: Option<String>,
 ) -> Result<()> {
-    state_store.save_changes(&context.state_changes).await?;
+    state_store.save_changes_with_guard(state_store_guard, &context.state_changes).await?;
 
     if let Some(sync_token) = sync_token {
         *state_store.sync_token.write().await = Some(sync_token);
@@ -118,12 +125,20 @@ fn apply_changes(
     }
 }
 
-async fn broadcast_room_info_notable_updates(context: &Context, state_store: &BaseStateStore) {
+fn broadcast_room_info_notable_updates(
+    context: &Context,
+    state_store: &BaseStateStore,
+    state_store_guard: &MutexGuard<'_, ()>,
+) -> Result<()> {
     for (room_id, room_info) in &context.state_changes.room_infos {
         if let Some(room) = state_store.room(room_id) {
             let room_info_notable_update_reasons =
                 context.room_info_notable_updates.get(room_id).copied().unwrap_or_default();
-            room.update_room_info(|_| (room_info.clone(), room_info_notable_update_reasons)).await;
+            room.update_room_info_with_store_guard(state_store_guard, |_| {
+                (room_info.clone(), room_info_notable_update_reasons)
+            })
+            .map_err(StoreError::from)?;
         }
     }
+    Ok(())
 }

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/tracked_users.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/tracked_users.rs
@@ -18,7 +18,7 @@ use matrix_sdk_common::timer;
 use matrix_sdk_crypto::OlmMachine;
 use ruma::{OwnedUserId, RoomId};
 
-use crate::{EncryptionState, Result, RoomMemberships, store::BaseStateStore};
+use crate::{EncryptionState, Result, RoomMemberships, StateStore, store::BaseStateStore};
 
 /// Update tracked users, if the room is encrypted.
 pub async fn update(

--- a/crates/matrix-sdk-base/src/room/call.rs
+++ b/crates/matrix-sdk-base/src/room/call.rs
@@ -94,7 +94,10 @@ mod tests {
         super::{Room, RoomState},
         CallIntentConsensus,
     };
-    use crate::{store::MemoryStore, utils::RawStateEventWithKeys};
+    use crate::{
+        store::{MemoryStore, SaveLockedStateStore},
+        utils::RawStateEventWithKeys,
+    };
 
     fn make_room_test_helper(room_type: RoomState) -> (Arc<MemoryStore>, Room) {
         let store = Arc::new(MemoryStore::new());
@@ -102,7 +105,10 @@ mod tests {
         let room_id = room_id!("!test:localhost");
         let (sender, _receiver) = tokio::sync::broadcast::channel(1);
 
-        (store.clone(), Room::new(user_id, store, room_id, room_type, sender))
+        (
+            store.clone(),
+            Room::new(user_id, SaveLockedStateStore::new(store), room_id, room_type, sender),
+        )
     }
 
     fn timestamp(minutes_ago: u32) -> MilliSecondsSinceUnixEpoch {

--- a/crates/matrix-sdk-base/src/room/display_name.rs
+++ b/crates/matrix-sdk-base/src/room/display_name.rs
@@ -25,7 +25,7 @@ use tracing::{debug, trace, warn};
 
 use super::{Room, RoomMemberships};
 use crate::{
-    RoomMember, RoomState,
+    RoomMember, RoomState, StateStore,
     deserialized_responses::SyncOrStrippedState,
     store::{Result as StoreResult, StateStoreExt},
 };
@@ -559,7 +559,8 @@ mod tests {
 
     use super::{Room, RoomDisplayName, compute_display_name_from_heroes};
     use crate::{
-        MinimalStateEvent, RoomHero, RoomState, StateChanges, StateStore, store::MemoryStore,
+        MinimalStateEvent, RoomHero, RoomState, StateChanges, StateStore,
+        store::{MemoryStore, SaveLockedStateStore},
     };
 
     fn make_room_test_helper(room_type: RoomState) -> (Arc<MemoryStore>, Room) {
@@ -568,7 +569,10 @@ mod tests {
         let room_id = room_id!("!test:localhost");
         let (sender, _receiver) = tokio::sync::broadcast::channel(1);
 
-        (store.clone(), Room::new(user_id, store, room_id, room_type, sender))
+        (
+            store.clone(),
+            Room::new(user_id, SaveLockedStateStore::new(store), room_id, room_type, sender),
+        )
     }
 
     fn make_stripped_member_event(user_id: &UserId, name: &str) -> Raw<StrippedRoomMemberEvent> {

--- a/crates/matrix-sdk-base/src/room/encryption.rs
+++ b/crates/matrix-sdk-base/src/room/encryption.rs
@@ -96,7 +96,11 @@ mod tests {
     };
 
     use super::{EncryptionState, Room};
-    use crate::{RoomState, store::MemoryStore, utils::RawStateEventWithKeys};
+    use crate::{
+        RoomState,
+        store::{MemoryStore, SaveLockedStateStore},
+        utils::RawStateEventWithKeys,
+    };
 
     fn make_room_test_helper(room_type: RoomState) -> (Arc<MemoryStore>, Room) {
         let store = Arc::new(MemoryStore::new());
@@ -104,7 +108,10 @@ mod tests {
         let room_id = room_id!("!test:localhost");
         let (sender, _receiver) = tokio::sync::broadcast::channel(1);
 
-        (store.clone(), Room::new(user_id, store, room_id, room_type, sender))
+        (
+            store.clone(),
+            Room::new(user_id, SaveLockedStateStore::new(store), room_id, room_type, sender),
+        )
     }
 
     fn timestamp(minutes_ago: u32) -> MilliSecondsSinceUnixEpoch {

--- a/crates/matrix-sdk-base/src/room/knock.rs
+++ b/crates/matrix-sdk-base/src/room/knock.rs
@@ -26,7 +26,7 @@ use tracing::warn;
 
 use super::Room;
 use crate::{
-    StateStoreDataKey, StateStoreDataValue, StoreError,
+    StateStore, StateStoreDataKey, StateStoreDataValue, StoreError,
     deserialized_responses::{MemberEvent, RawMemberEvent, SyncOrStrippedState},
     store::{Result as StoreResult, StateStoreExt},
 };

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -36,7 +36,7 @@ use tracing::debug;
 
 use super::Room;
 use crate::{
-    MinimalRoomMemberEvent, StoreError,
+    MinimalRoomMemberEvent, StateStore, StoreError,
     deserialized_responses::{DisplayName, MemberEvent},
     store::{Result as StoreResult, StateStoreExt, ambiguity_map::is_display_name_ambiguous},
 };

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -26,10 +26,7 @@ mod state;
 mod tags;
 mod tombstone;
 
-use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
-    sync::Arc,
-};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 pub use call::CallIntentConsensus;
 pub use create::*;
@@ -69,11 +66,11 @@ pub use tombstone::{PredecessorRoom, SuccessorRoom};
 use tracing::{info, instrument, warn};
 
 use crate::{
-    DmRoomDefinition, Error,
+    DmRoomDefinition, Error, StateStore,
     deserialized_responses::MemberEvent,
     notification_settings::RoomNotificationMode,
     read_receipts::RoomReadReceipts,
-    store::{DynStateStore, Result as StoreResult, StateStoreExt},
+    store::{Result as StoreResult, SaveLockedStateStore, StateStoreExt},
     sync::UnreadNotificationsCount,
 };
 
@@ -95,7 +92,7 @@ pub struct Room {
     pub(super) room_info_notable_update_sender: broadcast::Sender<RoomInfoNotableUpdate>,
 
     /// A clone of the state store.
-    pub(super) store: Arc<DynStateStore>,
+    pub(super) store: SaveLockedStateStore,
 
     /// A map for ids of room membership events in the knocking state linked to
     /// the user id of the user affected by the member event, that the current
@@ -110,7 +107,7 @@ pub struct Room {
 impl Room {
     pub(crate) fn new(
         own_user_id: &UserId,
-        store: Arc<DynStateStore>,
+        store: SaveLockedStateStore,
         room_id: &RoomId,
         room_state: RoomState,
         room_info_notable_update_sender: broadcast::Sender<RoomInfoNotableUpdate>,
@@ -121,7 +118,7 @@ impl Room {
 
     pub(crate) fn restore(
         own_user_id: &UserId,
-        store: Arc<DynStateStore>,
+        store: SaveLockedStateStore,
         room_info: RoomInfo,
         room_info_notable_update_sender: broadcast::Sender<RoomInfoNotableUpdate>,
     ) -> Self {

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -119,8 +119,20 @@ impl Room {
         if !std::ptr::eq(MutexGuard::mutex(guard), self.store.lock()) {
             return Err(IncorrectMutexGuardError);
         }
-        let (info, reasons) = f(self.clone_info());
-        self.set_room_info(info, reasons);
+
+        let (info, mut reasons) = f(self.clone_info());
+        self.info.set(info);
+
+        if reasons.is_empty() {
+            // TODO: remove this block!
+            // Read `RoomInfoNotableUpdateReasons::NONE` to understand why it must be
+            // removed.
+            reasons = RoomInfoNotableUpdateReasons::NONE;
+        }
+        let _ = self
+            .room_info_notable_update_sender
+            .send(RoomInfoNotableUpdate { room_id: self.room_id.clone(), reasons });
+
         Ok(())
     }
 
@@ -151,33 +163,8 @@ impl Room {
         let mut changes = StateChanges::default();
         changes.add_room(info.clone());
         self.store.save_changes_with_guard(guard, &changes).await?;
-        self.set_room_info(info, reasons);
+        self.update_room_info_with_store_guard(guard, |_| (info, reasons))?;
         Ok(())
-    }
-
-    /// Update the summary with given RoomInfo.
-    fn set_room_info(
-        &self,
-        room_info: RoomInfo,
-        room_info_notable_update_reasons: RoomInfoNotableUpdateReasons,
-    ) {
-        self.info.set(room_info);
-
-        if !room_info_notable_update_reasons.is_empty() {
-            // Ignore error if no receiver exists.
-            let _ = self.room_info_notable_update_sender.send(RoomInfoNotableUpdate {
-                room_id: self.room_id.clone(),
-                reasons: room_info_notable_update_reasons,
-            });
-        } else {
-            // TODO: remove this block!
-            // Read `RoomInfoNotableUpdateReasons::NONE` to understand why it must be
-            // removed.
-            let _ = self.room_info_notable_update_sender.send(RoomInfoNotableUpdate {
-                room_id: self.room_id.clone(),
-                reasons: RoomInfoNotableUpdateReasons::NONE,
-            });
-        }
     }
 }
 

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -58,6 +58,7 @@ use ruma::{
     serde::Raw,
 };
 use serde::{Deserialize, Serialize};
+use tokio::sync::MutexGuard;
 use tracing::{field::debug, info, instrument, warn};
 
 use super::{
@@ -65,13 +66,13 @@ use super::{
     RoomHero, RoomNotableTags, RoomState, RoomSummary,
 };
 use crate::{
-    MinimalStateEvent,
+    MinimalStateEvent, StateChanges, StoreError,
     deserialized_responses::RawSyncOrStrippedState,
     latest_event::LatestEventValue,
     notification_settings::RoomNotificationMode,
     read_receipts::RoomReadReceipts,
     room::call::CallIntentConsensus,
-    store::{SaveLockedStateStore, StateStoreExt},
+    store::{IncorrectMutexGuardError, SaveLockedStateStore, StateStoreExt},
     sync::UnreadNotificationsCount,
     utils::{AnyStateEventEnum, RawStateEventWithKeys},
 };
@@ -88,6 +89,70 @@ impl Room {
     /// Clone the inner `RoomInfo`.
     pub fn clone_info(&self) -> RoomInfo {
         self.info.get()
+    }
+
+    /// Update [`RoomInfo`] with the given function `F`. Updates are atomic as
+    /// this function acquires the lock of the underlying store before updating
+    /// the [`RoomInfo`].
+    pub async fn update_room_info<F>(&self, f: F)
+    where
+        F: FnOnce(RoomInfo) -> (RoomInfo, RoomInfoNotableUpdateReasons),
+    {
+        self.update_room_info_with_store_guard(&self.store.lock().lock().await, f)
+            .expect("should have correct mutex!")
+    }
+
+    /// Same as [`Self::update_room_info`], but allows the caller to provide a
+    /// guard for the lock of the underlying store in case it has already been
+    /// acquired.
+    ///
+    /// This function returns an [`IncorrectMutexGuardError`] if the provided
+    /// guard is not associated with the lock of the underlying store.
+    pub fn update_room_info_with_store_guard<F>(
+        &self,
+        guard: &MutexGuard<'_, ()>,
+        f: F,
+    ) -> Result<(), IncorrectMutexGuardError>
+    where
+        F: FnOnce(RoomInfo) -> (RoomInfo, RoomInfoNotableUpdateReasons),
+    {
+        if !std::ptr::eq(MutexGuard::mutex(guard), self.store.lock()) {
+            return Err(IncorrectMutexGuardError);
+        }
+        let (info, reasons) = f(self.clone_info());
+        self.set_room_info(info, reasons);
+        Ok(())
+    }
+
+    /// Same as [`Self::update_room_info`] but also saves the changes to the
+    /// underlying store.
+    pub async fn update_and_save_room_info<F>(&self, f: F) -> Result<(), StoreError>
+    where
+        F: FnOnce(RoomInfo) -> (RoomInfo, RoomInfoNotableUpdateReasons),
+    {
+        self.update_and_save_room_info_with_store_guard(&self.store.lock().lock().await, f).await
+    }
+
+    /// Same as [`Self::update_and_save_room_info`], but allows the caller to
+    /// provide a guard for the lock of the underlying store in case it has
+    /// already been acquired.
+    ///
+    /// This function returns an [`IncorrectMutexGuardError`] if the provided
+    /// guard is not associated with the lock of the underlying store.
+    pub async fn update_and_save_room_info_with_store_guard<F>(
+        &self,
+        guard: &MutexGuard<'_, ()>,
+        f: F,
+    ) -> Result<(), StoreError>
+    where
+        F: FnOnce(RoomInfo) -> (RoomInfo, RoomInfoNotableUpdateReasons),
+    {
+        let (info, reasons) = f(self.clone_info());
+        let mut changes = StateChanges::default();
+        changes.add_room(info.clone());
+        self.store.save_changes_with_guard(guard, &changes).await?;
+        self.set_room_info(info, reasons);
+        Ok(())
     }
 
     /// Update the summary with given RoomInfo.

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1420,9 +1420,13 @@ impl Default for RoomInfoNotableUpdateReasons {
 
 #[cfg(test)]
 mod tests {
-    use std::{str::FromStr, sync::Arc};
+    use std::{str::FromStr, sync::Arc, time::Duration};
 
     use assert_matches::assert_matches;
+    use futures_util::future::{self, Either};
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    use gloo_timers::future::sleep;
+    use matrix_sdk_common::executor::spawn;
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
     use ruma::{
         assign,
@@ -1437,13 +1441,17 @@ mod tests {
     };
     use serde_json::json;
     use similar_asserts::assert_eq;
+    use tokio::sync::Mutex;
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    use tokio::time::sleep;
 
     use super::{BaseRoomInfo, LatestEventValue, RoomInfo, SyncInfo};
     use crate::{
-        RoomDisplayName, RoomHero, RoomState, StateChanges, StateStore,
+        Room, RoomDisplayName, RoomHero, RoomInfoNotableUpdateReasons, RoomState, StateChanges,
+        StateStore,
         notification_settings::RoomNotificationMode,
         room::{RoomNotableTags, RoomSummary},
-        store::{IntoStateStore, MemoryStore, SaveLockedStateStore},
+        store::{IntoStateStore, MemoryStore, RoomLoadSettings, SaveLockedStateStore},
         sync::UnreadNotificationsCount,
     };
 
@@ -1812,5 +1820,220 @@ mod tests {
         assert!(info.base_info.name.is_none());
         assert!(info.base_info.tombstone.is_none());
         assert!(info.base_info.topic.is_none());
+    }
+
+    fn make_room_and_state_store(room_state: RoomState) -> (Room, SaveLockedStateStore) {
+        let state_store = SaveLockedStateStore::new(MemoryStore::new().into_state_store());
+        let user_id = user_id!("@user:localhost");
+        let room_id = room_id!("!room:localhost");
+        let (sender, _) = tokio::sync::broadcast::channel(1);
+        let room = Room::new(user_id, state_store.clone(), room_id, room_state, sender);
+        (room, state_store)
+    }
+
+    #[async_test]
+    async fn test_update_room_info_only_updates_in_memory_room_info() {
+        let (room, state_store) = make_room_and_state_store(RoomState::Joined);
+
+        let before = room.clone_info();
+        assert_eq!(before.state(), RoomState::Joined);
+        room.update_room_info(|mut info| {
+            info.mark_as_banned();
+            (info, RoomInfoNotableUpdateReasons::MEMBERSHIP)
+        })
+        .await;
+        let after = room.clone_info();
+        assert_eq!(after.state(), RoomState::Banned);
+
+        let infos = state_store
+            .get_room_infos(&RoomLoadSettings::One(room.room_id.clone()))
+            .await
+            .expect("get room info");
+        assert!(infos.is_empty());
+    }
+
+    #[async_test]
+    async fn test_update_room_info_with_store_guard_only_updates_in_memory_room_info() {
+        let (room, state_store) = make_room_and_state_store(RoomState::Joined);
+
+        let before = room.clone_info();
+        assert_eq!(before.state(), RoomState::Joined);
+        room.update_room_info_with_store_guard(&state_store.lock().lock().await, |mut info| {
+            info.mark_as_banned();
+            (info, RoomInfoNotableUpdateReasons::MEMBERSHIP)
+        })
+        .expect("update room info");
+        let after = room.clone_info();
+        assert_eq!(after.state(), RoomState::Banned);
+
+        let infos = state_store
+            .get_room_infos(&RoomLoadSettings::One(room.room_id.clone()))
+            .await
+            .expect("get room info");
+        assert!(infos.is_empty());
+    }
+
+    #[async_test]
+    async fn test_update_room_info_only_accepts_guard_for_underlying_mutex() {
+        let (room, state_store) = make_room_and_state_store(RoomState::Joined);
+
+        room.update_room_info_with_store_guard(&state_store.lock().lock().await, |info| {
+            (info, RoomInfoNotableUpdateReasons::NONE)
+        })
+        .expect("room accepts guard for underlying mutex");
+
+        let mutex = Mutex::new(());
+        room.update_room_info_with_store_guard(&mutex.lock().await, |info| {
+            (info, RoomInfoNotableUpdateReasons::NONE)
+        })
+        .expect_err("room does not accept guard for unknown mutex");
+    }
+
+    #[async_test]
+    async fn test_update_and_save_room_info_updates_room_info_in_memory_and_store() {
+        let (room, state_store) = make_room_and_state_store(RoomState::Joined);
+
+        let before = room.clone_info();
+        assert_eq!(before.state(), RoomState::Joined);
+        room.update_and_save_room_info(|mut info| {
+            info.mark_as_banned();
+            (info, RoomInfoNotableUpdateReasons::MEMBERSHIP)
+        })
+        .await
+        .expect("update and save room info");
+        let after = room.clone_info();
+        assert_eq!(after.state(), RoomState::Banned);
+
+        let infos = state_store
+            .get_room_infos(&RoomLoadSettings::One(room.room_id.clone()))
+            .await
+            .expect("get room info");
+        assert_eq!(infos.len(), 1);
+        assert_matches!(infos.first(), Some(info) => {
+            info.state() == RoomState::Banned
+        });
+    }
+
+    #[async_test]
+    async fn test_update_and_save_room_info_with_store_guard_updates_room_info_in_memory_and_store()
+    {
+        let (room, state_store) = make_room_and_state_store(RoomState::Joined);
+
+        let before = room.clone_info();
+        assert_eq!(before.state(), RoomState::Joined);
+        room.update_and_save_room_info_with_store_guard(
+            &state_store.lock().lock().await,
+            |mut info| {
+                info.mark_as_banned();
+                (info, RoomInfoNotableUpdateReasons::MEMBERSHIP)
+            },
+        )
+        .await
+        .expect("update and save room info");
+        let after = room.clone_info();
+        assert_eq!(after.state(), RoomState::Banned);
+
+        let infos = state_store
+            .get_room_infos(&RoomLoadSettings::One(room.room_id.clone()))
+            .await
+            .expect("get room info");
+        assert_eq!(infos.len(), 1);
+        assert_matches!(infos.first(), Some(info) => {
+            info.state() == RoomState::Banned
+        });
+    }
+
+    #[async_test]
+    async fn test_update_and_save_room_info_only_accepts_guard_for_underlying_mutex() {
+        let (room, state_store) = make_room_and_state_store(RoomState::Joined);
+
+        room.update_and_save_room_info_with_store_guard(&state_store.lock().lock().await, |info| {
+            (info, RoomInfoNotableUpdateReasons::NONE)
+        })
+        .await
+        .expect("room accepts guard for underlying mutex");
+
+        let mutex = Mutex::new(());
+        room.update_and_save_room_info_with_store_guard(&mutex.lock().await, |info| {
+            (info, RoomInfoNotableUpdateReasons::NONE)
+        })
+        .await
+        .expect_err("room does not accept guard for unknown mutex");
+    }
+
+    #[derive(Debug)]
+    struct Elapsed;
+
+    async fn timeout<F: Future + Unpin>(duration: Duration, f: F) -> Result<F::Output, Elapsed> {
+        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+        {
+            match future::select(sleep(duration), f).await {
+                Either::Left(_) => return Err(Elapsed),
+                Either::Right((output, _)) => Ok(output),
+            }
+        }
+        #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+        {
+            tokio::time::timeout(duration, f).await.map_err(|_| Elapsed)
+        }
+    }
+
+    #[async_test]
+    async fn test_update_room_info_waits_to_acquire_lock_before_updating_room_info() {
+        let (room, state_store) = make_room_and_state_store(RoomState::Joined);
+
+        // Acquire lock and hold it for 5 seconds
+        let lock_task = spawn({
+            let state_store = state_store.clone();
+            async move {
+                let lock = state_store.lock();
+                let _guard = lock.lock().await;
+                sleep(Duration::from_secs(5)).await;
+            }
+        });
+
+        // Try to update room info while the lock is held by another task
+        let save_task = spawn(async move {
+            room.update_room_info(|info| (info, RoomInfoNotableUpdateReasons::NONE)).await
+        });
+
+        // Ensure that the second task does not progress until the first task has
+        // completed and, therefore, releases the save lock
+        assert_matches!(future::select(lock_task, save_task).await, Either::Left((_, save_task)) => {
+            timeout(Duration::from_millis(100), save_task)
+                .await
+                .expect("task completes before timeout")
+                .expect("task completes successfully")
+        });
+    }
+
+    #[async_test]
+    async fn test_update_and_save_room_info_waits_to_acquire_lock_before_updating_room_info() {
+        let (room, state_store) = make_room_and_state_store(RoomState::Joined);
+
+        // Acquire lock and hold it for 5 seconds
+        let lock_task = spawn({
+            let state_store = state_store.clone();
+            async move {
+                let lock = state_store.lock();
+                let _guard = lock.lock().await;
+                sleep(Duration::from_secs(5)).await;
+            }
+        });
+
+        // Try to update room info while the lock is held by another task
+        let save_task = spawn(async move {
+            room.update_and_save_room_info(|info| (info, RoomInfoNotableUpdateReasons::NONE)).await
+        });
+
+        // Ensure that the second task does not progress until the first task has
+        // completed and, therefore, releases the save lock
+        assert_matches!(future::select(lock_task, save_task).await, Either::Left((_, save_task)) => {
+            timeout(Duration::from_millis(100), save_task)
+                .await
+                .expect("task completes before timeout")
+                .expect("task completes successfully")
+                .expect("update and save room info");
+        });
     }
 }

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -156,7 +156,7 @@ impl Room {
     }
 
     /// Update the summary with given RoomInfo.
-    pub fn set_room_info(
+    fn set_room_info(
         &self,
         room_info: RoomInfo,
         room_info_notable_update_reasons: RoomInfoNotableUpdateReasons,

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -71,7 +71,7 @@ use crate::{
     notification_settings::RoomNotificationMode,
     read_receipts::RoomReadReceipts,
     room::call::CallIntentConsensus,
-    store::{DynStateStore, StateStoreExt},
+    store::{SaveLockedStateStore, StateStoreExt},
     sync::UnreadNotificationsCount,
     utils::{AnyStateEventEnum, RawStateEventWithKeys},
 };
@@ -1183,7 +1183,7 @@ impl RoomInfo {
     /// Returns `true` if migrations were applied and this `RoomInfo` needs to
     /// be persisted to the state store.
     #[instrument(skip_all, fields(room_id = ?self.room_id))]
-    pub(crate) async fn apply_migrations(&mut self, store: Arc<DynStateStore>) -> bool {
+    pub(crate) async fn apply_migrations(&mut self, store: SaveLockedStateStore) -> bool {
         let mut migrated = false;
 
         if self.data_format_version < 1 {
@@ -1388,10 +1388,10 @@ mod tests {
 
     use super::{BaseRoomInfo, LatestEventValue, RoomInfo, SyncInfo};
     use crate::{
-        RoomDisplayName, RoomHero, RoomState, StateChanges,
+        RoomDisplayName, RoomHero, RoomState, StateChanges, StateStore,
         notification_settings::RoomNotificationMode,
         room::{RoomNotableTags, RoomSummary},
-        store::{IntoStateStore, MemoryStore},
+        store::{IntoStateStore, MemoryStore, SaveLockedStateStore},
         sync::UnreadNotificationsCount,
     };
 
@@ -1489,7 +1489,7 @@ mod tests {
 
     #[async_test]
     async fn test_room_info_migration_v1() {
-        let store = MemoryStore::new().into_state_store();
+        let store = SaveLockedStateStore::new(MemoryStore::new().into_state_store());
 
         let room_info_json = json!({
             "room_id": "!gda78o:server.tld",

--- a/crates/matrix-sdk-base/src/room/tags.rs
+++ b/crates/matrix-sdk-base/src/room/tags.rs
@@ -17,7 +17,7 @@ use ruma::events::{AnyRoomAccountDataEvent, RoomAccountDataEventType, tag::Tags}
 use serde::{Deserialize, Serialize};
 
 use super::Room;
-use crate::store::Result as StoreResult;
+use crate::{StateStore, store::Result as StoreResult};
 
 impl Room {
     /// Get the `Tags` for this room.

--- a/crates/matrix-sdk-base/src/room/tags.rs
+++ b/crates/matrix-sdk-base/src/room/tags.rs
@@ -144,6 +144,7 @@ mod tests {
         processors::changes::save_and_apply(
             context.clone(),
             &client.state_store,
+            &client.state_store_lock().lock().await,
             &client.ignore_user_list_changes,
             None,
         )
@@ -172,6 +173,7 @@ mod tests {
         processors::changes::save_and_apply(
             context,
             &client.state_store,
+            &client.state_store_lock().lock().await,
             &client.ignore_user_list_changes,
             None,
         )
@@ -241,6 +243,7 @@ mod tests {
         processors::changes::save_and_apply(
             context.clone(),
             &client.state_store,
+            &client.state_store_lock().lock().await,
             &client.ignore_user_list_changes,
             None,
         )
@@ -269,6 +272,7 @@ mod tests {
         processors::changes::save_and_apply(
             context,
             &client.state_store,
+            &client.state_store_lock().lock().await,
             &client.ignore_user_list_changes,
             None,
         )

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -115,7 +115,7 @@ impl BaseClient {
         let mut context = processors::Context::default();
 
         let state_store = self.state_store.clone();
-        let mut ambiguity_cache = AmbiguityCache::new(state_store.inner.clone());
+        let mut ambiguity_cache = AmbiguityCache::new(state_store.inner.store().clone());
 
         let global_account_data_processor =
             processors::account_data::global(&extensions.account_data.global);

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -115,7 +115,7 @@ impl BaseClient {
         let mut context = processors::Context::default();
 
         let state_store = self.state_store.clone();
-        let mut ambiguity_cache = AmbiguityCache::new(state_store.inner.store().clone());
+        let mut ambiguity_cache = AmbiguityCache::new(state_store.inner.clone());
 
         let global_account_data_processor =
             processors::account_data::global(&extensions.account_data.global);

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -21,6 +21,7 @@ use ruma::{
     OwnedRoomId, api::client::sync::sync_events::v5 as http, events::receipt::SyncReceiptEvent,
     serde::Raw,
 };
+use tokio::sync::MutexGuard;
 use tracing::{instrument, trace};
 
 use super::BaseClient;
@@ -45,6 +46,7 @@ impl BaseClient {
         &self,
         to_device: Option<&http::response::ToDevice>,
         e2ee: &http::response::E2EE,
+        state_store_guard: &MutexGuard<'_, ()>,
     ) -> Result<Option<Vec<ProcessedToDeviceEvent>>> {
         if to_device.is_none() && e2ee.is_empty() {
             return Ok(None);
@@ -75,6 +77,7 @@ impl BaseClient {
         processors::changes::save_and_apply(
             context,
             &self.state_store,
+            state_store_guard,
             &self.ignore_user_list_changes,
             None,
         )
@@ -94,6 +97,7 @@ impl BaseClient {
         &self,
         response: &http::Response,
         requested_required_states: &RequestedRequiredStates,
+        state_store_guard: &MutexGuard<'_, ()>,
     ) -> Result<SyncResponse> {
         let http::Response { rooms, lists, extensions, .. } = response;
 
@@ -204,6 +208,7 @@ impl BaseClient {
         processors::changes::save_and_apply(
             context,
             &self.state_store,
+            state_store_guard,
             &self.ignore_user_list_changes,
             None,
         )
@@ -221,7 +226,7 @@ impl BaseClient {
         .await;
 
         // Save the new display name updates if any.
-        processors::changes::save_only(context, &self.state_store).await?;
+        processors::changes::save_only(context, &self.state_store, state_store_guard).await?;
 
         Ok(SyncResponse {
             rooms: room_updates,
@@ -239,6 +244,7 @@ impl BaseClient {
         &self,
         room_id: &OwnedRoomId,
         response: &http::Response,
+        state_store_guard: &MutexGuard<'_, ()>,
     ) -> Result<Option<Raw<SyncReceiptEvent>>> {
         let mut context = processors::Context::default();
 
@@ -261,7 +267,7 @@ impl BaseClient {
 
         // Save the new `RoomInfo` if updated.
         if save_context {
-            processors::changes::save_only(context, &self.state_store).await?;
+            processors::changes::save_only(context, &self.state_store, state_store_guard).await?;
         }
 
         Ok(receipt_ephemeral_event)
@@ -318,7 +324,11 @@ mod tests {
         let response = response_with_room(room_id, room);
 
         let sync_resp = client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .unwrap();
 
@@ -359,7 +369,11 @@ mod tests {
         let response = response_with_room(room_id, room);
 
         let sync_resp = client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .unwrap();
 
@@ -386,7 +400,11 @@ mod tests {
         );
 
         let sync_response = client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -404,7 +422,11 @@ mod tests {
         let client = logged_in_base_client(None).await;
         let empty_response = http::Response::new("5".to_owned());
         client
-            .process_sliding_sync(&empty_response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &empty_response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
     }
@@ -421,7 +443,11 @@ mod tests {
         room.joined_count = Some(uint!(41));
         let response = response_with_room(room_id, room);
         let sync_resp = client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -449,7 +475,11 @@ mod tests {
         room.name = Some("little room".to_owned());
         let response = response_with_room(room_id, room);
         let sync_resp = client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -484,7 +514,11 @@ mod tests {
 
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -512,7 +546,11 @@ mod tests {
         room.name = Some("name from sliding sync response".to_owned());
         let response = response_with_room(room_id, room);
         let sync_resp = client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -551,7 +589,11 @@ mod tests {
 
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -578,7 +620,11 @@ mod tests {
 
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -601,7 +647,11 @@ mod tests {
 
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -636,7 +686,11 @@ mod tests {
 
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -657,7 +711,11 @@ mod tests {
         set_room_joined(&mut room, user_id);
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
         assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Joined);
@@ -667,7 +725,11 @@ mod tests {
         set_room_left(&mut room, user_id);
         let response = response_with_room(room_id, room);
         let sync_resp = client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -694,7 +756,11 @@ mod tests {
             set_room_joined(&mut room, user_a_id);
             let response = response_with_room(room_id, room);
             client
-                .process_sliding_sync(&response, &RequestedRequiredStates::default())
+                .process_sliding_sync(
+                    &response,
+                    &RequestedRequiredStates::default(),
+                    &client.state_store_lock().lock().await,
+                )
                 .await
                 .expect("Failed to process sync");
             assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Joined);
@@ -709,7 +775,11 @@ mod tests {
             ));
             let response = response_with_room(room_id, room);
             let sync_resp = client
-                .process_sliding_sync(&response, &RequestedRequiredStates::default())
+                .process_sliding_sync(
+                    &response,
+                    &RequestedRequiredStates::default(),
+                    &client.state_store_lock().lock().await,
+                )
                 .await
                 .expect("Failed to process sync");
 
@@ -745,7 +815,11 @@ mod tests {
         set_room_joined(&mut room, user_id);
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
         assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Joined);
@@ -755,7 +829,11 @@ mod tests {
         set_room_left_as_timeline_event(&mut room, user_id);
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -777,7 +855,11 @@ mod tests {
         set_room_joined(&mut room, user_id);
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
         // (sanity: state is join)
@@ -788,7 +870,11 @@ mod tests {
         set_room_left(&mut room, user_id);
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
         // (sanity: state is left)
@@ -799,7 +885,11 @@ mod tests {
         set_room_invited(&mut room, user_id, user_id);
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -931,7 +1021,11 @@ mod tests {
         };
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -960,7 +1054,11 @@ mod tests {
         };
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -977,7 +1075,11 @@ mod tests {
         let room = http::response::Room::new();
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -999,7 +1101,11 @@ mod tests {
         };
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1019,7 +1125,11 @@ mod tests {
         let room = room_with_avatar(mxc_uri!("mxc://e.uk/med1"), user_id);
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1045,7 +1155,11 @@ mod tests {
         set_room_invited(&mut room, user_id, user_id);
         let response = response_with_room(room_id, room);
         let sync_resp = client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1091,7 +1205,11 @@ mod tests {
         set_room_knocked(&mut room, user_id);
         let response = response_with_room(room_id, room);
         let sync_resp = client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1135,7 +1253,11 @@ mod tests {
         set_room_invited(&mut room, user_id, user_id);
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1161,7 +1283,11 @@ mod tests {
         set_room_invited(&mut room, user_id, user_id);
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1184,7 +1310,11 @@ mod tests {
         room.name = Some("This came from the server".to_owned());
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1208,7 +1338,11 @@ mod tests {
         let room = room_with_name("Hello World", user_id);
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1265,7 +1399,11 @@ mod tests {
             let room = room_with_name("Hello World", user_id);
             let response = response_with_room(room_id, room);
             client
-                .process_sliding_sync(&response, &RequestedRequiredStates::default())
+                .process_sliding_sync(
+                    &response,
+                    &RequestedRequiredStates::default(),
+                    &client.state_store_lock().lock().await,
+                )
                 .await
                 .expect("Failed to process sync");
 
@@ -1319,7 +1457,11 @@ mod tests {
         ]);
         let response = response_with_room(room_id, room);
         let _sync_resp = client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1358,7 +1500,11 @@ mod tests {
         });
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1380,7 +1526,11 @@ mod tests {
             });
             let response = response_with_room(room_id, room);
             client
-                .process_sliding_sync(&response, &RequestedRequiredStates::default())
+                .process_sliding_sync(
+                    &response,
+                    &RequestedRequiredStates::default(),
+                    &client.state_store_lock().lock().await,
+                )
                 .await
                 .expect("Failed to process sync");
 
@@ -1396,7 +1546,11 @@ mod tests {
             });
             let response = response_with_room(room_id, room);
             client
-                .process_sliding_sync(&response, &RequestedRequiredStates::default())
+                .process_sliding_sync(
+                    &response,
+                    &RequestedRequiredStates::default(),
+                    &client.state_store_lock().lock().await,
+                )
                 .await
                 .expect("Failed to process sync");
 
@@ -1413,7 +1567,11 @@ mod tests {
             });
             let response = response_with_room(room_id, room);
             client
-                .process_sliding_sync(&response, &RequestedRequiredStates::default())
+                .process_sliding_sync(
+                    &response,
+                    &RequestedRequiredStates::default(),
+                    &client.state_store_lock().lock().await,
+                )
                 .await
                 .expect("Failed to process sync");
 
@@ -1436,7 +1594,11 @@ mod tests {
         });
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1464,7 +1626,11 @@ mod tests {
         });
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1490,7 +1656,11 @@ mod tests {
         let room = http::response::Room::new();
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1531,7 +1701,11 @@ mod tests {
         });
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1564,7 +1738,11 @@ mod tests {
         });
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1590,7 +1768,11 @@ mod tests {
         let room = http::response::Room::new();
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1631,7 +1813,11 @@ mod tests {
         response.extensions.account_data.rooms.insert(room_id.to_owned(), room_account_data_events);
 
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1646,7 +1832,11 @@ mod tests {
 
         // But getting it again won't trigger a new notable update…
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1675,7 +1865,11 @@ mod tests {
         ];
         response.extensions.account_data.rooms.insert(room_id.to_owned(), room_account_data_events);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1700,7 +1894,11 @@ mod tests {
         let room = http::response::Room::new();
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1745,7 +1943,11 @@ mod tests {
             .insert(room_id.to_owned(), unstable_room_account_data_events.clone());
 
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1779,7 +1981,11 @@ mod tests {
             .rooms
             .insert(room_id.to_owned(), stable_room_account_data_events);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1801,7 +2007,11 @@ mod tests {
             .rooms
             .insert(room_id.to_owned(), unstable_room_account_data_events);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1836,7 +2046,11 @@ mod tests {
             .rooms
             .insert(room_id.to_owned(), stable_room_account_data_events);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1863,7 +2077,11 @@ mod tests {
         set_room_joined(&mut room_response, user_a_id);
         let response = response_with_room(room_id, room_response);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1882,7 +2100,11 @@ mod tests {
         ));
         let response = response_with_room(room_id, room_response);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1900,7 +2122,11 @@ mod tests {
         ));
         let response = response_with_room(room_id, room_response);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
         let pinned_event_ids = room.pinned_event_ids().unwrap();
@@ -1929,7 +2155,11 @@ mod tests {
             .global
             .push(make_global_account_data_event(DirectEventContent(direct_content)));
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -1941,7 +2171,11 @@ mod tests {
         set_room_joined(&mut room_response, user_b_id);
         let response = response_with_room(room_id_2, room_response);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -2005,7 +2239,11 @@ mod tests {
         }
 
         client
-            .process_sliding_sync(&response, &requested_required_states)
+            .process_sliding_sync(
+                &response,
+                &requested_required_states,
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -2059,7 +2297,11 @@ mod tests {
         }
 
         client
-            .process_sliding_sync(&response, &requested_required_states)
+            .process_sliding_sync(
+                &response,
+                &requested_required_states,
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
 
@@ -2126,7 +2368,11 @@ mod tests {
         let mut response = response_with_room(room_id, room);
         set_direct_with(&mut response, their_id.to_owned(), vec![room_id.to_owned()]);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
     }
@@ -2142,7 +2388,11 @@ mod tests {
         room.required_state.push(make_membership_event(user_id, new_state));
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &RequestedRequiredStates::default())
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
             .await
             .expect("Failed to process sync");
     }

--- a/crates/matrix-sdk-base/src/store/ambiguity_map.rs
+++ b/crates/matrix-sdk-base/src/store/ambiguity_map.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
-    sync::Arc,
-};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use ruma::{
     OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UserId,
@@ -23,10 +20,11 @@ use ruma::{
 };
 use tracing::{instrument, trace};
 
-use super::{DynStateStore, Result, StateChanges};
+use super::{Result, StateChanges};
 use crate::{
+    StateStore,
     deserialized_responses::{AmbiguityChange, DisplayName, SyncOrStrippedState},
-    store::StateStoreExt,
+    store::{SaveLockedStateStore, StateStoreExt},
 };
 
 /// A map of users that use a certain display name.
@@ -74,7 +72,7 @@ fn is_member_active(membership: &MembershipState) -> bool {
 
 #[derive(Debug)]
 pub(crate) struct AmbiguityCache {
-    pub store: Arc<DynStateStore>,
+    pub store: SaveLockedStateStore,
     pub cache: BTreeMap<OwnedRoomId, HashMap<DisplayName, BTreeSet<OwnedUserId>>>,
     pub changes: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, AmbiguityChange>>,
 }
@@ -90,7 +88,7 @@ pub(crate) fn is_display_name_ambiguous(
 
 impl AmbiguityCache {
     /// Create a new [`AmbiguityCache`] backed by the given state store.
-    pub fn new(store: Arc<DynStateStore>) -> Self {
+    pub fn new(store: SaveLockedStateStore) -> Self {
         Self { store, cache: BTreeMap::new(), changes: BTreeMap::new() }
     }
 
@@ -340,7 +338,7 @@ mod test {
             $description:literal $(,)?
         ) => {
             let store = MemoryStore::new();
-            let mut ambiguity_cache = AmbiguityCache::new(store.into_state_store());
+            let mut ambiguity_cache = AmbiguityCache::new(SaveLockedStateStore::new(store.into_state_store()));
 
             let changes = Default::default();
             let room_id = room_id!("!foo:bar");

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -251,7 +251,7 @@ impl BaseStateStore {
         for room_info in room_infos {
             let new_room = Room::restore(
                 user_id,
-                self.inner.store().clone(),
+                self.inner.clone(),
                 room_info,
                 self.room_info_notable_update_sender.clone(),
             );
@@ -373,7 +373,7 @@ impl BaseStateStore {
             .get_or_create(room_id, || {
                 Room::new(
                     user_id,
-                    self.inner.store().clone(),
+                    self.inner.clone(),
                     room_id,
                     room_state,
                     self.room_info_notable_update_sender.clone(),

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -94,8 +94,8 @@ pub use self::{
     },
     traits::{
         ComposerDraft, ComposerDraftType, DraftAttachment, DraftAttachmentContent, DraftThumbnail,
-        DynStateStore, IntoStateStore, SaveLockedStateStore, StateStore, StateStoreDataKey,
-        StateStoreDataValue, StateStoreExt, SupportedVersionsResponse,
+        DynStateStore, IncorrectMutexGuardError, IntoStateStore, SaveLockedStateStore, StateStore,
+        StateStoreDataKey, StateStoreDataValue, StateStoreExt, SupportedVersionsResponse,
         ThreadSubscriptionCatchupToken, WellKnownResponse,
     },
 };

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -94,9 +94,9 @@ pub use self::{
     },
     traits::{
         ComposerDraft, ComposerDraftType, DraftAttachment, DraftAttachmentContent, DraftThumbnail,
-        DynStateStore, IntoStateStore, StateStore, StateStoreDataKey, StateStoreDataValue,
-        StateStoreExt, SupportedVersionsResponse, ThreadSubscriptionCatchupToken,
-        WellKnownResponse,
+        DynStateStore, IntoStateStore, SaveLockedStateStore, StateStore, StateStoreDataKey,
+        StateStoreDataValue, StateStoreExt, SupportedVersionsResponse,
+        ThreadSubscriptionCatchupToken, WellKnownResponse,
     },
 };
 
@@ -176,7 +176,7 @@ pub type Result<T, E = StoreError> = std::result::Result<T, E>;
 /// `StateStore` implementation.
 #[derive(Clone)]
 pub(crate) struct BaseStateStore {
-    pub(super) inner: Arc<DynStateStore>,
+    pub(super) inner: SaveLockedStateStore,
     session_meta: Arc<OnceLock<SessionMeta>>,
     room_load_settings: Arc<RwLock<RoomLoadSettings>>,
 
@@ -189,10 +189,6 @@ pub(crate) struct BaseStateStore {
 
     /// All rooms the store knows about.
     rooms: Arc<StdRwLock<ObservableMap<OwnedRoomId, Room>>>,
-
-    /// A lock to synchronize access to the store, such that data by the sync is
-    /// never overwritten.
-    lock: Arc<Mutex<()>>,
 
     /// Which rooms have already logged a log line about missing room info, in
     /// the context of response processors?
@@ -215,20 +211,19 @@ impl BaseStateStore {
             broadcast::channel(500);
 
         Self {
-            inner,
+            inner: SaveLockedStateStore::new(inner),
             session_meta: Default::default(),
             room_load_settings: Default::default(),
             room_info_notable_update_sender,
             sync_token: Default::default(),
             rooms: Arc::new(StdRwLock::new(ObservableMap::new())),
-            lock: Default::default(),
             already_logged_missing_room: Default::default(),
         }
     }
 
     /// Get access to the syncing lock.
     pub fn lock(&self) -> &Mutex<()> {
-        &self.lock
+        self.inner.lock()
     }
 
     /// Set the [`SessionMeta`] into [`BaseStateStore::session_meta`].
@@ -256,7 +251,7 @@ impl BaseStateStore {
         for room_info in room_infos {
             let new_room = Room::restore(
                 user_id,
-                self.inner.clone(),
+                self.inner.store().clone(),
                 room_info,
                 self.room_info_notable_update_sender.clone(),
             );
@@ -278,7 +273,7 @@ impl BaseStateStore {
         let mut migrated_room_infos = Vec::with_capacity(room_infos.len());
 
         for room_info in room_infos.iter_mut() {
-            if room_info.apply_migrations(self.inner.clone()).await {
+            if room_info.apply_migrations(self.inner.store().clone()).await {
                 migrated_room_infos.push(room_info.clone());
             }
         }
@@ -378,7 +373,7 @@ impl BaseStateStore {
             .get_or_create(room_id, || {
                 Room::new(
                     user_id,
-                    self.inner.clone(),
+                    self.inner.store().clone(),
                     room_id,
                     room_state,
                     self.room_info_notable_update_sender.clone(),
@@ -412,10 +407,10 @@ impl fmt::Debug for BaseStateStore {
 }
 
 impl Deref for BaseStateStore {
-    type Target = DynStateStore;
+    type Target = SaveLockedStateStore;
 
     fn deref(&self) -> &Self::Target {
-        self.inner.deref()
+        &self.inner
     }
 }
 
@@ -874,7 +869,7 @@ mod tests {
     use ruma::{owned_device_id, owned_user_id, room_id, user_id};
 
     use super::{BaseStateStore, MemoryStore, RoomLoadSettings};
-    use crate::{RoomInfo, RoomState, SessionMeta, StateChanges};
+    use crate::{RoomInfo, RoomState, SessionMeta, StateChanges, StateStore};
 
     #[async_test]
     async fn test_set_session_meta() {

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -273,7 +273,7 @@ impl BaseStateStore {
         let mut migrated_room_infos = Vec::with_capacity(room_infos.len());
 
         for room_info in room_infos.iter_mut() {
-            if room_info.apply_migrations(self.inner.store().clone()).await {
+            if room_info.apply_migrations(self.inner.clone()).await {
                 migrated_room_infos.push(room_info.clone());
             }
         }

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -531,6 +531,306 @@ pub trait StateStore: AsyncTraitDeps {
 
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
+impl<T: StateStore> StateStore for &T {
+    type Error = T::Error;
+
+    async fn get_kv_data(
+        &self,
+        key: StateStoreDataKey<'_>,
+    ) -> Result<Option<StateStoreDataValue>, Self::Error> {
+        (*self).get_kv_data(key).await
+    }
+
+    async fn set_kv_data(
+        &self,
+        key: StateStoreDataKey<'_>,
+        value: StateStoreDataValue,
+    ) -> Result<(), Self::Error> {
+        (*self).set_kv_data(key, value).await
+    }
+
+    async fn remove_kv_data(&self, key: StateStoreDataKey<'_>) -> Result<(), Self::Error> {
+        (*self).remove_kv_data(key).await
+    }
+
+    async fn save_changes(&self, changes: &StateChanges) -> Result<(), Self::Error> {
+        (*self).save_changes(changes).await
+    }
+
+    async fn get_presence_event(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Option<Raw<PresenceEvent>>, Self::Error> {
+        (*self).get_presence_event(user_id).await
+    }
+
+    async fn get_presence_events(
+        &self,
+        user_ids: &[OwnedUserId],
+    ) -> Result<Vec<Raw<PresenceEvent>>, Self::Error> {
+        (*self).get_presence_events(user_ids).await
+    }
+
+    async fn get_state_event(
+        &self,
+        room_id: &RoomId,
+        event_type: StateEventType,
+        state_key: &str,
+    ) -> Result<Option<RawAnySyncOrStrippedState>, Self::Error> {
+        (*self).get_state_event(room_id, event_type, state_key).await
+    }
+
+    async fn get_state_events(
+        &self,
+        room_id: &RoomId,
+        event_type: StateEventType,
+    ) -> Result<Vec<RawAnySyncOrStrippedState>, Self::Error> {
+        (*self).get_state_events(room_id, event_type).await
+    }
+
+    async fn get_state_events_for_keys(
+        &self,
+        room_id: &RoomId,
+        event_type: StateEventType,
+        state_keys: &[&str],
+    ) -> Result<Vec<RawAnySyncOrStrippedState>, Self::Error> {
+        (*self).get_state_events_for_keys(room_id, event_type, state_keys).await
+    }
+
+    async fn get_profile(
+        &self,
+        room_id: &RoomId,
+        user_id: &UserId,
+    ) -> Result<Option<MinimalRoomMemberEvent>, Self::Error> {
+        (*self).get_profile(room_id, user_id).await
+    }
+
+    async fn get_profiles<'a>(
+        &self,
+        room_id: &RoomId,
+        user_ids: &'a [OwnedUserId],
+    ) -> Result<BTreeMap<&'a UserId, MinimalRoomMemberEvent>, Self::Error> {
+        (*self).get_profiles(room_id, user_ids).await
+    }
+
+    async fn get_user_ids(
+        &self,
+        room_id: &RoomId,
+        memberships: RoomMemberships,
+    ) -> Result<Vec<OwnedUserId>, Self::Error> {
+        (*self).get_user_ids(room_id, memberships).await
+    }
+
+    async fn get_room_infos(
+        &self,
+        room_load_settings: &RoomLoadSettings,
+    ) -> Result<Vec<RoomInfo>, Self::Error> {
+        (*self).get_room_infos(room_load_settings).await
+    }
+
+    async fn get_users_with_display_name(
+        &self,
+        room_id: &RoomId,
+        display_name: &DisplayName,
+    ) -> Result<BTreeSet<OwnedUserId>, Self::Error> {
+        (*self).get_users_with_display_name(room_id, display_name).await
+    }
+
+    async fn get_users_with_display_names<'a>(
+        &self,
+        room_id: &RoomId,
+        display_names: &'a [DisplayName],
+    ) -> Result<HashMap<&'a DisplayName, BTreeSet<OwnedUserId>>, Self::Error> {
+        (*self).get_users_with_display_names(room_id, display_names).await
+    }
+
+    async fn get_account_data_event(
+        &self,
+        event_type: GlobalAccountDataEventType,
+    ) -> Result<Option<Raw<AnyGlobalAccountDataEvent>>, Self::Error> {
+        (*self).get_account_data_event(event_type).await
+    }
+
+    async fn get_room_account_data_event(
+        &self,
+        room_id: &RoomId,
+        event_type: RoomAccountDataEventType,
+    ) -> Result<Option<Raw<AnyRoomAccountDataEvent>>, Self::Error> {
+        (*self).get_room_account_data_event(room_id, event_type).await
+    }
+
+    async fn get_user_room_receipt_event(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        user_id: &UserId,
+    ) -> Result<Option<(OwnedEventId, Receipt)>, Self::Error> {
+        (*self).get_user_room_receipt_event(room_id, receipt_type, thread, user_id).await
+    }
+
+    async fn get_event_room_receipt_events(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        event_id: &EventId,
+    ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error> {
+        (*self).get_event_room_receipt_events(room_id, receipt_type, thread, event_id).await
+    }
+
+    async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        (*self).get_custom_value(key).await
+    }
+
+    async fn set_custom_value(
+        &self,
+        key: &[u8],
+        value: Vec<u8>,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        (*self).set_custom_value(key, value).await
+    }
+
+    async fn remove_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        (*self).remove_custom_value(key).await
+    }
+
+    async fn remove_room(&self, room_id: &RoomId) -> Result<(), Self::Error> {
+        (*self).remove_room(room_id).await
+    }
+
+    async fn save_send_queue_request(
+        &self,
+        room_id: &RoomId,
+        transaction_id: OwnedTransactionId,
+        created_at: MilliSecondsSinceUnixEpoch,
+        request: QueuedRequestKind,
+        priority: usize,
+    ) -> Result<(), Self::Error> {
+        (*self)
+            .save_send_queue_request(room_id, transaction_id, created_at, request, priority)
+            .await
+    }
+
+    async fn update_send_queue_request(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        content: QueuedRequestKind,
+    ) -> Result<bool, Self::Error> {
+        (*self).update_send_queue_request(room_id, transaction_id, content).await
+    }
+
+    async fn remove_send_queue_request(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+    ) -> Result<bool, Self::Error> {
+        (*self).remove_send_queue_request(room_id, transaction_id).await
+    }
+
+    async fn load_send_queue_requests(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Vec<QueuedRequest>, Self::Error> {
+        (*self).load_send_queue_requests(room_id).await
+    }
+
+    async fn update_send_queue_request_status(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        error: Option<QueueWedgeError>,
+    ) -> Result<(), Self::Error> {
+        (*self).update_send_queue_request_status(room_id, transaction_id, error).await
+    }
+
+    async fn load_rooms_with_unsent_requests(&self) -> Result<Vec<OwnedRoomId>, Self::Error> {
+        (*self).load_rooms_with_unsent_requests().await
+    }
+
+    async fn save_dependent_queued_request(
+        &self,
+        room_id: &RoomId,
+        parent_txn_id: &TransactionId,
+        own_txn_id: ChildTransactionId,
+        created_at: MilliSecondsSinceUnixEpoch,
+        content: DependentQueuedRequestKind,
+    ) -> Result<(), Self::Error> {
+        (*self)
+            .save_dependent_queued_request(room_id, parent_txn_id, own_txn_id, created_at, content)
+            .await
+    }
+
+    async fn mark_dependent_queued_requests_as_ready(
+        &self,
+        room_id: &RoomId,
+        parent_txn_id: &TransactionId,
+        sent_parent_key: SentRequestKey,
+    ) -> Result<usize, Self::Error> {
+        (*self)
+            .mark_dependent_queued_requests_as_ready(room_id, parent_txn_id, sent_parent_key)
+            .await
+    }
+
+    async fn update_dependent_queued_request(
+        &self,
+        room_id: &RoomId,
+        own_transaction_id: &ChildTransactionId,
+        new_content: DependentQueuedRequestKind,
+    ) -> Result<bool, Self::Error> {
+        (*self).update_dependent_queued_request(room_id, own_transaction_id, new_content).await
+    }
+
+    async fn remove_dependent_queued_request(
+        &self,
+        room: &RoomId,
+        own_txn_id: &ChildTransactionId,
+    ) -> Result<bool, Self::Error> {
+        (*self).remove_dependent_queued_request(room, own_txn_id).await
+    }
+
+    async fn load_dependent_queued_requests(
+        &self,
+        room: &RoomId,
+    ) -> Result<Vec<DependentQueuedRequest>, Self::Error> {
+        (*self).load_dependent_queued_requests(room).await
+    }
+
+    async fn upsert_thread_subscriptions(
+        &self,
+        updates: Vec<(&RoomId, &EventId, StoredThreadSubscription)>,
+    ) -> Result<(), Self::Error> {
+        (*self).upsert_thread_subscriptions(updates).await
+    }
+
+    async fn remove_thread_subscription(
+        &self,
+        room: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<(), Self::Error> {
+        (*self).remove_thread_subscription(room, thread_id).await
+    }
+
+    async fn load_thread_subscription(
+        &self,
+        room: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<Option<StoredThreadSubscription>, Self::Error> {
+        (*self).load_thread_subscription(room, thread_id).await
+    }
+
+    async fn optimize(&self) -> Result<(), Self::Error> {
+        (*self).optimize().await
+    }
+
+    async fn get_size(&self) -> Result<Option<usize>, Self::Error> {
+        (*self).get_size().await
+    }
+}
+
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl<T: StateStore + ?Sized> StateStore for Arc<T> {
     type Error = T::Error;
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -16,6 +16,7 @@ use std::{
     borrow::Borrow,
     collections::{BTreeMap, BTreeSet, HashMap},
     fmt,
+    ops::Deref,
     sync::Arc,
 };
 
@@ -526,6 +527,306 @@ pub trait StateStore: AsyncTraitDeps {
 
     /// Returns the size of the store in bytes, if known.
     async fn get_size(&self) -> Result<Option<usize>, Self::Error>;
+}
+
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+impl<T: StateStore + ?Sized> StateStore for Arc<T> {
+    type Error = T::Error;
+
+    async fn get_kv_data(
+        &self,
+        key: StateStoreDataKey<'_>,
+    ) -> Result<Option<StateStoreDataValue>, Self::Error> {
+        self.deref().get_kv_data(key).await
+    }
+
+    async fn set_kv_data(
+        &self,
+        key: StateStoreDataKey<'_>,
+        value: StateStoreDataValue,
+    ) -> Result<(), Self::Error> {
+        self.deref().set_kv_data(key, value).await
+    }
+
+    async fn remove_kv_data(&self, key: StateStoreDataKey<'_>) -> Result<(), Self::Error> {
+        self.deref().remove_kv_data(key).await
+    }
+
+    async fn save_changes(&self, changes: &StateChanges) -> Result<(), Self::Error> {
+        self.deref().save_changes(changes).await
+    }
+
+    async fn get_presence_event(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Option<Raw<PresenceEvent>>, Self::Error> {
+        self.deref().get_presence_event(user_id).await
+    }
+
+    async fn get_presence_events(
+        &self,
+        user_ids: &[OwnedUserId],
+    ) -> Result<Vec<Raw<PresenceEvent>>, Self::Error> {
+        self.deref().get_presence_events(user_ids).await
+    }
+
+    async fn get_state_event(
+        &self,
+        room_id: &RoomId,
+        event_type: StateEventType,
+        state_key: &str,
+    ) -> Result<Option<RawAnySyncOrStrippedState>, Self::Error> {
+        self.deref().get_state_event(room_id, event_type, state_key).await
+    }
+
+    async fn get_state_events(
+        &self,
+        room_id: &RoomId,
+        event_type: StateEventType,
+    ) -> Result<Vec<RawAnySyncOrStrippedState>, Self::Error> {
+        self.deref().get_state_events(room_id, event_type).await
+    }
+
+    async fn get_state_events_for_keys(
+        &self,
+        room_id: &RoomId,
+        event_type: StateEventType,
+        state_keys: &[&str],
+    ) -> Result<Vec<RawAnySyncOrStrippedState>, Self::Error> {
+        self.deref().get_state_events_for_keys(room_id, event_type, state_keys).await
+    }
+
+    async fn get_profile(
+        &self,
+        room_id: &RoomId,
+        user_id: &UserId,
+    ) -> Result<Option<MinimalRoomMemberEvent>, Self::Error> {
+        self.deref().get_profile(room_id, user_id).await
+    }
+
+    async fn get_profiles<'a>(
+        &self,
+        room_id: &RoomId,
+        user_ids: &'a [OwnedUserId],
+    ) -> Result<BTreeMap<&'a UserId, MinimalRoomMemberEvent>, Self::Error> {
+        self.deref().get_profiles(room_id, user_ids).await
+    }
+
+    async fn get_user_ids(
+        &self,
+        room_id: &RoomId,
+        memberships: RoomMemberships,
+    ) -> Result<Vec<OwnedUserId>, Self::Error> {
+        self.deref().get_user_ids(room_id, memberships).await
+    }
+
+    async fn get_room_infos(
+        &self,
+        room_load_settings: &RoomLoadSettings,
+    ) -> Result<Vec<RoomInfo>, Self::Error> {
+        self.deref().get_room_infos(room_load_settings).await
+    }
+
+    async fn get_users_with_display_name(
+        &self,
+        room_id: &RoomId,
+        display_name: &DisplayName,
+    ) -> Result<BTreeSet<OwnedUserId>, Self::Error> {
+        self.deref().get_users_with_display_name(room_id, display_name).await
+    }
+
+    async fn get_users_with_display_names<'a>(
+        &self,
+        room_id: &RoomId,
+        display_names: &'a [DisplayName],
+    ) -> Result<HashMap<&'a DisplayName, BTreeSet<OwnedUserId>>, Self::Error> {
+        self.deref().get_users_with_display_names(room_id, display_names).await
+    }
+
+    async fn get_account_data_event(
+        &self,
+        event_type: GlobalAccountDataEventType,
+    ) -> Result<Option<Raw<AnyGlobalAccountDataEvent>>, Self::Error> {
+        self.deref().get_account_data_event(event_type).await
+    }
+
+    async fn get_room_account_data_event(
+        &self,
+        room_id: &RoomId,
+        event_type: RoomAccountDataEventType,
+    ) -> Result<Option<Raw<AnyRoomAccountDataEvent>>, Self::Error> {
+        self.deref().get_room_account_data_event(room_id, event_type).await
+    }
+
+    async fn get_user_room_receipt_event(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        user_id: &UserId,
+    ) -> Result<Option<(OwnedEventId, Receipt)>, Self::Error> {
+        self.deref().get_user_room_receipt_event(room_id, receipt_type, thread, user_id).await
+    }
+
+    async fn get_event_room_receipt_events(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        event_id: &EventId,
+    ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error> {
+        self.deref().get_event_room_receipt_events(room_id, receipt_type, thread, event_id).await
+    }
+
+    async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.deref().get_custom_value(key).await
+    }
+
+    async fn set_custom_value(
+        &self,
+        key: &[u8],
+        value: Vec<u8>,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.deref().set_custom_value(key, value).await
+    }
+
+    async fn remove_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.deref().remove_custom_value(key).await
+    }
+
+    async fn remove_room(&self, room_id: &RoomId) -> Result<(), Self::Error> {
+        self.deref().remove_room(room_id).await
+    }
+
+    async fn save_send_queue_request(
+        &self,
+        room_id: &RoomId,
+        transaction_id: OwnedTransactionId,
+        created_at: MilliSecondsSinceUnixEpoch,
+        request: QueuedRequestKind,
+        priority: usize,
+    ) -> Result<(), Self::Error> {
+        self.deref()
+            .save_send_queue_request(room_id, transaction_id, created_at, request, priority)
+            .await
+    }
+
+    async fn update_send_queue_request(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        content: QueuedRequestKind,
+    ) -> Result<bool, Self::Error> {
+        self.deref().update_send_queue_request(room_id, transaction_id, content).await
+    }
+
+    async fn remove_send_queue_request(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+    ) -> Result<bool, Self::Error> {
+        self.deref().remove_send_queue_request(room_id, transaction_id).await
+    }
+
+    async fn load_send_queue_requests(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Vec<QueuedRequest>, Self::Error> {
+        self.deref().load_send_queue_requests(room_id).await
+    }
+
+    async fn update_send_queue_request_status(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        error: Option<QueueWedgeError>,
+    ) -> Result<(), Self::Error> {
+        self.deref().update_send_queue_request_status(room_id, transaction_id, error).await
+    }
+
+    async fn load_rooms_with_unsent_requests(&self) -> Result<Vec<OwnedRoomId>, Self::Error> {
+        self.deref().load_rooms_with_unsent_requests().await
+    }
+
+    async fn save_dependent_queued_request(
+        &self,
+        room_id: &RoomId,
+        parent_txn_id: &TransactionId,
+        own_txn_id: ChildTransactionId,
+        created_at: MilliSecondsSinceUnixEpoch,
+        content: DependentQueuedRequestKind,
+    ) -> Result<(), Self::Error> {
+        self.deref()
+            .save_dependent_queued_request(room_id, parent_txn_id, own_txn_id, created_at, content)
+            .await
+    }
+
+    async fn mark_dependent_queued_requests_as_ready(
+        &self,
+        room_id: &RoomId,
+        parent_txn_id: &TransactionId,
+        sent_parent_key: SentRequestKey,
+    ) -> Result<usize, Self::Error> {
+        self.deref()
+            .mark_dependent_queued_requests_as_ready(room_id, parent_txn_id, sent_parent_key)
+            .await
+    }
+
+    async fn update_dependent_queued_request(
+        &self,
+        room_id: &RoomId,
+        own_transaction_id: &ChildTransactionId,
+        new_content: DependentQueuedRequestKind,
+    ) -> Result<bool, Self::Error> {
+        self.deref().update_dependent_queued_request(room_id, own_transaction_id, new_content).await
+    }
+
+    async fn remove_dependent_queued_request(
+        &self,
+        room: &RoomId,
+        own_txn_id: &ChildTransactionId,
+    ) -> Result<bool, Self::Error> {
+        self.deref().remove_dependent_queued_request(room, own_txn_id).await
+    }
+
+    async fn load_dependent_queued_requests(
+        &self,
+        room: &RoomId,
+    ) -> Result<Vec<DependentQueuedRequest>, Self::Error> {
+        self.deref().load_dependent_queued_requests(room).await
+    }
+
+    async fn upsert_thread_subscriptions(
+        &self,
+        updates: Vec<(&RoomId, &EventId, StoredThreadSubscription)>,
+    ) -> Result<(), Self::Error> {
+        self.deref().upsert_thread_subscriptions(updates).await
+    }
+
+    async fn remove_thread_subscription(
+        &self,
+        room: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<(), Self::Error> {
+        self.deref().remove_thread_subscription(room, thread_id).await
+    }
+
+    async fn load_thread_subscription(
+        &self,
+        room: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<Option<StoredThreadSubscription>, Self::Error> {
+        self.deref().load_thread_subscription(room, thread_id).await
+    }
+
+    async fn optimize(&self) -> Result<(), Self::Error> {
+        self.deref().optimize().await
+    }
+
+    async fn get_size(&self) -> Result<Option<usize>, Self::Error> {
+        self.deref().get_size().await
+    }
 }
 
 #[repr(transparent)]
@@ -1385,21 +1686,6 @@ where
 {
     fn into_state_store(self) -> Arc<DynStateStore> {
         Arc::new(EraseStateStoreError(self))
-    }
-}
-
-// Turns a given `Arc<T>` into `Arc<DynStateStore>` by attaching the
-// StateStore impl vtable of `EraseStateStoreError<T>`.
-impl<T> IntoStateStore for Arc<T>
-where
-    T: StateStore + 'static,
-{
-    fn into_state_store(self) -> Arc<DynStateStore> {
-        let ptr: *const T = Arc::into_raw(self);
-        let ptr_erased = ptr as *const EraseStateStoreError<T>;
-        // SAFETY: EraseStateStoreError is repr(transparent) so T and
-        //         EraseStateStoreError<T> have the same layout and ABI
-        unsafe { Arc::from_raw(ptr_erased) }
     }
 }
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -1456,7 +1456,6 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
 
 /// A wrapper around a [`StateStore`] that supports synchronizing calls to
 /// [`StateStore::save_changes`].
-#[allow(unused)]
 #[derive(Debug, Clone)]
 pub struct SaveLockedStateStore<T = Arc<DynStateStore>> {
     store: T,
@@ -1479,16 +1478,22 @@ impl From<IncorrectMutexGuardError> for StoreError {
 
 impl<T> SaveLockedStateStore<T> {
     /// Creates a new [`SaveLockedStateStore`] with the provided store.
-    #[allow(unused)]
     pub fn new(store: T) -> Self {
         Self { store, lock: Arc::new(Mutex::new(())) }
     }
 
     /// Returns a reference to the underlying [`Mutex`] used to synchronize
     /// calls to [`StateStore::save_changes`].
-    #[allow(unused)]
     pub fn lock(&self) -> &Mutex<()> {
         self.lock.as_ref()
+    }
+
+    // This function is added temporarily to allow for making incremental
+    // commits when types are being transitioned to use a [`SaveLockedStateStore`].
+    // This should be deleted once the transition is complete, as the underlying
+    // store should not be accessible outside of [`SaveLockedStateStore`].
+    pub(crate) fn store(&self) -> &T {
+        &self.store
     }
 }
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -46,6 +46,8 @@ use ruma::{
     serde::Raw,
 };
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::{Mutex, MutexGuard};
 
 use super::{
     ChildTransactionId, DependentQueuedRequest, DependentQueuedRequestKind, QueueWedgeError,
@@ -848,6 +850,364 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
 
     async fn get_size(&self) -> Result<Option<usize>, Self::Error> {
         self.0.get_size().await.map_err(Into::into)
+    }
+}
+
+/// A wrapper around a [`StateStore`] that supports synchronizing calls to
+/// [`StateStore::save_changes`].
+#[allow(unused)]
+#[derive(Debug, Clone)]
+pub struct SaveLockedStateStore<T = Arc<DynStateStore>> {
+    store: T,
+    lock: Arc<Mutex<()>>,
+}
+
+/// An error type that represents a scenario where a [`MutexGuard`] provided to
+/// a function does not reference the underlying [`Mutex`] in the enclosing
+/// [`SaveLockedStateStore`].
+#[allow(unused)]
+#[derive(Debug, Error)]
+#[error("a mutex guard was provided, but it does not reference the correct mutex")]
+pub struct IncorrectMutexGuardError;
+
+impl From<IncorrectMutexGuardError> for StoreError {
+    fn from(value: IncorrectMutexGuardError) -> Self {
+        Self::backend(value)
+    }
+}
+
+impl<T> SaveLockedStateStore<T> {
+    /// Creates a new [`SaveLockedStateStore`] with the provided store.
+    #[allow(unused)]
+    pub fn new(store: T) -> Self {
+        Self { store, lock: Arc::new(Mutex::new(())) }
+    }
+
+    /// Returns a reference to the underlying [`Mutex`] used to synchronize
+    /// calls to [`StateStore::save_changes`].
+    #[allow(unused)]
+    pub fn lock(&self) -> &Mutex<()> {
+        self.lock.as_ref()
+    }
+}
+
+impl<T: StateStore> SaveLockedStateStore<T> {
+    /// Provides a means of calling [`StateStore::save_changes`] when the caller
+    /// has already acquired the underlying [`Mutex`]. Returns an error if
+    /// the [`MutexGuard`] provided does not reference the underlying
+    /// [`Mutex`].
+    #[allow(unused)]
+    pub async fn save_changes_with_guard(
+        &self,
+        guard: &MutexGuard<'_, ()>,
+        changes: &StateChanges,
+    ) -> Result<(), StoreError> {
+        if !std::ptr::eq(MutexGuard::mutex(guard), self.lock()) {
+            Err(IncorrectMutexGuardError.into())
+        } else {
+            self.store.save_changes(changes).await.map_err(Into::into)
+        }
+    }
+}
+
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+impl<T: StateStore> StateStore for SaveLockedStateStore<T> {
+    type Error = T::Error;
+
+    async fn get_kv_data(
+        &self,
+        key: StateStoreDataKey<'_>,
+    ) -> Result<Option<StateStoreDataValue>, Self::Error> {
+        self.store.get_kv_data(key).await
+    }
+
+    async fn set_kv_data(
+        &self,
+        key: StateStoreDataKey<'_>,
+        value: StateStoreDataValue,
+    ) -> Result<(), Self::Error> {
+        self.store.set_kv_data(key, value).await
+    }
+
+    async fn remove_kv_data(&self, key: StateStoreDataKey<'_>) -> Result<(), Self::Error> {
+        self.store.remove_kv_data(key).await
+    }
+
+    async fn save_changes(&self, changes: &StateChanges) -> Result<(), Self::Error> {
+        let _guard = self.lock.lock().await;
+        self.store.save_changes(changes).await
+    }
+
+    async fn get_presence_event(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Option<Raw<PresenceEvent>>, Self::Error> {
+        self.store.get_presence_event(user_id).await
+    }
+
+    async fn get_presence_events(
+        &self,
+        user_ids: &[OwnedUserId],
+    ) -> Result<Vec<Raw<PresenceEvent>>, Self::Error> {
+        self.store.get_presence_events(user_ids).await
+    }
+
+    async fn get_state_event(
+        &self,
+        room_id: &RoomId,
+        event_type: StateEventType,
+        state_key: &str,
+    ) -> Result<Option<RawAnySyncOrStrippedState>, Self::Error> {
+        self.store.get_state_event(room_id, event_type, state_key).await
+    }
+
+    async fn get_state_events(
+        &self,
+        room_id: &RoomId,
+        event_type: StateEventType,
+    ) -> Result<Vec<RawAnySyncOrStrippedState>, Self::Error> {
+        self.store.get_state_events(room_id, event_type).await
+    }
+
+    async fn get_state_events_for_keys(
+        &self,
+        room_id: &RoomId,
+        event_type: StateEventType,
+        state_keys: &[&str],
+    ) -> Result<Vec<RawAnySyncOrStrippedState>, Self::Error> {
+        self.store.get_state_events_for_keys(room_id, event_type, state_keys).await
+    }
+
+    async fn get_profile(
+        &self,
+        room_id: &RoomId,
+        user_id: &UserId,
+    ) -> Result<Option<MinimalRoomMemberEvent>, Self::Error> {
+        self.store.get_profile(room_id, user_id).await
+    }
+
+    async fn get_profiles<'a>(
+        &self,
+        room_id: &RoomId,
+        user_ids: &'a [OwnedUserId],
+    ) -> Result<BTreeMap<&'a UserId, MinimalRoomMemberEvent>, Self::Error> {
+        self.store.get_profiles(room_id, user_ids).await
+    }
+
+    async fn get_user_ids(
+        &self,
+        room_id: &RoomId,
+        memberships: RoomMemberships,
+    ) -> Result<Vec<OwnedUserId>, Self::Error> {
+        self.store.get_user_ids(room_id, memberships).await
+    }
+
+    async fn get_room_infos(
+        &self,
+        room_load_settings: &RoomLoadSettings,
+    ) -> Result<Vec<RoomInfo>, Self::Error> {
+        self.store.get_room_infos(room_load_settings).await
+    }
+
+    async fn get_users_with_display_name(
+        &self,
+        room_id: &RoomId,
+        display_name: &DisplayName,
+    ) -> Result<BTreeSet<OwnedUserId>, Self::Error> {
+        self.store.get_users_with_display_name(room_id, display_name).await
+    }
+
+    async fn get_users_with_display_names<'a>(
+        &self,
+        room_id: &RoomId,
+        display_names: &'a [DisplayName],
+    ) -> Result<HashMap<&'a DisplayName, BTreeSet<OwnedUserId>>, Self::Error> {
+        self.store.get_users_with_display_names(room_id, display_names).await
+    }
+
+    async fn get_account_data_event(
+        &self,
+        event_type: GlobalAccountDataEventType,
+    ) -> Result<Option<Raw<AnyGlobalAccountDataEvent>>, Self::Error> {
+        self.store.get_account_data_event(event_type).await
+    }
+
+    async fn get_room_account_data_event(
+        &self,
+        room_id: &RoomId,
+        event_type: RoomAccountDataEventType,
+    ) -> Result<Option<Raw<AnyRoomAccountDataEvent>>, Self::Error> {
+        self.store.get_room_account_data_event(room_id, event_type).await
+    }
+
+    async fn get_user_room_receipt_event(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        user_id: &UserId,
+    ) -> Result<Option<(OwnedEventId, Receipt)>, Self::Error> {
+        self.store.get_user_room_receipt_event(room_id, receipt_type, thread, user_id).await
+    }
+
+    async fn get_event_room_receipt_events(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        event_id: &EventId,
+    ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error> {
+        self.store.get_event_room_receipt_events(room_id, receipt_type, thread, event_id).await
+    }
+
+    async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.store.get_custom_value(key).await
+    }
+
+    async fn set_custom_value(
+        &self,
+        key: &[u8],
+        value: Vec<u8>,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.store.set_custom_value(key, value).await
+    }
+
+    async fn remove_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.store.remove_custom_value(key).await
+    }
+
+    async fn remove_room(&self, room_id: &RoomId) -> Result<(), Self::Error> {
+        self.store.remove_room(room_id).await
+    }
+
+    async fn save_send_queue_request(
+        &self,
+        room_id: &RoomId,
+        transaction_id: OwnedTransactionId,
+        created_at: MilliSecondsSinceUnixEpoch,
+        request: QueuedRequestKind,
+        priority: usize,
+    ) -> Result<(), Self::Error> {
+        self.store
+            .save_send_queue_request(room_id, transaction_id, created_at, request, priority)
+            .await
+    }
+
+    async fn update_send_queue_request(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        content: QueuedRequestKind,
+    ) -> Result<bool, Self::Error> {
+        self.store.update_send_queue_request(room_id, transaction_id, content).await
+    }
+
+    async fn remove_send_queue_request(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+    ) -> Result<bool, Self::Error> {
+        self.store.remove_send_queue_request(room_id, transaction_id).await
+    }
+
+    async fn load_send_queue_requests(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Vec<QueuedRequest>, Self::Error> {
+        self.store.load_send_queue_requests(room_id).await
+    }
+
+    async fn update_send_queue_request_status(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        error: Option<QueueWedgeError>,
+    ) -> Result<(), Self::Error> {
+        self.store.update_send_queue_request_status(room_id, transaction_id, error).await
+    }
+
+    async fn load_rooms_with_unsent_requests(&self) -> Result<Vec<OwnedRoomId>, Self::Error> {
+        self.store.load_rooms_with_unsent_requests().await
+    }
+
+    async fn save_dependent_queued_request(
+        &self,
+        room_id: &RoomId,
+        parent_txn_id: &TransactionId,
+        own_txn_id: ChildTransactionId,
+        created_at: MilliSecondsSinceUnixEpoch,
+        content: DependentQueuedRequestKind,
+    ) -> Result<(), Self::Error> {
+        self.store
+            .save_dependent_queued_request(room_id, parent_txn_id, own_txn_id, created_at, content)
+            .await
+    }
+
+    async fn mark_dependent_queued_requests_as_ready(
+        &self,
+        room_id: &RoomId,
+        parent_txn_id: &TransactionId,
+        sent_parent_key: SentRequestKey,
+    ) -> Result<usize, Self::Error> {
+        self.store
+            .mark_dependent_queued_requests_as_ready(room_id, parent_txn_id, sent_parent_key)
+            .await
+    }
+
+    async fn update_dependent_queued_request(
+        &self,
+        room_id: &RoomId,
+        own_transaction_id: &ChildTransactionId,
+        new_content: DependentQueuedRequestKind,
+    ) -> Result<bool, Self::Error> {
+        self.store.update_dependent_queued_request(room_id, own_transaction_id, new_content).await
+    }
+
+    async fn remove_dependent_queued_request(
+        &self,
+        room: &RoomId,
+        own_txn_id: &ChildTransactionId,
+    ) -> Result<bool, Self::Error> {
+        self.store.remove_dependent_queued_request(room, own_txn_id).await
+    }
+
+    async fn load_dependent_queued_requests(
+        &self,
+        room: &RoomId,
+    ) -> Result<Vec<DependentQueuedRequest>, Self::Error> {
+        self.store.load_dependent_queued_requests(room).await
+    }
+
+    async fn upsert_thread_subscriptions(
+        &self,
+        updates: Vec<(&RoomId, &EventId, StoredThreadSubscription)>,
+    ) -> Result<(), Self::Error> {
+        self.store.upsert_thread_subscriptions(updates).await
+    }
+
+    async fn remove_thread_subscription(
+        &self,
+        room: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<(), Self::Error> {
+        self.store.remove_thread_subscription(room, thread_id).await
+    }
+
+    async fn load_thread_subscription(
+        &self,
+        room: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<Option<StoredThreadSubscription>, Self::Error> {
+        self.store.load_thread_subscription(room, thread_id).await
+    }
+
+    async fn optimize(&self) -> Result<(), Self::Error> {
+        self.store.optimize().await
+    }
+
+    async fn get_size(&self) -> Result<Option<usize>, Self::Error> {
+        self.store.get_size().await
     }
 }
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -1487,14 +1487,6 @@ impl<T> SaveLockedStateStore<T> {
     pub fn lock(&self) -> &Mutex<()> {
         self.lock.as_ref()
     }
-
-    // This function is added temporarily to allow for making incremental
-    // commits when types are being transitioned to use a [`SaveLockedStateStore`].
-    // This should be deleted once the transition is complete, as the underlying
-    // store should not be accessible outside of [`SaveLockedStateStore`].
-    pub(crate) fn store(&self) -> &T {
-        &self.store
-    }
 }
 
 impl<T: StateStore> SaveLockedStateStore<T> {

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -2421,3 +2421,96 @@ pub fn compare_thread_subscription_bump_stamps(
 
     true
 }
+
+#[cfg(test)]
+mod tests {
+    mod save_locked_state_store {
+        use std::time::Duration;
+
+        use assert_matches::assert_matches;
+        use futures_util::future::{self, Either};
+        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+        use gloo_timers::future::sleep;
+        use matrix_sdk_common::executor::spawn;
+        use matrix_sdk_test::async_test;
+        use tokio::sync::Mutex;
+        #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+        use tokio::time::sleep;
+
+        use crate::{
+            StateChanges, StateStore,
+            store::{IntoStateStore, MemoryStore, Result, SaveLockedStateStore},
+        };
+
+        async fn get_store() -> Result<impl StateStore> {
+            Ok(SaveLockedStateStore::new(MemoryStore::new()))
+        }
+
+        statestore_integration_tests!();
+
+        #[async_test]
+        async fn test_state_store_only_accepts_guard_for_underlying_mutex() {
+            let state_store = SaveLockedStateStore::new(MemoryStore::new());
+            let state_changes = StateChanges::default();
+            state_store
+                .save_changes_with_guard(&state_store.lock().lock().await, &state_changes)
+                .await
+                .expect("state store accepts guard for underlying mutex");
+
+            let mutex = Mutex::new(());
+            state_store
+                .save_changes_with_guard(&mutex.lock().await, &state_changes)
+                .await
+                .expect_err("state store does not accept guard for unknown mutex");
+        }
+
+        #[derive(Debug)]
+        struct Elapsed;
+
+        async fn timeout<F: Future + Unpin>(
+            duration: Duration,
+            f: F,
+        ) -> Result<F::Output, Elapsed> {
+            #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+            {
+                match future::select(sleep(duration), f).await {
+                    Either::Left(_) => return Err(Elapsed),
+                    Either::Right((output, _)) => Ok(output),
+                }
+            }
+            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+            {
+                tokio::time::timeout(duration, f).await.map_err(|_| Elapsed)
+            }
+        }
+
+        #[async_test]
+        async fn test_state_store_waits_to_acquire_lock_before_saving_changes() {
+            let state_store = SaveLockedStateStore::new(MemoryStore::new().into_state_store());
+
+            // Acquire lock and hold it for 5 seconds
+            let lock_task = spawn({
+                let state_store = state_store.clone();
+                async move {
+                    let lock = state_store.lock();
+                    let _guard = lock.lock().await;
+                    sleep(Duration::from_secs(5)).await;
+                }
+            });
+
+            // Try to save changes to the state store while the lock is held by another task
+            let save_task =
+                spawn(async move { state_store.save_changes(&StateChanges::default()).await });
+
+            // Ensure that the second task does not progress until the first task has
+            // completed and therefore release the save lock
+            assert_matches!(future::select(lock_task, save_task).await, Either::Left((_, save_task)) => {
+                timeout(Duration::from_millis(100), save_task)
+                    .await
+                    .expect("task completes before timeout")
+                    .expect("task completes successfully")
+                    .expect("task saves changes");
+            });
+        }
+    }
+}

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -1465,7 +1465,6 @@ pub struct SaveLockedStateStore<T = Arc<DynStateStore>> {
 /// An error type that represents a scenario where a [`MutexGuard`] provided to
 /// a function does not reference the underlying [`Mutex`] in the enclosing
 /// [`SaveLockedStateStore`].
-#[allow(unused)]
 #[derive(Debug, Error)]
 #[error("a mutex guard was provided, but it does not reference the correct mutex")]
 pub struct IncorrectMutexGuardError;
@@ -1494,7 +1493,6 @@ impl<T: StateStore> SaveLockedStateStore<T> {
     /// has already acquired the underlying [`Mutex`]. Returns an error if
     /// the [`MutexGuard`] provided does not reference the underlying
     /// [`Mutex`].
-    #[allow(unused)]
     pub async fn save_changes_with_guard(
         &self,
         guard: &MutexGuard<'_, ()>,

--- a/crates/matrix-sdk-ui/src/room_list_service/sorters/recency.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/sorters/recency.rs
@@ -163,17 +163,21 @@ mod tests {
         })
     }
 
-    fn set_latest_event_value(room: &mut RoomListItem, latest_event_value: LatestEventValue) {
-        let mut room_info = room.clone_info();
-        room_info.set_latest_event(latest_event_value);
-        room.set_room_info(room_info, RoomInfoNotableUpdateReasons::LATEST_EVENT);
+    async fn set_latest_event_value(room: &mut RoomListItem, latest_event_value: LatestEventValue) {
+        room.update_room_info(|mut info| {
+            info.set_latest_event(latest_event_value);
+            (info, RoomInfoNotableUpdateReasons::LATEST_EVENT)
+        })
+        .await;
         room.refresh_cached_data();
     }
 
-    fn set_recency_stamp(room: &mut RoomListItem, recency_stamp: RoomRecencyStamp) {
-        let mut room_info = room.clone_info();
-        room_info.update_recency_stamp(recency_stamp);
-        room.set_room_info(room_info, RoomInfoNotableUpdateReasons::RECENCY_STAMP);
+    async fn set_recency_stamp(room: &mut RoomListItem, recency_stamp: RoomRecencyStamp) {
+        room.update_room_info(|mut info| {
+            info.update_recency_stamp(recency_stamp);
+            (info, RoomInfoNotableUpdateReasons::RECENCY_STAMP)
+        })
+        .await;
         room.refresh_cached_data();
     }
 
@@ -184,15 +188,15 @@ mod tests {
         let [mut room_a, mut room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 
-        set_recency_stamp(&mut room_a, 1.into());
-        set_recency_stamp(&mut room_b, 2.into());
+        set_recency_stamp(&mut room_a, 1.into()).await;
+        set_recency_stamp(&mut room_b, 2.into()).await;
 
         // Both rooms have a `LatestEventValue::None`.
         //
         // Because there is no latest event, the recency stamp MUST BE USED.
         {
-            set_latest_event_value(&mut room_a, none());
-            set_latest_event_value(&mut room_b, none());
+            set_latest_event_value(&mut room_a, none()).await;
+            set_latest_event_value(&mut room_b, none()).await;
 
             assert_eq!(extract_scores(&room_a, &room_b), (Some(1), Some(2)));
         }
@@ -201,8 +205,8 @@ mod tests {
         //
         // One of the room has a latest event, so the recency stamp MUST BE IGNORED.
         {
-            set_latest_event_value(&mut room_a, none());
-            set_latest_event_value(&mut room_b, remote(3));
+            set_latest_event_value(&mut room_a, none()).await;
+            set_latest_event_value(&mut room_b, remote(3)).await;
 
             assert_eq!(extract_scores(&room_a, &room_b), (None, Some(3)));
         }
@@ -211,8 +215,8 @@ mod tests {
         //
         // One of the room has a latest event, so the recency stamp MUST BE IGNORED.
         {
-            set_latest_event_value(&mut room_a, remote(3));
-            set_latest_event_value(&mut room_b, none());
+            set_latest_event_value(&mut room_a, remote(3)).await;
+            set_latest_event_value(&mut room_b, none()).await;
 
             assert_eq!(extract_scores(&room_a, &room_b), (Some(3), None));
         }
@@ -225,8 +229,8 @@ mod tests {
         let [mut room_a, mut room_b] =
             new_rooms([room_id!("!a:b.c"), room_id!("!d:e.f")], &client, &server).await;
 
-        set_recency_stamp(&mut room_a, 1.into());
-        set_recency_stamp(&mut room_b, 2.into());
+        set_recency_stamp(&mut room_a, 1.into()).await;
+        set_recency_stamp(&mut room_b, 2.into()).await;
 
         // `room_a` and `room_b` has either `Remote` or `Local*`.
         //
@@ -236,8 +240,8 @@ mod tests {
                 for latest_event_value_b in
                     [remote(4), local_is_sending(4), local_cannot_be_sent(4)]
                 {
-                    set_latest_event_value(&mut room_a, latest_event_value_a.clone());
-                    set_latest_event_value(&mut room_b, latest_event_value_b);
+                    set_latest_event_value(&mut room_a, latest_event_value_a.clone()).await;
+                    set_latest_event_value(&mut room_b, latest_event_value_b).await;
 
                     assert_eq!(extract_scores(&room_a, &room_b), (Some(3), Some(4)));
                 }

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] Enforce atomic and synchronized updates to `RoomInfo`. Requires 
+  `StateStore::save_changes` to acquire state store lock and replaces `Room::set_room_info` 
+  with an atomic version, `Room::update_room_info`, which is also synchronized by
+  the state store lock.
+  ([#6478](https://github.com/matrix-org/matrix-rust-sdk/pull/6478))
 - Added `beacon` and `beacon_info` fields to `RoomPowerLevelChanges`, allowing callers to read
   and update the power levels required to send beacon (live location) message events and beacon
   info state events respectively.

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -23,8 +23,7 @@ use std::{
 use eyeball::SharedObservable;
 use eyeball_im::VectorDiff;
 use matrix_sdk_base::{
-    RoomInfoNotableUpdateReasons, StateChanges, apply_redaction,
-    check_validity_of_replacement_events,
+    RoomInfoNotableUpdateReasons, apply_redaction, check_validity_of_replacement_events,
     deserialized_responses::{ThreadSummary, ThreadSummaryStatus},
     event_cache::{
         Event, Gap,
@@ -1059,27 +1058,15 @@ impl<'a> RoomEventCacheStateLockWriteGuard<'a> {
             // The read receipt has changed! Do a little dance to update the `RoomInfo` in
             // the state store, and then in the room itself, so that observers
             // can be notified of the change.
-            let client = room.client();
-
-            // Take the state store lock.
-            let _state_store_lock = client.base_client().state_store_lock().lock().await;
-
-            // Don't reuse the room info from above, as it might have changed in the
-            // meanwhile. This access is somewhat protected by the state store locking, even
-            // though other code may call `set_room_info` concurrently.
-            let mut room_info = room.clone_info();
-            room_info.set_read_receipts(read_receipts);
-
-            let mut state_changes = StateChanges::default();
-            state_changes.add_room(room_info.clone());
-
-            // Update the `RoomInfo` in the state store.
-            if let Err(error) = client.state_store().save_changes(&state_changes).await {
+            let result = room
+                .update_and_save_room_info(|mut room_info| {
+                    room_info.set_read_receipts(read_receipts);
+                    (room_info, RoomInfoNotableUpdateReasons::READ_RECEIPT)
+                })
+                .await;
+            if let Err(error) = result {
                 error!(room_id = ?room.room_id(), ?error, "Failed to save the changes");
             }
-
-            // Update the `RoomInfo` of the room.
-            room.set_room_info(room_info, RoomInfoNotableUpdateReasons::READ_RECEIPT);
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
@@ -21,7 +21,7 @@ use eyeball::{AsyncLock, ObservableWriteGuard, SharedObservable, Subscriber};
 pub use matrix_sdk_base::latest_event::{
     LatestEventValue, LocalLatestEventValue, RemoteLatestEventValue,
 };
-use matrix_sdk_base::{RoomInfoNotableUpdateReasons, RoomState, StateChanges};
+use matrix_sdk_base::{RoomInfoNotableUpdateReasons, RoomState};
 use ruma::{EventId, OwnedEventId, UserId, events::room::power_levels::RoomPowerLevels};
 use tracing::{error, info, instrument, trace, warn};
 
@@ -246,26 +246,15 @@ impl LatestEvent {
             warn!(room_id = ?self.weak_room.room_id(), "Cannot store the latest event value because the room cannot be accessed");
             return;
         };
-
-        let client = room.client();
-
-        // Take the state store lock.
-        let _state_store_lock = client.base_client().state_store_lock().lock().await;
-
-        // Compute a new `RoomInfo`.
-        let mut room_info = room.clone_info();
-        room_info.set_latest_event(new_value);
-
-        let mut state_changes = StateChanges::default();
-        state_changes.add_room(room_info.clone());
-
-        // Update the `RoomInfo` in the state store.
-        if let Err(error) = client.state_store().save_changes(&state_changes).await {
+        let result = room
+            .update_and_save_room_info(|mut info| {
+                info.set_latest_event(new_value);
+                (info, RoomInfoNotableUpdateReasons::LATEST_EVENT)
+            })
+            .await;
+        if let Err(error) = result {
             error!(room_id = ?room.room_id(), ?error, "Failed to save the changes");
         }
-
-        // Update the `RoomInfo` of the room.
-        room.set_room_info(room_info, RoomInfoNotableUpdateReasons::LATEST_EVENT);
     }
 }
 
@@ -386,9 +375,11 @@ mod tests_latest_event {
 
         // Set the `RoomInfo`.
         {
-            let mut room_info = room.clone_info();
-            room_info.set_latest_event(LatestEventValue::LocalIsSending(local_room_message("foo")));
-            room.set_room_info(room_info, Default::default());
+            room.update_room_info(|mut info| {
+                info.set_latest_event(LatestEventValue::LocalIsSending(local_room_message("foo")));
+                (info, Default::default())
+            })
+            .await;
         }
 
         // Second time. We get `LocalIsSending` from `RoomInfo`.

--- a/crates/matrix-sdk/src/latest_events/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/mod.rs
@@ -1389,7 +1389,7 @@ mod tests {
         // `room_0` always has a `LatestEventValue::None` as its the default value.
         let mut room_info_1 = room_0.clone_info();
         room_info_1.set_latest_event(LatestEventValue::LocalIsSending(local_room_message("foo")));
-        room_1.set_room_info(room_info_1, Default::default());
+        room_1.update_room_info(|_| (room_info_1, Default::default())).await;
 
         let weak_client = WeakClient::from_client(&client);
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -41,7 +41,7 @@ use matrix_sdk_base::crypto::{
 pub use matrix_sdk_base::store::StoredThreadSubscription;
 use matrix_sdk_base::{
     ComposerDraft, EncryptionState, RoomInfoNotableUpdateReasons, RoomMemberships, SendOutsideWasm,
-    StateChanges, StateStoreDataKey, StateStoreDataValue,
+    StateStoreDataKey, StateStoreDataValue,
     deserialized_responses::{
         RawAnySyncOrStrippedState, RawSyncOrStrippedState, SyncOrStrippedState,
     },
@@ -1101,18 +1101,14 @@ impl Room {
                     Err(err) => return Err(err.into()),
                 };
 
-                let _state_store_lock = self.client.base_client().state_store_lock().lock().await;
-
                 // Persist the event and the fact that we requested it from the server in
                 // `RoomInfo`.
-                let mut room_info = self.clone_info();
-                room_info.mark_encryption_state_synced();
-                room_info.set_encryption_event(response);
-                let mut changes = StateChanges::default();
-                changes.add_room(room_info.clone());
-
-                self.client.state_store().save_changes(&changes).await?;
-                self.set_room_info(room_info, RoomInfoNotableUpdateReasons::empty());
+                self.update_and_save_room_info(|mut room_info| {
+                    room_info.mark_encryption_state_synced();
+                    room_info.set_encryption_event(response);
+                    (room_info, RoomInfoNotableUpdateReasons::empty())
+                })
+                .await?;
 
                 Ok(())
             })
@@ -2266,7 +2262,7 @@ impl Room {
             )
             .await;
 
-            let _state_store_lock = self.client.base_client().state_store_lock().lock().await;
+            let store_guard = self.client.base_client().state_store_lock().lock().await;
 
             // If encryption was enabled, return.
             #[cfg(not(feature = "experimental-encrypted-state-events"))]
@@ -2294,13 +2290,11 @@ impl Room {
             // assuming it's sync'd and correct (and not encrypted).
             debug!("still not marked as encrypted, marking encryption state as missing");
 
-            let mut room_info = self.clone_info();
-            room_info.mark_encryption_state_missing();
-            let mut changes = StateChanges::default();
-            changes.add_room(room_info.clone());
-
-            self.client.state_store().save_changes(&changes).await?;
-            self.set_room_info(room_info, RoomInfoNotableUpdateReasons::empty());
+            self.update_and_save_room_info_with_store_guard(&store_guard, |mut info| {
+                info.mark_encryption_state_missing();
+                (info, RoomInfoNotableUpdateReasons::empty())
+            })
+            .await?;
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -13,6 +13,7 @@ use ruma::{
     },
     events::GlobalAccountDataEventType,
 };
+use tokio::sync::MutexGuard;
 use tracing::error;
 
 use super::{SlidingSync, SlidingSyncBuilder};
@@ -142,8 +143,14 @@ impl Client {
         response: &http::Response,
         requested_required_states: &RequestedRequiredStates,
     ) -> Result<SyncResponse> {
-        let response =
-            self.base_client().process_sliding_sync(response, requested_required_states).await?;
+        let response = self
+            .base_client()
+            .process_sliding_sync(
+                response,
+                requested_required_states,
+                &self.base_client().state_store_lock().lock().await,
+            )
+            .await?;
 
         tracing::debug!("done processing on base_client");
         self.call_sync_response_handlers(&response).await?;
@@ -170,7 +177,11 @@ impl SlidingSyncResponseProcessor {
     }
 
     #[cfg(feature = "e2e-encryption")]
-    pub async fn handle_encryption(&mut self, extensions: &response::Extensions) -> Result<()> {
+    pub async fn handle_encryption(
+        &mut self,
+        extensions: &response::Extensions,
+        state_store_guard: &MutexGuard<'_, ()>,
+    ) -> Result<()> {
         // This is an internal API misuse if this is triggered (calling
         // `handle_room_response` before this function), so panic is fine.
         assert!(self.response.is_none());
@@ -178,7 +189,11 @@ impl SlidingSyncResponseProcessor {
         self.to_device_events = if let Some(to_device_events) = self
             .client
             .base_client()
-            .process_sliding_sync_e2ee(extensions.to_device.as_ref(), &extensions.e2ee)
+            .process_sliding_sync_e2ee(
+                extensions.to_device.as_ref(),
+                &extensions.e2ee,
+                state_store_guard,
+            )
             .await?
         {
             // Some new keys might have been received, so trigger a backup if needed.
@@ -196,6 +211,7 @@ impl SlidingSyncResponseProcessor {
         &mut self,
         response: &http::Response,
         requested_required_states: &RequestedRequiredStates,
+        state_store_guard: &MutexGuard<'_, ()>,
     ) -> Result<()> {
         subscribe_to_room_latest_events(&self.client, response.rooms.keys()).await;
 
@@ -209,10 +225,11 @@ impl SlidingSyncResponseProcessor {
         let mut sync_response = self
             .client
             .base_client()
-            .process_sliding_sync(response, requested_required_states)
+            .process_sliding_sync(response, requested_required_states, state_store_guard)
             .await?;
 
-        handle_receipts_extension(&self.client, response, &mut sync_response).await?;
+        handle_receipts_extension(&self.client, response, &mut sync_response, state_store_guard)
+            .await?;
 
         update_in_memory_caches(&self.client, &previously_joined_rooms, &sync_response).await;
 
@@ -319,6 +336,7 @@ async fn handle_receipts_extension(
     client: &Client,
     response: &http::Response,
     sync_response: &mut SyncResponse,
+    state_store_guard: &MutexGuard<'_, ()>,
 ) -> Result<()> {
     let _timer = timer!(tracing::Level::TRACE, "handle_receipts_extension");
 
@@ -337,7 +355,7 @@ async fn handle_receipts_extension(
     let futures = room_ids.into_iter().map(|room_id| async {
         let receipt_event = client
             .base_client()
-            .process_sliding_sync_receipts_extension_for_room(&room_id, response)
+            .process_sliding_sync_receipts_extension_for_room(&room_id, response, state_store_guard)
             .await?;
 
         Result::<_, crate::Error>::Ok(Some((room_id, receipt_event)))
@@ -684,10 +702,17 @@ mod tests {
         response.rooms.insert(room_id.to_owned(), room);
 
         let mut processor = SlidingSyncResponseProcessor::new(client.clone());
-        processor
-            .handle_room_response(&response, &RequestedRequiredStates::default())
-            .await
-            .expect("Failed to process sync");
+        {
+            let state_store_guard = client.base_client().state_store_lock().lock().await;
+            processor
+                .handle_room_response(
+                    &response,
+                    &RequestedRequiredStates::default(),
+                    &state_store_guard,
+                )
+                .await
+                .expect("Failed to process sync");
+        }
         processor.process_and_take_response().await.expect("Failed to finish processing sync");
 
         // Then room info notable updates are received.
@@ -722,10 +747,17 @@ mod tests {
         response.rooms.insert(room_id.to_owned(), room);
 
         let mut processor = SlidingSyncResponseProcessor::new(client.clone());
-        processor
-            .handle_room_response(&response, &RequestedRequiredStates::default())
-            .await
-            .expect("Failed to process sync");
+        {
+            let state_store_guard = client.base_client().state_store_lock().lock().await;
+            processor
+                .handle_room_response(
+                    &response,
+                    &RequestedRequiredStates::default(),
+                    &state_store_guard,
+                )
+                .await
+                .expect("Failed to process sync");
+        }
         processor.process_and_take_response().await.expect("Failed to finish processing sync");
 
         // Then room info notable updates are received.

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -283,7 +283,7 @@ impl SlidingSync {
             let response_processor = {
                 // Take the lock to synchronise accesses to the state store, to avoid concurrent
                 // sliding syncs overwriting each other's room infos.
-                let _state_store_lock = {
+                let state_store_guard = {
                     let _timer = timer!("acquiring the `state_store_lock`");
 
                     self.inner.client.base_client().state_store_lock().lock().await
@@ -310,14 +310,20 @@ impl SlidingSync {
 
                 #[cfg(feature = "e2e-encryption")]
                 if self.is_e2ee_enabled() {
-                    response_processor.handle_encryption(&sliding_sync_response.extensions).await?
+                    response_processor
+                        .handle_encryption(&sliding_sync_response.extensions, &state_store_guard)
+                        .await?
                 }
 
                 // Only handle the room's subsection of the response, if this sliding sync was
                 // configured to do so.
                 if must_process_rooms_response {
                     response_processor
-                        .handle_room_response(&sliding_sync_response, &requested_required_states)
+                        .handle_room_response(
+                            &sliding_sync_response,
+                            &requested_required_states,
+                            &state_store_guard,
+                        )
                         .await?;
                 }
 

--- a/crates/matrix-sdk/tests/integration/room/left.rs
+++ b/crates/matrix-sdk/tests/integration/room/left.rs
@@ -144,9 +144,11 @@ async fn test_forget_banned_room() {
 
     // Make the room banned
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
-    let mut room_info = room.clone_info();
-    room_info.mark_as_banned();
-    room.set_room_info(room_info, RoomInfoNotableUpdateReasons::MEMBERSHIP);
+    room.update_room_info(|mut room_info| {
+        room_info.mark_as_banned();
+        (room_info, RoomInfoNotableUpdateReasons::MEMBERSHIP)
+    })
+    .await;
     assert_eq!(room.state(), RoomState::Banned);
 
     room.forget().await.unwrap();


### PR DESCRIPTION
# Overview

Currently, updates to a `RoomInfo` object are typically persisted in two places.

1. An in-memory `Room` object via `Room::set_room_info`
2. A persistent `StateStore` via `StateStore::save_changes`

It is generally expected that the caller acquire a lock - often referred to as a **_state store lock_** - to synchronize these updates, but this is not enforced in any systematic way and is easy to forget.

The primary purpose of this pull request is to provide a better - albeit imperfect - way of ensuring all `RoomInfo` updates are synchronized, while also allowing the `RoomInfo` object of a `Room` to be read at any time - _even during an update_ (see #6384).

# Changes

## Synchronizing `StateStore::save_changes`

The primary change was to add a type, `SaveLockedStateStore`, that wraps an existing `StateStore` and ensures that calls to the underlying `StateStore::save_changes` are synchronized.

```rust
pub struct SaveLockedStateStore<T = Arc<DynStateStore>> {
    store: T,
    lock: Arc<Mutex<()>>,
}
```

This is accomplished by implementing `StateStore` for `SaveLockedStateStore` and ensuring that the lock is acquired before calling the underlying `StateStore::save_changes`.

```rust 
impl<T: StateStore> StateStore for SaveLockedStateStore<T> {
    // -- snip --

    async fn save_changes(&self, changes: &StateChanges) -> Result<(), Self::Error> {
        let _guard = self.lock.lock().await;
        self.store.save_changes(changes).await
    }
}
```

Additionally, the `SaveLockedStateStore` provides a means of acquiring the underlying lock and making calls `StateStore::save_changes` by providing the guard for that lock. This is ensured by checking the guard provided references the same `Mutex` held by `SaveLockedStateStore`. 

The benefit is that the lock may be held for an extended period where many operations may need to take place in order to build up the `StateChanges` - e.g., while processing a sync response.

```rust
impl<T: StateStore> SaveLockedStateStore<T> {
    pub fn lock(&self) -> &Mutex<()> {
        self.lock.as_ref()
    }

    pub async fn save_changes_with_guard(
        &self,
        guard: &MutexGuard<'_, ()>,
        changes: &StateChanges,
    ) -> Result<(), StoreError> {
        if !std::ptr::eq(MutexGuard::mutex(guard), self.lock()) {
            Err(IncorrectMutexGuardError.into())
        } else {
            self.store.save_changes(changes).await.map_err(Into::into)
        }
    }
}
```

Finally, `SaveLockedStateStore` replaces the underlying lock and store in `BaseStateStore` and clones are provided to downstream structures.

## Synchronzing `RoomInfo` updates to `Room`

The `SaveLockedStateStore` is cloned and provided to each `Room` created via the `BaseStateStore`. This allows a `Room` to synchronize its actions using the underlying lock in `SaveLockedStateStore`.

Furthermore, previous functions in `Room` for making changes to `RoomInfo` are replaced with atomic versions. `Room::update_room_info` ensures updates to the in-memory representations of the `RoomInfo` are atomic and `Room::update_and_save_room_info` ensures that updates to in-memory as well as persistent representations of `RoomInfo` are atomic. Both have versions which allow the caller to pass a guard for `SaveLockedStateStore::lock`.

_Note that the proposal in #6384 suggested using a token issued by the state store lock to ensure updates to `RoomInfo` were synchronized. Instead, this has been accomplished by checking reference equality between the guard and the underlying mutex._

# Considerations

While the abstractions outlined above offer some useful benefits, there are also some shortcomings to consider.

### 1. `SaveLockedStateStore` does not synchronize calls to all `StateStore` functions

While `StateStore::save_changes` is the primary function we care about, it's possible there are others that would be worth synchronizing. For instance, `StateStore::remove_room`, which modifies `Room`-related data.

### 2. `SaveLockedStateStore` does not provide atomic updates

While calls to `StateStore::save_changes` are synchronized, read-then-edit-then-write operations may overlap. For example, overlapping calls to `StateStore::get_room_infos` followed by `StateStore::save_changes` could overwrite one another's modifications.

### 3. It is easy to enter a deadlock

Because access is provided to the underlying lock in `SaveLockedStateStore`, it is a bit too easy to enter a deadlock. This can happen by acquiring the lock and then making a call to `StateStore::save_changes` rather than `SaveLockedStateStore::save_changes_with_guard`.

_An alternative here could be to make `StateStore::save_changes` simply try to acquire the lock and return an error if it fails._

# Questions

Currently, while executing a sync via `SlidingSync::sync_once`, a downstream function - i.e., `SlidingSync::handle_response` - acquires the underlying state store lock right before processing the response and holds it until it has finished processing the response. As of this pull request, the guard for that lock is also passed to many downstream functions so that updates to `RoomInfo` do not cause a deadlock.

https://github.com/matrix-org/matrix-rust-sdk/blob/4e8ceaac82af169aeae484c8e1db7befd4f8ac97/crates/matrix-sdk/src/sliding_sync/mod.rs#L280-L329

On the other hand, while executing a sync via `Client::sync_once`, downstream functions - e.g., `Client::process_sync` - do not hold the state store lock for the duration of the sync. They simply acquires it at very particular points during the process - e.g., in `Client::receive_sync_response_with_requested_required_states`.

https://github.com/matrix-org/matrix-rust-sdk/blob/fd6cb6647f8cdf1a02b93af1bf6c172bbf2d52da/crates/matrix-sdk-base/src/client.rs#L756-L766

Should executing a sync through `Client::sync_once` mimic the behavior of a `SlidingSync::sync_once` in this regard? It seems to me they should, but I may be overlooking a reason that `Client::sync_once` should not be holding a lock for the duration of the response processing logic.

---
Closes #6384.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
