### PR TITLE
Hold state store lock while while processing sync response in `Client::sync_once`

### DIFF
--- a/bindings/matrix-sdk-base/changelog.d/6555.changed.md
+++ b/bindings/matrix-sdk-base/changelog.d/6555.changed.md
@@ -1,0 +1,3 @@
+`Client::sync_once` acquires the state store lock when processing a sync and
+response and holds it until processing has completed. This mimics the behavior
+of `SlidingSync::sync_once`.

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -594,6 +594,10 @@ impl BaseClient {
 
         let now = if enabled!(Level::INFO) { Some(Instant::now()) } else { None };
 
+        // Acquire the state store lock and hold on to it while processing
+        // the sync response below.
+        let state_store_guard = self.state_store_lock().lock().await;
+
         let user_id = self
             .session_meta()
             .expect("Sync shouldn't run without an authenticated user")
@@ -766,7 +770,7 @@ impl BaseClient {
         processors::changes::save_and_apply(
             context,
             &self.state_store,
-            &self.state_store_lock().lock().await,
+            &state_store_guard,
             &self.ignore_user_list_changes,
             Some(response.next_batch.clone()),
         )
@@ -784,12 +788,7 @@ impl BaseClient {
         .await;
 
         // Save the new display name updates if any.
-        processors::changes::save_only(
-            context,
-            &self.state_store,
-            &self.state_store_lock().lock().await,
-        )
-        .await?;
+        processors::changes::save_only(context, &self.state_store, &state_store_guard).await?;
 
         for (room_id, member_ids) in updated_members_in_room {
             if let Some(room) = self.get_room(&room_id) {
@@ -797,6 +796,9 @@ impl BaseClient {
                     room.room_member_updates_sender.send(RoomMembersUpdate::Partial(member_ids));
             }
         }
+
+        // Release the state store lock
+        drop(state_store_guard);
 
         if enabled!(Level::INFO) {
             info!("Processed a sync response in {:?}", now.map(|now| now.elapsed()));


### PR DESCRIPTION
This pull request ensures that `Client::sync_once` holds the state store lock while processing a sync response. This amounts to acquiring the lock for the duration of `BaseClient::receive_sync_response_with_requested_required_states`, which is responsible for processing the response.

Note that this mimics the behavior of `SlidingSync::sync_once`.

---
Closes #6548.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
