### PR TITLE
fix(sdk-base): Filter out service members from room heroes

### DIFF
--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- Filter out service members from `Room::heroes`. This *should* be done by the homeservers, but some don't. 
+  ([#6535](https://github.com/matrix-org/matrix-rust-sdk/pull/6535))
 - Room keys are now rotated whenever the client fully reloads the member list by making a
   request to `/members`, which prevents clients using keys that may have been shared under
   [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) even if a gappy

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -471,8 +471,18 @@ impl Room {
     }
 
     /// Get the heroes for this room.
+    ///
+    /// This also filters out possible service members from the list of heroes
+    /// returned by the homeserver.
     pub fn heroes(&self) -> Vec<RoomHero> {
-        self.info.read().heroes().to_vec()
+        let guard = self.info.read();
+        let heroes = guard.heroes();
+
+        if let Some(service_members) = guard.service_members() {
+            heroes.iter().filter(|hero| !service_members.contains(&hero.user_id)).cloned().collect()
+        } else {
+            heroes.to_vec()
+        }
     }
 
     /// Get the receipt as an `OwnedEventId` and `Receipt` tuple for the given
@@ -589,4 +599,52 @@ pub(crate) enum AccountDataSource {
     /// The source is account data with the unstable prefix.
     #[default]
     Unstable,
+}
+
+#[cfg(test)]
+mod tests {
+    use matrix_sdk_test::{
+        JoinedRoomBuilder, SyncResponseBuilder, async_test, event_factory::EventFactory,
+    };
+    use ruma::{room_id, user_id};
+    use serde_json::json;
+
+    use super::*;
+    use crate::test_utils::logged_in_base_client;
+
+    #[async_test]
+    async fn test_room_heroes_filters_out_service_members() {
+        let client = logged_in_base_client(None).await;
+        let user_id = &client.session_meta().unwrap().user_id;
+        let service_member_id = user_id!("@service:example.org");
+        let alice_id = user_id!("@alice:example.org");
+        let room_id = room_id!("!room:example.org");
+
+        let room = client.get_or_create_room(room_id, RoomState::Joined);
+
+        // Create a room response with 2 heroes, one of them a service member.
+        let mut sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
+            .add_joined_room(
+                JoinedRoomBuilder::new(room_id)
+                    .set_room_summary(json!({
+                        "m.joined_member_count": 3,
+                        "m.invited_member_count": 0,
+                        "m.heroes": [alice_id.to_owned(), service_member_id.to_owned()],
+                    }))
+                    .add_state_event(
+                        EventFactory::new()
+                            .sender(user_id)
+                            .member_hints(BTreeSet::from([service_member_id.to_owned()])),
+                    ),
+            )
+            .build_sync_response();
+
+        client.receive_sync_response(response).await.unwrap();
+
+        // The service member should be filtered out.
+        let heroes = room.heroes();
+        assert_eq!(heroes.len(), 1);
+        assert_eq!(heroes[0].user_id, alice_id);
+    }
 }


### PR DESCRIPTION
The spec says the HS *should not* return service members in the heroes field, but some HS implementations still have this behavior, which can lead to the service member being treated as an important user in the room.

<!-- description of the changes in this PR -->

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
