### PR TITLE
Revert back to managing `CryptoStore` leases with `OlmMachine`

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -43,6 +43,8 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- Re-introduce cross-process lock generation logic in `OlmMachine`
+  ([#6496](https://github.com/matrix-org/matrix-rust-sdk/pull/6496))
 - [**breaking**] The `MegolmV1BackupKey::encrypt` now returns a `Result`
   ([#6477](https://github.com/matrix-org/matrix-rust-sdk/pull/6477))
 - [**breaking**] `CryptoStore::get_secrets_from_inbox` now returns a `Vec` of

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -176,6 +176,7 @@ impl std::fmt::Debug for OlmMachine {
 }
 
 impl OlmMachine {
+    const CURRENT_GENERATION_STORE_KEY: &'static str = "generation-counter";
     const HAS_MIGRATED_VERIFICATION_LATCH: &'static str = "HAS_MIGRATED_VERIFICATION_LATCH";
 
     /// Create a new memory based OlmMachine.
@@ -2843,6 +2844,127 @@ impl OlmMachine {
     /// the server.
     pub fn backup_machine(&self) -> &BackupMachine {
         &self.inner.backup_machine
+    }
+
+    /// Syncs the database and in-memory generation counter.
+    ///
+    /// This requires that the crypto store lock has been acquired already.
+    pub async fn initialize_crypto_store_generation(
+        &self,
+        generation: &Mutex<Option<u64>>,
+    ) -> StoreResult<()> {
+        // Avoid reentrant initialization by taking the lock for the entire's function
+        // scope.
+        let mut gen_guard = generation.lock().await;
+
+        let prev_generation =
+            self.inner.store.get_custom_value(Self::CURRENT_GENERATION_STORE_KEY).await?;
+
+        let generation = match prev_generation {
+            Some(val) => {
+                // There was a value in the store. We need to signal that we're a different
+                // process, so we don't just reuse the value but increment it.
+                u64::from_le_bytes(val.try_into().map_err(|_| {
+                    CryptoStoreError::InvalidLockGeneration("invalid format".to_owned())
+                })?)
+                .wrapping_add(1)
+            }
+            None => 0,
+        };
+
+        tracing::debug!("Initialising crypto store generation at {generation}");
+
+        self.inner
+            .store
+            .set_custom_value(Self::CURRENT_GENERATION_STORE_KEY, generation.to_le_bytes().to_vec())
+            .await?;
+
+        *gen_guard = Some(generation);
+
+        Ok(())
+    }
+
+    /// If needs be, update the local and on-disk crypto store generation.
+    ///
+    /// ## Requirements
+    ///
+    /// - This assumes that `initialize_crypto_store_generation` has been called
+    ///   beforehand.
+    /// - This requires that the crypto store lock has been acquired.
+    ///
+    /// # Arguments
+    ///
+    /// * `generation` - The in-memory generation counter (or rather, the
+    ///   `Mutex` wrapping it). This defines the "expected" generation on entry,
+    ///   and, if we determine an update is needed, is updated to hold the "new"
+    ///   generation.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing:
+    ///
+    /// * A `bool`, set to `true` if another process has updated the generation
+    ///   number in the `Store` since our expected value, and as such we've
+    ///   incremented and updated it in the database. Otherwise, `false`.
+    ///
+    /// * The (possibly updated) generation counter.
+    pub async fn maintain_crypto_store_generation(
+        &'_ self,
+        generation: &Mutex<Option<u64>>,
+    ) -> StoreResult<(bool, u64)> {
+        let mut gen_guard = generation.lock().await;
+
+        // The database value must be there:
+        // - either we could initialize beforehand, thus write into the database,
+        // - or we couldn't, and then another process was holding onto the database's
+        //   lock, thus
+        // has written a generation counter in there.
+        let actual_gen = self
+            .inner
+            .store
+            .get_custom_value(Self::CURRENT_GENERATION_STORE_KEY)
+            .await?
+            .ok_or_else(|| {
+                CryptoStoreError::InvalidLockGeneration("counter missing in store".to_owned())
+            })?;
+
+        let actual_gen =
+            u64::from_le_bytes(actual_gen.try_into().map_err(|_| {
+                CryptoStoreError::InvalidLockGeneration("invalid format".to_owned())
+            })?);
+
+        let new_gen = match gen_guard.as_ref() {
+            Some(expected_gen) => {
+                if actual_gen == *expected_gen {
+                    return Ok((false, actual_gen));
+                }
+                // Increment the biggest, and store it everywhere.
+                actual_gen.max(*expected_gen).wrapping_add(1)
+            }
+            None => {
+                // Some other process hold onto the lock when initializing, so we must reload.
+                // Increment database value, and store it everywhere.
+                actual_gen.wrapping_add(1)
+            }
+        };
+
+        tracing::debug!(
+            "Crypto store generation mismatch: previously known was {:?}, actual is {:?}, next is {}",
+            *gen_guard,
+            actual_gen,
+            new_gen
+        );
+
+        // Update known value.
+        *gen_guard = Some(new_gen);
+
+        // Update value in database.
+        self.inner
+            .store
+            .set_custom_value(Self::CURRENT_GENERATION_STORE_KEY, new_gen.to_le_bytes().to_vec())
+            .await?;
+
+        Ok((true, new_gen))
     }
 
     /// Manage dehydrated devices.

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -180,6 +180,9 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- Revert back to to determining lock dirtiness in `Encryption::{spin_lock_store, try_lock_once_store}`
+  through logic defined in `OlmMachine`, rather than `CrossProcessLock`.
+  ([#6496](https://github.com/matrix-org/matrix-rust-sdk/pull/6496))
 - [**breaking**] Update `Encryption::{spin_lock_store, try_lock_once_store}` so that lock dirtiness
   is determined entirely by `CrossProcessLock`, rather than logic defined by `OlmMachine`. Also enforce
   that lock generation is opaque by removing `CrossProcessLockStoreGuardWithGeneration`.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -245,6 +245,27 @@ pub(crate) struct ClientLocks {
 
     #[cfg(feature = "e2e-encryption")]
     pub(crate) cross_process_crypto_store_lock: OnceCell<CrossProcessLock<LockableCryptoStore>>,
+
+    /// Latest "generation" of data known by the crypto store.
+    ///
+    /// This is a counter that only increments, set in the database (and can
+    /// wrap). It's incremented whenever some process acquires a lock for the
+    /// first time. *This assumes the crypto store lock is being held, to
+    /// avoid data races on writing to this value in the store*.
+    ///
+    /// The current process will maintain this value in local memory and in the
+    /// DB over time. Observing a different value than the one read in
+    /// memory, when reading from the store indicates that somebody else has
+    /// written into the database under our feet.
+    ///
+    /// TODO: this should live in the `OlmMachine`, since it's information
+    /// related to the lock. As of today (2023-07-28), we blow up the entire
+    /// olm machine when there's a generation mismatch. So storing the
+    /// generation in the olm machine would make the client think there's
+    /// *always* a mismatch, and that's why we need to store the generation
+    /// outside the `OlmMachine`.
+    #[cfg(feature = "e2e-encryption")]
+    pub(crate) crypto_store_generation: Arc<Mutex<Option<u64>>>,
 }
 
 pub(crate) struct ClientInner {

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1817,6 +1817,22 @@ impl Encryption {
             CrossProcessLockConfig::multi_process(lock_value.to_owned()),
         );
 
+        // Gently try to initialize the crypto store generation counter.
+        //
+        // If we don't get the lock immediately, then it is already acquired by another
+        // process, and we'll get to reload next time we acquire the lock.
+        {
+            let lock_result = lock.try_lock_once().await?;
+
+            if lock_result.is_ok() {
+                olm_machine
+                    .initialize_crypto_store_generation(
+                        &self.client.locks().crypto_store_generation,
+                    )
+                    .await?;
+            }
+        }
+
         self.client
             .locks()
             .cross_process_crypto_store_lock
@@ -2385,15 +2401,6 @@ mod tests {
         assert!(initial_olm_machine.same_as(&after_enabling_lock));
 
         {
-            let acquired = client.encryption().try_lock_store_once().await.unwrap();
-            assert!(acquired.is_some());
-        }
-
-        // Taking the lock the first time will not update the olm machine.
-        let after_taking_lock_first_time = client.olm_machine().await.as_ref().unwrap().clone();
-        assert!(initial_olm_machine.same_as(&after_taking_lock_first_time));
-
-        {
             // Simulate that another client hold the lock before.
             let client2 = Client::builder()
                 .homeserver_url("http://localhost:1234")
@@ -2426,9 +2433,9 @@ mod tests {
             assert!(acquired.is_some());
         }
 
-        // Taking the lock the second time updates the olm machine.
-        let after_taking_lock_second_time = client.olm_machine().await.as_ref().unwrap().clone();
-        assert!(!after_taking_lock_first_time.same_as(&after_taking_lock_second_time));
+        // Taking the lock the first time will update the olm machine.
+        let after_taking_lock_first_time = client.olm_machine().await.as_ref().unwrap().clone();
+        assert!(!initial_olm_machine.same_as(&after_taking_lock_first_time));
 
         {
             let acquired = client.encryption().try_lock_store_once().await.unwrap();
@@ -2436,8 +2443,8 @@ mod tests {
         }
 
         // Re-taking the lock doesn't update the olm machine.
-        let after_taking_lock_third_time = client.olm_machine().await.as_ref().unwrap().clone();
-        assert!(after_taking_lock_second_time.same_as(&after_taking_lock_third_time));
+        let after_taking_lock_second_time = client.olm_machine().await.as_ref().unwrap().clone();
+        assert!(after_taking_lock_first_time.same_as(&after_taking_lock_second_time));
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -38,9 +38,7 @@ use futures_util::{
 use matrix_sdk_base::crypto::CollectStrategy;
 use matrix_sdk_base::{
     StateStoreDataKey, StateStoreDataValue,
-    cross_process_lock::{
-        AcquireCrossProcessLockFn, CrossProcessLock, CrossProcessLockError, CrossProcessLockState,
-    },
+    cross_process_lock::{AcquireCrossProcessLockFn, CrossProcessLock, CrossProcessLockError},
     crypto::{
         CrossSigningBootstrapRequests, OlmMachine,
         store::{
@@ -1842,6 +1840,34 @@ impl Encryption {
         Ok(())
     }
 
+    /// Maybe reload the `OlmMachine` after acquiring the lock for the first
+    /// time.
+    ///
+    /// Returns the current generation number.
+    async fn on_lock_newly_acquired(&self) -> Result<u64, Error> {
+        let olm_machine_guard = self.client.olm_machine().await;
+        if let Some(olm_machine) = olm_machine_guard.as_ref() {
+            let (new_gen, generation_number) = olm_machine
+                .maintain_crypto_store_generation(&self.client.locks().crypto_store_generation)
+                .await?;
+            // If the crypto store generation has changed,
+            if new_gen {
+                // (get rid of the reference to the current crypto store first)
+                drop(olm_machine_guard);
+                // Recreate the OlmMachine.
+                self.client.base_client().regenerate_olm(None).await?;
+            }
+            Ok(generation_number)
+        } else {
+            // XXX: not sure this is reachable. Seems like the OlmMachine should always have
+            // been initialised by the time we get here. Ideally we'd panic, or return an
+            // error, but for now I'm just adding some logging to check if it
+            // happens, and returning the magic number 0.
+            warn!("Encryption::on_lock_newly_acquired: called before OlmMachine initialised");
+            Ok(0)
+        }
+    }
+
     /// If a lock was created with [`Self::enable_cross_process_store_lock`],
     /// spin-waits until the lock is available.
     ///
@@ -1864,7 +1890,14 @@ impl Encryption {
     ///
     /// Returns a guard to the lock, if it was obtained.
     pub async fn try_lock_store_once(&self) -> Result<Option<CrossProcessLockGuard>, Error> {
-        self.lock_store(CrossProcessLock::try_lock_once).await
+        match self.lock_store(CrossProcessLock::try_lock_once).await {
+            Err(Error::CrossProcessLockError(e))
+                if matches!(*e, CrossProcessLockError::Unobtained(_)) =>
+            {
+                Ok(None)
+            }
+            other => other,
+        }
     }
 
     /// If a lock was created with [`Self::enable_cross_process_store_lock`],
@@ -1881,14 +1914,9 @@ impl Encryption {
             Error::CrossProcessLockError(Box::new(CrossProcessLockError::TryLock(Arc::new(e))))
         };
         if let Some(lock) = self.client.locks().cross_process_crypto_store_lock.get() {
-            Ok(Some(match acquire(lock).await.map_err(wrap_err)?? {
-                CrossProcessLockState::Clean(guard) => guard,
-                CrossProcessLockState::Dirty(guard) => {
-                    self.client.base_client().regenerate_olm(None).await?;
-                    guard.clear_dirty();
-                    guard
-                }
-            }))
+            let guard = acquire(lock).await.map_err(wrap_err)??;
+            let _ = self.on_lock_newly_acquired().await?;
+            Ok(Some(guard.into_guard()))
         } else {
             Ok(None)
         }
@@ -2202,7 +2230,7 @@ mod tests {
     };
 
     use crate::{
-        Client, Error, assert_next_matches_with_timeout,
+        Client, assert_next_matches_with_timeout,
         config::RequestConfig,
         encryption::{
             DuplicateOneTimeKeyErrorMessage, OAuthCrossSigningResetInfo, VerificationState,
@@ -2324,8 +2352,8 @@ mod tests {
         assert!(client1.encryption().backups().are_enabled().await);
 
         // The other client can't take the lock too.
-        let error = client2.encryption().try_lock_store_once().await.unwrap_err();
-        assert!(matches!(error, Error::CrossProcessLockError(_)));
+        let acquired2 = client2.encryption().try_lock_store_once().await.unwrap();
+        assert!(acquired2.is_none());
 
         // Now have the first client release the lock,
         drop(acquired1);


### PR DESCRIPTION
Due to a rise in duplicate one-time key errors since relying solely on `CrossProcessLock` to manage leases in `CryptoStore` (see #6482), this pull request reverts some of the changes in #6326.

# Changes

- Re-introduce the following fields and functions
    - `OlmMachine::CURRENT_GENERATION_STORE_KEY`
    - `OlmMachine::initialize_crypto_store_generation`
    - `OlmMachine::maintain_crypto_store_generation`
    - `ClientLocks::crypto_store_generation`
    - `Encryption::on_lock_newly_acquired`
- Initialize `CryptoStore` generation in `Encryption::enable_cross_process_store_lock`
- Call `Encryption::on_lock_newly_acquired` (which calls `OlmMachine::maintain_crypto_store_generation`) regardless of whether `CrossProcessLock` is clean or dirty.

# Migrations

I have not reverted any of the database migrations, nor have I added new ones. The re-introduced `OlmMachine` functions only use custom values in `CryptoStore`, which do not need any migrations.

# Questions

Prior to #6326, the generation stored in the `CryptoStore` via `OlmMachine` was exposed for logging purposes. During the review process, however, it became clear that the generation should be opaque, but could be logged internally (see [comment](https://github.com/matrix-org/matrix-rust-sdk/pull/6326#discussion_r2973775749)). 

Extra logging was introduced into `CrossProcessLock` to accommodate this, but now that `OlmMachine` is managing it's own generation key again, that logging may not be sufficient. Should more logging be introduced for the sake of tracking the generation key managed by `OlmMachine`?

---
Closes #6482.
 
- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
