### PR TITLE
chore(github): Run some workflows on `features/**` and `release-**` branches

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -3,9 +3,9 @@ name: Bindings tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: ["main", "features/**", "release-**"]
   pull_request:
-    branches: [main]
+    branches: ["main", "features/**", "release-**"]
     types:
       - opened
       - reopened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: Rust tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: ["main", "features/**", "release-**"]
   pull_request:
-    branches: [main]
+    branches: ["main", "features/**", "release-**"]
 
 permissions: {}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,9 @@ name: Code Coverage
 
 on:
   push:
-    branches: [main]
+    branches: ["main", "features/**"]
   pull_request:
-    branches: [main]
+    branches: ["main", "features/**"]
 
 permissions: {}
 

--- a/.github/workflows/detect-long-path.yml
+++ b/.github/workflows/detect-long-path.yml
@@ -6,7 +6,7 @@ name: Detect long path among changed files
 on:
   workflow_dispatch:
   pull_request: # focus on the changed files in current PR
-    branches: [main]
+    branches: ["main", "features/**", "release-**"]
 
 permissions: {}
 

--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -3,9 +3,9 @@ name: Rust version
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: ["main", "features/**", "release-**"]
   pull_request:
-    branches: [main]
+    branches: ["main", "features/**", "release-**"]
 
 permissions: {}
 


### PR DESCRIPTION
This patch updates a couple of workflows to run on the `features/**` and the `release-**` branches. Note that for `coverage`, we purposely exclude `release-**` as it often breaks and don't want to break the release process.

---

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.