### PR TITLE
fix(ffi): manually drop room if it's last in Arc

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -133,8 +133,10 @@ once_cell = "1.21.4"
 jvm-getter = "0.1.0"
 
 [dev-dependencies]
+matrix-sdk = { workspace = true, features = ["testing"] }
 similar-asserts.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -3281,4 +3281,51 @@ mod tests {
         assert_eq!(token.matrix_server_name, "example.com");
         assert_eq!(token.expires_in_seconds, 3_600);
     }
+
+    /// Dropping an FFI [`Client`] on a non-tokio thread must not panic.
+    ///
+    /// Regression test: `Client.inner` is wrapped in [`AsyncRuntimeDropped`]
+    /// precisely because dropping a sqlite-backed [`MatrixClient`] outside a
+    /// tokio runtime context causes `SyncWrapper<rusqlite::Connection>::drop`
+    /// to call `tokio::task::spawn_blocking`, which panics and triggers
+    /// SIGABRT. This test guards against accidentally removing that wrapper.
+    #[cfg(not(target_family = "wasm"))]
+    #[tokio::test]
+    async fn client_drop_on_non_tokio_thread_does_not_panic() {
+        use std::time::Duration;
+
+        use matrix_sdk::{Client, config::RequestConfig};
+        use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+
+        // SingleProcess lock avoids the session-delegate requirement in
+        // `Client::new`, keeping the test self-contained.
+        let sdk_client = Client::builder()
+            .homeserver_url("https://example.com")
+            .request_config(RequestConfig::new().disable_retry())
+            .sqlite_store(dir.path(), None)
+            .cross_process_store_config(CrossProcessLockConfig::SingleProcess)
+            .build()
+            .await
+            .unwrap();
+
+        // Allow background init tasks to complete; after this the only strong
+        // reference to `ClientInner` is the local `sdk_client` variable.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let ffi_client = super::Client::new(sdk_client.clone(), None, None).await.unwrap();
+
+        // Dropping `sdk_client` leaves `ffi_client` as the sole Arc holder of
+        // `ClientInner` — mirroring what happens when the last JS reference to
+        // a Client is garbage-collected on the Hermes JS thread.
+        drop(sdk_client);
+
+        // Simulate Hermes GC on the JS thread (a non-tokio thread).
+        // Without `AsyncRuntimeDropped` wrapping `Client.inner` this SIGABRT.
+        std::thread::spawn(move || drop(ffi_client))
+            .join()
+            .expect("Client::drop panicked on a non-tokio thread");
+    }
 }

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -98,13 +98,13 @@ impl From<RoomState> for Membership {
 
 #[derive(uniffi::Object)]
 pub struct Room {
-    pub(super) inner: SdkRoom,
+    pub(super) inner: AsyncRuntimeDropped<SdkRoom>,
     utd_hook_manager: Option<Arc<UtdHookManager>>,
 }
 
 impl Room {
     pub(crate) fn new(inner: SdkRoom, utd_hook_manager: Option<Arc<UtdHookManager>>) -> Self {
-        Room { inner, utd_hook_manager }
+        Room { inner: AsyncRuntimeDropped::new(inner), utd_hook_manager }
     }
 }
 
@@ -1979,5 +1979,53 @@ impl TryFrom<SdkRoomSendQueueUpdate> for RoomSendQueueUpdate {
                 Self::SentEvent { transaction_id: transaction_id.into(), event_id: event_id.into() }
             }
         })
