### PR TITLE
feat: Add `DmRoomDefinition` enum to specify what a DM room is

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -6,8 +6,8 @@ use matrix_sdk::{
     test_utils::mocks::MatrixMockServer,
 };
 use matrix_sdk_base::{
-    BaseClient, RoomInfo, RoomState, SessionMeta, StateChanges, StateStore, ThreadingSupport,
-    store::StoreConfig,
+    BaseClient, DmRoomDefinition, RoomInfo, RoomState, SessionMeta, StateChanges, StateStore,
+    ThreadingSupport, store::StoreConfig,
 };
 use matrix_sdk_sqlite::SqliteStateStore;
 use matrix_sdk_test::{JoinedRoomBuilder, base64_sha256_hash, event_factory::EventFactory};
@@ -63,6 +63,7 @@ pub fn receive_all_members_benchmark(c: &mut Criterion) {
         ))
         .state_store(sqlite_store),
         ThreadingSupport::Disabled,
+        DmRoomDefinition::default(),
     );
 
     runtime

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -44,6 +44,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Expose `ClientBuilder::dm_room_definition` to customize the DM room definition used by the `Client`, 
+  added `RoomInfo::is_dm` field based on it. ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))
 - Expose `HumanQrGrantLoginError::Unknown` reason in error message.
   ([#6514](https://github.com/matrix-org/matrix-rust-sdk/pull/6514))
 - Add a list of `declined_by: Vec<String>` to the `TimelineItemContent::RtcNotification`, this will contain the list

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -32,7 +32,10 @@ use matrix_sdk::{
         VersionBuilderError,
     },
 };
-use matrix_sdk_base::crypto::{CollectStrategy, DecryptionSettings, TrustRequirement};
+use matrix_sdk_base::{
+    DmRoomDefinition,
+    crypto::{CollectStrategy, DecryptionSettings, TrustRequirement},
+};
 use ruma::api::error::{DeserializationError, FromHttpResponseError};
 use tracing::debug;
 
@@ -152,6 +155,8 @@ pub struct ClientBuilder {
     additional_root_certificates: Vec<Vec<u8>>,
 
     threading_support: ThreadingSupport,
+
+    dm_room_definition: DmRoomDefinition,
 }
 
 /// The timeout applies to each read operation, and resets after a successful
@@ -196,7 +201,14 @@ impl ClientBuilder {
             request_config: Default::default(),
             threading_support: ThreadingSupport::Disabled,
             search_index_store: None,
+            dm_room_definition: DmRoomDefinition::MatrixSpec,
         })
