### PR TITLE
Reduce duplicate dependencies on `windows-sys` and `windows-targets`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,12 +694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,18 +2836,32 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-macros",
+ "jni-sys 0.4.1",
  "log",
- "thiserror 1.0.63",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2861,6 +2869,25 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "jobserver"
@@ -2917,7 +2944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a9353d43a802ba22de0de749f4aa51f3414a6a9b5037559eaac65584db65218"
 dependencies = [
  "goblin 0.9.3",
- "jni-sys",
+ "jni-sys 0.3.0",
  "libc",
  "windows-sys 0.60.2",
 ]
@@ -3425,7 +3452,6 @@ dependencies = [
  "eyeball-im",
  "futures-executor",
  "futures-util",
- "jni",
  "jvm-getter",
  "language-tags",
  "log-panics",
@@ -3879,7 +3905,7 @@ version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.0",
 ]
 
 [[package]]
@@ -5087,9 +5113,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -5526,6 +5552,22 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -7222,15 +7264,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -7272,21 +7305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7348,12 +7366,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -7372,12 +7384,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -7393,12 +7399,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7432,12 +7432,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -7453,12 +7447,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7480,12 +7468,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -7501,12 +7483,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4703,9 +4703,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ proptest = { version = "1.9.0", default-features = false, features = ["std"] }
 quote = { version = "1.0.37", default-features = false }
 rand = { version = "0.10.1", default-features = false, features = ["std", "std_rng", "thread_rng"] }
 regex = { version = "1.12.2", default-features = false }
-reqwest = { version = "0.13.1", default-features = false }
+reqwest = { version = "0.13.3", default-features = false }
 rmp-serde = { version = "1.3.0", default-features = false }
 ruma = { version = "0.15.1", features = [
     "client-api-c",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -122,10 +122,8 @@ uniffi = { workspace = true, features = ["tokio"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 paranoid-android = { version = "0.2.2", default-features = false }
-# Needed for `rustls-platform-verifier`. Newer versions aren't compatible with it.
-jni = "0.21.1"
 # Used to access the credential storage on Android
-rustls-platform-verifier = "0.6.2"
+rustls-platform-verifier = "0.7.0"
 # Needed for intializing and keeping the JavaVM reference around
 once_cell = "1.21.4"
 # Gobley's jvm-getter is used to get a JVM pointer from all Android versions


### PR DESCRIPTION
Since merging #6053, some duplicates of `windows-sys` and `windows-targets` could be attributed to `rustls-platform-verifier` using an outdated version of `jni`. As of `rustls-platform-verifier@0.7.0`, however, it uses the latest version of `jni`. So, this pull request aims to reduce those duplicates by updating `rustls-platform-verifier`.

## Changes

- Bump `reqwest` to `0.13.3` at the workspace level
    -  `reqwest` is the primary way in which `rustls-platform-verifier` enters the repository as a dependency.
- Bump `rustls-platform-verifier` to `0.7.0` in `matrix-sdk-ffi`
    - This also means it is possible to remove the explicit dependency on `jni` in `matrix-sdk-ffi`.

## Results

**_Updating `reqwest` and `rustls-platform-verifier` does indeed remove one of the duplicates in each of `windows-sys` and `windows-targets`, but it adds a duplicate version of `jni-sys` (see below)._** 

Removing the duplicate of `jni-sys` would be somewhat difficult, as the crates which depend on it don't seem to be under active development - i.e., [`jvm-getter`](https://github.com/gobley/jvm-getter) and [`paranoid-android`](https://github.com/raftario/paranoid-android).

I am not sure whether this outcome is preferable, but I will leave that to the reviewer to decide.

### `main`

_Note that there are 6 versions of `windows-sys`, 4 versions of `windows-targets`, and 1 version of `jni-sys`._

```bash
> cargo tree --workspace --all-features --target=all --invert windows-sys
error: There are multiple `windows-sys` packages in your project, and the specification `windows-sys` is ambiguous.
Please re-run this command with one of the following specifications:
  windows-sys@0.45.0
  windows-sys@0.48.0
  windows-sys@0.52.0
  windows-sys@0.59.0
  windows-sys@0.60.2
  windows-sys@0.61.2
> cargo tree --workspace --all-features --target=all --invert windows-targets
error: There are multiple `windows-targets` packages in your project, and the specification `windows-targets` is ambiguous.
Please re-run this command with one of the following specifications:
  windows-targets@0.42.2
  windows-targets@0.48.5
  windows-targets@0.52.6
  windows-targets@0.53.5
> cargo tree --workspace --all-features --target=all --invert jni-sys --depth 0
jni-sys v0.3.0
```

### `reduce-dup-deps-on-windows-sys-targets`

_Note that there are 5 versions of `windows-sys`, 3 versions of `windows-targets`, and 2 version of `jni-sys`._

```bash
> cargo tree --workspace --all-features --target=all --invert windows-sys
error: There are multiple `windows-sys` packages in your project, and the specification `windows-sys` is ambiguous.
Please re-run this command with one of the following specifications:
  windows-sys@0.48.0
  windows-sys@0.52.0
  windows-sys@0.59.0
  windows-sys@0.60.2
  windows-sys@0.61.2
> cargo tree --workspace --all-features --target=all --invert windows-targets
error: There are multiple `windows-targets` packages in your project, and the specification `windows-targets` is ambiguous.
Please re-run this command with one of the following specifications:
  windows-targets@0.48.5
  windows-targets@0.52.6
  windows-targets@0.53.5
> cargo tree --workspace --all-features --target=all --invert jni-sys
error: There are multiple `jni-sys` packages in your project, and the specification `jni-sys` is ambiguous.
Please re-run this command with one of the following specifications:
  jni-sys@0.3.0
  jni-sys@0.4.1
```

---
Closes #6238.

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
