### PR TITLE
fix(sdk): Expose `session` key in `OAuthCrossSigningResetInfo`

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -143,6 +143,9 @@ All notable changes to this project will be documented in this file.
 
 ### Bugfix
 
+- Add the `session` key in `OAuthCrossSigningResetInfo`, allowing to provide `AuthData::OAuth` in
+  `CrossSigningResetHandle::auth()`, to match the behavior described in the Matrix spec.
+  ([#6525](https://github.com/matrix-org/matrix-rust-sdk/pull/6525))
 - When threads are enabled, a focused event timeline is used and the focused event is not part of a thread, 
   hide other threaded events by default like it happens on the live focus timeline. 
   ([#6519](https://github.com/matrix-org/matrix-rust-sdk/pull/6519))

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -373,7 +373,11 @@ impl CrossSigningResetHandle {
 
                 match e.as_uiaa_response() {
                     Some(uiaa_info) => {
-                        if uiaa_info.auth_error.is_some() {
+                        // Return the error except if we are at the `m.oauth` stage where we want to
+                        // keep polling.
+                        if !matches!(self.auth_type, CrossSigningResetAuthType::OAuth(_))
+                            && uiaa_info.auth_error.is_some()
+                        {
                             return Err(e.into());
                         }
                     }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -435,6 +435,9 @@ impl CrossSigningResetAuthType {
 pub struct OAuthCrossSigningResetInfo {
     /// The URL where the user can approve the reset of the cross-signing keys.
     pub approval_url: Url,
+
+    /// Session key to use to complete the authentication.
+    pub session: Option<String>,
 }
 
 impl OAuthCrossSigningResetInfo {
@@ -443,7 +446,10 @@ impl OAuthCrossSigningResetInfo {
             return Ok(None);
         };
 
-        Ok(Some(OAuthCrossSigningResetInfo { approval_url: parameters.url.as_str().try_into()? }))
+        Ok(Some(OAuthCrossSigningResetInfo {
+            approval_url: parameters.url.as_str().try_into()?,
+            session: auth_info.session.clone(),
+        }))
     }
 }
 
@@ -1400,11 +1406,11 @@ impl Encryption {
     /// # Example
     ///
     /// ```no_run
-    /// # use matrix_sdk::{ruma::api::client::uiaa, Client, encryption::CrossSigningResetAuthType};
-    /// # use url::Url;
+    /// use matrix_sdk::{ruma::api::client::uiaa, encryption::CrossSigningResetAuthType};
+    ///
     /// # async {
-    /// # let homeserver = Url::parse("http://example.com")?;
-    /// # let client = Client::new(homeserver).await?;
+    /// # let homeserver = url::Url::parse("http://example.com")?;
+    /// # let client = matrix_sdk::Client::new(homeserver).await?;
     /// # let user_id = unimplemented!();
     /// let encryption = client.encryption();
     ///
@@ -1425,7 +1431,11 @@ impl Encryption {
     ///                 you first need to approve it at {}",
     ///                 o.approval_url
     ///             );
-    ///             handle.auth(None).await?;
+    ///
+    ///             let mut oauth = uiaa::OAuth::new();
+    ///             oauth.session = o.session;
+    ///
+    ///             handle.auth(Some(uiaa::AuthData::OAuth(oauth))).await?;
     ///         }
     ///     }
     /// }

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -22,6 +22,7 @@ use std::{
     sync::{Arc, Mutex, atomic::AtomicU32},
 };
 
+use as_variant::as_variant;
 use js_int::UInt;
 use matrix_sdk_base::deserialized_responses::TimelineEvent;
 #[cfg(feature = "experimental-element-recent-emojis")]
@@ -34,15 +35,18 @@ use percent_encoding::{AsciiSet, CONTROLS};
 use ruma::{
     DeviceId, EventId, MilliSecondsSinceUnixEpoch, MxcUri, OwnedDeviceId, OwnedEventId,
     OwnedOneTimeKeyId, OwnedRoomId, OwnedUserId, RoomId, ServerName, UserId,
-    api::client::{
-        discovery::get_capabilities::v3::Capabilities,
-        receipt::create_receipt::v3::ReceiptType,
-        room::Visibility,
-        sync::sync_events::v5,
-        threads::get_thread_subscriptions_changes::unstable::{
-            ThreadSubscription, ThreadUnsubscription,
+    api::{
+        client::{
+            discovery::get_capabilities::v3::Capabilities,
+            receipt::create_receipt::v3::ReceiptType,
+            room::Visibility,
+            sync::sync_events::v5,
+            threads::get_thread_subscriptions_changes::unstable::{
+                ThreadSubscription, ThreadUnsubscription,
+            },
+            uiaa,
         },
-        uiaa,
+        error::StandardErrorBody,
     },
     device_id,
     directory::PublicRoomsChunk,
@@ -3774,21 +3778,38 @@ impl<'a> MockEndpoint<'a, UploadCrossSigningKeysEndpoint> {
     }
 
     /// Returns an error response with a stable OAuth 2.0 UIAA stage with the
-    /// given session key.
-    pub fn uiaa_stable_oauth(self, session: &str) -> MatrixMock<'a> {
-        let server_uri = self.server.uri();
-        self.respond_with(ResponseTemplate::new(401).set_body_json(json!({
+    /// given session key and optional extra error message.
+    pub fn uiaa_stable_oauth(
+        self,
+        session: &str,
+        extra_error: Option<&StandardErrorBody>,
+    ) -> MatrixMock<'a> {
+        let mut json = json!({
             "session": session,
             "flows": [{
                 "stages": [ "m.oauth" ]
             }],
             "params": {
                 "m.oauth": {
-                    "url": format!("{server_uri}/account/?action=org.matrix.cross_signing_reset"),
+                    "url": format!("{}/account/?action=org.matrix.cross_signing_reset", self.server.uri()),
                 }
             },
             "msg": "To reset your end-to-end encryption cross-signing identity, you first need to approve it and then try again."
-        })))
+        });
+
+        if let Some(extra_error) = extra_error {
+            let extra_json = as_variant!(
+                serde_json::to_value(extra_error)
+                    .expect("extra error should serialize successfully"),
+                Value::Object
+            )
+            .expect("extra error should be a JSON object");
+
+            let json_object = json.as_object_mut().expect("UIAA response should be a JSON object");
+            json_object.extend(extra_json);
+        }
+
+        self.respond_with(ResponseTemplate::new(401).set_body_json(json))
     }
 }
 

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -42,6 +42,7 @@ use ruma::{
         threads::get_thread_subscriptions_changes::unstable::{
             ThreadSubscription, ThreadUnsubscription,
         },
+        uiaa,
     },
     device_id,
     directory::PublicRoomsChunk,
@@ -1923,6 +1924,14 @@ impl<'a, T> MockEndpoint<'a, T> {
         self
     }
 
+    /// Expect the given UIAA auth data in the body of the request.
+    pub fn expect_uiaa_auth_data(mut self, auth_data: &uiaa::AuthData) -> Self {
+        self.mock = self.mock.and(body_partial_json(json!({
+            "auth": auth_data,
+        })));
+        self
+    }
+
     /// Specify how to respond to a query (viz., like
     /// [`MockBuilder::respond_with`] does), when other predefined responses
     /// aren't sufficient.
@@ -3764,11 +3773,12 @@ impl<'a> MockEndpoint<'a, UploadCrossSigningKeysEndpoint> {
         })))
     }
 
-    /// Returns an error response with a stable OAuth 2.0 UIAA stage.
-    pub fn uiaa_stable_oauth(self) -> MatrixMock<'a> {
+    /// Returns an error response with a stable OAuth 2.0 UIAA stage with the
+    /// given session key.
+    pub fn uiaa_stable_oauth(self, session: &str) -> MatrixMock<'a> {
         let server_uri = self.server.uri();
         self.respond_with(ResponseTemplate::new(401).set_body_json(json!({
-            "session": "dummy",
+            "session": session,
             "flows": [{
                 "stages": [ "m.oauth" ]
             }],

--- a/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
@@ -15,7 +15,10 @@
 use assert_matches2::assert_let;
 use matrix_sdk::{encryption::CrossSigningResetAuthType, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_test::async_test;
-use ruma::api::client::uiaa;
+use ruma::api::{
+    client::uiaa,
+    error::{ErrorKind, StandardErrorBody},
+};
 use similar_asserts::assert_eq;
 
 #[async_test]
@@ -183,7 +186,7 @@ async fn test_reset_stable_oauth() {
     // request.
     server
         .mock_upload_cross_signing_keys()
-        .uiaa_stable_oauth(session)
+        .uiaa_stable_oauth(session, None)
         .mock_once()
         .named("Trying to upload the cross-signing keys with UIAA response without auth data")
         .mount()
@@ -191,10 +194,12 @@ async fn test_reset_stable_oauth() {
 
     // Then return the UIAA response 5 times while expecting the UIAA auth data in
     // the request.
+    let extra_error =
+        StandardErrorBody::new(ErrorKind::Forbidden, "Stage not completed".to_owned());
     server
         .mock_upload_cross_signing_keys()
         .expect_uiaa_auth_data(&expected_auth_data)
-        .uiaa_stable_oauth(session)
+        .uiaa_stable_oauth(session, Some(&extra_error))
         .up_to_n_times(5)
         .expect(5)
         .named("Trying to upload the cross-signing keys with UIAA response and auth data")

--- a/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
@@ -172,15 +172,32 @@ async fn test_reset_stable_oauth() {
         "Initially we shouldn't have any cross-signing keys",
     );
 
+    let session = "oauth_session";
+    let mut expected_oauth = uiaa::OAuth::new();
+    expected_oauth.session = Some(session.to_owned());
+    let expected_auth_data = uiaa::AuthData::OAuth(expected_oauth);
+
     server.mock_upload_keys().ok().expect(1).named("Initial device keys upload").mount().await;
 
-    // Return the UIAA response 5 times.
+    // First, return the UIAA response without expecting the UIAA auth data in the
+    // request.
     server
         .mock_upload_cross_signing_keys()
-        .uiaa_stable_oauth()
+        .uiaa_stable_oauth(session)
+        .mock_once()
+        .named("Trying to upload the cross-signing keys with UIAA response without auth data")
+        .mount()
+        .await;
+
+    // Then return the UIAA response 5 times while expecting the UIAA auth data in
+    // the request.
+    server
+        .mock_upload_cross_signing_keys()
+        .expect_uiaa_auth_data(&expected_auth_data)
+        .uiaa_stable_oauth(session)
         .up_to_n_times(5)
         .expect(5)
-        .named("Trying to upload the cross-signing keys with UIAA response")
+        .named("Trying to upload the cross-signing keys with UIAA response and auth data")
         .mount()
         .await;
 
@@ -189,6 +206,7 @@ async fn test_reset_stable_oauth() {
     // until it is invalidated by `up_to_n_times`.
     server
         .mock_upload_cross_signing_keys()
+        .expect_uiaa_auth_data(&expected_auth_data)
         .ok()
         .expect(1)
         .named("Succeeding to upload the cross-signing keys")
@@ -218,7 +236,9 @@ async fn test_reset_stable_oauth() {
     );
 
     // Then it retries until it succeeds.
-    reset_handle.auth(None).await.expect("We should be able to reset the cross-signing keys after some attempts, waiting for the auth issue to allow us to upload");
+    let mut oauth = uiaa::OAuth::new();
+    oauth.session = oauth_info.session.clone();
+    reset_handle.auth(Some(uiaa::AuthData::OAuth(oauth))).await.expect("We should be able to reset the cross-signing keys after some attempts, waiting for the auth issue to allow us to upload");
 
     assert!(
         client.encryption().cross_signing_status().await.unwrap().is_complete(),

--- a/examples/cross_signing_bootstrap/src/main.rs
+++ b/examples/cross_signing_bootstrap/src/main.rs
@@ -33,7 +33,10 @@ async fn bootstrap(client: Client, user_id: OwnedUserId, password: String) -> Re
                     you first need to approve it at {}",
                     oauth.approval_url
                 );
-                handle.auth(None).await?;
+
+                let mut oauth_data = uiaa::OAuth::new();
+                oauth_data.session = oauth.session.clone();
+                handle.auth(Some(uiaa::AuthData::OAuth(oauth_data))).await?;
             }
         }
     }

--- a/examples/oauth_cli/src/main.rs
+++ b/examples/oauth_cli/src/main.rs
@@ -32,7 +32,9 @@ use matrix_sdk::{
     encryption::{CrossSigningResetAuthType, recovery::RecoveryState},
     room::Room,
     ruma::{
-        api::client::discovery::get_authorization_server_metadata::v1::AccountManagementActionData,
+        api::client::{
+            discovery::get_authorization_server_metadata::v1::AccountManagementActionData, uiaa,
+        },
         events::room::message::{MessageType, OriginalSyncRoomMessageEvent},
         serde::Raw,
     },
@@ -354,7 +356,10 @@ impl OAuthCli {
                         you first need to approve it at {}",
                         o.approval_url
                     );
-                    handle.auth(None).await?;
+
+                    let mut oauth_data = uiaa::OAuth::new();
+                    oauth_data.session = o.session.clone();
+                    handle.auth(Some(uiaa::AuthData::OAuth(oauth_data))).await?;
                 }
             }
         }


### PR DESCRIPTION
Fixes #6521

This allows to provide `AuthData::OAuth` in `CrossSigningResetHandle::auth()`, to match the behavior expected
according to the Matrix spec.


- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

