### PR TITLE
Add extra logging for tracking `OlmMachine`'s generation in `CryptoStore`

### DIFF
--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -83,7 +83,7 @@ use serde::{Deserialize, de::Error as _};
 use tasks::BundleReceiverTask;
 use tokio::sync::{Mutex, RwLockReadGuard};
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
-use tracing::{debug, error, instrument, warn};
+use tracing::{Span, debug, error, instrument, warn};
 use url::Url;
 use vodozemac::Curve25519PublicKey;
 
@@ -1844,12 +1844,19 @@ impl Encryption {
     /// time.
     ///
     /// Returns the current generation number.
+    #[instrument(skip(self), fields(olm_machine_new_generation, olm_machine_generation))]
     async fn on_lock_newly_acquired(&self) -> Result<u64, Error> {
         let olm_machine_guard = self.client.olm_machine().await;
         if let Some(olm_machine) = olm_machine_guard.as_ref() {
             let (new_gen, generation_number) = olm_machine
                 .maintain_crypto_store_generation(&self.client.locks().crypto_store_generation)
                 .await?;
+
+            Span::current()
+                .record("olm_machine_new_generation", new_gen)
+                .record("olm_machine_generation", generation_number);
+            debug!("OlmMachine generation maintained in CryptoStore");
+
             // If the crypto store generation has changed,
             if new_gen {
                 // (get rid of the reference to the current crypto store first)


### PR DESCRIPTION
This is a follow-up to #6496. It adds some extra logging to `Encryption::on_lease_newly_acquired` to make it easier to track `OlmMachine`'s generation counter in the `CryptoStore`. Note that this is distinct from `CrossProcessLock`'s generation counter in the `CryptoStore`.

While this does not provide precisely the same logging as existed before #6326, I believe it should be sufficient. If we would like to provide more pointed logging, as shown below, we will need to expose the generation counters further up the stack.

https://github.com/matrix-org/matrix-rust-sdk/blob/16c1b9b57f0d03bf957a9057d475b1b8142ba898/crates/matrix-sdk-ui/src/encryption_sync_service.rs#L126-L208

---

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