+    }
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use std::time::Duration;
+
+    use matrix_sdk::{ruma::room_id, test_utils::mocks::MatrixMockServer};
+    use tempfile::tempdir;
+
+    use super::*;
+
+    /// Dropping an FFI [`Room`] on a non-tokio thread must not panic.
+    ///
+    /// Regression test: when `Room.inner` was `SdkRoom` (not wrapped in
+    /// [`AsyncRuntimeDropped`]), garbage-collection of an orphaned `Room` on
+    /// the Hermes JS thread caused `SyncWrapper<rusqlite::Connection>::drop`
+    /// to call `tokio::task::spawn_blocking` from a thread with no tokio
+    /// runtime context. Rust turns a panic inside `Drop` into SIGABRT.
+    ///
+    /// The fix wraps `inner` in [`AsyncRuntimeDropped`], which enters the
+    /// global tokio runtime context before running `SdkRoom`'s destructor.
+    #[tokio::test]
+    async fn room_drop_on_non_tokio_thread_does_not_panic() {
+        let server = MatrixMockServer::new().await;
+        let dir = tempdir().unwrap();
+
+        let client =
+            server.client_builder().on_builder(|b| b.sqlite_store(dir.path(), None)).build().await;
+
+        // Allow background init tasks to complete; after this the only strong
+        // reference to `ClientInner` is the local `client` variable.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let room_id = room_id!("!test:example.com");
+        let sdk_room = server.sync_joined_room(&client, room_id).await;
+        let ffi_room = Room::new(sdk_room, None);
+
+        // Dropping `client` makes `ffi_room` the sole Arc holder of
+        // `ClientInner`, mirroring the situation where the FFI client has
+        // already been released and GC finalises the last room JS object.
+        drop(client);
+
+        // Simulate Hermes GC on the JS thread (a non-tokio thread).
+        // Without the `AsyncRuntimeDropped` wrapper this causes a SIGABRT.
+        std::thread::spawn(move || drop(ffi_room))
+            .join()
+            .expect("Room::drop panicked on a non-tokio thread");
     }
 }

