### PR TITLE
feat: add client.subscribe_to_own_beacon_info_updates

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -127,6 +127,7 @@ use crate::{
     authentication::{HomeserverLoginDetails, OidcConfiguration, OidcError, SsoError, SsoHandler},
     client,
     encryption::Encryption,
+    live_locations_observer::BeaconInfoUpdate,
     notification::{
         NotificationClient, NotificationEvent, NotificationItem, NotificationRoomInfo,
         NotificationSenderInfo,
@@ -265,6 +266,13 @@ pub trait AccountDataListener: SyncOutsideWasm + SendOutsideWasm {
 pub trait DuplicateKeyUploadErrorListener: SyncOutsideWasm + SendOutsideWasm {
     /// Called once when uploading keys fails.
     fn on_duplicate_key_upload_error(&self, message: Option<DuplicateOneTimeKeyErrorMessage>);
+}
+
+/// A listener for the current user's client-wide beacon_info updates.
+#[matrix_sdk_ffi_macros::export(callback_interface)]
+pub trait BeaconInfoListener: SyncOutsideWasm + SendOutsideWasm {
+    /// Called whenever the current user's beacon_info changes in any room.
+    fn on_update(&self, update: BeaconInfoUpdate);
 }
 
 /// Information about the old and new key that caused a duplicate key upload
@@ -839,6 +847,25 @@ impl Client {
                 }
             }
         })))
+    }
+
+    /// Subscribe to beacon_info updates for the current user across all rooms.
+    ///
+    /// The listener is only called for new matching updates; there is no
+    /// initial replay.
+    pub fn subscribe_to_own_beacon_info_updates(
+        &self,
+        listener: Box<dyn BeaconInfoListener>,
+    ) -> Result<Arc<TaskHandle>, ClientError> {
+        let stream = self.inner.observe_own_beacon_info_updates()?;
+
+        Ok(Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
+            pin_mut!(stream);
+
+            while let Some(update) = stream.next().await {
+                listener.on_update(update.into());
+            }
+        }))))
     }
 
     /// Subscribe to updates of global account data events.

--- a/bindings/matrix-sdk-ffi/src/live_locations_observer.rs
+++ b/bindings/matrix-sdk-ffi/src/live_locations_observer.rs
@@ -17,7 +17,8 @@ use std::{fmt::Debug, sync::Arc};
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt as _;
 use matrix_sdk::live_locations_observer::{
-    LiveLocationShare as SdkLiveLocationShare, LiveLocationsObserver as SdkLiveLocationsObserver,
+    BeaconInfoUpdate as SdkBeaconInfoUpdate, LiveLocationShare as SdkLiveLocationShare,
+    LiveLocationsObserver as SdkLiveLocationsObserver,
 };
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
 
@@ -46,6 +47,17 @@ pub struct LiveLocationShare {
     pub timeout: u64,
     /// The event ID of the beacon_info state event for this share.
     pub beacon_id: String,
+}
+
+/// A beacon_info update for the current user's live location share.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BeaconInfoUpdate {
+    /// The room where the beacon_info event changed.
+    pub room_id: String,
+    /// The beacon_info event ID.
+    pub event_id: String,
+    /// Whether the share is currently live.
+    pub live: bool,
 }
 
 /// An update to the list of active live location shares.
@@ -142,6 +154,16 @@ impl From<SdkLiveLocationShare> for LiveLocationShare {
             start_ts,
             timeout,
             beacon_id,
+        }
+    }
+}
+
+impl From<SdkBeaconInfoUpdate> for BeaconInfoUpdate {
+    fn from(update: SdkBeaconInfoUpdate) -> Self {
+        Self {
+            room_id: update.room_id.to_string(),
+            event_id: update.event_id.to_string(),
+            live: update.content.live,
         }
     }
 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -76,7 +76,7 @@ use ruma::{
         path_builder::PathBuilder,
     },
     assign,
-    events::direct::DirectUserIdentifier,
+    events::{beacon_info::OriginalSyncBeaconInfoEvent, direct::DirectUserIdentifier},
     push::Ruleset,
     time::Instant,
 };
