### PR TITLE
feat: expose `RoomMember::is_service_member`

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Expose `RoomMember::is_service_member` field. ([#6536](https://github.com/matrix-org/matrix-rust-sdk/pull/6536))
 - Expose `ClientBuilder::dm_room_definition` to customize the DM room definition used by the `Client`, 
   added `RoomInfo::is_dm` field based on it. ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))
 - Expose `HumanQrGrantLoginError::Unknown` reason in error message.

--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -96,6 +96,7 @@ pub struct RoomMember {
     pub is_ignored: bool,
     pub suggested_role_for_power_level: RoomMemberRole,
     pub membership_change_reason: Option<String>,
+    pub is_service_member: bool,
 }
 
 impl TryFrom<SdkRoomMember> for RoomMember {
@@ -112,6 +113,7 @@ impl TryFrom<SdkRoomMember> for RoomMember {
             is_ignored: m.is_ignored(),
             suggested_role_for_power_level: m.suggested_role_for_power_level(),
             membership_change_reason: m.event().reason().map(|s| s.to_owned()),
+            is_service_member: m.is_service_member(),
         })
     }
 }

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add `RoomMember::is_service_member` that automatically checks the room info and retrieves this info. 
+  ([#6536](https://github.com/matrix-org/matrix-rust-sdk/pull/6536))
 - [**breaking**] Add `DmRoomDefinition` enum, allowing clients to specify what a DM 
   room should look like. A `Room::is_dm` method was added to check if a room is a DM room too, 
   using this definition. ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -199,6 +199,7 @@ impl Room {
             max_power_level,
             users_display_names,
             ignored_users,
+            service_members: self.service_members(),
         })
     }
 }
@@ -217,6 +218,7 @@ pub struct RoomMember {
     pub(crate) max_power_level: i64,
     pub(crate) display_name_ambiguous: bool,
     pub(crate) is_ignored: bool,
+    pub(crate) is_service_member: bool,
 }
 
 impl RoomMember {
@@ -226,14 +228,21 @@ impl RoomMember {
         presence: Option<PresenceEvent>,
         room_info: &MemberRoomInfo<'_>,
     ) -> Self {
-        let MemberRoomInfo { power_levels, max_power_level, users_display_names, ignored_users } =
-            room_info;
+        let MemberRoomInfo {
+            power_levels,
+            max_power_level,
+            users_display_names,
+            ignored_users,
+            service_members,
+        } = room_info;
 
+        let user_id = event.user_id().to_owned();
         let display_name = event.display_name();
         let display_name_ambiguous = users_display_names
             .get(&display_name)
             .is_some_and(|s| is_display_name_ambiguous(&display_name, s));
         let is_ignored = ignored_users.as_ref().is_some_and(|s| s.contains(event.user_id()));
+        let is_service_member = service_members.as_ref().is_some_and(|s| s.contains(&user_id));
 
         Self {
             event: event.into(),
@@ -243,6 +252,7 @@ impl RoomMember {
             max_power_level: *max_power_level,
             display_name_ambiguous,
             is_ignored,
+            is_service_member,
         }
     }
 
@@ -397,6 +407,11 @@ impl RoomMember {
     pub fn is_ignored(&self) -> bool {
         self.is_ignored
     }
+
+    /// Is the room member a service member.
+    pub fn is_service_member(&self) -> bool {
+        self.is_service_member
+    }
 }
 
 // Information about the room a member is in.
@@ -405,6 +420,7 @@ pub(crate) struct MemberRoomInfo<'a> {
     pub(crate) max_power_level: i64,
     pub(crate) users_display_names: HashMap<&'a DisplayName, BTreeSet<OwnedUserId>>,
     pub(crate) ignored_users: Option<BTreeSet<OwnedUserId>>,
+    pub(crate) service_members: Option<BTreeSet<OwnedUserId>>,
 }
 
 /// The kind of room member updates that just happened.


### PR DESCRIPTION
This will help clients filter out room members which are service members easily, without having to manually load and check the room info separately.<!-- description of the changes in this PR -->

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
