### PR TITLE
refactor: Make `SpaceRoom` compute `is_dm` on demand

### DIFF
--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+## Refactor
+
+- [**breaking**] `SpaceRoomList::rooms` and `SpaceRoomList::subscribe_to_room_updates` are now asynchronous.
+  ([#6561](https://github.com/matrix-org/matrix-rust-sdk/pull/6561))
+
 ## [0.17.0] - 2026-05-08
 
 ### Bug Fixes

--- a/bindings/matrix-sdk-ffi/src/spaces.rs
+++ b/bindings/matrix-sdk-ffi/src/spaces.rs
@@ -252,16 +252,16 @@ impl SpaceRoomList {
     }
 
     /// Return the current list of rooms.
-    pub fn rooms(&self) -> Vec<SpaceRoom> {
-        self.inner.rooms().into_iter().map(Into::into).collect()
+    pub async fn rooms(&self) -> Vec<SpaceRoom> {
+        self.inner.rooms().await.into_iter().map(Into::into).collect()
     }
 
     /// Subscribes to room list updates.
-    pub fn subscribe_to_room_update(
+    pub async fn subscribe_to_room_update(
         &self,
         listener: Box<dyn SpaceRoomListEntriesListener>,
     ) -> Arc<TaskHandle> {
-        let (initial_values, mut stream) = self.inner.subscribe_to_room_updates();
+        let (initial_values, mut stream) = self.inner.subscribe_to_room_updates().await;
 
         listener.on_update(vec![SpaceListUpdate::Reset {
             values: initial_values.into_iter().map(Into::into).collect(),

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+- Add `Room::compute_joined_service_members` to compute the number of joined service members in a room. 
+  This is needed for calculating display names of `SpaceRoom`s with service members. 
+  ([#6561](https://github.com/matrix-org/matrix-rust-sdk/pull/6561))
+
 ## [0.17.0] - 2026-05-08
 
 ### Bug Fixes

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -586,6 +586,39 @@ impl Room {
         }
     }
 
+    /// Computes the joined service members in this room.
+    ///
+    /// This result is useful for computing a room's display name, i.e.
+    #[instrument(skip_all, fields(room_id = ?self.room_id))]
+    pub async fn compute_joined_service_members(&self) -> StoreResult<Option<Vec<RoomMember>>> {
+        if !self.are_members_synced() {
+            trace!("Tried to compute joined service members in a room that is not synced");
+            return Ok(None);
+        }
+        if let Some(service_member_ids) = self.service_members() {
+            let mut ret = vec![];
+            for user_id in service_member_ids.iter() {
+                if let Some(member) = self.get_member(user_id).await.unwrap()
+                    && matches!(member.membership(), MembershipState::Join)
+                {
+                    trace!("Found a joined service member ({})", user_id);
+                    ret.push(member);
+                } else {
+                    trace!("Did not find a joined service member ({})", user_id);
+                }
+            }
+            trace!(
+                "Computed joined service members ({}) for service member count {}",
+                ret.len(),
+                service_member_ids.len()
+            );
+            Ok(Some(ret))
+        } else {
+            trace!("Tried to compute joined service members in a room that has no service members",);
+            Ok(None)
+        }
+    }
+
     /// Returns a cached value containing the active (joined/invited) service
     /// member count, if known.
     pub fn active_service_members_count(&self) -> Option<u64> {

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Refactor
+
+- [**breaking**] `SpaceRoom::new_from_known`  and `SpaceRoom::new_from_summary` are now asynchronous so we can 
+  properly check if they are DMs on demand instead of trusting the pre-computed value. Some other related functions 
+  are now `async` too. ([#6561](https://github.com/matrix-org/matrix-rust-sdk/pull/6561))
+
 ## [0.17.0] - 2026-05-08
 
 ### Bug Fixes

--- a/crates/matrix-sdk-ui/src/spaces/leave.rs
+++ b/crates/matrix-sdk-ui/src/spaces/leave.rs
@@ -102,7 +102,7 @@ impl LeaveSpaceHandle {
             let is_last_owner = joined_owner_ids == [room.own_user_id()];
 
             rooms.push(LeaveSpaceRoom {
-                space_room: SpaceRoom::new_from_known(&room, 0),
+                space_room: SpaceRoom::new_from_known(&room, 0).await,
                 is_last_owner,
                 are_creators_privileged,
             });

--- a/crates/matrix-sdk-ui/src/spaces/mod.rs
+++ b/crates/matrix-sdk-ui/src/spaces/mod.rs
@@ -134,7 +134,7 @@ struct SpaceState {
 ///     .await;
 ///
 /// // Which can be used to retrieve information about the children rooms
-/// let children = room_list.rooms();
+/// let children = room_list.rooms().await;
 /// # anyhow::Ok(()) };
 /// ```
 pub struct SpaceService {

--- a/crates/matrix-sdk-ui/src/spaces/mod.rs
+++ b/crates/matrix-sdk-ui/src/spaces/mod.rs
@@ -30,7 +30,7 @@
 use std::{cmp::Ordering, collections::HashMap, sync::Arc};
 
 use eyeball_im::{ObservableVector, VectorSubscriberBatchedStream};
-use futures_util::pin_mut;
+use futures_util::{future::join_all, pin_mut};
 use imbl::Vector;
 use itertools::Itertools;
 use matrix_sdk::{
@@ -317,8 +317,9 @@ impl SpaceService {
                 && power_levels.user_can_send_state(user_id, StateEventType::SpaceChild)
             {
                 let room_id = room.room_id();
-                editable_spaces
-                    .push(SpaceRoom::new_from_known(room, graph.children_of(room_id).len() as u64).await);
+                editable_spaces.push(
+                    SpaceRoom::new_from_known(room, graph.children_of(room_id).len() as u64).await,
+                );
             }
         }
 
@@ -339,17 +340,10 @@ impl SpaceService {
             .into_iter()
             .filter_map(|parent_id| self.client.get_room(parent_id));
 
-        Self::space_rooms_from_known_rooms(rooms, graph).await
-    }
-
-    async fn space_rooms_from_known_rooms(iter: impl Iterator<Item = Room>, graph: &SpaceGraph) -> Vec<SpaceRoom> {
-        let mut result = Vec::new();
-
-        for room in iter {
-            result.push(SpaceRoom::new_from_known(&room, graph.children_of(room.room_id()).len() as u64).await);
-        }
-
-        result
+        join_all(rooms.map(|room| async move {
+            SpaceRoom::new_from_known(&room, graph.children_of(room.room_id()).len() as u64).await
+        }))
+        .await
     }
 
     /// Returns the corresponding `SpaceRoom` for the given room ID, or `None`
@@ -360,7 +354,10 @@ impl SpaceService {
         if graph.has_node(room_id)
             && let Some(room) = self.client.get_room(room_id)
         {
-            Some(SpaceRoom::new_from_known(&room, graph.children_of(room.room_id()).len() as u64).await)
+            Some(
+                SpaceRoom::new_from_known(&room, graph.children_of(room.room_id()).len() as u64)
+                    .await,
+            )
         } else {
             None
         }
@@ -594,11 +591,15 @@ impl SpaceService {
         let mut top_level_spaces = Vec::new();
 
         for room in &top_level_space_rooms {
-            top_level_spaces.push(SpaceRoom::new_from_known(room, graph.children_of(room.room_id()).len() as u64).await);
+            top_level_spaces.push(
+                SpaceRoom::new_from_known(room, graph.children_of(room.room_id()).len() as u64)
+                    .await,
+            );
         }
 
         let space_filters =
-            Self::build_space_filters(client, &graph, top_level_space_rooms, space_child_states).await;
+            Self::build_space_filters(client, &graph, top_level_space_rooms, space_child_states)
+                .await;
 
         (top_level_spaces, space_filters, graph)
     }
@@ -631,8 +632,22 @@ impl SpaceService {
                 descendants: children.clone(),
             });
 
+            let children_rooms = join_all(
+                children
+                    .iter()
+                    .filter_map(|child| client.get_room(child))
+                    .filter(|room| room.is_space())
+                    .map(|room| async move {
+                        SpaceRoom::new_from_known(
+                            &room,
+                            graph.children_of(room.room_id()).len() as u64,
+                        )
+                        .await
+                    }),
+            )
+            .await;
             filters.append(
-                &mut children_rooms(&client, &children, graph).await
+                &mut children_rooms
                     .into_iter()
                     .sorted_by(|a, b| {
                         let a_state = space_child_states.get(&a.room_id).cloned();
@@ -654,23 +669,6 @@ impl SpaceService {
 
         filters
     }
-}
-
-async fn children_rooms(client: &Client, children: &[OwnedRoomId], graph: &SpaceGraph) -> Vec<SpaceRoom> {
-    let mut result = Vec::new();
-    for child_room_id in children {
-        let Some(room) = client.get_room(child_room_id) else {
-            continue;
-        };
-
-        if !room.is_space() {
-            continue;
-        }
-
-        let space_room = SpaceRoom::new_from_known(&room, graph.children_of(room.room_id()).len() as u64).await;
-        result.push(space_room);
-    }
-    result
 }
 
 // MSC3230: lexicographically by `order` and then by room ID
@@ -859,12 +857,13 @@ mod tests {
 
         assert_eq!(
             initial_values,
-            vec![SpaceRoom::new_from_known(&client.get_room(first_space_id).unwrap(), 0)].into()
+            vec![SpaceRoom::new_from_known(&client.get_room(first_space_id).unwrap(), 0).await]
+                .into()
         );
 
         assert_eq!(
             space_service.top_level_joined_spaces().await,
-            vec![SpaceRoom::new_from_known(&client.get_room(first_space_id).unwrap(), 0)]
+            vec![SpaceRoom::new_from_known(&client.get_room(first_space_id).unwrap(), 0).await]
         );
 
         // And the stream is still pending as the initial values were
@@ -893,8 +892,8 @@ mod tests {
         assert_eq!(
             space_service.top_level_joined_spaces().await,
             vec![
-                SpaceRoom::new_from_known(&client.get_room(first_space_id).unwrap(), 0),
-                SpaceRoom::new_from_known(&client.get_room(second_space_id).unwrap(), 1)
+                SpaceRoom::new_from_known(&client.get_room(first_space_id).unwrap(), 0).await,
+                SpaceRoom::new_from_known(&client.get_room(second_space_id).unwrap(), 1).await
             ]
         );
 
@@ -904,8 +903,10 @@ mod tests {
                 VectorDiff::Clear,
                 VectorDiff::Append {
                     values: vec![
-                        SpaceRoom::new_from_known(&client.get_room(first_space_id).unwrap(), 0),
+                        SpaceRoom::new_from_known(&client.get_room(first_space_id).unwrap(), 0)
+                            .await,
                         SpaceRoom::new_from_known(&client.get_room(second_space_id).unwrap(), 1)
+                            .await
                     ]
                     .into()
                 },
@@ -920,10 +921,10 @@ mod tests {
             vec![
                 VectorDiff::Clear,
                 VectorDiff::Append {
-                    values: vec![SpaceRoom::new_from_known(
-                        &client.get_room(first_space_id).unwrap(),
-                        0
-                    )]
+                    values: vec![
+                        SpaceRoom::new_from_known(&client.get_room(first_space_id).unwrap(), 0)
+                            .await
+                    ]
                     .into()
                 },
             ]
@@ -942,7 +943,7 @@ mod tests {
         assert_pending!(joined_spaces_subscriber);
         assert_eq!(
             space_service.top_level_joined_spaces().await,
-            vec![SpaceRoom::new_from_known(&client.get_room(first_space_id).unwrap(), 0)]
+            vec![SpaceRoom::new_from_known(&client.get_room(first_space_id).unwrap(), 0).await]
         );
     }
 
@@ -1083,10 +1084,10 @@ mod tests {
         assert_eq!(
             space_service.top_level_joined_spaces().await,
             vec![
-                SpaceRoom::new_from_known(&client.get_room(room_id!("!1:a.b")).unwrap(), 0),
-                SpaceRoom::new_from_known(&client.get_room(room_id!("!2:a.b")).unwrap(), 0),
-                SpaceRoom::new_from_known(&client.get_room(room_id!("!3:a.b")).unwrap(), 0),
-                SpaceRoom::new_from_known(&client.get_room(room_id!("!4:a.b")).unwrap(), 0),
+                SpaceRoom::new_from_known(&client.get_room(room_id!("!1:a.b")).unwrap(), 0).await,
+                SpaceRoom::new_from_known(&client.get_room(room_id!("!2:a.b")).unwrap(), 0).await,
+                SpaceRoom::new_from_known(&client.get_room(room_id!("!3:a.b")).unwrap(), 0).await,
+                SpaceRoom::new_from_known(&client.get_room(room_id!("!4:a.b")).unwrap(), 0).await,
             ]
         );
     }
@@ -1245,7 +1246,7 @@ mod tests {
         let found = space_service.get_space_room(space_id).await;
         assert!(found.is_some());
 
-        let expected = SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 0);
+        let expected = SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 0).await;
         assert_eq!(found.unwrap(), expected);
     }
 
@@ -1645,12 +1646,12 @@ mod tests {
 
         assert_eq!(
             initial_values,
-            vec![SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 0)].into()
+            vec![SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 0).await].into()
         );
 
         assert_eq!(
             space_service.top_level_joined_spaces().await,
-            vec![SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 0)]
+            vec![SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 0).await]
         );
 
         // Two children are added.
@@ -1674,15 +1675,17 @@ mod tests {
         // And expect the list to update.
         assert_eq!(
             space_service.top_level_joined_spaces().await,
-            vec![SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 2)]
+            vec![SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 2).await]
         );
         assert_next_eq!(
             joined_spaces_subscriber,
             vec![
                 VectorDiff::Clear,
                 VectorDiff::Append {
-                    values: vec![SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 2)]
-                        .into()
+                    values: vec![
+                        SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 2).await
+                    ]
+                    .into()
                 },
             ]
         );
@@ -1707,15 +1710,17 @@ mod tests {
         // And expect the list to update.
         assert_eq!(
             space_service.top_level_joined_spaces().await,
-            vec![SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 1)]
+            vec![SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 1).await]
         );
         assert_next_eq!(
             joined_spaces_subscriber,
             vec![
                 VectorDiff::Clear,
                 VectorDiff::Append {
-                    values: vec![SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 1)]
-                        .into()
+                    values: vec![
+                        SpaceRoom::new_from_known(&client.get_room(space_id).unwrap(), 1).await
+                    ]
+                    .into()
                 },
             ]
         );

--- a/crates/matrix-sdk-ui/src/spaces/mod.rs
+++ b/crates/matrix-sdk-ui/src/spaces/mod.rs
@@ -318,7 +318,7 @@ impl SpaceService {
             {
                 let room_id = room.room_id();
                 editable_spaces
-                    .push(SpaceRoom::new_from_known(room, graph.children_of(room_id).len() as u64));
+                    .push(SpaceRoom::new_from_known(room, graph.children_of(room_id).len() as u64).await);
             }
         }
 
@@ -334,14 +334,22 @@ impl SpaceService {
     pub async fn joined_parents_of_child(&self, child_id: &RoomId) -> Vec<SpaceRoom> {
         let graph = &self.space_state.lock().await.graph;
 
-        graph
+        let rooms = graph
             .parents_of(child_id)
             .into_iter()
-            .filter_map(|parent_id| self.client.get_room(parent_id))
-            .map(|room| {
-                SpaceRoom::new_from_known(&room, graph.children_of(room.room_id()).len() as u64)
-            })
-            .collect()
+            .filter_map(|parent_id| self.client.get_room(parent_id));
+
+        Self::space_rooms_from_known_rooms(rooms, graph).await
+    }
+
+    async fn space_rooms_from_known_rooms(iter: impl Iterator<Item = Room>, graph: &SpaceGraph) -> Vec<SpaceRoom> {
+        let mut result = Vec::new();
+
+        for room in iter {
+            result.push(SpaceRoom::new_from_known(&room, graph.children_of(room.room_id()).len() as u64).await);
+        }
+
+        result
     }
 
     /// Returns the corresponding `SpaceRoom` for the given room ID, or `None`
@@ -352,7 +360,7 @@ impl SpaceService {
         if graph.has_node(room_id)
             && let Some(room) = self.client.get_room(room_id)
         {
-            Some(SpaceRoom::new_from_known(&room, graph.children_of(room.room_id()).len() as u64))
+            Some(SpaceRoom::new_from_known(&room, graph.children_of(room.room_id()).len() as u64).await)
         } else {
             None
         }
@@ -583,15 +591,14 @@ impl SpaceService {
             })
             .collect::<Vec<_>>();
 
-        let top_level_spaces = top_level_space_rooms
-            .iter()
-            .map(|room| {
-                SpaceRoom::new_from_known(room, graph.children_of(room.room_id()).len() as u64)
-            })
-            .collect();
+        let mut top_level_spaces = Vec::new();
+
+        for room in &top_level_space_rooms {
+            top_level_spaces.push(SpaceRoom::new_from_known(room, graph.children_of(room.room_id()).len() as u64).await);
+        }
 
         let space_filters =
-            Self::build_space_filters(client, &graph, top_level_space_rooms, space_child_states);
+            Self::build_space_filters(client, &graph, top_level_space_rooms, space_child_states).await;
 
         (top_level_spaces, space_filters, graph)
     }
@@ -604,7 +611,7 @@ impl SpaceService {
     /// and second level ones so while the former are already sorted at this
     /// point the latter need to be manually taken care of here though the use
     /// of the collected `m.space.child` state event details.
-    fn build_space_filters(
+    async fn build_space_filters(
         client: &Client,
         graph: &SpaceGraph,
         top_level_space_rooms: Vec<&Room>,
@@ -619,22 +626,14 @@ impl SpaceService {
                 .collect::<Vec<_>>();
 
             filters.push(SpaceFilter {
-                space_room: SpaceRoom::new_from_known(top_level_space, children.len() as u64),
+                space_room: SpaceRoom::new_from_known(top_level_space, children.len() as u64).await,
                 level: 0,
                 descendants: children.clone(),
             });
 
             filters.append(
-                &mut children
-                    .iter()
-                    .filter_map(|id| client.get_room(id))
-                    .filter(|room| room.is_space())
-                    .map(|room| {
-                        SpaceRoom::new_from_known(
-                            &room,
-                            graph.children_of(room.room_id()).len() as u64,
-                        )
-                    })
+                &mut children_rooms(&client, &children, graph).await
+                    .into_iter()
                     .sorted_by(|a, b| {
                         let a_state = space_child_states.get(&a.room_id).cloned();
                         let b_state = space_child_states.get(&b.room_id).cloned();
@@ -655,6 +654,23 @@ impl SpaceService {
 
         filters
     }
+}
+
+async fn children_rooms(client: &Client, children: &[OwnedRoomId], graph: &SpaceGraph) -> Vec<SpaceRoom> {
+    let mut result = Vec::new();
+    for child_room_id in children {
+        let Some(room) = client.get_room(child_room_id) else {
+            continue;
+        };
+
+        if !room.is_space() {
+            continue;
+        }
+
+        let space_room = SpaceRoom::new_from_known(&room, graph.children_of(room.room_id()).len() as u64).await;
+        result.push(space_room);
+    }
+    result
 }
 
 // MSC3230: lexicographically by `order` and then by room ID

--- a/crates/matrix-sdk-ui/src/spaces/room.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room.rs
@@ -116,14 +116,14 @@ impl SpaceRoom {
     }
 
     /// Build a `SpaceRoom` from a room already known to this client.
-    pub(crate) fn new_from_known(known_room: &Room, children_count: u64) -> Self {
+    pub(crate) async fn new_from_known(known_room: &Room, children_count: u64) -> Self {
         let room_info = known_room.clone_info();
 
         let name = room_info.name().map(ToOwned::to_owned);
         let display_name = matrix_sdk_base::Room::compute_display_name_with_fields(
             name.clone(),
             room_info.canonical_alias(),
-            room_info.heroes().to_vec(),
+            known_room.heroes(),
             known_room.joined_members_count(),
         )
         .to_string();
@@ -145,10 +145,10 @@ impl SpaceRoom {
             is_direct: Some(known_room.direct_targets_length() != 0),
             children_count,
             state: Some(known_room.state()),
-            heroes: Some(room_info.heroes().to_vec()),
+            heroes: Some(known_room.heroes()),
             via: vec![],
             suggested: false,
-            is_dm: Some(known_room.is_dm()),
+            is_dm: known_room.compute_is_dm().await.ok(),
         }
     }
 

--- a/crates/matrix-sdk-ui/src/spaces/room.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room.rs
@@ -78,18 +78,25 @@ pub struct SpaceRoom {
 impl SpaceRoom {
     /// Build a `SpaceRoom` from a `RoomSummary` received from the /hierarchy
     /// endpoint.
-    pub(crate) fn new_from_summary(
+    pub(crate) async fn new_from_summary(
         summary: &RoomSummary,
         known_room: Option<Room>,
         children_count: u64,
         via: Vec<OwnedServerName>,
         suggested: bool,
     ) -> Self {
+        let num_joined_service_members = if let Some(known_room) = &known_room {
+            num_joined_service_members_or_default(known_room).await
+        } else {
+            0
+        };
+
+        let num_joined_members: u64 = summary.num_joined_members.into();
         let display_name = matrix_sdk_base::Room::compute_display_name_with_fields(
             summary.name.clone(),
             summary.canonical_alias.as_deref(),
             known_room.as_ref().map(|r| r.heroes().to_vec()).unwrap_or_default(),
-            summary.num_joined_members.into(),
+            num_joined_members - num_joined_service_members,
         )
         .to_string();
 
@@ -120,11 +127,13 @@ impl SpaceRoom {
         let room_info = known_room.clone_info();
 
         let name = room_info.name().map(ToOwned::to_owned);
+        let joined_service_members_count = num_joined_service_members_or_default(known_room).await;
+
         let display_name = matrix_sdk_base::Room::compute_display_name_with_fields(
             name.clone(),
             room_info.canonical_alias(),
             known_room.heroes(),
-            known_room.joined_members_count(),
+            known_room.joined_members_count() - joined_service_members_count,
         )
         .to_string();
 
@@ -193,6 +202,15 @@ impl From<&HierarchySpaceChildEvent> for SpaceRoomChildState {
             order: event.content.order.clone(),
             origin_server_ts: event.origin_server_ts,
         }
+    }
+}
+
+async fn num_joined_service_members_or_default(room: &Room) -> u64 {
+    match room.compute_joined_service_members().await {
+        Ok(Some(service_members)) => service_members.len() as u64,
+        // If we can't compute the joined service members count, assume all of them joined
+        // the room
+        _ => room.service_members().map(|members| members.len() as u64).unwrap_or_default(),
     }
 }
 

--- a/crates/matrix-sdk-ui/src/spaces/room_list.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room_list.rs
@@ -144,24 +144,32 @@ impl SpaceRoomList {
                                     continue;
                                 }
 
-                                let mut mutable_rooms = rooms.lock();
-
-                                updates.iter_all_room_ids().for_each(|updated_room_id| {
+                                let mut to_set = Vec::new();
+                                for updated_room_id in updates.iter_all_room_ids() {
+                                    let mutable_rooms = rooms.lock();
                                     if let Some((position, room)) = mutable_rooms
-                                        .clone()
                                         .iter()
                                         .find_position(|room| &room.room_id == updated_room_id)
-                                        && let Some(updated_room) = client.get_room(updated_room_id)
                                     {
-                                        mutable_rooms.set(
-                                            position,
-                                            SpaceRoom::new_from_known(
-                                                &updated_room,
-                                                room.children_count,
-                                            ),
-                                        );
+                                        to_set.push((position, room.clone()));
                                     }
-                                })
+                                    drop(mutable_rooms);
+                                }
+
+                                for (pos, room) in to_set {
+                                    let Some(updated_room) = client.get_room(&room.room_id) else {
+                                        continue
+                                    };
+                                    let space_room = SpaceRoom::new_from_known(
+                                        &updated_room,
+                                        room.children_count,
+                                    ).await;
+                                    let mut mutable_rooms = rooms.lock();
+                                    mutable_rooms.set(
+                                        pos,
+                                        space_room,
+                                    );
+                                }
                             }
                             Err(err) => {
                                 error!("error when listening to room updates: {err}");
@@ -191,14 +199,14 @@ impl SpaceRoomList {
                         while subscriber.next().await.is_some() {
                             if let Some(room) = client.get_room(&space_id) {
                                 space_observable
-                                    .set(Some(SpaceRoom::new_from_known(&room, children_count)));
+                                    .set(Some(SpaceRoom::new_from_known(&room, children_count).await));
                             }
                         }
                     }
                 })
                 .abort_on_drop();
 
-            (Some(SpaceRoom::new_from_known(&parent, children_count)), Some(space_update_handle))
+            (Some(SpaceRoom::new_from_known(&parent, children_count).await), Some(space_update_handle))
         } else {
             (None, None)
         };

--- a/crates/matrix-sdk-ui/src/spaces/room_list.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room_list.rs
@@ -70,7 +70,7 @@ pub enum SpaceRoomListPaginationState {
 ///     .await;
 ///
 /// // Start off with an empty and idle list
-/// room_list.rooms().is_empty();
+/// room_list.rooms().await.is_empty();
 ///
 /// assert_eq!(
 ///     room_list.pagination_state(),
@@ -82,7 +82,7 @@ pub enum SpaceRoomListPaginationState {
 ///     room_list.subscribe_to_pagination_state_updates();
 ///
 /// // And to room list updates
-/// let (_, room_stream) = room_list.subscribe_to_room_updates();
+/// let (_, room_stream) = room_list.subscribe_to_room_updates().await;
 ///
 /// // Run this in a background task so it doesn't block
 /// while let Some(pagination_state) = pagination_state_stream.next().await {
@@ -114,7 +114,7 @@ pub struct SpaceRoomList {
 
     pagination_state: SharedObservable<SpaceRoomListPaginationState>,
 
-    rooms: Arc<Mutex<ObservableVector<SpaceRoom>>>,
+    rooms: Arc<AsyncMutex<ObservableVector<SpaceRoom>>>,
 
     _space_update_handle: Option<BackgroundTaskHandle>,
 
@@ -124,7 +124,7 @@ pub struct SpaceRoomList {
 impl SpaceRoomList {
     /// Creates a new `SpaceRoomList` for the given space identifier.
     pub async fn new(client: Client, space_id: OwnedRoomId) -> Self {
-        let rooms = Arc::new(Mutex::new(ObservableVector::<SpaceRoom>::new()));
+        let rooms = Arc::new(AsyncMutex::new(ObservableVector::<SpaceRoom>::new()));
 
         let all_room_updates_receiver = client.subscribe_to_all_room_updates();
 
@@ -144,34 +144,24 @@ impl SpaceRoomList {
                                     continue;
                                 }
 
-                                // Given the MutexGuard used by `rooms`, we need to drop any
-                                // possible guard before calling `.await`, otherwise the compiler
-                                // will complain.
-                                let mut rooms_to_update_with_index = Vec::new();
-                                {
-                                    let mutable_rooms = rooms.lock();
-                                    for updated_room_id in updates.iter_all_room_ids() {
-                                        if let Some((position, room)) = mutable_rooms
-                                            .iter()
-                                            .find_position(|room| &room.room_id == updated_room_id)
-                                        {
-                                            rooms_to_update_with_index
-                                                .push((position, room.clone()));
-                                        }
-                                    }
-                                }
+                                let mut mutable_rooms = rooms.lock().await;
 
-                                for (idx, room) in rooms_to_update_with_index {
-                                    let Some(updated_room) = client.get_room(&room.room_id) else {
-                                        continue;
-                                    };
-                                    let space_room = SpaceRoom::new_from_known(
-                                        &updated_room,
-                                        room.children_count,
-                                    )
-                                    .await;
-                                    let mut mutable_rooms = rooms.lock();
-                                    mutable_rooms.set(idx, space_room);
+                                for updated_room_id in updates.iter_all_room_ids() {
+                                    if let Some((position, room)) = mutable_rooms
+                                        .clone()
+                                        .iter()
+                                        .find_position(|room| &room.room_id == updated_room_id)
+                                        && let Some(updated_room) = client.get_room(updated_room_id)
+                                    {
+                                        mutable_rooms.set(
+                                            position,
+                                            SpaceRoom::new_from_known(
+                                                &updated_room,
+                                                room.children_count,
+                                            )
+                                            .await,
+                                        );
+                                    }
                                 }
                             }
                             Err(err) => {
@@ -258,15 +248,15 @@ impl SpaceRoomList {
     }
 
     /// Return the current list of rooms.
-    pub fn rooms(&self) -> Vec<SpaceRoom> {
-        self.rooms.lock().iter().cloned().collect_vec()
+    pub async fn rooms(&self) -> Vec<SpaceRoom> {
+        self.rooms.lock().await.iter().cloned().collect_vec()
     }
 
     /// Subscribes to room list updates.
-    pub fn subscribe_to_room_updates(
+    pub async fn subscribe_to_room_updates(
         &self,
     ) -> (Vector<SpaceRoom>, VectorSubscriberBatchedStream<SpaceRoom>) {
-        self.rooms.lock().subscribe().into_values_and_batched_stream()
+        self.rooms.lock().await.subscribe().into_values_and_batched_stream()
     }
 
     /// Ask the list to retrieve the next page if the end hasn't been reached
@@ -340,10 +330,9 @@ impl SpaceRoomList {
                 }
 
                 let children_state = (*self.children_state.lock()).clone().unwrap_or_default();
+                let mut rooms = self.rooms.lock().await;
 
-                // Because of the `MutexGuard` used by `SpaceRoomList::rooms`, we need to
-                // perform all calls that involve `.await` before acquiring the lock.
-                let children_space_rooms = join_all(children.into_iter().map(|room| {
+                join_all(children.into_iter().map(|room| {
                     let children_state = children_state.clone();
                     async move {
                         let child_state = children_state.get(&room.summary.room_id);
@@ -361,13 +350,10 @@ impl SpaceRoomList {
                         .await
                     }
                 }))
-                .await;
-
-                let mut rooms = self.rooms.lock();
-                children_space_rooms
-                    .into_iter()
-                    .sorted_by(|a, b| Self::compare_rooms(a, b, &children_state))
-                    .for_each(|room| rooms.push_back(room));
+                .await
+                .into_iter()
+                .sorted_by(|a, b| Self::compare_rooms(a, b, &children_state))
+                .for_each(|room| rooms.push_back(room));
 
                 self.pagination_state.set(SpaceRoomListPaginationState::Idle {
                     end_reached: result.next_batch.is_none(),
@@ -395,7 +381,7 @@ impl SpaceRoomList {
         let mut pagination_token = self.token.lock().await;
         *pagination_token = None.into();
 
-        self.rooms.lock().clear();
+        self.rooms.lock().await.clear();
         self.children_state.lock().take();
 
         self.pagination_state.set(SpaceRoomListPaginationState::Idle { end_reached: false });
@@ -488,7 +474,7 @@ mod tests {
         );
 
         // without any rooms
-        assert_eq!(room_list.rooms(), vec![]);
+        assert_eq!(room_list.rooms().await, vec![]);
 
         // and with pending subscribers
 
@@ -496,7 +482,7 @@ mod tests {
         pin_mut!(pagination_state_subscriber);
         assert_pending!(pagination_state_subscriber);
 
-        let (_, rooms_subscriber) = room_list.subscribe_to_room_updates();
+        let (_, rooms_subscriber) = room_list.subscribe_to_room_updates().await;
         pin_mut!(rooms_subscriber);
         assert_pending!(rooms_subscriber);
 
@@ -579,14 +565,14 @@ mod tests {
         room_list.paginate().await.unwrap();
 
         // This space contains 2 rooms
-        assert_eq!(room_list.rooms().first().unwrap().room_id, child_room_id_1);
-        assert_eq!(room_list.rooms().last().unwrap().room_id, child_room_id_2);
+        assert_eq!(room_list.rooms().await.first().unwrap().room_id, child_room_id_1);
+        assert_eq!(room_list.rooms().await.last().unwrap().room_id, child_room_id_2);
 
         // and we don't know about either of them
-        assert_eq!(room_list.rooms().first().unwrap().state, None);
-        assert_eq!(room_list.rooms().last().unwrap().state, None);
+        assert_eq!(room_list.rooms().await.first().unwrap().state, None);
+        assert_eq!(room_list.rooms().await.last().unwrap().state, None);
 
-        let (_, rooms_subscriber) = room_list.subscribe_to_room_updates();
+        let (_, rooms_subscriber) = room_list.subscribe_to_room_updates().await;
         pin_mut!(rooms_subscriber);
         assert_pending!(rooms_subscriber);
 
@@ -595,21 +581,21 @@ mod tests {
 
         // Results in an update being pushed through
         assert_ready!(rooms_subscriber);
-        assert_eq!(room_list.rooms().first().unwrap().state, Some(RoomState::Joined));
-        assert_eq!(room_list.rooms().last().unwrap().state, None);
+        assert_eq!(room_list.rooms().await.first().unwrap().state, Some(RoomState::Joined));
+        assert_eq!(room_list.rooms().await.last().unwrap().state, None);
 
         // Same for the second one
         server.sync_room(&client, JoinedRoomBuilder::new(child_room_id_2)).await;
         assert_ready!(rooms_subscriber);
-        assert_eq!(room_list.rooms().first().unwrap().state, Some(RoomState::Joined));
-        assert_eq!(room_list.rooms().last().unwrap().state, Some(RoomState::Joined));
+        assert_eq!(room_list.rooms().await.first().unwrap().state, Some(RoomState::Joined));
+        assert_eq!(room_list.rooms().await.last().unwrap().state, Some(RoomState::Joined));
 
         // And when leaving them
         server.sync_room(&client, LeftRoomBuilder::new(child_room_id_1)).await;
         server.sync_room(&client, LeftRoomBuilder::new(child_room_id_2)).await;
         assert_ready!(rooms_subscriber);
-        assert_eq!(room_list.rooms().first().unwrap().state, Some(RoomState::Left));
-        assert_eq!(room_list.rooms().last().unwrap().state, Some(RoomState::Left));
+        assert_eq!(room_list.rooms().await.first().unwrap().state, Some(RoomState::Left));
+        assert_eq!(room_list.rooms().await.last().unwrap().state, Some(RoomState::Left));
     }
 
     #[async_test]
@@ -735,7 +721,7 @@ mod tests {
 
         let room_list = space_service.space_room_list(parent_space_id.to_owned()).await;
 
-        let (_, rooms_subscriber) = room_list.subscribe_to_room_updates();
+        let (_, rooms_subscriber) = room_list.subscribe_to_room_updates().await;
         pin_mut!(rooms_subscriber);
 
         // When retrieving the parent and children via /hierarchy
@@ -807,7 +793,7 @@ mod tests {
 
         let room_list = space_service.space_room_list(parent_space_id.to_owned()).await;
 
-        let (_, rooms_subscriber) = room_list.subscribe_to_room_updates();
+        let (_, rooms_subscriber) = room_list.subscribe_to_room_updates().await;
         pin_mut!(rooms_subscriber);
 
         // Mock a /hierarchy response where one child is suggested and the other is not.
@@ -1048,13 +1034,13 @@ mod tests {
         room_list.paginate().await.unwrap();
 
         // This space contains 1 room
-        assert_eq!(room_list.rooms().len(), 1);
+        assert_eq!(room_list.rooms().await.len(), 1);
 
         // Resetting the room list
         room_list.reset().await;
 
         // Clears the rooms and pagination token
-        assert_eq!(room_list.rooms().len(), 0);
+        assert_eq!(room_list.rooms().await.len(), 0);
         assert_matches!(
             room_list.pagination_state(),
             SpaceRoomListPaginationState::Idle { end_reached: false }
@@ -1062,7 +1048,7 @@ mod tests {
 
         // Allows paginating again
         room_list.paginate().await.unwrap();
-        assert_eq!(room_list.rooms().len(), 1);
+        assert_eq!(room_list.rooms().await.len(), 1);
     }
 
     fn make_space_room(

--- a/crates/matrix-sdk-ui/src/spaces/room_list.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room_list.rs
@@ -16,7 +16,7 @@ use std::{cmp::Ordering, collections::HashMap, sync::Arc};
 
 use eyeball::{ObservableWriteGuard, SharedObservable, Subscriber};
 use eyeball_im::{ObservableVector, VectorSubscriberBatchedStream};
-use futures_util::pin_mut;
+use futures_util::{future::join_all, pin_mut};
 use imbl::Vector;
 use itertools::Itertools;
 use matrix_sdk::{
@@ -144,31 +144,34 @@ impl SpaceRoomList {
                                     continue;
                                 }
 
-                                let mut to_set = Vec::new();
-                                for updated_room_id in updates.iter_all_room_ids() {
+                                // Given the MutexGuard used by `rooms`, we need to drop any
+                                // possible guard before calling `.await`, otherwise the compiler
+                                // will complain.
+                                let mut rooms_to_update_with_index = Vec::new();
+                                {
                                     let mutable_rooms = rooms.lock();
-                                    if let Some((position, room)) = mutable_rooms
-                                        .iter()
-                                        .find_position(|room| &room.room_id == updated_room_id)
-                                    {
-                                        to_set.push((position, room.clone()));
+                                    for updated_room_id in updates.iter_all_room_ids() {
+                                        if let Some((position, room)) = mutable_rooms
+                                            .iter()
+                                            .find_position(|room| &room.room_id == updated_room_id)
+                                        {
+                                            rooms_to_update_with_index
+                                                .push((position, room.clone()));
+                                        }
                                     }
-                                    drop(mutable_rooms);
                                 }
 
-                                for (pos, room) in to_set {
+                                for (idx, room) in rooms_to_update_with_index {
                                     let Some(updated_room) = client.get_room(&room.room_id) else {
-                                        continue
+                                        continue;
                                     };
                                     let space_room = SpaceRoom::new_from_known(
                                         &updated_room,
                                         room.children_count,
-                                    ).await;
+                                    )
+                                    .await;
                                     let mut mutable_rooms = rooms.lock();
-                                    mutable_rooms.set(
-                                        pos,
-                                        space_room,
-                                    );
+                                    mutable_rooms.set(idx, space_room);
                                 }
                             }
                             Err(err) => {
@@ -198,15 +201,19 @@ impl SpaceRoomList {
                     async move {
                         while subscriber.next().await.is_some() {
                             if let Some(room) = client.get_room(&space_id) {
-                                space_observable
-                                    .set(Some(SpaceRoom::new_from_known(&room, children_count).await));
+                                space_observable.set(Some(
+                                    SpaceRoom::new_from_known(&room, children_count).await,
+                                ));
                             }
                         }
                     }
                 })
                 .abort_on_drop();
 
-            (Some(SpaceRoom::new_from_known(&parent, children_count).await), Some(space_update_handle))
+            (
+                Some(SpaceRoom::new_from_known(&parent, children_count).await),
+                Some(space_update_handle),
+            )
         } else {
             (None, None)
         };
@@ -297,8 +304,6 @@ impl SpaceRoomList {
                     None => PaginationToken::HitEnd,
                 };
 
-                let mut rooms = self.rooms.lock();
-
                 // The space is part of the /hierarchy response. Partition the room array
                 // so we can use its details but also filter it out of the room list
                 let (space, children): (Vec<_>, Vec<_>) =
@@ -319,32 +324,33 @@ impl SpaceRoomList {
                     }
                     *self.children_state.lock() = Some(children_state);
 
-                    let mut space = self.space.write();
-                    if space.is_none() {
-                        ObservableWriteGuard::set(
-                            &mut space,
-                            Some(SpaceRoom::new_from_summary(
-                                &room.summary,
-                                self.client.get_room(&room.summary.room_id),
-                                room.children_state.len() as u64,
-                                vec![],
-                                false,
-                            )),
-                        );
+                    let space_is_none = self.space.read().is_none();
+                    if space_is_none {
+                        let space_room = SpaceRoom::new_from_summary(
+                            &room.summary,
+                            self.client.get_room(&room.summary.room_id),
+                            room.children_state.len() as u64,
+                            vec![],
+                            false,
+                        )
+                        .await;
+                        let mut space = self.space.write();
+                        ObservableWriteGuard::set(&mut space, Some(space_room));
                     }
                 }
 
                 let children_state = (*self.children_state.lock()).clone().unwrap_or_default();
 
-                children
-                    .iter()
-                    .map(|room| {
+                // Because of the `MutexGuard` used by `SpaceRoomList::rooms`, we need to
+                // perform all calls that involve `.await` before acquiring the lock.
+                let children_space_rooms = join_all(children.into_iter().map(|room| {
+                    let children_state = children_state.clone();
+                    async move {
                         let child_state = children_state.get(&room.summary.room_id);
                         let via =
                             child_state.map(|state| state.content.via.clone()).unwrap_or_default();
                         let suggested =
                             child_state.map(|state| state.content.suggested).unwrap_or(false);
-
                         SpaceRoom::new_from_summary(
                             &room.summary,
                             self.client.get_room(&room.summary.room_id),
@@ -352,7 +358,14 @@ impl SpaceRoomList {
                             via,
                             suggested,
                         )
-                    })
+                        .await
+                    }
+                }))
+                .await;
+
+                let mut rooms = self.rooms.lock();
+                children_space_rooms
+                    .into_iter()
                     .sorted_by(|a, b| Self::compare_rooms(a, b, &children_state))
                     .for_each(|room| rooms.push_back(room));
 
@@ -523,6 +536,7 @@ mod tests {
                         vec![],
                         false,
                     )
+                    .await
                 },
                 VectorDiff::PushBack {
                     value: SpaceRoom::new_from_summary(
@@ -537,7 +551,8 @@ mod tests {
                         1,
                         vec![],
                         false,
-                    ),
+                    )
+                    .await,
                 }
             ]
         );
@@ -756,6 +771,7 @@ mod tests {
                         vec![owned_server_name!("matrix-client.example.org")],
                         false,
                     )
+                    .await
                 },
                 VectorDiff::PushBack {
                     value: SpaceRoom::new_from_summary(
@@ -770,7 +786,8 @@ mod tests {
                         2,
                         vec![owned_server_name!("other-matrix-client.example.org")],
                         false,
-                    ),
+                    )
+                    .await,
                 }
             ]
         );


### PR DESCRIPTION
This means making both `SpaceRoom::new_from_summary` and `SpaceRoom::new_from_known_room` async, which in turn forces us to change how we instantiate those in quite a few places.

Why do we need this? It seems like the pre-computed `active_service_member_count` is not usually available for these rooms: if you are in spaces with lots of rooms you haven't visited before, you wouldn't have triggered their `sync_members` call that would compute this value. In those cases, you'd get the wrong computed room display names and `is_dm` values.

Also, I tweaked a bit how the display name computation and the `heroes` values are returned:

- The computed display name will try computing the joined service member count first now that we can do it, so that rooms with service members display the proper display name (i.e. in a room with you, Alice and a Bot service member it'll display simply 'Alice' instead of 'Alice, and 2 others', those 2 others being you and the bot). This happens because in `compute_display_name_from_heroes` the `if num_heroes < num_joined_invited_except_self && num_joined_invited > 1` line would always be triggered for rooms with service members.
- When using the heroes to compute the display name and when returning the `heroes` field in `SpaceRoom`, use `Room::heroes` instead of `RoomInfo::heroes`. The latter just stores what the HS returns, while the former filters out service members that should not be considered heroes.

---

Changes after review: the `SpaceRoomList::rooms` Mutex is now an `AsyncMutex`. This changes some other method signatures so they're async now too.

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 