### PR TITLE
fix: set recursion limit to 256

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -173,6 +173,8 @@ All notable changes to this project will be documented in this file.
   ([#5940](https://github.com/matrix-org/matrix-rust-sdk/pull/5940))
 - Remove an unwrap in `SlidingSync::send_sync_request` when an asynchronous task panics or is cancelled.
   ([#6316](https://github.com/matrix-org/matrix-rust-sdk/pull/6316))
+- Add a recursion limit attribute that raises it from the default value of 128 to 256.
+  ([#6489](https://github.com/matrix-org/matrix-rust-sdk/pull/6489))
 
 ### Refactor
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -131,6 +131,8 @@ All notable changes to this project will be documented in this file.
 
 ### Bugfix
 
+- Add a recursion limit attribute that raises it from the default value of 128 to 256.
+  ([#6489](https://github.com/matrix-org/matrix-rust-sdk/pull/6489))
 - Reject invalid edits as candidates for the latest event.
   ([#6454](https://github.com/matrix-org/matrix-rust-sdk/pull/6454))
 - Fix an infinite loop when loading pinned events from the storage.
@@ -173,8 +175,6 @@ All notable changes to this project will be documented in this file.
   ([#5940](https://github.com/matrix-org/matrix-rust-sdk/pull/5940))
 - Remove an unwrap in `SlidingSync::send_sync_request` when an asynchronous task panics or is cancelled.
   ([#6316](https://github.com/matrix-org/matrix-rust-sdk/pull/6316))
-- Add a recursion limit attribute that raises it from the default value of 128 to 256.
-  ([#6489](https://github.com/matrix-org/matrix-rust-sdk/pull/6489))
 
 ### Refactor
 

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![recursion_limit="256"]
+#![recursion_limit = "256"]
 #![doc = include_str!("../README.md")]
 #![warn(missing_debug_implementations, missing_docs)]
 #![cfg_attr(target_family = "wasm", allow(clippy::arc_with_non_send_sync))]

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit="256"]
 #![doc = include_str!("../README.md")]
 #![warn(missing_debug_implementations, missing_docs)]
 #![cfg_attr(target_family = "wasm", allow(clippy::arc_with_non_send_sync))]


### PR DESCRIPTION
~~rustc v1.94.0 and above have reverted an earlier doubling of recursion limit. sync method inside matrix-sdk the call stack rises by 130, going over the limit.~~ My apologies, this comment is likely at least partially wrong, and wholly unnecessary anyways. I hope it does not takeaway any urgency of this issue and fixing it.

<!-- description of the changes in this PR -->

Added line #![recursion_limit="256"] to crates matrix-sdk lib.rs file. Closes #6254 

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Joonas Tuomi <github@joonastuomi.fi>
