### PR TITLE
perf: Parallelize creating stores to make session restoration faster

### DIFF
--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -133,7 +133,7 @@ impl SqliteCryptoStore {
         path: impl AsRef<Path>,
         passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {
-        Self::open_with_config(SqliteStoreConfig::new(path).passphrase(passphrase)).await
+        Self::open_with_config(&SqliteStoreConfig::new(path).passphrase(passphrase)).await
     }
 
     /// Open the SQLite-based crypto store at the given path using the given
@@ -142,17 +142,17 @@ impl SqliteCryptoStore {
         path: impl AsRef<Path>,
         key: Option<&[u8; 32]>,
     ) -> Result<Self, OpenStoreError> {
-        Self::open_with_config(SqliteStoreConfig::new(path).key(key)).await
+        Self::open_with_config(&SqliteStoreConfig::new(path).key(key)).await
     }
 
     /// Open the SQLite-based crypto store with the config open config.
-    pub async fn open_with_config(config: SqliteStoreConfig) -> Result<Self, OpenStoreError> {
+    pub async fn open_with_config(config: &SqliteStoreConfig) -> Result<Self, OpenStoreError> {
         fs::create_dir_all(&config.path).await.map_err(OpenStoreError::CreateDir)?;
 
         let pool = config.build_pool_of_connections(DATABASE_NAME)?;
 
-        let this = Self::open_with_pool(pool, config.secret).await?;
-        this.pool.get().await?.apply_runtime_config(config.runtime_config).await?;
+        let this = Self::open_with_pool(pool, config.secret.clone()).await?;
+        this.pool.get().await?.apply_runtime_config(config.runtime_config.clone()).await?;
 
         Ok(this)
     }
@@ -1873,7 +1873,7 @@ mod tests {
         let store_open_config =
             SqliteStoreConfig::new(TMP_DIR.path().join("test_pool_size")).pool_max_size(42);
 
-        let store = SqliteCryptoStore::open_with_config(store_open_config).await.unwrap();
+        let store = SqliteCryptoStore::open_with_config(&store_open_config).await.unwrap();
 
         assert_eq!(store.pool.status().max_size, 42);
     }
@@ -2280,7 +2280,7 @@ mod tests {
             .unwrap();
 
         // After we open the store, the data will be migrated
-        let store = SqliteCryptoStore::open_with_config(config).await.unwrap();
+        let store = SqliteCryptoStore::open_with_config(&config).await.unwrap();
 
         // and we should be able to read the secrets from the inbox
         let secrets =

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -104,7 +104,7 @@ impl SqliteEventCacheStore {
         path: impl AsRef<Path>,
         passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {
-        Self::open_with_config(SqliteStoreConfig::new(path).passphrase(passphrase)).await
+        Self::open_with_config(&SqliteStoreConfig::new(path).passphrase(passphrase)).await
     }
 
     /// Open the SQLite-based event cache store at the given path using the
@@ -113,12 +113,12 @@ impl SqliteEventCacheStore {
         path: impl AsRef<Path>,
         key: Option<&[u8; 32]>,
     ) -> Result<Self, OpenStoreError> {
-        Self::open_with_config(SqliteStoreConfig::new(path).key(key)).await
+        Self::open_with_config(&SqliteStoreConfig::new(path).key(key)).await
     }
 
     /// Open the SQLite-based event cache store with the config open config.
     #[instrument(skip(config), fields(path = ?config.path))]
-    pub async fn open_with_config(config: SqliteStoreConfig) -> Result<Self, OpenStoreError> {
+    pub async fn open_with_config(config: &SqliteStoreConfig) -> Result<Self, OpenStoreError> {
         debug!(?config);
 
         let _timer = timer!("open_with_config");
@@ -127,8 +127,8 @@ impl SqliteEventCacheStore {
 
         let pool = config.build_pool_of_connections(DATABASE_NAME)?;
 
-        let this = Self::open_with_pool(pool, config.secret).await?;
-        this.write().await?.apply_runtime_config(config.runtime_config).await?;
+        let this = Self::open_with_pool(pool, config.secret.clone()).await?;
+        this.write().await?.apply_runtime_config(config.runtime_config.clone()).await?;
 
         Ok(this)
     }
@@ -1696,7 +1696,7 @@ mod tests {
         let tmpdir_path = new_event_cache_store_workspace();
         let store_open_config = SqliteStoreConfig::new(tmpdir_path).pool_max_size(42);
 
-        let store = SqliteEventCacheStore::open_with_config(store_open_config).await.unwrap();
+        let store = SqliteEventCacheStore::open_with_config(&store_open_config).await.unwrap();
 
         assert_eq!(store.pool.status().max_size, 42);
     }

--- a/crates/matrix-sdk-sqlite/src/media_store.rs
+++ b/crates/matrix-sdk-sqlite/src/media_store.rs
@@ -96,7 +96,7 @@ impl SqliteMediaStore {
         path: impl AsRef<Path>,
         passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {
-        Self::open_with_config(SqliteStoreConfig::new(path).passphrase(passphrase)).await
+        Self::open_with_config(&SqliteStoreConfig::new(path).passphrase(passphrase)).await
     }
 
     /// Open the SQLite-based media store at the given path using the given
@@ -105,12 +105,12 @@ impl SqliteMediaStore {
         path: impl AsRef<Path>,
         key: Option<&[u8; 32]>,
     ) -> Result<Self, OpenStoreError> {
-        Self::open_with_config(SqliteStoreConfig::new(path).key(key)).await
+        Self::open_with_config(&SqliteStoreConfig::new(path).key(key)).await
     }
 
     /// Open the SQLite-based media store with the config open config.
     #[instrument(skip(config), fields(path = ?config.path))]
-    pub async fn open_with_config(config: SqliteStoreConfig) -> Result<Self, OpenStoreError> {
+    pub async fn open_with_config(config: &SqliteStoreConfig) -> Result<Self, OpenStoreError> {
         debug!(?config);
 
         let _timer = timer!("open_with_config");
@@ -119,8 +119,8 @@ impl SqliteMediaStore {
 
         let pool = config.build_pool_of_connections(DATABASE_NAME)?;
 
-        let this = Self::open_with_pool(pool, config.secret).await?;
-        this.write().await?.apply_runtime_config(config.runtime_config).await?;
+        let this = Self::open_with_pool(pool, config.secret.clone()).await?;
+        this.write().await?.apply_runtime_config(config.runtime_config.clone()).await?;
 
         Ok(this)
     }
@@ -722,7 +722,7 @@ mod tests {
         let tmpdir_path = new_media_store_workspace();
         let store_open_config = SqliteStoreConfig::new(tmpdir_path).pool_max_size(42);
 
-        let store = SqliteMediaStore::open_with_config(store_open_config).await.unwrap();
+        let store = SqliteMediaStore::open_with_config(&store_open_config).await.unwrap();
 
         assert_eq!(store.pool.status().max_size, 42);
     }

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -101,7 +101,7 @@ impl SqliteStateStore {
         path: impl AsRef<Path>,
         passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {
-        Self::open_with_config(SqliteStoreConfig::new(path).passphrase(passphrase)).await
+        Self::open_with_config(&SqliteStoreConfig::new(path).passphrase(passphrase)).await
     }
 
     /// Open the SQLite-based state store at the given path using the given
@@ -110,17 +110,17 @@ impl SqliteStateStore {
         path: impl AsRef<Path>,
         key: Option<&[u8; 32]>,
     ) -> Result<Self, OpenStoreError> {
-        Self::open_with_config(SqliteStoreConfig::new(path).key(key)).await
+        Self::open_with_config(&SqliteStoreConfig::new(path).key(key)).await
     }
 
     /// Open the SQLite-based state store with the config open config.
-    pub async fn open_with_config(config: SqliteStoreConfig) -> Result<Self, OpenStoreError> {
+    pub async fn open_with_config(config: &SqliteStoreConfig) -> Result<Self, OpenStoreError> {
         fs::create_dir_all(&config.path).await.map_err(OpenStoreError::CreateDir)?;
 
         let pool = config.build_pool_of_connections(DATABASE_NAME)?;
 
-        let this = Self::open_with_pool(pool, config.secret).await?;
-        this.pool.get().await?.apply_runtime_config(config.runtime_config).await?;
+        let this = Self::open_with_pool(pool, config.secret.clone()).await?;
+        this.pool.get().await?.apply_runtime_config(config.runtime_config.clone()).await?;
 
         Ok(this)
     }
@@ -2444,7 +2444,7 @@ mod encrypted_tests {
         let tmpdir_path = new_state_store_workspace();
         let store_open_config = SqliteStoreConfig::new(tmpdir_path).pool_max_size(42);
 
-        let store = SqliteStateStore::open_with_config(store_open_config).await.unwrap();
+        let store = SqliteStateStore::open_with_config(&store_open_config).await.unwrap();
 
         assert_eq!(store.pool.status().max_size, 42);
     }
@@ -2454,7 +2454,7 @@ mod encrypted_tests {
         let tmpdir_path = new_state_store_workspace();
         let store_open_config = SqliteStoreConfig::new(tmpdir_path).cache_size(1500);
 
-        let store = SqliteStateStore::open_with_config(store_open_config).await.unwrap();
+        let store = SqliteStateStore::open_with_config(&store_open_config).await.unwrap();
 
         let conn = store.pool.get().await.unwrap();
         let cache_size =
@@ -2471,7 +2471,7 @@ mod encrypted_tests {
         let tmpdir_path = new_state_store_workspace();
         let store_open_config = SqliteStoreConfig::new(tmpdir_path).journal_size_limit(1500);
 
-        let store = SqliteStateStore::open_with_config(store_open_config).await.unwrap();
+        let store = SqliteStateStore::open_with_config(&store_open_config).await.unwrap();
 
         let conn = store.pool.get().await.unwrap();
         let journal_size_limit = conn

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -23,6 +23,8 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::{collections::BTreeSet, fmt, sync::Arc};
 
+#[cfg(feature = "sqlite")]
+use futures_util::try_join;
 use homeserver_config::*;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::DecryptionSettings;
@@ -44,8 +46,6 @@ use thiserror::Error;
 #[cfg(feature = "experimental-search")]
 use tokio::sync::Mutex;
 use tokio::sync::OnceCell;
-#[cfg(feature = "sqlite")]
-use tokio::try_join;
 use tracing::{Span, debug, field::debug, instrument};
 
 use super::{Client, ClientInner};
@@ -691,7 +691,7 @@ async fn build_store_config(
     let store_config = match builder_config {
         #[cfg(feature = "sqlite")]
         BuilderStoreConfig::Sqlite { config, cache_path } => {
-            let caches_config = if let Some(ref cache_path) = cache_path {
+            let config_with_cache_path = if let Some(ref cache_path) = cache_path {
                 config.clone().path(cache_path)
             } else {
                 config.clone()
@@ -700,14 +700,14 @@ async fn build_store_config(
             #[cfg(feature = "e2e-encryption")]
             let (state_store, event_cache_store, media_store, crypto_store) = try_join!(
                 matrix_sdk_sqlite::SqliteStateStore::open_with_config(&config),
-                matrix_sdk_sqlite::SqliteEventCacheStore::open_with_config(&caches_config),
-                matrix_sdk_sqlite::SqliteMediaStore::open_with_config(&caches_config),
+                matrix_sdk_sqlite::SqliteEventCacheStore::open_with_config(&config_with_cache_path),
+                matrix_sdk_sqlite::SqliteMediaStore::open_with_config(&config_with_cache_path),
                 matrix_sdk_sqlite::SqliteCryptoStore::open_with_config(&config),
             )?;
             #[cfg(not(feature = "e2e-encryption"))]
             let (state_store, event_cache_store, media_store) = try_join!(
                 matrix_sdk_sqlite::SqliteStateStore::open_with_config(&config),
-                matrix_sdk_sqlite::SqliteEventCacheStore::open_with_config(&caches_config),
+                matrix_sdk_sqlite::SqliteEventCacheStore::open_with_config(&config_with_cache_path),
                 matrix_sdk_sqlite::SqliteMediaStore::open_with_config(&config),
             )?;
             let store_config = StoreConfig::new(cross_process_store_config.clone())

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -44,6 +44,8 @@ use thiserror::Error;
 #[cfg(feature = "experimental-search")]
 use tokio::sync::Mutex;
 use tokio::sync::OnceCell;
+#[cfg(feature = "sqlite")]
+use tokio::try_join;
 use tracing::{Span, debug, field::debug, instrument};
 
 use super::{Client, ClientInner};
@@ -689,33 +691,32 @@ async fn build_store_config(
     let store_config = match builder_config {
         #[cfg(feature = "sqlite")]
         BuilderStoreConfig::Sqlite { config, cache_path } => {
-            let store_config = StoreConfig::new(cross_process_store_config.clone())
-                .state_store(
-                    matrix_sdk_sqlite::SqliteStateStore::open_with_config(config.clone()).await?,
-                )
-                .event_cache_store({
-                    let mut config = config.clone();
-
-                    if let Some(ref cache_path) = cache_path {
-                        config = config.path(cache_path);
-                    }
-
-                    matrix_sdk_sqlite::SqliteEventCacheStore::open_with_config(config).await?
-                })
-                .media_store({
-                    let mut config = config.clone();
-
-                    if let Some(ref cache_path) = cache_path {
-                        config = config.path(cache_path);
-                    }
-
-                    matrix_sdk_sqlite::SqliteMediaStore::open_with_config(config).await?
-                });
+            let caches_config = if let Some(ref cache_path) = cache_path {
+                config.clone().path(cache_path)
+            } else {
+                config.clone()
+            };
 
             #[cfg(feature = "e2e-encryption")]
-            let store_config = store_config.crypto_store(
-                matrix_sdk_sqlite::SqliteCryptoStore::open_with_config(config).await?,
-            );
+            let (state_store, event_cache_store, media_store, crypto_store) = try_join!(
+                matrix_sdk_sqlite::SqliteStateStore::open_with_config(&config),
+                matrix_sdk_sqlite::SqliteEventCacheStore::open_with_config(&caches_config),
+                matrix_sdk_sqlite::SqliteMediaStore::open_with_config(&caches_config),
+                matrix_sdk_sqlite::SqliteCryptoStore::open_with_config(&config),
+            )?;
+            #[cfg(not(feature = "e2e-encryption"))]
+            let (state_store, event_cache_store, media_store) = try_join!(
+                matrix_sdk_sqlite::SqliteStateStore::open_with_config(&config),
+                matrix_sdk_sqlite::SqliteEventCacheStore::open_with_config(&caches_config),
+                matrix_sdk_sqlite::SqliteMediaStore::open_with_config(&config),
+            )?;
+            let store_config = StoreConfig::new(cross_process_store_config.clone())
+                .state_store(state_store)
+                .event_cache_store(event_cache_store)
+                .media_store(media_store);
+
+            #[cfg(feature = "e2e-encryption")]
+            let store_config = store_config.crypto_store(crypto_store);
 
             store_config
         }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -26,7 +26,7 @@ use std::{
 use eyeball::{SharedObservable, Subscriber};
 use eyeball_im::{Vector, VectorDiff};
 use futures_core::Stream;
-use futures_util::StreamExt;
+use futures_util::{StreamExt, join};
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::{
     DecryptionSettings, store::LockableCryptoStore, store::types::RoomPendingKeyBundleDetails,
@@ -472,19 +472,16 @@ impl ClientInner {
         #[cfg(feature = "e2e-encryption")]
         client.e2ee.initialize_tasks(&client);
 
-        let _ = client
-            .event_cache
-            .get_or_init(|| async {
-                EventCache::new(&client, client.base_client.event_cache_store().clone())
-            })
-            .await;
+        let init_event_cache = client.event_cache.get_or_init(|| async {
+            EventCache::new(&client, client.base_client.event_cache_store().clone())
+        });
 
-        let _ = client
-            .thread_subscription_catchup
-            .get_or_init(|| async {
+        let init_thread_subscription_catchup =
+            client.thread_subscription_catchup.get_or_init(|| async {
                 ThreadSubscriptionCatchup::new(Client { inner: client.clone() })
-            })
-            .await;
+            });
+
+        let _ = join!(init_event_cache, init_thread_subscription_catchup);
 
         client
     }


### PR DESCRIPTION
# Changes

- Parallelize creating stores for `Client` instances.
- Also try parallelizing `get_or_init` for `Client::event_cache` and `Client::thread_subscription_catchup`. This may not do much, since the intialization is actually sync unless there was already some value (maybe not worth it?).

---

Codspeed doesn't seem to return different results, but I could definitely see changes when tested in a real client:

```
# Without joins

09:53:50.618 org.matrix.rust.sdk     io.element.android.x.debug           D  matrix_sdk::client::builder: Starting to build the Client | crates/matrix-sdk/src/client/builder/mod.rs:560 | spans: build
09:53:51.659 org.matrix.rust.sdk     io.element.android.x.debug           D  elementx: Session restored successfully for sessionId: @jorgem:element.io | RustMatrixAuthenticationService.kt:112
~1.05s

09:54:29.128 org.matrix.rust.sdk     io.element.android.x.debug           D  matrix_sdk::client::builder: Starting to build the Client | crates/matrix-sdk/src/client/builder/mod.rs:560 | spans: build
09:54:30.278 org.matrix.rust.sdk     io.element.android.x.debug           D  elementx: Session restored successfully for sessionId: @jorgem:element.io | RustMatrixAuthenticationService.kt:112
~1.15s

09:55:02.873 org.matrix.rust.sdk     io.element.android.x.debug           D  matrix_sdk::client::builder: Starting to build the Client | crates/matrix-sdk/src/client/builder/mod.rs:560 | spans: build
09:55:04.119 org.matrix.rust.sdk     io.element.android.x.debug           D  elementx: Session restored successfully for sessionId: @jorgem:element.io | RustMatrixAuthenticationService.kt:112
~1.45s

09:58:59.290 org.matrix.rust.sdk     io.element.android.x.debug           D  matrix_sdk::client::builder: Starting to build the Client | crates/matrix-sdk/src/client/builder/mod.rs:560 | spans: build
09:59:00.641 org.matrix.rust.sdk     io.element.android.x.debug           D  elementx: Session restored successfully for sessionId: @jorgem:element.io | RustMatrixAuthenticationService.kt:112
~1.3s

------------------------

# With joins

09:52:46.243 org.matrix.rust.sdk     io.element.android.x.debug           D  matrix_sdk::client::builder: Starting to build the Client | crates/matrix-sdk/src/client/builder/mod.rs:562 | spans: build
09:52:46.913 org.matrix.rust.sdk     io.element.android.x.debug           D  elementx: Session restored successfully for sessionId: @jorgem:element.io | RustMatrixAuthenticationService.kt:112
~650ms


09:56:23.745 org.matrix.rust.sdk     io.element.android.x.debug           D  matrix_sdk::client::builder: Starting to build the Client | crates/matrix-sdk/src/client/builder/mod.rs:562 | spans: build
09:56:24.755 org.matrix.rust.sdk     io.element.android.x.debug           D  elementx: Session restored successfully for sessionId: @jorgem:element.io | RustMatrixAuthenticationService.kt:112
~1s


09:57:14.194 org.matrix.rust.sdk     io.element.android.x.debug           D  matrix_sdk::client::builder: Starting to build the Client | crates/matrix-sdk/src/client/builder/mod.rs:562 | spans: build
09:57:14.821 org.matrix.rust.sdk     io.element.android.x.debug           D  elementx: Session restored successfully for sessionId: @jorgem:element.io | RustMatrixAuthenticationService.kt:112
~630ms


09:57:53.431 org.matrix.rust.sdk     io.element.android.x.debug           D  matrix_sdk::client::builder: Starting to build the Client | crates/matrix-sdk/src/client/builder/mod.rs:562 | spans: build
09:57:54.058 org.matrix.rust.sdk     io.element.android.x.debug           D  elementx: Session restored successfully for sessionId: @jorgem:element.io | RustMatrixAuthenticationService.kt:112
~600ms
```

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
