### PR TITLE
feat(ffi): expose beacon_id through ffi 

### DIFF
--- a/bindings/matrix-sdk-ffi/src/live_locations_observer.rs
+++ b/bindings/matrix-sdk-ffi/src/live_locations_observer.rs
@@ -44,6 +44,8 @@ pub struct LiveLocationShare {
     /// The duration that the location sharing will be live.
     /// Meaning that the location will stop being shared at ts + timeout.
     pub timeout: u64,
+    /// The event ID of the beacon_info state event for this share.
+    pub beacon_id: String,
 }
 
 /// An update to the list of active live location shares.
@@ -120,6 +122,7 @@ impl LiveLocationsObserver {
 
 impl From<SdkLiveLocationShare> for LiveLocationShare {
     fn from(share: SdkLiveLocationShare) -> Self {
+        let beacon_id = share.beacon_id.into();
         let start_ts = share.beacon_info.ts.0.into();
         let timeout = share.beacon_info.timeout.as_millis() as u64;
         let asset = share.beacon_info.asset.type_.into();
@@ -133,7 +136,13 @@ impl From<SdkLiveLocationShare> for LiveLocationShare {
             },
             ts: l.ts.0.into(),
         });
-        LiveLocationShare { user_id: share.user_id.to_string(), last_location, start_ts, timeout }
+        LiveLocationShare {
+            user_id: share.user_id.to_string(),
+            last_location,
+            start_ts,
+            timeout,
+            beacon_id,
+        }
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -1081,9 +1081,12 @@ impl Room {
     }
 
     /// Start the current users live location share in the room.
-    pub async fn start_live_location_share(&self, duration_millis: u64) -> Result<(), ClientError> {
-        self.inner.start_live_location_share(duration_millis, None).await?;
-        Ok(())
+    pub async fn start_live_location_share(
+        &self,
+        duration_millis: u64,
+    ) -> Result<String, ClientError> {
+        let response = self.inner.start_live_location_share(duration_millis, None).await?;
+        Ok(response.event_id.into())
     }
 
     /// Stop the current users live location share in the room.


### PR DESCRIPTION
This allows client to identify the current active share.

<!-- description of the changes in this PR -->

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