@@ -110,6 +110,7 @@ use crate::{
     },
     http_client::{HttpClient, SupportedAuthScheme, SupportedPathBuilder},
     latest_events::LatestEvents,
+    live_locations_observer::BeaconInfoUpdate,
     media::MediaError,
     notification_settings::NotificationSettings,
     room::RoomMember,
@@ -1067,6 +1068,33 @@ impl Client {
                 room_id,
             )),
         )
+    }
+
+    /// Subscribe to future `beacon_info` updates for the current user across
+    /// all rooms.
+    ///
+    /// This stream is push-only: it emits only future updates observed during
+    /// sync processing and does not replay existing state.
+    pub fn observe_own_beacon_info_updates(
+        &self,
+    ) -> Result<impl Stream<Item = BeaconInfoUpdate> + use<>> {
+        let observer = self.observe_events::<OriginalSyncBeaconInfoEvent, Room>();
+        let mut stream = observer.subscribe();
+        let own_user_id = self.user_id().ok_or(Error::AuthenticationRequired)?.to_owned();
+        Ok(async_stream::stream! {
+            let _observer = observer;
+
+            while let Some((event, room)) = stream.next().await {
+                if event.state_key != own_user_id {
+                    continue;
+                }
+                yield BeaconInfoUpdate {
+                    room_id: room.room_id().to_owned(),
+                    event_id: event.event_id,
+                    content: event.content,
+                };
+            }
+        })
     }
 
     /// Remove the event handler associated with the handle.

