### PR TITLE
set a higher retry limit for `send_location_beacon`

### DIFF
--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -4014,7 +4014,11 @@ impl Room {
 
         if beacon_info_event.content.is_live() {
             let content = BeaconEventContent::new(beacon_info_event.event_id, geo_uri, None);
-            Ok(self.send(content).await?.response)
+            Ok(self
+                .send(content)
+                .with_request_config(RequestConfig::new().retry_limit(6))
+                .await?
+                .response)
         } else {
             Err(BeaconError::NotLive)
         }


### PR DESCRIPTION
Usually clients set a retry limit of 3, but for sending location beacons which are required to keep alive a live location, this might not be enough, so we are giving a higher retry limit, precisely we are doubling the default amount to 6, in this way when rate limited the system can continue trying to send the beacon info for longer amount of times.