### PR TITLE
feat(sdk-ui): Aggregation of call declines on to the notification event

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -161,6 +161,9 @@ All notable changes to this project will be documented in this file.
 - Add `RoomInfo::active_room_call_consensus_intent` method to get the call intent for the current call,
   based on what members are advertising.
   ([#6274](https://github.com/matrix-org/matrix-rust-sdk/pull/6274))
+- Add a list of `declined_by: Vec<String>` to the `TimelineItemContent::RtcNotification`, this will contain the list
+  of users that have declined the call.
+  ([#6494](https://github.com/matrix-org/matrix-rust-sdk/pull/6494))
 
 ### Refactor
 

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -44,6 +44,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add a list of `declined_by: Vec<String>` to the `TimelineItemContent::RtcNotification`, this will contain the list
+  of users that have declined the call.
+  ([#6494](https://github.com/matrix-org/matrix-rust-sdk/pull/6494))
 - Add `RoomInfo::active_service_members_count` and `NotificationRoomInfo::active_service_members_count`,
   returning the amount of service members that are part of the room.
   ([#6483](https://github.com/matrix-org/matrix-rust-sdk/pull/6483))
@@ -161,9 +164,6 @@ All notable changes to this project will be documented in this file.
 - Add `RoomInfo::active_room_call_consensus_intent` method to get the call intent for the current call,
   based on what members are advertising.
   ([#6274](https://github.com/matrix-org/matrix-rust-sdk/pull/6274))
-- Add a list of `declined_by: Vec<String>` to the `TimelineItemContent::RtcNotification`, this will contain the list
-  of users that have declined the call.
-  ([#6494](https://github.com/matrix-org/matrix-rust-sdk/pull/6494))
 
 ### Refactor
 

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -40,10 +40,12 @@ impl From<matrix_sdk_ui::timeline::TimelineItemContent> for TimelineItemContent 
 
             Content::CallInvite => TimelineItemContent::CallInvite,
 
-            Content::RtcNotification { call_intent } => TimelineItemContent::RtcNotification {
-                call_intent: call_intent.map(|s| s.to_string()),
-            },
-
+            Content::RtcNotification { call_intent, declinations } => {
+                TimelineItemContent::RtcNotification {
+                    call_intent: call_intent.map(|s| s.to_string()),
+                    declined_by: declinations.iter().map(|u| u.to_string()).collect(),
+                }
+            }
             Content::MembershipChange(membership) => {
                 let reason = match membership.content() {
                     StateEventContentChange::Original { content, .. } => content.reason.clone(),
@@ -163,6 +165,7 @@ pub enum TimelineItemContent {
     CallInvite,
     RtcNotification {
         call_intent: Option<String>,
+        declined_by: Vec<String>,
     },
     RoomMembership {
         user_id: String,

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -40,7 +40,7 @@ impl From<matrix_sdk_ui::timeline::TimelineItemContent> for TimelineItemContent 
 
             Content::CallInvite => TimelineItemContent::CallInvite,
 
-            Content::RtcNotification { call_intent, declinations } => {
+            Content::RtcNotification { call_intent, declined_by: declinations } => {
                 TimelineItemContent::RtcNotification {
                     call_intent: call_intent.map(|s| s.to_string()),
                     declined_by: declinations.iter().map(|u| u.to_string()).collect(),

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -96,6 +96,9 @@ All notable changes to this project will be documented in this file.
   the user who forwarded the keys used to decrypt the event as part of an [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268)
   key bundle.
   ([#6000](https://github.com/matrix-org/matrix-rust-sdk/pull/6000))
+- Add a list of `declined_by: Vec<OwnedUserId>` to the `TimelineItemContent::RtcNotification`, this will contain the list
+  of users that have declined the call.
+  ([#6494](https://github.com/matrix-org/matrix-rust-sdk/pull/6494))
   
 ### Refactor
 

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -38,6 +38,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add a list of `declined_by: Vec<OwnedUserId>` to the `TimelineItemContent::RtcNotification`, this will contain the list
+  of users that have declined the call.
+  ([#6494](https://github.com/matrix-org/matrix-rust-sdk/pull/6494))
 - [**breaking**] Add the `suggested` field to the `SpaceRoom` struct,
   which indicates whether a space's admins have marked that sub-space/room
   as a "suggested" one to join. ([6417](https://github.com/matrix-org/matrix-rust-sdk/pull/6417))
@@ -96,9 +99,6 @@ All notable changes to this project will be documented in this file.
   the user who forwarded the keys used to decrypt the event as part of an [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268)
   key bundle.
   ([#6000](https://github.com/matrix-org/matrix-rust-sdk/pull/6000))
-- Add a list of `declined_by: Vec<OwnedUserId>` to the `TimelineItemContent::RtcNotification`, this will contain the list
-  of users that have declined the call.
-  ([#6494](https://github.com/matrix-org/matrix-rust-sdk/pull/6494))
   
 ### Refactor
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
@@ -472,19 +472,9 @@ impl Aggregation {
                 ApplyAggregationResult::Error(AggregationError::CantUndoBeaconStop)
             }
 
-            AggregationKind::CallDeclined { sender } => {
-                match rtc_notification_declinations_from_item(event) {
-                    Ok(declinations) => {
-                        let before = declinations.len();
-                        declinations.retain(|s| s != sender);
-                        if declinations.len() < before {
-                            ApplyAggregationResult::UpdatedItem
-                        } else {
-                            ApplyAggregationResult::LeftItemIntact
-                        }
-                    }
-                    Err(err) => ApplyAggregationResult::Error(err),
-                }
+            AggregationKind::CallDeclined { .. } => {
+                // One cannot un-decline a call
+                ApplyAggregationResult::Error(AggregationError::CantUndoRtcDecline)
             }
         }
     }
@@ -1085,6 +1075,9 @@ pub(crate) enum AggregationError {
 
     #[error("a beacon stop can't be unapplied")]
     CantUndoBeaconStop,
+
+    #[error("a call decline can't be unapplied")]
+    CantUndoRtcDecline,
 
     #[error(
         "trying to apply an aggregation of one type to an invalid target: \

--- a/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
@@ -223,21 +223,13 @@ fn live_location_state_from_item<'a>(
 fn rtc_notification_declinations_from_item<'a>(
     event: &'a mut Cow<'_, EventTimelineItem>,
 ) -> Result<&'a mut Vec<OwnedUserId>, AggregationError> {
-    if event.content().is_rtc_notification() {
-        // It was an RtcNotification! Now return the declinations as mutable.
-        let declinations = event
-            .to_mut()
-            .content_mut()
-            .as_rtc_notification_mut()
-            .expect("it was an rtc notification just above");
-
-        Ok(declinations)
-    } else {
-        Err(AggregationError::InvalidType {
+    let debug_string = event.content().debug_string().to_owned();
+    event.to_mut().content_mut().as_rtc_notification_mut().ok_or_else(|| {
+        AggregationError::InvalidType {
             expected: "an rtc notification".to_owned(),
-            actual: event.content().debug_string().to_owned(),
-        })
-    }
+            actual: debug_string,
+        }
+    })
 }
 
 impl Aggregation {

--- a/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
@@ -154,6 +154,12 @@ pub(crate) enum AggregationKind {
     ///
     /// Unlike [`BeaconUpdate`], a beacon stop is not reversible.
     BeaconStop { content: BeaconInfoEventContent },
+
+    /// An m.rtc.decline event for an m.rtc.notification event
+    CallDeclined {
+        /// Sender of the decline.
+        sender: OwnedUserId,
+    },
 }
 
 /// An aggregation is an event related to another event (for instance a
@@ -208,6 +214,27 @@ fn live_location_state_from_item<'a>(
     } else {
         Err(AggregationError::InvalidType {
             expected: "a live location".to_owned(),
+            actual: event.content().debug_string().to_owned(),
+        })
+    }
+}
+
+/// Gets the mutable list of users that did decline this notification event.
+fn rtc_notification_declinations_from_item<'a>(
+    event: &'a mut Cow<'_, EventTimelineItem>,
+) -> Result<&'a mut Vec<OwnedUserId>, AggregationError> {
+    if event.content().is_rtc_notification() {
+        // It was an RtcNotification! Now return the declinations as mutable.
+        let declinations = event
+            .to_mut()
+            .content_mut()
+            .as_rtc_notification_mut()
+            .expect("it was an rtc notification just above");
+
+        Ok(declinations)
+    } else {
+        Err(AggregationError::InvalidType {
+            expected: "an rtc notification".to_owned(),
             actual: event.content().debug_string().to_owned(),
         })
     }
@@ -335,6 +362,20 @@ impl Aggregation {
                 }
                 Err(err) => ApplyAggregationResult::Error(err),
             },
+
+            AggregationKind::CallDeclined { sender } => {
+                match rtc_notification_declinations_from_item(event) {
+                    Ok(declinations) => {
+                        if declinations.contains(sender) {
+                            ApplyAggregationResult::LeftItemIntact
+                        } else {
+                            declinations.push(sender.clone());
+                            ApplyAggregationResult::UpdatedItem
+                        }
+                    }
+                    Err(err) => ApplyAggregationResult::Error(err),
+                }
+            }
         }
     }
 
@@ -429,6 +470,21 @@ impl Aggregation {
             AggregationKind::BeaconStop { .. } => {
                 // Stopping a live location share is not reversible.
                 ApplyAggregationResult::Error(AggregationError::CantUndoBeaconStop)
+            }
+
+            AggregationKind::CallDeclined { sender } => {
+                match rtc_notification_declinations_from_item(event) {
+                    Ok(declinations) => {
+                        let before = declinations.len();
+                        declinations.retain(|s| s != sender);
+                        if declinations.len() < before {
+                            ApplyAggregationResult::UpdatedItem
+                        } else {
+                            ApplyAggregationResult::LeftItemIntact
+                        }
+                    }
+                    Err(err) => ApplyAggregationResult::Error(err),
+                }
             }
         }
     }
@@ -739,7 +795,8 @@ impl Aggregations {
                 | AggregationKind::PollEnd { .. }
                 | AggregationKind::Edit(..)
                 | AggregationKind::BeaconUpdate { .. }
-                | AggregationKind::BeaconStop { .. } => {
+                | AggregationKind::BeaconStop { .. }
+                | AggregationKind::CallDeclined { .. } => {
                     // Nothing particular to do.
                 }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -314,6 +314,9 @@ pub fn default_event_filter(event: &AnySyncTimelineEvent, rules: &RoomVersionRul
                         // their parent `beacon_info` state event's timeline
                         // item. They are never rendered as standalone items.
                         AnyMessageLikeEventContent::Beacon(_) => false,
+                        // Ignore decline events, the matching RtcNotification event will be updated
+                        // to reflect the decline.
+                        AnyMessageLikeEventContent::RtcDecline(_) => false,
 
                         _ => false,
                     }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -418,7 +418,7 @@ impl TimelineAction {
             AnyMessageLikeEventContent::RtcNotification(c) => {
                 Self::add_item(TimelineItemContent::RtcNotification {
                     call_intent: c.call_intent,
-                    declinations: Vec::new(),
+                    declined_by: Vec::new(),
                 })
             }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -166,6 +166,9 @@ pub(super) enum HandleAggregationKind {
     /// this does not carry a `relates_to` event ID; instead the target live
     /// item is found by matching the sender.
     BeaconStop { content: BeaconInfoEventContent },
+
+    /// A decline for an `m.rtc.notification` call.
+    CallDeclined,
 }
 
 impl HandleAggregationKind {
@@ -180,6 +183,7 @@ impl HandleAggregationKind {
             HandleAggregationKind::PollEnd => "a poll end",
             HandleAggregationKind::BeaconUpdate { .. } => "a beacon location update",
             HandleAggregationKind::BeaconStop { .. } => "a beacon stop",
+            HandleAggregationKind::CallDeclined => "a call decline",
         }
     }
 }
@@ -412,8 +416,16 @@ impl TimelineAction {
             }
 
             AnyMessageLikeEventContent::RtcNotification(c) => {
-                Self::add_item(TimelineItemContent::RtcNotification { call_intent: c.call_intent })
+                Self::add_item(TimelineItemContent::RtcNotification {
+                    call_intent: c.call_intent,
+                    declinations: Vec::new(),
+                })
             }
+
+            AnyMessageLikeEventContent::RtcDecline(c) => Self::HandleAggregation {
+                related_event: c.relates_to.event_id,
+                kind: HandleAggregationKind::CallDeclined,
+            },
 
             AnyMessageLikeEventContent::Sticker(content) => {
                 Self::add_item(TimelineItemContent::MsgLike(MsgLikeContent {
@@ -653,6 +665,9 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 }
                 HandleAggregationKind::BeaconStop { content } => {
                     self.handle_beacon_stop(content);
+                }
+                HandleAggregationKind::CallDeclined => {
+                    self.handle_call_declined(related_event);
                 }
             },
         }
@@ -898,6 +913,24 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 true
             }
         }
+    }
+
+    /// Handle a call decline event by updating the related call notification
+    /// event and adding the new decliner to the list via the manager.
+    fn handle_call_declined(&mut self, notification_event_id: OwnedEventId) {
+        let target = TimelineEventItemId::EventId(notification_event_id);
+        let aggregation = Aggregation::new(
+            self.ctx.flow.timeline_item_id(),
+            AggregationKind::CallDeclined { sender: self.ctx.sender.clone() },
+        );
+        self.meta.aggregations.add(target.clone(), aggregation.clone());
+        find_item_and_apply_aggregation(
+            &self.meta.aggregations,
+            self.items,
+            &target,
+            aggregation,
+            &self.meta.room_version_rules,
+        );
     }
 
     /// Add a new event item in the timeline.

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -124,6 +124,8 @@ pub enum TimelineItemContent {
     RtcNotification {
         /// The intent of this notification.
         call_intent: Option<CallIntent>,
+        /// Users who have declined this call notification
+        declinations: Vec<OwnedUserId>,
     },
 }
 
@@ -233,10 +235,24 @@ impl TimelineItemContent {
         }) => state)
     }
 
+    pub(in crate::timeline) fn as_rtc_notification_mut(&mut self) -> Option<&mut Vec<OwnedUserId>> {
+        if let TimelineItemContent::RtcNotification { declinations, .. } = self {
+            Some(declinations)
+        } else {
+            None
+        }
+    }
+
     /// Check whether this item's content is a
     /// [`LiveLocation`][MsgLikeKind::LiveLocation].
     pub fn is_live_location(&self) -> bool {
         matches!(self, Self::MsgLike(MsgLikeContent { kind: MsgLikeKind::LiveLocation(_), .. }))
+    }
+
+    /// Check whether this item's content is an
+    /// [`RtcNotification`][Self::RtcNotification].
+    pub fn is_rtc_notification(&self) -> bool {
+        matches!(self, Self::RtcNotification { .. })
     }
 
     /// If `self` is of the [`MsgLike`][Self::MsgLike] variant, return the

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -125,7 +125,7 @@ pub enum TimelineItemContent {
         /// The intent of this notification.
         call_intent: Option<CallIntent>,
         /// Users who have declined this call notification
-        declinations: Vec<OwnedUserId>,
+        declined_by: Vec<OwnedUserId>,
     },
 }
 
@@ -236,8 +236,8 @@ impl TimelineItemContent {
     }
 
     pub(in crate::timeline) fn as_rtc_notification_mut(&mut self) -> Option<&mut Vec<OwnedUserId>> {
-        if let TimelineItemContent::RtcNotification { declinations, .. } = self {
-            Some(declinations)
+        if let TimelineItemContent::RtcNotification { declined_by, .. } = self {
+            Some(declined_by)
         } else {
             None
         }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -60,6 +60,7 @@ mod replies;
 mod subscribe;
 mod thread;
 
+mod rtc;
 pub(crate) mod sliding_sync;
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
@@ -54,8 +54,7 @@ async fn test_decline_call() {
     let event_item = message.as_event().unwrap();
     assert!(event_item.content().is_rtc_notification());
     assert_let!(
-        TimelineItemContent::RtcNotification { call_intent: _, declinations } =
-            event_item.content()
+        TimelineItemContent::RtcNotification { call_intent: _, declined_by } = event_item.content()
     );
     assert_eq!(declinations.len(), 0);
 
@@ -65,7 +64,7 @@ async fn test_decline_call() {
     let event_item = updated_message.as_event().unwrap();
 
     assert_let!(
-        TimelineItemContent::RtcNotification { call_intent, declinations } = event_item.content()
+        TimelineItemContent::RtcNotification { call_intent, declined_by } = event_item.content()
     );
     assert_eq!(declinations.len(), 1);
     assert_eq!(declinations[0], *BOB);
@@ -119,8 +118,7 @@ async fn test_multiple_decline_call() {
     let event_item = message.as_event().unwrap();
     assert!(event_item.content().is_rtc_notification());
     assert_let!(
-        TimelineItemContent::RtcNotification { call_intent: _, declinations } =
-            event_item.content()
+        TimelineItemContent::RtcNotification { call_intent: _, declined_by } = event_item.content()
     );
     assert_eq!(declinations.len(), 0);
 
@@ -130,8 +128,7 @@ async fn test_multiple_decline_call() {
     let event_item = updated_message.as_event().unwrap();
 
     assert_let!(
-        TimelineItemContent::RtcNotification { call_intent: _, declinations } =
-            event_item.content()
+        TimelineItemContent::RtcNotification { call_intent: _, declined_by } = event_item.content()
     );
     assert_eq!(declinations.len(), 1);
     assert_eq!(declinations[0], *BOB);
@@ -142,8 +139,7 @@ async fn test_multiple_decline_call() {
     let event_item = updated_message.as_event().unwrap();
 
     assert_let!(
-        TimelineItemContent::RtcNotification { call_intent: _, declinations } =
-            event_item.content()
+        TimelineItemContent::RtcNotification { call_intent: _, declined_by } = event_item.content()
     );
     assert_eq!(declinations.len(), 2);
     assert_eq!(declinations[0], *BOB);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
@@ -1,0 +1,149 @@
+use assert_matches2::assert_let;
+use eyeball_im::VectorDiff;
+use matrix_sdk::{assert_let_timeout, test_utils::mocks::MatrixMockServer};
+use matrix_sdk_test::{
+    ALICE, BOB, CAROL, JoinedRoomBuilder, async_test, event_factory::EventFactory,
+};
+use matrix_sdk_ui::timeline::{RoomExt, TimelineItemContent};
+use ruma::{
+    event_id,
+    events::rtc::notification::{CallIntent, NotificationType},
+    room_id,
+};
+use tokio_stream::StreamExt;
+
+#[async_test]
+async fn test_decline_call() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let timeline = room.timeline().await.unwrap();
+    let (_, mut timeline_stream) = timeline.subscribe().await;
+
+    let notification_event_id = event_id!("$notify");
+    let declination_event_id = event_id!("$decline");
+
+    let f = EventFactory::new();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    f.rtc_notification(NotificationType::Ring)
+                        .call_intent(CallIntent::Audio)
+                        .sender(&ALICE)
+                        .event_id(notification_event_id),
+                )
+                .add_timeline_event(
+                    f.call_decline(notification_event_id)
+                        .sender(&BOB)
+                        .event_id(declination_event_id),
+                ),
+        )
+        .await;
+
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
+    assert_eq!(timeline_updates.len(), 4);
+
+    assert_let!(VectorDiff::PushBack { value: message } = &timeline_updates[0]);
+    let event_item = message.as_event().unwrap();
+    assert!(event_item.content().is_rtc_notification());
+    assert_let!(
+        TimelineItemContent::RtcNotification { call_intent: _, declinations } = event_item.content()
+    );
+    assert_eq!(declinations.len(), 0);
+
+    // Ignore update 1 (implicit read receipt following the declination)
+    // Then the decline is taken into account.
+    assert_let!(VectorDiff::Set { index: 0, value: updated_message } = &timeline_updates[2]);
+    let event_item = updated_message.as_event().unwrap();
+
+    assert_let!(
+        TimelineItemContent::RtcNotification { call_intent, declinations } = event_item.content()
+    );
+    assert_eq!(declinations.len(), 1);
+    assert_eq!(declinations[0], *BOB);
+    assert_eq!(call_intent.clone().unwrap(), CallIntent::Audio);
+}
+
+#[async_test]
+async fn test_multiple_decline_call() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let timeline = room.timeline().await.unwrap();
+    let (_, mut timeline_stream) = timeline.subscribe().await;
+
+    let notification_event_id = event_id!("$notify");
+    let declination_event_id_bob = event_id!("$decline1");
+    let declination_event_id_carol = event_id!("$decline2");
+
+    let f = EventFactory::new();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    f.rtc_notification(NotificationType::Ring)
+                        .sender(&ALICE)
+                        .event_id(notification_event_id),
+                )
+                .add_timeline_event(
+                    f.call_decline(notification_event_id)
+                        .sender(&BOB)
+                        .event_id(declination_event_id_bob),
+                )
+                .add_timeline_event(
+                    f.call_decline(notification_event_id)
+                        .sender(&CAROL)
+                        .event_id(declination_event_id_carol),
+                ),
+        )
+        .await;
+
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
+    assert_eq!(timeline_updates.len(), 6);
+
+    assert_let!(VectorDiff::PushBack { value: message } = &timeline_updates[0]);
+    let event_item = message.as_event().unwrap();
+    assert!(event_item.content().is_rtc_notification());
+    assert_let!(
+        TimelineItemContent::RtcNotification { call_intent: _, declinations } = event_item.content()
+    );
+    assert_eq!(declinations.len(), 0);
+
+    // Ignore update 1 (implicit read receipt following the declination)
+    // Then the first decline is taken into account.
+    assert_let!(VectorDiff::Set { index: 0, value: updated_message } = &timeline_updates[2]);
+    let event_item = updated_message.as_event().unwrap();
+
+    assert_let!(
+        TimelineItemContent::RtcNotification { call_intent: _, declinations } =
+            event_item.content()
+    );
+    assert_eq!(declinations.len(), 1);
+    assert_eq!(declinations[0], *BOB);
+
+    // Ignore update 3 (implicit read receipt following the declination)
+    // Then the second decline is taken into account.
+    assert_let!(VectorDiff::Set { index: 0, value: updated_message } = &timeline_updates[4]);
+    let event_item = updated_message.as_event().unwrap();
+
+    assert_let!(
+        TimelineItemContent::RtcNotification { call_intent: _, declinations } =
+            event_item.content()
+    );
+    assert_eq!(declinations.len(), 2);
+    assert_eq!(declinations[0], *BOB);
+    assert_eq!(declinations[1], *CAROL);
+}

--- a/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
@@ -56,7 +56,7 @@ async fn test_decline_call() {
     assert_let!(
         TimelineItemContent::RtcNotification { call_intent: _, declined_by } = event_item.content()
     );
-    assert_eq!(declinations.len(), 0);
+    assert_eq!(declined_by.len(), 0);
 
     // Ignore update 1 (implicit read receipt following the declination)
     // Then the decline is taken into account.
@@ -66,8 +66,8 @@ async fn test_decline_call() {
     assert_let!(
         TimelineItemContent::RtcNotification { call_intent, declined_by } = event_item.content()
     );
-    assert_eq!(declinations.len(), 1);
-    assert_eq!(declinations[0], *BOB);
+    assert_eq!(declined_by.len(), 1);
+    assert_eq!(declined_by[0], *BOB);
     assert_eq!(call_intent.clone().unwrap(), CallIntent::Audio);
 }
 
@@ -120,7 +120,7 @@ async fn test_multiple_decline_call() {
     assert_let!(
         TimelineItemContent::RtcNotification { call_intent: _, declined_by } = event_item.content()
     );
-    assert_eq!(declinations.len(), 0);
+    assert_eq!(declined_by.len(), 0);
 
     // Ignore update 1 (implicit read receipt following the declination)
     // Then the first decline is taken into account.
@@ -130,8 +130,8 @@ async fn test_multiple_decline_call() {
     assert_let!(
         TimelineItemContent::RtcNotification { call_intent: _, declined_by } = event_item.content()
     );
-    assert_eq!(declinations.len(), 1);
-    assert_eq!(declinations[0], *BOB);
+    assert_eq!(declined_by.len(), 1);
+    assert_eq!(declined_by[0], *BOB);
 
     // Ignore update 3 (implicit read receipt following the declination)
     // Then the second decline is taken into account.
@@ -141,7 +141,7 @@ async fn test_multiple_decline_call() {
     assert_let!(
         TimelineItemContent::RtcNotification { call_intent: _, declined_by } = event_item.content()
     );
-    assert_eq!(declinations.len(), 2);
-    assert_eq!(declinations[0], *BOB);
-    assert_eq!(declinations[1], *CAROL);
+    assert_eq!(declined_by.len(), 2);
+    assert_eq!(declined_by[0], *BOB);
+    assert_eq!(declined_by[1], *CAROL);
 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
@@ -54,7 +54,8 @@ async fn test_decline_call() {
     let event_item = message.as_event().unwrap();
     assert!(event_item.content().is_rtc_notification());
     assert_let!(
-        TimelineItemContent::RtcNotification { call_intent: _, declinations } = event_item.content()
+        TimelineItemContent::RtcNotification { call_intent: _, declinations } =
+            event_item.content()
     );
     assert_eq!(declinations.len(), 0);
 
@@ -118,7 +119,8 @@ async fn test_multiple_decline_call() {
     let event_item = message.as_event().unwrap();
     assert!(event_item.content().is_rtc_notification());
     assert_let!(
-        TimelineItemContent::RtcNotification { call_intent: _, declinations } = event_item.content()
+        TimelineItemContent::RtcNotification { call_intent: _, declinations } =
+            event_item.content()
     );
     assert_eq!(declinations.len(), 0);
 


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Update of the RTCNotification event so that it can "aggregate" the list of users that declined the call.
```
    RtcNotification {
        /// The intent of this notification.
        call_intent: Option<CallIntent>,
        /// Users who have declined this call notification
        declined_by: Vec<OwnedUserId>,
    },
```

As per [MSC4310](https://github.com/matrix-org/matrix-spec-proposals/pull/4310), `m.rtc.decline` events have a relation to the `m.rtc.notification` they declined. I used the aggregation module to manage that (~similar to reactions?)


- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
