### PR TITLE
feat(sdk): stop_live_location_share checks beacon_info.live

### DIFF
--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3984,6 +3984,7 @@ impl Room {
         self.ensure_room_joined()?;
 
         let mut beacon_info_event = self.get_user_beacon_info(self.own_user_id()).await?;
+
         if beacon_info_event.content.live {
             beacon_info_event.content.stop();
             Ok(self.send_state_event_for_key(self.own_user_id(), beacon_info_event.content).await?)

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3976,15 +3976,20 @@ impl Room {
     /// # Errors
     ///
     /// Returns an error if the room is not joined, if the beacon information
-    /// is redacted or stripped, or if the state event is not found.
+    /// is redacted or stripped, if the state event is not found, or if the
+    /// existing beacon is no longer live.
     pub async fn stop_live_location_share(
         &self,
     ) -> Result<send_state_event::v3::Response, BeaconError> {
         self.ensure_room_joined()?;
 
         let mut beacon_info_event = self.get_user_beacon_info(self.own_user_id()).await?;
-        beacon_info_event.content.stop();
-        Ok(self.send_state_event_for_key(self.own_user_id(), beacon_info_event.content).await?)
+        if beacon_info_event.content.live {
+            beacon_info_event.content.stop();
+            Ok(self.send_state_event_for_key(self.own_user_id(), beacon_info_event.content).await?)
+        } else {
+            Err(BeaconError::NotLive)
+        }
     }
 
     /// Send a location beacon event in the current room.

--- a/crates/matrix-sdk/tests/integration/room/beacon_info/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon_info/mod.rs
@@ -1,11 +1,18 @@
 use std::time::Duration;
 
 use js_int::uint;
-use matrix_sdk::config::{SyncSettings, SyncToken};
-use matrix_sdk_test::{DEFAULT_TEST_ROOM_ID, async_test, test_json};
+use matrix_sdk::{
+    BeaconError,
+    config::{SyncSettings, SyncToken},
+    test_utils::mocks::MatrixMockServer,
+};
+use matrix_sdk_test::{
+    DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, async_test, event_factory::EventFactory, test_json,
+};
 use ruma::{
     MilliSecondsSinceUnixEpoch, event_id,
     events::{AnySyncStateEvent, StateEventType, location::AssetType},
+    user_id,
 };
 use serde_json::json;
 use wiremock::{
@@ -247,4 +254,49 @@ async fn test_stop_sharing_live_location() {
     assert_eq!(content.asset.type_, AssetType::Self_);
 
     assert!(!content.live);
+}
+
+#[async_test]
+async fn test_stop_sharing_live_location_fails_if_not_live() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let current_time = MilliSecondsSinceUnixEpoch::now();
+    let f = EventFactory::new();
+
+    let beacon_info_event = f
+        .beacon_info(
+            Some("Live Share".to_owned()),
+            Duration::from_millis(3000),
+            false,
+            Some(current_time),
+        )
+        .event_id(event_id!("$15139375514XsgmR:localhost"))
+        .sender(user_id!("@example:localhost"))
+        .state_key(user_id!("@example:localhost"))
+        .into_raw_sync_state();
+
+    server
+        .mock_room_send_state()
+        .body_matches_partial_json(json!({
+            "description": "Live Share",
+            "live": false,
+            "timeout": 3000,
+            "org.matrix.msc3488.asset": { "type": "m.self" }
+        }))
+        .ok(event_id!("$h29iv0s8:example.com"))
+        .expect(0)
+        .mount()
+        .await;
+
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(*DEFAULT_TEST_ROOM_ID).add_state_event(beacon_info_event),
+        )
+        .await;
+
+    let room = client.get_room(*DEFAULT_TEST_ROOM_ID).unwrap();
+
+    assert!(matches!(room.stop_live_location_share().await, Err(BeaconError::NotLive)));
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
