### PR TITLE
Store `SlidingSyncPositionMarkers` in `EventCacheStore`

### DIFF
--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -33,6 +33,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [**breaking**] Add functions for storing custom values in `EventCacheStore`.
+  ([#6541](https://github.com/matrix-org/matrix-rust-sdk/pull/6541))
 - Add `RoomMember::is_service_member` that automatically checks the room info and retrieves this info. 
   ([#6536](https://github.com/matrix-org/matrix-rust-sdk/pull/6536))
 - [**breaking**] Add `DmRoomDefinition` enum, allowing clients to specify what a DM 

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -237,6 +237,10 @@ pub trait EventCacheStoreIntegrationTests {
     /// Test multiple things related to distinguishing a thread linked chunk
     /// from a room linked chunk.
     async fn test_thread_vs_room_linked_chunk(&self);
+
+    /// Test that custom values can be stored, retrieved, and removed from the
+    /// store.
+    async fn test_custom_values(&self);
 }
 
 impl EventCacheStoreIntegrationTests for DynEventCacheStore {
@@ -2262,6 +2266,35 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert_eq!(observed_items.len(), 1);
         assert_eq!(observed_items[0].event_id(), thread1_ev.event_id());
     }
+
+    async fn test_custom_values(&self) {
+        let key = "key";
+        let value = Vec::from(b"value");
+
+        // Before the value is set, it cannot be retrieved
+        let retrieved = self.get_custom_value(key).await.expect("get custom value");
+        assert_eq!(retrieved, None);
+
+        // After the value is set, it can be retrieved
+        self.set_custom_value(key, value.clone()).await.expect("set custom value");
+        let retrieved = self.get_custom_value(key).await.expect("get custom value");
+        assert_matches!(retrieved, Some(bytes) => assert_eq!(bytes, value));
+
+        // After the value is set again, the new value can be retrieved but the original
+        // value cannot
+        let new_value = Vec::from(b"new-value");
+        self.set_custom_value(key, new_value.clone()).await.expect("set custom value");
+        let retrieved = self.get_custom_value(key).await.expect("get custom value");
+        assert_matches!(retrieved, Some(bytes) => {
+            assert_ne!(bytes, value);
+            assert_eq!(bytes, new_value);
+        });
+
+        // After the value is removed, it can no longer be retrieved
+        self.remove_custom_value(key).await.expect("remove custom value");
+        let retrieved = self.get_custom_value(key).await.expect("get custom value");
+        assert_eq!(retrieved, None);
+    }
 }
 
 /// Macro building to allow your `EventCacheStore` implementation to run the
@@ -2518,6 +2551,13 @@ macro_rules! event_cache_store_integration_tests {
                 let event_cache_store =
                     get_event_cache_store().await.unwrap().into_event_cache_store();
                 event_cache_store.test_thread_vs_room_linked_chunk().await;
+            }
+
+            #[async_test]
+            async fn test_custom_values() {
+                let event_cache_store =
+                    get_event_cache_store().await.unwrap().into_event_cache_store();
+                event_cache_store.test_custom_values().await;
             }
         }
     };

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -292,6 +292,18 @@ impl EventCacheStore for MemoryStore {
         Ok(())
     }
 
+    async fn get_custom_value(&self, _: &str) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(None)
+    }
+
+    async fn set_custom_value(&self, _: &str, _: Vec<u8>) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn remove_custom_value(&self, _: &str) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     async fn optimize(&self) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -52,6 +52,7 @@ pub struct MemoryStore {
 struct MemoryStoreInner {
     leases: HashMap<String, Lease>,
     events: RelationalLinkedChunk<OwnedEventId, Event, Gap>,
+    values: HashMap<String, Vec<u8>>,
 }
 
 impl Default for MemoryStore {
@@ -60,6 +61,7 @@ impl Default for MemoryStore {
             inner: Arc::new(StdRwLock::new(MemoryStoreInner {
                 leases: Default::default(),
                 events: RelationalLinkedChunk::new(),
+                values: Default::default(),
             })),
         }
     }
@@ -292,15 +294,17 @@ impl EventCacheStore for MemoryStore {
         Ok(())
     }
 
-    async fn get_custom_value(&self, _: &str) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(None)
+    async fn get_custom_value(&self, key: &str) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(self.inner.read().unwrap().values.get(key).cloned())
     }
 
