### PR TITLE
Ensure all relevant `SaveLockedStateStore` functions are synchronized with `SaveLockedStateStore::save_changes`

### DIFF
--- a/crates/matrix-sdk-base/changelog.d/6547.fixed.md
+++ b/crates/matrix-sdk-base/changelog.d/6547.fixed.md
@@ -1,0 +1,3 @@
+Ensure any `SaveLockedStateStore` functions which may interfere with its
+implementation of `StateStore::save_changes` are synchronized using the
+underlying lock.

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -1540,6 +1540,22 @@ impl<T: StateStore> SaveLockedStateStore<T> {
             self.store.save_changes(changes).await.map_err(Into::into)
         }
     }
+
+    /// Provides a means of calling [`StateStore::remove_room`] when the caller
+    /// has already acquired the underlying [`Mutex`]. Returns an error if
+    /// the [`MutexGuard`] provided does not reference the underlying
+    /// [`Mutex`].
+    pub async fn remove_room_with_guard(
+        &self,
+        guard: &MutexGuard<'_, ()>,
+        room_id: &RoomId,
+    ) -> Result<(), StoreError> {
+        if !std::ptr::eq(MutexGuard::mutex(guard), self.lock()) {
+            Err(IncorrectMutexGuardError.into())
+        } else {
+            self.store.remove_room(room_id).await.map_err(Into::into)
+        }
+    }
 }
 
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
@@ -1710,6 +1726,7 @@ impl<T: StateStore> StateStore for SaveLockedStateStore<T> {
     }
 
     async fn remove_room(&self, room_id: &RoomId) -> Result<(), Self::Error> {
+        let _guard = self.lock.lock().await;
         self.store.remove_room(room_id).await
     }
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -2492,6 +2492,7 @@ mod tests {
         use gloo_timers::future::sleep;
         use matrix_sdk_common::executor::spawn;
         use matrix_sdk_test::async_test;
+        use ruma::room_id;
         use tokio::sync::Mutex;
         #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
         use tokio::time::sleep;
@@ -2508,7 +2509,7 @@ mod tests {
         statestore_integration_tests!();
 
         #[async_test]
-        async fn test_state_store_only_accepts_guard_for_underlying_mutex() {
+        async fn test_save_changes_only_accepts_guard_for_underlying_mutex() {
             let state_store = SaveLockedStateStore::new(MemoryStore::new());
             let state_changes = StateChanges::default();
             state_store
@@ -2519,6 +2520,22 @@ mod tests {
             let mutex = Mutex::new(());
             state_store
                 .save_changes_with_guard(&mutex.lock().await, &state_changes)
+                .await
+                .expect_err("state store does not accept guard for unknown mutex");
+        }
+
+        #[async_test]
+        async fn test_remove_room_only_accepts_guard_for_underlying_mutex() {
+            let state_store = SaveLockedStateStore::new(MemoryStore::new());
+            let room_id = room_id!("!room");
+            state_store
+                .remove_room_with_guard(&state_store.lock().lock().await, room_id)
+                .await
+                .expect("state store accepts guard for underlying mutex");
+
+            let mutex = Mutex::new(());
+            state_store
+                .remove_room_with_guard(&mutex.lock().await, room_id)
                 .await
                 .expect_err("state store does not accept guard for unknown mutex");
         }
@@ -2565,6 +2582,36 @@ mod tests {
             // completed and therefore release the save lock
             assert_matches!(future::select(lock_task, save_task).await, Either::Left((_, save_task)) => {
                 timeout(Duration::from_millis(100), save_task)
+                    .await
+                    .expect("task completes before timeout")
+                    .expect("task completes successfully")
+                    .expect("task saves changes");
+            });
+        }
+
+        #[async_test]
+        async fn test_state_store_waits_to_acquire_lock_before_removing_room() {
+            let state_store = SaveLockedStateStore::new(MemoryStore::new().into_state_store());
+
+            // Acquire lock and hold it for 5 seconds
+            let lock_task = spawn({
+                let state_store = state_store.clone();
+                async move {
+                    let lock = state_store.lock();
+                    let _guard = lock.lock().await;
+                    sleep(Duration::from_secs(5)).await;
+                }
+            });
+
+            // Try to remove room from the state store while the lock is held by another
+            // task
+            let remove_task =
+                spawn(async move { state_store.remove_room(room_id!("!room")).await });
+
+            // Ensure that the second task does not progress until the first task has
+            // completed and therefore release the save lock
+            assert_matches!(future::select(lock_task, remove_task).await, Either::Left((_, remove_task)) => {
+                timeout(Duration::from_millis(100), remove_task)
                     .await
                     .expect("task completes before timeout")
                     .expect("task completes successfully")


### PR DESCRIPTION
Since #6478, the `BaseStateStore` uses a `SaveLockedStateStore` to ensure that calls to the underlying `StateStore::save_changes` are synchronized. It likely makes sense, however, to synchronize calls to other `StateStore` functions which may interfere with `StateStore::save_changes`.

### Changes

- Update `SaveLockedStateStore::remove_room` so that it acquires the lock before issuing a call to the underlying store.
- Add a function, `SaveLockedStateStore::remove_room_with_guard` for cases where the lock has already been acquired and the caller would like to remove a room from the underlying store.

### Considerations

Below is a list of other `StateStore` functions which write to the database. It does not seem like any of these would interfere with `StateStore::save_changes`, but they are listed below for examination by the reviewer, in case I have overlooked something.

1. [`set_kv_data`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.set_kv_data)
2. [`remove_kv_data`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.remove_kv_data)
3. [`set_custom_value`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.set_custom_value)
4. [`remove_custom_value`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.remove_custom_value)
5. [`save_send_queue_request`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.save_send_queue_request)
6. [`update_send_queue_request`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.update_send_queue_request)
7. [`remove_send_queue_request`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.remove_send_queue_request)
8. [`update_send_queue_request_status`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.update_send_queue_request_status)
9. [`save_dependent_queued_request`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.save_dependent_queued_request)
10. [`mark_dependent_queued_requests_as_ready`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.mark_dependent_queued_requests_as_ready)
11. [`update_dependent_queued_request`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.update_dependent_queued_request)
12. [`remove_dependent_queued_request`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.remove_dependent_queued_request)
13. [`upsert_thread_subscription`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.upsert_thread_subscription)
14. [`remove_thread_subscription`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#tymethod.remove_thread_subscription)
15. [`set_custom_value_no_read`](https://docs.rs/matrix-sdk-base/latest/matrix_sdk_base/store/trait.StateStore.html#method.set_custom_value_no_read)

---
Closes #6546.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
