### PR TITLE
FFI: Rename OIDC to OAuth.

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -164,6 +164,9 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- [**breaking**] All OIDC related types and functions have been renamed from `Oidc`/`oidc` to `OAuth`/`oauth` to align
+  with the finalised naming in the spec.
+  ([#6500](https://github.com/matrix-org/matrix-rust-sdk/pull/6500))
 - [**breaking**] `LiveLocationShares` has been renamed to `LiveLocationsObserver` and
   `Room::live_location_shares` to `Room::live_locations_observer`.
   ([#6446](https://github.com/matrix-org/matrix-rust-sdk/pull/6446))

--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -29,14 +29,14 @@ use matrix_sdk::{
 use ruma::serde::Raw;
 use url::Url;
 
-use crate::client::{Client, OidcPrompt, SlidingSyncVersion};
+use crate::client::{Client, OAuthPrompt, SlidingSyncVersion};
 
 #[derive(uniffi::Object)]
 pub struct HomeserverLoginDetails {
     pub(crate) url: String,
     pub(crate) sliding_sync_version: SlidingSyncVersion,
     pub(crate) supports_oidc_login: bool,
-    pub(crate) supported_oidc_prompts: Vec<OidcPrompt>,
+    pub(crate) supported_oidc_prompts: Vec<OAuthPrompt>,
     pub(crate) supports_sso_login: bool,
     pub(crate) supports_password_login: bool,
 }
@@ -65,7 +65,7 @@ impl HomeserverLoginDetails {
 
     /// The prompts advertised by the authentication issuer for use in the login
     /// URL.
-    pub fn supported_oidc_prompts(&self) -> Vec<OidcPrompt> {
+    pub fn supported_oidc_prompts(&self) -> Vec<OAuthPrompt> {
         self.supported_oidc_prompts.clone()
     }
 

--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -35,8 +35,8 @@ use crate::client::{Client, OAuthPrompt, SlidingSyncVersion};
 pub struct HomeserverLoginDetails {
     pub(crate) url: String,
     pub(crate) sliding_sync_version: SlidingSyncVersion,
-    pub(crate) supports_oidc_login: bool,
-    pub(crate) supported_oidc_prompts: Vec<OAuthPrompt>,
+    pub(crate) supports_oauth_login: bool,
+    pub(crate) supported_oauth_prompts: Vec<OAuthPrompt>,
     pub(crate) supports_sso_login: bool,
     pub(crate) supports_password_login: bool,
 }
@@ -53,20 +53,20 @@ impl HomeserverLoginDetails {
         self.sliding_sync_version.clone()
     }
 
-    /// Whether the current homeserver supports login using OIDC.
-    pub fn supports_oidc_login(&self) -> bool {
-        self.supports_oidc_login
+    /// Whether the current homeserver supports login using OAuth.
+    pub fn supports_oauth_login(&self) -> bool {
+        self.supports_oauth_login
+    }
+
+    /// The prompts advertised by the authentication issuer for use in the login
+    /// URL.
+    pub fn supported_oauth_prompts(&self) -> Vec<OAuthPrompt> {
+        self.supported_oauth_prompts.clone()
     }
 
     /// Whether the current homeserver supports login using legacy SSO.
     pub fn supports_sso_login(&self) -> bool {
         self.supports_sso_login
-    }
-
-    /// The prompts advertised by the authentication issuer for use in the login
-    /// URL.
-    pub fn supported_oidc_prompts(&self) -> Vec<OAuthPrompt> {
-        self.supported_oidc_prompts.clone()
     }
 
     /// Whether the current homeserver supports the password login flow.

--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -150,11 +150,11 @@ pub struct OAuthConfiguration {
 }
 
 impl OAuthConfiguration {
-    pub(crate) fn redirect_uri(&self) -> Result<Url, OidcError> {
-        Url::parse(&self.redirect_uri).map_err(|_| OidcError::CallbackUrlInvalid)
+    pub(crate) fn redirect_uri(&self) -> Result<Url, OAuthError> {
+        Url::parse(&self.redirect_uri).map_err(|_| OAuthError::CallbackUrlInvalid)
     }
 
-    pub(crate) fn client_metadata(&self) -> Result<Raw<ClientMetadata>, OidcError> {
+    pub(crate) fn client_metadata(&self) -> Result<Raw<ClientMetadata>, OAuthError> {
         let redirect_uri = self.redirect_uri()?;
         let client_name = self.client_name.as_ref().map(|n| Localized::new(n.to_owned(), []));
         let client_uri = self.client_uri.localized_url()?;
@@ -178,10 +178,10 @@ impl OAuthConfiguration {
             )
         };
 
-        Raw::new(&metadata).map_err(|_| OidcError::MetadataInvalid)
+        Raw::new(&metadata).map_err(|_| OAuthError::MetadataInvalid)
     }
 
-    pub(crate) fn registration_data(&self) -> Result<ClientRegistrationData, OidcError> {
+    pub(crate) fn registration_data(&self) -> Result<ClientRegistrationData, OAuthError> {
         let client_metadata = self.client_metadata()?;
 
         let mut registration_data = ClientRegistrationData::new(client_metadata);
@@ -208,43 +208,43 @@ impl OAuthConfiguration {
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[uniffi(flat_error)]
-pub enum OidcError {
+pub enum OAuthError {
     #[error(
         "The homeserver doesn't provide an authentication issuer in its well-known configuration."
     )]
     NotSupported,
-    #[error("Unable to use OIDC as the supplied client metadata is invalid.")]
+    #[error("Unable to use OAuth as the supplied client metadata is invalid.")]
     MetadataInvalid,
-    #[error("The supplied callback URL used to complete OIDC is invalid.")]
+    #[error("The supplied callback URL used to complete OAuth is invalid.")]
     CallbackUrlInvalid,
-    #[error("The OIDC login was cancelled by the user.")]
+    #[error("The OAuth login was cancelled by the user.")]
     Cancelled,
 
     #[error("An error occurred: {message}")]
     Generic { message: String },
 }
 
-impl From<SdkOAuthError> for OidcError {
-    fn from(e: SdkOAuthError) -> OidcError {
+impl From<SdkOAuthError> for OAuthError {
+    fn from(e: SdkOAuthError) -> OAuthError {
         match e {
-            SdkOAuthError::Discovery(error) if error.is_not_supported() => OidcError::NotSupported,
+            SdkOAuthError::Discovery(error) if error.is_not_supported() => OAuthError::NotSupported,
             SdkOAuthError::AuthorizationCode(OAuthAuthorizationCodeError::RedirectUri(_))
             | SdkOAuthError::AuthorizationCode(OAuthAuthorizationCodeError::InvalidState) => {
-                OidcError::CallbackUrlInvalid
+                OAuthError::CallbackUrlInvalid
             }
             SdkOAuthError::AuthorizationCode(OAuthAuthorizationCodeError::Cancelled) => {
-                OidcError::Cancelled
+                OAuthError::Cancelled
             }
-            _ => OidcError::Generic { message: e.to_string() },
+            _ => OAuthError::Generic { message: e.to_string() },
         }
     }
 }
 
-impl From<Error> for OidcError {
-    fn from(e: Error) -> OidcError {
+impl From<Error> for OAuthError {
+    fn from(e: Error) -> OAuthError {
         match e {
             Error::OAuth(e) => (*e).into(),
-            _ => OidcError::Generic { message: e.to_string() },
+            _ => OAuthError::Generic { message: e.to_string() },
         }
     }
 }
@@ -254,11 +254,11 @@ impl From<Error> for OidcError {
 trait OptionExt {
     /// Convenience method to convert an `Option<String>` to a URL and returns
     /// it as a Localized URL. No localization is actually performed.
-    fn localized_url(&self) -> Result<Option<Localized<Url>>, OidcError>;
+    fn localized_url(&self) -> Result<Option<Localized<Url>>, OAuthError>;
 }
 
 impl OptionExt for Option<String> {
-    fn localized_url(&self) -> Result<Option<Localized<Url>>, OidcError> {
+    fn localized_url(&self) -> Result<Option<Localized<Url>>, OAuthError> {
         self.as_deref().map(StrExt::localized_url).transpose()
     }
 }
@@ -266,11 +266,11 @@ impl OptionExt for Option<String> {
 trait StrExt {
     /// Convenience method to convert a string to a URL and returns it as a
     /// Localized URL. No localization is actually performed.
-    fn localized_url(&self) -> Result<Localized<Url>, OidcError>;
+    fn localized_url(&self) -> Result<Localized<Url>, OAuthError>;
 }
 
 impl StrExt for str {
-    fn localized_url(&self) -> Result<Localized<Url>, OidcError> {
-        Ok(Localized::new(Url::parse(self).map_err(|_| OidcError::MetadataInvalid)?, []))
+    fn localized_url(&self) -> Result<Localized<Url>, OAuthError> {
+        Ok(Localized::new(Url::parse(self).map_err(|_| OAuthError::MetadataInvalid)?, []))
     }
 }

--- a/bindings/matrix-sdk-ffi/src/authentication.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication.rs
@@ -124,12 +124,12 @@ pub enum SsoError {
     Generic { message: String },
 }
 
-/// The configuration to use when authenticating with OIDC.
+/// The configuration to use when authenticating with OAuth.
 #[derive(uniffi::Record)]
-pub struct OidcConfiguration {
-    /// The name of the client that will be shown during OIDC authentication.
+pub struct OAuthConfiguration {
+    /// The name of the client that will be shown during OAuth authentication.
     pub client_name: Option<String>,
-    /// The redirect URI that will be used when OIDC authentication is
+    /// The redirect URI that will be used when OAuth authentication is
     /// successful.
     pub redirect_uri: String,
     /// A URI that contains information about the client.
@@ -149,7 +149,7 @@ pub struct OidcConfiguration {
     pub static_registrations: HashMap<String, String>,
 }
 
-impl OidcConfiguration {
+impl OAuthConfiguration {
     pub(crate) fn redirect_uri(&self) -> Result<Url, OidcError> {
         Url::parse(&self.redirect_uri).map_err(|_| OidcError::CallbackUrlInvalid)
     }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2694,23 +2694,23 @@ impl Session {
                     sliding_sync_version,
                 })
             }
-            // Build the session from the OIDC UserSession.
+            // Build the session from the OAuth UserSession.
             AuthApi::OAuth(api) => {
                 let matrix_sdk::authentication::oauth::UserSession {
                     meta: matrix_sdk::SessionMeta { user_id, device_id },
                     tokens: matrix_sdk::SessionTokens { access_token, refresh_token },
                 } = api.user_session().context("Missing session")?;
-                let client_id = api.client_id().context("OIDC client ID is missing.")?.clone();
-                let oidc_data = OidcSessionData { client_id };
+                let client_id = api.client_id().context("OAuth client ID is missing.")?.clone();
+                let oauth_data = OAuthSessionData { client_id };
 
-                let oidc_data = serde_json::to_string(&oidc_data).ok();
+                let oauth_data_string = serde_json::to_string(&oauth_data).ok();
                 Ok(Session {
                     access_token,
                     refresh_token,
                     user_id: user_id.to_string(),
                     device_id: device_id.to_string(),
                     homeserver_url,
-                    oidc_data,
+                    oidc_data: oauth_data_string,
                     sliding_sync_version,
                 })
             }
@@ -2732,13 +2732,13 @@ impl TryFrom<Session> for AuthSession {
             user_id,
             device_id,
             homeserver_url: _,
-            oidc_data,
+            oidc_data: oauth_data_string,
             sliding_sync_version: _,
         } = value;
 
-        if let Some(oidc_data) = oidc_data {
-            // Create an OidcSession.
-            let oidc_data = serde_json::from_str::<OidcSessionData>(&oidc_data)?;
+        if let Some(oauth_data_string) = oauth_data_string {
+            // Create an OAuth Session.
+            let oauth_data = serde_json::from_str::<OAuthSessionData>(&oauth_data_string)?;
 
             let user_session = matrix_sdk::authentication::oauth::UserSession {
                 meta: matrix_sdk::SessionMeta {
@@ -2748,7 +2748,7 @@ impl TryFrom<Session> for AuthSession {
                 tokens: matrix_sdk::SessionTokens { access_token, refresh_token },
             };
 
-            let session = OAuthSession { client_id: oidc_data.client_id, user: user_session };
+            let session = OAuthSession { client_id: oauth_data.client_id, user: user_session };
 
             Ok(AuthSession::OAuth(session.into()))
         } else {
@@ -2766,10 +2766,9 @@ impl TryFrom<Session> for AuthSession {
     }
 }
 
-/// Represents a client registration against an OpenID Connect authentication
-/// issuer.
+/// Represents a client registration against an OAuth authentication issuer.
 #[derive(Serialize, Deserialize)]
-pub(crate) struct OidcSessionData {
+pub(crate) struct OAuthSessionData {
     client_id: ClientId,
 }
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -594,10 +594,10 @@ impl Client {
         Ok(Arc::new(SsoHandler { client: Arc::clone(self), url }))
     }
 
-    /// Requests the URL needed for opening a web view using OIDC. Once the web
-    /// view has succeeded, call `login_with_oidc_callback` with the callback it
-    /// returns. If a failure occurs and a callback isn't available, make sure
-    /// to call `abort_oidc_auth` to inform the client of this.
+    /// Requests the URL needed for opening a web view using OAuth. Once the web
+    /// view has succeeded, call `login_with_oauth_callback` with the callback
+    /// it returns. If a failure occurs and a callback isn't available, make
+    /// sure to call `abort_oauth_auth` to inform the client of this.
     ///
     /// # Arguments
     ///
@@ -626,7 +626,7 @@ impl Client {
     ///   The scopes for API access and the device ID according to the
     ///   [specification](https://spec.matrix.org/v1.15/client-server-api/#allocated-scope-tokens)
     ///   are always requested.
-    pub async fn url_for_oidc(
+    pub async fn url_for_oauth(
         &self,
         oauth_configuration: &OAuthConfiguration,
         prompt: Option<OidcPrompt>,
@@ -661,14 +661,14 @@ impl Client {
         Ok(Arc::new(data))
     }
 
-    /// Aborts an existing OIDC login operation that might have been cancelled,
+    /// Aborts an existing OAuth login operation that might have been cancelled,
     /// failed etc.
-    pub async fn abort_oidc_auth(&self, authorization_data: Arc<OAuthAuthorizationData>) {
+    pub async fn abort_oauth_auth(&self, authorization_data: Arc<OAuthAuthorizationData>) {
         self.inner.oauth().abort_login(&authorization_data.state).await;
     }
 
-    /// Completes the OIDC login process.
-    pub async fn login_with_oidc_callback(&self, callback_url: String) -> Result<(), OidcError> {
+    /// Completes the OAuth login process.
+    pub async fn login_with_oauth_callback(&self, callback_url: String) -> Result<(), OidcError> {
         let url = Url::parse(&callback_url).or(Err(OidcError::CallbackUrlInvalid))?;
 
         self.inner.oauth().finish_login(url.into()).await?;

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -124,7 +124,7 @@ use super::{
 };
 use crate::{
     ClientError,
-    authentication::{HomeserverLoginDetails, OidcConfiguration, OidcError, SsoError, SsoHandler},
+    authentication::{HomeserverLoginDetails, OAuthConfiguration, OidcError, SsoError, SsoHandler},
     client,
     encryption::Encryption,
     notification::{
@@ -601,7 +601,7 @@ impl Client {
     ///
     /// # Arguments
     ///
-    /// * `oidc_configuration` - The configuration used to load the credentials
+    /// * `oauth_configuration` - The configuration used to load the credentials
     ///   of the client if it is already registered with the authorization
     ///   server, or register the client and store its credentials if it isn't.
     ///
@@ -628,14 +628,14 @@ impl Client {
     ///   are always requested.
     pub async fn url_for_oidc(
         &self,
-        oidc_configuration: &OidcConfiguration,
+        oauth_configuration: &OAuthConfiguration,
         prompt: Option<OidcPrompt>,
         login_hint: Option<String>,
         device_id: Option<String>,
         additional_scopes: Option<Vec<String>>,
     ) -> Result<Arc<OAuthAuthorizationData>, OidcError> {
-        let registration_data = oidc_configuration.registration_data()?;
-        let redirect_uri = oidc_configuration.redirect_uri()?;
+        let registration_data = oauth_configuration.registration_data()?;
+        let redirect_uri = oauth_configuration.redirect_uri()?;
 
         let device_id = device_id.map(OwnedDeviceId::from);
 
@@ -681,13 +681,13 @@ impl Client {
     ///
     /// # Arguments
     ///
-    /// * `oidc_configuration` - The data to restore or register the client with
-    ///   the server.
+    /// * `oauth_configuration` - The data to restore or register the client
+    ///   with the server.
     pub fn new_login_with_qr_code_handler(
         self: Arc<Self>,
-        oidc_configuration: OidcConfiguration,
+        oauth_configuration: OAuthConfiguration,
     ) -> LoginWithQrCodeHandler {
-        LoginWithQrCodeHandler::new(self.inner.oauth(), oidc_configuration)
+        LoginWithQrCodeHandler::new(self.inner.oauth(), oauth_configuration)
     }
 
     /// Create a handler for granting login from this device to a new device by

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -28,7 +28,9 @@ use matrix_sdk::STATE_STORE_DATABASE_NAME;
 use matrix_sdk::media::MediaFileHandle as SdkMediaFileHandle;
 use matrix_sdk::{
     Account, AuthApi, AuthSession, Client as MatrixClient, Error, SessionChange, SessionTokens,
-    authentication::oauth::{ClientId, OAuthAuthorizationData, OAuthError, OAuthSession},
+    authentication::oauth::{
+        ClientId, OAuthAuthorizationData, OAuthError as SdkOAuthError, OAuthSession,
+    },
     deserialized_responses::RawAnySyncOrStrippedTimelineEvent,
     executor::AbortOnDrop,
     media::{MediaFormat, MediaRequestParameters, MediaRetentionPolicy, MediaThumbnailSettings},
@@ -124,7 +126,9 @@ use super::{
 };
 use crate::{
     ClientError,
-    authentication::{HomeserverLoginDetails, OAuthConfiguration, OidcError, SsoError, SsoHandler},
+    authentication::{
+        HomeserverLoginDetails, OAuthConfiguration, OAuthError, SsoError, SsoHandler,
+    },
     client,
     encryption::Encryption,
     notification::{
@@ -633,7 +637,7 @@ impl Client {
         login_hint: Option<String>,
         device_id: Option<String>,
         additional_scopes: Option<Vec<String>>,
-    ) -> Result<Arc<OAuthAuthorizationData>, OidcError> {
+    ) -> Result<Arc<OAuthAuthorizationData>, OAuthError> {
         let registration_data = oauth_configuration.registration_data()?;
         let redirect_uri = oauth_configuration.redirect_uri()?;
 
@@ -668,8 +672,8 @@ impl Client {
     }
 
     /// Completes the OAuth login process.
-    pub async fn login_with_oauth_callback(&self, callback_url: String) -> Result<(), OidcError> {
-        let url = Url::parse(&callback_url).or(Err(OidcError::CallbackUrlInvalid))?;
+    pub async fn login_with_oauth_callback(&self, callback_url: String) -> Result<(), OAuthError> {
+        let url = Url::parse(&callback_url).or(Err(OAuthError::CallbackUrlInvalid))?;
 
         self.inner.oauth().finish_login(url.into()).await?;
 
@@ -1209,7 +1213,7 @@ impl Client {
             Ok(server_metadata) => server_metadata,
             Err(e) => {
                 error!("Failed retrieving cached server metadata: {e}");
-                return Err(OAuthError::from(e).into());
+                return Err(SdkOAuthError::from(e).into());
             }
         };
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2665,7 +2665,7 @@ pub struct Session {
     pub homeserver_url: String,
     /// Additional data for this session if OpenID Connect was used for
     /// authentication.
-    pub oidc_data: Option<String>,
+    pub oauth_data: Option<String>,
     /// The sliding sync version used for this session.
     pub sliding_sync_version: SlidingSyncVersion,
 }
@@ -2690,7 +2690,7 @@ impl Session {
                     user_id: user_id.to_string(),
                     device_id: device_id.to_string(),
                     homeserver_url,
-                    oidc_data: None,
+                    oauth_data: None,
                     sliding_sync_version,
                 })
             }
@@ -2710,7 +2710,7 @@ impl Session {
                     user_id: user_id.to_string(),
                     device_id: device_id.to_string(),
                     homeserver_url,
-                    oidc_data: oauth_data_string,
+                    oauth_data: oauth_data_string,
                     sliding_sync_version,
                 })
             }
@@ -2732,7 +2732,7 @@ impl TryFrom<Session> for AuthSession {
             user_id,
             device_id,
             homeserver_url: _,
-            oidc_data: oauth_data_string,
+            oauth_data: oauth_data_string,
             sliding_sync_version: _,
         } = value;
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -38,7 +38,7 @@ use matrix_sdk::{
             account::request_openid_token,
             discovery::{
                 discover_homeserver::RtcFocusInfo,
-                get_authorization_server_metadata::v1::Prompt as RumaOidcPrompt,
+                get_authorization_server_metadata::v1::Prompt as RumaOAuthPrompt,
             },
             push::{EmailPusherData, PusherIds, PusherInit, PusherKind as RumaPusherKind},
             room::{Visibility, create_room},
@@ -629,7 +629,7 @@ impl Client {
     pub async fn url_for_oauth(
         &self,
         oauth_configuration: &OAuthConfiguration,
-        prompt: Option<OidcPrompt>,
+        prompt: Option<OAuthPrompt>,
         login_hint: Option<String>,
         device_id: Option<String>,
         additional_scopes: Option<Vec<String>>,
@@ -2891,7 +2891,7 @@ impl TryFrom<SlidingSyncVersion> for SdkSlidingSyncVersion {
 }
 
 #[derive(Clone, uniffi::Enum)]
-pub enum OidcPrompt {
+pub enum OAuthPrompt {
     /// The Authorization Server should prompt the End-User to create a user
     /// account.
     ///
@@ -2910,10 +2910,10 @@ pub enum OidcPrompt {
     Unknown { value: String },
 }
 
-impl From<RumaOidcPrompt> for OidcPrompt {
-    fn from(value: RumaOidcPrompt) -> Self {
+impl From<RumaOAuthPrompt> for OAuthPrompt {
+    fn from(value: RumaOAuthPrompt) -> Self {
         match value {
-            RumaOidcPrompt::Create => Self::Create,
+            RumaOAuthPrompt::Create => Self::Create,
             value => match value.as_str() {
                 "consent" => Self::Consent,
                 "login" => Self::Login,
@@ -2923,13 +2923,13 @@ impl From<RumaOidcPrompt> for OidcPrompt {
     }
 }
 
-impl From<OidcPrompt> for RumaOidcPrompt {
-    fn from(value: OidcPrompt) -> Self {
+impl From<OAuthPrompt> for RumaOAuthPrompt {
+    fn from(value: OAuthPrompt) -> Self {
         match value {
-            OidcPrompt::Create => Self::Create,
-            OidcPrompt::Consent => Self::from("consent"),
-            OidcPrompt::Login => Self::from("login"),
-            OidcPrompt::Unknown { value } => value.into(),
+            OAuthPrompt::Create => Self::Create,
+            OAuthPrompt::Consent => Self::from("consent"),
+            OAuthPrompt::Login => Self::from("login"),
+            OAuthPrompt::Unknown { value } => value.into(),
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -462,7 +462,7 @@ impl Client {
     /// Information about login options for the client's homeserver.
     pub async fn homeserver_login_details(&self) -> Arc<HomeserverLoginDetails> {
         let oauth = self.inner.oauth();
-        let (supports_oidc_login, supported_oidc_prompts) = match oauth.server_metadata().await {
+        let (supports_oauth_login, supported_oauth_prompts) = match oauth.server_metadata().await {
             Ok(metadata) => {
                 let prompts =
                     metadata.prompt_values_supported.into_iter().map(Into::into).collect();
@@ -470,7 +470,7 @@ impl Client {
                 (true, prompts)
             }
             Err(error) => {
-                error!("Failed to fetch OIDC provider metadata: {error}");
+                error!("Failed to fetch OAuth provider metadata: {error}");
                 (false, Default::default())
             }
         };
@@ -498,8 +498,8 @@ impl Client {
         Arc::new(HomeserverLoginDetails {
             url: self.homeserver(),
             sliding_sync_version,
-            supports_oidc_login,
-            supported_oidc_prompts,
+            supports_oauth_login,
+            supported_oauth_prompts,
             supports_sso_login,
             supports_password_login,
         })

--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -863,29 +863,27 @@ impl IdentityResetHandle {
 pub enum CrossSigningResetAuthType {
     /// The homeserver requires user-interactive authentication.
     Uiaa,
-    // /// OIDC is used for authentication and the user needs to open a URL to
-    // /// approve the upload of cross-signing keys.
-    Oidc {
-        info: OidcCrossSigningResetInfo,
-    },
+    /// OAuth is used for authentication and the user needs to open a URL to
+    /// approve the upload of cross-signing keys.
+    OAuth { info: OAuthCrossSigningResetInfo },
 }
 
 impl From<&matrix_sdk::encryption::CrossSigningResetAuthType> for CrossSigningResetAuthType {
     fn from(value: &matrix_sdk::encryption::CrossSigningResetAuthType) -> Self {
         match value {
             encryption::CrossSigningResetAuthType::Uiaa(_) => Self::Uiaa,
-            encryption::CrossSigningResetAuthType::OAuth(info) => Self::Oidc { info: info.into() },
+            encryption::CrossSigningResetAuthType::OAuth(info) => Self::OAuth { info: info.into() },
         }
     }
 }
 
 #[derive(uniffi::Record)]
-pub struct OidcCrossSigningResetInfo {
+pub struct OAuthCrossSigningResetInfo {
     /// The URL where the user can approve the reset of the cross-signing keys.
     pub approval_url: String,
 }
 
-impl From<&matrix_sdk::encryption::OAuthCrossSigningResetInfo> for OidcCrossSigningResetInfo {
+impl From<&matrix_sdk::encryption::OAuthCrossSigningResetInfo> for OAuthCrossSigningResetInfo {
     fn from(value: &matrix_sdk::encryption::OAuthCrossSigningResetInfo) -> Self {
         Self { approval_url: value.approval_url.to_string() }
     }

--- a/bindings/matrix-sdk-ffi/src/qr_code.rs
+++ b/bindings/matrix-sdk-ffi/src/qr_code.rs
@@ -73,7 +73,7 @@ impl LoginWithQrCodeHandler {
         let registration_data = self
             .oauth_configuration
             .registration_data()
-            .map_err(|_| HumanQrLoginError::OidcMetadataInvalid)?;
+            .map_err(|_| HumanQrLoginError::OAuthMetadataInvalid)?;
 
         let login =
             self.oauth.login_with_qr_code(Some(&registration_data)).scan(&qr_code_data.inner);
@@ -118,7 +118,7 @@ impl LoginWithQrCodeHandler {
         let registration_data = self
             .oauth_configuration
             .registration_data()
-            .map_err(|_| HumanQrLoginError::OidcMetadataInvalid)?;
+            .map_err(|_| HumanQrLoginError::OAuthMetadataInvalid)?;
 
         let login = self.oauth.login_with_qr_code(Some(&registration_data)).generate();
 
@@ -322,8 +322,8 @@ pub enum HumanQrLoginError {
     Unknown,
     #[error("The homeserver doesn't provide sliding sync in its configuration.")]
     SlidingSyncNotAvailable,
-    #[error("Unable to use OIDC as the supplied client metadata is invalid.")]
-    OidcMetadataInvalid,
+    #[error("Unable to use OAuth as the supplied client metadata is invalid.")]
+    OAuthMetadataInvalid,
     #[error("The other device is not signed in and as such can't sign in other devices.")]
     OtherDeviceNotSignedIn,
     #[error("The check code was already sent.")]

--- a/bindings/matrix-sdk-ffi/src/qr_code.rs
+++ b/bindings/matrix-sdk-ffi/src/qr_code.rs
@@ -25,19 +25,19 @@ use matrix_sdk_base::crypto::types::qr_login::{self, QrCodeIntent};
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm, stream::StreamExt};
 
 use crate::{
-    authentication::OidcConfiguration, runtime::get_runtime_handle, task_handle::TaskHandle,
+    authentication::OAuthConfiguration, runtime::get_runtime_handle, task_handle::TaskHandle,
 };
 
 /// Handler for logging in with a QR code.
 #[derive(uniffi::Object)]
 pub struct LoginWithQrCodeHandler {
     oauth: OAuth,
-    oidc_configuration: OidcConfiguration,
+    oauth_configuration: OAuthConfiguration,
 }
 
 impl LoginWithQrCodeHandler {
-    pub(crate) fn new(oauth: OAuth, oidc_configuration: OidcConfiguration) -> Self {
-        Self { oauth, oidc_configuration }
+    pub(crate) fn new(oauth: OAuth, oauth_configuration: OAuthConfiguration) -> Self {
+        Self { oauth, oauth_configuration }
     }
 }
 
@@ -71,7 +71,7 @@ impl LoginWithQrCodeHandler {
         progress_listener: Box<dyn QrLoginProgressListener>,
     ) -> Result<(), HumanQrLoginError> {
         let registration_data = self
-            .oidc_configuration
+            .oauth_configuration
             .registration_data()
             .map_err(|_| HumanQrLoginError::OidcMetadataInvalid)?;
 
@@ -116,7 +116,7 @@ impl LoginWithQrCodeHandler {
         progress_listener: Box<dyn GeneratedQrLoginProgressListener>,
     ) -> Result<(), HumanQrLoginError> {
         let registration_data = self
-            .oidc_configuration
+            .oauth_configuration
             .registration_data()
             .map_err(|_| HumanQrLoginError::OidcMetadataInvalid)?;
 


### PR DESCRIPTION
Complementary PR to #6498, this PR renames all of the OIDC types/methods in the FFI to OAuth types/functions.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.
