### PR TITLE
feat(sdk): Add an expiry to the cached homeserver capabilities

### DIFF
--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -93,7 +93,7 @@ struct MemoryStoreInner {
     seen_knock_requests: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, OwnedUserId>>,
     thread_subscriptions: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, StoredThreadSubscription>>,
     thread_subscriptions_catchup_tokens: Option<Vec<ThreadSubscriptionCatchupToken>>,
-    homeserver_capabilities: Option<Capabilities>,
+    homeserver_capabilities: Option<TtlValue<Capabilities>>,
 }
 
 /// In-memory, non-persistent implementation of the `StateStore`.

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -1145,7 +1145,7 @@ pub enum StateStoreDataValue {
     ThreadSubscriptionsCatchupTokens(Vec<ThreadSubscriptionCatchupToken>),
 
     /// The capabilities the homeserver supports or disables.
-    HomeserverCapabilities(Capabilities),
+    HomeserverCapabilities(TtlValue<Capabilities>),
 }
 
 /// Tokens to use when catching up on thread subscriptions.
@@ -1350,7 +1350,7 @@ impl StateStoreDataValue {
 
     /// Get this value if it is the data for the capabilities the homeserver
     /// supports or disables.
-    pub fn into_homeserver_capabilities(self) -> Option<Capabilities> {
+    pub fn into_homeserver_capabilities(self) -> Option<TtlValue<Capabilities>> {
         as_variant!(self, Self::HomeserverCapabilities)
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -674,7 +674,7 @@ impl_state_store!({
                 .transpose()?
                 .map(StateStoreDataValue::ThreadSubscriptionsCatchupTokens),
             StateStoreDataKey::HomeserverCapabilities => value
-                .map(|f| self.deserialize_value::<Capabilities>(&f))
+                .map(|f| self.deserialize_value::<TtlValue<Capabilities>>(&f))
                 .transpose()?
                 .map(StateStoreDataValue::HomeserverCapabilities),
         };

--- a/crates/matrix-sdk/src/client/caches.rs
+++ b/crates/matrix-sdk/src/client/caches.rs
@@ -18,7 +18,10 @@ use matrix_sdk_base::{store::WellKnownResponse, ttl_cache::TtlCache};
 use matrix_sdk_common::{locks::Mutex, ttl_cache::TtlValue};
 use ruma::api::{
     SupportedVersions,
-    client::discovery::get_authorization_server_metadata::v1::AuthorizationServerMetadata,
+    client::discovery::{
+        get_authorization_server_metadata::v1::AuthorizationServerMetadata,
+        get_capabilities::v3::Capabilities,
+    },
 };
 use tokio::sync::Mutex as AsyncMutex;
 
@@ -37,6 +40,8 @@ pub(crate) struct ClientCaches {
     /// Well-known information.
     pub(super) well_known: Cache<Option<WellKnownResponse>>,
     pub(crate) server_metadata: AsyncMutex<TtlCache<String, AuthorizationServerMetadata>>,
+    /// Homeserver capabilities.
+    pub(crate) homeserver_capabilities: Cache<Capabilities>,
 }
 
 /// A cached value that can either be set or not set, used to avoid confusion
@@ -74,6 +79,11 @@ pub(crate) struct Cache<Value> {
 }
 
 impl<Value> Cache<Value> {
+    /// Construct a new empty `Cache`.
+    pub(crate) fn new() -> Self {
+        Self::with_value(CachedValue::NotSet)
+    }
+
     /// Construct a new `Cache` with the given value.
     pub(crate) fn with_value(value: CachedValue<TtlValue<Value>>) -> Self {
         Self { value: Mutex::new(value), refresh_lock: AsyncMutex::new(Ok(())) }

--- a/crates/matrix-sdk/src/client/homeserver_capabilities.rs
+++ b/crates/matrix-sdk/src/client/homeserver_capabilities.rs
@@ -1,4 +1,6 @@
-use matrix_sdk_base::{StateStoreDataKey, StateStoreDataValue};
+use std::sync::Arc;
+
+use matrix_sdk_base::{StateStoreDataKey, StateStoreDataValue, StoreError, ttl_cache::TtlValue};
 use ruma::{
     api::{
         Metadata,
@@ -15,9 +17,9 @@ use ruma::{
     },
     profile::ProfileFieldName,
 };
-use tracing::warn;
+use tracing::{debug, warn};
 
-use crate::{Client, HttpResult};
+use crate::{Client, HttpError, HttpResult, client::caches::CachedValue};
 
 /// Helper to check what [`Capabilities`] are supported by the homeserver.
 ///
@@ -135,6 +137,47 @@ impl HomeserverCapabilities {
         Ok(capabilities.forget_forced_upon_leave.enabled)
     }
 
+    /// Gets the supported [`Capabilities`] from the local cache.
+    async fn homeserver_capabilities_cached(&self) -> Result<Option<Capabilities>, StoreError> {
+        let capabilities_cache = &self.client.inner.caches.homeserver_capabilities;
+
+        let value = if let CachedValue::Cached(cached) = capabilities_cache.value() {
+            cached
+        } else if let Some(stored) = self
+            .client
+            .state_store()
+            .get_kv_data(StateStoreDataKey::HomeserverCapabilities)
+            .await?
+            .and_then(|value| value.into_homeserver_capabilities())
+        {
+            // Copy the data from the store in the in-memory cache.
+            capabilities_cache.set_value(stored.clone());
+
+            stored
+        } else {
+            return Ok(None);
+        };
+
+        // Spawn a task to refresh the cache if it has expired.
+        if value.has_expired() {
+            debug!("spawning task to refresh homeserver capabilities cache");
+
+            let homeserver_capabilities = self.clone();
+            self.client.task_monitor().spawn_finite_task(
+                "refresh homeserver capabilities cache",
+                async move {
+                    if let Err(error) =
+                        homeserver_capabilities.get_and_cache_remote_capabilities().await
+                    {
+                        warn!("failed to refresh homeserver capabilities cache: {error}");
+                    }
+                },
+            );
+        }
+
+        Ok(Some(value.into_data()))
+    }
+
     /// Gets the supported [`Capabilities`] either from the local cache or from
     /// the homeserver using the `/capabilities` endpoint if the data is not
     /// cached.
@@ -142,12 +185,9 @@ impl HomeserverCapabilities {
     /// To ensure you get updated values, you should call [`Self::refresh`]
     /// instead.
     async fn load_or_fetch_homeserver_capabilities(&self) -> crate::Result<Capabilities> {
-        match self.client.state_store().get_kv_data(StateStoreDataKey::HomeserverCapabilities).await
-        {
-            Ok(Some(stored)) => {
-                if let Some(capabilities) = stored.into_homeserver_capabilities() {
-                    return Ok(capabilities);
-                }
+        match self.homeserver_capabilities_cached().await {
+            Ok(Some(capabilities)) => {
+                return Ok(capabilities);
             }
             Ok(None) => {
                 // fallthrough: cache is empty
@@ -163,21 +203,58 @@ impl HomeserverCapabilities {
 
     /// Gets and caches the capabilities of the homeserver.
     async fn get_and_cache_remote_capabilities(&self) -> HttpResult<Capabilities> {
-        let res = self.client.send(get_capabilities::v3::Request::new()).await?;
+        let capabilities_cache = &self.client.inner.caches.homeserver_capabilities;
+
+        let mut capabilities_guard = match capabilities_cache.refresh_lock.try_lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                // There is already a refresh in progress, wait for it to finish.
+                let guard = capabilities_cache.refresh_lock.lock().await;
+
+                if let Err(error) = guard.as_ref() {
+                    // There was an error in the previous refresh, return it.
+                    return Err(HttpError::Cached(error.clone()));
+                }
+
+                // Reuse the data if it was cached and it hasn't expired.
+                if let CachedValue::Cached(value) = capabilities_cache.value()
+                    && !value.has_expired()
+                {
+                    return Ok(value.into_data());
+                }
+
+                // The data wasn't cached or has expired, we need to make another request.
+                guard
+            }
+        };
+
+        let capabilities = match self.client.send(get_capabilities::v3::Request::new()).await {
+            Ok(response) => {
+                *capabilities_guard = Ok(());
+                TtlValue::new(response.capabilities)
+            }
+            Err(error) => {
+                let error = Arc::new(error);
+                *capabilities_guard = Err(error.clone());
+                return Err(HttpError::Cached(error));
+            }
+        };
 
         if let Err(err) = self
             .client
             .state_store()
             .set_kv_data(
                 StateStoreDataKey::HomeserverCapabilities,
-                StateStoreDataValue::HomeserverCapabilities(res.capabilities.clone()),
+                StateStoreDataValue::HomeserverCapabilities(capabilities.clone()),
             )
             .await
         {
             warn!("error when caching homeserver capabilities: {err}");
         }
 
-        Ok(res.capabilities)
+        capabilities_cache.set_value(capabilities.clone());
+
+        Ok(capabilities.into_data())
     }
 
     /// Gets or computes the supported [`ProfileCapabilities`].
@@ -234,6 +311,10 @@ struct ProfileCapabilities {
 
 #[cfg(all(not(target_family = "wasm"), test))]
 mod tests {
+    use std::time::Duration;
+
+    use assert_matches::assert_matches;
+    use matrix_sdk_base::sleep::sleep;
     use matrix_sdk_test::async_test;
     #[allow(deprecated)]
     use ruma::api::{
@@ -321,14 +402,27 @@ mod tests {
         server
             .mock_get_homeserver_capabilities()
             .ok_with_capabilities(expected_capabilities)
-            // Ensure it's not called, since we'd be using the cached values instead
-            .never()
+            .expect(1)
             .mount()
             .await;
 
         // Check the values we get are not updated without a refresh, they're loaded
         // from the cache
         assert!(capabilities.can_change_displayname().await.expect("checking capabilities failed"));
+
+        // Force an expiry of the data.
+        let capabilities_data =
+            capabilities.homeserver_capabilities_cached().await.unwrap().unwrap();
+        let mut ttl_value = TtlValue::new(capabilities_data);
+        ttl_value.expire();
+        client.inner.caches.homeserver_capabilities.set_value(ttl_value);
+
+        // Call a method to trigger a cache refresh background task.
+        capabilities.homeserver_capabilities_cached().await.unwrap().unwrap();
+
+        // We wait for the task to finish, the endpoint should have been called again.
+        sleep(Duration::from_secs(1)).await;
+        assert_matches!(client.inner.caches.homeserver_capabilities.value(), CachedValue::Cached(value) if !value.has_expired());
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -406,6 +406,7 @@ impl ClientInner {
             supported_versions: Cache::with_value(supported_versions),
             well_known: Cache::with_value(well_known),
             server_metadata: Mutex::new(TtlCache::new()),
+            homeserver_capabilities: Cache::new(),
         };
 
         let client = Self {
@@ -2188,7 +2189,7 @@ impl Client {
 
                 if let Err(error) = guard.as_ref() {
                     // There was an error in the previous refresh, return it.
-                    return Err(HttpError::SupportedVersions(error.clone()));
+                    return Err(HttpError::Cached(error.clone()));
                 }
 
                 // Reuse the data if it was cached and it hasn't expired.
@@ -2211,7 +2212,7 @@ impl Client {
             Err(error) => {
                 let error = Arc::new(error);
                 *supported_versions_guard = Err(error.clone());
-                return Err(HttpError::SupportedVersions(error));
+                return Err(HttpError::Cached(error));
             }
         };
 

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -106,9 +106,12 @@ pub enum HttpError {
     #[error(transparent)]
     RefreshToken(RefreshTokenError),
 
-    /// Error while fetching the versions supported by the homeserver.
+    /// Error while fetching data that is cached.
+    ///
+    /// This variant is present for convenience because cached data wraps
+    /// [`HttpError`] into an [`Arc`] to be able to clone it.
     #[error(transparent)]
-    SupportedVersions(Arc<HttpError>),
+    Cached(Arc<HttpError>),
 
     /// Error creating the TLS verifier.
     #[cfg(target_os = "android")]


### PR DESCRIPTION
I believe that it is a footgun to cache the data indefinitely by default so this copies the same behavior as for the supported versions in the `ClientCaches` (#6463): it sets an expiry duration of 1 day and refreshes the data in the background when it has expired.

This also caches the data in memory to benefit from the `refresh_lock`, if this is unwanted, this part can be reverted.

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

