### PR TITLE
feat(ui): Add `Client::get_dm_rooms`

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -44,6 +44,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add `Client::get_dm_rooms` function to get a list with the DMs for the provided user id.
+  ([#6487](https://github.com/matrix-org/matrix-rust-sdk/pull/6487))
 - Expose `ffi::NotificationRoomInfo::service_members` so clients can use the list of service
   members to calculate if a room is a DM from the notification info.
   ([#6474](https://github.com/matrix-org/matrix-rust-sdk/pull/6474))

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1483,6 +1483,7 @@ impl Client {
         Ok(room)
     }
 
+    /// Get the first existing DM room with the given user, if any.
     pub fn get_dm_room(&self, user_id: String) -> Result<Option<Arc<Room>>, ClientError> {
         let user_id = UserId::parse(user_id)?;
         let sdk_room = self.inner.get_dm_room(&user_id);
@@ -1491,6 +1492,7 @@ impl Client {
         Ok(dm)
     }
 
+    /// Get an iterator with the existing DM rooms for the given user.
     pub fn get_dm_rooms(&self, user_id: String) -> Result<Vec<Arc<Room>>, ClientError> {
         let user_id = UserId::parse(user_id)?;
         let sdk_rooms = self.inner.get_dm_rooms(&user_id);

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1491,6 +1491,15 @@ impl Client {
         Ok(dm)
     }
 
+    pub fn get_dm_rooms(&self, user_id: String) -> Result<Vec<Arc<Room>>, ClientError> {
+        let user_id = UserId::parse(user_id)?;
+        let sdk_rooms = self.inner.get_dm_rooms(&user_id);
+        let dms = sdk_rooms
+            .map(|room| Arc::new(Room::new(room, self.utd_hook_manager.get().cloned())))
+            .collect();
+        Ok(dms)
+    }
+
     pub async fn search_users(
         &self,
         search_term: String,

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add `Client::get_dm_rooms` function to get an iterator with the DMs for the provided user id. 
+  ([#6487](https://github.com/matrix-org/matrix-rust-sdk/pull/6487))
 - Support the stable `m.key_backup` prefix for MSC4287: Sharing key backup
   preference between clients.
   ([#6410](https://github.com/matrix-org/matrix-rust-sdk/pull/6410))

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1796,7 +1796,7 @@ impl Client {
         self.get_dm_rooms(user_id).next()
     }
 
-    /// Get an iterator with the existing DM rooms with the given user.
+    /// Get an iterator with the existing DM rooms for the given user.
     pub fn get_dm_rooms(&self, user_id: &UserId) -> impl Iterator<Item = Room> {
         let rooms = self.joined_rooms();
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1791,18 +1791,23 @@ impl Client {
         self.create_room(request).await
     }
 
-    /// Get the existing DM room with the given user, if any.
+    /// Get the first existing DM room with the given user, if any.
     pub fn get_dm_room(&self, user_id: &UserId) -> Option<Room> {
+        self.get_dm_rooms(user_id).next()
+    }
+
+    /// Get an iterator with the existing DM rooms with the given user.
+    pub fn get_dm_rooms(&self, user_id: &UserId) -> impl Iterator<Item = Room> {
         let rooms = self.joined_rooms();
 
         // Find the room we share with the `user_id` and only with `user_id`
-        let room = rooms.into_iter().find(|r| {
+        let rooms = rooms.into_iter().filter(move |r| {
             let targets = r.direct_targets();
             targets.len() == 1 && targets.contains(<&DirectUserIdentifier>::from(user_id))
         });
 
-        trace!(?user_id, ?room, "Found DM room with user");
-        room
+        trace!(?user_id, ?rooms, "Found DM rooms with user");
+        rooms
     }
 
     /// Search the homeserver's directory for public rooms with a filter.


### PR DESCRIPTION
This function returns an iterator with all the available rooms that match the behaviour previously in `Client::get_dm_room`. `Client::get_dm_room` now just calls this function and returns the first item.<!-- description of the changes in this PR -->

It's the first step of a potential solution to https://github.com/element-hq/element-x-ios/issues/5467.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
