### PR TITLE
feat(client): mechanism for closing and reopening a client and its underlying stores

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -466,6 +466,24 @@ impl Client {
         Ok(self.inner.optimize_stores().await?)
     }
 
+    /// Pause the client, releasing all database connections and file locks.
+    ///
+    /// Call this when the app enters the background on iOS to prevent
+    /// `0xdead10cc` terminations. Waits for all in-flight database
+    /// operations to complete before returning.
+    ///
+    /// Call `resume()` when the app returns to the foreground.
+    pub async fn pause(&self) -> Result<(), ClientError> {
+        Ok(self.inner.pause().await?)
+    }
+
+    /// Resume the client after a `pause()`, re-opening database connections.
+    ///
+    /// Call this when the app returns to the foreground.
+    pub async fn resume(&self) -> Result<(), ClientError> {
+        Ok(self.inner.resume().await?)
+    }
+
     /// Returns the sizes of the existing stores, if known.
     pub async fn get_store_sizes(&self) -> Result<StoreSizes, ClientError> {
         Ok(self.inner.get_store_sizes().await?.into())

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -466,20 +466,33 @@ impl Client {
         Ok(self.inner.optimize_stores().await?)
     }
 
-    /// Pause the client, releasing all database connections and file locks.
+    /// Pause the client for background suspension.
     ///
-    /// Call this when the app enters the background on iOS to prevent
-    /// `0xdead10cc` terminations. Waits for all in-flight database
-    /// operations to complete before returning.
+    /// This method:
+    /// 1. Disables all send queues (prevents new message sends).
+    /// 2. Pauses all database stores, waiting for in-flight operations and
+    ///    releasing all connections and file locks.
     ///
-    /// Call `resume()` when the app returns to the foreground.
+    /// Call [`Client::resume()`] when the app returns to the foreground.
+    ///
+    /// # iOS
+    ///
+    /// Call this before the app is suspended to avoid `0xdead10cc` kills.
+    /// Typically called from
+    /// [`applicationDidEnterBackground`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationdidenterbackground(_:))
+    /// or an equivalent SwiftUI lifecycle event, *after* stopping the
+    /// `matrix_sdk_ui::sync_service::SyncService`.
     pub async fn pause(&self) -> Result<(), ClientError> {
         Ok(self.inner.pause().await?)
     }
 
-    /// Resume the client after a `pause()`, re-opening database connections.
+    /// Resume the client after a [`Client::pause()`].
     ///
-    /// Call this when the app returns to the foreground.
+    /// Re-acquires store resources and re-enables send queues.
+    ///
+    /// If your app stopped the `matrix_sdk_ui::sync_service::SyncService`
+    /// before pausing, restart it separately as appropriate for your app
+    /// lifecycle.
     pub async fn resume(&self) -> Result<(), ClientError> {
         Ok(self.inner.resume().await?)
     }

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1150,28 +1150,28 @@ impl BaseClient {
         Ok(result)
     }
 
-    /// Pause all stores, releasing database connections and file locks.
+    /// Close all stores, releasing database connections and file locks.
     ///
     /// In-flight operations will complete before this returns.
-    pub async fn pause_stores(&self) -> Result<()> {
-        self.state_store.pause().await?;
-        self.event_cache_store.pause().await.map_err(Error::EventCacheStore)?;
-        self.media_store.pause().await.map_err(Error::MediaStore)?;
+    pub async fn close_stores(&self) -> Result<()> {
+        self.state_store.close().await?;
+        self.event_cache_store.close().await.map_err(Error::EventCacheStore)?;
+        self.media_store.close().await.map_err(Error::MediaStore)?;
 
         #[cfg(feature = "e2e-encryption")]
-        self.crypto_store.pause().await.map_err(Error::CryptoStore)?;
+        self.crypto_store.close().await.map_err(Error::CryptoStore)?;
 
         Ok(())
     }
 
-    /// Resume all stores after a pause, re-opening database connections.
-    pub async fn resume_stores(&self) -> Result<()> {
+    /// Reopen all stores after a close, re-opening database connections.
+    pub async fn reopen_stores(&self) -> Result<()> {
         #[cfg(feature = "e2e-encryption")]
-        self.crypto_store.resume().await.map_err(Error::CryptoStore)?;
+        self.crypto_store.reopen().await.map_err(Error::CryptoStore)?;
 
-        self.media_store.resume().await.map_err(Error::MediaStore)?;
-        self.event_cache_store.resume().await.map_err(Error::EventCacheStore)?;
-        self.state_store.resume().await?;
+        self.media_store.reopen().await.map_err(Error::MediaStore)?;
+        self.event_cache_store.reopen().await.map_err(Error::EventCacheStore)?;
+        self.state_store.reopen().await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1149,6 +1149,32 @@ impl BaseClient {
         };
         Ok(result)
     }
+
+    /// Pause all stores, releasing database connections and file locks.
+    ///
+    /// In-flight operations will complete before this returns.
+    pub async fn pause_stores(&self) -> Result<()> {
+        self.state_store.pause().await?;
+        self.event_cache_store.pause().await.map_err(Error::EventCacheStore)?;
+        self.media_store.pause().await.map_err(Error::MediaStore)?;
+
+        #[cfg(feature = "e2e-encryption")]
+        self.crypto_store.pause().await.map_err(Error::CryptoStore)?;
+
+        Ok(())
+    }
+
+    /// Resume all stores after a pause, re-opening database connections.
+    pub async fn resume_stores(&self) -> Result<()> {
+        #[cfg(feature = "e2e-encryption")]
+        self.crypto_store.resume().await.map_err(Error::CryptoStore)?;
+
+        self.media_store.resume().await.map_err(Error::MediaStore)?;
+        self.event_cache_store.resume().await.map_err(Error::EventCacheStore)?;
+        self.state_store.resume().await?;
+
+        Ok(())
+    }
 }
 
 /// Represent the `required_state` values sent by a sync request.

--- a/crates/matrix-sdk-base/src/error.rs
+++ b/crates/matrix-sdk-base/src/error.rs
@@ -20,7 +20,7 @@ use matrix_sdk_common::cross_process_lock::CrossProcessLockError;
 use matrix_sdk_crypto::{CryptoStoreError, MegolmError, OlmError};
 use thiserror::Error;
 
-use crate::event_cache::store::EventCacheStoreError;
+use crate::{event_cache::store::EventCacheStoreError, media::store::MediaStoreError};
 
 /// Result type of the rust-sdk.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -48,6 +48,10 @@ pub enum Error {
     /// An error happened while manipulating the event cache store.
     #[error(transparent)]
     EventCacheStore(#[from] EventCacheStoreError),
+
+    /// An error happened in the media store.
+    #[error(transparent)]
+    MediaStore(#[from] MediaStoreError),
 
     /// An error happened while attempting to lock the event cache store.
     #[error(transparent)]

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -77,11 +77,11 @@ impl MemoryStore {
 impl EventCacheStore for MemoryStore {
     type Error = EventCacheStoreError;
 
-    async fn pause(&self) -> Result<(), Self::Error> {
+    async fn close(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
+    async fn reopen(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -77,6 +77,14 @@ impl MemoryStore {
 impl EventCacheStore for MemoryStore {
     type Error = EventCacheStoreError;
 
+    async fn pause(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     async fn try_take_leased_lock(
         &self,
         lease_duration_ms: u32,

--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -80,6 +80,16 @@ impl EventCacheStoreLock {
         Self { cross_process_lock, store }
     }
 
+    /// Pause the store, releasing database connections and file locks.
+    pub async fn pause(&self) -> Result<(), EventCacheStoreError> {
+        self.store.pause().await
+    }
+
+    /// Resume the store after a pause.
+    pub async fn resume(&self) -> Result<(), EventCacheStoreError> {
+        self.store.resume().await
+    }
+
     /// Acquire a spin lock (see [`CrossProcessLock::spin_lock`]).
     pub async fn lock(&self) -> Result<EventCacheStoreLockState, CrossProcessLockError> {
         Ok(self.cross_process_lock.spin_lock(None).await??.map(|cross_process_lock_guard| {

--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -80,14 +80,14 @@ impl EventCacheStoreLock {
         Self { cross_process_lock, store }
     }
 
-    /// Pause the store, releasing database connections and file locks.
-    pub async fn pause(&self) -> Result<(), EventCacheStoreError> {
-        self.store.pause().await
+    /// Close the store, releasing database connections and file locks.
+    pub async fn close(&self) -> Result<(), EventCacheStoreError> {
+        self.store.close().await
     }
 
-    /// Resume the store after a pause.
-    pub async fn resume(&self) -> Result<(), EventCacheStoreError> {
-        self.store.resume().await
+    /// Reopen the store after a close.
+    pub async fn reopen(&self) -> Result<(), EventCacheStoreError> {
+        self.store.reopen().await
     }
 
     /// Acquire a spin lock (see [`CrossProcessLock::spin_lock`]).

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -176,6 +176,25 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// without causing an error.
     async fn save_event(&self, room_id: &RoomId, event: Event) -> Result<(), Self::Error>;
 
+    /// Pause the store, releasing all held resources (database connections,
+    /// file descriptors, file locks).
+    ///
+    /// In-flight operations complete before this method returns. After it
+    /// returns, operations will fail until [`Self::resume()`] is called.
+    ///
+    /// The default implementation is a no-op (suitable for in-memory stores).
+    async fn pause(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Resume the store after a [`Self::pause()`], re-acquiring database
+    /// connections.
+    ///
+    /// The default implementation is a no-op.
+    async fn resume(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     /// Perform database optimizations if any are available, i.e. vacuuming in
     /// SQLite.
     ///
@@ -292,6 +311,14 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
 
     async fn save_event(&self, room_id: &RoomId, event: Event) -> Result<(), Self::Error> {
         self.0.save_event(room_id, event).await.map_err(Into::into)
+    }
+
+    async fn pause(&self) -> Result<(), Self::Error> {
+        self.0.pause().await.map_err(Into::into)
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        self.0.resume().await.map_err(Into::into)
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -176,16 +176,16 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// without causing an error.
     async fn save_event(&self, room_id: &RoomId, event: Event) -> Result<(), Self::Error>;
 
-    /// Pause the store, releasing all held resources (database connections,
+    /// Close the store, releasing all held resources (database connections,
     /// file descriptors, file locks).
     ///
     /// In-flight operations complete before this method returns. After it
-    /// returns, operations will fail until [`Self::resume()`] is called.
-    async fn pause(&self) -> Result<(), Self::Error>;
+    /// returns, operations will fail until [`Self::reopen()`] is called.
+    async fn close(&self) -> Result<(), Self::Error>;
 
-    /// Resume the store after a [`Self::pause()`], re-acquiring database
+    /// Reopen the store after a [`Self::close()`], re-acquiring database
     /// connections.
-    async fn resume(&self) -> Result<(), Self::Error>;
+    async fn reopen(&self) -> Result<(), Self::Error>;
 
     /// Perform database optimizations if any are available, i.e. vacuuming in
     /// SQLite.
@@ -305,12 +305,12 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
         self.0.save_event(room_id, event).await.map_err(Into::into)
     }
 
-    async fn pause(&self) -> Result<(), Self::Error> {
-        self.0.pause().await.map_err(Into::into)
+    async fn close(&self) -> Result<(), Self::Error> {
+        self.0.close().await.map_err(Into::into)
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
-        self.0.resume().await.map_err(Into::into)
+    async fn reopen(&self) -> Result<(), Self::Error> {
+        self.0.reopen().await.map_err(Into::into)
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -181,19 +181,11 @@ pub trait EventCacheStore: AsyncTraitDeps {
     ///
     /// In-flight operations complete before this method returns. After it
     /// returns, operations will fail until [`Self::resume()`] is called.
-    ///
-    /// The default implementation is a no-op (suitable for in-memory stores).
-    async fn pause(&self) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    async fn pause(&self) -> Result<(), Self::Error>;
 
     /// Resume the store after a [`Self::pause()`], re-acquiring database
     /// connections.
-    ///
-    /// The default implementation is a no-op.
-    async fn resume(&self) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    async fn resume(&self) -> Result<(), Self::Error>;
 
     /// Perform database optimizations if any are available, i.e. vacuuming in
     /// SQLite.

--- a/crates/matrix-sdk-base/src/media/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/media/store/memory_store.rs
@@ -227,11 +227,11 @@ impl MediaStore for MemoryMediaStore {
         Ok(None)
     }
 
-    async fn pause(&self) -> Result<(), Self::Error> {
+    async fn close(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
+    async fn reopen(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/crates/matrix-sdk-base/src/media/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/media/store/memory_store.rs
@@ -226,6 +226,14 @@ impl MediaStore for MemoryMediaStore {
     async fn get_size(&self) -> Result<Option<usize>, Self::Error> {
         Ok(None)
     }
+
+    async fn pause(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]

--- a/crates/matrix-sdk-base/src/media/store/mod.rs
+++ b/crates/matrix-sdk-base/src/media/store/mod.rs
@@ -129,6 +129,16 @@ impl MediaStoreLock {
         Self { cross_process_lock, store }
     }
 
+    /// Pause the store, releasing database connections and file locks.
+    pub async fn pause(&self) -> Result<(), MediaStoreError> {
+        self.store.pause().await
+    }
+
+    /// Resume the store after a pause.
+    pub async fn resume(&self) -> Result<(), MediaStoreError> {
+        self.store.resume().await
+    }
+
     /// Acquire a spin lock (see [`CrossProcessLock::spin_lock`]).
     pub async fn lock(&self) -> Result<MediaStoreLockGuard<'_>, CrossProcessLockError> {
         let cross_process_lock_guard = match self.cross_process_lock.spin_lock(None).await?? {

--- a/crates/matrix-sdk-base/src/media/store/mod.rs
+++ b/crates/matrix-sdk-base/src/media/store/mod.rs
@@ -129,14 +129,14 @@ impl MediaStoreLock {
         Self { cross_process_lock, store }
     }
 
-    /// Pause the store, releasing database connections and file locks.
-    pub async fn pause(&self) -> Result<(), MediaStoreError> {
-        self.store.pause().await
+    /// Close the store, releasing database connections and file locks.
+    pub async fn close(&self) -> Result<(), MediaStoreError> {
+        self.store.close().await
     }
 
-    /// Resume the store after a pause.
-    pub async fn resume(&self) -> Result<(), MediaStoreError> {
-        self.store.resume().await
+    /// Reopen the store after a close.
+    pub async fn reopen(&self) -> Result<(), MediaStoreError> {
+        self.store.reopen().await
     }
 
     /// Acquire a spin lock (see [`CrossProcessLock::spin_lock`]).

--- a/crates/matrix-sdk-base/src/media/store/traits.rs
+++ b/crates/matrix-sdk-base/src/media/store/traits.rs
@@ -166,6 +166,25 @@ pub trait MediaStore: AsyncTraitDeps {
     /// If there is already an ongoing cleanup, this is a noop.
     async fn clean(&self) -> Result<(), Self::Error>;
 
+    /// Pause the store, releasing all held resources (database connections,
+    /// file descriptors, file locks).
+    ///
+    /// In-flight operations complete before this method returns. After it
+    /// returns, operations will fail until [`Self::resume()`] is called.
+    ///
+    /// The default implementation is a no-op (suitable for in-memory stores).
+    async fn pause(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Resume the store after a [`Self::pause()`], re-acquiring database
+    /// connections.
+    ///
+    /// The default implementation is a no-op.
+    async fn resume(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     /// Perform database optimizations if any are available, i.e. vacuuming in
     /// SQLite.
     ///
@@ -391,6 +410,14 @@ impl<T: MediaStore> MediaStore for EraseMediaStoreError<T> {
 
     async fn clean(&self) -> Result<(), Self::Error> {
         self.0.clean().await.map_err(Into::into)
+    }
+
+    async fn pause(&self) -> Result<(), Self::Error> {
+        self.0.pause().await.map_err(Into::into)
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        self.0.resume().await.map_err(Into::into)
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-base/src/media/store/traits.rs
+++ b/crates/matrix-sdk-base/src/media/store/traits.rs
@@ -171,19 +171,11 @@ pub trait MediaStore: AsyncTraitDeps {
     ///
     /// In-flight operations complete before this method returns. After it
     /// returns, operations will fail until [`Self::resume()`] is called.
-    ///
-    /// The default implementation is a no-op (suitable for in-memory stores).
-    async fn pause(&self) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    async fn pause(&self) -> Result<(), Self::Error>;
 
     /// Resume the store after a [`Self::pause()`], re-acquiring database
     /// connections.
-    ///
-    /// The default implementation is a no-op.
-    async fn resume(&self) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    async fn resume(&self) -> Result<(), Self::Error>;
 
     /// Perform database optimizations if any are available, i.e. vacuuming in
     /// SQLite.

--- a/crates/matrix-sdk-base/src/media/store/traits.rs
+++ b/crates/matrix-sdk-base/src/media/store/traits.rs
@@ -166,16 +166,16 @@ pub trait MediaStore: AsyncTraitDeps {
     /// If there is already an ongoing cleanup, this is a noop.
     async fn clean(&self) -> Result<(), Self::Error>;
 
-    /// Pause the store, releasing all held resources (database connections,
+    /// Close the store, releasing all held resources (database connections,
     /// file descriptors, file locks).
     ///
     /// In-flight operations complete before this method returns. After it
-    /// returns, operations will fail until [`Self::resume()`] is called.
-    async fn pause(&self) -> Result<(), Self::Error>;
+    /// returns, operations will fail until [`Self::reopen()`] is called.
+    async fn close(&self) -> Result<(), Self::Error>;
 
-    /// Resume the store after a [`Self::pause()`], re-acquiring database
+    /// Reopen the store after a [`Self::close()`], re-acquiring database
     /// connections.
-    async fn resume(&self) -> Result<(), Self::Error>;
+    async fn reopen(&self) -> Result<(), Self::Error>;
 
     /// Perform database optimizations if any are available, i.e. vacuuming in
     /// SQLite.
@@ -404,12 +404,12 @@ impl<T: MediaStore> MediaStore for EraseMediaStoreError<T> {
         self.0.clean().await.map_err(Into::into)
     }
 
-    async fn pause(&self) -> Result<(), Self::Error> {
-        self.0.pause().await.map_err(Into::into)
+    async fn close(&self) -> Result<(), Self::Error> {
+        self.0.close().await.map_err(Into::into)
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
-        self.0.resume().await.map_err(Into::into)
+    async fn reopen(&self) -> Result<(), Self::Error> {
+        self.0.reopen().await.map_err(Into::into)
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -154,6 +154,14 @@ impl MemoryStore {
 impl StateStore for MemoryStore {
     type Error = StoreError;
 
+    async fn pause(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     async fn get_kv_data(&self, key: StateStoreDataKey<'_>) -> Result<Option<StateStoreDataValue>> {
         let inner = self.inner.read().unwrap();
 

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -154,11 +154,11 @@ impl MemoryStore {
 impl StateStore for MemoryStore {
     type Error = StoreError;
 
-    async fn pause(&self) -> Result<(), Self::Error> {
+    async fn close(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
+    async fn reopen(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -522,19 +522,11 @@ pub trait StateStore: AsyncTraitDeps {
     ///
     /// In-flight operations complete before this method returns. After it
     /// returns, operations will fail until [`Self::resume()`] is called.
-    ///
-    /// The default implementation is a no-op (suitable for in-memory stores).
-    async fn pause(&self) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    async fn pause(&self) -> Result<(), Self::Error>;
 
     /// Resume the store after a [`Self::pause()`], re-acquiring database
     /// connections.
-    ///
-    /// The default implementation is a no-op.
-    async fn resume(&self) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    async fn resume(&self) -> Result<(), Self::Error>;
 
     /// Perform database optimizations if any are available, i.e. vacuuming in
     /// SQLite.
@@ -839,6 +831,14 @@ impl<T: StateStore> StateStore for &T {
         (*self).load_thread_subscription(room, thread_id).await
     }
 
+    async fn pause(&self) -> Result<(), Self::Error> {
+        (*self).pause().await
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        (*self).resume().await
+    }
+
     async fn optimize(&self) -> Result<(), Self::Error> {
         (*self).optimize().await
     }
@@ -1137,6 +1137,14 @@ impl<T: StateStore + ?Sized> StateStore for Arc<T> {
         thread_id: &EventId,
     ) -> Result<Option<StoredThreadSubscription>, Self::Error> {
         self.deref().load_thread_subscription(room, thread_id).await
+    }
+
+    async fn pause(&self) -> Result<(), Self::Error> {
+        self.deref().pause().await
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        self.deref().resume().await
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {
@@ -1809,6 +1817,14 @@ impl<T: StateStore> StateStore for SaveLockedStateStore<T> {
         self.store.upsert_thread_subscriptions(updates).await
     }
 
+    async fn load_thread_subscription(
+        &self,
+        room: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<Option<StoredThreadSubscription>, Self::Error> {
+        self.store.load_thread_subscription(room, thread_id).await
+    }
+
     async fn remove_thread_subscription(
         &self,
         room: &RoomId,
@@ -1817,12 +1833,12 @@ impl<T: StateStore> StateStore for SaveLockedStateStore<T> {
         self.store.remove_thread_subscription(room, thread_id).await
     }
 
-    async fn load_thread_subscription(
-        &self,
-        room: &RoomId,
-        thread_id: &EventId,
-    ) -> Result<Option<StoredThreadSubscription>, Self::Error> {
-        self.store.load_thread_subscription(room, thread_id).await
+    async fn pause(&self) -> Result<(), Self::Error> {
+        self.store.pause().await
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        self.store.resume().await
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -517,16 +517,16 @@ pub trait StateStore: AsyncTraitDeps {
         thread_id: &EventId,
     ) -> Result<Option<StoredThreadSubscription>, Self::Error>;
 
-    /// Pause the store, releasing all held resources (database connections,
+    /// Close the store, releasing all held resources (database connections,
     /// file descriptors, file locks).
     ///
     /// In-flight operations complete before this method returns. After it
-    /// returns, operations will fail until [`Self::resume()`] is called.
-    async fn pause(&self) -> Result<(), Self::Error>;
+    /// returns, operations will fail until [`Self::reopen()`] is called.
+    async fn close(&self) -> Result<(), Self::Error>;
 
-    /// Resume the store after a [`Self::pause()`], re-acquiring database
+    /// Reopen the store after a [`Self::close()`], re-acquiring database
     /// connections.
-    async fn resume(&self) -> Result<(), Self::Error>;
+    async fn reopen(&self) -> Result<(), Self::Error>;
 
     /// Perform database optimizations if any are available, i.e. vacuuming in
     /// SQLite.
@@ -831,12 +831,12 @@ impl<T: StateStore> StateStore for &T {
         (*self).load_thread_subscription(room, thread_id).await
     }
 
-    async fn pause(&self) -> Result<(), Self::Error> {
-        (*self).pause().await
+    async fn close(&self) -> Result<(), Self::Error> {
+        (*self).close().await
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
-        (*self).resume().await
+    async fn reopen(&self) -> Result<(), Self::Error> {
+        (*self).reopen().await
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {
@@ -1139,12 +1139,12 @@ impl<T: StateStore + ?Sized> StateStore for Arc<T> {
         self.deref().load_thread_subscription(room, thread_id).await
     }
 
-    async fn pause(&self) -> Result<(), Self::Error> {
-        self.deref().pause().await
+    async fn close(&self) -> Result<(), Self::Error> {
+        self.deref().close().await
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
-        self.deref().resume().await
+    async fn reopen(&self) -> Result<(), Self::Error> {
+        self.deref().reopen().await
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {
@@ -1472,12 +1472,12 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         self.0.remove_thread_subscription(room, thread_id).await.map_err(Into::into)
     }
 
-    async fn pause(&self) -> Result<(), Self::Error> {
-        self.0.pause().await.map_err(Into::into)
+    async fn close(&self) -> Result<(), Self::Error> {
+        self.0.close().await.map_err(Into::into)
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
-        self.0.resume().await.map_err(Into::into)
+    async fn reopen(&self) -> Result<(), Self::Error> {
+        self.0.reopen().await.map_err(Into::into)
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {
@@ -1833,12 +1833,12 @@ impl<T: StateStore> StateStore for SaveLockedStateStore<T> {
         self.store.remove_thread_subscription(room, thread_id).await
     }
 
-    async fn pause(&self) -> Result<(), Self::Error> {
-        self.store.pause().await
+    async fn close(&self) -> Result<(), Self::Error> {
+        self.store.close().await
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
-        self.store.resume().await
+    async fn reopen(&self) -> Result<(), Self::Error> {
+        self.store.reopen().await
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -517,6 +517,25 @@ pub trait StateStore: AsyncTraitDeps {
         thread_id: &EventId,
     ) -> Result<Option<StoredThreadSubscription>, Self::Error>;
 
+    /// Pause the store, releasing all held resources (database connections,
+    /// file descriptors, file locks).
+    ///
+    /// In-flight operations complete before this method returns. After it
+    /// returns, operations will fail until [`Self::resume()`] is called.
+    ///
+    /// The default implementation is a no-op (suitable for in-memory stores).
+    async fn pause(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Resume the store after a [`Self::pause()`], re-acquiring database
+    /// connections.
+    ///
+    /// The default implementation is a no-op.
+    async fn resume(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     /// Perform database optimizations if any are available, i.e. vacuuming in
     /// SQLite.
     ///
@@ -1443,6 +1462,14 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         thread_id: &EventId,
     ) -> Result<(), Self::Error> {
         self.0.remove_thread_subscription(room, thread_id).await.map_err(Into::into)
+    }
+
+    async fn pause(&self) -> Result<(), Self::Error> {
+        self.0.pause().await.map_err(Into::into)
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        self.0.resume().await.map_err(Into::into)
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -197,11 +197,11 @@ type Result<T> = std::result::Result<T, Infallible>;
 impl CryptoStore for MemoryStore {
     type Error = Infallible;
 
-    async fn pause(&self) -> Result<()> {
+    async fn close(&self) -> Result<()> {
         Ok(())
     }
 
-    async fn resume(&self) -> Result<()> {
+    async fn reopen(&self) -> Result<()> {
         Ok(())
     }
 
@@ -1400,12 +1400,12 @@ mod integration_tests {
     impl CryptoStore for PersistentMemoryStore {
         type Error = <MemoryStore as CryptoStore>::Error;
 
-        async fn pause(&self) -> Result<(), Self::Error> {
-            self.0.pause().await
+        async fn close(&self) -> Result<(), Self::Error> {
+            self.0.close().await
         }
 
-        async fn resume(&self) -> Result<(), Self::Error> {
-            self.0.resume().await
+        async fn reopen(&self) -> Result<(), Self::Error> {
+            self.0.reopen().await
         }
 
         async fn load_account(&self) -> Result<Option<Account>, Self::Error> {

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -197,6 +197,14 @@ type Result<T> = std::result::Result<T, Infallible>;
 impl CryptoStore for MemoryStore {
     type Error = Infallible;
 
+    async fn pause(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn resume(&self) -> Result<()> {
+        Ok(())
+    }
+
     async fn load_account(&self) -> Result<Option<Account>> {
         let pickled_account: Option<PickledAccount> = self.account.read().as_ref().map(|acc| {
             serde_json::from_str(acc)
@@ -1391,6 +1399,14 @@ mod integration_tests {
     #[cfg_attr(not(target_family = "wasm"), async_trait)]
     impl CryptoStore for PersistentMemoryStore {
         type Error = <MemoryStore as CryptoStore>::Error;
+
+        async fn pause(&self) -> Result<(), Self::Error> {
+            self.0.pause().await
+        }
+
+        async fn resume(&self) -> Result<(), Self::Error> {
+            self.0.resume().await
+        }
 
         async fn load_account(&self) -> Result<Option<Account>, Self::Error> {
             self.0.load_account().await

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -418,6 +418,25 @@ pub trait CryptoStore: AsyncTraitDeps {
     /// Load the next-batch token for a to-device query, if any.
     async fn next_batch_token(&self) -> Result<Option<String>, Self::Error>;
 
+    /// Pause the store, releasing all held resources (database connections,
+    /// file descriptors, file locks).
+    ///
+    /// In-flight operations complete before this method returns. After it
+    /// returns, operations will fail until [`Self::resume()`] is called.
+    ///
+    /// The default implementation is a no-op (suitable for in-memory stores).
+    async fn pause(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Resume the store after a [`Self::pause()`], re-acquiring database
+    /// connections.
+    ///
+    /// The default implementation is a no-op.
+    async fn resume(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     /// Returns the size of the store in bytes, if known.
     async fn get_size(&self) -> Result<Option<usize>, Self::Error>;
 }
@@ -685,6 +704,14 @@ impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
 
     async fn next_batch_token(&self) -> Result<Option<String>, Self::Error> {
         self.0.next_batch_token().await.map_err(Into::into)
+    }
+
+    async fn pause(&self) -> Result<(), Self::Error> {
+        self.0.pause().await.map_err(Into::into)
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        self.0.resume().await.map_err(Into::into)
     }
 
     async fn get_size(&self) -> Result<Option<usize>, Self::Error> {

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -423,19 +423,11 @@ pub trait CryptoStore: AsyncTraitDeps {
     ///
     /// In-flight operations complete before this method returns. After it
     /// returns, operations will fail until [`Self::resume()`] is called.
-    ///
-    /// The default implementation is a no-op (suitable for in-memory stores).
-    async fn pause(&self) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    async fn pause(&self) -> Result<(), Self::Error>;
 
     /// Resume the store after a [`Self::pause()`], re-acquiring database
     /// connections.
-    ///
-    /// The default implementation is a no-op.
-    async fn resume(&self) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    async fn resume(&self) -> Result<(), Self::Error>;
 
     /// Returns the size of the store in bytes, if known.
     async fn get_size(&self) -> Result<Option<usize>, Self::Error>;

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -418,16 +418,16 @@ pub trait CryptoStore: AsyncTraitDeps {
     /// Load the next-batch token for a to-device query, if any.
     async fn next_batch_token(&self) -> Result<Option<String>, Self::Error>;
 
-    /// Pause the store, releasing all held resources (database connections,
+    /// Close the store, releasing all held resources (database connections,
     /// file descriptors, file locks).
     ///
     /// In-flight operations complete before this method returns. After it
-    /// returns, operations will fail until [`Self::resume()`] is called.
-    async fn pause(&self) -> Result<(), Self::Error>;
+    /// returns, operations will fail until [`Self::reopen()`] is called.
+    async fn close(&self) -> Result<(), Self::Error>;
 
-    /// Resume the store after a [`Self::pause()`], re-acquiring database
+    /// Reopen the store after a [`Self::close()`], re-acquiring database
     /// connections.
-    async fn resume(&self) -> Result<(), Self::Error>;
+    async fn reopen(&self) -> Result<(), Self::Error>;
 
     /// Returns the size of the store in bytes, if known.
     async fn get_size(&self) -> Result<Option<usize>, Self::Error>;
@@ -698,12 +698,12 @@ impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
         self.0.next_batch_token().await.map_err(Into::into)
     }
 
-    async fn pause(&self) -> Result<(), Self::Error> {
-        self.0.pause().await.map_err(Into::into)
+    async fn close(&self) -> Result<(), Self::Error> {
+        self.0.close().await.map_err(Into::into)
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
-        self.0.resume().await.map_err(Into::into)
+    async fn reopen(&self) -> Result<(), Self::Error> {
+        self.0.reopen().await.map_err(Into::into)
     }
 
     async fn get_size(&self) -> Result<Option<usize>, Self::Error> {

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -1738,6 +1738,14 @@ impl_crypto_store! {
     async fn get_size(&self) -> Result<Option<usize>> {
         Ok(None)
     }
+
+    async fn pause(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn resume(&self) -> Result<()> {
+        Ok(())
+    }
 }
 
 impl Drop for IndexeddbCryptoStore {

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -1739,11 +1739,13 @@ impl_crypto_store! {
         Ok(None)
     }
 
-    async fn pause(&self) -> Result<()> {
+    #[allow(clippy::unused_async)]
+    async fn close(&self) -> Result<()> {
         Ok(())
     }
 
-    async fn resume(&self) -> Result<()> {
+    #[allow(clippy::unused_async)]
+    async fn reopen(&self) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -616,11 +616,11 @@ impl EventCacheStore for IndexeddbEventCacheStore {
         Ok(None)
     }
 
-    async fn pause(&self) -> Result<(), Self::Error> {
+    async fn close(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
+    async fn reopen(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -615,6 +615,14 @@ impl EventCacheStore for IndexeddbEventCacheStore {
     async fn get_size(&self) -> Result<Option<usize>, Self::Error> {
         Ok(None)
     }
+
+    async fn pause(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 #[cfg(all(test, target_family = "wasm"))]

--- a/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
@@ -278,11 +278,11 @@ impl MediaStore for IndexeddbMediaStore {
         Ok(None)
     }
 
-    async fn pause(&self) -> Result<(), Self::Error> {
+    async fn close(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
+    async fn reopen(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
@@ -277,6 +277,14 @@ impl MediaStore for IndexeddbMediaStore {
     async fn get_size(&self) -> Result<Option<usize>, Self::Error> {
         Ok(None)
     }
+
+    async fn pause(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 #[cfg(target_family = "wasm")]

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -2060,6 +2060,14 @@ impl_state_store!({
     async fn get_size(&self) -> Result<Option<usize>> {
         Ok(None)
     }
+
+    async fn pause(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn resume(&self) -> Result<()> {
+        Ok(())
+    }
 });
 
 /// A room member.

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -2061,11 +2061,13 @@ impl_state_store!({
         Ok(None)
     }
 
-    async fn pause(&self) -> Result<()> {
+    #[allow(clippy::unused_async)]
+    async fn close(&self) -> Result<()> {
         Ok(())
     }
 
-    async fn resume(&self) -> Result<()> {
+    #[allow(clippy::unused_async)]
+    async fn reopen(&self) -> Result<()> {
         Ok(())
     }
 });

--- a/crates/matrix-sdk-sqlite/src/connection.rs
+++ b/crates/matrix-sdk-sqlite/src/connection.rs
@@ -64,11 +64,13 @@
 //! [spawn_blocking]: https://github.com/deadpool-rs/deadpool/blob/d6f7d58756f0cc7bdd1f3d54d820c1332d67e4d5/crates/deadpool-sync/src/lib.rs#L113-L131
 //! [WAL]: https://www.sqlite.org/wal.html
 
-use std::{convert::Infallible, path::PathBuf};
+use std::{convert::Infallible, path::PathBuf, sync::Arc, time::Duration};
 
 pub use deadpool::managed::reexports::*;
-use deadpool::managed::{self, Metrics, RecycleError};
+use deadpool::managed::{self, Metrics, PoolConfig, RecycleError};
 use deadpool_sync::SyncWrapper;
+use tokio::sync::Mutex;
+use tracing::{info, warn};
 
 /// The default runtime used by `matrix-sdk-sqlite` for `deadpool`.
 pub const RUNTIME: Runtime = Runtime::Tokio1;
@@ -87,14 +89,14 @@ pub type Connection = Object;
 /// [`Manager`][managed::Manager] for creating and recycling SQLite
 /// [`Connection`]s.
 #[derive(Debug)]
-pub struct Manager {
-    database_path: PathBuf,
+pub(crate) struct Manager {
+    pub(crate) database_path: PathBuf,
 }
 
 impl Manager {
     /// Creates a new [`Manager`] for a database.
     #[must_use]
-    pub fn new(database_path: PathBuf) -> Self {
+    pub(crate) fn new(database_path: PathBuf) -> Self {
         Self { database_path }
     }
 }
@@ -121,4 +123,138 @@ impl managed::Manager for Manager {
 
         Ok(())
     }
+}
+
+/// Gracefully close a write connection.
+///
+/// 1. Waits for any in-flight write to complete by acquiring the lock.
+/// 2. Runs a WAL checkpoint (TRUNCATE) to flush pending data to the main
+///    database file and release WAL locks.
+/// 3. Drops the connection on a blocking thread, awaiting completion so the
+///    caller knows the file descriptor has been released.
+pub async fn close_connection(write_connection: Arc<Mutex<Connection>>) {
+    // Acquire the lock to wait for any in-flight write to complete.
+    let guard = write_connection.lock().await;
+
+    // Flush WAL and release locks while we still own the connection.
+    let _ = guard
+        .interact(|raw| {
+            raw.execute_batch("PRAGMA locking_mode = NORMAL; PRAGMA wal_checkpoint(TRUNCATE);")
+                .ok();
+        })
+        .await;
+
+    drop(guard);
+
+    // Drop on a blocking thread, awaiting the join handle so we know the
+    // file descriptor has been released.
+    let _ = tokio::task::spawn_blocking(move || drop(write_connection)).await;
+}
+
+/// Live database connections held by each SQLite store.
+///
+/// Wrapped in `Option<SqliteConnections>` guarded by a `Mutex` inside each
+/// store; `Some` means the store is active, `None` means it is paused.
+pub(crate) struct SqliteConnections {
+    /// The pool of read connections.
+    pub(crate) pool: Pool,
+    /// The dedicated write connection.
+    pub(crate) write_connection: Arc<Mutex<Connection>>,
+}
+
+/// Pause a store by taking its connections out.
+///
+/// After this returns, any call to `read()` or `write()` on the store will
+/// fail with [`crate::error::Error::StorePaused`] until
+/// [`resume_connections`] is called.
+///
+/// Idempotent: if the store is already paused this is a no-op.
+pub(crate) async fn pause_connections(connections: &Mutex<Option<SqliteConnections>>, label: &str) {
+    let mut guard = connections.lock().await;
+    let Some(conns) = guard.take() else {
+        // Already paused — idempotent.
+        return;
+    };
+
+    let SqliteConnections { pool, write_connection } = conns;
+
+    // Close the pool. Idle read connections are dropped immediately;
+    // in-flight reads complete and their connections are discarded (not
+    // recycled) on release. New pool.get() calls return PoolError::Closed.
+    pool.close();
+
+    let status = pool.status();
+    info!(
+        size = status.size,
+        max_size = status.max_size,
+        available = status.available,
+        "{label} pause: pool closed"
+    );
+
+    // Close the write connection: wait for any in-flight write to finish,
+    // run a WAL checkpoint, then drop on a blocking thread.
+    close_connection(write_connection).await;
+
+    let status = pool.status();
+    info!(
+        size = status.size,
+        max_size = status.max_size,
+        available = status.available,
+        "{label} pause: write connection released"
+    );
+
+    // Wait for any in-flight read connections to drain.
+    // The write connection has already been released above, so
+    // pool.status().size == 0 now correctly means every connection is gone
+    // and no SQLite file locks are held.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while pool.status().size > 0 {
+        if tokio::time::Instant::now() >= deadline {
+            let status = pool.status();
+            warn!(
+                size = status.size,
+                max_size = status.max_size,
+                available = status.available,
+                "Timed out waiting for SQLite pool connections to drain"
+            );
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    drop(pool);
+}
+
+/// Resume a store by rebuilding its connections.
+///
+/// Idempotent: if the store is already active this is a no-op.
+pub(crate) async fn resume_connections(
+    connections: &Mutex<Option<SqliteConnections>>,
+    db_path: PathBuf,
+    pool_config: PoolConfig,
+    runtime_config: crate::RuntimeConfig,
+) -> crate::error::Result<()> {
+    use crate::utils::SqliteAsyncConnExt as _;
+
+    let mut guard = connections.lock().await;
+    if guard.is_some() {
+        // Not paused — idempotent.
+        return Ok(());
+    }
+
+    // Rebuild the pool (connections are created lazily on first get()).
+    let pool =
+        Pool::builder(Manager::new(db_path)).config(pool_config).runtime(RUNTIME).build().map_err(
+            |e| crate::error::Error::InvalidData {
+                details: format!("Failed to rebuild connection pool: {e}"),
+            },
+        )?;
+
+    let write_conn = pool.get().await?;
+    // Re-apply runtime config (WAL mode, busy timeout, etc.)
+    write_conn.apply_runtime_config(runtime_config).await?;
+
+    *guard = Some(SqliteConnections { pool, write_connection: Arc::new(Mutex::new(write_conn)) });
+
+    Ok(())
 }

--- a/crates/matrix-sdk-sqlite/src/connection.rs
+++ b/crates/matrix-sdk-sqlite/src/connection.rs
@@ -89,14 +89,14 @@ pub type Connection = Object;
 /// [`Manager`][managed::Manager] for creating and recycling SQLite
 /// [`Connection`]s.
 #[derive(Debug)]
-pub(crate) struct Manager {
+pub struct Manager {
     pub(crate) database_path: PathBuf,
 }
 
 impl Manager {
     /// Creates a new [`Manager`] for a database.
     #[must_use]
-    pub(crate) fn new(database_path: PathBuf) -> Self {
+    pub fn new(database_path: PathBuf) -> Self {
         Self { database_path }
     }
 }

--- a/crates/matrix-sdk-sqlite/src/connection.rs
+++ b/crates/matrix-sdk-sqlite/src/connection.rs
@@ -160,7 +160,7 @@ pub async fn close_connection(write_connection: Arc<Mutex<Connection>>) {
 /// Live database connections held by each SQLite store.
 ///
 /// Wrapped in `Option<SqliteConnections>` guarded by a `Mutex` inside each
-/// store; `Some` means the store is active, `None` means it is paused.
+/// store; `Some` means the store is active, `None` means it is closed.
 pub(crate) struct SqliteConnections {
     /// The pool of read connections.
     pub pool: Pool,
@@ -172,17 +172,17 @@ pub(crate) struct SqliteConnections {
     pub write_connection: Arc<Mutex<Connection>>,
 }
 
-/// Pause a store by taking its connections out.
+/// Close a store by taking its connections out.
 ///
 /// After this returns, any new call to `read()` or `write()` through the
-/// store will fail with [`crate::error::Error::StorePaused`] until
-/// [`resume_connections`] is called.
+/// store will fail with [`crate::error::Error::StoreClosed`] until
+/// [`reopen_connections`] is called.
 ///
-/// Idempotent: if the store is already paused this is a no-op.
-pub(crate) async fn pause_connections(connections: &Mutex<Option<SqliteConnections>>, label: &str) {
+/// Idempotent: if the store is already closed this is a no-op.
+pub(crate) async fn close_connections(connections: &Mutex<Option<SqliteConnections>>, label: &str) {
     let mut guard = connections.lock().await;
     let Some(conns) = guard.take() else {
-        // Already paused — idempotent.
+        // Already closed — idempotent.
         return;
     };
 
@@ -236,7 +236,7 @@ pub(crate) async fn pause_connections(connections: &Mutex<Option<SqliteConnectio
 /// Resume a store by rebuilding its connections.
 ///
 /// Idempotent: if the store is already active this is a no-op.
-pub(crate) async fn resume_connections(
+pub(crate) async fn reopen_connections(
     connections: &Mutex<Option<SqliteConnections>>,
     db_path: PathBuf,
     pool_config: PoolConfig,
@@ -246,7 +246,7 @@ pub(crate) async fn resume_connections(
 
     let mut guard = connections.lock().await;
     if guard.is_some() {
-        // Not paused — idempotent.
+        // Not closed — idempotent.
         return Ok(());
     }
 

--- a/crates/matrix-sdk-sqlite/src/connection.rs
+++ b/crates/matrix-sdk-sqlite/src/connection.rs
@@ -125,13 +125,20 @@ impl managed::Manager for Manager {
     }
 }
 
-/// Gracefully close a write connection.
+/// Gracefully close the store-owned write connection.
+///
+/// Callers are expected to remove the enclosing [`SqliteConnections`] from the
+/// store before calling this helper so no new write acquisitions can happen
+/// through the store API.
 ///
 /// 1. Waits for any in-flight write to complete by acquiring the lock.
 /// 2. Runs a WAL checkpoint (TRUNCATE) to flush pending data to the main
 ///    database file and release WAL locks.
-/// 3. Drops the connection on a blocking thread, awaiting completion so the
-///    caller knows the file descriptor has been released.
+/// 3. Drops the store-owned `Arc` on a blocking thread.
+///
+/// This is still best effort: if another cloned `Arc` or an
+/// `OwnedMutexGuard<Connection>` is still alive elsewhere, the underlying
+/// SQLite connection may remain alive until that handle is dropped.
 pub async fn close_connection(write_connection: Arc<Mutex<Connection>>) {
     // Acquire the lock to wait for any in-flight write to complete.
     let guard = write_connection.lock().await;
@@ -146,8 +153,7 @@ pub async fn close_connection(write_connection: Arc<Mutex<Connection>>) {
 
     drop(guard);
 
-    // Drop on a blocking thread, awaiting the join handle so we know the
-    // file descriptor has been released.
+    // Drop the store-owned Arc on a blocking thread.
     let _ = tokio::task::spawn_blocking(move || drop(write_connection)).await;
 }
 
@@ -157,15 +163,19 @@ pub async fn close_connection(write_connection: Arc<Mutex<Connection>>) {
 /// store; `Some` means the store is active, `None` means it is paused.
 pub(crate) struct SqliteConnections {
     /// The pool of read connections.
-    pub(crate) pool: Pool,
+    pub pool: Pool,
     /// The dedicated write connection.
-    pub(crate) write_connection: Arc<Mutex<Connection>>,
+    ///
+    /// This lives behind `Arc<Mutex<_>>` so stores can clone the `Arc` and
+    /// obtain an `OwnedMutexGuard<Connection>` without holding the outer
+    /// `connections` mutex across await points.
+    pub write_connection: Arc<Mutex<Connection>>,
 }
 
 /// Pause a store by taking its connections out.
 ///
-/// After this returns, any call to `read()` or `write()` on the store will
-/// fail with [`crate::error::Error::StorePaused`] until
+/// After this returns, any new call to `read()` or `write()` through the
+/// store will fail with [`crate::error::Error::StorePaused`] until
 /// [`resume_connections`] is called.
 ///
 /// Idempotent: if the store is already paused this is a no-op.
@@ -221,8 +231,6 @@ pub(crate) async fn pause_connections(connections: &Mutex<Option<SqliteConnectio
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
-
-    drop(pool);
 }
 
 /// Resume a store by rebuilding its connections.

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -1811,6 +1811,14 @@ impl CryptoStore for SqliteCryptoStore {
         }
     }
 
+    async fn pause(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn resume(&self) -> Result<()> {
+        Ok(())
+    }
+
     async fn get_size(&self) -> Result<Option<usize>, Self::Error> {
         Ok(Some(self.pool.get().await?.get_db_size().await?))
     }

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -16,11 +16,12 @@ use std::{
     collections::HashMap,
     fmt,
     ops::Deref,
-    path::Path,
+    path::{Path, PathBuf},
     sync::{Arc, RwLock},
 };
 
 use async_trait::async_trait;
+use deadpool::managed::PoolConfig;
 use matrix_sdk_base::cross_process_lock::CrossProcessLockGeneration;
 use matrix_sdk_crypto::{
     Account, DeviceData, GossipRequest, GossippedSecret, SecretInfo, TrackedUser, UserIdentityData,
@@ -52,8 +53,8 @@ use vodozemac::Curve25519PublicKey;
 use zeroize::Zeroizing;
 
 use crate::{
-    OpenStoreError, Secret, SqliteStoreConfig,
-    connection::{Connection as SqliteAsyncConn, Pool as SqlitePool},
+    OpenStoreError, RuntimeConfig, Secret, SqliteStoreConfig,
+    connection::{self, Connection as SqliteAsyncConn, Pool as SqlitePool, SqliteConnections},
     error::{Error, Result},
     utils::{
         EncryptableStore, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
@@ -69,14 +70,18 @@ const DATABASE_NAME: &str = "matrix-sdk-crypto.sqlite3";
 pub struct SqliteCryptoStore {
     store_cipher: Option<Arc<StoreCipher>>,
 
-    /// The pool of connections.
-    pool: SqlitePool,
+    /// `Some` when active, `None` when paused.
+    /// The outer `Mutex` serialises pause/resume with connection access.
+    connections: Arc<Mutex<Option<SqliteConnections>>>,
 
-    /// We make the difference between connections for read operations, and for
-    /// write operations. We keep a single connection apart from write
-    /// operations. All other connections are used for read operations. The
-    /// lock is used to ensure there is one owner at a time.
-    write_connection: Arc<Mutex<SqliteAsyncConn>>,
+    /// Retained so we can rebuild the pool on resume.
+    db_path: PathBuf,
+
+    /// Retained so we can rebuild the pool on resume.
+    pool_config: PoolConfig,
+
+    /// Retained so we can re-apply runtime config on resume.
+    runtime_config: RuntimeConfig,
 
     // DB values cached in memory
     static_account: Arc<RwLock<Option<StaticAccountData>>>,
@@ -112,16 +117,25 @@ impl SqliteCryptoStore {
         secret: Option<Secret>,
         pool: SqlitePool,
         conn: SqliteAsyncConn,
+        pool_config: PoolConfig,
+        runtime_config: RuntimeConfig,
     ) -> Result<Self, OpenStoreError> {
         let store_cipher = match secret {
             Some(s) => Some(Arc::new(conn.get_or_create_store_cipher(s).await?)),
             None => None,
         };
 
+        let db_path = pool.manager().database_path.clone();
+
         Ok(Self {
             store_cipher,
-            pool,
-            write_connection: Arc::new(Mutex::new(conn)),
+            connections: Arc::new(Mutex::new(Some(SqliteConnections {
+                pool,
+                write_connection: Arc::new(Mutex::new(conn)),
+            }))),
+            db_path,
+            pool_config,
+            runtime_config,
             static_account: Arc::new(RwLock::new(None)),
             save_changes_lock: Default::default(),
         })
@@ -150,9 +164,12 @@ impl SqliteCryptoStore {
         fs::create_dir_all(&config.path).await.map_err(OpenStoreError::CreateDir)?;
 
         let pool = config.build_pool_of_connections(DATABASE_NAME)?;
+        let pool_config = config.pool_config();
+        let runtime_config = config.runtime_config();
 
-        let this = Self::open_with_pool(pool, config.secret.clone()).await?;
-        this.pool.get().await?.apply_runtime_config(config.runtime_config.clone()).await?;
+        let this =
+            Self::open_with_pool(pool, config.secret.clone(), pool_config, runtime_config).await?;
+        this.read().await?.apply_runtime_config(runtime_config).await?;
 
         Ok(this)
     }
@@ -162,6 +179,8 @@ impl SqliteCryptoStore {
     async fn open_with_pool(
         pool: SqlitePool,
         secret: Option<Secret>,
+        pool_config: PoolConfig,
+        runtime_config: RuntimeConfig,
     ) -> Result<Self, OpenStoreError> {
         let conn = pool.get().await?;
 
@@ -170,11 +189,11 @@ impl SqliteCryptoStore {
 
         let version = initialize_store(&conn, version).await?;
 
-        let store = Self::create_raw(secret, pool, conn).await?;
+        let store = Self::create_raw(secret, pool, conn, pool_config, runtime_config).await?;
 
         run_migrations(&store, version, None).await?;
 
-        store.write().await.wal_checkpoint().await;
+        store.write().await?.wal_checkpoint().await;
 
         Ok(store)
     }
@@ -210,13 +229,23 @@ impl SqliteCryptoStore {
     /// Acquire a connection for executing read operations.
     #[instrument(skip_all)]
     async fn read(&self) -> Result<SqliteAsyncConn> {
-        Ok(self.pool.get().await?)
+        let pool = {
+            let guard = self.connections.lock().await;
+            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            conns.pool.clone()
+        };
+        Ok(pool.get().await?)
     }
 
     /// Acquire a connection for executing write operations.
     #[instrument(skip_all)]
-    pub(crate) async fn write(&self) -> OwnedMutexGuard<SqliteAsyncConn> {
-        self.write_connection.clone().lock_owned().await
+    pub(crate) async fn write(&self) -> Result<OwnedMutexGuard<SqliteAsyncConn>> {
+        let write_connection = {
+            let guard = self.connections.lock().await;
+            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            conns.write_connection.clone()
+        };
+        Ok(write_connection.lock_owned().await)
     }
 }
 
@@ -276,7 +305,7 @@ pub(crate) async fn run_migrations(
     version: u8,
     max_version: Option<u8>,
 ) -> Result<()> {
-    let conn = store.write().await;
+    let conn = store.write().await?;
 
     if version < 2 {
         debug!("Upgrading database to version 2");
@@ -1090,7 +1119,7 @@ impl CryptoStore for SqliteCryptoStore {
 
         let this = self.clone();
         self.write()
-            .await
+            .await?
             .with_transaction(move |txn| {
                 if let Some(pickled_account) = pickled_account {
                     let serialized_account = this.serialize_value(&pickled_account)?;
@@ -1142,7 +1171,7 @@ impl CryptoStore for SqliteCryptoStore {
 
         let this = self.clone();
         self.write()
-            .await
+            .await?
             .with_transaction(move |txn| {
                 if let Some(pickled_private_identity) = &pickled_private_identity {
                     let serialized_private_identity =
@@ -1415,7 +1444,7 @@ impl CryptoStore for SqliteCryptoStore {
     ) -> Result<()> {
         Ok(self
             .write()
-            .await
+            .await?
             .mark_inbound_group_sessions_as_backed_up(
                 session_ids
                     .iter()
@@ -1426,7 +1455,7 @@ impl CryptoStore for SqliteCryptoStore {
     }
 
     async fn reset_backup_state(&self) -> Result<()> {
-        Ok(self.write().await.reset_inbound_group_session_backup_state().await?)
+        Ok(self.write().await?.reset_inbound_group_session_backup_state().await?)
     }
 
     async fn load_backup_keys(&self) -> Result<BackupKeys> {
@@ -1457,7 +1486,7 @@ impl CryptoStore for SqliteCryptoStore {
     }
 
     async fn delete_dehydrated_device_pickle_key(&self) -> Result<(), Self::Error> {
-        Ok(self.write().await.clear_kv(DEHYDRATED_DEVICE_PICKLE_KEY).await?)
+        Ok(self.write().await?.clear_kv(DEHYDRATED_DEVICE_PICKLE_KEY).await?)
     }
     async fn get_outbound_group_session(
         &self,
@@ -1502,7 +1531,7 @@ impl CryptoStore for SqliteCryptoStore {
             })
             .collect::<Result<_>>()?;
 
-        Ok(self.write().await.add_tracked_users(users).await?)
+        Ok(self.write().await?.add_tracked_users(users).await?)
     }
 
     async fn get_device(
@@ -1609,7 +1638,7 @@ impl CryptoStore for SqliteCryptoStore {
 
     async fn delete_outgoing_secret_requests(&self, request_id: &TransactionId) -> Result<()> {
         let request_id = self.encode_key("key_requests", request_id.as_bytes());
-        Ok(self.write().await.delete_key_request(request_id).await?)
+        Ok(self.write().await?.delete_key_request(request_id).await?)
     }
 
     async fn get_secrets_from_inbox(
@@ -1629,7 +1658,7 @@ impl CryptoStore for SqliteCryptoStore {
 
     async fn delete_secrets_from_inbox(&self, secret_name: &SecretName) -> Result<()> {
         let secret_name = self.encode_key("secrets_inbox", secret_name.to_string());
-        self.write().await.delete_secrets_from_inbox(secret_name).await
+        self.write().await?.delete_secrets_from_inbox(secret_name).await
     }
 
     async fn get_withheld_info(
@@ -1741,14 +1770,14 @@ impl CryptoStore for SqliteCryptoStore {
             value
         };
 
-        self.write().await.set_kv(key, serialized).await?;
+        self.write().await?.set_kv(key, serialized).await?;
         Ok(())
     }
 
     async fn remove_custom_value(&self, key: &str) -> Result<()> {
         let key = key.to_owned();
         self.write()
-            .await
+            .await?
             .interact(move |conn| conn.execute("DELETE FROM kv WHERE key = ?1", (&key,)))
             .await
             .unwrap()?;
@@ -1771,7 +1800,7 @@ impl CryptoStore for SqliteCryptoStore {
         // Learn about the `excluded` keyword in https://sqlite.org/lang_upsert.html.
         let generation = self
             .write()
-            .await
+            .await?
             .with_transaction(move |txn| {
                 txn.query_row(
                     "INSERT INTO lease_locks (key, holder, expiration)
@@ -1812,15 +1841,23 @@ impl CryptoStore for SqliteCryptoStore {
     }
 
     async fn pause(&self) -> Result<()> {
+        connection::pause_connections(&self.connections, "Crypto store").await;
         Ok(())
     }
 
     async fn resume(&self) -> Result<()> {
+        connection::resume_connections(
+            &self.connections,
+            self.db_path.clone(),
+            self.pool_config,
+            self.runtime_config,
+        )
+        .await?;
         Ok(())
     }
 
     async fn get_size(&self) -> Result<Option<usize>, Self::Error> {
-        Ok(Some(self.pool.get().await?.get_db_size().await?))
+        Ok(Some(self.read().await?.get_db_size().await?))
     }
 }
 
@@ -1883,7 +1920,9 @@ mod tests {
 
         let store = SqliteCryptoStore::open_with_config(&store_open_config).await.unwrap();
 
-        assert_eq!(store.pool.status().max_size, 42);
+        let guard = store.connections.lock().await;
+        let conns = guard.as_ref().unwrap();
+        assert_eq!(conns.pool.status().max_size, 42);
     }
 
     /// Test that we didn't regress in our storage layer by loading data from a
@@ -2251,10 +2290,17 @@ mod tests {
         let pool = config.build_pool_of_connections(super::DATABASE_NAME).unwrap();
         let conn = pool.get().await.unwrap();
         let version = super::initialize_store(&conn, 0).await.unwrap();
-        let old_data_store =
-            SqliteCryptoStore::create_raw(config.secret.clone(), pool, conn).await.unwrap();
+        let old_data_store = SqliteCryptoStore::create_raw(
+            config.secret.clone(),
+            pool,
+            conn,
+            config.pool_config(),
+            config.runtime_config(),
+        )
+        .await
+        .unwrap();
         super::run_migrations(&old_data_store, version, Some(16)).await.unwrap();
-        old_data_store.write().await.wal_checkpoint().await;
+        old_data_store.write().await.unwrap().wal_checkpoint().await;
 
         // Store a secret using the old format
         let secret = GossippedSecret {
@@ -2281,6 +2327,7 @@ mod tests {
         old_data_store
             .write()
             .await
+            .unwrap()
             .prepare("INSERT INTO secrets (secret_name, data) VALUES (?1, ?2)", |mut stmt| {
                 stmt.execute((SecretName::CrossSigningMasterKey.to_string(), value))
             })

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -2396,3 +2396,170 @@ mod encrypted_tests {
     cryptostore_integration_tests!();
     cryptostore_integration_tests_time!();
 }
+
+#[cfg(test)]
+mod pause_resume_tests {
+    use std::sync::LazyLock;
+
+    use matrix_sdk_crypto::store::CryptoStore;
+    use matrix_sdk_test::async_test;
+    use tempfile::{TempDir, tempdir};
+
+    use super::SqliteCryptoStore;
+
+    static TMP_DIR: LazyLock<TempDir> = LazyLock::new(|| tempdir().unwrap());
+
+    async fn new_store(name: &str) -> SqliteCryptoStore {
+        let tmpdir_path = TMP_DIR.path().join(name);
+        SqliteCryptoStore::open(tmpdir_path, None).await.unwrap()
+    }
+
+    #[async_test]
+    async fn test_pause_completes_without_timeout() {
+        let store = new_store("pause_no_timeout").await;
+
+        // Pause should complete quickly without hitting the 5s timeout.
+        let start = std::time::Instant::now();
+        store.pause().await.unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "pause() took {elapsed:?}, expected < 2s (no timeout)"
+        );
+
+        // Connections should be None after pause.
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none(), "connections should be None after pause");
+    }
+
+    #[async_test]
+    async fn test_resume_restores_connections() {
+        let store = new_store("resume_restores").await;
+
+        store.pause().await.unwrap();
+
+        {
+            let guard = store.connections.lock().await;
+            assert!(guard.is_none());
+        }
+
+        store.resume().await.unwrap();
+
+        {
+            let guard = store.connections.lock().await;
+            assert!(guard.is_some(), "connections should be Some after resume");
+        }
+    }
+
+    #[async_test]
+    async fn test_pause_is_idempotent() {
+        let store = new_store("pause_idempotent").await;
+
+        store.pause().await.unwrap();
+        // Second pause should be a no-op.
+        store.pause().await.unwrap();
+
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none());
+    }
+
+    #[async_test]
+    async fn test_resume_is_idempotent() {
+        let store = new_store("resume_idempotent").await;
+
+        // Resume on an active store should be a no-op.
+        store.resume().await.unwrap();
+
+        let guard = store.connections.lock().await;
+        assert!(guard.is_some());
+    }
+
+    #[async_test]
+    async fn test_read_fails_when_paused() {
+        let store = new_store("read_fails_paused").await;
+        store.pause().await.unwrap();
+
+        let err = store.load_account().await;
+        assert!(err.is_err(), "read should fail when paused");
+
+        let err_msg = err.unwrap_err().to_string();
+        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+    }
+
+    #[async_test]
+    async fn test_operations_work_after_resume() {
+        let store = new_store("ops_after_resume").await;
+
+        store.pause().await.unwrap();
+        store.resume().await.unwrap();
+
+        // A read operation should work immediately after resume.
+        let account = store.load_account().await;
+        assert!(account.is_ok(), "load_account should succeed after resume");
+        // No account was saved, so this should be None.
+        assert!(account.unwrap().is_none());
+    }
+
+    #[async_test]
+    async fn test_multiple_pause_resume_cycles() {
+        let store = new_store("multi_cycles").await;
+
+        for _ in 0..5 {
+            store.pause().await.unwrap();
+            store.resume().await.unwrap();
+
+            // After each cycle, the store should be fully operational.
+            let account = store.load_account().await;
+            assert!(account.is_ok(), "store should work after pause/resume cycle");
+        }
+    }
+
+    #[async_test]
+    async fn test_pool_is_fully_drained_after_pause() {
+        let store = new_store("pool_drained").await;
+
+        // Do a few reads to exercise the pool.
+        let _ = store.load_account().await;
+        let _ = store.load_account().await;
+
+        store.pause().await.unwrap();
+
+        // After pause, the connections field should be None.
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none(), "all connections should be released after pause");
+    }
+
+    #[async_test]
+    async fn test_close_waits_for_held_read_connection_to_drain() {
+        let store = new_store("held_read_drain").await;
+
+        // Acquire a read connection and hold it, simulating an in-flight read.
+        let held_conn = store.read().await.unwrap();
+
+        // Spawn close in a background task — it will close the pool and then
+        // poll-wait for pool.status().size == 0 in the drain loop.
+        let store_clone = store.clone();
+        let close_handle = tokio::spawn(async move {
+            store_clone.close().await.unwrap();
+        });
+
+        // Give close() a moment to close the pool and enter the drain loop.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // The close task should still be running because we hold a connection.
+        assert!(!close_handle.is_finished(), "close should be waiting for the held connection");
+
+        // Release the held connection — this lets pool.status().size drop to 0.
+        drop(held_conn);
+
+        // Now close should complete promptly (well within the 5s timeout).
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(3), close_handle).await;
+        assert!(timeout.is_ok(), "close should complete after the held connection is released");
+        timeout.unwrap().unwrap();
+
+        // Verify the store is fully closed.
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none(), "connections should be None after close");
+    }
+}

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -70,17 +70,17 @@ const DATABASE_NAME: &str = "matrix-sdk-crypto.sqlite3";
 pub struct SqliteCryptoStore {
     store_cipher: Option<Arc<StoreCipher>>,
 
-    /// `Some` when active, `None` when paused.
-    /// The outer `Mutex` serialises pause/resume with connection access.
+    /// `Some` when active, `None` when closed.
+    /// The outer `Mutex` serialises close/reopen with connection access.
     connections: Arc<Mutex<Option<SqliteConnections>>>,
 
-    /// Retained so we can rebuild the pool on resume.
+    /// Retained so we can rebuild the pool on reopen.
     db_path: PathBuf,
 
-    /// Retained so we can rebuild the pool on resume.
+    /// Retained so we can rebuild the pool on reopen.
     pool_config: PoolConfig,
 
-    /// Retained so we can re-apply runtime config on resume.
+    /// Retained so we can re-apply runtime config on reopen.
     runtime_config: RuntimeConfig,
 
     // DB values cached in memory
@@ -231,7 +231,7 @@ impl SqliteCryptoStore {
     async fn read(&self) -> Result<SqliteAsyncConn> {
         let pool = {
             let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
             conns.pool.clone()
         };
         Ok(pool.get().await?)
@@ -242,7 +242,7 @@ impl SqliteCryptoStore {
     pub(crate) async fn write(&self) -> Result<OwnedMutexGuard<SqliteAsyncConn>> {
         let write_connection = {
             let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
             conns.write_connection.clone()
         };
         Ok(write_connection.lock_owned().await)
@@ -1840,13 +1840,13 @@ impl CryptoStore for SqliteCryptoStore {
         }
     }
 
-    async fn pause(&self) -> Result<()> {
-        connection::pause_connections(&self.connections, "Crypto store").await;
+    async fn close(&self) -> Result<()> {
+        connection::close_connections(&self.connections, "Crypto store").await;
         Ok(())
     }
 
-    async fn resume(&self) -> Result<()> {
-        connection::resume_connections(
+    async fn reopen(&self) -> Result<()> {
+        connection::reopen_connections(
             &self.connections,
             self.db_path.clone(),
             self.pool_config,
@@ -2398,7 +2398,7 @@ mod encrypted_tests {
 }
 
 #[cfg(test)]
-mod pause_resume_tests {
+mod close_reopen_tests {
     use std::sync::LazyLock;
 
     use matrix_sdk_crypto::store::CryptoStore;
@@ -2415,119 +2415,119 @@ mod pause_resume_tests {
     }
 
     #[async_test]
-    async fn test_pause_completes_without_timeout() {
-        let store = new_store("pause_no_timeout").await;
+    async fn test_close_completes_without_timeout() {
+        let store = new_store("close_no_timeout").await;
 
-        // Pause should complete quickly without hitting the 5s timeout.
+        // Close should complete quickly without hitting the 5s timeout.
         let start = std::time::Instant::now();
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
         let elapsed = start.elapsed();
 
         assert!(
             elapsed < std::time::Duration::from_secs(2),
-            "pause() took {elapsed:?}, expected < 2s (no timeout)"
+            "close() took {elapsed:?}, expected < 2s (no timeout)"
         );
 
-        // Connections should be None after pause.
+        // Connections should be None after close.
         let guard = store.connections.lock().await;
-        assert!(guard.is_none(), "connections should be None after pause");
+        assert!(guard.is_none(), "connections should be None after close");
     }
 
     #[async_test]
-    async fn test_resume_restores_connections() {
-        let store = new_store("resume_restores").await;
+    async fn test_reopen_restores_connections() {
+        let store = new_store("reopen_restores").await;
 
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
         {
             let guard = store.connections.lock().await;
             assert!(guard.is_none());
         }
 
-        store.resume().await.unwrap();
+        store.reopen().await.unwrap();
 
         {
             let guard = store.connections.lock().await;
-            assert!(guard.is_some(), "connections should be Some after resume");
+            assert!(guard.is_some(), "connections should be Some after reopen");
         }
     }
 
     #[async_test]
-    async fn test_pause_is_idempotent() {
-        let store = new_store("pause_idempotent").await;
+    async fn test_close_is_idempotent() {
+        let store = new_store("close_idempotent").await;
 
-        store.pause().await.unwrap();
-        // Second pause should be a no-op.
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
+        // Second close should be a no-op.
+        store.close().await.unwrap();
 
         let guard = store.connections.lock().await;
         assert!(guard.is_none());
     }
 
     #[async_test]
-    async fn test_resume_is_idempotent() {
-        let store = new_store("resume_idempotent").await;
+    async fn test_reopen_is_idempotent() {
+        let store = new_store("reopen_idempotent").await;
 
-        // Resume on an active store should be a no-op.
-        store.resume().await.unwrap();
+        // Reopen on an active store should be a no-op.
+        store.reopen().await.unwrap();
 
         let guard = store.connections.lock().await;
         assert!(guard.is_some());
     }
 
     #[async_test]
-    async fn test_read_fails_when_paused() {
-        let store = new_store("read_fails_paused").await;
-        store.pause().await.unwrap();
+    async fn test_read_fails_when_closed() {
+        let store = new_store("read_fails_closed").await;
+        store.close().await.unwrap();
 
         let err = store.load_account().await;
-        assert!(err.is_err(), "read should fail when paused");
+        assert!(err.is_err(), "read should fail when closed");
 
         let err_msg = err.unwrap_err().to_string();
-        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+        assert!(err_msg.contains("closed"), "error should mention 'closed', got: {err_msg}");
     }
 
     #[async_test]
-    async fn test_operations_work_after_resume() {
-        let store = new_store("ops_after_resume").await;
+    async fn test_operations_work_after_reopen() {
+        let store = new_store("ops_after_reopen").await;
 
-        store.pause().await.unwrap();
-        store.resume().await.unwrap();
+        store.close().await.unwrap();
+        store.reopen().await.unwrap();
 
-        // A read operation should work immediately after resume.
+        // A read operation should work immediately after reopen.
         let account = store.load_account().await;
-        assert!(account.is_ok(), "load_account should succeed after resume");
+        assert!(account.is_ok(), "load_account should succeed after reopen");
         // No account was saved, so this should be None.
         assert!(account.unwrap().is_none());
     }
 
     #[async_test]
-    async fn test_multiple_pause_resume_cycles() {
+    async fn test_multiple_close_reopen_cycles() {
         let store = new_store("multi_cycles").await;
 
         for _ in 0..5 {
-            store.pause().await.unwrap();
-            store.resume().await.unwrap();
+            store.close().await.unwrap();
+            store.reopen().await.unwrap();
 
             // After each cycle, the store should be fully operational.
             let account = store.load_account().await;
-            assert!(account.is_ok(), "store should work after pause/resume cycle");
+            assert!(account.is_ok(), "store should work after close/reopen cycle");
         }
     }
 
     #[async_test]
-    async fn test_pool_is_fully_drained_after_pause() {
+    async fn test_pool_is_fully_drained_after_close() {
         let store = new_store("pool_drained").await;
 
         // Do a few reads to exercise the pool.
         let _ = store.load_account().await;
         let _ = store.load_account().await;
 
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
-        // After pause, the connections field should be None.
+        // After close, the connections field should be None.
         let guard = store.connections.lock().await;
-        assert!(guard.is_none(), "all connections should be released after pause");
+        assert!(guard.is_none(), "all connections should be released after close");
     }
 
     #[async_test]

--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -113,6 +113,9 @@ pub enum Error {
 
     #[error("The store contains invalid data: {details}")]
     InvalidData { details: String },
+
+    #[error("The store is paused")]
+    StorePaused,
 }
 
 macro_rules! impl_from {

--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -114,8 +114,8 @@ pub enum Error {
     #[error("The store contains invalid data: {details}")]
     InvalidData { details: String },
 
-    #[error("The store is paused")]
-    StorePaused,
+    #[error("The store is closed")]
+    StoreClosed,
 }
 
 macro_rules! impl_from {

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -223,6 +223,14 @@ impl SqliteEventCacheStore {
     async fn get_db_size(&self) -> Result<Option<usize>> {
         Ok(Some(self.pool.get().await?.get_db_size().await?))
     }
+
+    pub async fn pause(&self) -> Result<()> {
+        Ok(())
+    }
+
+    pub async fn resume(&self) -> Result<()> {
+        Ok(())
+    }
 }
 
 struct EncodedEvent {

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -81,16 +81,16 @@ const CHUNK_TYPE_GAP_TYPE_STRING: &str = "G";
 pub struct SqliteEventCacheStore {
     store_cipher: Option<Arc<StoreCipher>>,
 
-    /// `Some` when active, `None` when paused.
+    /// `Some` when active, `None` when closed.
     connections: Arc<Mutex<Option<SqliteConnections>>>,
 
-    /// Retained so we can rebuild the pool on resume.
+    /// Retained so we can rebuild the pool on reopen.
     db_path: PathBuf,
 
-    /// Retained so we can rebuild the pool on resume.
+    /// Retained so we can rebuild the pool on reopen.
     pool_config: PoolConfig,
 
-    /// Retained so we can re-apply runtime config on resume.
+    /// Retained so we can re-apply runtime config on reopen.
     runtime_config: RuntimeConfig,
 }
 
@@ -193,7 +193,7 @@ impl SqliteEventCacheStore {
     async fn read(&self) -> Result<SqliteAsyncConn> {
         let pool = {
             let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
             conns.pool.clone()
         };
 
@@ -213,7 +213,7 @@ impl SqliteEventCacheStore {
     async fn write(&self) -> Result<OwnedMutexGuard<SqliteAsyncConn>> {
         let write_connection = {
             let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
             conns.write_connection.clone()
         };
 
@@ -259,7 +259,7 @@ impl SqliteEventCacheStore {
     pub async fn vacuum(&self) -> Result<()> {
         let write_connection = {
             let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
             conns.write_connection.clone()
         };
         write_connection.lock().await.vacuum().await
@@ -268,19 +268,19 @@ impl SqliteEventCacheStore {
     async fn get_db_size(&self) -> Result<Option<usize>> {
         let pool = {
             let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
             conns.pool.clone()
         };
         Ok(Some(pool.get().await?.get_db_size().await?))
     }
 
-    pub async fn pause(&self) -> Result<()> {
-        connection::pause_connections(&self.connections, "Event cache store").await;
+    pub async fn close(&self) -> Result<()> {
+        connection::close_connections(&self.connections, "Event cache store").await;
         Ok(())
     }
 
-    pub async fn resume(&self) -> Result<()> {
-        connection::resume_connections(
+    pub async fn reopen(&self) -> Result<()> {
+        connection::reopen_connections(
             &self.connections,
             self.db_path.clone(),
             self.pool_config,
@@ -1520,12 +1520,12 @@ impl EventCacheStore for SqliteEventCacheStore {
             .await
     }
 
-    async fn pause(&self) -> Result<(), Self::Error> {
-        SqliteEventCacheStore::pause(self).await
+    async fn close(&self) -> Result<(), Self::Error> {
+        SqliteEventCacheStore::close(self).await
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
-        SqliteEventCacheStore::resume(self).await
+    async fn reopen(&self) -> Result<(), Self::Error> {
+        SqliteEventCacheStore::reopen(self).await
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {
@@ -2015,7 +2015,7 @@ mod encrypted_tests {
 }
 
 #[cfg(test)]
-mod pause_resume_tests {
+mod close_reopen_tests {
     use std::sync::{
         LazyLock,
         atomic::{AtomicU32, Ordering::SeqCst},
@@ -2037,151 +2037,151 @@ mod pause_resume_tests {
     }
 
     #[async_test]
-    async fn test_pause_completes_without_timeout() {
+    async fn test_close_completes_without_timeout() {
         let store = new_store().await;
 
-        // Pause should complete quickly without hitting the 5s timeout.
+        // Close should complete quickly without hitting the 5s timeout.
         let start = std::time::Instant::now();
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
         let elapsed = start.elapsed();
 
         assert!(
             elapsed < std::time::Duration::from_secs(2),
-            "pause() took {elapsed:?}, expected < 2s (no timeout)"
+            "close() took {elapsed:?}, expected < 2s (no timeout)"
         );
 
-        // Connections should be None after pause.
+        // Connections should be None after close.
         let guard = store.connections.lock().await;
-        assert!(guard.is_none(), "connections should be None after pause");
+        assert!(guard.is_none(), "connections should be None after close");
     }
 
     #[async_test]
-    async fn test_resume_restores_connections() {
+    async fn test_reopen_restores_connections() {
         let store = new_store().await;
 
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
         {
             let guard = store.connections.lock().await;
             assert!(guard.is_none());
         }
 
-        store.resume().await.unwrap();
+        store.reopen().await.unwrap();
 
         {
             let guard = store.connections.lock().await;
-            assert!(guard.is_some(), "connections should be Some after resume");
+            assert!(guard.is_some(), "connections should be Some after reopen");
         }
     }
 
     #[async_test]
-    async fn test_pause_is_idempotent() {
+    async fn test_close_is_idempotent() {
         let store = new_store().await;
 
-        store.pause().await.unwrap();
-        // Second pause should be a no-op.
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
+        // Second close should be a no-op.
+        store.close().await.unwrap();
 
         let guard = store.connections.lock().await;
         assert!(guard.is_none());
     }
 
     #[async_test]
-    async fn test_resume_is_idempotent() {
+    async fn test_reopen_is_idempotent() {
         let store = new_store().await;
 
-        // Resume on an active (non-paused) store should be a no-op.
-        store.resume().await.unwrap();
+        // Reopen on an active store should be a no-op.
+        store.reopen().await.unwrap();
 
         let guard = store.connections.lock().await;
         assert!(guard.is_some());
     }
 
     #[async_test]
-    async fn test_read_fails_when_paused() {
+    async fn test_read_fails_when_closed() {
         let store = new_store().await;
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
         let err = store.load_all_chunks(LinkedChunkId::Room(*DEFAULT_TEST_ROOM_ID)).await;
-        assert!(err.is_err(), "read should fail when paused");
+        assert!(err.is_err(), "read should fail when closed");
 
         let err_msg = err.unwrap_err().to_string();
-        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+        assert!(err_msg.contains("closed"), "error should mention 'closed', got: {err_msg}");
     }
 
     #[async_test]
-    async fn test_write_fails_when_paused() {
+    async fn test_write_fails_when_closed() {
         let store = new_store().await;
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
         let err = store.try_take_leased_lock(1000, "test_lock", "holder").await;
-        assert!(err.is_err(), "write should fail when paused");
+        assert!(err.is_err(), "write should fail when closed");
 
         let err_msg = err.unwrap_err().to_string();
-        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+        assert!(err_msg.contains("closed"), "error should mention 'closed', got: {err_msg}");
     }
 
     #[async_test]
-    async fn test_data_persists_across_pause_resume() {
+    async fn test_data_persists_across_close_reopen() {
         let store = new_store().await;
 
         // Take a lease lock — this is persisted in the database.
         let result = store.try_take_leased_lock(60_000, "test_lock", "holder").await.unwrap();
         assert!(result.is_some(), "should have acquired the lock");
 
-        // Pause and resume.
-        store.pause().await.unwrap();
-        store.resume().await.unwrap();
+        // Close and reopen.
+        store.close().await.unwrap();
+        store.reopen().await.unwrap();
 
-        // The lock should still be held by the original holder after resume.
+        // The lock should still be held by the original holder after reopen.
         let result = store.try_take_leased_lock(60_000, "test_lock", "other_holder").await.unwrap();
-        assert!(result.is_none(), "lock should still be held by the original holder after resume");
+        assert!(result.is_none(), "lock should still be held by the original holder after reopen");
     }
 
     #[async_test]
-    async fn test_multiple_pause_resume_cycles() {
+    async fn test_multiple_close_reopen_cycles() {
         let store = new_store().await;
 
         for _ in 0..5 {
-            store.pause().await.unwrap();
-            store.resume().await.unwrap();
+            store.close().await.unwrap();
+            store.reopen().await.unwrap();
 
             // After each cycle, the store should be fully operational.
             let result = store.load_all_chunks(LinkedChunkId::Room(*DEFAULT_TEST_ROOM_ID)).await;
-            assert!(result.is_ok(), "store should work after pause/resume cycle");
+            assert!(result.is_ok(), "store should work after close/reopen cycle");
         }
     }
 
     #[async_test]
-    async fn test_pool_is_fully_drained_after_pause() {
+    async fn test_pool_is_fully_drained_after_close() {
         let store = new_store().await;
 
         // Do a few reads to exercise the pool.
         let _ = store.load_all_chunks(LinkedChunkId::Room(*DEFAULT_TEST_ROOM_ID)).await;
         let _ = store.load_all_chunks(LinkedChunkId::Room(*DEFAULT_TEST_ROOM_ID)).await;
 
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
-        // After pause, the connections field should be None (pool and write
+        // After close, the connections field should be None (pool and write
         // connection have been fully torn down).
         let guard = store.connections.lock().await;
-        assert!(guard.is_none(), "all connections should be released after pause");
+        assert!(guard.is_none(), "all connections should be released after close");
     }
 
     #[async_test]
-    async fn test_operations_work_immediately_after_resume() {
+    async fn test_operations_work_immediately_after_reopen() {
         let store = new_store().await;
 
-        store.pause().await.unwrap();
-        store.resume().await.unwrap();
+        store.close().await.unwrap();
+        store.reopen().await.unwrap();
 
-        // Read should work immediately after resume.
+        // Read should work immediately after reopen.
         let result = store.load_all_chunks(LinkedChunkId::Room(*DEFAULT_TEST_ROOM_ID)).await;
-        assert!(result.is_ok(), "read should succeed immediately after resume");
+        assert!(result.is_ok(), "read should succeed immediately after reopen");
 
-        // Write should work immediately after resume.
+        // Write should work immediately after reopen.
         let result = store.try_take_leased_lock(1000, "test_lock", "holder").await;
-        assert!(result.is_ok(), "write should succeed immediately after resume");
+        assert!(result.is_ok(), "write should succeed immediately after reopen");
     }
 
     #[async_test]

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -14,9 +14,16 @@
 
 //! An SQLite-based backend for the [`EventCacheStore`].
 
-use std::{collections::HashMap, fmt, iter::once, path::Path, sync::Arc};
+use std::{
+    collections::HashMap,
+    fmt,
+    iter::once,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
+use deadpool::managed::PoolConfig;
 use matrix_sdk_base::{
     cross_process_lock::CrossProcessLockGeneration,
     deserialized_responses::TimelineEvent,
@@ -44,8 +51,8 @@ use tokio::{
 use tracing::{debug, error, instrument, trace};
 
 use crate::{
-    OpenStoreError, Secret, SqliteStoreConfig,
-    connection::{Connection as SqliteAsyncConn, Pool as SqlitePool},
+    OpenStoreError, RuntimeConfig, Secret, SqliteStoreConfig,
+    connection::{self, Connection as SqliteAsyncConn, Pool as SqlitePool, SqliteConnections},
     error::{Error, Result},
     utils::{
         EncryptableStore, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
@@ -74,14 +81,17 @@ const CHUNK_TYPE_GAP_TYPE_STRING: &str = "G";
 pub struct SqliteEventCacheStore {
     store_cipher: Option<Arc<StoreCipher>>,
 
-    /// The pool of connections.
-    pool: SqlitePool,
+    /// `Some` when active, `None` when paused.
+    connections: Arc<Mutex<Option<SqliteConnections>>>,
 
-    /// We make the difference between connections for read operations, and for
-    /// write operations. We keep a single connection apart from write
-    /// operations. All other connections are used for read operations. The
-    /// lock is used to ensure there is one owner at a time.
-    write_connection: Arc<Mutex<SqliteAsyncConn>>,
+    /// Retained so we can rebuild the pool on resume.
+    db_path: PathBuf,
+
+    /// Retained so we can rebuild the pool on resume.
+    pool_config: PoolConfig,
+
+    /// Retained so we can re-apply runtime config on resume.
+    runtime_config: RuntimeConfig,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -125,10 +135,18 @@ impl SqliteEventCacheStore {
 
         fs::create_dir_all(&config.path).await.map_err(OpenStoreError::CreateDir)?;
 
+        let db_path = config.path.join(DATABASE_NAME);
+        let pool_config = config.pool_config();
+        let runtime_config = config.runtime_config();
+
         let pool = config.build_pool_of_connections(DATABASE_NAME)?;
 
-        let this = Self::open_with_pool(pool, config.secret.clone()).await?;
-        this.write().await?.apply_runtime_config(config.runtime_config.clone()).await?;
+        let this =
+            Self::open_with_pool(pool, db_path, pool_config, runtime_config, config.secret.clone())
+                .await?;
+
+        // Apply runtime config on the write connection.
+        this.write().await?.apply_runtime_config(runtime_config).await?;
 
         Ok(this)
     }
@@ -137,6 +155,9 @@ impl SqliteEventCacheStore {
     /// pool. The given secret will be used to encrypt private data.
     async fn open_with_pool(
         pool: SqlitePool,
+        db_path: PathBuf,
+        pool_config: PoolConfig,
+        runtime_config: RuntimeConfig,
         secret: Option<Secret>,
     ) -> Result<Self, OpenStoreError> {
         let conn = pool.get().await?;
@@ -152,18 +173,31 @@ impl SqliteEventCacheStore {
             None => None,
         };
 
+        let connections = SqliteConnections {
+            pool,
+            // Use `conn` as our selected write connection.
+            write_connection: Arc::new(Mutex::new(conn)),
+        };
+
         Ok(Self {
             store_cipher,
-            pool,
-            // Use `conn` as our selected write connections.
-            write_connection: Arc::new(Mutex::new(conn)),
+            connections: Arc::new(Mutex::new(Some(connections))),
+            db_path,
+            pool_config,
+            runtime_config,
         })
     }
 
     /// Acquire a connection for executing read operations.
     #[instrument(skip_all)]
     async fn read(&self) -> Result<SqliteAsyncConn> {
-        let connection = self.pool.get().await?;
+        let pool = {
+            let guard = self.connections.lock().await;
+            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            conns.pool.clone()
+        };
+
+        let connection = pool.get().await?;
 
         // Per https://www.sqlite.org/foreignkeys.html#fk_enable, foreign key
         // support must be enabled on a per-connection basis. Execute it every
@@ -177,7 +211,13 @@ impl SqliteEventCacheStore {
     /// Acquire a connection for executing write operations.
     #[instrument(skip_all)]
     async fn write(&self) -> Result<OwnedMutexGuard<SqliteAsyncConn>> {
-        let connection = self.write_connection.clone().lock_owned().await;
+        let write_connection = {
+            let guard = self.connections.lock().await;
+            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            conns.write_connection.clone()
+        };
+
+        let connection = write_connection.lock_owned().await;
 
         // Per https://www.sqlite.org/foreignkeys.html#fk_enable, foreign key
         // support must be enabled on a per-connection basis. Execute it every
@@ -217,19 +257,44 @@ impl SqliteEventCacheStore {
     }
 
     pub async fn vacuum(&self) -> Result<()> {
-        self.write_connection.lock().await.vacuum().await
+        let write_connection = {
+            let guard = self.connections.lock().await;
+            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            conns.write_connection.clone()
+        };
+        write_connection.lock().await.vacuum().await
     }
 
     async fn get_db_size(&self) -> Result<Option<usize>> {
-        Ok(Some(self.pool.get().await?.get_db_size().await?))
+        let pool = {
+            let guard = self.connections.lock().await;
+            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            conns.pool.clone()
+        };
+        Ok(Some(pool.get().await?.get_db_size().await?))
     }
 
     pub async fn pause(&self) -> Result<()> {
+        connection::pause_connections(&self.connections, "Event cache store").await;
         Ok(())
     }
 
     pub async fn resume(&self) -> Result<()> {
+        connection::resume_connections(
+            &self.connections,
+            self.db_path.clone(),
+            self.pool_config,
+            self.runtime_config,
+        )
+        .await?;
         Ok(())
+    }
+
+    /// Returns the pool size status, for testing purposes.
+    #[cfg(test)]
+    async fn pool_max_size(&self) -> Option<usize> {
+        let guard = self.connections.lock().await;
+        guard.as_ref().map(|conns| conns.pool.status().max_size)
     }
 }
 
@@ -1455,6 +1520,14 @@ impl EventCacheStore for SqliteEventCacheStore {
             .await
     }
 
+    async fn pause(&self) -> Result<(), Self::Error> {
+        SqliteEventCacheStore::pause(self).await
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        SqliteEventCacheStore::resume(self).await
+    }
+
     async fn optimize(&self) -> Result<(), Self::Error> {
         Ok(self.vacuum().await?)
     }
@@ -1706,7 +1779,7 @@ mod tests {
 
         let store = SqliteEventCacheStore::open_with_config(&store_open_config).await.unwrap();
 
-        assert_eq!(store.pool.status().max_size, 42);
+        assert_eq!(store.pool_max_size().await, Some(42));
     }
 
     #[async_test]

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -2013,3 +2013,207 @@ mod encrypted_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod pause_resume_tests {
+    use std::sync::{
+        LazyLock,
+        atomic::{AtomicU32, Ordering::SeqCst},
+    };
+
+    use matrix_sdk_base::{event_cache::store::EventCacheStore, linked_chunk::LinkedChunkId};
+    use matrix_sdk_test::{DEFAULT_TEST_ROOM_ID, async_test};
+    use tempfile::{TempDir, tempdir};
+
+    use super::SqliteEventCacheStore;
+
+    static TMP_DIR: LazyLock<TempDir> = LazyLock::new(|| tempdir().unwrap());
+    static NUM: AtomicU32 = AtomicU32::new(0);
+
+    async fn new_store() -> SqliteEventCacheStore {
+        let name = NUM.fetch_add(1, SeqCst).to_string();
+        let tmpdir_path = TMP_DIR.path().join(name);
+        SqliteEventCacheStore::open(tmpdir_path, None).await.unwrap()
+    }
+
+    #[async_test]
+    async fn test_pause_completes_without_timeout() {
+        let store = new_store().await;
+
+        // Pause should complete quickly without hitting the 5s timeout.
+        let start = std::time::Instant::now();
+        store.pause().await.unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "pause() took {elapsed:?}, expected < 2s (no timeout)"
+        );
+
+        // Connections should be None after pause.
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none(), "connections should be None after pause");
+    }
+
+    #[async_test]
+    async fn test_resume_restores_connections() {
+        let store = new_store().await;
+
+        store.pause().await.unwrap();
+
+        {
+            let guard = store.connections.lock().await;
+            assert!(guard.is_none());
+        }
+
+        store.resume().await.unwrap();
+
+        {
+            let guard = store.connections.lock().await;
+            assert!(guard.is_some(), "connections should be Some after resume");
+        }
+    }
+
+    #[async_test]
+    async fn test_pause_is_idempotent() {
+        let store = new_store().await;
+
+        store.pause().await.unwrap();
+        // Second pause should be a no-op.
+        store.pause().await.unwrap();
+
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none());
+    }
+
+    #[async_test]
+    async fn test_resume_is_idempotent() {
+        let store = new_store().await;
+
+        // Resume on an active (non-paused) store should be a no-op.
+        store.resume().await.unwrap();
+
+        let guard = store.connections.lock().await;
+        assert!(guard.is_some());
+    }
+
+    #[async_test]
+    async fn test_read_fails_when_paused() {
+        let store = new_store().await;
+        store.pause().await.unwrap();
+
+        let err = store.load_all_chunks(LinkedChunkId::Room(*DEFAULT_TEST_ROOM_ID)).await;
+        assert!(err.is_err(), "read should fail when paused");
+
+        let err_msg = err.unwrap_err().to_string();
+        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+    }
+
+    #[async_test]
+    async fn test_write_fails_when_paused() {
+        let store = new_store().await;
+        store.pause().await.unwrap();
+
+        let err = store.try_take_leased_lock(1000, "test_lock", "holder").await;
+        assert!(err.is_err(), "write should fail when paused");
+
+        let err_msg = err.unwrap_err().to_string();
+        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+    }
+
+    #[async_test]
+    async fn test_data_persists_across_pause_resume() {
+        let store = new_store().await;
+
+        // Take a lease lock — this is persisted in the database.
+        let result = store.try_take_leased_lock(60_000, "test_lock", "holder").await.unwrap();
+        assert!(result.is_some(), "should have acquired the lock");
+
+        // Pause and resume.
+        store.pause().await.unwrap();
+        store.resume().await.unwrap();
+
+        // The lock should still be held by the original holder after resume.
+        let result = store.try_take_leased_lock(60_000, "test_lock", "other_holder").await.unwrap();
+        assert!(result.is_none(), "lock should still be held by the original holder after resume");
+    }
+
+    #[async_test]
+    async fn test_multiple_pause_resume_cycles() {
+        let store = new_store().await;
+
+        for _ in 0..5 {
+            store.pause().await.unwrap();
+            store.resume().await.unwrap();
+
+            // After each cycle, the store should be fully operational.
+            let result = store.load_all_chunks(LinkedChunkId::Room(*DEFAULT_TEST_ROOM_ID)).await;
+            assert!(result.is_ok(), "store should work after pause/resume cycle");
+        }
+    }
+
+    #[async_test]
+    async fn test_pool_is_fully_drained_after_pause() {
+        let store = new_store().await;
+
+        // Do a few reads to exercise the pool.
+        let _ = store.load_all_chunks(LinkedChunkId::Room(*DEFAULT_TEST_ROOM_ID)).await;
+        let _ = store.load_all_chunks(LinkedChunkId::Room(*DEFAULT_TEST_ROOM_ID)).await;
+
+        store.pause().await.unwrap();
+
+        // After pause, the connections field should be None (pool and write
+        // connection have been fully torn down).
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none(), "all connections should be released after pause");
+    }
+
+    #[async_test]
+    async fn test_operations_work_immediately_after_resume() {
+        let store = new_store().await;
+
+        store.pause().await.unwrap();
+        store.resume().await.unwrap();
+
+        // Read should work immediately after resume.
+        let result = store.load_all_chunks(LinkedChunkId::Room(*DEFAULT_TEST_ROOM_ID)).await;
+        assert!(result.is_ok(), "read should succeed immediately after resume");
+
+        // Write should work immediately after resume.
+        let result = store.try_take_leased_lock(1000, "test_lock", "holder").await;
+        assert!(result.is_ok(), "write should succeed immediately after resume");
+    }
+
+    #[async_test]
+    async fn test_close_waits_for_held_read_connection_to_drain() {
+        let store = new_store().await;
+
+        // Acquire a read connection and hold it, simulating an in-flight read.
+        let held_conn = store.read().await.unwrap();
+
+        // Spawn close in a background task — it will close the pool and then
+        // poll-wait for pool.status().size == 0 in the drain loop.
+        let store_clone = store.clone();
+        let close_handle = tokio::spawn(async move {
+            store_clone.close().await.unwrap();
+        });
+
+        // Give close() a moment to close the pool and enter the drain loop.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // The close task should still be running because we hold a connection.
+        assert!(!close_handle.is_finished(), "close should be waiting for the held connection");
+
+        // Release the held connection — this lets pool.status().size drop to 0.
+        drop(held_conn);
+
+        // Now close should complete promptly (well within the 5s timeout).
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(3), close_handle).await;
+        assert!(timeout.is_ok(), "close should complete after the held connection is released");
+        timeout.unwrap().unwrap();
+
+        // Verify the store is fully closed.
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none(), "connections should be None after close");
+    }
+}

--- a/crates/matrix-sdk-sqlite/src/lib.rs
+++ b/crates/matrix-sdk-sqlite/src/lib.rs
@@ -208,6 +208,16 @@ impl SqliteStoreConfig {
         self
     }
 
+    /// Returns the pool configuration.
+    pub(crate) fn pool_config(&self) -> PoolConfig {
+        self.pool_config
+    }
+
+    /// Returns the runtime configuration.
+    pub(crate) fn runtime_config(&self) -> RuntimeConfig {
+        self.runtime_config
+    }
+
     /// Build a pool of active connections to a particular database.
     pub fn build_pool_of_connections(
         &self,
@@ -228,7 +238,7 @@ impl SqliteStoreConfig {
 ///
 /// This configuration is applied by
 /// [`utils::SqliteAsyncConnExt::apply_runtime_config`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 struct RuntimeConfig {
     /// If `true`, [`utils::SqliteAsyncConnExt::optimize`] will be called.
     optimize: bool,

--- a/crates/matrix-sdk-sqlite/src/media_store.rs
+++ b/crates/matrix-sdk-sqlite/src/media_store.rs
@@ -192,6 +192,14 @@ impl SqliteMediaStore {
     async fn get_db_size(&self) -> Result<Option<usize>> {
         Ok(Some(self.pool.get().await?.get_db_size().await?))
     }
+
+    pub async fn pause(&self) -> Result<()> {
+        Ok(())
+    }
+
+    pub async fn resume(&self) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Run migrations for the given version of the database.

--- a/crates/matrix-sdk-sqlite/src/media_store.rs
+++ b/crates/matrix-sdk-sqlite/src/media_store.rs
@@ -69,16 +69,16 @@ const DATABASE_NAME: &str = "matrix-sdk-media.sqlite3";
 pub struct SqliteMediaStore {
     store_cipher: Option<Arc<StoreCipher>>,
 
-    /// `Some` when active, `None` when paused.
+    /// `Some` when active, `None` when closed.
     connections: Arc<Mutex<Option<SqliteConnections>>>,
 
-    /// Retained so we can rebuild the pool on resume.
+    /// Retained so we can rebuild the pool on reopen.
     db_path: PathBuf,
 
-    /// Retained so we can rebuild the pool on resume.
+    /// Retained so we can rebuild the pool on reopen.
     pool_config: PoolConfig,
 
-    /// Retained so we can re-apply runtime config on resume.
+    /// Retained so we can re-apply runtime config on reopen.
     runtime_config: RuntimeConfig,
 
     media_service: MediaService,
@@ -188,7 +188,7 @@ impl SqliteMediaStore {
     async fn read(&self) -> Result<SqliteAsyncConn> {
         let pool = {
             let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
             conns.pool.clone()
         };
 
@@ -208,7 +208,7 @@ impl SqliteMediaStore {
     async fn write(&self) -> Result<OwnedMutexGuard<SqliteAsyncConn>> {
         let write_connection = {
             let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
             conns.write_connection.clone()
         };
 
@@ -226,7 +226,7 @@ impl SqliteMediaStore {
     pub async fn vacuum(&self) -> Result<()> {
         let write_connection = {
             let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
             conns.write_connection.clone()
         };
         write_connection.lock().await.vacuum().await
@@ -235,19 +235,19 @@ impl SqliteMediaStore {
     async fn get_db_size(&self) -> Result<Option<usize>> {
         let pool = {
             let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
             conns.pool.clone()
         };
         Ok(Some(pool.get().await?.get_db_size().await?))
     }
 
-    pub async fn pause(&self) -> Result<()> {
-        connection::pause_connections(&self.connections, "Media store").await;
+    pub async fn close(&self) -> Result<()> {
+        connection::close_connections(&self.connections, "Media store").await;
         Ok(())
     }
 
-    pub async fn resume(&self) -> Result<()> {
-        connection::resume_connections(
+    pub async fn reopen(&self) -> Result<()> {
+        connection::reopen_connections(
             &self.connections,
             self.db_path.clone(),
             self.pool_config,
@@ -458,12 +458,12 @@ impl MediaStore for SqliteMediaStore {
         self.media_service.clean(self).await
     }
 
-    async fn pause(&self) -> Result<(), Self::Error> {
-        SqliteMediaStore::pause(self).await
+    async fn close(&self) -> Result<(), Self::Error> {
+        SqliteMediaStore::close(self).await
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
-        SqliteMediaStore::resume(self).await
+    async fn reopen(&self) -> Result<(), Self::Error> {
+        SqliteMediaStore::reopen(self).await
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {
@@ -873,7 +873,7 @@ mod tests {
 }
 
 #[cfg(test)]
-mod pause_resume_tests {
+mod close_reopen_tests {
     use std::sync::{
         LazyLock,
         atomic::{AtomicU32, Ordering::SeqCst},
@@ -906,94 +906,94 @@ mod pause_resume_tests {
     }
 
     #[async_test]
-    async fn test_pause_completes_without_timeout() {
+    async fn test_close_completes_without_timeout() {
         let store = new_store().await;
 
-        // Pause should complete quickly without hitting any timeout.
+        // Close should complete quickly without hitting any timeout.
         let start = std::time::Instant::now();
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
         let elapsed = start.elapsed();
 
         assert!(
             elapsed < std::time::Duration::from_secs(2),
-            "pause() took {elapsed:?}, expected < 2s (no timeout)"
+            "close() took {elapsed:?}, expected < 2s (no timeout)"
         );
 
-        // Connections should be None after pause.
+        // Connections should be None after close.
         let guard = store.connections.lock().await;
-        assert!(guard.is_none(), "connections should be None after pause");
+        assert!(guard.is_none(), "connections should be None after close");
     }
 
     #[async_test]
-    async fn test_resume_restores_connections() {
+    async fn test_reopen_restores_connections() {
         let store = new_store().await;
 
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
         {
             let guard = store.connections.lock().await;
             assert!(guard.is_none());
         }
 
-        store.resume().await.unwrap();
+        store.reopen().await.unwrap();
 
         {
             let guard = store.connections.lock().await;
-            assert!(guard.is_some(), "connections should be Some after resume");
+            assert!(guard.is_some(), "connections should be Some after reopen");
         }
     }
 
     #[async_test]
-    async fn test_pause_is_idempotent() {
+    async fn test_close_is_idempotent() {
         let store = new_store().await;
 
-        store.pause().await.unwrap();
-        // Second pause should be a no-op.
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
+        // Second close should be a no-op.
+        store.close().await.unwrap();
 
         let guard = store.connections.lock().await;
         assert!(guard.is_none());
     }
 
     #[async_test]
-    async fn test_resume_is_idempotent() {
+    async fn test_reopen_is_idempotent() {
         let store = new_store().await;
 
-        // Resume on an active (non-paused) store should be a no-op.
-        store.resume().await.unwrap();
+        // Reopen on an active store should be a no-op.
+        store.reopen().await.unwrap();
 
         let guard = store.connections.lock().await;
         assert!(guard.is_some());
     }
 
     #[async_test]
-    async fn test_read_fails_when_paused() {
+    async fn test_read_fails_when_closed() {
         let store = new_store().await;
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
         let err = store.get_media_content(&test_request()).await;
-        assert!(err.is_err(), "read should fail when paused");
+        assert!(err.is_err(), "read should fail when closed");
 
         let err_msg = err.unwrap_err().to_string();
-        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+        assert!(err_msg.contains("closed"), "error should mention 'closed', got: {err_msg}");
     }
 
     #[async_test]
-    async fn test_write_fails_when_paused() {
+    async fn test_write_fails_when_closed() {
         let store = new_store().await;
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
         let err = store
             .add_media_content(&test_request(), b"data".to_vec(), IgnoreMediaRetentionPolicy::No)
             .await;
-        assert!(err.is_err(), "write should fail when paused");
+        assert!(err.is_err(), "write should fail when closed");
 
         let err_msg = err.unwrap_err().to_string();
-        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+        assert!(err_msg.contains("closed"), "error should mention 'closed', got: {err_msg}");
     }
 
     #[async_test]
-    async fn test_data_persists_across_pause_resume() {
+    async fn test_data_persists_across_close_reopen() {
         let store = new_store().await;
 
         // Write some media content.
@@ -1010,69 +1010,69 @@ mod pause_resume_tests {
         let content = store.get_media_content(&test_request()).await.unwrap();
         assert_eq!(content.as_deref(), Some(b"hello world".as_slice()));
 
-        // Pause and resume.
-        store.pause().await.unwrap();
-        store.resume().await.unwrap();
+        // Close and reopen.
+        store.close().await.unwrap();
+        store.reopen().await.unwrap();
 
-        // Content should still be there after resume.
+        // Content should still be there after reopen.
         let content = store.get_media_content(&test_request()).await.unwrap();
         assert_eq!(
             content.as_deref(),
             Some(b"hello world".as_slice()),
-            "media content should persist across pause/resume"
+            "media content should persist across close/reopen"
         );
     }
 
     #[async_test]
-    async fn test_multiple_pause_resume_cycles() {
+    async fn test_multiple_close_reopen_cycles() {
         let store = new_store().await;
 
         for _ in 0..5 {
-            store.pause().await.unwrap();
-            store.resume().await.unwrap();
+            store.close().await.unwrap();
+            store.reopen().await.unwrap();
 
             // After each cycle, the store should be fully operational.
             let result = store.get_media_content(&test_request()).await;
-            assert!(result.is_ok(), "store should work after pause/resume cycle");
+            assert!(result.is_ok(), "store should work after close/reopen cycle");
         }
     }
 
     #[async_test]
-    async fn test_pool_is_fully_drained_after_pause() {
+    async fn test_pool_is_fully_drained_after_close() {
         let store = new_store().await;
 
         // Do a few reads to exercise the pool.
         let _ = store.get_media_content(&test_request()).await;
         let _ = store.get_media_content(&test_request()).await;
 
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
-        // After pause, the connections field should be None (pool and write
+        // After close, the connections field should be None (pool and write
         // connection have been fully torn down).
         let guard = store.connections.lock().await;
-        assert!(guard.is_none(), "all connections should be released after pause");
+        assert!(guard.is_none(), "all connections should be released after close");
     }
 
     #[async_test]
-    async fn test_operations_work_immediately_after_resume() {
+    async fn test_operations_work_immediately_after_reopen() {
         let store = new_store().await;
 
-        store.pause().await.unwrap();
-        store.resume().await.unwrap();
+        store.close().await.unwrap();
+        store.reopen().await.unwrap();
 
-        // Read should work immediately after resume.
+        // Read should work immediately after reopen.
         let result = store.get_media_content(&test_request()).await;
-        assert!(result.is_ok(), "read should succeed immediately after resume");
+        assert!(result.is_ok(), "read should succeed immediately after reopen");
 
-        // Write should work immediately after resume.
+        // Write should work immediately after reopen.
         let result = store
             .add_media_content(
                 &test_request(),
-                b"after_resume".to_vec(),
+                b"after_reopen".to_vec(),
                 IgnoreMediaRetentionPolicy::No,
             )
             .await;
-        assert!(result.is_ok(), "write should succeed immediately after resume");
+        assert!(result.is_ok(), "write should succeed immediately after reopen");
     }
 
     #[async_test]

--- a/crates/matrix-sdk-sqlite/src/media_store.rs
+++ b/crates/matrix-sdk-sqlite/src/media_store.rs
@@ -14,9 +14,14 @@
 
 //! An SQLite-based backend for the [`MediaStore`].
 
-use std::{fmt, path::Path, sync::Arc};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
+use deadpool::managed::PoolConfig;
 use matrix_sdk_base::{
     cross_process_lock::CrossProcessLockGeneration,
     media::{
@@ -38,8 +43,8 @@ use tokio::{
 use tracing::{debug, instrument};
 
 use crate::{
-    OpenStoreError, Secret, SqliteStoreConfig,
-    connection::{Connection as SqliteAsyncConn, Pool as SqlitePool},
+    OpenStoreError, RuntimeConfig, Secret, SqliteStoreConfig,
+    connection::{self, Connection as SqliteAsyncConn, Pool as SqlitePool, SqliteConnections},
     error::{Error, Result},
     utils::{
         EncryptableStore, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
@@ -64,14 +69,17 @@ const DATABASE_NAME: &str = "matrix-sdk-media.sqlite3";
 pub struct SqliteMediaStore {
     store_cipher: Option<Arc<StoreCipher>>,
 
-    /// The pool of connections.
-    pool: SqlitePool,
+    /// `Some` when active, `None` when paused.
+    connections: Arc<Mutex<Option<SqliteConnections>>>,
 
-    /// We make the difference between connections for read operations, and for
-    /// write operations. We keep a single connection apart from write
-    /// operations. All other connections are used for read operations. The
-    /// lock is used to ensure there is one owner at a time.
-    write_connection: Arc<Mutex<SqliteAsyncConn>>,
+    /// Retained so we can rebuild the pool on resume.
+    db_path: PathBuf,
+
+    /// Retained so we can rebuild the pool on resume.
+    pool_config: PoolConfig,
+
+    /// Retained so we can re-apply runtime config on resume.
+    runtime_config: RuntimeConfig,
 
     media_service: MediaService,
 }
@@ -117,10 +125,18 @@ impl SqliteMediaStore {
 
         fs::create_dir_all(&config.path).await.map_err(OpenStoreError::CreateDir)?;
 
+        let db_path = config.path.join(DATABASE_NAME);
+        let pool_config = config.pool_config();
+        let runtime_config = config.runtime_config();
+
         let pool = config.build_pool_of_connections(DATABASE_NAME)?;
 
-        let this = Self::open_with_pool(pool, config.secret.clone()).await?;
-        this.write().await?.apply_runtime_config(config.runtime_config.clone()).await?;
+        let this =
+            Self::open_with_pool(pool, db_path, pool_config, runtime_config, config.secret.clone())
+                .await?;
+
+        // Apply runtime config on the write connection.
+        this.write().await?.apply_runtime_config(runtime_config).await?;
 
         Ok(this)
     }
@@ -129,6 +145,9 @@ impl SqliteMediaStore {
     /// pool. The given passphrase will be used to encrypt private data.
     async fn open_with_pool(
         pool: SqlitePool,
+        db_path: PathBuf,
+        pool_config: PoolConfig,
+        runtime_config: RuntimeConfig,
         secret: Option<Secret>,
     ) -> Result<Self, OpenStoreError> {
         let conn = pool.get().await?;
@@ -138,8 +157,8 @@ impl SqliteMediaStore {
 
         conn.wal_checkpoint().await;
 
-        let store_cipher = match secret {
-            Some(s) => Some(Arc::new(conn.get_or_create_store_cipher(s).await?)),
+        let store_cipher = match &secret {
+            Some(s) => Some(Arc::new(conn.get_or_create_store_cipher(s.clone()).await?)),
             None => None,
         };
 
@@ -148,11 +167,18 @@ impl SqliteMediaStore {
         let last_media_cleanup_time = conn.get_serialized_kv(keys::LAST_MEDIA_CLEANUP_TIME).await?;
         media_service.restore(media_retention_policy, last_media_cleanup_time);
 
+        let connections = SqliteConnections {
+            pool,
+            // Use `conn` as our selected write connection.
+            write_connection: Arc::new(Mutex::new(conn)),
+        };
+
         Ok(Self {
             store_cipher,
-            pool,
-            // Use `conn` as our selected write connections.
-            write_connection: Arc::new(Mutex::new(conn)),
+            connections: Arc::new(Mutex::new(Some(connections))),
+            db_path,
+            pool_config,
+            runtime_config,
             media_service,
         })
     }
@@ -160,7 +186,13 @@ impl SqliteMediaStore {
     // Acquire a connection for executing read operations.
     #[instrument(skip_all)]
     async fn read(&self) -> Result<SqliteAsyncConn> {
-        let connection = self.pool.get().await?;
+        let pool = {
+            let guard = self.connections.lock().await;
+            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            conns.pool.clone()
+        };
+
+        let connection = pool.get().await?;
 
         // Per https://www.sqlite.org/foreignkeys.html#fk_enable, foreign key
         // support must be enabled on a per-connection basis. Execute it every
@@ -174,7 +206,13 @@ impl SqliteMediaStore {
     // Acquire a connection for executing write operations.
     #[instrument(skip_all)]
     async fn write(&self) -> Result<OwnedMutexGuard<SqliteAsyncConn>> {
-        let connection = self.write_connection.clone().lock_owned().await;
+        let write_connection = {
+            let guard = self.connections.lock().await;
+            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            conns.write_connection.clone()
+        };
+
+        let connection = write_connection.lock_owned().await;
 
         // Per https://www.sqlite.org/foreignkeys.html#fk_enable, foreign key
         // support must be enabled on a per-connection basis. Execute it every
@@ -186,19 +224,44 @@ impl SqliteMediaStore {
     }
 
     pub async fn vacuum(&self) -> Result<()> {
-        self.write_connection.lock().await.vacuum().await
+        let write_connection = {
+            let guard = self.connections.lock().await;
+            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            conns.write_connection.clone()
+        };
+        write_connection.lock().await.vacuum().await
     }
 
     async fn get_db_size(&self) -> Result<Option<usize>> {
-        Ok(Some(self.pool.get().await?.get_db_size().await?))
+        let pool = {
+            let guard = self.connections.lock().await;
+            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            conns.pool.clone()
+        };
+        Ok(Some(pool.get().await?.get_db_size().await?))
     }
 
     pub async fn pause(&self) -> Result<()> {
+        connection::pause_connections(&self.connections, "Media store").await;
         Ok(())
     }
 
     pub async fn resume(&self) -> Result<()> {
+        connection::resume_connections(
+            &self.connections,
+            self.db_path.clone(),
+            self.pool_config,
+            self.runtime_config,
+        )
+        .await?;
         Ok(())
+    }
+
+    /// Returns the pool size status, for testing purposes.
+    #[cfg(test)]
+    async fn pool_max_size(&self) -> Option<usize> {
+        let guard = self.connections.lock().await;
+        guard.as_ref().map(|conns| conns.pool.status().max_size)
     }
 }
 
@@ -393,6 +456,14 @@ impl MediaStore for SqliteMediaStore {
         let _timer = timer!("method");
 
         self.media_service.clean(self).await
+    }
+
+    async fn pause(&self) -> Result<(), Self::Error> {
+        SqliteMediaStore::pause(self).await
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        SqliteMediaStore::resume(self).await
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {
@@ -732,7 +803,7 @@ mod tests {
 
         let store = SqliteMediaStore::open_with_config(&store_open_config).await.unwrap();
 
-        assert_eq!(store.pool.status().max_size, 42);
+        assert_eq!(store.pool_max_size().await.unwrap(), 42);
     }
 
     #[async_test]

--- a/crates/matrix-sdk-sqlite/src/media_store.rs
+++ b/crates/matrix-sdk-sqlite/src/media_store.rs
@@ -873,6 +873,243 @@ mod tests {
 }
 
 #[cfg(test)]
+mod pause_resume_tests {
+    use std::sync::{
+        LazyLock,
+        atomic::{AtomicU32, Ordering::SeqCst},
+    };
+
+    use matrix_sdk_base::media::{
+        MediaFormat, MediaRequestParameters,
+        store::{IgnoreMediaRetentionPolicy, MediaStore},
+    };
+    use matrix_sdk_test::async_test;
+    use ruma::{events::room::MediaSource, mxc_uri};
+    use tempfile::{TempDir, tempdir};
+
+    use super::SqliteMediaStore;
+
+    static TMP_DIR: LazyLock<TempDir> = LazyLock::new(|| tempdir().unwrap());
+    static NUM: AtomicU32 = AtomicU32::new(0);
+
+    async fn new_store() -> SqliteMediaStore {
+        let name = NUM.fetch_add(1, SeqCst).to_string();
+        let tmpdir_path = TMP_DIR.path().join(name);
+        SqliteMediaStore::open(tmpdir_path, None).await.unwrap()
+    }
+
+    fn test_request() -> MediaRequestParameters {
+        MediaRequestParameters {
+            source: MediaSource::Plain(mxc_uri!("mxc://localhost/test_media").to_owned()),
+            format: MediaFormat::File,
+        }
+    }
+
+    #[async_test]
+    async fn test_pause_completes_without_timeout() {
+        let store = new_store().await;
+
+        // Pause should complete quickly without hitting any timeout.
+        let start = std::time::Instant::now();
+        store.pause().await.unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "pause() took {elapsed:?}, expected < 2s (no timeout)"
+        );
+
+        // Connections should be None after pause.
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none(), "connections should be None after pause");
+    }
+
+    #[async_test]
+    async fn test_resume_restores_connections() {
+        let store = new_store().await;
+
+        store.pause().await.unwrap();
+
+        {
+            let guard = store.connections.lock().await;
+            assert!(guard.is_none());
+        }
+
+        store.resume().await.unwrap();
+
+        {
+            let guard = store.connections.lock().await;
+            assert!(guard.is_some(), "connections should be Some after resume");
+        }
+    }
+
+    #[async_test]
+    async fn test_pause_is_idempotent() {
+        let store = new_store().await;
+
+        store.pause().await.unwrap();
+        // Second pause should be a no-op.
+        store.pause().await.unwrap();
+
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none());
+    }
+
+    #[async_test]
+    async fn test_resume_is_idempotent() {
+        let store = new_store().await;
+
+        // Resume on an active (non-paused) store should be a no-op.
+        store.resume().await.unwrap();
+
+        let guard = store.connections.lock().await;
+        assert!(guard.is_some());
+    }
+
+    #[async_test]
+    async fn test_read_fails_when_paused() {
+        let store = new_store().await;
+        store.pause().await.unwrap();
+
+        let err = store.get_media_content(&test_request()).await;
+        assert!(err.is_err(), "read should fail when paused");
+
+        let err_msg = err.unwrap_err().to_string();
+        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+    }
+
+    #[async_test]
+    async fn test_write_fails_when_paused() {
+        let store = new_store().await;
+        store.pause().await.unwrap();
+
+        let err = store
+            .add_media_content(&test_request(), b"data".to_vec(), IgnoreMediaRetentionPolicy::No)
+            .await;
+        assert!(err.is_err(), "write should fail when paused");
+
+        let err_msg = err.unwrap_err().to_string();
+        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+    }
+
+    #[async_test]
+    async fn test_data_persists_across_pause_resume() {
+        let store = new_store().await;
+
+        // Write some media content.
+        store
+            .add_media_content(
+                &test_request(),
+                b"hello world".to_vec(),
+                IgnoreMediaRetentionPolicy::Yes,
+            )
+            .await
+            .unwrap();
+
+        // Verify it's there.
+        let content = store.get_media_content(&test_request()).await.unwrap();
+        assert_eq!(content.as_deref(), Some(b"hello world".as_slice()));
+
+        // Pause and resume.
+        store.pause().await.unwrap();
+        store.resume().await.unwrap();
+
+        // Content should still be there after resume.
+        let content = store.get_media_content(&test_request()).await.unwrap();
+        assert_eq!(
+            content.as_deref(),
+            Some(b"hello world".as_slice()),
+            "media content should persist across pause/resume"
+        );
+    }
+
+    #[async_test]
+    async fn test_multiple_pause_resume_cycles() {
+        let store = new_store().await;
+
+        for _ in 0..5 {
+            store.pause().await.unwrap();
+            store.resume().await.unwrap();
+
+            // After each cycle, the store should be fully operational.
+            let result = store.get_media_content(&test_request()).await;
+            assert!(result.is_ok(), "store should work after pause/resume cycle");
+        }
+    }
+
+    #[async_test]
+    async fn test_pool_is_fully_drained_after_pause() {
+        let store = new_store().await;
+
+        // Do a few reads to exercise the pool.
+        let _ = store.get_media_content(&test_request()).await;
+        let _ = store.get_media_content(&test_request()).await;
+
+        store.pause().await.unwrap();
+
+        // After pause, the connections field should be None (pool and write
+        // connection have been fully torn down).
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none(), "all connections should be released after pause");
+    }
+
+    #[async_test]
+    async fn test_operations_work_immediately_after_resume() {
+        let store = new_store().await;
+
+        store.pause().await.unwrap();
+        store.resume().await.unwrap();
+
+        // Read should work immediately after resume.
+        let result = store.get_media_content(&test_request()).await;
+        assert!(result.is_ok(), "read should succeed immediately after resume");
+
+        // Write should work immediately after resume.
+        let result = store
+            .add_media_content(
+                &test_request(),
+                b"after_resume".to_vec(),
+                IgnoreMediaRetentionPolicy::No,
+            )
+            .await;
+        assert!(result.is_ok(), "write should succeed immediately after resume");
+    }
+
+    #[async_test]
+    async fn test_close_waits_for_held_read_connection_to_drain() {
+        let store = new_store().await;
+
+        // Acquire a read connection and hold it, simulating an in-flight read.
+        let held_conn = store.read().await.unwrap();
+
+        // Spawn close in a background task — it will close the pool and then
+        // poll-wait for pool.status().size == 0 in the drain loop.
+        let store_clone = store.clone();
+        let close_handle = tokio::spawn(async move {
+            store_clone.close().await.unwrap();
+        });
+
+        // Give close() a moment to close the pool and enter the drain loop.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // The close task should still be running because we hold a connection.
+        assert!(!close_handle.is_finished(), "close should be waiting for the held connection");
+
+        // Release the held connection — this lets pool.status().size drop to 0.
+        drop(held_conn);
+
+        // Now close should complete promptly (well within the 5s timeout).
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(3), close_handle).await;
+        assert!(timeout.is_ok(), "close should complete after the held connection is released");
+        timeout.unwrap().unwrap();
+
+        // Verify the store is fully closed.
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none(), "connections should be None after close");
+    }
+}
+
+#[cfg(test)]
 mod encrypted_tests {
     use std::sync::{
         LazyLock,

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -2368,6 +2368,14 @@ impl StateStore for SqliteStateStore {
     async fn get_size(&self) -> Result<Option<usize>, Self::Error> {
         self.get_db_size().await
     }
+
+    async fn pause(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn resume(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -78,16 +78,16 @@ pub const DATABASE_NAME: &str = "matrix-sdk-state.sqlite3";
 pub struct SqliteStateStore {
     store_cipher: Option<Arc<StoreCipher>>,
 
-    /// `Some` when active, `None` when paused.
+    /// `Some` when active, `None` when closed.
     connections: Arc<Mutex<Option<SqliteConnections>>>,
 
-    /// Retained so we can rebuild the pool on resume.
+    /// Retained so we can rebuild the pool on reopen.
     db_path: PathBuf,
 
-    /// Retained so we can rebuild the pool on resume.
+    /// Retained so we can rebuild the pool on reopen.
     pool_config: PoolConfig,
 
-    /// Retained so we can re-apply runtime config on resume.
+    /// Retained so we can re-apply runtime config on reopen.
     runtime_config: RuntimeConfig,
 }
 
@@ -548,24 +548,24 @@ impl SqliteStateStore {
     }
 
     /// Acquire a connection for executing read operations.
-    /// Returns `StorePaused` if paused.
+    /// Returns `StoreClosed` if closed.
     #[instrument(skip_all)]
     async fn read(&self) -> Result<SqliteAsyncConn> {
         let pool = {
             let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
             conns.pool.clone()
         };
         Ok(pool.get().await?)
     }
 
     /// Acquire a connection for executing write operations.
-    /// Returns `StorePaused` if paused.
+    /// Returns `StoreClosed` if closed.
     #[instrument(skip_all)]
     async fn write(&self) -> Result<OwnedMutexGuard<SqliteAsyncConn>> {
         let write_conn = {
             let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
             conns.write_connection.clone()
         };
         Ok(write_conn.lock_owned().await)
@@ -2395,13 +2395,13 @@ impl StateStore for SqliteStateStore {
         self.get_db_size().await
     }
 
-    async fn pause(&self) -> Result<(), Self::Error> {
-        connection::pause_connections(&self.connections, "State store").await;
+    async fn close(&self) -> Result<(), Self::Error> {
+        connection::close_connections(&self.connections, "State store").await;
         Ok(())
     }
 
-    async fn resume(&self) -> Result<(), Self::Error> {
-        connection::resume_connections(
+    async fn reopen(&self) -> Result<(), Self::Error> {
+        connection::reopen_connections(
             &self.connections,
             self.db_path.clone(),
             self.pool_config,
@@ -2955,7 +2955,7 @@ mod migration_tests {
 }
 
 #[cfg(test)]
-mod pause_resume_tests {
+mod close_reopen_tests {
     use std::sync::{
         LazyLock,
         atomic::{AtomicU32, Ordering::SeqCst},
@@ -2977,64 +2977,64 @@ mod pause_resume_tests {
     }
 
     #[async_test]
-    async fn test_pause_completes_without_timeout() {
+    async fn test_close_completes_without_timeout() {
         let store = new_store().await;
 
-        // Pause should complete quickly without hitting the 5s timeout.
+        // Close should complete quickly without hitting the 5s timeout.
         let start = std::time::Instant::now();
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
         let elapsed = start.elapsed();
 
         assert!(
             elapsed < std::time::Duration::from_secs(2),
-            "pause() took {elapsed:?}, expected < 2s (no timeout)"
+            "close() took {elapsed:?}, expected < 2s (no timeout)"
         );
 
-        // Connections should be None after pause.
+        // Connections should be None after close.
         let guard = store.connections.lock().await;
-        assert!(guard.is_none(), "connections should be None after pause");
+        assert!(guard.is_none(), "connections should be None after close");
     }
 
     #[async_test]
-    async fn test_resume_restores_connections() {
+    async fn test_reopen_restores_connections() {
         let store = new_store().await;
 
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
-        // Connections should be None after pause.
+        // Connections should be None after close.
         {
             let guard = store.connections.lock().await;
             assert!(guard.is_none());
         }
 
-        store.resume().await.unwrap();
+        store.reopen().await.unwrap();
 
-        // Connections should be Some after resume.
+        // Connections should be Some after reopen.
         {
             let guard = store.connections.lock().await;
-            assert!(guard.is_some(), "connections should be Some after resume");
+            assert!(guard.is_some(), "connections should be Some after reopen");
         }
     }
 
     #[async_test]
-    async fn test_pause_is_idempotent() {
+    async fn test_close_is_idempotent() {
         let store = new_store().await;
 
-        // First pause.
-        store.pause().await.unwrap();
-        // Second pause should also succeed (no-op).
-        store.pause().await.unwrap();
+        // First close.
+        store.close().await.unwrap();
+        // Second close should also succeed (no-op).
+        store.close().await.unwrap();
 
         let guard = store.connections.lock().await;
         assert!(guard.is_none());
     }
 
     #[async_test]
-    async fn test_resume_is_idempotent() {
+    async fn test_reopen_is_idempotent() {
         let store = new_store().await;
 
-        // Resume on an active (non-paused) store should be a no-op.
-        store.resume().await.unwrap();
+        // Reopen on an active store should be a no-op.
+        store.reopen().await.unwrap();
 
         // Connections should still be Some.
         let guard = store.connections.lock().await;
@@ -3042,31 +3042,31 @@ mod pause_resume_tests {
     }
 
     #[async_test]
-    async fn test_read_fails_when_paused() {
+    async fn test_read_fails_when_closed() {
         let store = new_store().await;
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
         let err = store.get_custom_value(b"some_key").await;
-        assert!(err.is_err(), "read should fail when paused");
+        assert!(err.is_err(), "read should fail when closed");
 
         let err_msg = err.unwrap_err().to_string();
-        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+        assert!(err_msg.contains("closed"), "error should mention 'closed', got: {err_msg}");
     }
 
     #[async_test]
-    async fn test_write_fails_when_paused() {
+    async fn test_write_fails_when_closed() {
         let store = new_store().await;
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
         let err = store.set_custom_value(b"key", b"value".to_vec()).await;
-        assert!(err.is_err(), "write should fail when paused");
+        assert!(err.is_err(), "write should fail when closed");
 
         let err_msg = err.unwrap_err().to_string();
-        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+        assert!(err_msg.contains("closed"), "error should mention 'closed', got: {err_msg}");
     }
 
     #[async_test]
-    async fn test_data_persists_across_pause_resume() {
+    async fn test_data_persists_across_close_reopen() {
         let store = new_store().await;
 
         // Write some data.
@@ -3076,21 +3076,21 @@ mod pause_resume_tests {
         let value = store.get_custom_value(b"test_key").await.unwrap();
         assert_eq!(value.as_deref(), Some(b"test_value".as_slice()));
 
-        // Pause and resume.
-        store.pause().await.unwrap();
-        store.resume().await.unwrap();
+        // Close and reopen.
+        store.close().await.unwrap();
+        store.reopen().await.unwrap();
 
-        // Data should still be there after resume.
+        // Data should still be there after reopen.
         let value = store.get_custom_value(b"test_key").await.unwrap();
         assert_eq!(
             value.as_deref(),
             Some(b"test_value".as_slice()),
-            "data should persist across pause/resume"
+            "data should persist across close/reopen"
         );
     }
 
     #[async_test]
-    async fn test_multiple_pause_resume_cycles() {
+    async fn test_multiple_close_reopen_cycles() {
         let store = new_store().await;
 
         for i in 0..3 {
@@ -3099,8 +3099,8 @@ mod pause_resume_tests {
 
             store.set_custom_value(key.as_bytes(), value.as_bytes().to_vec()).await.unwrap();
 
-            store.pause().await.unwrap();
-            store.resume().await.unwrap();
+            store.close().await.unwrap();
+            store.reopen().await.unwrap();
 
             // Verify all previously written data is still accessible.
             for j in 0..=i {
@@ -3117,66 +3117,66 @@ mod pause_resume_tests {
     }
 
     #[async_test]
-    async fn test_pool_is_fully_drained_after_pause() {
+    async fn test_pool_is_fully_drained_after_close() {
         let store = new_store().await;
 
         // Do a few reads to exercise the pool.
         let _ = store.get_custom_value(b"key1").await;
         let _ = store.get_custom_value(b"key2").await;
 
-        store.pause().await.unwrap();
+        store.close().await.unwrap();
 
-        // After pause, the connections field should be None (pool and write
+        // After close, the connections field should be None (pool and write
         // connection have been fully torn down).
         let guard = store.connections.lock().await;
-        assert!(guard.is_none(), "all connections should be released after pause");
+        assert!(guard.is_none(), "all connections should be released after close");
     }
 
     #[async_test]
-    async fn test_operations_work_immediately_after_resume() {
+    async fn test_operations_work_immediately_after_reopen() {
         let store = new_store().await;
 
-        store.pause().await.unwrap();
-        store.resume().await.unwrap();
+        store.close().await.unwrap();
+        store.reopen().await.unwrap();
 
         // Write should work immediately.
-        store.set_custom_value(b"after_resume", b"works".to_vec()).await.unwrap();
+        store.set_custom_value(b"after_reopen", b"works".to_vec()).await.unwrap();
 
         // Read should work immediately.
-        let value = store.get_custom_value(b"after_resume").await.unwrap();
+        let value = store.get_custom_value(b"after_reopen").await.unwrap();
         assert_eq!(value.as_deref(), Some(b"works".as_slice()));
     }
 
     #[async_test]
-    async fn test_pause_waits_for_held_read_connection_to_drain() {
+    async fn test_close_waits_for_held_read_connection_to_drain() {
         let store = new_store().await;
 
         // Acquire a read connection and hold it, simulating an in-flight read.
         let held_conn = store.read().await.unwrap();
 
-        // Spawn pause in a background task — it will close the pool and then
+        // Spawn close in a background task — it will close the pool and then
         // poll-wait for pool.status().size == 0 in the drain loop.
         let store_clone = store.clone();
-        let pause_handle = tokio::spawn(async move {
-            store_clone.pause().await.unwrap();
+        let close_handle = tokio::spawn(async move {
+            store_clone.close().await.unwrap();
         });
 
-        // Give pause() a moment to close the pool and enter the drain loop.
+        // Give close() a moment to close the pool and enter the drain loop.
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
-        // The pause task should still be running because we hold a connection.
-        assert!(!pause_handle.is_finished(), "pause should be waiting for the held connection");
+        // The close task should still be running because we hold a connection.
+        assert!(!close_handle.is_finished(), "close should be waiting for the held connection");
 
         // Release the held connection — this lets pool.status().size drop to 0.
         drop(held_conn);
 
-        // Now pause should complete promptly (well within the 5s timeout).
-        let timeout = tokio::time::timeout(std::time::Duration::from_secs(3), pause_handle).await;
-        assert!(timeout.is_ok(), "pause should complete after the held connection is released");
+        // Now close should complete promptly (well within the 5s timeout).
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(3), close_handle).await;
+        assert!(timeout.is_ok(), "close should complete after the held connection is released");
         timeout.unwrap().unwrap();
 
-        // Verify the store is fully paused.
+        // Verify the store is fully closed.
         let guard = store.connections.lock().await;
-        assert!(guard.is_none(), "connections should be None after pause");
+        assert!(guard.is_none(), "connections should be None after close");
     }
 }

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -2,12 +2,13 @@ use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashMap},
     fmt, iter,
-    path::Path,
+    path::{Path, PathBuf},
     str::FromStr as _,
     sync::Arc,
 };
 
 use async_trait::async_trait;
+use deadpool::managed::PoolConfig;
 use matrix_sdk_base::{
     MinimalRoomMemberEvent, ROOM_VERSION_FALLBACK, ROOM_VERSION_RULES_FALLBACK, RoomInfo,
     RoomMemberships, RoomState, StateChanges, StateStore, StateStoreDataKey, StateStoreDataValue,
@@ -44,8 +45,8 @@ use tokio::{
 use tracing::{debug, instrument, warn};
 
 use crate::{
-    OpenStoreError, Secret, SqliteStoreConfig,
-    connection::{Connection as SqliteAsyncConn, Pool as SqlitePool},
+    OpenStoreError, RuntimeConfig, Secret, SqliteStoreConfig,
+    connection::{self, Connection as SqliteAsyncConn, Pool as SqlitePool, SqliteConnections},
     error::{Error, Result},
     utils::{
         EncryptableStore, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
@@ -77,14 +78,17 @@ pub const DATABASE_NAME: &str = "matrix-sdk-state.sqlite3";
 pub struct SqliteStateStore {
     store_cipher: Option<Arc<StoreCipher>>,
 
-    /// The pool of connections.
-    pool: SqlitePool,
+    /// `Some` when active, `None` when paused.
+    connections: Arc<Mutex<Option<SqliteConnections>>>,
 
-    /// We make the difference between connections for read operations, and for
-    /// write operations. We keep a single connection apart from write
-    /// operations. All other connections are used for read operations. The
-    /// lock is used to ensure there is one owner at a time.
-    write_connection: Arc<Mutex<SqliteAsyncConn>>,
+    /// Retained so we can rebuild the pool on resume.
+    db_path: PathBuf,
+
+    /// Retained so we can rebuild the pool on resume.
+    pool_config: PoolConfig,
+
+    /// Retained so we can re-apply runtime config on resume.
+    runtime_config: RuntimeConfig,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -118,19 +122,25 @@ impl SqliteStateStore {
         fs::create_dir_all(&config.path).await.map_err(OpenStoreError::CreateDir)?;
 
         let pool = config.build_pool_of_connections(DATABASE_NAME)?;
+        let pool_config = config.pool_config;
+        let runtime_config = config.runtime_config;
 
-        let this = Self::open_with_pool(pool, config.secret.clone()).await?;
-        this.pool.get().await?.apply_runtime_config(config.runtime_config.clone()).await?;
+        let this =
+            Self::open_with_pool(pool, config.secret.clone(), pool_config, runtime_config).await?;
+        this.read().await?.apply_runtime_config(runtime_config).await?;
 
         Ok(this)
     }
 
     /// Create an SQLite-based state store using the given SQLite database pool.
     /// The given secret will be used to encrypt private data.
-    pub async fn open_with_pool(
+    pub(crate) async fn open_with_pool(
         pool: SqlitePool,
         secret: Option<Secret>,
+        pool_config: PoolConfig,
+        runtime_config: RuntimeConfig,
     ) -> Result<Self, OpenStoreError> {
+        let db_path = pool.manager().database_path.clone();
         let conn = pool.get().await?;
 
         let mut version = conn.db_version().await?;
@@ -146,9 +156,13 @@ impl SqliteStateStore {
         };
         let this = Self {
             store_cipher,
-            pool,
-            // Use `conn` as our selected write connections.
-            write_connection: Arc::new(Mutex::new(conn)),
+            connections: Arc::new(Mutex::new(Some(SqliteConnections {
+                pool,
+                write_connection: Arc::new(Mutex::new(conn)),
+            }))),
+            db_path,
+            pool_config,
+            runtime_config,
         };
         this.run_migrations(version, None).await?;
 
@@ -166,7 +180,7 @@ impl SqliteStateStore {
             return Ok(());
         }
 
-        let conn = self.write().await;
+        let conn = self.write().await?;
 
         if from < 2 {
             debug!("Upgrading database to version 2");
@@ -534,15 +548,27 @@ impl SqliteStateStore {
     }
 
     /// Acquire a connection for executing read operations.
+    /// Returns `StorePaused` if paused.
     #[instrument(skip_all)]
     async fn read(&self) -> Result<SqliteAsyncConn> {
-        Ok(self.pool.get().await?)
+        let pool = {
+            let guard = self.connections.lock().await;
+            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            conns.pool.clone()
+        };
+        Ok(pool.get().await?)
     }
 
     /// Acquire a connection for executing write operations.
+    /// Returns `StorePaused` if paused.
     #[instrument(skip_all)]
-    async fn write(&self) -> OwnedMutexGuard<SqliteAsyncConn> {
-        self.write_connection.clone().lock_owned().await
+    async fn write(&self) -> Result<OwnedMutexGuard<SqliteAsyncConn>> {
+        let write_conn = {
+            let guard = self.connections.lock().await;
+            let conns = guard.as_ref().ok_or(Error::StorePaused)?;
+            conns.write_connection.clone()
+        };
+        Ok(write_conn.lock_owned().await)
     }
 
     fn remove_maybe_stripped_room_data(
@@ -559,11 +585,11 @@ impl SqliteStateStore {
     }
 
     pub async fn vacuum(&self) -> Result<()> {
-        self.write_connection.lock().await.vacuum().await
+        self.write().await?.vacuum().await
     }
 
     pub async fn get_db_size(&self) -> Result<Option<usize>> {
-        let read_conn = self.pool.get().await?;
+        let read_conn = self.read().await?;
         Ok(Some(read_conn.get_db_size().await?))
     }
 }
@@ -1225,20 +1251,20 @@ impl StateStore for SqliteStateStore {
         };
 
         self.write()
-            .await
+            .await?
             .set_kv_blob(self.encode_state_store_data_key(key), serialized_value)
             .await
     }
 
     async fn remove_kv_data(&self, key: StateStoreDataKey<'_>) -> Result<()> {
-        self.write().await.delete_kv_blob(self.encode_state_store_data_key(key)).await
+        self.write().await?.delete_kv_blob(self.encode_state_store_data_key(key)).await
     }
 
     async fn save_changes(&self, changes: &StateChanges) -> Result<()> {
         let changes = changes.to_owned();
         let this = self.clone();
         self.write()
-            .await
+            .await?
             .with_transaction(move |txn| {
                 let StateChanges {
                     sync_token,
@@ -1873,14 +1899,14 @@ impl StateStore for SqliteStateStore {
     }
 
     async fn set_custom_value_no_read(&self, key: &[u8], value: Vec<u8>) -> Result<()> {
-        let conn = self.write().await;
+        let conn = self.write().await?;
         let key = self.encode_custom_key(key);
         conn.set_kv_blob(key, value).await?;
         Ok(())
     }
 
     async fn set_custom_value(&self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
-        let conn = self.write().await;
+        let conn = self.write().await?;
         let key = self.encode_custom_key(key);
         let previous = conn.get_kv_blob(key.clone()).await?;
         conn.set_kv_blob(key, value).await?;
@@ -1888,7 +1914,7 @@ impl StateStore for SqliteStateStore {
     }
 
     async fn remove_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        let conn = self.write().await;
+        let conn = self.write().await?;
         let key = self.encode_custom_key(key);
         let previous = conn.get_kv_blob(key.clone()).await?;
         if previous.is_some() {
@@ -1901,7 +1927,7 @@ impl StateStore for SqliteStateStore {
         let this = self.clone();
         let room_id = room_id.to_owned();
 
-        let conn = self.write().await;
+        let conn = self.write().await?;
 
         conn.with_transaction(move |txn| -> Result<()> {
             let room_info_room_id = this.encode_key(keys::ROOM_INFO, &room_id);
@@ -1965,7 +1991,7 @@ impl StateStore for SqliteStateStore {
 
         let created_at_ts: u64 = created_at.0.into();
         self.write()
-            .await
+            .await?
             .with_transaction(move |txn| {
                 txn.prepare_cached("INSERT INTO send_queue_events (room_id, room_id_val, transaction_id, content, priority, created_at) VALUES (?, ?, ?, ?, ?, ?)")?.execute((room_id_key, room_id_value, transaction_id.to_string(), content, priority, created_at_ts))?;
                 Ok(())
@@ -1987,7 +2013,7 @@ impl StateStore for SqliteStateStore {
         let transaction_id = transaction_id.to_string();
 
         let num_updated = self.write()
-            .await
+            .await?
             .with_transaction(move |txn| {
                 txn.prepare_cached("UPDATE send_queue_events SET wedge_reason = NULL, content = ? WHERE room_id = ? AND transaction_id = ?")?.execute((content, room_id, transaction_id))
             })
@@ -2008,7 +2034,7 @@ impl StateStore for SqliteStateStore {
 
         let num_deleted = self
             .write()
-            .await
+            .await?
             .with_transaction(move |txn| {
                 txn.prepare_cached(
                     "DELETE FROM send_queue_events WHERE room_id = ? AND transaction_id = ?",
@@ -2077,7 +2103,7 @@ impl StateStore for SqliteStateStore {
         let error_value = error.map(|e| self.serialize_value(&e)).transpose()?;
 
         self.write()
-            .await
+            .await?
             .with_transaction(move |txn| {
                 txn.prepare_cached("UPDATE send_queue_events SET wedge_reason = ? WHERE room_id = ? AND transaction_id = ?")?.execute((error_value, room_id, transaction_id))?;
                 Ok(())
@@ -2125,7 +2151,7 @@ impl StateStore for SqliteStateStore {
 
         let created_at_ts: u64 = created_at.0.into();
         self.write()
-            .await
+            .await?
             .with_transaction(move |txn| {
                 txn.prepare_cached(
                     r#"INSERT INTO dependent_send_queue_events
@@ -2158,7 +2184,7 @@ impl StateStore for SqliteStateStore {
 
         let num_updated = self
             .write()
-            .await
+            .await?
             .with_transaction(move |txn| {
                 txn.prepare_cached(
                     r#"UPDATE dependent_send_queue_events
@@ -2190,7 +2216,7 @@ impl StateStore for SqliteStateStore {
         let parent_txn_id = parent_txn_id.to_string();
 
         self.write()
-            .await
+            .await?
             .with_transaction(move |txn| {
                 Ok(txn.prepare_cached(
                     "UPDATE dependent_send_queue_events SET parent_key = ? WHERE parent_transaction_id = ? and room_id = ?",
@@ -2212,7 +2238,7 @@ impl StateStore for SqliteStateStore {
 
         let num_deleted = self
             .write()
-            .await
+            .await?
             .with_transaction(move |txn| {
                 txn.prepare_cached(
                     "DELETE FROM dependent_send_queue_events WHERE own_transaction_id = ? AND room_id = ?",
@@ -2281,7 +2307,7 @@ impl StateStore for SqliteStateStore {
             .collect();
 
         self.write()
-            .await
+            .await?
             .with_transaction(move |txn| {
                 let mut txn = txn.prepare_cached(
                     "INSERT INTO thread_subscriptions (room_id, event_id, status, bump_stamp)
@@ -2351,7 +2377,7 @@ impl StateStore for SqliteStateStore {
         let thread_id = self.encode_key(keys::THREAD_SUBSCRIPTIONS, thread_id);
 
         self.write()
-            .await
+            .await?
             .execute(
                 "DELETE FROM thread_subscriptions WHERE room_id = ? AND event_id = ?",
                 (room_id, thread_id),
@@ -2370,10 +2396,18 @@ impl StateStore for SqliteStateStore {
     }
 
     async fn pause(&self) -> Result<(), Self::Error> {
+        connection::pause_connections(&self.connections, "State store").await;
         Ok(())
     }
 
     async fn resume(&self) -> Result<(), Self::Error> {
+        connection::resume_connections(
+            &self.connections,
+            self.db_path.clone(),
+            self.pool_config,
+            self.runtime_config,
+        )
+        .await?;
         Ok(())
     }
 }
@@ -2454,7 +2488,8 @@ mod encrypted_tests {
 
         let store = SqliteStateStore::open_with_config(&store_open_config).await.unwrap();
 
-        assert_eq!(store.pool.status().max_size, 42);
+        let guard = store.connections.lock().await;
+        assert_eq!(guard.as_ref().unwrap().pool.status().max_size, 42);
     }
 
     #[async_test]
@@ -2464,7 +2499,7 @@ mod encrypted_tests {
 
         let store = SqliteStateStore::open_with_config(&store_open_config).await.unwrap();
 
-        let conn = store.pool.get().await.unwrap();
+        let conn = store.read().await.unwrap();
         let cache_size =
             conn.query_row("PRAGMA cache_size", (), |row| row.get::<_, i32>(0)).await.unwrap();
 
@@ -2481,7 +2516,7 @@ mod encrypted_tests {
 
         let store = SqliteStateStore::open_with_config(&store_open_config).await.unwrap();
 
-        let conn = store.pool.get().await.unwrap();
+        let conn = store.read().await.unwrap();
         let journal_size_limit = conn
             .query_row("PRAGMA journal_size_limit", (), |row| row.get::<_, u32>(0))
             .await
@@ -2533,7 +2568,7 @@ mod migration_tests {
 
     use super::{DATABASE_NAME, SqliteStateStore, init, keys};
     use crate::{
-        OpenStoreError, Secret, SqliteStoreConfig,
+        OpenStoreError, Secret, SqliteStoreConfig, connection,
         error::{Error, Result},
         utils::{EncryptableStore as _, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt},
     };
@@ -2553,6 +2588,7 @@ mod migration_tests {
         fs::create_dir_all(&config.path).await.map_err(OpenStoreError::CreateDir).unwrap();
 
         let pool = config.build_pool_of_connections(DATABASE_NAME).unwrap();
+        let db_path = pool.manager().database_path.clone();
         let conn = pool.get().await?;
 
         init(&conn).await?;
@@ -2564,9 +2600,13 @@ mod migration_tests {
         ));
         let this = SqliteStateStore {
             store_cipher,
-            pool,
-            // Use `conn` as our selected write connections.
-            write_connection: Arc::new(Mutex::new(conn)),
+            connections: Arc::new(Mutex::new(Some(connection::SqliteConnections {
+                pool,
+                write_connection: Arc::new(Mutex::new(conn)),
+            }))),
+            db_path,
+            pool_config: deadpool::managed::PoolConfig::default(),
+            runtime_config: crate::RuntimeConfig::default(),
         };
         this.run_migrations(1, Some(version)).await?;
 
@@ -2623,7 +2663,7 @@ mod migration_tests {
         // Create and populate db.
         {
             let db = create_fake_db(&path, 1).await.unwrap();
-            let conn = db.pool.get().await.unwrap();
+            let conn = db.read().await.unwrap();
 
             let this = db.clone();
             conn.with_transaction(move |txn| {
@@ -2746,7 +2786,7 @@ mod migration_tests {
         // Create and populate db.
         {
             let db = create_fake_db(&path, 2).await.unwrap();
-            let conn = db.pool.get().await.unwrap();
+            let conn = db.read().await.unwrap();
 
             let this = db.clone();
             conn.with_transaction(move |txn| {
@@ -2798,7 +2838,7 @@ mod migration_tests {
         // Create and populate db.
         {
             let db = create_fake_db(&path, 7).await.unwrap();
-            let conn = db.pool.get().await.unwrap();
+            let conn = db.read().await.unwrap();
 
             let wedge_tx = wedged_event_transaction_id.clone();
             let local_tx = local_event_transaction_id.clone();

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -2953,3 +2953,230 @@ mod migration_tests {
         });
     }
 }
+
+#[cfg(test)]
+mod pause_resume_tests {
+    use std::sync::{
+        LazyLock,
+        atomic::{AtomicU32, Ordering::SeqCst},
+    };
+
+    use matrix_sdk_base::StateStore;
+    use matrix_sdk_test::async_test;
+    use tempfile::{TempDir, tempdir};
+
+    use super::SqliteStateStore;
+
+    static TMP_DIR: LazyLock<TempDir> = LazyLock::new(|| tempdir().unwrap());
+    static NUM: AtomicU32 = AtomicU32::new(0);
+
+    async fn new_store() -> SqliteStateStore {
+        let name = NUM.fetch_add(1, SeqCst).to_string();
+        let tmpdir_path = TMP_DIR.path().join(name);
+        SqliteStateStore::open(tmpdir_path.to_str().unwrap(), None).await.unwrap()
+    }
+
+    #[async_test]
+    async fn test_pause_completes_without_timeout() {
+        let store = new_store().await;
+
+        // Pause should complete quickly without hitting the 5s timeout.
+        let start = std::time::Instant::now();
+        store.pause().await.unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "pause() took {elapsed:?}, expected < 2s (no timeout)"
+        );
+
+        // Connections should be None after pause.
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none(), "connections should be None after pause");
+    }
+
+    #[async_test]
+    async fn test_resume_restores_connections() {
+        let store = new_store().await;
+
+        store.pause().await.unwrap();
+
+        // Connections should be None after pause.
+        {
+            let guard = store.connections.lock().await;
+            assert!(guard.is_none());
+        }
+
+        store.resume().await.unwrap();
+
+        // Connections should be Some after resume.
+        {
+            let guard = store.connections.lock().await;
+            assert!(guard.is_some(), "connections should be Some after resume");
+        }
+    }
+
+    #[async_test]
+    async fn test_pause_is_idempotent() {
+        let store = new_store().await;
+
+        // First pause.
+        store.pause().await.unwrap();
+        // Second pause should also succeed (no-op).
+        store.pause().await.unwrap();
+
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none());
+    }
+
+    #[async_test]
+    async fn test_resume_is_idempotent() {
+        let store = new_store().await;
+
+        // Resume on an active (non-paused) store should be a no-op.
+        store.resume().await.unwrap();
+
+        // Connections should still be Some.
+        let guard = store.connections.lock().await;
+        assert!(guard.is_some());
+    }
+
+    #[async_test]
+    async fn test_read_fails_when_paused() {
+        let store = new_store().await;
+        store.pause().await.unwrap();
+
+        let err = store.get_custom_value(b"some_key").await;
+        assert!(err.is_err(), "read should fail when paused");
+
+        let err_msg = err.unwrap_err().to_string();
+        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+    }
+
+    #[async_test]
+    async fn test_write_fails_when_paused() {
+        let store = new_store().await;
+        store.pause().await.unwrap();
+
+        let err = store.set_custom_value(b"key", b"value".to_vec()).await;
+        assert!(err.is_err(), "write should fail when paused");
+
+        let err_msg = err.unwrap_err().to_string();
+        assert!(err_msg.contains("paused"), "error should mention 'paused', got: {err_msg}");
+    }
+
+    #[async_test]
+    async fn test_data_persists_across_pause_resume() {
+        let store = new_store().await;
+
+        // Write some data.
+        store.set_custom_value(b"test_key", b"test_value".to_vec()).await.unwrap();
+
+        // Verify it's there.
+        let value = store.get_custom_value(b"test_key").await.unwrap();
+        assert_eq!(value.as_deref(), Some(b"test_value".as_slice()));
+
+        // Pause and resume.
+        store.pause().await.unwrap();
+        store.resume().await.unwrap();
+
+        // Data should still be there after resume.
+        let value = store.get_custom_value(b"test_key").await.unwrap();
+        assert_eq!(
+            value.as_deref(),
+            Some(b"test_value".as_slice()),
+            "data should persist across pause/resume"
+        );
+    }
+
+    #[async_test]
+    async fn test_multiple_pause_resume_cycles() {
+        let store = new_store().await;
+
+        for i in 0..3 {
+            let key = format!("key_{i}");
+            let value = format!("value_{i}");
+
+            store.set_custom_value(key.as_bytes(), value.as_bytes().to_vec()).await.unwrap();
+
+            store.pause().await.unwrap();
+            store.resume().await.unwrap();
+
+            // Verify all previously written data is still accessible.
+            for j in 0..=i {
+                let k = format!("key_{j}");
+                let v = format!("value_{j}");
+                let retrieved = store.get_custom_value(k.as_bytes()).await.unwrap();
+                assert_eq!(
+                    retrieved.as_deref(),
+                    Some(v.as_bytes()),
+                    "data for key_{j} should persist after cycle {i}"
+                );
+            }
+        }
+    }
+
+    #[async_test]
+    async fn test_pool_is_fully_drained_after_pause() {
+        let store = new_store().await;
+
+        // Do a few reads to exercise the pool.
+        let _ = store.get_custom_value(b"key1").await;
+        let _ = store.get_custom_value(b"key2").await;
+
+        store.pause().await.unwrap();
+
+        // After pause, the connections field should be None (pool and write
+        // connection have been fully torn down).
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none(), "all connections should be released after pause");
+    }
+
+    #[async_test]
+    async fn test_operations_work_immediately_after_resume() {
+        let store = new_store().await;
+
+        store.pause().await.unwrap();
+        store.resume().await.unwrap();
+
+        // Write should work immediately.
+        store.set_custom_value(b"after_resume", b"works".to_vec()).await.unwrap();
+
+        // Read should work immediately.
+        let value = store.get_custom_value(b"after_resume").await.unwrap();
+        assert_eq!(value.as_deref(), Some(b"works".as_slice()));
+    }
+
+    #[async_test]
+    async fn test_pause_waits_for_held_read_connection_to_drain() {
+        let store = new_store().await;
+
+        // Acquire a read connection and hold it, simulating an in-flight read.
+        let held_conn = store.read().await.unwrap();
+
+        // Spawn pause in a background task — it will close the pool and then
+        // poll-wait for pool.status().size == 0 in the drain loop.
+        let store_clone = store.clone();
+        let pause_handle = tokio::spawn(async move {
+            store_clone.pause().await.unwrap();
+        });
+
+        // Give pause() a moment to close the pool and enter the drain loop.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // The pause task should still be running because we hold a connection.
+        assert!(!pause_handle.is_finished(), "pause should be waiting for the held connection");
+
+        // Release the held connection — this lets pool.status().size drop to 0.
+        drop(held_conn);
+
+        // Now pause should complete promptly (well within the 5s timeout).
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(3), pause_handle).await;
+        assert!(timeout.is_ok(), "pause should complete after the held connection is released");
+        timeout.unwrap().unwrap();
+
+        // Verify the store is fully paused.
+        let guard = store.connections.lock().await;
+        assert!(guard.is_none(), "connections should be None after pause");
+    }
+}

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -457,10 +457,6 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
         }
 
         if !duplicates.is_empty() {
-            #[cfg(any(debug_assertions, test))]
-            panic!("duplicate read receipts in this timeline: {duplicates:?}\n{:?}", self.items);
-
-            #[cfg(not(any(debug_assertions, test)))]
             tracing::error!(
                 ?duplicates,
                 items = ?self.items,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3409,15 +3409,16 @@ impl Client {
     /// This method:
     /// 1. Disables all send queues (prevents new message sends).
     /// 2. Pauses all database stores, waiting for in-flight operations and
-    ///    releasing all SQLite connections and file locks.
+    ///    releasing all connections and file locks.
     ///
     /// Call [`Client::resume()`] when the app returns to the foreground.
     ///
     /// # iOS
     ///
     /// Call this before the app is suspended to avoid `0xdead10cc` kills.
-    /// Typically called from `applicationDidEnterBackground` or an
-    /// equivalent SwiftUI lifecycle event, *after* stopping the
+    /// Typically called from
+    /// [`applicationDidEnterBackground`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationdidenterbackground(_:))
+    /// or an equivalent SwiftUI lifecycle event, *after* stopping the
     /// `matrix_sdk_ui::sync_service::SyncService`.
     pub async fn pause(&self) -> Result<()> {
         info!("Client::pause — releasing database resources");
@@ -3434,7 +3435,11 @@ impl Client {
 
     /// Resume the client after a [`Client::pause()`].
     ///
-    /// Re-opens database connections and re-enables send queues.
+    /// Re-acquires store resources and re-enables send queues.
+    ///
+    /// If your app stopped the `matrix_sdk_ui::sync_service::SyncService`
+    /// before pausing, restart it separately as appropriate for your app
+    /// lifecycle.
     pub async fn resume(&self) -> Result<()> {
         info!("Client::resume — re-acquiring database resources");
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3426,8 +3426,8 @@ impl Client {
         // Disable send queues so no new sends hit the stores.
         self.send_queue().set_enabled(false).await;
 
-        // Pause all stores (waits for in-flight ops, closes connections).
-        self.base_client().pause_stores().await?;
+        // Close all stores (waits for in-flight ops, closes connections).
+        self.base_client().close_stores().await?;
 
         info!("Client::pause — complete, all database connections released");
         Ok(())
@@ -3443,8 +3443,8 @@ impl Client {
     pub async fn resume(&self) -> Result<()> {
         info!("Client::resume — re-acquiring database resources");
 
-        // Resume stores (creates new connection pools).
-        self.base_client().resume_stores().await?;
+        // Reopen stores (creates new connection pools).
+        self.base_client().reopen_stores().await?;
 
         // Re-enable send queues.
         self.send_queue().set_enabled(true).await;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3404,6 +3404,50 @@ impl Client {
         self.inner.thread_subscription_catchup.get().unwrap()
     }
 
+    /// Pause the client for background suspension.
+    ///
+    /// This method:
+    /// 1. Disables all send queues (prevents new message sends).
+    /// 2. Pauses all database stores, waiting for in-flight operations and
+    ///    releasing all SQLite connections and file locks.
+    ///
+    /// Call [`Client::resume()`] when the app returns to the foreground.
+    ///
+    /// # iOS
+    ///
+    /// Call this before the app is suspended to avoid `0xdead10cc` kills.
+    /// Typically called from `applicationDidEnterBackground` or an
+    /// equivalent SwiftUI lifecycle event, *after* stopping the
+    /// `matrix_sdk_ui::sync_service::SyncService`.
+    pub async fn pause(&self) -> Result<()> {
+        info!("Client::pause — releasing database resources");
+
+        // Disable send queues so no new sends hit the stores.
+        self.send_queue().set_enabled(false).await;
+
+        // Pause all stores (waits for in-flight ops, closes connections).
+        self.base_client().pause_stores().await?;
+
+        info!("Client::pause — complete, all database connections released");
+        Ok(())
+    }
+
+    /// Resume the client after a [`Client::pause()`].
+    ///
+    /// Re-opens database connections and re-enables send queues.
+    pub async fn resume(&self) -> Result<()> {
+        info!("Client::resume — re-acquiring database resources");
+
+        // Resume stores (creates new connection pools).
+        self.base_client().resume_stores().await?;
+
+        // Re-enable send queues.
+        self.send_queue().set_enabled(true).await;
+
+        info!("Client::resume — complete");
+        Ok(())
+    }
+
     /// Perform database optimizations if any are available, i.e. vacuuming in
     /// SQLite.
     ///

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -1179,6 +1179,14 @@ mod tests {
     impl EventCacheStore for DelayingStore {
         type Error = EventCacheStoreError;
 
+        async fn pause(&self) -> Result<(), EventCacheStoreError> {
+            self.memory_store.pause().await
+        }
+
+        async fn resume(&self) -> Result<(), EventCacheStoreError> {
+            self.memory_store.resume().await
+        }
+
         async fn try_take_leased_lock(
             &self,
             lease_duration_ms: u32,

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -1179,12 +1179,12 @@ mod tests {
     impl EventCacheStore for DelayingStore {
         type Error = EventCacheStoreError;
 
-        async fn pause(&self) -> Result<(), EventCacheStoreError> {
-            self.memory_store.pause().await
+        async fn close(&self) -> Result<(), EventCacheStoreError> {
+            self.memory_store.close().await
         }
 
-        async fn resume(&self) -> Result<(), EventCacheStoreError> {
-            self.memory_store.resume().await
+        async fn reopen(&self) -> Result<(), EventCacheStoreError> {
+            self.memory_store.reopen().await
         }
 
         async fn try_take_leased_lock(

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -64,6 +64,8 @@ use ruma::{
 use serde_json::{Value as JsonValue, json};
 use stream_assert::{assert_next_matches, assert_pending};
 use tempfile::tempdir;
+#[cfg(feature = "sqlite")]
+use tokio::time::timeout;
 use tokio_stream::wrappers::BroadcastStream;
 use wiremock::{
     Mock, Request, ResponseTemplate,
@@ -1567,6 +1569,121 @@ async fn test_restore_room() {
     let room = client.get_room(room_id).unwrap();
     assert!(room.is_favourite());
     assert!(!room.pinned_event_ids().unwrap().is_empty());
+}
+
+#[async_test]
+#[cfg(feature = "sqlite")]
+async fn test_client_pause_resume_with_sqlite_store() {
+    let tempdir = tempdir().unwrap();
+
+    let server = MatrixMockServer::new().await;
+    let client = server
+        .client_builder()
+        .on_builder(|builder| builder.sqlite_store(tempdir.path(), None))
+        .build()
+        .await;
+
+    client
+        .state_store()
+        .set_custom_value(b"pause_resume_key", b"before_pause".to_vec())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        client.state_store().get_custom_value(b"pause_resume_key").await.unwrap().as_deref(),
+        Some(b"before_pause".as_slice())
+    );
+
+    client.pause().await.unwrap();
+
+    let read_err = client.state_store().get_custom_value(b"pause_resume_key").await.unwrap_err();
+    assert!(
+        read_err.to_string().contains("paused"),
+        "read while paused should mention 'paused', got: {read_err}"
+    );
+
+    let write_err = client
+        .state_store()
+        .set_custom_value(b"pause_resume_key", b"while_paused".to_vec())
+        .await
+        .unwrap_err();
+    assert!(
+        write_err.to_string().contains("paused"),
+        "write while paused should mention 'paused', got: {write_err}"
+    );
+
+    client.resume().await.unwrap();
+
+    assert_eq!(
+        client.state_store().get_custom_value(b"pause_resume_key").await.unwrap().as_deref(),
+        Some(b"before_pause".as_slice())
+    );
+
+    client
+        .state_store()
+        .set_custom_value(b"pause_resume_key", b"after_resume".to_vec())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        client.state_store().get_custom_value(b"pause_resume_key").await.unwrap().as_deref(),
+        Some(b"after_resume".as_slice())
+    );
+}
+
+#[async_test]
+#[cfg(feature = "sqlite")]
+async fn test_client_pause_waits_for_held_state_store_write() {
+    let tempdir = tempdir().unwrap();
+
+    let server = MatrixMockServer::new().await;
+    let client = server
+        .client_builder()
+        .on_builder(|builder| builder.sqlite_store(tempdir.path(), None))
+        .build()
+        .await;
+
+    client.state_store().set_custom_value(b"held_write_key", b"initial".to_vec()).await.unwrap();
+
+    let write_fut = client.state_store().set_custom_value(b"held_write_key", b"updated".to_vec());
+    tokio::pin!(write_fut);
+
+    assert!(
+        write_fut.as_mut().now_or_never().is_none(),
+        "write future should not complete immediately before being awaited"
+    );
+
+    let client_clone = client.clone();
+    let pause_handle = spawn(async move {
+        client_clone.pause().await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    assert!(
+        !pause_handle.is_finished(),
+        "pause should wait for the in-flight state store write to finish"
+    );
+
+    write_fut.await.unwrap();
+
+    timeout(Duration::from_secs(3), pause_handle)
+        .await
+        .expect("pause should complete after the held write finishes")
+        .unwrap();
+
+    let paused_err = client.state_store().get_custom_value(b"held_write_key").await.unwrap_err();
+    assert!(
+        paused_err.to_string().contains("paused"),
+        "store should be paused after pause completes, got: {paused_err}"
+    );
+
+    client.resume().await.unwrap();
+
+    assert_eq!(
+        client.state_store().get_custom_value(b"held_write_key").await.unwrap().as_deref(),
+        Some(b"updated".as_slice())
+    );
 }
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -1598,8 +1598,8 @@ async fn test_client_pause_resume_with_sqlite_store() {
 
     let read_err = client.state_store().get_custom_value(b"pause_resume_key").await.unwrap_err();
     assert!(
-        read_err.to_string().contains("paused"),
-        "read while paused should mention 'paused', got: {read_err}"
+        read_err.to_string().contains("closed"),
+        "read while client is paused should mention 'closed', got: {read_err}"
     );
 
     let write_err = client
@@ -1608,8 +1608,8 @@ async fn test_client_pause_resume_with_sqlite_store() {
         .await
         .unwrap_err();
     assert!(
-        write_err.to_string().contains("paused"),
-        "write while paused should mention 'paused', got: {write_err}"
+        write_err.to_string().contains("closed"),
+        "write while client is paused should mention 'closed', got: {write_err}"
     );
 
     client.resume().await.unwrap();
@@ -1672,10 +1672,10 @@ async fn test_client_pause_waits_for_held_state_store_write() {
         .expect("pause should complete after the held write finishes")
         .unwrap();
 
-    let paused_err = client.state_store().get_custom_value(b"held_write_key").await.unwrap_err();
+    let closed_err = client.state_store().get_custom_value(b"held_write_key").await.unwrap_err();
     assert!(
-        paused_err.to_string().contains("paused"),
-        "store should be paused after pause completes, got: {paused_err}"
+        closed_err.to_string().contains("closed"),
+        "store should be closed after client pause completes, got: {closed_err}"
     );
 
     client.resume().await.unwrap();


### PR DESCRIPTION
This patch exposes the pause/resume mechanism for SDK stores all the way up to the FFI `Client`, so apps can temporarily release SQLite resources when moving to the background and re-acquire them on resume.

The main use case is iOS backgrounding, where keeping SQLite file descriptors and locks open can contribute to `0xdead10cc` terminations by the operating system.

The main change are limited to the sqlite crate with in memory stores no-oping trough the default trait implementations:
- a new type called `SqliteConnections` has been introduced which now holds a store's read connection pools as well as the always on write connection. This lives as an optional on each store's level and gets set to None whenever the store is paused
- during the pausing phase `SqliteConnections` (through its `pause_connections` method) does the following:
    - closes the read pool, directly dropping idle connections
    - waits for in flight writes to finish
    - tries a best effort WAL checkpoint
    - drops the write connection on a blocking thread
    - and waits for in-flight read connections to drain
    - this is all best effort with an eventual timeout
- resuming connections is also shared between the stores through `SqliteConnections` and consists in building a new pool with the previous configuration and creating a new write connection

Handles https://github.com/matrix-org/matrix-rust-sdk/issues/6366

Event with this in place though the client side isn't entirely straight forward as the sync service, send queue and pause/resume mechanisms still need to be coordinator in the right order. A better solution would be the to incorporate all of those within an app specific service on the rust side (which we've talked about multiple times over the years) and let the SDK coordinate them instead.