-    async fn set_custom_value(&self, _: &str, _: Vec<u8>) -> Result<(), Self::Error> {
+    async fn set_custom_value(&self, key: &str, value: Vec<u8>) -> Result<(), Self::Error> {
+        self.inner.write().unwrap().values.insert(key.to_owned(), value);
         Ok(())
     }
 
-    async fn remove_custom_value(&self, _: &str) -> Result<(), Self::Error> {
+    async fn remove_custom_value(&self, key: &str) -> Result<(), Self::Error> {
+        self.inner.write().unwrap().values.remove(key);
         Ok(())
     }
 

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -176,6 +176,16 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// without causing an error.
     async fn save_event(&self, room_id: &RoomId, event: Event) -> Result<(), Self::Error>;
 
+    /// Get the value (as bytes) that is associated with the provided key from
+    /// the store.
+    async fn get_custom_value(&self, key: &str) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Store the provided key and associated value in the store.
+    async fn set_custom_value(&self, key: &str, value: Vec<u8>) -> Result<(), Self::Error>;
+
+    /// Remove the provided key and its associated value from the store.
+    async fn remove_custom_value(&self, key: &str) -> Result<(), Self::Error>;
+
     /// Perform database optimizations if any are available, i.e. vacuuming in
     /// SQLite.
     ///
@@ -292,6 +302,18 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
 
     async fn save_event(&self, room_id: &RoomId, event: Event) -> Result<(), Self::Error> {
         self.0.save_event(room_id, event).await.map_err(Into::into)
+    }
+
+    async fn get_custom_value(&self, key: &str) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.0.get_custom_value(key).await.map_err(Into::into)
+    }
+
+    async fn set_custom_value(&self, key: &str, value: Vec<u8>) -> Result<(), Self::Error> {
+        self.0.set_custom_value(key, value).await.map_err(Into::into)
+    }
+
+    async fn remove_custom_value(&self, key: &str) -> Result<(), Self::Error> {
+        self.0.remove_custom_value(key).await.map_err(Into::into)
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-common/CHANGELOG.md
+++ b/crates/matrix-sdk-common/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add function `MappedCrossProcessLockState::into_inner` for extracting the inner
+  value without regard for whether the lock is clean or dirty.
+  ([#6541](https://github.com/matrix-org/matrix-rust-sdk/pull/6541))
 - [**breaking**] Change to the stable identifiers for `m.history_not_shared`.
   We still support reading the unstable identifier.
   ([#6467](https://github.com/matrix-org/matrix-rust-sdk/pull/6467))

--- a/crates/matrix-sdk-common/src/cross_process_lock.rs
+++ b/crates/matrix-sdk-common/src/cross_process_lock.rs
@@ -591,6 +591,14 @@ impl<G> MappedCrossProcessLockState<G> {
             Self::Dirty(_) => None,
         }
     }
+
+    /// Map this value into the inner type, ignoring whether
+    /// it is clean or dirty.
+    pub fn into_inner(self) -> G {
+        match self {
+            Self::Clean(inner) | Self::Dirty(inner) => inner,
+        }
+    }
 }
 
 /// Represent an unsuccessful result of a lock attempt, either by

--- a/crates/matrix-sdk-indexeddb/CHANGELOG.md
+++ b/crates/matrix-sdk-indexeddb/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add implementations of `EventCacheStore` functions for storing custom values.
+  ([#6541](https://github.com/matrix-org/matrix-rust-sdk/pull/6541))
 - Add support in the implementation of `EventCacheStore` for
   having duplicate events in a room, where each duplicate is in a different
   `LinkedChunk`. This is useful, e.g., when an event is in a room and a

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -21,10 +21,10 @@ use thiserror::Error;
 
 /// The current version and keys used in the database.
 pub mod current {
-    use super::{Version, v4};
+    use super::{Version, v5};
 
-    pub const VERSION: Version = Version::V4;
-    pub use v4::keys;
+    pub const VERSION: Version = Version::V5;
+    pub use v5::keys;
 }
 
 /// Opens a connection to the IndexedDB database and takes care of upgrading it
@@ -60,6 +60,8 @@ pub enum Version {
     V3 = 3,
     /// Version 4 of the database, for details see [`v4`].
     V4 = 4,
+    /// Version 5 of the database, for details see [`v5`].
+    V5 = 5,
 }
 
 impl Version {
@@ -70,7 +72,8 @@ impl Version {
             Self::V1 => v1::upgrade(transaction).map(Some),
             Self::V2 => v2::upgrade(transaction).map(Some),
             Self::V3 => v3::upgrade(transaction).map(Some),
-            Self::V4 => Ok(None),
+            Self::V4 => v4::upgrade(transaction).map(Some),
+            Self::V5 => Ok(None),
         }
     }
 }
@@ -89,6 +92,7 @@ impl TryFrom<u32> for Version {
             2 => Ok(Version::V2),
             3 => Ok(Version::V3),
             4 => Ok(Version::V4),
+            5 => Ok(Version::V5),
             v => Err(UnknownVersionError(v)),
         }
     }
@@ -330,6 +334,43 @@ mod v4 {
         let events = transaction.object_store(keys::EVENTS)?;
         events.clear()?;
 
+        Ok(())
+    }
+
+    /// Upgrade database from `v4` to `v5`
+    pub fn upgrade(transaction: &Transaction<'_>) -> Result<Version, Error> {
+        v5::create_custom_values_object_store(transaction)?;
+        Ok(Version::V5)
+    }
+}
+
+pub mod v5 {
+    use indexed_db_futures::Build;
+
+    use super::*;
+
+    pub mod keys {
+        // Re-use all the same keys from [`v4`], and add another
+        // for the custom values object store.
+        pub use super::v4::keys::*;
+
+        pub const CUSTOM_VALUES: &str = "custom-values";
+        pub const CUSTOM_VALUES_KEY_PATH: &str = "id";
+    }
+
+    /// Create an object store for tracking custom values.
+    ///
+    /// * Primary Key - `id`
+    ///
+    /// Note that this object store expects binary data values - e.g.,
+    /// [`Vec<u8>`]. It is intended to hold any individual values that are
+    /// not appropriate for storing in other parts of the database.
+    pub fn create_custom_values_object_store(transaction: &Transaction<'_>) -> Result<(), Error> {
+        let _ = transaction
+            .db()
+            .create_object_store(keys::CUSTOM_VALUES)
+            .with_key_path(keys::CUSTOM_VALUES_KEY_PATH.into())
+            .build()?;
         Ok(())
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -608,15 +608,24 @@ impl EventCacheStore for IndexeddbEventCacheStore {
         Ok(())
     }
 
-    async fn get_custom_value(&self, _: &str) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(None)
+    async fn get_custom_value(&self, key: &str) -> Result<Option<Vec<u8>>, Self::Error> {
+        let transaction = self.transaction(&[keys::CUSTOM_VALUES], IdbTransactionMode::Readonly)?;
+        Ok(transaction.get_custom_value(key).await?.map(|v| v.value))
     }
 
-    async fn set_custom_value(&self, _: &str, _: Vec<u8>) -> Result<(), Self::Error> {
+    async fn set_custom_value(&self, key: &str, value: Vec<u8>) -> Result<(), Self::Error> {
+        let transaction =
+            self.transaction(&[keys::CUSTOM_VALUES], IdbTransactionMode::Readwrite)?;
+        transaction.put_custom_value(key, value).await?;
+        transaction.commit().await?;
         Ok(())
     }
 
-    async fn remove_custom_value(&self, _: &str) -> Result<(), Self::Error> {
+    async fn remove_custom_value(&self, key: &str) -> Result<(), Self::Error> {
+        let transaction =
+            self.transaction(&[keys::CUSTOM_VALUES], IdbTransactionMode::Readwrite)?;
+        transaction.delete_custom_value(key).await?;
+        transaction.commit().await?;
         Ok(())
     }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -608,6 +608,18 @@ impl EventCacheStore for IndexeddbEventCacheStore {
         Ok(())
     }
 
+    async fn get_custom_value(&self, _: &str) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(None)
+    }
+
+    async fn set_custom_value(&self, _: &str, _: Vec<u8>) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn remove_custom_value(&self, _: &str) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     async fn optimize(&self) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
@@ -41,7 +41,7 @@ use crate::{
             INDEXED_KEY_LOWER_EVENT_POSITION, INDEXED_KEY_UPPER_CHUNK_IDENTIFIER,
             INDEXED_KEY_UPPER_EVENT_INDEX, INDEXED_KEY_UPPER_EVENT_POSITION,
         },
-        types::{Chunk, Event, Gap, Lease, Position},
+        types::{Chunk, CustomValue, Event, Gap, Lease, Position},
     },
     serializer::{
         indexed_type::{
@@ -94,6 +94,9 @@ pub type IndexedEventContent = MaybeEncrypted;
 
 /// A (possibly) encrypted representation of a [`Gap`]
 pub type IndexedGapContent = MaybeEncrypted;
+
+/// A (possibly) encrypted representation of a [`CustomValue`]
+pub type IndexedCustomValueContent = MaybeEncrypted;
 
 /// Represents the [`LEASES`][1] object store.
 ///
@@ -657,5 +660,67 @@ impl<'a> IndexedPrefixKeyComponentBounds<'a, Gap, LinkedChunkId<'a>> for Indexed
         <Self as IndexedPrefixKeyComponentBounds<Chunk, _>>::upper_key_components_with_prefix(
             linked_chunk_id,
         )
+    }
+}
+
+/// Represents the [`CUSTOM_VALUES`][1] object store.
+///
+/// [1]: crate::event_cache_store::migrations::v5::create_custom_values_object_store
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IndexedCustomValue {
+    /// The primary key of the object store.
+    pub id: IndexedCustomValueIdKey,
+    /// The (possibly encrypted) content - i.e., a [`CustomValue`].
+    pub content: IndexedCustomValueContent,
+}
+
+impl Indexed for CustomValue {
+    type IndexedType = IndexedCustomValue;
+
+    const OBJECT_STORE: &'static str = keys::CUSTOM_VALUES;
+
+    type Error = CryptoStoreError;
+
+    fn to_indexed(
+        &self,
+        serializer: &SafeEncodeSerializer,
+    ) -> Result<Self::IndexedType, Self::Error> {
+        Ok(IndexedCustomValue {
+            id: <IndexedCustomValueIdKey as IndexedKey<CustomValue>>::encode(&self.key, serializer),
+            content: serializer.maybe_encrypt_value(self)?,
+        })
+    }
+
+    fn from_indexed(
+        indexed: Self::IndexedType,
+        serializer: &SafeEncodeSerializer,
+    ) -> Result<Self, Self::Error> {
+        serializer.maybe_decrypt_value(indexed.content)
+    }
+}
+
+/// The value associated with the [primary key](IndexedCustomValue::id) of the
+/// [`CUSTOM_VALUES`][1] object store, which is constructed from the value in
+/// [`CustomValue::key`]. This value may or may not be hashed depending on the
+/// provided [`IndexeddbSerializer`].
+///
+/// [1]: crate::event_cache_store::migrations::v1::create_custom_values_object_store
+pub type IndexedCustomValueIdKey = String;
+
+impl IndexedKey<CustomValue> for IndexedCustomValueIdKey {
+    type KeyComponents<'a> = &'a str;
+
+    fn encode(components: Self::KeyComponents<'_>, serializer: &SafeEncodeSerializer) -> Self {
+        serializer.encode_key_as_string(keys::CUSTOM_VALUES, components)
+    }
+}
+
+impl IndexedKeyComponentBounds<CustomValue> for IndexedCustomValueIdKey {
+    fn lower_key_components() -> Self::KeyComponents<'static> {
+        INDEXED_KEY_LOWER_STRING.as_str()
+    }
+
+    fn upper_key_components() -> Self::KeyComponents<'static> {
+        INDEXED_KEY_UPPER_STRING.as_str()
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -26,11 +26,12 @@ use crate::{
     error::AsyncErrorDeps,
     event_cache_store::{
         serializer::indexed_types::{
-            IndexedChunk, IndexedChunkIdKey, IndexedEvent, IndexedEventIdKey,
-            IndexedEventPositionKey, IndexedEventRelationKey, IndexedEventRoomKey, IndexedGapIdKey,
-            IndexedLease, IndexedLeaseIdKey, IndexedNextChunkIdKey,
+            IndexedChunk, IndexedChunkIdKey, IndexedCustomValue, IndexedCustomValueIdKey,
+            IndexedEvent, IndexedEventIdKey, IndexedEventPositionKey, IndexedEventRelationKey,
+            IndexedEventRoomKey, IndexedGapIdKey, IndexedLease, IndexedLeaseIdKey,
+            IndexedNextChunkIdKey,
         },
-        types::{Chunk, ChunkType, Event, Gap, Lease, Position},
+        types::{Chunk, ChunkType, CustomValue, Event, Gap, Lease, Position},
     },
     serializer::indexed_type::{
         IndexedTypeSerializer,
@@ -528,5 +529,31 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         linked_chunk_id: LinkedChunkId<'_>,
     ) -> Result<(), TransactionError> {
         self.delete_items_by_linked_chunk_id::<Gap, IndexedGapIdKey>(linked_chunk_id).await
+    }
+
+    /// Query IndexedDB for the custom value that matches the given key. If
+    /// more than one custom value is found, an error is returned.
+    pub async fn get_custom_value(
+        &self,
+        key: &str,
+    ) -> Result<Option<CustomValue>, TransactionError> {
+        self.get_item_by_key_components::<CustomValue, IndexedCustomValueIdKey>(key).await
+    }
+
+    /// Puts a custom value into IndexedDB. If a custom value with the same key
+    /// already exists, it will be overwritten. When the custom value is
+    /// successfully put, the function returns the intermediary type
+    /// [`IndexedCustomValue`] in case inspection is needed.
+    pub async fn put_custom_value(
+        &self,
+        key: &str,
+        value: Vec<u8>,
+    ) -> Result<IndexedCustomValue, TransactionError> {
+        self.put_item(&CustomValue { key: key.to_owned(), value }).await
+    }
+
+    /// Delete custom value that matches the given key
+    pub async fn delete_custom_value(&self, key: &str) -> Result<(), TransactionError> {
+        self.delete_item_by_key::<CustomValue, IndexedCustomValueIdKey>(key).await
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -232,3 +232,13 @@ pub struct Gap {
     #[serde(alias = "prev_token")]
     pub token: String,
 }
+
+/// An arbitrary key-value pair where the value is unstructured binary data
+/// which can be stored in IndexedDB.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CustomValue {
+    /// The key associated with [`Self::value`].
+    pub key: String,
+    /// The value associated with [`Self::key`].
+    pub value: Vec<u8>,
+}

--- a/crates/matrix-sdk-sqlite/CHANGELOG.md
+++ b/crates/matrix-sdk-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add implementations of `EventCacheStore` functions for storing custom values.
+  ([#6541](https://github.com/matrix-org/matrix-rust-sdk/pull/6541))
 - Implement `CryptoStore::get_pending_key_bundle_details_for_room` and
   `CryptoStore::get_all_rooms_pending_key_bundle`, and process
   `rooms_pending_key_bundle` field in `Changes`.

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -1447,6 +1447,18 @@ impl EventCacheStore for SqliteEventCacheStore {
             .await
     }
 
+    async fn get_custom_value(&self, _: &str) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(None)
+    }
+
+    async fn set_custom_value(&self, _: &str, _: Vec<u8>) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn remove_custom_value(&self, _: &str) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     async fn optimize(&self) -> Result<(), Self::Error> {
         Ok(self.vacuum().await?)
     }

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -1447,16 +1447,32 @@ impl EventCacheStore for SqliteEventCacheStore {
             .await
     }
 
-    async fn get_custom_value(&self, _: &str) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(None)
+    async fn get_custom_value(&self, key: &str) -> Result<Option<Vec<u8>>, Self::Error> {
+        let Some(serialized) = self.read().await?.get_kv(key).await? else {
+            return Ok(None);
+        };
+        let value = if let Some(cipher) = &self.store_cipher {
+            let encrypted = rmp_serde::from_slice(&serialized)?;
+            cipher.decrypt_value_data(encrypted)?
+        } else {
+            serialized
+        };
+        Ok(Some(value))
     }
 
-    async fn set_custom_value(&self, _: &str, _: Vec<u8>) -> Result<(), Self::Error> {
+    async fn set_custom_value(&self, key: &str, value: Vec<u8>) -> Result<(), Self::Error> {
+        let serialized = if let Some(cipher) = &self.store_cipher {
+            let encrypted = cipher.encrypt_value_data(value)?;
+            rmp_serde::to_vec_named(&encrypted)?
+        } else {
+            value
+        };
+        self.write().await?.set_kv(key, serialized).await?;
         Ok(())
     }
 
-    async fn remove_custom_value(&self, _: &str) -> Result<(), Self::Error> {
-        Ok(())
+    async fn remove_custom_value(&self, key: &str) -> Result<(), Self::Error> {
+        self.write().await?.clear_kv(key).await.map_err(Into::into)
     }
 
     async fn optimize(&self) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Store `SlidingSyncPositionMarkers` in `EventCacheStore` rather than `CryptoStore`, allowing
+  position markers to be stored even when end-to-end encryption is disabled.
+  ([#6541](https://github.com/matrix-org/matrix-rust-sdk/pull/6541))
 - Added `DmRoomDefinition` as a parameter of `ClientBuilder` so we can specify it when creating a Client. 
   Also added a `Room::is_dm` method and added some logic to use the new DM definitions in `Client::get_dm_rooms` 
   and when using message search. ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -1271,6 +1271,18 @@ mod tests {
             self.memory_store.save_event(room_id, event).await
         }
 
+        async fn get_custom_value(&self, key: &str) -> Result<Option<Vec<u8>>, Self::Error> {
+            self.memory_store.get_custom_value(key).await
+        }
+
+        async fn set_custom_value(&self, key: &str, value: Vec<u8>) -> Result<(), Self::Error> {
+            self.memory_store.set_custom_value(key, value).await
+        }
+
+        async fn remove_custom_value(&self, key: &str) -> Result<(), Self::Error> {
+            self.memory_store.remove_custom_value(key).await
+        }
+
         async fn optimize(&self) -> Result<(), Self::Error> {
             self.memory_store.optimize().await
         }

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -22,7 +22,6 @@ pub(super) fn format_storage_key_prefix(id: &str, user_id: &UserId) -> String {
 
 /// Be careful: as this is used as a storage key; changing it requires migrating
 /// data!
-#[cfg(feature = "e2e-encryption")]
 fn format_storage_key_for_sliding_sync(storage_key: &str) -> String {
     format!("{storage_key}::instance")
 }
@@ -46,26 +45,20 @@ async fn remove_cached_list(
 /// Store the `SlidingSync`'s state in the storage.
 pub(super) async fn store_sliding_sync_state(
     sliding_sync: &SlidingSync,
-    _position: &SlidingSyncPositionMarkers,
+    position: &SlidingSyncPositionMarkers,
 ) -> Result<()> {
     let storage_key = &sliding_sync.inner.storage_key;
 
     trace!(storage_key, "Saving a `SlidingSync` to the state store");
     let storage = sliding_sync.inner.client.state_store();
 
-    #[cfg(feature = "e2e-encryption")]
     {
-        let position = _position;
+        // We can ignore the lock state, as we are dealing with the store directly.
+        let event_cache_store =
+            sliding_sync.inner.client.event_cache_store().lock().await?.into_inner();
         let instance_storage_key = format_storage_key_for_sliding_sync(storage_key);
-
-        // FIXME (TERRIBLE HACK): we want to save `pos` in a cross-process safe manner,
-        // with both processes sharing the same database backend; that needs to
-        // go in the crypto process store at the moment, but should be fixed
-        // later on.
-        if let Some(olm_machine) = &*sliding_sync.inner.client.olm_machine().await {
-            let pos_blob = serde_json::to_vec(&FrozenSlidingSyncPos { pos: position.pos.clone() })?;
-            olm_machine.store().set_custom_value(&instance_storage_key, pos_blob).await?;
-        }
+        let pos_blob = serde_json::to_vec(&FrozenSlidingSyncPos { pos: position.pos.clone() })?;
+        event_cache_store.set_custom_value(&instance_storage_key, pos_blob).await?;
     }
 
     // Write every `SlidingSyncList` that's configured for caching into the store.
@@ -151,7 +144,6 @@ pub(super) struct RestoredFields {
 
 /// A sliding sync position marker that can be persisted or restored from a
 /// store.
-#[cfg(feature = "e2e-encryption")]
 #[derive(serde::Serialize, serde::Deserialize)]
 struct FrozenSlidingSyncPos {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -163,39 +155,38 @@ struct FrozenSlidingSyncPos {
 /// If one cache is obsolete (corrupted, and cannot be deserialized or
 /// anything), the entire `SlidingSync` cache is removed.
 pub(super) async fn restore_sliding_sync_state(
-    _client: &Client,
-    _storage_key: &str,
+    client: &Client,
+    storage_key: &str,
 ) -> Result<Option<RestoredFields>> {
-    #[cfg(not(feature = "e2e-encryption"))]
-    return Ok(Some(Default::default()));
+    let _timer = timer!(format!("loading sliding sync {storage_key} state from DB"));
+
+    let mut restored_fields = RestoredFields::default();
+
+    {
+        // We can ignore the lock state, as we are dealing with the store directly.
+        let event_cache_store = client.event_cache_store().lock().await?.into_inner();
+        let instance_storage_key = format_storage_key_for_sliding_sync(storage_key);
+        if let Ok(Some(blob)) = event_cache_store.get_custom_value(&instance_storage_key).await
+            && let Ok(frozen) = serde_json::from_slice::<FrozenSlidingSyncPos>(&blob)
+        {
+            trace!("Successfully read the `Sliding Sync` pos from the event cache store");
+            restored_fields.pos = frozen.pos;
+        }
+    }
 
     #[cfg(feature = "e2e-encryption")]
     {
-        let _timer = timer!(format!("loading sliding sync {_storage_key} state from DB"));
-
-        let mut restored_fields = RestoredFields::default();
-
-        if let Some(olm_machine) = &*_client.olm_machine().await {
+        if let Some(olm_machine) = &*client.olm_machine().await {
             match olm_machine.store().next_batch_token().await? {
                 Some(token) => {
                     restored_fields.to_device_token = Some(token);
                 }
                 None => trace!("Couldn't read the previous to-device token from the crypto store"),
             }
-
-            let instance_storage_key = format_storage_key_for_sliding_sync(_storage_key);
-
-            if let Ok(Some(blob)) =
-                olm_machine.store().get_custom_value(&instance_storage_key).await
-                && let Ok(frozen_pos) = serde_json::from_slice::<FrozenSlidingSyncPos>(&blob)
-            {
-                trace!("Successfully read the `Sliding Sync` pos from the crypto store cache");
-                restored_fields.pos = frozen_pos.pos;
-            }
         }
-
-        Ok(Some(restored_fields))
     }
+
+    Ok(Some(restored_fields))
 }
 
 #[cfg(test)]
@@ -204,11 +195,10 @@ mod tests {
 
     use matrix_sdk_test::async_test;
 
-    #[cfg(feature = "e2e-encryption")]
-    use super::format_storage_key_for_sliding_sync;
     use super::{
-        super::SlidingSyncList, format_storage_key_for_sliding_sync_list,
-        format_storage_key_prefix, restore_sliding_sync_state, store_sliding_sync_state,
+        super::SlidingSyncList, format_storage_key_for_sliding_sync,
+        format_storage_key_for_sliding_sync_list, format_storage_key_prefix,
+        restore_sliding_sync_state, store_sliding_sync_state,
     };
     use crate::{Result, test_utils::logged_in_client};
 


### PR DESCRIPTION
Currently, the `SlidingSyncPositionMarkers` are stored in the `CryptoStore`. This store was chosen, as the position markers needed to be accessible in a way that could be synchronized across processes - i.e., a store protected by a cross-process lock. 

Originally, the only store to provide this functionality was the `CryptoStore`, but this means that when end-to-end encryption is not enabled, there is no way to store the position markers. So, now that the `EventCacheStore` is protected by a cross-process lock and is always accessible, it is a more reasonable option.

## Changes
- Add functions to the `EventCacheStore` trait for getting, setting, and removing custom values
    - This mimics the `CryptoStore`, which makes this pull request simpler - but we could use more tailored functions for this behavior, if that is preferable.
- Implement the above functions for in-memory, SQLite, and IndexedDB implementations of `EventCacheStore`

---
Closes #6401.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
