### PR TITLE
feat: compute and cache `RoomInfo::active_service_members`

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -44,6 +44,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- `RoomNotificationInfo`, `NotificationItem` and `SpaceRoom` now have `is_dm` fields. 
+  ([#6537](https://github.com/matrix-org/matrix-rust-sdk/pull/6537))
 - Expose `RoomMember::is_service_member` field. ([#6536](https://github.com/matrix-org/matrix-rust-sdk/pull/6536))
 - Expose `beacon` and `beacon_info` fields in `RoomPowerLevelsValues` and `RoomPowerLevelChanges`,
   allowing clients to read and update the power levels required to send beacon (live location)

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2223,7 +2223,7 @@ async fn notification_handler(
             .map(ToString::to_string)
             .collect(),
         active_service_members_count: room
-            .active_service_members()
+            .update_active_service_members()
             .await
             .ok()
             .flatten()

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2232,6 +2232,7 @@ async fn notification_handler(
         is_encrypted: Some(room.encryption_state().is_encrypted()),
         is_direct,
         is_space: room.is_space(),
+        is_dm: room.compute_is_dm().await.ok().unwrap_or_default(),
     };
 
     listener.on_notification(

--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -54,6 +54,7 @@ pub struct NotificationRoomInfo {
     pub is_encrypted: Option<bool>,
     pub is_direct: bool,
     pub is_space: bool,
+    pub is_dm: bool,
 }
 
 #[derive(uniffi::Record)]
@@ -113,6 +114,7 @@ impl NotificationItem {
                 is_encrypted: item.is_room_encrypted,
                 is_direct: item.is_direct_message_room,
                 is_space: item.is_space,
+                is_dm: item.room_is_dm,
             },
             is_noisy: item.is_noisy,
             has_mention: item.has_mention,

--- a/bindings/matrix-sdk-ffi/src/room/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room/room_info.rs
@@ -147,9 +147,6 @@ impl RoomInfo {
             .ok()
             .map(|p| RoomPowerLevels::new(p, room.own_user_id().to_owned()));
 
-        let active_service_members_count =
-            room.active_service_members().await?.unwrap_or_default().len() as u64;
-
         Ok(Self {
             id: room.room_id().to_string(),
             encryption_state: room.encryption_state(),
@@ -186,7 +183,7 @@ impl RoomInfo {
             active_members_count: room.active_members_count(),
             invited_members_count: room.invited_members_count(),
             joined_members_count: room.joined_members_count(),
-            active_service_members_count,
+            active_service_members_count: room.active_service_members_count().unwrap_or_default(),
             service_members: room
                 .service_members()
                 .iter()

--- a/bindings/matrix-sdk-ffi/src/room/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room/room_info.rs
@@ -161,7 +161,7 @@ impl RoomInfo {
             topic: room.topic(),
             avatar_url: room.avatar_url().map(Into::into),
             is_direct: room.is_direct().await?,
-            is_dm: room.is_dm().await?,
+            is_dm: room.compute_is_dm().await?,
             is_public: room.is_public(),
             is_space: room.is_space(),
             successor_room: room.successor_room().map(Into::into),

--- a/bindings/matrix-sdk-ffi/src/spaces.rs
+++ b/bindings/matrix-sdk-ffi/src/spaces.rs
@@ -359,6 +359,10 @@ pub struct SpaceRoom {
     pub heroes: Option<Vec<RoomHero>>,
     /// The via parameters of the room.
     pub via: Vec<String>,
+    /// Whether this room is a DM, if known.
+    /// Note this value can be calculated following some assumptions and is not
+    /// guaranteed to be accurate.
+    pub is_dm: Option<bool>,
 }
 
 impl From<UISpaceRoom> for SpaceRoom {
@@ -380,6 +384,7 @@ impl From<UISpaceRoom> for SpaceRoom {
             state: room.state.map(Into::into),
             heroes: room.heroes.map(|heroes| heroes.into_iter().map(Into::into).collect()),
             via: room.via.into_iter().map(Into::into).collect(),
+            is_dm: room.is_dm,
         }
     }
 }

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -33,6 +33,11 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] Add `RoomSummary::active_service_members` field to act as a cached value that will be computed 
+  when we sync members. Rename `Room::is_dm` to `Room::compute_is_dm` since it will now also store the computed 
+  active service members count in the new cached field. `Room::active_service_members` is now 
+  `Room::update_active_service_members` for the same reason.
+  ([#6537](https://github.com/matrix-org/matrix-rust-sdk/pull/6537))
 - [**breaking**] Enforce atomic and synchronized updates to `RoomInfo`. Requires 
   `StateStore::save_changes` to acquire state store lock and replaces `Room::set_room_info` 
   with an atomic version, `Room::update_room_info`, which is also synchronized by

--- a/crates/matrix-sdk-base/src/room/display_name.rs
+++ b/crates/matrix-sdk-base/src/room/display_name.rs
@@ -378,6 +378,10 @@ pub(crate) struct RoomSummary {
     pub joined_member_count: u64,
     /// The number of members that are considered to be invited to the room.
     pub invited_member_count: u64,
+    /// The number of active (joined/invited) service members in the room, if
+    /// known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_service_members: Option<u64>,
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -565,6 +565,12 @@ impl Room {
             Ok(None)
         }
     }
+
+    /// Returns a cached value containing the active (joined/invited) service
+    /// member count, if known.
+    pub fn active_service_members_count(&self) -> Option<u64> {
+        self.info.read().summary.active_service_members
+    }
 }
 
 // See https://github.com/matrix-org/matrix-rust-sdk/pull/3749#issuecomment-2312939823.

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -301,9 +301,9 @@ impl Room {
         }
     }
 
-    /// Checks if the current room is a DM based on the rules from the
-    /// [`DmRoomDefinition`].
-    pub async fn is_dm(&self, dm_room_definition: &DmRoomDefinition) -> StoreResult<bool> {
+    /// Computes if the current room is a DM based on the rules from the
+    /// [`DmRoomDefinition`], updating the active service members.
+    pub async fn compute_is_dm(&self, dm_room_definition: &DmRoomDefinition) -> StoreResult<bool> {
         let is_direct = self.is_direct().await?;
 
         match *dm_room_definition {

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -63,7 +63,7 @@ pub use state::{RoomState, RoomStateFilter};
 pub(crate) use tags::RoomNotableTags;
 use tokio::sync::broadcast;
 pub use tombstone::{PredecessorRoom, SuccessorRoom};
-use tracing::{info, instrument, warn};
+use tracing::{info, instrument, trace, warn};
 
 use crate::{
     DmRoomDefinition, Error, StateStore,
@@ -313,7 +313,7 @@ impl Room {
                     return Ok(false);
                 }
                 let active_service_member_count =
-                    self.active_service_members().await?.unwrap_or_default().len() as u64;
+                    self.update_active_service_members().await?.unwrap_or_default().len() as u64;
                 let has_at_most_two_members =
                     self.active_members_count().saturating_sub(active_service_member_count) <= 2;
                 Ok(has_at_most_two_members)
@@ -541,7 +541,7 @@ impl Room {
     /// Returns the list of service members that are either in a joined or
     /// invited state in this room, checking the service member list against the
     /// locally available room members.
-    pub async fn active_service_members(&self) -> StoreResult<Option<Vec<RoomMember>>> {
+    pub async fn update_active_service_members(&self) -> StoreResult<Option<Vec<RoomMember>>> {
         if let Some(service_members) = self.service_members() {
             let mut found = Vec::new();
             for user_id in service_members {
@@ -560,8 +560,32 @@ impl Room {
                 }
             }
 
+            trace!(
+                "Updating active service members ({}) in room {:?}",
+                found.len(),
+                self.room_id()
+            );
+
+            let new_active_service_member_count = found.len() as u64;
+            let current_active_service_member_count =
+                self.info.read().summary.active_service_members.unwrap_or_default();
+            if new_active_service_member_count != current_active_service_member_count {
+                self.update_and_save_room_info(|mut info| {
+                    info.update_active_service_member_count(Some(new_active_service_member_count));
+                    (info, RoomInfoNotableUpdateReasons::ACTIVE_SERVICE_MEMBERS)
+                })
+                .await?;
+            }
+
             Ok(Some(found))
         } else {
+            if self.info.read().summary.active_service_members.is_some() {
+                self.update_and_save_room_info(|mut info| {
+                    info.update_active_service_member_count(None);
+                    (info, RoomInfoNotableUpdateReasons::ACTIVE_SERVICE_MEMBERS)
+                })
+                .await?;
+            }
             Ok(None)
         }
     }

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -538,9 +538,9 @@ impl Room {
         self.info.read().pinned_event_ids()
     }
 
-    /// Returns the list of service members that are either in a joined or
-    /// invited state in this room, checking the service member list against the
-    /// locally available room members.
+    /// Computes and stores the list of service members that are either in a
+    /// joined or invited state in this room, checking the service member
+    /// list against the locally available room members.
     pub async fn update_active_service_members(&self) -> StoreResult<Option<Vec<RoomMember>>> {
         if let Some(service_members) = self.service_members() {
             let mut found = Vec::new();

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -560,11 +560,7 @@ impl Room {
                 }
             }
 
-            trace!(
-                "Updating active service members ({}) in room {:?}",
-                found.len(),
-                self.room_id()
-            );
+            trace!("Updating active service members ({}) in room {}", found.len(), self.room_id());
 
             let new_active_service_member_count = found.len() as u64;
             let current_active_service_member_count =

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1410,6 +1410,9 @@ bitflags! {
         /// The display name has changed.
         const DISPLAY_NAME = 0b0010_0000;
 
+        /// The active service members have changed.
+        const ACTIVE_SERVICE_MEMBERS = 0b0100_0000;
+
         /// This is a temporary hack.
         ///
         /// So here is the thing. Ideally, we DO NOT want to emit this reason. It does not

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -823,7 +823,24 @@ impl RoomInfo {
         &mut self,
         raw_event: &mut RawStateEventWithKeys<AnySyncStateEvent>,
     ) -> bool {
-        // Store the state event in the `BaseRoomInfo` first.
+        // When we receive a `m.room.member_hints` event
+        if raw_event.event_type == StateEventType::MemberHints
+            && let Some(AnySyncStateEvent::MemberHints(new_hints)) = raw_event.deserialize()
+            // If we have both old and new member hints events
+            && let (Some(current_hints), Some(new)) =
+                (&self.base_info.member_hints, new_hints.as_original())
+            // Then we check if their contents don't match
+            && current_hints
+                .content
+                .service_members
+                .as_ref()
+                .is_some_and(|current_members| *current_members != new.content.service_members)
+        {
+            // And reset the computed value in that case
+            self.summary.active_service_members = None;
+        }
+
+        // Store the state event in the `BaseRoomInfo`.
         let base_info_has_been_modified = self.base_info.handle_state_event(raw_event);
 
         if raw_event.event_type == StateEventType::RoomEncryption && raw_event.state_key.is_empty()

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1285,6 +1285,18 @@ impl RoomInfo {
 
         migrated
     }
+
+    /// Returns the number of active (joined/invited) service members in the
+    /// room, if known.
+    pub fn active_service_member_count(&self) -> Option<u64> {
+        self.summary.active_service_members
+    }
+
+    /// Updates the cached value for the number of active service members in the
+    /// room.
+    pub fn update_active_service_member_count(&mut self, count: Option<u64>) {
+        self.summary.active_service_members = count;
+    }
 }
 
 /// Type to represent a `RoomInfo::recency_stamp`.
@@ -1476,6 +1488,7 @@ mod tests {
                 }],
                 joined_member_count: 5,
                 invited_member_count: 0,
+                active_service_members: None,
             },
             members_synced: true,
             last_prev_batch: Some("pb".to_owned()),

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1456,7 +1456,7 @@ impl Default for RoomInfoNotableUpdateReasons {
 
 #[cfg(test)]
 mod tests {
-    use std::{str::FromStr, sync::Arc, time::Duration};
+    use std::{collections::BTreeSet, str::FromStr, sync::Arc, time::Duration};
 
     use assert_matches::assert_matches;
     use futures_util::future::{self, Either};
@@ -1483,8 +1483,8 @@ mod tests {
 
     use super::{BaseRoomInfo, LatestEventValue, RoomInfo, SyncInfo};
     use crate::{
-        Room, RoomDisplayName, RoomHero, RoomInfoNotableUpdateReasons, RoomState, StateChanges,
-        StateStore,
+        RawStateEventWithKeys, Room, RoomDisplayName, RoomHero, RoomInfoNotableUpdateReasons,
+        RoomState, StateChanges, StateStore,
         notification_settings::RoomNotificationMode,
         room::{RoomNotableTags, RoomSummary},
         store::{IntoStateStore, MemoryStore, RoomLoadSettings, SaveLockedStateStore},
@@ -1857,6 +1857,100 @@ mod tests {
         assert!(info.base_info.name.is_none());
         assert!(info.base_info.tombstone.is_none());
         assert!(info.base_info.topic.is_none());
+    }
+
+    #[test]
+    fn test_member_hints_with_different_contents_reset_computed_value() {
+        let expected = BTreeSet::from_iter([
+            owned_user_id!("@alice:example.org"),
+            owned_user_id!("@bob:example.org"),
+        ]);
+
+        let info_json = json!({
+            "room_id": "!gda78o:server.tld",
+            "room_state": "Invited",
+            "notification_counts": {
+                "highlight_count": 1,
+                "notification_count": 2,
+            },
+            "summary": {
+                "room_heroes": [{
+                    "user_id": "@somebody:example.org",
+                    "display_name": "Somebody",
+                    "avatar_url": "mxc://example.org/abc"
+                }],
+                "joined_member_count": 5,
+                "invited_member_count": 0,
+                "active_service_members": 2,
+            },
+            "members_synced": true,
+            "last_prev_batch": "pb",
+            "sync_info": "FullySynced",
+            "encryption_state_synced": true,
+            "base_info": {
+                "avatar": null,
+                "canonical_alias": null,
+                "create": null,
+                "dm_targets": [],
+                "encryption": null,
+                "guest_access": null,
+                "history_visibility": null,
+                "join_rules": null,
+                "max_power_level": 100,
+                "member_hints": {
+                    "Original": {
+                        "content": {
+                            "service_members": ["@alice:example.org", "@bob:example.org"]
+                        }
+                    }
+                },
+                "name": null,
+                "tombstone": null,
+                "topic": null,
+            },
+        });
+
+        let info: RoomInfo = serde_json::from_value(info_json.clone()).unwrap();
+        assert_eq!(info.base_info.member_hints.unwrap().content.service_members.unwrap(), expected);
+        assert_eq!(info.summary.active_service_members, Some(2));
+
+        // We receive a new event with the same values as the stored ones
+        let mut info: RoomInfo = serde_json::from_value(info_json.clone()).unwrap();
+        let mut raw_state_event_with_keys = RawStateEventWithKeys::try_from_raw_state_event(
+            EventFactory::new()
+                .sender(user_id!("@alice:example.org"))
+                .member_hints(expected.clone())
+                .into_raw_sync_state(),
+        )
+        .expect("Expected member hints event is created");
+
+        info.handle_state_event(&mut raw_state_event_with_keys);
+
+        // Nothing changed
+        assert_eq!(info.base_info.member_hints.unwrap().content.service_members.unwrap(), expected);
+        // And the computed value is kept
+        assert_eq!(info.summary.active_service_members, Some(2));
+
+        // We receive a new event with different values from the stored ones
+        let mut info: RoomInfo = serde_json::from_value(info_json).unwrap();
+        let new_member_hints = BTreeSet::from_iter([owned_user_id!("@alice:example.org")]);
+        let mut raw_state_event_with_keys = RawStateEventWithKeys::try_from_raw_state_event(
+            EventFactory::new()
+                .sender(user_id!("@alice:example.org"))
+                .member_hints(new_member_hints.clone())
+                .into_raw_sync_state(),
+        )
+        .expect("New member hints event is created");
+
+        info.handle_state_event(&mut raw_state_event_with_keys);
+
+        // The new member hints were applied
+        assert_eq!(
+            info.base_info.member_hints.unwrap().content.service_members.unwrap(),
+            new_member_hints
+        );
+        // And the computed value is reset
+        assert!(info.summary.active_service_members.is_none());
     }
 
     fn make_room_and_state_store(room_state: RoomState) -> (Room, SaveLockedStateStore) {

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -924,6 +924,10 @@ impl RoomInfo {
             }
         }
 
+        if changed {
+            self.summary.active_service_members = None;
+        }
+
         changed
     }
 

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- `SpaceRoom` and `NotificationItem` now have an `is_dm` field to indicate whether the room is a DM room. 
+  ([#6537](https://github.com/matrix-org/matrix-rust-sdk/pull/6537))
 - Add a list of `declined_by: Vec<OwnedUserId>` to the `TimelineItemContent::RtcNotification`, this will contain the list
   of users that have declined the call.
   ([#6494](https://github.com/matrix-org/matrix-rust-sdk/pull/6494))

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -955,6 +955,9 @@ pub struct NotificationItem {
 
     /// The push actions for this notification (notify, sound, highlight, etc.).
     pub actions: Option<Vec<Action>>,
+
+    /// Whether the room this notification is from is a DM or not.
+    pub room_is_dm: bool,
 }
 
 impl NotificationItem {
@@ -1061,6 +1064,7 @@ impl NotificationItem {
             has_mention,
             thread_id,
             actions: push_actions.map(|actions| actions.to_vec()),
+            room_is_dm: room.compute_is_dm().await?,
         };
 
         Ok(item)

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -1034,7 +1034,7 @@ impl NotificationItem {
             .collect_vec();
 
         let active_service_members_count =
-            room.active_service_members().await?.unwrap_or_default().len() as u64;
+            room.update_active_service_members().await?.unwrap_or_default().len() as u64;
 
         let item = NotificationItem {
             event,

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/category.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/category.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use matrix_sdk_base::DmRoomDefinition;
-
 use super::{super::RoomListItem, Filter};
 
 /// An enum to represent whether a room is about “people” (strictly 2 users) or
@@ -32,55 +30,10 @@ pub enum RoomCategory {
     People,
 }
 
-type DirectTargetsLength = usize;
-
-/// _Direct targets_ mean the number of users in a direct room, except us.
-/// So if it returns 1, it means there are 2 users in the direct room.
-fn matches<F>(number_of_direct_targets: F, room: &RoomListItem, expected_kind: RoomCategory) -> bool
-where
-    F: Fn(&RoomListItem) -> Option<DirectTargetsLength>,
-{
-    let client = room.client();
-    let dm_room_definition = client.dm_room_definition();
-    let Some(targets) = number_of_direct_targets(room) else {
-        // Don't know.
-        return false;
-    };
-    let kind = match dm_room_definition {
-        DmRoomDefinition::MatrixSpec => {
-            if targets == 1 {
-                // If there is a single target, it's a direct room.
-                RoomCategory::People
-            } else {
-                // If smaller than 1, we are not sure it's a direct room, it's then a `Group`.
-                // If greater than 1, we are sure it's a direct room but not between
-                // two users, so it's a `Group` based on our expectation.
-                RoomCategory::Group
-            }
-        }
-        DmRoomDefinition::TwoMembers => {
-            // We can't fully rely on the `service_members` value, as it only contains the
-            // user ids that should be considered service members in the room,
-            // not the service members that are active in the room. We can only
-            // make a good guess and assume those service members are in the room.
-            // Note this can return false positives if some service members aren't in the
-            // room, but they were replaced by other members.
-            let service_member_count =
-                room.service_members().map(|members| members.len()).unwrap_or_default() as u64;
-            let active_non_service_members =
-                room.active_members_count().saturating_sub(service_member_count);
-            if targets == 1 && active_non_service_members <= 2 {
-                // If lower than or equal to 2, we are sure it's a direct room between two
-                // users.
-                RoomCategory::People
-            } else {
-                // If smaller than 1, we are not sure it's a direct room, it's then a `Group`.
-                // If greater than 1, we are sure it's a direct room but not between
-                // two users, so it's a `Group` based on our expectation.
-                RoomCategory::Group
-            }
-        }
-    };
+/// Checks if the room belongs in the expected category based on whether it's a
+/// DM or not.
+fn matches(room: &RoomListItem, expected_kind: RoomCategory) -> bool {
+    let kind = if room.is_dm() { RoomCategory::People } else { RoomCategory::Group };
 
     kind == expected_kind
 }
@@ -89,41 +42,74 @@ where
 /// `expected_category`. The category is defined by [`RoomCategory`], see this
 /// type to learn more.
 pub fn new_filter(expected_category: RoomCategory) -> impl Filter {
-    let number_of_direct_targets = move |room: &RoomListItem| Some(room.direct_targets_length());
-
-    move |room| -> bool { matches(number_of_direct_targets, room, expected_category) }
+    move |room| -> bool { matches(room, expected_category) }
 }
 
 #[cfg(test)]
 mod tests {
     use std::ops::Not;
 
-    use matrix_sdk::test_utils::mocks::{AnyRoomBuilder, MatrixMockServer};
-    use matrix_sdk_test::{JoinedRoomBuilder, async_test};
-    use ruma::room_id;
+    use matrix_sdk::{Client, test_utils::mocks::MatrixMockServer};
+    use matrix_sdk_base::DmRoomDefinition;
+    use matrix_sdk_test::{JoinedRoomBuilder, async_test, event_factory::EventFactory};
+    use ruma::{UserId, room_id};
 
-    use super::{super::new_rooms, *};
+    use crate::room_list_service::{
+        RoomListItem,
+        filters::{RoomCategory, category::matches},
+    };
+
+    async fn setup_room(
+        client: &Client,
+        server: &MatrixMockServer,
+        targets: u64,
+        joined_members: u32,
+    ) -> RoomListItem {
+        let room_id = room_id!("!a:b.c");
+        server
+            .mock_sync()
+            .ok_and_run(client, |builder| {
+                let mut direct = EventFactory::new().direct();
+                for idx in 0..targets {
+                    direct = direct.add_user(
+                        UserId::parse(format!("@user_{idx}:example.org"))
+                            .expect("UserId is valid")
+                            .into(),
+                        room_id,
+                    );
+                }
+
+                let mut joined_room_builder = JoinedRoomBuilder::new(room_id);
+                if joined_members > 0 {
+                    joined_room_builder =
+                        joined_room_builder.set_joined_members_count(joined_members);
+                }
+                builder.add_global_account_data(direct).add_joined_room(joined_room_builder);
+            })
+            .await;
+
+        client.get_room(room_id).expect("Room should exist").into()
+    }
 
     #[async_test]
     async fn test_kind_is_group_with_matrix_spec_definition() {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
-        let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let number_of_direct_targets = |_room: &RoomListItem| Some(42);
+        let room = setup_room(&client, &server, 42, 10).await;
 
         // Expect `People`.
         {
             let expected_kind = RoomCategory::People;
 
-            assert!(matches(number_of_direct_targets, &room, expected_kind).not());
+            assert!(matches(&room, expected_kind).not());
         }
 
         // Expect `Group`.
         {
             let expected_kind = RoomCategory::Group;
 
-            assert!(matches(number_of_direct_targets, &room, expected_kind));
+            assert!(matches(&room, expected_kind));
         }
     }
 
@@ -131,22 +117,21 @@ mod tests {
     async fn test_kind_is_people_with_matrix_spec_definition() {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
-        let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let number_of_direct_targets = |_room: &RoomListItem| Some(1);
+        let room = setup_room(&client, &server, 1, 10).await;
 
         // Expect `People`.
         {
             let expected_kind = RoomCategory::People;
 
-            assert!(matches(number_of_direct_targets, &room, expected_kind));
+            assert!(matches(&room, expected_kind));
         }
 
         // Expect `Group`.
         {
             let expected_kind = RoomCategory::Group;
 
-            assert!(matches(number_of_direct_targets, &room, expected_kind).not());
+            assert!(matches(&room, expected_kind).not());
         }
     }
 
@@ -158,23 +143,15 @@ mod tests {
             .on_builder(|b| b.dm_room_definition(DmRoomDefinition::TwoMembers))
             .build()
             .await;
-        let room_id = room_id!("!a:b.c");
 
         // We have 3 members in the room.
-        let room = server
-            .sync_room(
-                &client,
-                AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(3)),
-            )
-            .await;
-
-        let number_of_direct_targets = |_room: &RoomListItem| Some(1);
+        let room = setup_room(&client, &server, 1, 3).await;
 
         // It's Group.
         {
             let expected_kind = RoomCategory::Group;
 
-            assert!(matches(number_of_direct_targets, &room.into(), expected_kind));
+            assert!(matches(&room, expected_kind));
         }
     }
 
@@ -186,105 +163,28 @@ mod tests {
             .on_builder(|b| b.dm_room_definition(DmRoomDefinition::TwoMembers))
             .build()
             .await;
-        let room_id = room_id!("!a:b.c");
 
         // The room has 2 members, but it has no direct targets, so it should not be
         // considered a `People` room.
-        let room = server
-            .sync_room(
-                &client,
-                AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(2)),
-            )
-            .await;
-
-        let number_of_direct_targets = |_room: &RoomListItem| Some(0);
-
-        // It's not People.
-        {
-            let expected_kind = RoomCategory::People;
-
-            assert!(matches(number_of_direct_targets, &room.into(), expected_kind).not());
-        }
+        let room = setup_room(&client, &server, 0, 2).await;
+        assert!(matches(&room, RoomCategory::People).not());
 
         // The room has 2 members, but it has several direct targets, so it should not
         // be considered a `People` room.
-        let room = server
-            .sync_room(
-                &client,
-                AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(2)),
-            )
-            .await;
-
-        let number_of_direct_targets = |_room: &RoomListItem| Some(43);
-
-        // It's not People.
-        {
-            let expected_kind = RoomCategory::People;
-
-            assert!(matches(number_of_direct_targets, &room.into(), expected_kind).not());
-        }
+        let room = setup_room(&client, &server, 42, 2).await;
+        assert!(matches(&room, RoomCategory::People).not());
 
         // The room has 2 members and a single target, so it should be considered a
         // `People` room.
-        let room = server
-            .sync_room(
-                &client,
-                AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(2)),
-            )
-            .await;
-
-        let number_of_direct_targets = |_room: &RoomListItem| Some(1);
-
-        // It's People.
-        {
-            let expected_kind = RoomCategory::People;
-
-            assert!(matches(number_of_direct_targets, &room.into(), expected_kind));
-        }
+        let room = setup_room(&client, &server, 1, 2).await;
+        assert!(matches(&room, RoomCategory::People));
 
         // The room has 1 member, so it should be considered a `People` room.
-        let room = server
-            .sync_room(
-                &client,
-                AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(1)),
-            )
-            .await;
-
-        let number_of_direct_targets = |_room: &RoomListItem| Some(1);
-
-        // It's People.
-        {
-            let expected_kind = RoomCategory::People;
-
-            assert!(matches(number_of_direct_targets, &room.into(), expected_kind));
-        }
+        let room = setup_room(&client, &server, 1, 1).await;
+        assert!(matches(&room, RoomCategory::People));
 
         // The room has no members, so it should be considered a `People` room.
-        let room = server
-            .sync_room(
-                &client,
-                AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(0)),
-            )
-            .await;
-
-        let number_of_direct_targets = |_room: &RoomListItem| Some(1);
-
-        // It's People.
-        {
-            let expected_kind = RoomCategory::People;
-
-            assert!(matches(number_of_direct_targets, &room.into(), expected_kind));
-        }
-    }
-
-    #[async_test]
-    async fn test_room_kind_cannot_be_found() {
-        let server = MatrixMockServer::new().await;
-        let client = server.client_builder().build().await;
-        let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
-
-        let number_of_direct_targets = |_room: &RoomListItem| None;
-
-        assert!(matches(number_of_direct_targets, &room, RoomCategory::Group).not());
+        let room = setup_room(&client, &server, 1, 0).await;
+        assert!(matches(&room, RoomCategory::People));
     }
 }

--- a/crates/matrix-sdk-ui/src/spaces/room.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room.rs
@@ -69,6 +69,10 @@ pub struct SpaceRoom {
     ///
     /// Defaults to `false` if not specified in the `m.space.child` event.
     pub suggested: bool,
+    /// Whether this room is a DM, if known.
+    /// Note this value can be calculated following some assumptions and is not
+    /// guaranteed to be accurate.
+    pub is_dm: Option<bool>,
 }
 
 impl SpaceRoom {
@@ -104,9 +108,10 @@ impl SpaceRoom {
             is_direct: known_room.as_ref().map(|r| r.direct_targets_length() != 0),
             children_count,
             state: known_room.as_ref().map(|r| r.state()),
-            heroes: known_room.map(|r| r.heroes()),
+            heroes: known_room.as_ref().map(|r| r.heroes()),
             via,
             suggested,
+            is_dm: known_room.as_ref().map(|r| r.is_dm()),
         }
     }
 
@@ -143,6 +148,7 @@ impl SpaceRoom {
             heroes: Some(room_info.heroes().to_vec()),
             via: vec![],
             suggested: false,
+            is_dm: Some(known_room.is_dm()),
         }
     }
 

--- a/crates/matrix-sdk-ui/src/spaces/room_list.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room_list.rs
@@ -1070,6 +1070,7 @@ mod tests {
             heroes: None,
             via: vec![],
             suggested: false,
+            is_dm: None,
         }
     }
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] `Room::is_dm` was renamed to `Room::compute_is_dm` to match its behavior, since it'll now compute 
+  and cache the result. A new *synchronous* `Room::is_dm` function was added which centralizes the logic of 
+  checking if something is a DM based on that cached value and the provided `DmRoomDefinition`. `Room::sync_members` 
+  will also now compute active service members. ([#6537](https://github.com/matrix-org/matrix-rust-sdk/pull/6537))
 - [**breaking**] Enforce atomic and synchronized updates to `RoomInfo`. Requires 
   `StateStore::save_changes` to acquire state store lock and replaces `Room::set_room_info` 
   with an atomic version, `Room::update_room_info`, which is also synchronized by

--- a/crates/matrix-sdk/src/message_search.rs
+++ b/crates/matrix-sdk/src/message_search.rs
@@ -221,7 +221,7 @@ impl GlobalSearchBuilder {
     pub async fn only_dm_rooms(mut self) -> Result<Self, crate::Error> {
         let mut to_remove = HashSet::new();
         for room in &self.room_set {
-            if !room.is_dm().await? {
+            if !room.compute_is_dm().await? {
                 to_remove.insert(room.room_id().to_owned());
             }
         }
@@ -233,7 +233,7 @@ impl GlobalSearchBuilder {
     pub async fn no_dms(mut self) -> Result<Self, crate::Error> {
         let mut to_remove = HashSet::new();
         for room in &self.room_set {
-            if room.is_dm().await? {
+            if room.compute_is_dm().await? {
                 to_remove.insert(room.room_id().to_owned());
             }
         }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -4578,6 +4578,10 @@ impl Room {
     /// Checks if the current room is a DM.
     pub async fn is_dm(&self) -> Result<bool> {
         Ok(self.inner.is_dm(self.client.dm_room_definition()).await?)
+    /// Computes if the current room is a DM, stores the loaded values, and then
+    /// returns the result.
+    pub async fn compute_is_dm(&self) -> Result<bool> {
+        Ok(self.inner.compute_is_dm(self.client.dm_room_definition()).await?)
     }
 }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -40,8 +40,8 @@ use matrix_sdk_base::crypto::{
 };
 pub use matrix_sdk_base::store::StoredThreadSubscription;
 use matrix_sdk_base::{
-    ComposerDraft, EncryptionState, RoomInfoNotableUpdateReasons, RoomMemberships, SendOutsideWasm,
-    StateStoreDataKey, StateStoreDataValue,
+    ComposerDraft, DmRoomDefinition, EncryptionState, RoomInfoNotableUpdateReasons,
+    RoomMemberships, SendOutsideWasm, StateStoreDataKey, StateStoreDataValue,
     deserialized_responses::{
         RawAnySyncOrStrippedState, RawSyncOrStrippedState, SyncOrStrippedState,
     },
@@ -4575,13 +4575,39 @@ impl Room {
         }
     }
 
-    /// Checks if the current room is a DM.
-    pub async fn is_dm(&self) -> Result<bool> {
-        Ok(self.inner.is_dm(self.client.dm_room_definition()).await?)
     /// Computes if the current room is a DM, stores the loaded values, and then
     /// returns the result.
     pub async fn compute_is_dm(&self) -> Result<bool> {
         Ok(self.inner.compute_is_dm(self.client.dm_room_definition()).await?)
+    }
+
+    /// Checks if the current room is a DM in a synchronous way, without
+    /// actually checking any local stores. Note this can be either a cached or
+    /// an approximate value, since some important data may be unavailable
+    /// and we may need to make some assumptions.
+    pub fn is_dm(&self) -> bool {
+        // Note: this value may be wrong for invited rooms.
+        let is_direct = self.direct_targets_length() == 1;
+        match self.client.dm_room_definition() {
+            DmRoomDefinition::MatrixSpec => {
+                // If there is a single target, it's a DM.
+                is_direct
+            }
+            DmRoomDefinition::TwoMembers => {
+                // If there is a single target and at most 2 active members, it's a DM.
+                // Try getting the calculated active service members count from the room info.
+                let active_service_member_count =
+                    self.active_service_members_count().unwrap_or_else(|| {
+                        // Otherwise just use an approximated value based on the service members
+                        // count.
+                        self.service_members().map(|members| members.len()).unwrap_or_default()
+                            as u64
+                    });
+                let has_at_most_two_active_members =
+                    self.active_members_count().saturating_sub(active_service_member_count) <= 2;
+                is_direct && has_at_most_two_active_members
+            }
+        }
     }
 }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2035,9 +2035,6 @@ impl Room {
         // but before the /sync request could fetch the membership change event.
         self.mark_members_missing();
 
-        // Re-calculate active service members
-        self.update_active_service_members().await?;
-
         Ok(())
     }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1178,7 +1178,16 @@ impl Room {
             return Ok(());
         }
 
-        if !self.are_members_synced() { self.request_members().await } else { Ok(()) }
+        if !self.are_members_synced() {
+            self.request_members().await?;
+
+            // While we're at it, calculate the active service members
+            self.update_active_service_members().await?;
+
+            Ok(())
+        } else {
+            Ok(())
+        }
     }
 
     /// Get a specific member of this room.
@@ -2025,6 +2034,9 @@ impl Room {
         // that can happen when some event is sent after a room member has been invited
         // but before the /sync request could fetch the membership change event.
         self.mark_members_missing();
+
+        // Re-calculate active service members
+        self.update_active_service_members().await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -921,7 +921,7 @@ async fn test_is_dm_using_matrix_spec() {
     let room = server.sync_joined_room(&client, room_id).await;
     // Room has direct targets, so it's considered direct and a DM using the spec
     // definition.
-    assert!(room.is_dm().await.unwrap());
+    assert!(room.compute_is_dm().await.unwrap());
 
     // We mock the m.direct account data with no targets
     let direct_data = EventFactory::new().direct().into_raw::<AnyGlobalAccountDataEvent>();
@@ -934,7 +934,7 @@ async fn test_is_dm_using_matrix_spec() {
 
     // Room doesn't have direct targets anymore, so it's not a DM using the spec
     // definition.
-    assert!(room.is_dm().await.unwrap().not());
+    assert!(room.compute_is_dm().await.unwrap().not());
 }
 
 #[async_test]
@@ -968,7 +968,7 @@ async fn test_is_dm_using_at_most_two_members_definition() {
             AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(2)),
         )
         .await;
-    assert!(room.is_dm().await.unwrap());
+    assert!(room.compute_is_dm().await.unwrap());
 
     // The room has direct targets, and a single active user, so it's a DM.
     let room = server
@@ -977,7 +977,7 @@ async fn test_is_dm_using_at_most_two_members_definition() {
             AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(1)),
         )
         .await;
-    assert!(room.is_dm().await.unwrap());
+    assert!(room.compute_is_dm().await.unwrap());
 
     // The room has direct targets, and > 2 active users, so it's NOT a DM.
     let room = server
@@ -986,5 +986,5 @@ async fn test_is_dm_using_at_most_two_members_definition() {
             AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(3)),
         )
         .await;
-    assert!(!room.is_dm().await.unwrap());
+    assert!(!room.compute_is_dm().await.unwrap());
 }

--- a/crates/matrix-sdk/tests/integration/sync.rs
+++ b/crates/matrix-sdk/tests/integration/sync.rs
@@ -22,6 +22,7 @@ use ruma::{
             guest_access::{GuestAccess, RoomGuestAccessEventContent},
             history_visibility::{HistoryVisibility, RoomHistoryVisibilityEventContent},
             join_rules::RoomJoinRulesEventContent,
+            member::RoomMemberEvent,
             name::RoomNameEventContent,
             pinned_events::RoomPinnedEventsEventContent,
             power_levels::RoomPowerLevelsEventContent,
@@ -2384,7 +2385,7 @@ async fn test_receive_stripped_room_topic_event_via_sync() {
 }
 
 #[async_test]
-async fn test_active_service_members() {
+async fn test_update_active_service_members() {
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
     let user_id = client.user_id().unwrap();
@@ -2421,6 +2422,7 @@ async fn test_active_service_members() {
     assert_eq!(active_members.len(), 1);
     assert_eq!(room.service_members().unwrap().len(), 2);
     assert!(room.update_active_service_members().await.unwrap().unwrap().is_empty());
+    assert!(room.active_service_members_count().is_none());
 
     // Now another user joined the room
     let human_user = EventFactory::new()
@@ -2441,6 +2443,7 @@ async fn test_active_service_members() {
     assert_eq!(active_members.len(), 2);
     assert_eq!(room.service_members().unwrap().len(), 2);
     assert!(room.update_active_service_members().await.unwrap().unwrap().is_empty());
+    assert!(room.active_service_members_count().is_none());
 
     // Now one of the service members in the member hints joined the room
     let service_member_1 =
@@ -2460,6 +2463,7 @@ async fn test_active_service_members() {
     assert_eq!(active_members.len(), 3);
     assert_eq!(room.service_members().unwrap().len(), 2);
     assert_eq!(room.update_active_service_members().await.unwrap().unwrap().len(), 1);
+    assert_eq!(room.active_service_members_count().unwrap_or_default(), 1);
 
     // And a second one joins too
     let service_member_2 =
@@ -2479,6 +2483,7 @@ async fn test_active_service_members() {
     assert_eq!(active_members.len(), 4);
     assert_eq!(room.service_members().unwrap().len(), 2);
     assert_eq!(room.update_active_service_members().await.unwrap().unwrap().len(), 2);
+    assert_eq!(room.active_service_members_count().unwrap_or_default(), 2);
 
     // And now the 2nd service member leaves the room
     let service_member_2_left = EventFactory::new()
@@ -2501,4 +2506,184 @@ async fn test_active_service_members() {
     assert_eq!(active_members.len(), 3);
     assert_eq!(room.service_members().unwrap().len(), 2);
     assert_eq!(room.update_active_service_members().await.unwrap().unwrap().len(), 1);
+    assert_eq!(room.active_service_members_count().unwrap_or_default(), 1);
+}
+
+#[async_test]
+async fn test_active_service_members_resets_when_member_counts_change() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+    let user_id = client.user_id().unwrap();
+    let service_member_id_1 = owned_user_id!("@service_1:localhost");
+    let service_member_id_2 = owned_user_id!("@service_2:localhost");
+
+    let room_id = room_id!("!room:localhost");
+    let service_members_event = EventFactory::new()
+        .room(room_id)
+        .sender(user_id)
+        .member_hints(BTreeSet::from_iter(vec![
+            service_member_id_1.clone(),
+            service_member_id_2.clone(),
+        ]))
+        .into_raw_sync_state();
+    let own_member_event =
+        EventFactory::new().room(room_id).member(user_id).display_name("Me").into_raw_sync_state();
+    let service_member_1 =
+        EventFactory::new().room(room_id).member(&service_member_id_1).into_raw_sync_state();
+    let service_member_2 =
+        EventFactory::new().room(room_id).member(&service_member_id_2).into_raw_sync_state();
+
+    // We start with just the room and our own member event, no service events
+    let room = server
+        .sync_room(
+            &client,
+            AnyRoomBuilder::Joined(
+                JoinedRoomBuilder::new(room_id)
+                    .add_state_event(own_member_event)
+                    .add_state_event(service_member_1)
+                    .add_state_event(service_member_2)
+                    .add_state_event(service_members_event),
+            ),
+        )
+        .await;
+
+    let active_members = room.members_no_sync(RoomMemberships::ACTIVE).await.unwrap();
+    assert_eq!(active_members.len(), 3);
+    assert_eq!(room.service_members().unwrap().len(), 2);
+
+    // We got some computed values after update_active_service_members
+    assert_eq!(room.update_active_service_members().await.unwrap().unwrap().len(), 2);
+    assert_eq!(room.active_service_members_count().unwrap(), 2);
+
+    // But then the member counts change
+    let room = server
+        .sync_room(
+            &client,
+            AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(32)),
+        )
+        .await;
+
+    // And the active service members should be reset to None
+    assert!(room.active_service_members_count().is_none());
+}
+
+#[async_test]
+async fn test_cached_active_service_members_resets_when_member_counts_change() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+    let user_id = client.user_id().unwrap();
+    let service_member_id_1 = owned_user_id!("@service_1:localhost");
+    let service_member_id_2 = owned_user_id!("@service_2:localhost");
+
+    let room_id = room_id!("!room:localhost");
+    let service_members_event = EventFactory::new()
+        .room(room_id)
+        .sender(user_id)
+        .member_hints(BTreeSet::from_iter(vec![
+            service_member_id_1.clone(),
+            service_member_id_2.clone(),
+        ]))
+        .into_raw_sync_state();
+    let own_member_event =
+        EventFactory::new().room(room_id).member(user_id).display_name("Me").into_raw_sync_state();
+    let service_member_1 =
+        EventFactory::new().room(room_id).member(&service_member_id_1).into_raw();
+    let service_member_2 =
+        EventFactory::new().room(room_id).member(&service_member_id_2).into_raw();
+
+    // We start with just the room and our own member event, no service events
+    let room = server
+        .sync_room(
+            &client,
+            AnyRoomBuilder::Joined(
+                JoinedRoomBuilder::new(room_id)
+                    .add_state_event(own_member_event)
+                    .add_state_event(service_member_1)
+                    .add_state_event(service_member_2)
+                    .add_state_event(service_members_event),
+            ),
+        )
+        .await;
+
+    let active_members = room.members_no_sync(RoomMemberships::ACTIVE).await.unwrap();
+    assert_eq!(active_members.len(), 3);
+    assert_eq!(room.service_members().unwrap().len(), 2);
+
+    // We got some computed values after update_active_service_members
+    assert_eq!(room.update_active_service_members().await.unwrap().unwrap().len(), 2);
+    assert_eq!(room.active_service_members_count().unwrap(), 2);
+
+    // But then the member counts change
+    let room = server
+        .sync_room(
+            &client,
+            AnyRoomBuilder::Joined(JoinedRoomBuilder::new(room_id).set_joined_members_count(32)),
+        )
+        .await;
+
+    // And the active service members should be reset to None
+    assert!(room.active_service_members_count().is_none());
+}
+
+#[async_test]
+async fn test_cached_active_service_members_updates_on_sync_members() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+    let user_id = client.user_id().unwrap();
+    let service_member_id_1 = owned_user_id!("@service_1:localhost");
+    let service_member_id_2 = owned_user_id!("@service_2:localhost");
+
+    let room_id = room_id!("!room:localhost");
+    let service_members_event = EventFactory::new()
+        .room(room_id)
+        .sender(user_id)
+        .member_hints(BTreeSet::from_iter(vec![
+            service_member_id_1.clone(),
+            service_member_id_2.clone(),
+        ]))
+        .into_raw_sync_state();
+    let own_member_event =
+        EventFactory::new().room(room_id).member(user_id).display_name("Me").into_raw_sync_state();
+    let service_member_1 = EventFactory::new()
+        .room(room_id)
+        .member(&service_member_id_1)
+        .into_raw::<RoomMemberEvent>();
+    let service_member_2 = EventFactory::new()
+        .room(room_id)
+        .member(&service_member_id_2)
+        .into_raw::<RoomMemberEvent>();
+
+    // We start with just the room and our own member event, no service events
+    let room = server
+        .sync_room(
+            &client,
+            AnyRoomBuilder::Joined(
+                JoinedRoomBuilder::new(room_id)
+                    .add_state_event(own_member_event)
+                    .add_state_event(service_members_event),
+            ),
+        )
+        .await;
+
+    let active_members = room.members_no_sync(RoomMemberships::ACTIVE).await.unwrap();
+    assert_eq!(active_members.len(), 1);
+    assert_eq!(room.service_members().unwrap().len(), 2);
+
+    // We don't have a computed value for active service members yet
+    assert!(room.active_service_members_count().is_none());
+
+    // But if we now sync the room members, the active service members should be
+    // updated
+    server
+        .mock_get_members()
+        .ok(vec![service_member_1, service_member_2])
+        .mock_once()
+        .mount()
+        .await;
+
+    room.sync_members().await.expect("sync_members");
+
+    // We got some computed values after sync_members
+    assert!(room.active_service_members_count().is_some());
+    assert_eq!(room.active_service_members_count().unwrap(), 2);
 }

--- a/crates/matrix-sdk/tests/integration/sync.rs
+++ b/crates/matrix-sdk/tests/integration/sync.rs
@@ -2420,7 +2420,7 @@ async fn test_active_service_members() {
     let active_members = room.members_no_sync(RoomMemberships::ACTIVE).await.unwrap();
     assert_eq!(active_members.len(), 1);
     assert_eq!(room.service_members().unwrap().len(), 2);
-    assert!(room.active_service_members().await.unwrap().unwrap().is_empty());
+    assert!(room.update_active_service_members().await.unwrap().unwrap().is_empty());
 
     // Now another user joined the room
     let human_user = EventFactory::new()
@@ -2440,7 +2440,7 @@ async fn test_active_service_members() {
     let active_members = room.members_no_sync(RoomMemberships::ACTIVE).await.unwrap();
     assert_eq!(active_members.len(), 2);
     assert_eq!(room.service_members().unwrap().len(), 2);
-    assert!(room.active_service_members().await.unwrap().unwrap().is_empty());
+    assert!(room.update_active_service_members().await.unwrap().unwrap().is_empty());
 
     // Now one of the service members in the member hints joined the room
     let service_member_1 =
@@ -2459,7 +2459,7 @@ async fn test_active_service_members() {
     let active_members = room.members_no_sync(RoomMemberships::ACTIVE).await.unwrap();
     assert_eq!(active_members.len(), 3);
     assert_eq!(room.service_members().unwrap().len(), 2);
-    assert_eq!(room.active_service_members().await.unwrap().unwrap().len(), 1);
+    assert_eq!(room.update_active_service_members().await.unwrap().unwrap().len(), 1);
 
     // And a second one joins too
     let service_member_2 =
@@ -2478,7 +2478,7 @@ async fn test_active_service_members() {
     let active_members = room.members_no_sync(RoomMemberships::ACTIVE).await.unwrap();
     assert_eq!(active_members.len(), 4);
     assert_eq!(room.service_members().unwrap().len(), 2);
-    assert_eq!(room.active_service_members().await.unwrap().unwrap().len(), 2);
+    assert_eq!(room.update_active_service_members().await.unwrap().unwrap().len(), 2);
 
     // And now the 2nd service member leaves the room
     let service_member_2_left = EventFactory::new()
@@ -2500,5 +2500,5 @@ async fn test_active_service_members() {
     let active_members = room.members_no_sync(RoomMemberships::ACTIVE).await.unwrap();
     assert_eq!(active_members.len(), 3);
     assert_eq!(room.service_members().unwrap().len(), 2);
-    assert_eq!(room.active_service_members().await.unwrap().unwrap().len(), 1);
+    assert_eq!(room.update_active_service_members().await.unwrap().unwrap().len(), 1);
 }


### PR DESCRIPTION
## Changes

- Add a new `RoomSummary::active_room_members` field that will be used as a cache.
- Rename `Room::active_service_members` to `Room::update_active_service_members`, which will compute new values for the cache.
- Also reset this cached value when the member counts change in sync responses.
- Rename `async fn Room::is_dm` to `Room::compute_is_dm` and also trigger `Room::update_active_service_members` to re-calculate the cache.
- Add a new synchronous `Room::is_dm` function that will use the cached `active_service_members` value or calculate an approximate value as a fallback.
- Then expose this `Room::compute_is_dm` and `Room::is_dm` in `RoomInfo`, `NotificationRoomInfo` and `SpaceRoom`.

## Motivation

For both the room list filtering and the `SpaceRoom` instances we can't rely on an accurate value computed in place, since those APIs are synchronous. The approximate value previously calculated could be wrong in several cases, so if we can compute a better one instead that should make the checks more accurate.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