--- a/crates/matrix-sdk/src/live_locations_observer.rs
+++ b/crates/matrix-sdk/src/live_locations_observer.rs
@@ -24,7 +24,7 @@ use imbl::Vector;
 use matrix_sdk_base::{deserialized_responses::SyncOrStrippedState, event_cache::Event};
 use matrix_sdk_common::locks::Mutex;
 use ruma::{
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId,
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId,
     events::{
         AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncStateEvent,
         beacon::OriginalSyncBeaconEvent,
@@ -57,6 +57,17 @@ pub struct LiveLocationShare {
     pub beacon_id: OwnedEventId,
     /// Information about the associated beacon event.
     pub beacon_info: BeaconInfoEventContent,
+}
+
+/// A `beacon_info` update for the current user in one room.
+#[derive(Clone, Debug)]
+pub struct BeaconInfoUpdate {
+    /// The room where the `beacon_info` update was observed.
+    pub room_id: OwnedRoomId,
+    /// The event ID of the `beacon_info` event.
+    pub event_id: OwnedEventId,
+    /// The `beacon_info` event content.
+    pub content: BeaconInfoEventContent,
 }
 
 /// Tracks active live location shares in a room using an [`ObservableVector`].

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -2,12 +2,13 @@ use std::{collections::BTreeMap, ops::Not as _, time::Duration};
 
 use assert_matches2::{assert_let, assert_matches};
 use eyeball_im::VectorDiff;
-use futures_util::FutureExt;
+use futures_util::{FutureExt, StreamExt, pin_mut};
 use matrix_sdk::{
     Client, Error, MemoryStore, SlidingSyncList, StateChanges, StateStore, ThreadingSupport,
     assert_let_timeout,
     authentication::oauth::{OAuthError, error::OAuthTokenRevocationError},
     config::{RequestConfig, StoreConfig, SyncSettings, SyncToken},
+    live_locations_observer::BeaconInfoUpdate,
     sleep::sleep,
     store::{RoomLoadSettings, ThreadSubscriptionStatus},
     sync::{RoomUpdate, State},
@@ -30,7 +31,7 @@ use matrix_sdk_test::{
     },
 };
 use ruma::{
-    EventId, Int, OwnedUserId, RoomId, RoomVersionId,
+    EventId, Int, MilliSecondsSinceUnixEpoch, OwnedUserId, RoomId, RoomVersionId,
     api::client::{
         directory::{
             get_public_rooms,
@@ -1317,6 +1318,137 @@ async fn test_rooms_stream() {
     assert_eq!(room_3.room_id(), room_id_3);
 
     assert_pending!(rooms_stream);
+}
+
+#[async_test]
+async fn test_observe_own_beacon_info_updates_emits_room_id_event_id_and_content() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let stream = client.observe_own_beacon_info_updates().unwrap();
+    pin_mut!(stream);
+
+    let now = MilliSecondsSinceUnixEpoch::now();
+    let f = EventFactory::new();
+
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(*DEFAULT_TEST_ROOM_ID).add_state_event(
+                f.beacon_info(
+                    Some("Live Share".to_owned()),
+                    Duration::from_millis(300_000),
+                    true,
+                    Some(now),
+                )
+                .event_id(event_id!("$own_beacon_info"))
+                .sender(user_id!("@example:localhost"))
+                .state_key(user_id!("@example:localhost"))
+                .into_raw_sync_state(),
+            ),
+        )
+        .await;
+
+    let update: BeaconInfoUpdate = stream.next().await.expect("expected a beacon_info update");
+    assert_eq!(update.room_id, *DEFAULT_TEST_ROOM_ID);
+    assert_eq!(update.event_id, event_id!("$own_beacon_info"));
+    assert_eq!(update.content.description, Some("Live Share".to_owned()));
+    assert!(update.content.live);
+}
+
+#[async_test]
+async fn test_observe_own_beacon_info_updates_filters_other_users() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let stream = client.observe_own_beacon_info_updates().unwrap();
+    pin_mut!(stream);
+
+    let now = MilliSecondsSinceUnixEpoch::now();
+    let f = EventFactory::new();
+
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(*DEFAULT_TEST_ROOM_ID).add_state_event(
+                f.beacon_info(None, Duration::from_millis(300_000), true, Some(now))
+                    .event_id(event_id!("$other_beacon_info"))
+                    .sender(user_id!("@alice:localhost"))
+                    .state_key(user_id!("@alice:localhost"))
+                    .into_raw_sync_state(),
+            ),
+        )
+        .await;
+
+    assert!(stream.next().now_or_never().is_none());
+}
+
+#[async_test]
+async fn test_observe_own_beacon_info_updates_delivers_updates_from_multiple_rooms() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let stream = client.observe_own_beacon_info_updates().unwrap();
+    pin_mut!(stream);
+
+    let now = MilliSecondsSinceUnixEpoch::now();
+    let f = EventFactory::new();
+    let second_room = room_id!("!second:example.org");
+
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(*DEFAULT_TEST_ROOM_ID).add_state_event(
+                f.beacon_info(None, Duration::from_millis(300_000), true, Some(now))
+                    .event_id(event_id!("$room1_beacon"))
+                    .sender(user_id!("@example:localhost"))
+                    .state_key(user_id!("@example:localhost"))
+                    .into_raw_sync_state(),
+            ),
+        )
+        .await;
+
+    let first = stream.next().await.expect("expected first update");
+
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(second_room).add_state_event(
+                f.beacon_info(None, Duration::from_millis(300_000), false, Some(now))
+                    .event_id(event_id!("$room2_beacon"))
+                    .sender(user_id!("@example:localhost"))
+                    .state_key(user_id!("@example:localhost"))
+                    .into_raw_sync_state(),
+            ),
+        )
+        .await;
+
+    let second = stream.next().await.expect("expected second update");
+
+    assert_eq!(first.room_id, *DEFAULT_TEST_ROOM_ID);
+    assert_eq!(second.room_id, second_room.to_owned());
+}
+
+#[async_test]
+async fn test_observe_own_beacon_info_updates_stays_idle_without_matching_updates() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let stream = client.observe_own_beacon_info_updates().unwrap();
+    pin_mut!(stream);
+
+    server.sync_joined_room(&client, *DEFAULT_TEST_ROOM_ID).await;
+
+    assert!(stream.next().now_or_never().is_none());
+}
+
+#[async_test]
+async fn test_observe_own_beacon_info_updates_requires_known_own_user_id() {
+    let (client, _server) = no_retry_test_client_with_server().await;
+
+    let res = client.observe_own_beacon_info_updates();
+
+    assert!(matches!(res, Err(Error::AuthenticationRequired)));
 }
 
 #[async_test]


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Allow subscribing to own beacon info updates across all rooms, so we can know when live location are started/stopped remotely.

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