--- a/bindings/matrix-sdk-ffi/src/search.rs
+++ b/bindings/matrix-sdk-ffi/src/search.rs
@@ -54,7 +54,7 @@ impl Room {
     /// a time.
     pub fn search_messages(&self, query: String, num_results_per_batch: u32) -> RoomSearchIterator {
         RoomSearchIterator {
-            sdk_room: self.inner.clone(),
+            sdk_room: (*self.inner).clone(),
             inner: Mutex::new(self.inner.search_messages(query, num_results_per_batch as usize)),
         }
     }

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -55,7 +55,7 @@ impl WidgetDriver {
         };
 
         let capabilities_provider = CapabilitiesProviderWrap(capabilities_provider.into());
-        if let Err(()) = driver.run(room.inner.clone(), capabilities_provider).await {
+        if let Err(()) = driver.run((*room.inner).clone(), capabilities_provider).await {
             // TODO
         }
     }


### PR DESCRIPTION
The FFI Client.inner is already wrapped in AsyncRuntimeDropped because dropping a sqlite-backed MatrixClient outside a tokio runtime causes `SyncWrapper<rusqlite::Connection>::drop` to call `tokio::task::spawn_blocking`. Without runtime context that panics, and a panic inside Drop aborts the process (SIGABRT).

`Room.inner: SdkRoom` was not wrapped. An `SdkRoom` holds an `Arc<ClientInner>`. When the FFI Client had already been released and React Native's Hermes GC finalized the last JS reference to a Room on the JS thread (non-tokio), `Room::drop` →  `SdkRoom::drop` → last `Arc<ClientInner>::drop` → `sqlite` drop → `spawn_blocking` panic → SIGABRT.

This completes the pattern from #4168, with #2815 / #2821 being reference fixes for deadpool/sqlite drop-context root cause.

#### TL;DR
Element X (iOS/Android) and other Tauri-style consumers don't hit this because they keep a single long-lived Client for the app/session lifetime, so Room drops never release the last Arc<ClientInner>. React Native + Hermes hits it because the JS Client can be released while old Room JS references await GC on a non-tokio thread; when Hermes finalizes them, the drop chain reaches sqlite::Connection::drop → spawn_blocking outside any runtime → SIGABRT. 

The wrapper fixes that one corner case without affecting any other consumer.

`Timeline` FFI type **is the next strongest candidate**, will follow-up.


#### History of the Drop-on-non-tokio-thread problem                                                                                                                                                                                               
                                                                                                                                                                                                                                              
#####  2023 — original problem and first hack                                                                                                                                                                                                                                                                                                                                                                                                                                                    
- PR #2815 fix(ffi): don't leak Client instances — Benjamin Bouvier, Nov 3 2023 (commit ad5761bfb)                                                                                                                                          
- First documented FFI Drop crash. Quote: "the Client holds references to deadpool's pools, which require to be in a tokio Runtime because their Drop impl will use block_on. Now, we can't just drop the stores without breaking all the abstractions."                                                                                                                                                                                                                              
- Fix: hack Drop for Client that did RUNTIME.block_on(async move { self.inner = MatrixClient::builder()...build().await.unwrap() }) — i.e., replace the inner client with a dummy in-memory one inside a tokio context, so the original gets dropped under the runtime.
- PR #2821 ffi: Simplify Drop implementation for Client — Jonas Platte, Nov 6 2023 (commit e788a6b09)                                                                                                                                       
- Replaced Bouvier's swap-with-dummy hack with ManuallyDrop<MatrixClient> plus an explicit Drop impl that does let _guard = RUNTIME.enter(); ManuallyDrop::drop(&mut self.inner);.                                                        
- Comment changes from "deadpool's block_on" to "deadpool drops sqlite connections in the DB pool on tokio's blocking threadpool to avoid blocking async worker threads" — i.e., it's actually spawn_blocking (not block_on) that fails without runtime context.                                                                                                                                                                                                                    
- This is the canonical pattern still in use today.
                                                                                                                                                                                                                                              
#####  2024 — pattern proliferation, then helper                                                                                                                                                                                                                                              
- PR #4152 chore(room_preview): add RoomListItem::preview_room — Oct 25 2024 (commit 40f4fc138)                                                                                                                                             
- Same ManuallyDrop recipe copy-pasted into RoomList and RoomPreview because each holds its own Arc<ClientInner>.
- PR #4168 chore(ffi): introduce AsyncRuntimeDropped helper — Benjamin Bouvier, Oct 25 2024 (commit c08194aa4)                                                                                                                              
- Quote: "avoids proliferation of ManuallyDrop in the code base, by having a single type that's used for dropping under an async runtime."                                                                                                
- Three call sites converted: Client.inner, RoomList.inner, RoomPreview.inner.                                                                                                                                                            
- Room.inner was NOT converted — it remained a bare SdkRoom. (This is the gap our fix closes.)                                                                                                                                            
                                                                                                                                                                                                                                              
##### 2025 — wasm extension                                                                                                                                                                                                                                                                                                                                                                                                                                                        
- PR #5221 feat(wasm): Add Wasm version of AsyncRuntimeDropped — Jun 11 2025                                                                                                                                                                
- Made the helper a no-op on wasm targets (no tokio runtime there).
                                                                                                                                                                                                                                              
##### 2026 — this PR                                                                                                                                                                                                                                  
- manually-drop-room branch (commit b78d14a, today)                                                                                                                                                                                       
- Wraps Room.inner in AsyncRuntimeDropped<SdkRoom>, completing the pattern that #4168 left half-finished.
- Adds regression tests for both Client::drop and Room::drop on non-tokio threads to prevent any of these wrappers from being silently removed in future refactors.                                                                       
                                                                                                                                                                                                                                              
#### Why upstream didn't catch it                                                                                                                                                                                                                                                                                                                                                                                                                                                   
- Element X (iOS/Android) drops the FFI Client first; Room objects either die with it under the same tokio runtime or are dropped from a tokio task. The bug only surfaces when the FFI Client outlives no rooms or when a Room outlives the Client and is then dropped from a non-tokio thread.
- React Native's Hermes runs JS on a dedicated non-tokio thread. If a JS room reference is GC'd after its parent client has already been released — and the FFI Room is the last Arc<ClientInner> holder — the destructor runs on Hermes'   
  thread. SdkRoom → Arc<ClientInner> last-strong-drop → SyncWrapper<rusqlite::Connection>::drop → tokio::task::spawn_blocking from a non-tokio thread → panic in Drop → SIGABRT.                                                              
- This is the exact scenario Client.inner's wrapper has prevented since 2023; Room.inner only needed the same treatment.

-----

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [X] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
