### PR TITLE
chore:  Avoid one clone and use better iterators

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -96,7 +96,7 @@ async fn test_votes_after_end_are_discarded() {
     // Alice votes but it's too late, her vote won't count
     timeline.send_poll_response(&ALICE, vec!["id_up"], &poll_id).await;
     let results = timeline.poll_state().await.results();
-    for (_, votes) in results.votes.iter() {
+    for votes in results.votes.values() {
         assert!(votes.is_empty());
     }
 }

--- a/crates/matrix-sdk/src/room/knock_requests.rs
+++ b/crates/matrix-sdk/src/room/knock_requests.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::slice;
+
 use js_int::UInt;
 use ruma::{EventId, OwnedEventId, OwnedMxcUri, OwnedUserId, RoomId};
 
@@ -56,7 +58,7 @@ impl KnockRequest {
     /// Marks the knock request as 'seen' so the client can ignore it in the
     /// future.
     pub async fn mark_as_seen(&self) -> Result<(), Error> {
-        self.room.mark_knock_requests_as_seen(&[self.member_info.user_id.to_owned()]).await?;
+        self.room.mark_knock_requests_as_seen(slice::from_ref(&self.member_info.user_id)).await?;
         Ok(())
     }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1815,7 +1815,7 @@ impl Room {
                 }
             }
         } else {
-            for (_, list) in content.iter_mut() {
+            for list in content.values_mut() {
                 list.retain(|room_id| *room_id != this_room_id);
             }
 


### PR DESCRIPTION
The first patch uses `slice::from_ref` to create a `&[T]` from a `&T`. In our case, it saves the cost of one clone.

The second patch uses `values()` instead of `iter()` and discard the keys.

---

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.