+    }
+
+    pub fn dm_room_definition(self: Arc<Self>, dm_room_definition: DmRoomDefinition) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.dm_room_definition = dm_room_definition;
+        Arc::new(builder)
     }
 
     pub fn cross_process_lock_config(
@@ -551,7 +563,9 @@ impl ClientBuilder {
             inner_builder = inner_builder.request_config(updated_config);
         }
 
-        inner_builder = inner_builder.with_threading_support(builder.threading_support);
+        inner_builder = inner_builder
+            .dm_room_definition(builder.dm_room_definition)
+            .with_threading_support(builder.threading_support);
 
         let sdk_client = inner_builder.build().await?;
 

--- a/bindings/matrix-sdk-ffi/src/room/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room/room_info.rs
@@ -64,6 +64,7 @@ pub struct RoomInfo {
     topic: Option<String>,
     avatar_url: Option<String>,
     is_direct: bool,
+    is_dm: bool,
     /// Whether the room is public or not, based on the join rules.
     ///
     /// Can be `None` if the join rules state event is not available for this
@@ -160,6 +161,7 @@ impl RoomInfo {
             topic: room.topic(),
             avatar_url: room.avatar_url().map(Into::into),
             is_direct: room.is_direct().await?,
+            is_dm: room.is_dm().await?,
             is_public: room.is_public(),
             is_space: room.is_space(),
             successor_room: room.successor_room().map(Into::into),

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -31,6 +31,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] Add `DmRoomDefinition` enum, allowing clients to specify what a DM 
+  room should look like. A `Room::is_dm` method was added to check if a room is a DM room too, 
+  using this definition. ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))
 - Add `Room::active_room_members`, returning a list of all the service room members 
   that are active in the room. 
   ([#6843](https://github.com/matrix-org/matrix-rust-sdk/pull/6483))

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -79,7 +79,9 @@ use crate::{
 /// rather through `matrix_sdk::Client`.
 ///
 /// ```rust
-/// use matrix_sdk_base::{BaseClient, ThreadingSupport, store::StoreConfig};
+/// use matrix_sdk_base::{
+///     BaseClient, DmRoomDefinition, ThreadingSupport, store::StoreConfig,
+/// };
 /// use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
 ///
 /// let client = BaseClient::new(
@@ -87,6 +89,7 @@ use crate::{
 ///         "cross-process-holder-name".to_owned(),
 ///     )),
 ///     ThreadingSupport::Disabled,
+///     DmRoomDefinition::default(),
 /// );
 /// ```
 #[derive(Clone)]
@@ -131,6 +134,9 @@ pub struct BaseClient {
 
     /// Whether the client supports threads or not.
     pub threading_support: ThreadingSupport,
+
+    /// The definition of what is considered a DM room.
+    pub dm_room_definition: DmRoomDefinition,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -176,7 +182,11 @@ impl BaseClient {
     ///
     /// * `config` - the configuration for the stores (state store, event cache
     ///   store and crypto store).
-    pub fn new(config: StoreConfig, threading_support: ThreadingSupport) -> Self {
+    pub fn new(
+        config: StoreConfig,
+        threading_support: ThreadingSupport,
+        dm_room_definition: DmRoomDefinition,
+    ) -> Self {
         let store = BaseStateStore::new(config.state_store);
 
         BaseClient {
@@ -197,6 +207,7 @@ impl BaseClient {
             #[cfg(feature = "e2e-encryption")]
             handle_verification_events: true,
             threading_support,
+            dm_room_definition,
         }
     }
 
@@ -228,6 +239,7 @@ impl BaseClient {
             decryption_settings: self.decryption_settings.clone(),
             handle_verification_events,
             threading_support: self.threading_support,
+            dm_room_definition: self.dm_room_definition.clone(),
         };
 
         copy.state_store.derive_from_other(&self.state_store).await?;
@@ -245,7 +257,7 @@ impl BaseClient {
         _handle_verification_events: bool,
     ) -> Result<Self> {
         let config = StoreConfig::new(cross_process_store_config).state_store(MemoryStore::new());
-        Ok(Self::new(config, ThreadingSupport::Disabled))
+        Ok(Self::new(config, ThreadingSupport::Disabled, DmRoomDefinition::default()))
     }
 
     /// Get the session meta information.
@@ -440,11 +452,15 @@ impl BaseClient {
     /// # Examples
     ///
     /// ```rust
-    /// # use matrix_sdk_base::{BaseClient, store::StoreConfig, RoomState, ThreadingSupport};
+    /// # use matrix_sdk_base::{BaseClient, store::StoreConfig, RoomState, ThreadingSupport, DmRoomDefinition};
     /// # use ruma::{OwnedRoomId, OwnedUserId, RoomId};
     /// use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
     /// # async {
-    /// # let client = BaseClient::new(StoreConfig::new(CrossProcessLockConfig::multi_process("example")), ThreadingSupport::Disabled);
+    /// # let client = BaseClient::new(
+    ///     StoreConfig::new(CrossProcessLockConfig::multi_process("example")),
+    ///     ThreadingSupport::Disabled,
+    ///     DmRoomDefinition::default()
+    /// );
     /// # async fn send_join_request() -> anyhow::Result<OwnedRoomId> { todo!() }
     /// # async fn maybe_get_inviter(room_id: &RoomId) -> anyhow::Result<Option<OwnedUserId>> { todo!() }
     /// # let room_id: &RoomId = todo!();
@@ -1240,7 +1256,7 @@ mod tests {
 
     use super::{BaseClient, RequestedRequiredStates};
     use crate::{
-        RoomDisplayName, RoomState, SessionMeta,
+        DmRoomDefinition, RoomDisplayName, RoomState, SessionMeta,
         client::ThreadingSupport,
         store::{RoomLoadSettings, StateStoreExt, StoreConfig},
         test_utils::logged_in_base_client,
@@ -1534,6 +1550,7 @@ mod tests {
         let client = BaseClient::new(
             StoreConfig::new(CrossProcessLockConfig::SingleProcess),
             ThreadingSupport::Disabled,
+            DmRoomDefinition::default(),
         );
         client
             .activate(
@@ -1596,6 +1613,7 @@ mod tests {
         let client = BaseClient::new(
             StoreConfig::new(CrossProcessLockConfig::SingleProcess),
             ThreadingSupport::Disabled,
+            DmRoomDefinition::default(),
         );
         client
             .activate(
@@ -1660,6 +1678,7 @@ mod tests {
         let client = BaseClient::new(
             StoreConfig::new(CrossProcessLockConfig::SingleProcess),
             ThreadingSupport::Disabled,
+            DmRoomDefinition::default(),
         );
         client
             .activate(
@@ -1724,6 +1743,7 @@ mod tests {
         let client = BaseClient::new(
             StoreConfig::new(CrossProcessLockConfig::SingleProcess),
             ThreadingSupport::Disabled,
+            DmRoomDefinition::default(),
         );
 
         client

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1202,6 +1202,19 @@ impl From<&v5::Request> for RequestedRequiredStates {
     }
 }
 
+/// An enum that defines what the [`BaseClient`] should consider a DM room.
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum DmRoomDefinition {
+    /// Standard Matrix spec definition: a room linked to a user in an
+    /// `m.direct` event.
+    #[default]
+    MatrixSpec,
+    /// A room that is direct, as per the spec but also contains at most 2
+    /// active members.
+    TwoMembers,
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -45,6 +45,8 @@ pub mod sync;
 mod test_utils;
 mod utils;
 
+pub use client::DmRoomDefinition;
+
 #[cfg(feature = "experimental-element-recent-emojis")]
 pub mod recent_emojis;
 

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -69,7 +69,7 @@ pub use tombstone::{PredecessorRoom, SuccessorRoom};
 use tracing::{info, instrument, warn};
 
 use crate::{
-    Error,
+    DmRoomDefinition, Error,
     deserialized_responses::MemberEvent,
     notification_settings::RoomNotificationMode,
     read_receipts::RoomReadReceipts,
@@ -301,6 +301,26 @@ impl Room {
 
             // TODO: implement logic once we have the stripped events as we'd have with an Invite
             RoomState::Knocked => Ok(false),
+        }
+    }
+
+    /// Checks if the current room is a DM based on the rules from the
+    /// [`DmRoomDefinition`].
+    pub async fn is_dm(&self, dm_room_definition: &DmRoomDefinition) -> StoreResult<bool> {
+        let is_direct = self.is_direct().await?;
+
+        match *dm_room_definition {
+            DmRoomDefinition::MatrixSpec => Ok(is_direct),
+            DmRoomDefinition::TwoMembers => {
+                if !is_direct {
+                    return Ok(false);
+                }
+                let active_service_member_count =
+                    self.active_service_members().await?.unwrap_or_default().len() as u64;
+                let has_at_most_two_members =
+                    self.active_members_count().saturating_sub(active_service_member_count) <= 2;
+                Ok(has_at_most_two_members)
+            }
         }
     }
 

--- a/crates/matrix-sdk-base/src/room/tags.rs
+++ b/crates/matrix-sdk-base/src/room/tags.rs
@@ -83,7 +83,7 @@ mod tests {
 
     use super::{super::BaseRoomInfo, RoomNotableTags};
     use crate::{
-        BaseClient, RoomState, SessionMeta,
+        BaseClient, DmRoomDefinition, RoomState, SessionMeta,
         client::ThreadingSupport,
         response_processors as processors,
         store::{RoomLoadSettings, StoreConfig},
@@ -95,6 +95,7 @@ mod tests {
         let client = BaseClient::new(
             StoreConfig::new(CrossProcessLockConfig::SingleProcess),
             ThreadingSupport::Disabled,
+            DmRoomDefinition::default(),
         );
 
         client
@@ -191,6 +192,7 @@ mod tests {
         let client = BaseClient::new(
             StoreConfig::new(CrossProcessLockConfig::SingleProcess),
             ThreadingSupport::Disabled,
+            DmRoomDefinition::default(),
         );
 
         client

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -298,8 +298,8 @@ mod tests {
 
     use super::http;
     use crate::{
-        BaseClient, EncryptionState, RequestedRequiredStates, RoomInfoNotableUpdate, RoomState,
-        SessionMeta,
+        BaseClient, DmRoomDefinition, EncryptionState, RequestedRequiredStates,
+        RoomInfoNotableUpdate, RoomState, SessionMeta,
         client::ThreadingSupport,
         room::{RoomHero, RoomInfoNotableUpdateReasons},
         store::{RoomLoadSettings, StoreConfig},
@@ -1245,7 +1245,8 @@ mod tests {
                 let store = StoreConfig::new(CrossProcessLockConfig::SingleProcess);
                 state_store = store.state_store.clone();
 
-                let client = BaseClient::new(store, ThreadingSupport::Disabled);
+                let client =
+                    BaseClient::new(store, ThreadingSupport::Disabled, DmRoomDefinition::default());
                 client
                     .activate(
                         session_meta.clone(),
@@ -1276,7 +1277,8 @@ mod tests {
             let client = {
                 let mut store = StoreConfig::new(CrossProcessLockConfig::SingleProcess);
                 store.state_store = state_store;
-                let client = BaseClient::new(store, ThreadingSupport::Disabled);
+                let client =
+                    BaseClient::new(store, ThreadingSupport::Disabled, DmRoomDefinition::default());
                 client
                     .activate(
                         session_meta,

--- a/crates/matrix-sdk-base/src/test_utils.rs
+++ b/crates/matrix-sdk-base/src/test_utils.rs
@@ -20,7 +20,7 @@ use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
 use ruma::{UserId, owned_user_id};
 
 use crate::{
-    BaseClient, SessionMeta,
+    BaseClient, DmRoomDefinition, SessionMeta,
     client::ThreadingSupport,
     store::{RoomLoadSettings, StoreConfig},
 };
@@ -33,6 +33,7 @@ pub(crate) async fn logged_in_base_client(user_id: Option<&UserId>) -> BaseClien
             "cross-process-store-locks-holder-name",
         )),
         ThreadingSupport::Disabled,
+        DmRoomDefinition::default(),
     );
     let user_id =
         user_id.map(|user_id| user_id.to_owned()).unwrap_or_else(|| owned_user_id!("@u:e.uk"));

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -102,6 +102,8 @@ All notable changes to this project will be documented in this file.
   
 ### Refactor
 
+- Use `DmRoomDefinition` to check if a room should be considered part of the `RoomCategory::People` or 
+  `RoomCategory::Room` when using room list filters. ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))
 - [**breaking**] `AnyOtherStateEventContentChange::RoomAliases` was removed. This state event type
   was removed from the Matrix specification a while ago, and support for it has been removed in Ruma.
   ([#6414](https://github.com/matrix-org/matrix-rust-sdk/pull/6414))

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/category.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/category.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use matrix_sdk_base::DmRoomDefinition;
+
 use super::{super::RoomListItem, Filter};
 
 /// An enum to represent whether a room is about “people” (strictly 2 users) or
@@ -38,18 +40,46 @@ fn matches<F>(number_of_direct_targets: F, room: &RoomListItem, expected_kind: R
 where
     F: Fn(&RoomListItem) -> Option<DirectTargetsLength>,
 {
-    let kind = match number_of_direct_targets(room) {
-        // If 1, we are sure it's a direct room between two users. It's the strict
-        // definition of the `People` category, all good.
-        Some(1) => RoomCategory::People,
-
-        // If smaller than 1, we are not sure it's a direct room, it's then a `Group`.
-        // If greater than 1, we are sure it's a direct room but not between
-        // two users, so it's a `Group` based on our expectation.
-        Some(_) => RoomCategory::Group,
-
+    let client = room.client();
+    let dm_room_definition = client.dm_room_definition();
+    let Some(targets) = number_of_direct_targets(room) else {
         // Don't know.
-        None => return false,
+        return false;
+    };
+    let kind = match dm_room_definition {
+        DmRoomDefinition::MatrixSpec => {
+            if targets == 1 {
+                // If there is a single target, it's a direct room.
+                RoomCategory::People
+            } else {
+                // If smaller than 1, we are not sure it's a direct room, it's then a `Group`.
+                // If greater than 1, we are sure it's a direct room but not between
+                // two users, so it's a `Group` based on our expectation.
+                RoomCategory::Group
+            }
+        }
+        DmRoomDefinition::TwoMembers => {
+            // We can't fully rely on the `service_members` value, as it only contains the
+            // user ids that should be considered service members in the room,
+            // not the service members that are active in the room. We can only
+            // make a good guess and assume those service members are in the room.
+            // Note this can return false positives if some service members aren't in the
+            // room, but they were replaced by other members.
+            let service_member_count =
+                room.service_members().map(|members| members.len()).unwrap_or_default() as u64;
+            let active_non_service_members =
+                room.active_members_count().saturating_sub(service_member_count);
+            if targets == 1 && active_non_service_members <= 2 {
+                // If lower than or equal to 2, we are sure it's a direct room between two
+                // users.
+                RoomCategory::People
+            } else {
+                // If smaller than 1, we are not sure it's a direct room, it's then a `Group`.
+                // If greater than 1, we are sure it's a direct room but not between
+                // two users, so it's a `Group` based on our expectation.
+                RoomCategory::Group
+            }
+        }
     };
 
     kind == expected_kind
@@ -68,14 +98,14 @@ pub fn new_filter(expected_category: RoomCategory) -> impl Filter {
 mod tests {
     use std::ops::Not;
 
-    use matrix_sdk::test_utils::mocks::MatrixMockServer;
-    use matrix_sdk_test::async_test;
+    use matrix_sdk::test_utils::mocks::{AnyRoomBuilder, MatrixMockServer};
+    use matrix_sdk_test::{JoinedRoomBuilder, async_test};
     use ruma::room_id;
 
     use super::{super::new_rooms, *};
 
     #[async_test]
-    async fn test_kind_is_group() {
+    async fn test_kind_is_group_with_matrix_spec_definition() {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
@@ -98,7 +128,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_kind_is_people() {
+    async fn test_kind_is_people_with_matrix_spec_definition() {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
@@ -117,6 +147,133 @@ mod tests {
             let expected_kind = RoomCategory::Group;
 
             assert!(matches(number_of_direct_targets, &room, expected_kind).not());
+        }
+    }
+
+    #[async_test]
+    async fn test_kind_is_group_with_two_people_definition() {
+        let server = MatrixMockServer::new().await;
+        let client = server
+            .client_builder()
+            .on_builder(|b| b.dm_room_definition(DmRoomDefinition::TwoMembers))
+            .build()
+            .await;
+        let room_id = room_id!("!a:b.c");
+
+        // We have 3 members in the room.
+        let room = server
+            .sync_room(
+                &client,
+                AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(3)),
+            )
+            .await;
+
+        let number_of_direct_targets = |_room: &RoomListItem| Some(1);
+
+        // It's Group.
+        {
+            let expected_kind = RoomCategory::Group;
+
+            assert!(matches(number_of_direct_targets, &room.into(), expected_kind));
+        }
+    }
+
+    #[async_test]
+    async fn test_kind_is_people_with_two_people_definition() {
+        let server = MatrixMockServer::new().await;
+        let client = server
+            .client_builder()
+            .on_builder(|b| b.dm_room_definition(DmRoomDefinition::TwoMembers))
+            .build()
+            .await;
+        let room_id = room_id!("!a:b.c");
+
+        // The room has 2 members, but it has no direct targets, so it should not be
+        // considered a `People` room.
+        let room = server
+            .sync_room(
+                &client,
+                AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(2)),
+            )
+            .await;
+
+        let number_of_direct_targets = |_room: &RoomListItem| Some(0);
+
+        // It's not People.
+        {
+            let expected_kind = RoomCategory::People;
+
+            assert!(matches(number_of_direct_targets, &room.into(), expected_kind).not());
+        }
+
+        // The room has 2 members, but it has several direct targets, so it should not
+        // be considered a `People` room.
+        let room = server
+            .sync_room(
+                &client,
+                AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(2)),
+            )
+            .await;
+
+        let number_of_direct_targets = |_room: &RoomListItem| Some(43);
+
+        // It's not People.
+        {
+            let expected_kind = RoomCategory::People;
+
+            assert!(matches(number_of_direct_targets, &room.into(), expected_kind).not());
+        }
+
+        // The room has 2 members and a single target, so it should be considered a
+        // `People` room.
+        let room = server
+            .sync_room(
+                &client,
+                AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(2)),
+            )
+            .await;
+
+        let number_of_direct_targets = |_room: &RoomListItem| Some(1);
+
+        // It's People.
+        {
+            let expected_kind = RoomCategory::People;
+
+            assert!(matches(number_of_direct_targets, &room.into(), expected_kind));
+        }
+
+        // The room has 1 member, so it should be considered a `People` room.
+        let room = server
+            .sync_room(
+                &client,
+                AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(1)),
+            )
+            .await;
+
+        let number_of_direct_targets = |_room: &RoomListItem| Some(1);
+
+        // It's People.
+        {
+            let expected_kind = RoomCategory::People;
+
+            assert!(matches(number_of_direct_targets, &room.into(), expected_kind));
+        }
+
+        // The room has no members, so it should be considered a `People` room.
+        let room = server
+            .sync_room(
+                &client,
+                AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(0)),
+            )
+            .await;
+
+        let number_of_direct_targets = |_room: &RoomListItem| Some(1);
+
+        // It's People.
+        {
+            let expected_kind = RoomCategory::People;
+
+            assert!(matches(number_of_direct_targets, &room.into(), expected_kind));
         }
     }
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Added `DmRoomDefinition` as a parameter of `ClientBuilder` so we can specify it when creating a Client. 
+  Also added a `Room::is_dm` method and added some logic to use the new DM definitions in `Client::get_dm_rooms` 
+  and when using message search. ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))
 - Sharing encrypted history on room invite, per
   [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) is
   now enabled by default (though can still be disabled via

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -28,7 +28,9 @@ use homeserver_config::*;
 use matrix_sdk_base::crypto::DecryptionSettings;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::{CollectStrategy, TrustRequirement};
-use matrix_sdk_base::{BaseClient, ThreadingSupport, store::StoreConfig, ttl::TtlValue};
+use matrix_sdk_base::{
+    BaseClient, DmRoomDefinition, ThreadingSupport, store::StoreConfig, ttl::TtlValue,
+};
 use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
 #[cfg(feature = "sqlite")]
 use matrix_sdk_sqlite::SqliteStoreConfig;
@@ -126,6 +128,7 @@ pub struct ClientBuilder {
     threading_support: ThreadingSupport,
     #[cfg(feature = "experimental-search")]
     search_index_store_kind: SearchIndexStoreKind,
+    dm_room_definition: DmRoomDefinition,
 }
 
 impl ClientBuilder {
@@ -162,7 +165,16 @@ impl ClientBuilder {
             threading_support: ThreadingSupport::Disabled,
             #[cfg(feature = "experimental-search")]
             search_index_store_kind: SearchIndexStoreKind::InMemory,
+            dm_room_definition: DmRoomDefinition::MatrixSpec,
         }
+    }
+
+    /// Sets the definition the [`Client`] will use to check if a room is a DM.
+    ///
+    /// By default this is [`DmRoomDefinition::MatrixSpec`].
+    pub fn dm_room_definition(mut self, dm_room_definition: DmRoomDefinition) -> Self {
+        self.dm_room_definition = dm_room_definition;
+        self
     }
 
     /// Set the homeserver URL to use.
@@ -567,6 +579,7 @@ impl ClientBuilder {
             let mut client = BaseClient::new(
                 build_store_config(self.store_config, &self.cross_process_lock_config).await?,
                 self.threading_support,
+                self.dm_room_definition,
             );
 
             #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -32,8 +32,9 @@ use matrix_sdk_base::crypto::{
     DecryptionSettings, store::LockableCryptoStore, store::types::RoomPendingKeyBundleDetails,
 };
 use matrix_sdk_base::{
-    BaseClient, RoomInfoNotableUpdate, RoomState, RoomStateFilter, SendOutsideWasm, SessionMeta,
-    StateStoreDataKey, StateStoreDataValue, StoreError, SyncOutsideWasm, ThreadingSupport,
+    BaseClient, DmRoomDefinition, RoomInfoNotableUpdate, RoomState, RoomStateFilter,
+    SendOutsideWasm, SessionMeta, StateStoreDataKey, StateStoreDataValue, StoreError,
+    SyncOutsideWasm, ThreadingSupport,
     event_cache::store::EventCacheStoreLock,
     media::store::MediaStoreLock,
     store::{DynStateStore, RoomLoadSettings, SupportedVersionsResponse, WellKnownResponse},
@@ -1846,10 +1847,23 @@ impl Client {
     pub fn get_dm_rooms(&self, user_id: &UserId) -> impl Iterator<Item = Room> {
         let rooms = self.joined_rooms();
 
+        let dm_definition = &self.base_client().dm_room_definition;
+
         // Find the room we share with the `user_id` and only with `user_id`
         let rooms = rooms.into_iter().filter(move |r| {
             let targets = r.direct_targets();
-            targets.len() == 1 && targets.contains(<&DirectUserIdentifier>::from(user_id))
+            let targets_match =
+                targets.len() == 1 && targets.contains(<&DirectUserIdentifier>::from(user_id));
+            match dm_definition {
+                DmRoomDefinition::MatrixSpec => targets_match,
+                DmRoomDefinition::TwoMembers => {
+                    let service_members_count =
+                        r.service_members().map(|s| s.len()).unwrap_or_default() as u64;
+                    let active_non_service_members =
+                        r.active_members_count().saturating_sub(service_members_count);
+                    targets_match && active_non_service_members <= 2
+                }
+            }
         });
 
         trace!(?user_id, ?rooms, "Found DM rooms with user");

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3488,6 +3488,12 @@ impl Client {
     ) -> Result<Option<RoomPendingKeyBundleDetails>> {
         Ok(self.base_client().get_pending_key_bundle_details_for_room(room_id).await?)
     }
+
+    /// Returns the [`DmRoomDefinition`] this client uses to check if a room is
+    /// a DM.
+    pub fn dm_room_definition(&self) -> &DmRoomDefinition {
+        &self.inner.base_client.dm_room_definition
+    }
 }
 
 /// Contains the disk size of the different stores, if known. It won't be

--- a/crates/matrix-sdk/src/message_search.rs
+++ b/crates/matrix-sdk/src/message_search.rs
@@ -221,7 +221,7 @@ impl GlobalSearchBuilder {
     pub async fn only_dm_rooms(mut self) -> Result<Self, crate::Error> {
         let mut to_remove = HashSet::new();
         for room in &self.room_set {
-            if !room.is_direct().await? {
+            if !room.is_dm().await? {
                 to_remove.insert(room.room_id().to_owned());
             }
         }
@@ -233,7 +233,7 @@ impl GlobalSearchBuilder {
     pub async fn no_dms(mut self) -> Result<Self, crate::Error> {
         let mut to_remove = HashSet::new();
         for room in &self.room_set {
-            if room.is_direct().await? {
+            if room.is_dm().await? {
                 to_remove.insert(room.room_id().to_owned());
             }
         }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -4568,6 +4568,11 @@ impl Room {
             Ok(false)
         }
     }
+
+    /// Checks if the current room is a DM.
+    pub async fn is_dm(&self) -> Result<bool> {
+        Ok(self.inner.is_dm(self.client.dm_room_definition()).await?)
+    }
 }
 
 #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, iter, time::Duration};
+use std::{collections::BTreeMap, iter, ops::Not, time::Duration};
 
 use assert_matches2::{assert_let, assert_matches};
 use js_int::uint;
@@ -6,8 +6,9 @@ use matrix_sdk::{
     RoomDisplayName, RoomMemberships,
     config::{SyncSettings, SyncToken},
     room::RoomMember,
-    test_utils::mocks::MatrixMockServer,
+    test_utils::mocks::{AnyRoomBuilder, MatrixMockServer},
 };
+use matrix_sdk_base::DmRoomDefinition;
 use matrix_sdk_test::{
     BOB, DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, LeftRoomBuilder, SyncResponseBuilder, async_test,
     bulk_room_members, event_factory::EventFactory, sync_state_event, test_json,
@@ -15,7 +16,7 @@ use matrix_sdk_test::{
 use ruma::{
     event_id,
     events::{
-        AnySyncStateEvent, AnySyncTimelineEvent, StateEventType,
+        AnyGlobalAccountDataEvent, AnySyncStateEvent, AnySyncTimelineEvent, StateEventType,
         direct::DirectUserIdentifier,
         room::{avatar, member::MembershipState, message::RoomMessageEventContent},
     },
@@ -891,4 +892,99 @@ async fn test_room_avatar() {
     assert_eq!(avatar_info.width, Some(uint!(200)));
     assert_eq!(avatar_info.mimetype.as_deref(), Some("image/png"));
     assert_eq!(avatar_info.size, Some(uint!(5243)));
+}
+
+#[async_test]
+async fn test_is_dm_using_matrix_spec() {
+    let server = MatrixMockServer::new().await;
+    let client = server
+        .client_builder()
+        .on_builder(|b| b.dm_room_definition(DmRoomDefinition::MatrixSpec))
+        .build()
+        .await;
+    let alice_user_id = user_id!("@alice:localhost");
+
+    let room_id = room_id!("!room:localhost");
+
+    // We mock the m.direct account data with a single target for the room id
+    let direct_data = EventFactory::new()
+        .direct()
+        .add_user(alice_user_id.to_owned().into(), room_id)
+        .into_raw::<AnyGlobalAccountDataEvent>();
+    server
+        .mock_sync()
+        .ok_and_run(&client, |response| {
+            response.add_global_account_data(direct_data);
+        })
+        .await;
+
+    let room = server.sync_joined_room(&client, room_id).await;
+    // Room has direct targets, so it's considered direct and a DM using the spec
+    // definition.
+    assert!(room.is_dm().await.unwrap());
+
+    // We mock the m.direct account data with no targets
+    let direct_data = EventFactory::new().direct().into_raw::<AnyGlobalAccountDataEvent>();
+    server
+        .mock_sync()
+        .ok_and_run(&client, |response| {
+            response.add_global_account_data(direct_data);
+        })
+        .await;
+
+    // Room doesn't have direct targets anymore, so it's not a DM using the spec
+    // definition.
+    assert!(room.is_dm().await.unwrap().not());
+}
+
+#[async_test]
+async fn test_is_dm_using_at_most_two_members_definition() {
+    let server = MatrixMockServer::new().await;
+    let client = server
+        .client_builder()
+        .on_builder(|b| b.dm_room_definition(DmRoomDefinition::TwoMembers))
+        .build()
+        .await;
+    let alice_user_id = user_id!("@alice:localhost");
+
+    let room_id = room_id!("!room:localhost");
+
+    // We mock the m.direct account data with a single target for the room id
+    let direct_data = EventFactory::new()
+        .direct()
+        .add_user(alice_user_id.to_owned().into(), room_id)
+        .into_raw::<AnyGlobalAccountDataEvent>();
+    server
+        .mock_sync()
+        .ok_and_run(&client, |response| {
+            response.add_global_account_data(direct_data);
+        })
+        .await;
+
+    // The room has direct targets, and 2 active users, so it's a DM.
+    let room = server
+        .sync_room(
+            &client,
+            AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(2)),
+        )
+        .await;
+    assert!(room.is_dm().await.unwrap());
+
+    // The room has direct targets, and a single active user, so it's a DM.
+    let room = server
+        .sync_room(
+            &client,
+            AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(1)),
+        )
+        .await;
+    assert!(room.is_dm().await.unwrap());
+
+    // The room has direct targets, and > 2 active users, so it's NOT a DM.
+    let room = server
+        .sync_room(
+            &client,
+            AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(3)),
+        )
+        .await;
+    assert!(!room.is_dm().await.unwrap());
 }


### PR DESCRIPTION
There are several places in the SDK where 'what is a DM' need to be calculated, and there are even more situations in the implementing clients that need this check. At least in the Element X apps this has been a source of issues because the definition didn't match and some checks in the apps and apps vs SDK were returning conflicting results.

These changes are an attempt to fix this by adding a `DmRoomDefinition` enum that's set up for the `Client` and should be used everywhere. Now it's the SDK who tells the clients if a room is a DM or not, based on the client's preferences.

## Changes

- Added `DmRoomDefinition` enum with `MatrixSpec` and `TwoMembers` cases, the first one keeps the current behaviour, the latter tries to check there are at most 2 active non-service members in the room to consider the room a DM.
- Split the logic used for applying the `People` room list filter.
- Use the definitions for `Client::get_dm_rooms` too.
- Add `Room::is_dm` function, which is also checked using the enum to specify the logic.
- Use `Room::is_dm` instead of `Room::is_direct` for the global room search.
- Expose `ffi::RoomInfo::is_dm` so clients can use this as the source of truth for whether a room is a DM.

Note some checks like the room list filtering or the `get_dm_rooms` one may not always give accurate results because the only synchronous information we can get for service members is the list of users to be considered service members in a room, not the number of *active* users that are service members in the room, which can only be computed asynchronously... or would require an `active_service_members` value being returned in the sync responses.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
