### PR TITLE
Expose HumanQrGrantLoginError::Unknown reason in error message

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -44,6 +44,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Expose `HumanQrGrantLoginError::Unknown` reason in error message.
+  ([#6514](https://github.com/matrix-org/matrix-rust-sdk/pull/6514))
 - Add a list of `declined_by: Vec<String>` to the `TimelineItemContent::RtcNotification`, this will contain the list
   of users that have declined the call.
   ([#6494](https://github.com/matrix-org/matrix-rust-sdk/pull/6494))

--- a/bindings/matrix-sdk-ffi/src/qr_code.rs
+++ b/bindings/matrix-sdk-ffi/src/qr_code.rs
@@ -423,7 +423,7 @@ pub enum HumanQrGrantLoginError {
     NotFound,
 
     /// An unknown error has happened.
-    #[error("An unknown error has happened.")]
+    #[error("An unknown error has happened: {0}")]
     Unknown(String),
 
     /// The requested device was not returned by the homeserver.


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Hugh Nimmo-Smith <hughns@element.io>
